### PR TITLE
added userfriendly settings for the size of cope popup window

### DIFF
--- a/js/tinymce/plugins/code/plugin.js
+++ b/js/tinymce/plugins/code/plugin.js
@@ -14,12 +14,13 @@ tinymce.PluginManager.add('code', function(editor) {
 	function showSourceEditor() {
 		editor.windowManager.open({
 			title: "Source code",
+            width: parseInt(editor.getParam("plugin_code_width", "600"), 10),
+            height: parseInt(editor.getParam("plugin_code_height", "600"), 10),
 			body: {
 				type: 'textbox',
 				name: 'code',
 				multiline: true,
-				minWidth: 600,
-				minHeight: 500,
+                minHeight: parseInt(editor.getParam("plugin_code_height", "600"), 10)-50,
 				value: editor.getContent({source_view: true}),
 				spellcheck: false
 			},


### PR DESCRIPTION
on mobile devices / small screens / framesets the popups are often bigger than the available space, so parts of the popups are "outside" the visible area.
For the preview plugin its possible to override the default width and height by adding config params to the init function:

<pre>tinyMCE.init({
    ...
    plugin_preview_width: window.innerWidth,
    plugin_preview_height: window.innerHeight-90,
    ...
});</pre>


which makes it possible to set the size of the popups dynamically to fit them to the screen size
