### PR TITLE
Issue with IE6 loading local copy of TinyMCE

### DIFF
--- a/jscripts/tiny_mce/classes/dom/ScriptLoader.js
+++ b/jscripts/tiny_mce/classes/dom/ScriptLoader.js
@@ -73,7 +73,7 @@
 
 				// If script is from same domain and we
 				// use IE 6 then use XHR since it's more reliable
-				if (uri.host == loc.hostname && uri.port == loc.port && (uri.protocol + ':') == loc.protocol) {
+				if (uri.host == loc.hostname && uri.port == loc.port && (uri.protocol + ':') == loc.protocol && uri.protocol.toLowerCase() != 'file') {
 					tinymce.util.XHR.send({
 						url : tinymce._addVer(uri.getURI()),
 						success : function(content) {


### PR DESCRIPTION
Hi there,

(Please bear with me... this is my first time using github...)

I just submitted a fix to an issue where IE6 would error out when TinyMCE was being opened locally (i.e. "file:///").  It was due to a workaround for IE6 that would perform an XMLHTTP request to load the javascript as opposed to doing it normally, and the request would fail with an access denied error.  In my fix, it allows local javascript files to be loaded normally.

Thanks,
Christopher
