### PR TITLE
Only remove system br elements or br elements without attributes

### DIFF
--- a/jscripts/tiny_mce/classes/html/DomParser.js
+++ b/jscripts/tiny_mce/classes/html/DomParser.js
@@ -632,7 +632,7 @@
 							prev = prev.prev;
 						}
 
-						if (node) {
+						if (node && (node.attributes.length == 0 || node.attr('data-mce-bogus'))) {
 							node.remove();
 
 							// Is the parent to be considered empty after we removed the BR


### PR DESCRIPTION
This modification allows for br elements at the end of block elements to be retained if they contain attributes.

Only br elements without attributes or those with a data-mce-bogus attribute will be removed.
