### PR TITLE
Should set the "theme_advanced_resize_horizontal" to "true"

### DIFF
--- a/jscripts/tiny_mce/plugins/fullscreen/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/fullscreen/editor_plugin_src.js
@@ -99,6 +99,7 @@
 					s.fullscreen_is_enabled = true;
 					s.fullscreen_editor_id = ed.id;
 					s.theme_advanced_resizing = false;
+					s.theme_advanced_resize_horizontal = true;
 					s.save_onsavecallback = function() {
 						ed.setContent(tinyMCE.get(s.id).getContent());
 						ed.execCommand('mceSave');


### PR DESCRIPTION
In fullscreen mode, the editor width is not updated when the "theme_advanced_resize_horizontal" of original settings is "false".
