### PR TITLE
alternate fix for bug #5887

### DIFF
--- a/js/tinymce/skins/lightgray/MenuBar.less
+++ b/js/tinymce/skins/lightgray/MenuBar.less
@@ -16,7 +16,7 @@
 	color: @text-color;
 }
 
-.mce-menubar .mce-menubtn:hover, .mce-menubar .mce-menubtn.mce-active, .mce-menubar .mce-menubtn:focus {
+.mce-menubar .mce-menubtn:hover, .mce-menubar .mce-menubtn.mce-active {
 	border-color: transparent;
 	background: @menubar-background-active;
 	filter: none;


### PR DESCRIPTION
This is an alternative fix for bug #5887 (Chrome).

It may be more complete than my last pull request. This fix would also remove the leftover shading from a menubar button (e.g., 'Tools') if you were to click on it twice and then move the mouse outside the button without passing through another menubar button.
