### PR TITLE
Added missing protocol prefix to the jquery cdn url

### DIFF
--- a/tests/tinymce/dom/DOMUtils_jquery.html
+++ b/tests/tinymce/dom/DOMUtils_jquery.html
@@ -4,7 +4,7 @@
 <title>Unit tests for tinymce.dom.DOMUtils</title>
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-git.css" type="text/css" />
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
 <script src="http://code.jquery.com/qunit/qunit-git.js"></script>
 <script src="../../js/qunit/reporter.js"></script>
 <script src="../../js/utils.js"></script>


### PR DESCRIPTION
DOMUtils_jquery tests were failing with the message "load jquery first". This was because the jquery cdn url did not have the protocol prefix. The tests pass with this fix in place.
