### PR TITLE
Bug3222

### DIFF
--- a/jscripts/tiny_mce/plugins/table/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/table/editor_plugin_src.js
@@ -143,6 +143,9 @@
 
 				if (node.nodeType == 3) {
 					each(dom.getParents(node.parentNode, null, cell).reverse(), function(node) {
+						if (node.nodeName == 'A') {
+							return;
+						}
 						node = cloneNode(node, false);
 
 						if (!formatNode)


### PR DESCRIPTION
Fix of bug 3222 http://tinymce.moxiecode.com/develop/bugtracker_view.php?id=3222 . When cloning cells, ignore 'A' nodes.
