### PR TITLE
fix for chrome menubutton retaining focus

### DIFF
--- a/js/tinymce/classes/ui/MenuButton.js
+++ b/js/tinymce/classes/ui/MenuButton.js
@@ -187,6 +187,7 @@ define("tinymce/ui/MenuButton", [
 							}
 
 							ctrl.hideMenu();
+							ctrl.blur();
 						}
 					});
 


### PR DESCRIPTION
This fixed bug #5887 for me in Chrome. The menubutton was retaining the :focus class even though it was no longer active.
