### PR TITLE
Added exact option for StyleFormats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ jscripts/tiny_mce/tiny_mce_jquery_src.js
 jscripts/tiny_mce/tiny_mce_prototype.js
 jscripts/tiny_mce/tiny_mce_prototype_src.js
 jscripts/tiny_mce/tiny_mce_src.js
+nbproject

--- a/jscripts/tiny_mce/classes/Formatter.js
+++ b/jscripts/tiny_mce/classes/Formatter.js
@@ -171,15 +171,10 @@
 					});
 
 					each(fmt.classes, function(value) {
-						if(!fmt.exact) {
-							value = replaceVars(value, vars);
+						value = replaceVars(value, vars);
 
-							if (!dom.hasClass(elm, value))
-								dom.addClass(elm, value);
-						}
-						else {
-							dom.setAttrib(elm, 'class', replaceVars(value, vars));
-						}
+						if (!dom.hasClass(elm, value))
+						dom.addClass(elm, value);
 					});
 				}
 			};


### PR DESCRIPTION
This fix make it possible to use the same exact option as in the "formats" option in the config of tinymce.
