### PR TITLE
Custom Tags and IE browsers

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -1005,7 +1005,7 @@
 						} else
 							n = 'div';
 
-						o.content = o.content.replace(new RegExp('<(' + v + ')(\\s[^>]*)>', 'g'), '<' + n + ' _mce_name="$1"$2>');
+						o.content = o.content.replace(new RegExp('<(' + v + ')(\\s[^>]*)?>', 'g'), '<' + n + ' _mce_name="$1"$2>');
 						o.content = o.content.replace(new RegExp('</(' + v + ')>', 'g'), '</' + n + '>');
 					});
 				};


### PR DESCRIPTION
I think I have found an issue with a regular expression under the custom tag function.  The current regex has a problem in IE browsers.  If I have a custom tag <t> and also use <table> tags, the table tag will be converted to <t> tags because the regex is too greedy.  To fix this, I added \s to the expression to allow for whitespace.
