### PR TITLE
Bug/scroll into view

### DIFF
--- a/jscripts/tiny_mce/classes/dom/TridentSelection.js
+++ b/jscripts/tiny_mce/classes/dom/TridentSelection.js
@@ -186,7 +186,6 @@
 						ctrlRng = body.createControlRange();
 						ctrlRng.addElement(startContainer.childNodes[startOffset]);
 						ctrlRng.select();
-						ctrlRng.scrollIntoView();
 						return;
 					} catch (ex) {
 						// Ignore
@@ -200,7 +199,6 @@
 
 			// Select the new range and scroll it into view
 			ieRng.select();
-			ieRng.scrollIntoView();
 		};
 
 		this.getRangeAt = function() {


### PR DESCRIPTION
The scrollIntoView method for IE ranges is problematic as in some situations (especially when tables are involved) it will cause the outer page to scroll instead of just the iframe TinyMCE is using for editing.  Since Selection.select doesn't cause any other browser to scroll to the new selection, this patch removes the call to scrollIntoView on IE.  This makes the selection behaviour consistent across browsers and avoids the problems with incorrect scrolling on IE.
