### PR TITLE
Fix for image plugin's style textbox

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -237,6 +237,8 @@ tinymce.PluginManager.add('image', function(editor) {
 			var data = win.toJSON();
 			var css = dom.parseStyle(data.style);
 
+			dom.setAttrib(imgElm, 'style', '');
+
 			delete css.margin;
 			css['margin-top'] = css['margin-bottom'] = addPixelSuffix(data.vspace);
 			css['margin-left'] = css['margin-right'] = addPixelSuffix(data.hspace);


### PR DESCRIPTION
When reopened, the style textbox in the advanced tab gets repopulated with attributes that had been previously deleted. It appears that the element's 'data-mce-style' attribute is not getting cleared properly.
