### PR TITLE
Focus/caret issue in Firefox 3/4

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -2976,8 +2976,12 @@
 						if (t._isHidden()) {
 							try {
 								if (!s.content_editable) {
-									d.body.contentEditable = false;
-									d.body.contentEditable = true;
+									if (/Firefox\/[1-4]/.test(navigator.userAgent)) {
+										d.body.designMode = 'on';
+									} else {
+										d.body.contentEditable = false;
+										d.body.contentEditable = true;
+									}
 								}
 							} catch (ex) {
 								// Fails if it's hidden


### PR DESCRIPTION
(Cleaned up pull request 85 and added fix in another section of the code)

Fix for strange cursor/caret behavior in Firefox 3/4.

Expected behavior:
1) Load examples/full.html. Do not click in the editor.
2) In the Firebug console run: tinymce.editors[0].focus(); window.focus();
3) The caret should be visible in the editor body.
3) Type some characters.
4) Hit enter.
5) Type some more characters.
6) The characters should show up on a new line.

Actual behavior:
The caret is not visible in the body and the characters typed after hitting enter show up on the first line, with the newline showing up below that.

Also see bug #4639.
