### PR TITLE
Convert textcolor buttons into split buttons

### DIFF
--- a/js/tinymce/classes/ui/ColorButton.js
+++ b/js/tinymce/classes/ui/ColorButton.js
@@ -9,18 +9,21 @@
  */
 
 /**
- * This class creates a color button control. This is a button that has a visual representation
- * of the currently selected color. It will also display a color picker if you click the control
- * allowing the user to select a new color.
+ * This class creates a color button control. This is a split button in which the main
+ * button has a visual representation of the currently selected color. When clicked 
+ * the caret button displays a color picker, allowing the user to select a new color.
  *
  * @-x-less ColorButton.less
  * @class tinymce.ui.ColorButton
  * @extends tinymce.ui.PanelButton
  */
 define("tinymce/ui/ColorButton", [
-	"tinymce/ui/PanelButton"
-], function(PanelButton) {
+	"tinymce/ui/PanelButton",
+	"tinymce/dom/DOMUtils"
+], function(PanelButton, DomUtils) {
 	"use strict";
+	
+	var DOM = DomUtils.DOM;
 
 	return PanelButton.extend({
 		/**
@@ -63,14 +66,38 @@ define("tinymce/ui/ColorButton", [
 			var image = self.settings.image ? ' style="background-image: url(\'' + self.settings.image + '\')"' : '';
 
 			return (
-				'<div id="' + id + '" class="' + self.classes() + '" tabindex="-1">' +
-					'<button role="presentation" type="button" tabindex="-1">' +
+				'<div id="' + id + '" class="' + self.classes() + '">' +
+					'<button role="presentation" hidefocus type="button" tabindex="-1">' +
 						(icon ? '<i class="' + icon + '"' + image + '></i>' : '') +
 						'<span id="' + id + '-preview" class="' + prefix + 'preview"></span>' +
-						(self._text ? (icon ? ' ' : '') + self.encode(self._text) : '') +
+						(self._text ? (icon ? ' ' : '') + (self._text) : '') +
+					'</button>' +
+					'<button type="button" class="' + prefix + 'open" hidefocus tabindex="-1">' +
+						' <i class="' + prefix + 'caret"></i>' +
 					'</button>' +
 				'</div>'
 			);
+		},
+		
+		/**
+		 * Called after the control has been rendered.
+		 *
+		 * @method postRender
+		 */
+		postRender: function() {
+			var self = this, onClickHandler = self.settings.onclick;
+
+			self.on('click', function(e) {
+				if (e.control == self && !DOM.getParent(e.target, '.' + self.classPrefix + 'open')) {
+					e.stopImmediatePropagation();
+					onClickHandler.call(self, e);
+				}
+			});
+
+			delete self.settings.onclick;
+
+			return self._super();
 		}
+		
 	});
 });

--- a/js/tinymce/classes/ui/ComboBox.js
+++ b/js/tinymce/classes/ui/ComboBox.js
@@ -1,5 +1,5 @@
 /**
- * ColorButton.js
+ * ComboBox.js
  *
  * Copyright, Moxiecode Systems AB
  * Released under LGPL License.

--- a/js/tinymce/plugins/textcolor/plugin.js
+++ b/js/tinymce/plugins/textcolor/plugin.js
@@ -116,9 +116,13 @@ tinymce.PluginManager.add('textcolor', function(editor) {
 			buttonCtrl.hidePanel();
 			value = '#' + value;
 			buttonCtrl.color(value);
-			buttonCtrl.hidePanel();
 			editor.execCommand(buttonCtrl.settings.selectcmd, false, value);
 		}
+	}
+	
+	function onButtonClick() {
+		var self = this;
+		editor.execCommand(self.settings.selectcmd, false, self._color);
 	}
 
 	editor.addButton('forecolor', {
@@ -129,7 +133,8 @@ tinymce.PluginManager.add('textcolor', function(editor) {
 		panel: {
 			html: renderColorPicker,
 			onclick: onPanelClick
-		}
+		},
+		onclick: onButtonClick
 	});
 
 	editor.addButton('backcolor', {
@@ -140,6 +145,7 @@ tinymce.PluginManager.add('textcolor', function(editor) {
 		panel: {
 			html: renderColorPicker,
 			onclick: onPanelClick
-		}
+		},
+		onclick: onButtonClick
 	});
 });

--- a/js/tinymce/skins/lightgray/ColorButton.less
+++ b/js/tinymce/skins/lightgray/ColorButton.less
@@ -27,18 +27,31 @@
 	}
 }
 
-.mce-colorbutton {
-	position: relative;
+.mce-colorbutton button {
+	padding-right: 4px;
 }
 
 .mce-colorbutton .mce-preview {
+	padding-right: 3px;
 	display: block;
 	position: absolute;
-	left: 50%; top: 50%;
-	margin-left: -8px;
+	left: 50%;
+	top: 50%;
+	margin-left: -14px;
 	margin-top: 7px;
 	background: gray;
-	width: 16px;
+	width: 13px;
 	height: 2px;
 	overflow: hidden;
+}
+
+.mce-colorbutton .mce-open {
+	padding-left: 4px;
+	border-left: 1px solid transparent;
+	border-right: 1px solid transparent;
+}
+
+.mce-colorbutton:hover .mce-open {
+	border-left-color: @btn-border-color;
+	border-right-color: @btn-border-color;
 }


### PR DESCRIPTION
Changes to the ColorButton class are based on provisions in the SplitButton class.

Although this request is submitted as changes to the existing ColorButton class and textcolor plugin, it may be cleaner to add these provisions as a brand new class and plugin.

This addresses my feature request #5868.
