### PR TITLE
Added a conditional test at line 320 as this code breaks ajax modal wind...

### DIFF
--- a/jscripts/tiny_mce/classes/dom/Serializer.js
+++ b/jscripts/tiny_mce/classes/dom/Serializer.js
@@ -316,25 +316,28 @@
 				// Older builds of Opera crashes if you attach the node to an document created dynamically
 				// and since we can't feature detect a crash we need to sniff the acutal build number
 				// This fix will make DOM ranges and make Sizzle happy!
-				impl = node.ownerDocument.implementation;
-				if (impl.createHTMLDocument) {
-					// Create an empty HTML document
-					doc = impl.createHTMLDocument("");
+				// Added a test for Opera and build numbers as this breaks modal ajax windows in Firefox
+                if(tinymce.isOpera && opera.buildNumber() >= 1767) {
+  				   impl = node.ownerDocument.implementation;
+				   if (impl.createHTMLDocument) {
+				   	   // Create an empty HTML document
+					   doc = impl.createHTMLDocument("");
 
-					// Add the element or it's children if it's a body element to the new document
-					each(node.nodeName == 'BODY' ? node.childNodes : [node], function(node) {
-						doc.body.appendChild(doc.importNode(node, true));
-					});
+					   // Add the element or it's children if it's a body element to the new document
+					   each(node.nodeName == 'BODY' ? node.childNodes : [node], function(node) {
+						   doc.body.appendChild(doc.importNode(node, true));
+				   	   });
 
-					// Grab first child or body element for serialization
-					if (node.nodeName != 'BODY')
-						node = doc.body.firstChild;
-					else
-						node = doc.body;
+					   // Grab first child or body element for serialization
+					   if (node.nodeName != 'BODY')
+						   node = doc.body.firstChild;
+					   else
+						   node = doc.body;
 
-					// set the new document in DOMUtils so createElement etc works
-					oldDoc = dom.doc;
-					dom.doc = doc;
+					   // set the new document in DOMUtils so createElement etc works
+					   oldDoc = dom.doc;
+					   dom.doc = doc;
+				   }
 				}
 
 				args = args || {};


### PR DESCRIPTION
There is an issue with ajax modal windows in Firefox as described in the bug report listed below.   We ran into this problem at NBC and the work around listed in 3152 does work.  I simplified the work around listed in 3152 by simply wrapping the code in classes/dom/Serialize.js with a conditional that checks to see if the browser is Opera, instead of replacing the whole block of code as suggested in 3152.

See bug report www.tinymce.com/develop/bugtracker_view.php?id=3152 for details on this issue
