### PR TITLE
Delete only first child when deleting bullet from start of list.

### DIFF
--- a/jscripts/tiny_mce/plugins/lists/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/lists/editor_plugin_src.js
@@ -440,9 +440,9 @@
 			}
 
 			function fixDeletingFirstCharOfList(ed, e) {
-				function listElements(list, li) {
+				function listElements(li) {
 					var elements = [];
-					var walker = new tinymce.dom.TreeWalker(li, list);
+					var walker = new tinymce.dom.TreeWalker(li.firstChild, li);
 					for (var node = walker.current(); node; node = walker.next()) {
 						if (ed.dom.is(node, 'ol,ul,li')) {
 							elements.push(node);
@@ -454,9 +454,11 @@
 				if (e.keyCode == tinymce.VK.BACKSPACE) {
 					var li = getLi();
 					if (li) {
-						var list = ed.dom.getParent(li, 'ol,ul');
-						if (list && list.firstChild === li) {
-							var elements = listElements(list, li);
+						var list = ed.dom.getParent(li, 'ol,ul'),
+							rng  = ed.selection.getRng();
+						if (list && list.firstChild === li && rng.startOffset == 0) {
+							var elements = listElements(li);
+							elements.unshift(li)
 							ed.execCommand("Outdent", false, elements);
 							ed.undoManager.add();
 							return Event.cancel(e);

--- a/tests/lists_general.html
+++ b/tests/lists_general.html
@@ -200,6 +200,24 @@ asyncTest('Caret positioned correctly after escaping list and applying formattin
 	}
 });
 
+asyncTest('Deleting text-node from start of list', function() {
+	editor.setContent("<ul><li>a</li><li>b</li></ul>");
+	setSelection('li', 1);
+	robot.type(BACKSPACE, false, function() {
+		equal(editor.getContent(), "<ul><li></li><li>b</li></ul>");
+		start();
+	}, editor.selection.getNode());
+});
+
+asyncTest('Deleting bullet from start of list', function() {
+	editor.setContent("<ul><li>a</li><li>b</li></ul>");
+	setSelection('li', 0);
+	robot.type(BACKSPACE, false, function() {
+		equal(editor.getContent(), "<p>a</p><ul><li>b</li></ul>");
+		start();
+	}, editor.selection.getNode());
+});
+
 asyncTest('Deleting bullet from start of list outdents inner lists items', function() {
 	editor.setContent("<p>a</p><ul><li>b<ul><li>c</li><li>d</li></ul></li></ul>");
 	setSelection('li', 0);


### PR DESCRIPTION
In webkit and gecko, outdented all list items when delete key is pressed at any position of first child of list.

http://screencast.com/t/hIxiQAyh
