### PR TITLE
handle null / undef check cleanly in jQuery plugin

### DIFF
--- a/js/tinymce/classes/jquery.tinymce.js
+++ b/js/tinymce/classes/jquery.tinymce.js
@@ -213,7 +213,7 @@
 			var self = this, ed;
 
 			// Handle set value
-			if (value !== undef) {
+			if (value != null) {
 				removeEditors.call(self);
 
 				// Saves the contents before get/set value of textarea/div


### PR DESCRIPTION
Re-opening #173 against 4.0 branch.

jQuery plugins need to be able to handle setting content to `null` without crashing (see #173). The `==` check guards against both `null` and `undefined`.
