### PR TITLE
Improve paste_text_linebreaktype in paste plugin

### DIFF
--- a/jscripts/tiny_mce/plugins/paste/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/paste/editor_plugin_src.js
@@ -27,7 +27,7 @@
 			paste_text_sticky : false,
 			paste_text_sticky_default : false,
 			paste_text_notifyalways : false,
-			paste_text_linebreaktype : "p",
+			paste_text_linebreaktype : "combined",
 			paste_text_replacements : [
 				[/\u2026/g, "..."],
 				[/[\x93\x94\u201c\u201d]/g, '"'],
@@ -805,14 +805,24 @@
 
 				// Treat paragraphs as specified in the config
 				if (linebr == "none") {
+					// Convert all line breaks to space
 					process([
 						[/\n+/g, " "]
 					]);
 				} else if (linebr == "br") {
+					// Convert all line breaks to <br />
 					process([
 						[/\n/g, "<br />"]
 					]);
+				} else if (linebr == "p") {
+					// Convert all line breaks to <p>...</p>
+					process([
+						[/\n+/g, "</p><p>"],
+						[/^(.*<\/p>)(<p>)$/, '<p>$1']
+					]);
 				} else {
+					// defaults to "combined"
+					// Convert single line breaks to <br /> and double line breaks to <p>...</p>
 					process([
 						[/\n\n/g, "</p><p>"],
 						[/^(.*<\/p>)(<p>)$/, '<p>$1'],


### PR DESCRIPTION
Improved paste plugin to paste text originating from pdf or plain text
files. There already is the option "paste_text_linebreaktype" with three
possible values: "n" (converts newline to space), "br" which creates
&lt;br> tags out of line breaks and "p". I'd expect "p" to only add &lt;p>
tags, but it used to create &lt;br> on single breaks and &lt;p> only on two
consecutive line breaks. I've renamed this value to "combined" and
created a now "p" value which takes any number of consecutive line
breaks and transforms them into a single &lt;p> paragraph. The default is
"combined", so the plugin should behave as before for everyone who
does not touch this option. If don't want any &lt;br> tags in your pasted
text, you set "paste_text_linebreaktype" to "p" and you're done.
