### PR TITLE
Bug #4775 - Editor add formatting only at first line when select all content

### DIFF
--- a/jscripts/tiny_mce/classes/Formatter.js
+++ b/jscripts/tiny_mce/classes/Formatter.js
@@ -181,11 +181,7 @@
 				function findSelectionEnd(start, end) {
 					var walker = new TreeWalker(end);
 					for (node = walker.current(); node; node = walker.prev()) {
-						if (node.childNodes.length > 1 || node == start) {
-							return node;
-						}
-						// Bug #4775
-						else if (node.childNodes.length == 1 && node.childNodes[0].tagName != 'BR') {
+						if (node.childNodes.length > 1 || node == start || node.tagName == 'BR') {
 							return node;
 						}
 					}


### PR DESCRIPTION
I sent the fix for this bug but I found out that I broke the old fix (the test 'Format selection over two lines', for more details, see a8231397d86a54e67d10645839b458ae24e302f5)

Now, I think that the old fix is ok again and the bug #4775 is ok too.
