### PR TITLE
Fixed remove formatting at end of line moving selection to document

### DIFF
--- a/jscripts/tiny_mce/classes/Formatter.js
+++ b/jscripts/tiny_mce/classes/Formatter.js
@@ -733,7 +733,7 @@
 				selection.moveToBookmark(bookmark);
 
 				// Check if start element still has formatting then we are at: "<b>text|</b>text" and need to move the start into the next text node
-				if (match(name, vars, selection.getStart())) {
+				if (format.inline && match(name, vars, selection.getStart())) {
 					moveStart(selection.getRng(true));
 				}
 

--- a/tests/tinymce.Formatter_remove.html
+++ b/tests/tinymce.Formatter_remove.html
@@ -235,6 +235,21 @@ test('Formatter - remove and verify start element', function() {
 	equals(editor.selection.getStart().nodeName, 'P');
 });
 
+test('Formatter - remove with selection collapsed ensure correct caret position', function() {
+	var rng,
+		content = '<p>test</p><p>testing</p>';
+
+	editor.formatter.register('format', {block : 'p'});
+	rng = editor.dom.createRng();
+	editor.getBody().innerHTML = content;
+	rng.setStart(editor.dom.select('p')[0].firstChild, 4);
+	rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+	editor.selection.setRng(rng);
+	editor.formatter.remove('format');
+	equals(getContent(), content);
+	equals(editor.selection.getStart(), editor.dom.select('p')[0]);
+});
+
 tinyMCE.init({
 	mode : "exact",
 	elements : "elm1",


### PR DESCRIPTION
I think there was an assumption when this code was written ([fcb66a5e9196](https://github.com/wwalser/tinymce/commit/fcb66a5e9196e5aef50c8922f9b62ddde138c840)) that moveStart would only be called when an inline formatting was being called. This can occasionally be untrue though as the if statement above has checks isCollapsed() || format.inline.

In particular, when the remove formatting button/command is clicked/run while the caret is at the end of a line (collapsed) a few different things happen. In chrome the selection changes to the document, breaking further user interaction. In firefox the caret moves to the next element.
