### PR TITLE
Fix for spellchecker plugin context menu

### DIFF
--- a/jscripts/tiny_mce/plugins/spellchecker/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/spellchecker/editor_plugin_src.js
@@ -285,8 +285,6 @@
 		_showMenu : function(ed, e) {
 			var t = this, ed = t.editor, m = t._menu, p1, dom = ed.dom, vp = dom.getViewPort(ed.getWin()), wordSpan = e.target;
 
-			e = 0; // Fixes IE memory leak
-
 			if (!m) {
 				m = ed.controlManager.createDropMenu('spellcheckermenu', {'class' : 'mceNoIcons'});
 				t._menu = m;
@@ -381,8 +379,12 @@
 				p1 = dom.getPos(wordSpan);
 				m.showMenu(p1.x, p1.y + wordSpan.offsetHeight - vp.y);
 
-				return tinymce.dom.Event.cancel(e);
+				tinymce.dom.Event.cancel(e);
+				e = 0; // Fixes IE memory leak
+
+				return false;
 			} else
+				e = 0; // Fixes IE memory leak
 				m.hideMenu();
 		},
 


### PR DESCRIPTION
When using the spellchecker plugin the context menu it provides did not cancel events.
This meant that when you right clicked a word you got the spellcheck context menu as well as the browser context menu.

Looking at the code it seemed to be the IE memory leak fix which zeroed out the event variable before calling the cancel function.
