### PR TITLE
Add native icon to searchreplace plugin's menu item and toolbar button

### DIFF
--- a/js/tinymce/plugins/searchreplace/plugin.js
+++ b/js/tinymce/plugins/searchreplace/plugin.js
@@ -338,6 +338,7 @@
 
 		self.init = function(ed) {
 			ed.addMenuItem('searchreplace', {
+				icon: 'searchreplace',
 				text: 'Find and replace',
 				shortcut: 'Ctrl+F',
 				onclick: showDialog,
@@ -346,6 +347,7 @@
 			});
 
 			ed.addButton('searchreplace', {
+				icon: 'searchreplace',
 				tooltip: 'Find and replace',
 				shortcut: 'Ctrl+F',
 				onclick: showDialog


### PR DESCRIPTION
The 'searchreplace' icon is already provided for in the Icons.less file as:

```
 {content: "\e009";}
```

I'm assuming here that its omission from the plugin was inadvertent, rather than intentional.

Thanks for accepting, and fixing, my prior pull request. You seem to have your hands full in finalizing version 4.0.
