### PR TITLE
Fixed bug #5881.

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1009,6 +1009,11 @@ define("tinymce/Editor", [
 					self.getWin().focus();
 				}
 
+				if (document != self.getDoc()) {
+					//WebKit in iOs needs a window focus call if the current document is different than self.getDoc().
+					self.getWin().focus();
+				}
+
 				// Focus the body as well since it's contentEditable
 				if (isGecko || contentEditable) {
 					body = self.getBody();


### PR DESCRIPTION
Tested on iOs WebKit: If the Editor's origin document element is different than the actual contentEditable's document then it needs a focus call on the contentEditable's window object to have the correct focus again.
Without this the contentEditable element does not have the proper focus and therefore keyboard input has no effect to the actual content after clicking on toolbar items.
