### PR TITLE
Prevent EditorManager.get() from returning Array.prototype methods

### DIFF
--- a/jscripts/tiny_mce/classes/EditorManager.js
+++ b/jscripts/tiny_mce/classes/EditorManager.js
@@ -275,6 +275,9 @@
 			if (id === undef)
 				return this.editors;
 
+			if (!this.editors.hasOwnProperty(id))
+				return undef;
+
 			return this.editors[id];
 		},
 


### PR DESCRIPTION
If you end up with an element id that conflict with core Array methods
like for example `<div id="sort">` then EditorManager.get('sort') will
return Array.prototype.sort and everything will break.
