### PR TITLE
Small Fix For What I Believe Is A Bug With The Auto Focus Feature

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -865,7 +865,7 @@
 			// Handle auto focus
 			if (settings.auto_focus) {
 				setTimeout(function () {
-					var ed = tinymce.get(settings.auto_focus);
+					var ed = tinymce.get(self.id);
 
 					ed.selection.select(ed.getBody(), 1);
 					ed.selection.collapse(1);


### PR DESCRIPTION
Was playing with the latest version of TinyMCE and notice I was getting the following on the console - "Uncaught TypeError: Cannot read property 'selection' of undefined". I tracked this down to the use of the auto_focus setting and I've made a correction that I believe makes sense. I've given this a basic test (i.e. running it through the code I was using) and it seems to be returning a sensible result.
