### PR TITLE
Fixing javascript error in IE7, fetching href property with % symbol in it.

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -1808,7 +1808,7 @@
 						return;
 
 					case 'A':
-						if (!elm.href) {
+						if (!dom.getAttrib(elm, 'href', false)) {
 							value = dom.getAttrib(elm, 'name') || elm.id;
 							cls = 'mceItemAnchor';
 


### PR DESCRIPTION
IE7 breaks when you try to retrieve the href property if it contact a percent symbol (except when it is an urlencoded other symbol, eg: %20). Using the getAttrib lets it fall back to the tiny-mce-href property which does not break.
