### PR TITLE
Configuration parameter to control the default selected link target

### DIFF
--- a/jscripts/tiny_mce/themes/advanced/js/link.js
+++ b/jscripts/tiny_mce/themes/advanced/js/link.js
@@ -146,6 +146,11 @@ var LinkDialog = {
 				lst.options[lst.options.length] = new Option(v[0], v[1]);
 			});
 		}
+    if (v = tinyMCEPopup.getParam('theme_advanced_link_default_target')) {
+       tinymce.each(lst.options, function(option) {
+          option.selected = option.value == v;
+       });
+    }
 	}
 };
 


### PR DESCRIPTION
Create a new configuration parameter 'theme_advanced_link_default_target'.

Setting this allows one to preselect one of the targets in the select box for the user. It can be one of the existing defaults, or loaded with the theme_advanced_link_targets configuration
