### PR TITLE
Trigger change event after img is appended to editor

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -36,6 +36,7 @@ tinymce.PluginManager.add('image', function(editor) {
 		style.width = style.height = 'auto';
 
 		document.body.appendChild(img);
+    tinyMCE.activeEditor.fire('change');
 	}
 
 	function createImageList(callback) {


### PR DESCRIPTION
There is currently a bug where when I add an image to the editor using the Image plugin, the editor does not resize itself after the image is added even if the autoresize plugin is included.

I'm not sure if that's the right way to do it but I fire a change event on the activeEditor so it can properly resize itself (autoresize plugin) when an image is added. This way the autoresize plugin kicks in and resize the editor.
