### PR TITLE
Bug #2455

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version 3.4.1.x (2011-03-xx)
 	Fixed bug where merging of table cells on IE 6, 7 wouldn't look correctly until the contents was refreshed.
 	Fixed bug where context menu wouldn't work properly on Safari since it was passing out the ctrl key as pressed.
 	Fixed bug where image border color/style values were overwritten by advimage plugin.
+	Fixed bug where setting border in advimage plugin would throw error in IE.
 	Fixed bug where the context menu wouldn't select images on WebKit browsers.
 Version 3.4.1 (2011-03-24)
 	Added significantly improved list handling via the new 'lists' plugin.

--- a/jscripts/tiny_mce/plugins/advimage/js/image.js
+++ b/jscripts/tiny_mce/plugins/advimage/js/image.js
@@ -361,7 +361,7 @@ var ImageDialog = {
 	},
 
 	updateStyle : function(ty) {
-		var dom = tinyMCEPopup.dom, b, bStyle, bColor, v, f = document.forms[0], img = dom.create('img', {style : dom.get('style').value});
+		var dom = tinyMCEPopup.dom, b, bStyle, bColor, v, isIE = tinymce.isIE, f = document.forms[0], img = dom.create('img', {style : dom.get('style').value});
 
 		if (tinyMCEPopup.editor.settings.inline_styles) {
 			// Handle align
@@ -389,10 +389,16 @@ var ImageDialog = {
 				v = f.border.value;
 				if (v || v == '0') {
 					if (v == '0')
-						img.style.border = '0 none none';
+						img.style.border = isIE ? '0' : '0 none none';
 					else {
-						bStyle = b[1] ? b[1] : bStyle ? bStyle : 'solid';
-						bColor = b[2] ? b[2] : bColor ? bColor : 'black';
+						if (b.length == 3 && b[isIE ? 2 : 1])
+							bStyle = b[isIE ? 2 : 1];
+						else if (!bStyle || bStyle == 'none')
+							bStyle = 'solid';
+						if (b.length == 3 && b[isIE ? 0 : 2])
+							bColor = b[isIE ? 0 : 2];
+						else if (!bColor || bColor == 'none')
+							bColor = 'black';
 						img.style.border = v + 'px ' + bStyle + ' ' + bColor;
 					}
 				}


### PR DESCRIPTION
Fixed bug where image border color/style values were overwritten by advimage plugin.

It also fixes javascript error on IE, where img.style.border = '0 none none' doesn't work.
