### PR TITLE
Change nonbreaking_force_tab config option

### DIFF
--- a/js/tinymce/plugins/nonbreaking/plugin.js
+++ b/js/tinymce/plugins/nonbreaking/plugin.js
@@ -11,6 +11,8 @@
 /*global tinymce:true */
 
 tinymce.PluginManager.add('nonbreaking', function(editor) {
+	var setting = editor.getParam('nonbreaking_force_tab');
+
 	editor.addCommand('mceNonBreaking', function() {
 		editor.insertContent(
 			(editor.plugins.visualchars && editor.plugins.visualchars.state) ?
@@ -29,14 +31,20 @@ tinymce.PluginManager.add('nonbreaking', function(editor) {
 		context: 'insert'
 	});
 
-	if (editor.getParam('nonbreaking_force_tab')) {
+	if (setting) {
+		var spaces = +setting > 1 ? +setting : 3;  // defaults to 3 spaces if setting is true (or 1)
+
 		editor.on('keydown', function(e) {
 			if (e.keyCode == 9) {
-				e.preventDefault();
 
-				editor.execCommand('mceNonBreaking');
-				editor.execCommand('mceNonBreaking');
-				editor.execCommand('mceNonBreaking');
+				if (e.shiftKey) {
+					return;
+				}
+
+				e.preventDefault();
+				for (var i = 0; i < spaces; i++) {
+					editor.execCommand('mceNonBreaking');
+				}
 			}
 		});
 	}


### PR DESCRIPTION
This commit changes the nonbreaking_force_tab config option so that you can specify the number of spaces to be inserted when the user presses the tab key.

This commit also preserves the default behavior of the shift + tab keypress so that it doesn't insert any spaces.
