### PR TITLE
Fix issue with onchange_callback in IE8 being called onKeyDown but not onKeyUp

### DIFF
--- a/jscripts/tiny_mce/classes/UndoManager.js
+++ b/jscripts/tiny_mce/classes/UndoManager.js
@@ -85,6 +85,13 @@
 			if ((keyCode >= 33 && keyCode <= 36) || (keyCode >= 37 && keyCode <= 40) || keyCode == 45 || keyCode == 13 || e.ctrlKey) {
 				addNonTypingUndoLevel();
 			}
+			
+			// If key isn't shift,ctrl,alt,capslock,metakey
+			if ((keyCode < 16 || keyCode > 20) && keyCode != 224 && keyCode != 91 && !self.typing) {
+				self.beforeChange();
+				self.typing = true;
+				self.add();
+			}
 		});
 
 		editor.onKeyDown.add(function(editor, e) {


### PR DESCRIPTION
Noticed in IE8 when I was formatting my text (underlining, highlighting, ect..) it was trigger the onchange_callback onkeydown.  This was an issue for me since our onchange_callback is used to update our backbone models.  The issue is the onkeydown send back what is there before the change actually happens.  

For example:  If I type

1234 the last event sends back 123 
1234 then delete 4 it sends back 1234

I looked at the undo manager and looked like there was a block of code to call the change callback, so I added that to the onKeyUp.  This solved the issue for me, and did not appear to create any other issues.
