### PR TITLE
Fix jQuery adapter to work with newer versions of jQuery

### DIFF
--- a/jscripts/tiny_mce/classes/adapter/jquery/adapter.js
+++ b/jscripts/tiny_mce/classes/adapter/jquery/adapter.js
@@ -156,6 +156,11 @@
 			},
 
 			is : function(n, patt) {
+				// Simple all selector, jQuery 1.8 and above returns true for text nodes, different from previous versions
+				if (n.nodeType !== 1 && patt === '*') {
+					return false;
+				}
+
 				return $(this.get(n)).is(patt);
 			}
 

--- a/tests/js/tinymce.dom.DOMUtils.js
+++ b/tests/js/tinymce.dom.DOMUtils.js
@@ -228,13 +228,16 @@
 		DOM.remove('test');
 	});
 
-	test('is', 3, function() {
+	test('is', 5, function() {
 		DOM.add(document.body, 'div', {id : 'test'});
 		DOM.setHTML('test', '<div id="textX" class="test">test 1</div>');
 
 		ok(DOM.is(DOM.get('textX'), 'div'));
 		ok(DOM.is(DOM.get('textX'), 'div#textX.test'));
 		ok(!DOM.is(DOM.get('textX'), 'div#textX2'));
+
+		ok(DOM.is(DOM.get('textX'), '*'));
+		ok(!DOM.is(DOM.get('textX').childNodes[0], '*'));
 
 		DOM.remove('test');
 	});

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -32,6 +32,7 @@ provide([
 			{"title": "Serializer", "url": "tinymce.dom.Serializer.html"},
 			{"title": "DOMUtils", "url": "tinymce.dom.DOMUtils.html"},
 			{"title": "DOMUtils (jQuery)", "url": "tinymce.dom.DOMUtils_jquery.html"},
+			{"title": "DOMUtils (jQuery 1.8)", "url": "tinymce.dom.DOMUtils_jquery_1.8.html"},
 			{"title": "EventUtils", "url": "tinymce.dom.EventUtils.html"}
 		]},
 

--- a/tests/tinymce.dom.DOMUtils_jquery_1.8.html
+++ b/tests/tinymce.dom.DOMUtils_jquery_1.8.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>Unit tests for tinymce.dom.DOMUtils</title>
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-git.css" type="text/css" />
+<script src="http://code.jquery.com/qunit/qunit-git.js"></script>
+<script src="qunit/connector.js"></script>
+<script type="text/javascript" src="qunit/runner.js"></script>
+<script type="text/javascript" src="js/utils.js"></script>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
+<script type="text/javascript" src="../jscripts/tiny_mce/tiny_mce_jquery.js"></script>
+</head>
+<body>
+<script type="text/javascript">
+QUnit.config.reorder = false;
+
+module("tinymce.dom.DOMUtils (jQuery 1.8)", {
+});
+</script>
+<script type="text/javascript" src="js/tinymce.dom.DOMUtils.js"></script>
+	<h1 id="qunit-header">Unit tests for tinymce.dom.DOMUtils (jQuery 1.8)</h1>
+	<h2 id="qunit-banner"></h2>
+	<div id="qunit-testrunner-toolbar"></div>
+	<h2 id="qunit-userAgent"></h2>
+	<ol id="qunit-tests"></ol>
+	<div id="content"></div>
+</body>
+</html>


### PR DESCRIPTION
Newer jQuery returns true when asking if a text node matches the selector *, where previous versions did not.  Internal tinyMCE DOMUtils returns false, as did prior versions of jQuery.

This causes removeFormat() to fail when it recurses over a text node because it tries to process it instead of skipping it.

Add a test case that tries to match \* against a DOM node and a text node
Add a test suite that runs the tinyMCE DOMUtil jquery adapter tests against jQuery 1.8, which shows this bug
