### PR TITLE
Corrects for metakey-delete not deleting by word

### DIFF
--- a/jscripts/tiny_mce/classes/util/Quirks.js
+++ b/jscripts/tiny_mce/classes/util/Quirks.js
@@ -25,7 +25,7 @@
 			var rng, blockElm, node, clonedSpan, isDelete;
 
 			isDelete = e.keyCode == DELETE;
-			if (isDelete || e.keyCode == BACKSPACE) {
+			if ((isDelete || e.keyCode == BACKSPACE) && !VK.modifierPressed(e)) {
 				e.preventDefault();
 				rng = selection.getRng();
 


### PR DESCRIPTION
Ctrl and alt are needed for windows and mac respectively. It also catches shift, but I don't really think that matters.

If it's too lazy let me know and I'll add in the browser checks.
