### PR TITLE
Fixed spell checker

### DIFF
--- a/js/tinymce/plugins/spellchecker/classes/Plugin.js
+++ b/js/tinymce/plugins/spellchecker/classes/Plugin.js
@@ -124,7 +124,7 @@ define("tinymce/spellcheckerplugin/Plugin", [
 			}
 
 			// Find all words and make an unique words array
-			textFilter = new DomTextMatcher(/\w+/g, editor.getBody(), editor.schema).each(function(match) {
+			textFilter = new DomTextMatcher(/[^\\\s!"#$%&()*+,-./:;<=>?@[\]^_{|}§©«®±¶·¸»¼½¾¿×÷¤\u201d\u201c\'’´`„]+/g, editor.getBody(), editor.schema).each(function(match) {
 				if (!uniqueWords[match[2][0]]) {
 					words.push(match[2][0]);
 					uniqueWords[match[2][0]] = true;


### PR DESCRIPTION
\w does not match all "word" characters. E.g. accented characters (é, è, etc) get ignored. With this pull request a "negative" matcher is used to match everything except specified non-word characters.
