### PR TITLE
Fix legacyoutput bug with bold/italics buttons

### DIFF
--- a/jscripts/tiny_mce/plugins/legacyoutput/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/legacyoutput/editor_plugin_src.js
@@ -37,10 +37,24 @@
 					alignfull : {selector : alignElements, attributes : {align : 'full'}},
 
 					// Change the basic formatting elements to use deprecated element types
-					bold : {inline : 'b'},
-					italic : {inline : 'i'},
-					underline : {inline : 'u'},
-					strikethrough : {inline : 'strike'},
+					bold : [
+						{inline : 'b'},
+						{inline : 'strong'},
+						{inline : 'span', styles : {fontWeight : 'bold'}}
+					],
+					italic : [
+						{inline : 'i'},
+						{inline : 'em'},
+						{inline : 'span', styles : {fontStyle : 'italic'}}
+					],
+					underline : [
+						{inline : 'u'},
+						{inline : 'span', styles : {textDecoration : 'underline'}, exact : true}
+					],
+					strikethrough : [
+						{inline : 'strike'},
+						{inline : 'span', styles : {textDecoration: 'line-through'}, exact : true}
+					],
 
 					// Change font size and font family to use the deprecated font element
 					fontname : {inline : 'font', attributes : {face : '%value'}},


### PR DESCRIPTION
This fixes mixed XHTML1.0-strict/HTML4-transitional content for the italic/bold button state edited with legacyoutput enabled
