### PR TITLE
Fix autoresize issue with IE10 and editors not shrinking.

### DIFF
--- a/jscripts/tiny_mce/classes/tinymce.js
+++ b/jscripts/tiny_mce/classes/tinymce.js
@@ -122,6 +122,15 @@
 			t.isIE9 = t.isIE && /MSIE [9]/.test(ua);
 
 			/**
+			 * Constant that is true if the browser is IE 10.
+			 *
+			 * @property isIE10
+			 * @type Boolean
+			 * @final
+			 */
+			t.isIE10 = t.isIE && /MSIE [10]/.test(ua);
+
+			/**
 			 * Constant that is true if the browser is Gecko.
 			 *
 			 * @property isGecko

--- a/jscripts/tiny_mce/plugins/autoresize/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/autoresize/editor_plugin_src.js
@@ -38,7 +38,11 @@
 				var deltaSize, d = ed.getDoc(), body = d.body, de = d.documentElement, DOM = tinymce.DOM, resizeHeight = t.autoresize_min_height, myHeight;
 
 				// Get height differently depending on the browser used
-				myHeight = tinymce.isIE ? body.scrollHeight : (tinymce.isWebKit && body.clientHeight == 0 ? 0 : body.offsetHeight);
+				if(tinymce.isIE10) {
+					myHeight = body.offsetHeight;
+				} else {
+					myHeight = tinymce.isIE ? body.scrollHeight : (tinymce.isWebKit && body.clientHeight == 0 ? 0 : body.offsetHeight);
+				}
 
 				// Don't make it smaller than the minimum height
 				if (myHeight > t.autoresize_min_height)


### PR DESCRIPTION
Fixes the following bug: 
http://www.tinymce.com/develop/bugtracker_view.php?id=5519

IE10's scrollHeight was incorrect, but offsetHeight works as expected.
