### PR TITLE
specify event name when unbinding from BeforeUnload on editor manager

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1997,7 +1997,7 @@ define("tinymce/Editor", [
 			}
 
 			if (!automatic) {
-				self.editorManager.off(self._beforeUnload);
+				self.editorManager.off('BeforeUnload', self._beforeUnload);
 
 				// Manual destroy
 				if (self.theme && self.theme.destroy) {


### PR DESCRIPTION
when unbinding from BeforeUnload event on editor manager, make sure to specify event name
