### PR TITLE
Feature/configurable font detection

### DIFF
--- a/jscripts/tiny_mce/themes/advanced/editor_template_src.js
+++ b/jscripts/tiny_mce/themes/advanced/editor_template_src.js
@@ -935,7 +935,7 @@
 						cl = n.className;
 				}
 
-				if (ed.dom.is(n, ed.settings.theme_advanced_font_selector)) {
+				if (ed.dom.is(n, s.theme_advanced_font_selector)) {
 					if (!fz && n.style.fontSize)
 						fz = n.style.fontSize;
 


### PR DESCRIPTION
If you use template content, it's common to have something like:

<div style="font-family: Arial">Content here</div>


Since TinyMCE only looks for font family and font-size styles on span tags, it won't display the current font if it's inherited from a parent tag like this.  This patch allows the administrator to provide a custom selector for tags to check for font family and size styles to improve the behaviour in cases like the above.  Most commonly it would be either left as the default of 'span' or changed to:

theme_advanced_font_selector: '*'

to pick up styles from any available element.
