### PR TITLE
Set selection loses caret position

### DIFF
--- a/jscripts/tiny_mce/classes/dom/Selection.js
+++ b/jscripts/tiny_mce/classes/dom/Selection.js
@@ -154,6 +154,7 @@
 
 				// Move to caret marker
 				c = t.dom.get('__caret');
+
 				// Make sure we wrap it compleatly, Opera fails with a simple select call
 				r = d.createRange();
 				r.setStartBefore(c);
@@ -162,6 +163,7 @@
 
 				// Remove the caret position
 				t.dom.remove('__caret');
+				t.setRng(r);
 			} else {
 				if (r.item) {
 					// Delete content and get caret text selection

--- a/tests/selection.html
+++ b/tests/selection.html
@@ -72,6 +72,44 @@ test('setContent', function() {
 	editor.selection.setContent('<div>test</div>');
 	equals(editor.getContent(), '<div>test</div><p>text</p>', 'Set contents at selection (collapsed)');
 
+	// Insert in middle of paragraph
+	editor.setContent('<p>beforeafter</p>');
+	rng = editor.dom.createRng();
+	rng.setStart(editor.getBody().firstChild.firstChild, 'before'.length);
+	rng.setEnd(editor.getBody().firstChild.firstChild, 'before'.length);
+	editor.selection.setRng(rng);
+	editor.selection.setContent('<br />');
+	equals(editor.getContent(), '<p>before<br />after</p>', 'Set contents at selection (inside paragraph)');
+	
+	// Check the caret is left in the correct position.
+	rng = editor.selection.getRng(true);
+	equals(rng.startContainer, editor.getBody().firstChild, 'Selection start container');
+	equals(rng.startOffset, 2, 'Selection start offset');
+	equals(rng.endContainer, editor.getBody().firstChild, 'Selection end container');
+	equals(rng.endOffset, 2, 'Selection end offset');
+
+	
+	editor.setContent('<p>text</p>');
+	rng = editor.dom.createRng();
+	rng.setStart(editor.getBody(), 0);
+	rng.setEnd(editor.getBody(), 0);
+	editor.selection.setRng(rng);
+	editor.selection.setContent('');
+	equals(editor.getContent(), '<p>text</p>', 'Set contents to empty at selection (collapsed)');
+	rng = editor.selection.getRng(true);
+	if (!document.createRange) {
+		// The old IE selection can only be positioned in text nodes
+		equals(rng.startContainer, editor.getBody().firstChild.firstChild, 'Selection start container');
+		equals(rng.startOffset, 0, 'Selection start offset');
+		equals(rng.endContainer, editor.getBody().firstChild.firstChild, 'Selection end container');
+		equals(rng.endOffset, 0, 'Selection end offset');
+	} else {
+		equals(rng.startContainer, editor.getBody(), 'Selection start container');
+		equals(rng.startOffset, 0, 'Selection start offset');
+		equals(rng.endContainer, editor.getBody(), 'Selection end container');
+		equals(rng.endOffset, 0, 'Selection end offset');
+	}
+	
 	// Set selected contents, onSetContent event
 	eventObj = {};
 


### PR DESCRIPTION
If you start with the content:

<p>Content<img src="http://www.google.com/images/logo.gif" border="0" alt="" hspace="5" vspace="5" align="right" /></p>

and have the 'paste' plugin enabled, then:
1. click the image to select it
2. copy (control/command-C)
3. Move the selection into between the t and e in Content.
4. Paste (control/command-V)
5. Paste again (control/command-V)

In Firefox & IE this works correctly and two images are pasted next to each other.  However, in WebKit based browsers after the first paste, the selection is lost and the startContainer/endContainer become the document, so the second paste fails.  This comes down to the code in Selection.setContent which is currently positioning the caret then removing the caret marker.  This patch simply reverses the order of those operations so the caret position is set after removal, thus if the remove moves the caret position, it gets restored correctly.

Also tested this on Opera and it works correctly.

Patch merges cleanly with both master and 3.4, but if you need it, there's also a ready-merged-with-3.4 branch at http://github.com/ephox/tinymce/tree/bug/3.4-setSelectionLosesCaretPosition
