### PR TITLE
Add missing Ctrl+P shortcut to print plugin

### DIFF
--- a/js/tinymce/plugins/print/plugin.js
+++ b/js/tinymce/plugins/print/plugin.js
@@ -10,12 +10,17 @@
 
 /*global tinymce:true */
 
-tinymce.PluginManager.add('print',function(editor) {
+tinymce.PluginManager.add('print', function(editor) {
 	editor.addCommand('mcePrint', function() {
 		editor.getWin().print();
 	});
 
-	editor.addButton('print', {title: 'Print', cmd: 'mcePrint'});
+	editor.addButton('print', {
+		title: 'Print',
+		cmd: 'mcePrint'
+	});
+
+	editor.addShortcut('Ctrl+P', '', 'mcePrint');
 
 	editor.addMenuItem('print', {
 		text: 'Print',


### PR DESCRIPTION
Otherwise, pressing Ctrl+P also prints the menubar and toolbars, instead of just the editor's contents.
