### PR TITLE
Convert list item to paragraph even if item is empty.

### DIFF
--- a/jscripts/tiny_mce/plugins/lists/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/lists/editor_plugin_src.js
@@ -722,7 +722,8 @@
 			} else {
 				actions = {
 					defaultAction: convertListItemToParagraph,
-					elements: this.selectedBlocks()
+					elements: this.selectedBlocks(),
+					processEvenIfEmpty: true
 				};
 			}
 			this.process(actions);
@@ -826,7 +827,7 @@
 
 			function processElement(element) {
 				dom.removeClass(element, '_mce_act_on');
-				if (!element || element.nodeType !== 1 || selectedBlocks.length > 1 && isEmptyElement(element)) {
+				if (!element || element.nodeType !== 1 || ! actions.processEvenIfEmpty && selectedBlocks.length > 1 && isEmptyElement(element)) {
 					return;
 				}
 				element = findItemToOperateOn(element, dom);


### PR DESCRIPTION
### Steps to reproduce
1. Click "Insert bulleted list".
2. Input three items.
3. Make second item empty.
4. Select entire list.
5. Click "Remove bulleted list".
### Expected

Converted all list item.
### Result

An empty item remains.
### Screen cast

http://screencast.com/t/egGNjeCOQIHA
