### PR TITLE
Fixed js error when opening dropdown context menus for editor id/name containing dot characters (Bug #4863)

### DIFF
--- a/jscripts/tiny_mce/classes/ui/DropMenu.js
+++ b/jscripts/tiny_mce/classes/ui/DropMenu.js
@@ -392,7 +392,7 @@
 		// Internal functions
 		_setupKeyboardNav : function(){
 			var contextMenu, menuItems, t=this; 
-			contextMenu = DOM.select('#menu_' + t.id)[0];
+			contextMenu = DOM.get('menu_' + t.id);
 			menuItems = DOM.select('a[role=option]', 'menu_' + t.id);
 			menuItems.splice(0,0,contextMenu);
 			t.keyboardNav = new tinymce.ui.KeyboardNavigation({


### PR DESCRIPTION
Fixed js error when opening dropdown context menus for editor id/name containing dot characters (Bug 4863)

View original issue description at: http://www.tinymce.com/develop/bugtracker_view.php?id=4863

As per (x)HTML specifications ( http://www.w3.org/TR/REC-html40/types.html#h-6.2 ) id and name attributes can contain dots apart from other valid characters. However the code line in concern previously used the Sizzle engine where the dot character is used to denote class names and this caused the line to fail when the ID itself
had dots. Since the line was already expecting a ID (notice # selector), it makes more sense to directly use the document.getElementById or a similar method which would find DOM elements directly using ID. I am deliberately not going the CSS selector route to avoid additional "." dot escaping logic.
