### PR TITLE
Don't remove HTML comments from otherwise empty elements.

### DIFF
--- a/jscripts/tiny_mce/classes/dom/DOMUtils.js
+++ b/jscripts/tiny_mce/classes/dom/DOMUtils.js
@@ -1613,6 +1613,10 @@
 						}
 					}
 
+					// Keep comment nodes
+					if (type == 8)
+						return false;
+
 					// Keep non whitespace text nodes
 					if ((type === 3 && !whiteSpaceRegExp.test(node.nodeValue)))
 						return false;

--- a/tests/js/tinymce.dom.DOMUtils.js
+++ b/tests/js/tinymce.dom.DOMUtils.js
@@ -593,7 +593,7 @@
 		DOM.remove('test');
 	});
 
-	test('isEmpty', 13, function() {
+	test('isEmpty', 14, function() {
 		DOM.schema = new tinymce.html.Schema(); // A schema will be added when used within a editor instance
 		DOM.add(document.body, 'div', {id : 'test'}, '');
 
@@ -634,6 +634,9 @@
 
 		DOM.setHTML('test', '<span data-mce-style="color:Red"></span>');
 		ok(DOM.isEmpty(DOM.get('test')), 'Span with data-mce attribute.');
+
+		DOM.setHTML('test', '<div><!-- comment --></div>');
+		ok(!DOM.isEmpty(DOM.get('test')), 'Element with comment.');
 
 		DOM.remove('test');
 	});


### PR DESCRIPTION
HTML comments were removed from empty DIV's

This fixes issue #4558.
I added a unit test.

See http://www.tinymce.com/develop/bugtracker_view.php?id=4558
