### PR TITLE
Fix a bug in insert, when ref_node has no next value

### DIFF
--- a/js/tinymce/classes/html/Node.js
+++ b/js/tinymce/classes/html/Node.js
@@ -343,6 +343,9 @@ define("tinymce/html/Node", [], function() {
 				if (ref_node === parent.lastChild) {
 					parent.lastChild = node;
 				} else {
+					if (ref_node.next == null)
+				        	ref_node.next = ref_node;
+				        	
 					ref_node.next.prev = node;
 				}
 


### PR DESCRIPTION
bug happens when we try to insert an iframe (with media plugins or with source code editor)

iframe used :  <iframe style="height:540px;width:960px" src="http://channel9.msdn.com/Events/Build/2013/3-017/player?w=960&h=540" frameBorder="0" scrolling="no" ></iframe>
