### PR TITLE
Changed the 'Cancel' button label to 'Close'.

### DIFF
--- a/jscripts/tiny_mce/plugins/searchreplace/searchreplace.htm
+++ b/jscripts/tiny_mce/plugins/searchreplace/searchreplace.htm
@@ -93,7 +93,7 @@
 		<input type="submit" id="insert" name="insert" value="{#searchreplace_dlg.findnext}" />
 		<input type="button" class="button" id="replaceBtn" name="replaceBtn" value="{#searchreplace_dlg.replace}" onclick="SearchReplaceDialog.searchNext('current');" />
 		<input type="button" class="button" id="replaceAllBtn" name="replaceAllBtn" value="{#searchreplace_dlg.replaceall}" onclick="SearchReplaceDialog.searchNext('all');" />
-		<input type="button" id="cancel" name="cancel" value="{#cancel}" onclick="tinyMCEPopup.close();" />
+		<input type="button" id="cancel" name="close" value="{#close}" onclick="tinyMCEPopup.close();" />
 	</div>
 </form>
 </body>


### PR DESCRIPTION
The user's actions are not undone (canceled) when they close this plugin window. Therefore 'Cancel' is misleading since they are really only closing the popup.
