### PR TITLE
Undo after table insertion now sets the selection correctly

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -2254,9 +2254,9 @@
 			if (!/^(mceAddUndoLevel|mceEndUndoLevel|mceBeginUndoLevel|mceRepaint|SelectAll)$/.test(cmd) && (!a || !a.skip_focus))
 				t.focus();
 
-			o = {};
-			t.onBeforeExecCommand.dispatch(t, cmd, ui, val, o);
-			if (o.terminate)
+			a = extend({}, a);
+			t.onBeforeExecCommand.dispatch(t, cmd, ui, val, a);
+			if (a.terminate)
 				return false;
 
 			// Command callback

--- a/jscripts/tiny_mce/plugins/table/js/table.js
+++ b/jscripts/tiny_mce/plugins/table/js/table.js
@@ -144,7 +144,7 @@ function insertTable() {
 		//elm.outerHTML = elm.outerHTML;
 
 		inst.nodeChanged();
-		inst.execCommand('mceEndUndoLevel');
+		inst.execCommand('mceEndUndoLevel', false, {}, {skip_undo: true});
 
 		// Repaint if dimensions changed
 		if (formObj.width.value != orgTableWidth || formObj.height.value != orgTableHeight)
@@ -260,7 +260,7 @@ function insertTable() {
 	});
 
 	inst.addVisual();
-	inst.execCommand('mceEndUndoLevel');
+	inst.execCommand('mceEndUndoLevel', false, {}, {skip_undo: true});
 
 	tinyMCEPopup.close();
 }


### PR DESCRIPTION
I had an issue where using undo after a table insertion would cause the wrong thing to become focused. In FF and Chrome it was innocuous enough, only setting the caret to the top of the iframe's body but in IE it was causing the parent window (not the iframe) to become focused which prevented typing. 

This code fixes that problem and prevents execCommands with the skip_undo property set from incorrectly modifying the beforeChange property of the undoManager. 
