### PR TITLE
Fix a js error when user delete all the content from a textarea with tinymce

### DIFF
--- a/jscripts/tiny_mce/classes/html/DomParser.js
+++ b/jscripts/tiny_mce/classes/html/DomParser.js
@@ -561,11 +561,13 @@
 								elementRule = schema.getElementRule(parent.name);
 
 								// Remove or padd the element depending on schema rule
-								if (elementRule.removeEmpty)
-									parent.remove();
-								else if (elementRule.paddEmpty) 
-									parent.empty().append(new tinymce.html.Node('#text', 3)).value = '\u00a0';
-							}
+								if (elementRule) {
+								  if (elementRule.removeEmpty)
+									  parent.remove();
+								  else if (elementRule.paddEmpty)
+									  parent.empty().append(new tinymce.html.Node('#text', 3)).value = '\u00a0';
+							  }
+              }
 						}
 					}
 				}


### PR DESCRIPTION
I was having issues with a form which is submitted by ajax and it has some fields using tinymce. I found that when a tinymce textarea has some content and the user leave it blank, the submit fails because an js error happens before. The bug occurs because the elementRule is undefined, please see my changes and note I've just added an additional checking for elementRule.

Cheers,
Jorge
