### PR TITLE
Select only content by the mceSelectNodeDepth for IE8 or any older version.

### DIFF
--- a/jscripts/tiny_mce/classes/EditorCommands.js
+++ b/jscripts/tiny_mce/classes/EditorCommands.js
@@ -272,10 +272,14 @@
 
 			mceSelectNodeDepth : function(command, ui, value) {
 				var counter = 0;
+				var content = false;
+				if ( tinymce.isIE6 || tinymce.isIE7 || tinymce.isIE8 ) {
+					content = true;
+				}
 
 				dom.getParent(selection.getNode(), function(node) {
 					if (node.nodeType == 1 && counter++ == value) {
-						selection.select(node);
+						selection.select(node, content);
 						return FALSE;
 					}
 				}, editor.getBody());

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -571,6 +571,25 @@ test('custom elements', function() {
 	equal(editor.getContent().replace(/[\r\n]/g, ''), '<custom1>c1</custom1><p><custom2>c1</custom2></p>');
 });
 
+test('commands - mceSelectNodeDepth', function() {
+	var t = this;
+	function getContent() {
+		return editor.selection.getContent({format: 'text'}).replace(/\r\n|\r|\n/, '');
+	}
+
+	expect(2);
+
+	editor.execCommand('mceSetContent', false, '<ul><li>a</li><li>b</li></p>');
+
+	editor.selection.select(editor.dom.select('li')[0]);
+	editor.selection.collapse(1);
+	editor.execCommand('mceSelectNodeDepth', false, 0);
+	equal(getContent(), 'a');
+
+	editor.execCommand('mceSelectNodeDepth', false, 1);
+	equal(getContent(), 'ab');
+});
+
 tinyMCE.init({
 	mode : "exact",
 	elements : "elm1",


### PR DESCRIPTION
Can't select sometime by clicking path in IE8.
## Steps
1. Input "&lt;ul>&lt;li>a&lt;/li>&lt;li>b&lt;/li>&lt;/ul>"
2. Move caret to the head of first list item.
3. Click "li" in the path.
4. Click "ul" in the path.
## Expected

Selected list entirely.
## Observed

Selected only the first list item.
## Screen cast

http://screencast.com/t/qIAH8Ppv
