### PR TITLE
Table row / col insert issue (#5583, #5673)

### DIFF
--- a/js/tinymce/plugins/table/classes/TableGrid.js
+++ b/js/tinymce/plugins/table/classes/TableGrid.js
@@ -135,34 +135,39 @@ define("tinymce/tableplugin/TableGrid", [
 			dom.remove(table);
 		}
 
-		function cloneCell(cell) {
+		function cloneCell(cell, children) {
 			var formatNode;
+			if (children === undefined){
+				children = true; // Assume we want to clone children unless otherwise told
+			}
+			//If we want to clone children
+			if (children){
+				// Clone formats
+				Tools.walk(cell, function(node) {
+					var curNode;
 
-			// Clone formats
-			Tools.walk(cell, function(node) {
-				var curNode;
+					if (node.nodeType == 3) {
+						each(dom.getParents(node.parentNode, null, cell).reverse(), function(node) {
+							node = cloneNode(node, false);
 
-				if (node.nodeType == 3) {
-					each(dom.getParents(node.parentNode, null, cell).reverse(), function(node) {
-						node = cloneNode(node, false);
+							if (!formatNode) {
+								formatNode = curNode = node;
+							} else if (curNode) {
+								curNode.appendChild(node);
+							}
 
-						if (!formatNode) {
-							formatNode = curNode = node;
-						} else if (curNode) {
-							curNode.appendChild(node);
+							curNode = node;
+						});
+
+						// Add something to the inner node
+						if (curNode) {
+							curNode.innerHTML = Env.ie ? '&nbsp;' : '<br data-mce-bogus="1" />';
 						}
 
-						curNode = node;
-					});
-
-					// Add something to the inner node
-					if (curNode) {
-						curNode.innerHTML = Env.ie ? '&nbsp;' : '<br data-mce-bogus="1" />';
+						return false;
 					}
-
-					return false;
-				}
-			}, 'childNodes');
+				}, 'childNodes');
+			}
 
 			cell = cloneNode(cell, false);
 			setSpanVal(cell, 'rowSpan', 1);
@@ -411,7 +416,7 @@ define("tinymce/tableplugin/TableGrid", [
 					}
 
 					// Insert new cell into new row
-					newCell = cloneCell(cell);
+					newCell = cloneCell(cell, false);
 					setSpanVal(newCell, 'colSpan', cell.colSpan);
 
 					newRow.appendChild(newCell);
@@ -463,10 +468,10 @@ define("tinymce/tableplugin/TableGrid", [
 
 					if (colSpan == 1) {
 						if (!before) {
-							dom.insertAfter(cloneCell(cell), cell);
+							dom.insertAfter(cloneCell(cell,false), cell);
 							fillLeftDown(posX, y, rowSpan - 1, colSpan);
 						} else {
-							cell.parentNode.insertBefore(cloneCell(cell), cell);
+							cell.parentNode.insertBefore(cloneCell(cell,false), cell);
 							fillLeftDown(posX, y, rowSpan - 1, colSpan);
 						}
 					} else {


### PR DESCRIPTION
Modified the `cloneCell()` method to take a boolean value (children) that will clone child nodes.

(this defaults to true to keep current expected functionality)

`insertRow()` and `insertCol()` then modified to call `cloneCell()` with `children = false`

This enures only a clean `<tr><td>..</td></tr>` element is copied

I can only find 2 issues that are cause by this, but I am sure there is more.
- http://www.tinymce.com/develop/bugtracker_view.php?id=5673
- http://www.tinymce.com/develop/bugtracker_view.php?id=5583
