### PR TITLE
Shuold specify the first "table" element explicitly

### DIFF
--- a/jscripts/tiny_mce/plugins/fullscreen/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/fullscreen/editor_plugin_src.js
@@ -128,7 +128,7 @@
 						var vp = tinymce.DOM.getViewPort(), fed = t.fullscreenEditor, outerSize, innerSize;
 
 						// Get outer/inner size to get a delta size that can be used to calc the new iframe size
-						outerSize = fed.dom.getSize(fed.getContainer().firstChild);
+						outerSize = fed.dom.getSize(fed.getContainer().getElementsByTagName('table')[0]);
 						innerSize = fed.dom.getSize(fed.getContainer().getElementsByTagName('iframe')[0]);
 
 						fed.theme.resizeTo(vp.w - outerSize.w + innerSize.w, vp.h - outerSize.h + innerSize.h);


### PR DESCRIPTION
Currently, the firstChild is not a "table" element but the "span#mce_fullscreen_voice".
Therefore, I think it is necessary to specify the first "table" element explicitly.
