### PR TITLE
Media Plugin youtu.be URLs

### DIFF
--- a/jscripts/tiny_mce/plugins/media/js/media.js
+++ b/jscripts/tiny_mce/plugins/media/js/media.js
@@ -273,11 +273,11 @@
                 } else if (data.type == 'audio') {
                     if (data.video.sources[0])
                         setVal('src', data.video.sources[0].src);
-                    
+
                     src = data.video.sources[1];
                     if (src)
                         setVal('audio_altsource1', src.src);
-                    
+
                     src = data.video.sources[2];
                     if (src)
                         setVal('audio_altsource2', src.src);
@@ -296,12 +296,12 @@
 				src = getVal("src");
 
 				// YouTube *NEW*
-				if (src.match(/youtu.be\/[a-z1-9.-_]+/)) {
+				if (src.match(/youtu.be\/[\w\-.]+/)) {
 					data.width = 425;
 					data.height = 350;
 					data.params.frameborder = '0';
 					data.type = 'iframe';
-					src = 'http://www.youtube.com/embed/' + src.match(/youtu.be\/([a-z1-9.-_]+)/)[1];
+					src = 'http://www.youtube.com/embed/' + src.match(/youtu.be\/([\w\-.]+)/)[1];
 					setVal('src', src);
 					setVal('media_type', data.type);
 				}
@@ -326,7 +326,7 @@
 					setVal('src', src);
 					setVal('media_type', data.type);
 				}
-				
+
 				// Vimeo
 				if (src.match(/vimeo.com\/([0-9]+)/)) {
 					data.width = 425;
@@ -337,7 +337,7 @@
 					setVal('src', src);
 					setVal('media_type', data.type);
 				}
-            
+
 				// stream.cz
 				if (src.match(/stream.cz\/((?!object).)*\/([0-9]+)/)) {
 					data.width = 425;
@@ -348,7 +348,7 @@
 					setVal('src', src);
 					setVal('media_type', data.type);
 				}
-				
+
 				// Google maps
 				if (src.match(/maps.google.([a-z]{2,3})\/maps\/(.+)msid=(.+)/)) {
 					data.width = 425;
@@ -376,13 +376,13 @@
                 } else if (data.type == 'audio') {
                     if (!data.video.sources)
                         data.video.sources = [];
-                    
+
                     data.video.sources[0] = {src : src};
-                    
+
                     src = getVal("audio_altsource1");
                     if (src)
                         data.video.sources[1] = {src : src};
-                    
+
                     src = getVal("audio_altsource2");
                     if (src)
                         data.video.sources[2] = {src : src};


### PR DESCRIPTION
A bug was reported in our app, which ended up being a YouTube video with a hyphen in the video ID. I tracked it down to a regex in the media plugin. This commit should address that issue. It also appears as if the old regex did not support capital letters, but this one should, since it just uses `\w` (equivalent to `A-Za-z0-9_`).
