### PR TITLE
Allows tiny to be loaded asynchronously and work

### DIFF
--- a/jscripts/tiny_mce/classes/dom/EventUtils.js
+++ b/jscripts/tiny_mce/classes/dom/EventUtils.js
@@ -315,6 +315,12 @@
 				return;
 			}
 
+			// When loaded asynchronously, the DOM Content may already be loaded
+			if (doc.readyState === 'complete') {
+				t._pageInit(win);
+				return;
+			}
+
 			// Use IE method
 			if (doc.attachEvent) {
 				doc.attachEvent("onreadystatechange", function() {

--- a/tests/async.html
+++ b/tests/async.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>Unit tests for the loading TinyMCE asynchronously</title>
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-git.css" type="text/css" />
+<script src="http://code.jquery.com/qunit/qunit-git.js"></script>
+<script src="qunit/connector.js"></script>
+<script type="text/javascript" src="qunit/runner.js"></script>
+<script>
+QUnit.config.reorder = false;
+QUnit.config.autostart = false;
+
+
+// This test can only be run with a built version of tinyMCE since the dev
+// version uses document.write to put tiny on the page :(
+module("Loading TinyMCE asynchronously", {
+	autostart: false
+});
+
+// kicks off the test by installing an interval checking for domready.
+// Not a robust or typical domready check, but suitable for the test.
+var attempts = 0;
+var readyStateTimer = setInterval(function() {
+	if (document.readyState !== 'complete' && attemps < 100) return;
+	clearInterval(readyStateTimer);
+	loadTinyMCE();
+}, 20);
+
+var loadTinyMCE = function() {
+	injectScript('../jscripts/tiny_mce/tiny_mce.js', initEditor);
+};
+
+// simple script injection helper
+var injectScript = (function() {
+	var relative = document.getElementsByTagName('script')[0];
+	var loadEvent = 'onload' in relative ? 'onload' : 'onreadystatechange';
+	return function(src, callback) {
+		var script = document.createElement('script');
+		script.async = 1;
+		script.src = src;
+		if (callback) script[loadEvent] = callback;
+		relative.parentNode.insertBefore(script, relative);
+		return script;
+	}
+}());
+
+var initEditor = function(script) {
+	tinyMCE.init({
+		mode : 'exact',
+		elements : 'elm1',
+		init_instance_callback : runTests
+	});
+};
+
+var runTests = function(editor) {
+	test('editor initialized with async load of tinyMCE', 1, function() {
+		editor.focus();
+		editor.setContent('test 123');
+		equals(editor.getContent(), '<p>test 123</p>');
+	});
+	QUnit.start();
+};
+</script>
+</head>
+<body>
+	<h1 id="qunit-header">Unit tests for the loading TinyMCE asynchronously</h1>
+	<h2 id="qunit-banner"></h2>
+	<div id="qunit-testrunner-toolbar"></div>
+	<h2 id="qunit-userAgent"></h2>
+	<ol id="qunit-tests"></ol>
+	<textarea id="elm1" name="elm1"></textarea>
+</body>
+</html>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -4,7 +4,8 @@ provide([
 			{"title": "Core API", "url": "api.html"},
 			{"title": "Basic functionality", "url": "basic.html"},
 			{"title": "Remove", "url": "remove.html", "jsrobot": true},
-			{"title": "Undo", "url": "undo.html", "jsrobot": true}
+			{"title": "Undo", "url": "undo.html", "jsrobot": true},
+			{"title": "Asynchronous Loading", "url": "async.html"}
 		]},
 
 		{"title": "Plugins tests", "tests": [


### PR DESCRIPTION
If tiny was loaded on-demand it wouldn't work. The initialization work it does on DOMContentLoaded is never done if the DOM is already ready.

Tiny is a significant expense to load, we defer loading it until the user actually needs it, hence this pull request.

Because the test suite uses `document.write` to get all of tiny's components on the page, the test added here can only be run with a built version of tiny.

Let me know any changes you'd like to see and I'll update the commit.

Thanks :v:
