### PR TITLE
onBeforeExecCommand always overwrites the beforeBookmark

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -2254,9 +2254,9 @@
 			if (!/^(mceAddUndoLevel|mceEndUndoLevel|mceBeginUndoLevel|mceRepaint|SelectAll)$/.test(cmd) && (!a || !a.skip_focus))
 				t.focus();
 
-			o = {};
-			t.onBeforeExecCommand.dispatch(t, cmd, ui, val, o);
-			if (o.terminate)
+			a = extend({}, a);
+			t.onBeforeExecCommand.dispatch(t, cmd, ui, val, a);
+			if (a.terminate)
 				return false;
 
 			// Command callback


### PR DESCRIPTION
onBeforeExecCommand always overwrites the beforeBookmark (in bookmarkManager) despite skip_undo being checked further into the call stack. Different variables were being passed to onBefore than onExec. This causes commands that skip_undo to modify the undoManagers state.
