### PR TITLE
Enable to ignore empty child nodes if specified.

### DIFF
--- a/jscripts/tiny_mce/plugins/lists/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/lists/editor_plugin_src.js
@@ -173,8 +173,15 @@
 				return ed.selection.isCollapsed() && isEmptyListItem(getLi());
 			}
 
-			function getLi() {
+			function getLi(ignore_empty_child_nodes) {
 				var n = ed.selection.getStart();
+
+				if (ignore_empty_child_nodes) {
+					while ((n.innerText || n.textContent).replace(/[\s\r\n]+/, '') == '' && n.tagName != 'LI' && n.parentNode) {
+						n = n.parentNode;
+					}
+				}
+
 				// Get start will return BR if the LI only contains a BR or an empty element as we use these to fix caret position
 				return ((n.tagName == 'BR' || n.tagName == '') && n.parentNode.tagName == 'LI') ? n.parentNode : n;
 			}
@@ -452,7 +459,7 @@
 				}
 
 				if (e.keyCode == tinymce.VK.BACKSPACE) {
-					var li = getLi();
+					var li = getLi(true);
 					if (li) {
 						var list = ed.dom.getParent(li, 'ol,ul'),
 							rng  = ed.selection.getRng();

--- a/tests/lists_general.html
+++ b/tests/lists_general.html
@@ -246,6 +246,18 @@ asyncTest('Deleting empty li with nested list is deleted in Webkit', function(){
 	}
 });
 
+asyncTest('Deleting li containing empty a', function(){
+	editor.setContent('<ul><li><a href="#" id="a">a</a></li><li>b</li></ul>');
+	setSelection('#a', 0, '#a', 1);
+	editor.focus();
+	robot.type(BACKSPACE, false, function() {
+		robot.type(BACKSPACE, false, function() {
+			equal(editor.dom.select('span').length, 0);
+			start();
+		});
+	}, editor.selection.getNode());
+});
+
 asyncTest('Creates new list item without surrounding element when caret at end of list item', function(){
 	function testCreateNewList(el) {
 		queue.add(function() {


### PR DESCRIPTION
# Steps to reproduce this bug
1. Input `<ul><li><a href="#" id="a">a</a></li><li>b</li></ul>`.
2. Select anchor element.
3. Type backspace key twice.
# Expected
- `<p></p><ul><li>b</li></ul>`

or
- `<p><a href="#"></a></p><ul><li>b</li></ul>`
# Result
- `<p><span color="#0000ee" style="color: #0000ee;"><span style="text-decoration: underline;">&nbsp</span></span></p><ul><li>b</li></ul>`
