### PR TITLE
When I load the tinymce editor on the page getDoc method return null and the editor doesn't work. I've commetted a little patch to solve this problem. Hope this help.

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -1747,7 +1747,7 @@
 					self.contentDocument = win.document;
 			}
 
-			return self.contentDocument;
+			return self.contentDocument || document;
 		},
 
 		/**


### PR DESCRIPTION
Prevent document is undefined when load tinymce.
