### PR TITLE
Fix for bug #4444

### DIFF
--- a/jscripts/tiny_mce/plugins/inlinepopups/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/inlinepopups/editor_plugin_src.js
@@ -219,7 +219,10 @@
 				t.focus(id);
 
 				if (n.nodeName == 'A' || n.nodeName == 'a') {
-					if (n.className == 'mceMax') {
+					if (n.className == 'mceClose') {
+						t.close(null, id);
+						return Event.cancel(e);
+					} else if (n.className == 'mceMax') {
 						w.oldPos = w.element.getXY();
 						w.oldSize = w.element.getSize();
 


### PR DESCRIPTION
This is a fix for my own reported bug #4444. When the close button is outside the viewport the popup window can't be closed if you use IE.
