### PR TITLE
Fixed table crash when trying to paste rows with nothing on the clipboard

### DIFF
--- a/jscripts/tiny_mce/plugins/table/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/table/editor_plugin_src.js
@@ -551,6 +551,10 @@
 		};
 
 		function pasteRows(rows, before) {
+			// If we don't have any rows in the clipboard, return immediately
+			if(!rows)
+				return;
+
 			var selectedRows = getSelectedRows(),
 				targetRow = selectedRows[before ? 0 : selectedRows.length - 1],
 				targetCellCount = targetRow.cells.length;


### PR DESCRIPTION
Link to bug report: http://www.tinymce.com/develop/bugtracker_view.php?id=5596
