### PR TITLE
Documented the Editor.initialized property

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -1739,6 +1739,16 @@
 			t.load({initial : true, format : 'html'});
 			t.startContent = t.getContent({format : 'raw'});
 			t.undoManager.add();
+			/**
+			 * Is set to true after the editor instance has been initialized
+			 *
+			 * @property initialized
+			 * @type Boolean
+			 * @example
+			 * function isEditorInitialized(editor) {
+			 *     return editor && editor.initialized;
+			 * }
+			 */
 			t.initialized = true;
 
 			t.onInit.dispatch(t);


### PR DESCRIPTION
We created a property that does exactly the same thing in our own code and I came across this a few days ago. Basically created this pull request to ask if you consider it safe for public use, if so, we'll deprecate our own implementation and consider this one canonical. 

I documented it's behavior so that it will show up in the docs.

Thanks!
