### PR TITLE
`content` variable needs to be localized in autosave plugin

### DIFF
--- a/jscripts/tiny_mce/plugins/autosave/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/autosave/editor_plugin_src.js
@@ -335,7 +335,7 @@
 		 * @method restoreDraft
 		 */
 		restoreDraft : function() {
-			var self = this, storage = self.storage;
+			var self = this, storage = self.storage, content;
 
 			if (storage) {
 				content = storage.getItem(self.key);


### PR DESCRIPTION
When restoring from an autosave, the global `content` is being overwritten.

This was a quick fix - added `content` as a local variable before assigning to the restored content.
