### PR TITLE
Fix for bug #5477, return on text node.

### DIFF
--- a/jscripts/tiny_mce/classes/Formatter.js
+++ b/jscripts/tiny_mce/classes/Formatter.js
@@ -651,6 +651,11 @@
 			function process(node) {
 				var children, i, l, localContentEditable, lastContentEditable, hasContentEditableState;
 
+				// Skip on text nodes as they have neither format to remove nor children
+				if (node.nodeType === 3) {
+					return;
+				}
+
 				// Node has a contentEditable value
 				if (node.nodeType === 1 && getContentEditable(node)) {
 					lastContentEditable = contentEditable;


### PR DESCRIPTION
Filter out TextNode's from removal processing to avoid removeAttribute TypeErrors.
