### PR TITLE
Should use the "classBasedEach" method in recursive call.

### DIFF
--- a/jscripts/tiny_mce/plugins/lists/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/lists/editor_plugin_src.js
@@ -839,7 +839,7 @@
 			}
 
 			function recurse(element) {
-				t.splitSafeEach(element.childNodes, processElement);
+				t.splitSafeEach(element.childNodes, processElement, true);
 			}
 
 			function brAtEdgeOfSelection(container, offset) {
@@ -890,9 +890,11 @@
 			}
 		},
 
-		splitSafeEach: function(elements, f) {
-			if (tinymce.isGecko && (/Firefox\/[12]\.[0-9]/.test(navigator.userAgent) ||
-					/Firefox\/3\.[0-4]/.test(navigator.userAgent))) {
+		splitSafeEach: function(elements, f, forceClassBase) {
+			if (forceClassBase ||
+				(tinymce.isGecko &&
+					(/Firefox\/[12]\.[0-9]/.test(navigator.userAgent) ||
+					 /Firefox\/3\.[0-4]/.test(navigator.userAgent)))) {
 				this.classBasedEach(elements, f);
 			} else {
 				each(elements, f);

--- a/tests/lists_general.html
+++ b/tests/lists_general.html
@@ -249,6 +249,28 @@ asyncTest('Creates new list item without surrounding element when caret at end o
 	queue.done();
 });
 
+asyncTest('Select the entire document, and apply and remove ordered list', function() {
+  editor.setContent("<p>a</p><p>b</p>");
+  editor.focus();
+  robot.typeAsShortcut('a', function() {
+	  editor.execCommand('InsertOrderedList');
+	  editor.execCommand('InsertOrderedList');
+	  equal(editor.getContent(), "<p>a</p><p>b</p>");
+	  start();
+  });
+});
+
+asyncTest('Select the entire document, and apply and remove unordered list', function() {
+  editor.setContent("<p>a</p><p>b</p>");
+  editor.focus();
+  robot.typeAsShortcut('a', function() {
+	  editor.execCommand('InsertUnorderedList');
+	  editor.execCommand('InsertUnorderedList');
+	  equal(editor.getContent(), "<p>a</p><p>b</p>");
+	  start();
+  });
+});
+
 var initTinyFunction = function(){
 	tinyMCE.init({
 		mode : "exact",


### PR DESCRIPTION
Applying and removing sometimes fails for list operation.
## Steps to reproduce
1. Input "`<p>a</p><p>b</p>`".
2. Press "Ctrl-A".
3. Click "Insert / Remove Ordered List" button.
4. Click "Insert / Remove Ordered List" button again.
## Expected

`<p>a</p><p>b</p>`
## Result

The "li" element remained.
## Browsers
- Firefox
- IE
- Chrome
## ScreenCast

http://screencast.com/t/oJQL5yUk
