### PR TITLE
Bug/ie range without block

### DIFF
--- a/jscripts/tiny_mce/classes/dom/Selection.js
+++ b/jscripts/tiny_mce/classes/dom/Selection.js
@@ -192,10 +192,6 @@
 					}
 				}
 
-				// If start element is body element try to move to the first child if it exists
-				if (startElement && startElement.nodeName == 'BODY')
-					return startElement.firstChild || startElement;
-
 				return startElement;
 			} else {
 				startElement = rng.startContainer;

--- a/tests/ie_selection.html
+++ b/tests/ie_selection.html
@@ -307,6 +307,29 @@ if (tinyMCE.isIE) {
 		equals(rng.endContainer.nodeName, '#text');
 		equals(rng.endOffset, 3);
 	});
+
+	test("Selection of text outside of a block element", function() {
+		var r;
+		
+		editor.settings.forced_root_block = '';
+		editor.focus();
+		editor.getBody().innerHTML = '<ul><li>Item</li></ul>Text';
+
+		r = editor.dom.createRng();
+		r.setStart(editor.getBody().lastChild, 2);
+		r.setEnd(editor.getBody().lastChild, 2);
+		editor.selection.setRng(r);
+
+		r = editor.selection.getRng(true);
+		equals(r.startContainer, editor.getBody().lastChild, "Start container is text node.");
+		equals(r.endContainer, editor.getBody().lastChild, "End container is text node.");
+		equals(r.startOffset, 2);
+		equals(r.endOffset, 2);
+
+		equals(editor.selection.getStart(), editor.getBody(), "Selection start is body.");
+		same(editor.selection.getSelectedBlocks(), [], "No blocks selected.");
+	});
+	
 } else {
 	test("Skipped ie_selection tests as not running in IE.", function() {});
 }


### PR DESCRIPTION
The IE selection implementation differed from other browsers in how it handled the selection start container being the body element.  In IE, it would return the first child of the body, in all other browsers it returned the body itself. This caused getSelectedBlocks to return an incorrect set of elements.

This problem is only likely to be encountered when forced_root_block is set to ''.
