### PR TITLE
Fixed IE10 show the first template in the list.

### DIFF
--- a/js/tinymce/plugins/template/plugin.js
+++ b/js/tinymce/plugins/template/plugin.js
@@ -68,7 +68,10 @@ tinymce.PluginManager.add('template', function(editor) {
 			}
 		});
 
-		win.find('listbox')[0].fire('select');
+		setTimeout(function(){
+		    win.find('listbox')[0].fire('select');
+		}, 450);
+		
 	}
 
 	function getDateTime(fmt, date) {


### PR DESCRIPTION
In IE10 when the dialog opens and there's at least one template in the list, it tries to load the iframe. I've delayed the trigger on the list.
