### PR TITLE
Two UI simplifications

### DIFF
--- a/jscripts/tiny_mce/plugins/spellchecker/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/spellchecker/editor_plugin_src.js
@@ -319,57 +319,59 @@
 						m.add({title : 'spellchecker.no_sug', 'class' : 'mceMenuItemTitle'}).setDisabled(1);
 
 					ignoreRpc = t.editor.getParam("spellchecker_enable_ignore_rpc", '');
-					m.add({
-						title : 'spellchecker.ignore_word',
-						onclick : function() {
-							var word = wordSpan.innerHTML;
-
-							dom.remove(wordSpan, 1);
-							t._checkDone();
-
-							// tell the server if we need to
-							if (ignoreRpc) {
-								ed.setProgressState(1);
-								t._sendRPC('ignoreWord', [t.selectedLang, word], function(r) {
-									ed.setProgressState(0);
-								});
-							}
-						}
-					});
-
-					m.add({
-						title : 'spellchecker.ignore_words',
-						onclick : function() {
-							var word = wordSpan.innerHTML;
-
-							t._removeWords(dom.decode(word));
-							t._checkDone();
-
-							// tell the server if we need to
-							if (ignoreRpc) {
-								ed.setProgressState(1);
-								t._sendRPC('ignoreWords', [t.selectedLang, word], function(r) {
-									ed.setProgressState(0);
-								});
-							}
-						}
-					});
-
-					if (t.editor.getParam("spellchecker_enable_learn_rpc")) {
+					if (t.editor.getParam("spellchecker_enable_ignore")) {
 						m.add({
-							title : 'spellchecker.learn_word',
+							title : 'spellchecker.ignore_word',
 							onclick : function() {
 								var word = wordSpan.innerHTML;
 
 								dom.remove(wordSpan, 1);
 								t._checkDone();
 
-								ed.setProgressState(1);
-								t._sendRPC('learnWord', [t.selectedLang, word], function(r) {
-									ed.setProgressState(0);
-								});
+								// tell the server if we need to
+								if (ignoreRpc) {
+									ed.setProgressState(1);
+									t._sendRPC('ignoreWord', [t.selectedLang, word], function(r) {
+										ed.setProgressState(0);
+									});
+								}
 							}
 						});
+
+						m.add({
+							title : 'spellchecker.ignore_words',
+							onclick : function() {
+								var word = wordSpan.innerHTML;
+
+								t._removeWords(dom.decode(word));
+								t._checkDone();
+
+								// tell the server if we need to
+								if (ignoreRpc) {
+									ed.setProgressState(1);
+									t._sendRPC('ignoreWords', [t.selectedLang, word], function(r) {
+										ed.setProgressState(0);
+									});
+								}
+							}
+						});
+
+						if (t.editor.getParam("spellchecker_enable_learn_rpc")) {
+							m.add({
+								title : 'spellchecker.learn_word',
+								onclick : function() {
+									var word = wordSpan.innerHTML;
+
+									dom.remove(wordSpan, 1);
+									t._checkDone();
+
+									ed.setProgressState(1);
+									t._sendRPC('learnWord', [t.selectedLang, word], function(r) {
+										ed.setProgressState(0);
+									});
+								}
+							});
+						}
 					}
 
 					m.update();


### PR DESCRIPTION
1)Don't display the language menu if only one language is available

The language menu is a little bit confusing if you only offer one choice
for dictionaries. Disable it if there is only one language.

2)Disable "Ignore Word" and "Ignore All" options by default

Ignoring words doesn't make sense in spell-check environments where
there are multiple servers, or in environments where users shouldn't be
able to affect the dictionary for everyone. Disable it by default.
