### PR TITLE
Stop calling "focus" if a target iframe already has focus.

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -903,7 +903,9 @@
 
 				// Focus the window iframe
 				if (!contentEditable) {
-					self.getWin().focus();
+					if (! (doc && doc.hasFocus && doc.hasFocus())) {
+						self.getWin().focus();
+					}
 				}
 
 				// Focus the body as well since it's contentEditable

--- a/tests/tinymce.dom.Selection.html
+++ b/tests/tinymce.dom.Selection.html
@@ -492,6 +492,15 @@ test('select table text 2', 2, function() {
 	equal(editor.dom.getParent(editor.selection.getEnd(), 'td').id, 'b', 'Expand to text content 2 (end)');
 });
 
+test('select from very top of the document', function() {
+	expect(1);
+
+	editor.setContent("<p>test 123</p>");
+	setSelection('html', 0, 'p', 8);
+	editor.execCommand('Bold');
+	equal(editor.getContent(), "<p><strong>test 123</strong></p>");
+});
+
 test('getNode', function() {
 	var rng;
 


### PR DESCRIPTION
In IE10, if "focus" is applied to an iframe window, it becomes impossible to get the right range.
# Steps to reproduce this bug
1. Input `<p>test 123</p>`.
2. Select  from very top of the document to "p" element.
3. Click "Bold" button.
# Expected
- `<p><bold>test 123</bold></p>`
# Result
- `<p></p><p>test 123</p>`
# Screencast

http://www.screencast.com/t/lUYp228dg
# Comment

Although this bug seldom occurs when the default content_css is used, 
but when the custom content_css that has a large margin is being used, it occurs frequently. 
