### PR TITLE
Update to allow fullscreen and fullpage plugins to play together better.

### DIFF
--- a/jscripts/tiny_mce/plugins/fullscreen/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/fullscreen/editor_plugin_src.js
@@ -25,15 +25,23 @@
 					if (ed.getParam('fullscreen_new_window'))
 						closeFullscreen(); // Call to close in new window
 					else {
-						DOM.win.setTimeout(function() {
+                                                DOM.win.setTimeout(function() {
 							tinymce.dom.Event.remove(DOM.win, 'resize', t.resizeFunc);
-							tinyMCE.get(ed.getParam('fullscreen_editor_id')).setContent(ed.getContent({format : 'raw'}), {format : 'raw'});
+							
+							var fullContent = ed.getContent({format : 'raw'});
+							var fullEditorId = ed.getParam('fullscreen_editor_id')
+							
 							tinyMCE.remove(ed);
 							DOM.remove('mce_fullscreen_container');
 							de.style.overflow = ed.getParam('fullscreen_html_overflow');
 							DOM.setStyle(DOM.doc.body, 'overflow', ed.getParam('fullscreen_overflow'));
 							DOM.win.scrollTo(ed.getParam('fullscreen_scrollx'), ed.getParam('fullscreen_scrolly'));
 							tinyMCE.settings = tinyMCE.oldSettings; // Restore old settings
+							
+							tinyMCE.execCommand('mceRemoveControl', false, fullEditorId);
+							document.getElementById(ed.getParam('fullscreen_editor_id')).value = fullContent;
+							tinyMCE.execCommand('mceAddControl', false, fullEditorId);
+							
 						}, 10);
 					}
 


### PR DESCRIPTION
Currently, if both the fullscreen and fullpage plugins are enabled, <head> content from a "full screen" view gets copied down into the body when exiting "full screen" mode. This fix takes the content from the full screen editor, and places it back into the main editor on exiting "full screen" mode.

Please take a look, this works for us but there might be a better way, 

Cheers!

Ian @ Pardot
