### PR TITLE
Disable the async ScriptLoader

### DIFF
--- a/jscripts/tiny_mce/classes/dom/ScriptLoader.js
+++ b/jscripts/tiny_mce/classes/dom/ScriptLoader.js
@@ -53,6 +53,9 @@
 		 * @param {Object} scope Optional scope to execute callback in.
 		 */
 		function loadScript(url, callback) {
+			// Fix for Rails asset pipeline. All assets are already loaded.
+			callback(); return;
+
 			var t = this, dom = tinymce.DOM, elm, uri, loc, id;
 
 			// Execute callback when script is loaded


### PR DESCRIPTION
We previously had this tidbit of code in our vendored version.

It disables the ScriptLoader as all the assets are already included in our asset package.
