### PR TITLE
Additional fix to prevent removing HTML comments from empty elements

### DIFF
--- a/jscripts/tiny_mce/classes/html/Node.js
+++ b/jscripts/tiny_mce/classes/html/Node.js
@@ -424,6 +424,10 @@
 						}
 					}
 
+					// Keep comments
+					if (node.type === 8)
+						return false;
+					
 					// Keep non whitespace text nodes
 					if ((node.type === 3 && !whiteSpaceRegExp.test(node.value)))
 						return false;


### PR DESCRIPTION
This is an additional fix to prevent the removal of HTML comments from empty elements.

This completes the fix for bug #4558 and is a follow-up fix for pull request #108.  

See bug report here:  http://www.tinymce.com/develop/bugtracker_view.php?id=4558
