### PR TITLE
Add try/catch around node.ownerDocument.implementation

### DIFF
--- a/js/tinymce/classes/dom/Serializer.js
+++ b/js/tinymce/classes/dom/Serializer.js
@@ -281,7 +281,12 @@ define("tinymce/dom/Serializer", [
 
 				// Nodes needs to be attached to something in WebKit/Opera
 				// This fix will make DOM ranges and make Sizzle happy!
-				impl = node.ownerDocument.implementation;
+				try {
+					impl = node.ownerDocument.implementation;
+				}
+				catch (e) {
+					impl = false;
+				}
 				if (impl.createHTMLDocument) {
 					// Create an empty HTML document
 					doc = impl.createHTMLDocument("");


### PR DESCRIPTION
Fixes Firefox NS_ERROR_UNEXPECTED bug when dynamically adding and removing editors.

This is related to PR #175, which was for the 3.x branch.
