### PR TITLE
Chrome window scrolling on paste

### DIFF
--- a/jscripts/tiny_mce/plugins/paste/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/paste/editor_plugin_src.js
@@ -177,7 +177,7 @@
 				// Styles needs to be applied after the element is added to the document since WebKit will otherwise remove all styles
 				dom.setStyles(n, {
 					position : 'absolute',
-					left : -10000,
+					left : 0,
 					top : posY,
 					width : 1,
 					height : 1,


### PR DESCRIPTION
Fix to avoid page scrolling in Chrome on each paste attempt when window height is less than total height of content before editor area.

Steps to reproduce:
- Open Chrome browser
- Load a page where total height of content before the editor is at least 400px (ex. below)
- Resize browser window to 200px in height
- Paste multiple times any amount of content into tinymce

Observed behaviour:
Window scrolls down with each paste attempt

Expected behaviour:
Window position remains unchanged

Sample html for reproduction:

``` html
<!DOCTYPE html>
<html>
<head>
  <script type="text/javascript" src="tiny_mce/tiny_mce.js"></script>
  <script>
    tinyMCE.init({mode : "textareas", plugins : "paste"});
  </script>
</head>
<body style="padding: 800px 0">
<textarea></textarea>
</body>
</html>
```
