### PR TITLE
Webkit, paste/scroll

### DIFF
--- a/jscripts/tiny_mce/plugins/paste/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/paste/editor_plugin_src.js
@@ -151,7 +151,7 @@
 				if (body != ed.getDoc().body)
 					posY = dom.getPos(ed.selection.getStart(), body).y;
 				else
-					posY = body.scrollTop;
+					posY = body.scrollTop + dom.getViewPort().y;
 
 				// Styles needs to be applied after the element is added to the document since WebKit will otherwise remove all styles
 				dom.setStyles(n, {


### PR DESCRIPTION
This fixes the behavior of webkit browsers scrolling to the top of the iframe when some text gets pasted if the iframe's top is out of the windows viewing area.

Reproduce by:
- use safari or chrome
- resize the tinymce to eg 800px in height
- resize the browser's window to 400px in height
- write about 20 lines in tinymce
- scroll down the browser windows until you just see the last line
- past something below the last line

Expected result:
-Keep the scrolling position

Actual result:
-scroll the browser's window back to the top of the iframe
