### PR TITLE
Data attributes are always allowed, even if they are not in valid_elements

### DIFF
--- a/jscripts/tiny_mce/classes/html/Node.js
+++ b/jscripts/tiny_mce/classes/html/Node.js
@@ -419,7 +419,7 @@
 						i = node.attributes.length;
 						while (i--) {
 							name = node.attributes[i].name;
-							if (name === "name" || name.indexOf('data-') === 0)
+							if (name === "name" || name.indexOf('data-mce-') === 0)
 								return false;
 						}
 					}

--- a/jscripts/tiny_mce/classes/html/SaxParser.js
+++ b/jscripts/tiny_mce/classes/html/SaxParser.js
@@ -119,7 +119,7 @@
 				value = name in fillAttrsMap ? name : decode(value || val2 || val3 || ''); // Handle boolean attribute than value attribute
 
 				// Validate name and value
-				if (validate && !isInternalElement && name.indexOf('data-') !== 0) {
+				if (validate && !isInternalElement && name.indexOf('data-mce-') !== 0) {
 					attrRule = validAttributesMap[name];
 
 					// Find rule by pattern matching


### PR DESCRIPTION
I use the valid_elements configuration option to only allow limited formatting options. When I drag and drop some HTML into the editor and then save, the disallowed elements and attributes are removed, except for attributes where the name starts with "data-". These attributes are kept, even though they are not allowed, and this makes my server side input validation fail.

My changes fixes it, but I don't know exactly why, or if this breaks something else. Based on the commit where the code was introduced, https://github.com/tinymce/tinymce/commit/dc76f1514e47b951aec62c31ccd4b2aeb0e9fc56 , I think my changes should work.
