### PR TITLE
onbeforeunload fired in IE8 when hiding external toolbar

### DIFF
--- a/jscripts/tiny_mce/themes/advanced/editor_template_src.js
+++ b/jscripts/tiny_mce/themes/advanced/editor_template_src.js
@@ -831,6 +831,7 @@
 					var f = Event.add(ed.id + '_external_close', 'click', function() {
 						DOM.hide(ed.id + '_external');
 						Event.remove(ed.id + '_external_close', 'click', f);
+						return false;
 					});
 
 					DOM.show(e);


### PR DESCRIPTION
I use onbeforeunload on my page to prompt the user if he has not saved his changes yet. I use the advanced theme with the external toolbar.

theme: "advanced",
theme_advanced_toolbar_location: "external",

When I click the close X in the upper right corner of the toolbar in IE8, my onbeforeunload handler is called. This problem does not occur in IE9 or Firefox.

The X button is an < a > element with a javascript href, and IE8 thinks clicking it will result in leaving the page, and it only finds out after the onbeforeunload that the page will not be left. This commit tells the browser to prevent the default action of the link click, so that the onbeforeunload event does not fire.
