### PR TITLE
Fixed save_enablewhendirty functionality

### DIFF
--- a/js/tinymce/plugins/save/plugin.js
+++ b/js/tinymce/plugins/save/plugin.js
@@ -67,7 +67,7 @@ tinymce.PluginManager.add('save', function(editor) {
 		var self = this;
 
 		editor.on('nodeChange', function() {
-			self.disabled(!editor.isDirty());
+			self.disabled(editor.getParam("save_enablewhendirty") && !editor.isDirty());
 		});
 	}
 


### PR DESCRIPTION
Added param check. Save button is now enabled on load if save_enablewhendirty is false. Otherwise, it is hidden until editor.isDirty() is true.
