### PR TITLE
Fixed a bug where paste didn't create an undo step

### DIFF
--- a/jscripts/tiny_mce/plugins/paste/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/paste/editor_plugin_src.js
@@ -149,6 +149,7 @@
 			function grabContent(e) {
 				var n, or, rng, oldRng, sel = ed.selection, dom = ed.dom, body = ed.getBody(), posY, textContent;
 
+				ed.undoManager.add();
 				// Check if browser supports direct plaintext access
 				if (e.clipboardData || dom.doc.dataTransfer) {
 					textContent = (e.clipboardData || dom.doc.dataTransfer).getData('Text');

--- a/tests/paste.html
+++ b/tests/paste.html
@@ -191,6 +191,29 @@ test('paste invalid content with spans on page', function(){
 	equals(editor.getContent().replace(/[\r\n]+/g, ''), insertedContent + startingContent);
 });
 
+asyncTest('paste creates correct undo level', function(){
+	var startingContent = '123 testing',
+		pasteContent = 'foobar';
+	
+	editor.setContent(startingContent);
+	rng = editor.dom.createRng();
+	rng.setStart(editor.dom.select('p')[0].firstChild, 0);
+	rng.setEnd(editor.dom.select('p')[0].firstChild, 0);
+	editor.selection.setRng(rng);
+	
+	robot.type('a', false, function() {
+		robot.pasteText(pasteContent, function(){
+			QUnit.start();
+
+			//ensure content got pasted correctly
+			equals(editor.getContent(), '<p>a' + pasteContent + startingContent + '</p>');
+			editor.undoManager.undo();
+			//ensure that the character typed before the paste doesn't get removed
+			equals(editor.getContent(), '<p>a' + startingContent + '</p>');
+		});
+	});
+});
+
 tinyMCE.init({
 	mode : "exact",
 	elements : "elm1",
@@ -199,7 +222,6 @@ tinyMCE.init({
 	plugins : 'paste',
 	init_instance_callback : function(ed) {
 		editor = ed;
-		QUnit.start();
 	}
 });
 </script>
@@ -215,5 +237,9 @@ tinyMCE.init({
 		<a href="javascript:alert(tinymce.EditorManager.get('elm1').getContent({format : 'raw'}));">[getRawContents]</a>
 		<a href="javascript:alert(tinymce.EditorManager.get('elm1').getContent());">[getContents]</a>
 	</div>
+	<script type="text/javascript" language="JavaScript" src="jsrobot/robot.js"></script>
+	<script>
+	initWhenTinyAndRobotAreReady();
+	</script>
 </body>
 </html>


### PR DESCRIPTION
To reproduce bug:
Open an instance of TinyMCE
Copy some text "foobar"
type some content "testing"
paste (using keyboard shortcut)
undo

Expected: "foobar" is removed
Actual Result: "testing" and "foobar" is removed.

I used robot.js to perform the testing, so it's now loaded on the paste.html test page.
