### PR TITLE
Bug fix - paste into invalid location causes removal of unselected content.

### DIFF
--- a/jscripts/tiny_mce/classes/EditorCommands.js
+++ b/jscripts/tiny_mce/classes/EditorCommands.js
@@ -365,7 +365,7 @@
 					value = serializer.serialize(
 						parser.parse(
 							// Need to replace by using a function since $ in the contents would otherwise be a problem
-							value.replace(/<span (id="mce_marker"|id=mce_marker).+<\/span>/i, function() {
+							value.replace(/<span (id="mce_marker"|id=mce_marker).+?<\/span>/i, function() {
 								return serializer.serialize(fragment);
 							})
 						)

--- a/tests/paste.html
+++ b/tests/paste.html
@@ -175,6 +175,19 @@ test("Disable default filters", function() {
 	editor.settings.paste_enable_default_filters = true;
 });
 
+test('paste invalid content with spans on page', function(){
+	var startingContent = '<p>123 testing <span>span later in document</span></p>',
+		insertedContent = '<ul><li>u</li><li>l</li></ul>';
+	editor.setContent(startingContent);
+	rng = editor.dom.createRng();
+	rng.setStart(editor.dom.select('p')[0].firstChild, 0);
+	rng.setEnd(editor.dom.select('p')[0].firstChild, 0);
+	editor.selection.setRng(rng);
+	editor.execCommand('mceInsertClipboardContent', false, {content : insertedContent});
+
+	equals(editor.getContent().replace(/[\r\n]+/g, ''), insertedContent + startingContent);
+});
+
 tinyMCE.init({
 	mode : "exact",
 	elements : "elm1",

--- a/tests/tinymce.EditorCommands.html
+++ b/tests/tinymce.EditorCommands.html
@@ -262,6 +262,19 @@ test('mceInsertContent - mixed inline content inside td', function() {
 	equals(editor.getContent(), '<table><tbody><tr><td>test<strong>123</strong><!-- a -->X</td></tr></tbody></table>');
 });
 
+test('mceInsertContent - invalid insertion with spans on page', function(){
+	var startingContent = '<p>123 testing <span>span later in document</span></p>',
+		insertedContent = '<ul><li>u</li><li>l</li></ul>';
+	editor.setContent(startingContent);
+	rng = editor.dom.createRng();
+	rng.setStart(editor.dom.select('p')[0].firstChild, 0);
+	rng.setEnd(editor.dom.select('p')[0].firstChild, 0);
+	editor.selection.setRng(rng);
+	editor.execCommand('mceInsertContent', false, insertedContent);
+
+	equals(editor.getContent(), insertedContent + startingContent);
+});
+
 test('InsertHorizontalRule', function() {
 	var rng;
 	


### PR DESCRIPTION
fixed a bug where pasting content into an invalid location could result in removal of large portions of unrelated content within the document.
