### PR TITLE
Wrong usage of call leads to compat problems with other js libraries (Closure)

### DIFF
--- a/jscripts/tiny_mce/classes/ui/ListBox.js
+++ b/jscripts/tiny_mce/classes/ui/ListBox.js
@@ -121,7 +121,7 @@
 				return t.selectByIndex(-1);
 
 			// Is string or number make function selector
-			if (va && va.call)
+			if (va && typeof(va)=="function")
 				f = va;
 			else {
 				f = function(v) {

--- a/jscripts/tiny_mce/classes/ui/NativeListBox.js
+++ b/jscripts/tiny_mce/classes/ui/NativeListBox.js
@@ -69,7 +69,7 @@
 				return t.selectByIndex(-1);
 
 			// Is string or number make function selector
-			if (va && va.call)
+			if (va && typeof(va)=="function")
 				f = va;
 			else {
 				f = function(v) {


### PR DESCRIPTION
Fixed bad coding practice. To check if a member is a function instead use
typeof(). Using call can lead to global collisions 
as is the case at the moment with combining 
tinyMCE with the Closure js library.
