### PR TITLE
Added custom color palette option to textcolor plugin.

### DIFF
--- a/js/tinymce/plugins/textcolor/plugin.js
+++ b/js/tinymce/plugins/textcolor/plugin.js
@@ -14,7 +14,7 @@ tinymce.PluginManager.add('textcolor', function(editor) {
 	function mapColors() {
 		var i, colors = [], colorMap;
 
-		colorMap = [
+		colorMap = editor.settings.textcolor_map || [
 			"000000", "Black",
 			"993300", "Burnt orange",
 			"333300", "Dark olive",
@@ -68,30 +68,38 @@ tinymce.PluginManager.add('textcolor', function(editor) {
 	}
 
 	function renderColorPicker() {
-		var ctrl = this, colors, html, size, x, y;
+		var ctrl = this, colors, color, html, size, last, rows, cols, x, y, i;
 
 		colors = mapColors();
 
 		html = '<table class="mce-grid mce-colorbutton-grid" role="presentation" cellspacing="0"><tbody>';
 		size = Math.ceil(Math.sqrt(colors.length));
+		last = colors.length - 1;
+		rows = editor.settings.textcolor_rows || 5;
+		cols = editor.settings.textcolor_cols || 8;
 
-		for (y = 0; y < 5; y++) {
+		for (y = 0; y < rows; y++) {
 			html += '<tr>';
 
-			for (x = 0; x < 8; x++) {
-				var color = colors[y * 8 + x];
+			for (x = 0; x < cols; x++) {
+				i = y * cols + x;
 
-				html += (
-					'<td>' +
-						'<div id="' + ctrl._id + '-' + (y * 8 + x) + '"' +
-							' data-mce-color="' + color.color + '"' +
-							' role="option"' +
-							' tabIndex="-1"' +
-							' style="' + (color ? 'background-color: #' + color.color : '') + '"' +
-							' title="' + color.text + '">' +
-						'</div>' +
-					'</td>'
-				);
+				if (i > last) {
+					html += '<td></td>';
+				} else {
+					color = colors[i];
+					html += (
+						'<td>' +
+							'<div id="' + ctrl._id + '-' + i + '"' +
+								' data-mce-color="' + color.color + '"' +
+								' role="option"' +
+								' tabIndex="-1"' +
+								' style="' + (color ? 'background-color: #' + color.color : '') + '"' +
+								' title="' + color.text + '">' +
+							'</div>' +
+						'</td>'
+					);
+				}
 			}
 
 			html += '</tr>';


### PR DESCRIPTION
I wanted to use the fore color interface (rather than styles), but I wanted to be able to limit the user to a limited selection of custom colors. I created 3 options to create a custom color palette.

I noticed the code contains a `size` variable that is not used anywhere. I think it should be removed, but I left it there because I wasn't sure if you had future plans for it or not.

I've included information below that could be used for the documentation.

**Plugin Options**
- textcolor_map: Array of colors for a custom color palette. Odd items are hex color values and even items are color titles.
- textcolor_rows: Number of rows in palette table. Defaults to 5.
- textcolor_cols: Number of columns in palette table. Defaults to 8.

**textcolor_map**

This option lets you specify a custom color palette. Array has even number of elements with odd items defining hex color values and even items defining color titles. The default colors are shown below. If you define a different number of colors, you should also set textcolor_rows and/or textcolor_cols.

Example

```
tinymce.init({
    plugins: "textcolor",
    textcolor_map: [
        "000000", "Black",
        "993300", "Burnt orange",
        "333300", "Dark olive",
        "003300", "Dark green",
        "003366", "Dark azure",
        "000080", "Navy Blue",
        "333399", "Indigo",
        "333333", "Very dark gray",
        "800000", "Maroon",
        "FF6600", "Orange",
        "808000", "Olive",
        "008000", "Green",
        "008080", "Teal",
        "0000FF", "Blue",
        "666699", "Grayish blue",
        "808080", "Gray",
        "FF0000", "Red",
        "FF9900", "Amber",
        "99CC00", "Yellow green",
        "339966", "Sea green",
        "33CCCC", "Turquoise",
        "3366FF", "Royal blue",
        "800080", "Purple",
        "999999", "Medium gray",
        "FF00FF", "Magenta",
        "FFCC00", "Gold",
        "FFFF00", "Yellow",
        "00FF00", "Lime",
        "00FFFF", "Aqua",
        "00CCFF", "Sky blue",
        "993366", "Brown",
        "C0C0C0", "Silver",
        "FF99CC", "Pink",
        "FFCC99", "Peach",
        "FFFF99", "Light yellow",
        "CCFFCC", "Pale green",
        "CCFFFF", "Pale cyan",
        "99CCFF", "Light sky blue",
        "CC99FF", "Plum",
        "FFFFFF", "White"
    ]
});
```

**textcolor_rows**

This option lets you specify the number of rows used in building the color palette table. Defaults to 5. The number of rows multiplied by the number of columns should equal the number of colors.

Example

```
tinymce.init({
    plugins: "textcolor",
    textcolor_map: [
        "FF0000", "Red",
        "008000", "Green",
        "0000FF", "Blue",
        "808080", "Gray"
    ],
    textcolor_rows: 1,
    textcolor_cols: 4
});
```

**textcolor_cols**

This option lets you specify the number of columns used in building the color palette table. Defaults to 8. The number of rows multiplied by the number of columns should equal the number of colors.

Example

```
tinymce.init({
    plugins: "textcolor",
    textcolor_map: [
        "FF0000", "Red",
        "008000", "Green",
        "0000FF", "Blue",
        "808080", "Gray"
    ],
    textcolor_rows: 1,
    textcolor_cols: 4
});
```
