### PR TITLE
Bug/paste border styles merge

### DIFF
--- a/jscripts/tiny_mce/classes/dom/DOMUtils.js
+++ b/jscripts/tiny_mce/classes/dom/DOMUtils.js
@@ -877,19 +877,30 @@
 				delete o[p + '-left' + s];
 			};
 
+			function canCompress(key) {
+				var split, value = o[key];
+				if (!value || value.indexOf(' ') < 0) {
+					return;
+				}
+				split = value.split(' ');
+				if (each(split, function(v) { return v === split[0]; })) {
+					o[key] = split[0];
+					return true;
+				} else {
+					return false;
+				}
+			}
+
 			function compress2(ta, a, b, c) {
 				var t;
-
-				t = o[a];
-				if (!t)
+				
+				if (!canCompress(a))
 					return;
 
-				t = o[b];
-				if (!t)
+				if (!canCompress(b))
 					return;
 
-				t = o[c];
-				if (!t)
+				if (!canCompress(c))
 					return;
 
 				// Compress

--- a/tests/js/api.js
+++ b/tests/js/api.js
@@ -377,7 +377,7 @@ function fakeKeyEvent(e, na, o) {
 (function() {
 	var DOM = new tinymce.dom.DOMUtils(document, {keep_values : true});
 
-	test('tinymce.dom.DOMUtils - parseStyle', 9, function() {
+	test('tinymce.dom.DOMUtils - parseStyle', 11, function() {
 		var dom;
 
 		DOM.add(document.body, 'div', {id : 'test'});
@@ -399,6 +399,16 @@ function fakeKeyEvent(e, na, o) {
 		equals(
 			dom.serializeStyle(dom.parseStyle('border-top: 1px solid red; border-left: 1px solid red; border-bottom: 1px solid red; border-right: 1px solid red;')),
 			'border: 1px solid red;'
+		);
+		
+		equals(
+			dom.serializeStyle(dom.parseStyle('border-width: 1pt 1pt 1pt 1pt; border-style: none none none none; border-color: black black black black;')),
+			'border: 1pt none black;'
+		);
+		
+		equals(
+			dom.serializeStyle(dom.parseStyle('border-width: 1pt 4pt 2pt 3pt; border-style: solid dashed dotted none; border-color: black red green blue;')),
+			'border-width: 1pt 4pt 2pt 3pt; border-style: solid dashed dotted none; border-color: black red green blue;'
 		);
 
 		equals(


### PR DESCRIPTION
DOMUtils.compress2 incorrectly merged shorthand styles (like border-width into border). This can only be validly done if all four values in border-width are equal.  The new tests in 'tinymce.dom.DOMUtils - parseStyle' are probably the easiest way to understand the problem.
