### PR TITLE
build.xml: make building of docs optional

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,7 @@
 	<taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="tasks.classpath" loaderref="tasks.classpath.loader" />
 
 	<!-- Generate JS documentation -->
-	<target name="moxiedoc" depends="" description="Generates HTML documentation out of js source">
+	<target name="moxiedoc" depends="" description="Generates HTML documentation out of js source" unless="nomoxiedoc">
 		<mkdir dir="docs"/>
 		<delete quiet="true">
 			<fileset dir="docs/api" includes="**/*"/>

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,10 @@ Will generate API Documentation for the project using the Moxiedoc tool. The doc
 
 Will produce an release package of the current repository code. The release packages will be placed in the tmp directory.
 
+`ant release -Dnomoxiedoc=true`
+
+Same as above, but don't generate API Documentation.
+
 Contributing to the TinyMCE project
 ------------------------------------
 You can read more about how to contribute to this project at [http://tinymce.moxiecode.com/contributing](http://tinymce.moxiecode.com/contributing)


### PR DESCRIPTION
This can be skipped by passing `-Dnomoxiedoc=true` to Ant.
