### PR TITLE
null guard in `loadOrSave`

### DIFF
--- a/jscripts/tiny_mce/classes/adapter/jquery/jquery.tinymce.js
+++ b/jscripts/tiny_mce/classes/adapter/jquery/jquery.tinymce.js
@@ -209,7 +209,7 @@
 			var self = this, ed;
 
 			// Handle set value
-			if (value !== undef) {
+			if (value !== undef && value !== null) {
 				removeEditors.call(self);
 
 				// Saves the contents before get/set value of textarea/div


### PR DESCRIPTION
Currently setting a null `val()` to a tinymce jquery (e.g. `$(':tinymce').first().val(null)`) will case an unhandled crash.

This is perfectly legal in jquery ([fails silently](http://james.padolsey.com/jquery/#v=1.7.2&fn=jQuery.fn.val)), but ed.setContent doesn't allow null values to be passed through, so we need to guard against that.
