### PR TITLE
Add unicode range to HTML Entities regular expression

### DIFF
--- a/jscripts/tiny_mce/classes/html/Entities.js
+++ b/jscripts/tiny_mce/classes/html/Entities.js
@@ -10,8 +10,8 @@
 
 (function(tinymce) {
 	var namedEntities, baseEntities, reverseEntities,
-		attrsCharsRegExp = /[&<>\"\u007E-\uD7FF]|[\uD800-\uDBFF][\uDC00-\uDFFF]/g,
-		textCharsRegExp = /[<>&\u007E-\uD7FF]|[\uD800-\uDBFF][\uDC00-\uDFFF]/g,
+		attrsCharsRegExp = /[&<>\"\u007E-\uD7FF\uE000-\uFFEF]|[\uD800-\uDBFF][\uDC00-\uDFFF]/g,
+		textCharsRegExp = /[<>&\u007E-\uD7FF\uE000-\uFFEF]|[\uD800-\uDBFF][\uDC00-\uDFFF]/g,
 		rawCharsRegExp = /[<>&\"\']/g,
 		entityRegExp = /&(#x|#)?([\w]+);/g,
 		asciiMap = {


### PR DESCRIPTION
Add unicode range \uE000-\uFFEF to HTML entity regular expression to allow some special Japanese kanji

---

You can see an example of a Japanese character not being converted to a HTML entity here:
http://fiddle.tinymce.com/baaaab/225

Run the fiddle, then view the HTML source, only the first two are converted, not the third.

tinymce/tests/tinymce.html.Entities.html also passes

This is my first pull request, so let me know if there are any issues I should fix.
