### PR TITLE
Added Advanced tab to Link dialog, similar to Images'

### DIFF
--- a/js/tinymce/plugins/link/plugin.js
+++ b/js/tinymce/plugins/link/plugin.js
@@ -32,6 +32,7 @@ tinymce.PluginManager.add('link', function(editor) {
 		var data = {}, selection = editor.selection, dom = editor.dom, selectedElm, anchorElm, initialText;
 		var win, linkListCtrl, relListCtrl, targetListCtrl;
 
+		// URLs
 		function linkListChangeHandler(e) {
 			var textCtrl = win.find('#text');
 
@@ -55,39 +56,67 @@ tinymce.PluginManager.add('link', function(editor) {
 
 			return linkListItems;
 		}
+		
+		
+		// RELs
+		function relListChangeHandler(e) {
+			var textCtrl = win.find('#text');
 
-		function buildRelList(relValue) {
+			if (!textCtrl.value() || (e.lastControl && textCtrl.value() == e.lastControl.text())) {
+				textCtrl.value(e.control.text());
+			}
+
+			win.find('#rel').value(e.control.value());
+		}
+
+		function buildRelList(rel) {
 			var relListItems = [{text: 'None', value: ''}];
 
 			tinymce.each(editor.settings.rel_list, function(rel) {
 				relListItems.push({
 					text: rel.text || rel.title,
 					value: rel.value,
-					selected: relValue === rel.value
+					selected: rel === rel.value
 				});
 			});
 
 			return relListItems;
 		}
 
-		function buildTargetList(targetValue) {
-			var targetListItems = [{text: 'None', value: ''}];
 
-			if (!editor.settings.target_list) {
-				targetListItems.push({text: 'New window', value: '_blank'});
+		// TARGETs
+		function targetListChangeHandler(e) {
+			var textCtrl = win.find('#text');
+
+			if (!textCtrl.value() || (e.lastControl && textCtrl.value() == e.lastControl.text())) {
+				textCtrl.value(e.control.text());
 			}
 
-			tinymce.each(editor.settings.target_list, function(target) {
-				targetListItems.push({
-					text: target.text || target.title,
-					value: target.value,
-					selected: targetValue === target.value
+			win.find('#target').value(e.control.value());
+		}
+
+		function buildTargetList(target) {
+			var targetListItems = [{text: 'None', value: ''}];
+			
+			if (!editor.settings.target_list) {
+				// DEFAULTs
+				targetListItems.push({text: 'Same Window/Tab', value: '_self'});
+				targetListItems.push({text: 'New Window/Tab', value: '_blank'});
+			} else {
+				tinymce.each(editor.settings.target_list, function(target) {
+					targetListItems.push({
+						text: target.text || target.title,
+						value: target.value,
+						selected: target === target.value
+					});
 				});
-			});
+			}
 
 			return targetListItems;
 		}
-
+		
+		
+		// ANCHORs
 		function buildAnchorListControl(url) {
 			var anchorList = [];
 
@@ -115,6 +144,10 @@ tinymce.PluginManager.add('link', function(editor) {
 				};
 			}
 		}
+		
+		
+		
+		
 
 		function updateText() {
 			if (!initialText && data.text.length === 0) {
@@ -127,8 +160,9 @@ tinymce.PluginManager.add('link', function(editor) {
 
 		data.text = initialText = anchorElm ? (anchorElm.innerText || anchorElm.textContent) : selection.getContent({format: 'text'});
 		data.href = anchorElm ? dom.getAttrib(anchorElm, 'href') : '';
-		data.target = anchorElm ? dom.getAttrib(anchorElm, 'target') : '';
+		data.title = anchorElm ? dom.getAttrib(anchorElm, 'title') : '';
 		data.rel = anchorElm ? dom.getAttrib(anchorElm, 'rel') : '';
+		data.target = anchorElm ? dom.getAttrib(anchorElm, 'target') : '';
 
 		if (selectedElm.nodeName == "IMG") {
 			data.text = initialText = " ";
@@ -137,133 +171,183 @@ tinymce.PluginManager.add('link', function(editor) {
 		if (linkList) {
 			linkListCtrl = {
 				type: 'listbox',
-				label: 'Link list',
+				label: 'Links',
 				values: buildLinkList(),
 				onselect: linkListChangeHandler
 			};
 		}
 
-		if (editor.settings.target_list !== false) {
-			targetListCtrl = {
-				name: 'target',
-				type: 'listbox',
-				label: 'Target',
-				values: buildTargetList(data.target)
-			};
-		}
-
 		if (editor.settings.rel_list) {
 			relListCtrl = {
-				name: 'rel',
+				name: 'rellist',
 				type: 'listbox',
-				label: 'Rel',
-				values: buildRelList(data.rel)
+				label: 'Rels',
+				values: buildRelList(data.rel),
+				onselect: relListChangeHandler
 			};
 		}
 
-		win = editor.windowManager.open({
-			title: 'Insert link',
-			data: data,
-			body: [
-				{
-					name: 'href',
-					type: 'filepicker',
-					filetype: 'file',
-					size: 40,
-					autofocus: true,
-					label: 'Url',
-					onchange: updateText,
-					onkeyup: updateText
-				},
-				{name: 'text', type: 'textbox', size: 40, label: 'Text to display', onchange: function() {
-					data.text = this.value();
-				}},
-				buildAnchorListControl(data.href),
-				linkListCtrl,
-				relListCtrl,
-				targetListCtrl
-			],
-			onSubmit: function(e) {
-				var data = e.data, href = data.href;
+		targetListCtrl = {
+			name: 'targetlist',
+			type: 'listbox',
+			label: 'Targets',
+			values: buildTargetList(data.target),
+			onselect: targetListChangeHandler
+		};
 
-				// Delay confirm since onSubmit will move focus
-				function delayedConfirm(message, callback) {
-					window.setTimeout(function() {
-						editor.windowManager.confirm(message, callback);
-					}, 0);
-				}
 
-				function insertLink() {
-					if (data.text != initialText) {
-						if (anchorElm) {
-							editor.focus();
-							anchorElm.innerHTML = data.text;
 
-							dom.setAttribs(anchorElm, {
-								href: href,
-								target: data.target ? data.target : null,
-								rel: data.rel ? data.rel : null
-							});
+		function onSubmitForm() {
+			var data = win.toJSON();
+			var data = data, href = data.href, target = data.target;
 
-							selection.select(anchorElm);
-						} else {
-							editor.insertContent(dom.createHTML('a', {
-								href: href,
-								target: data.target ? data.target : null,
-								rel: data.rel ? data.rel : null
-							}, data.text));
-						}
-					} else {
-						editor.execCommand('mceInsertLink', false, {
+			// Delay confirm since onSubmit will move focus
+			function delayedConfirm(message, callback) {
+				window.setTimeout(function() {
+					editor.windowManager.confirm(message, callback);
+				}, 0);
+			}
+
+			function insertLink() {
+				if (data.text != initialText) {
+					if (anchorElm) {
+						editor.focus();
+						anchorElm.innerHTML = data.text;
+
+						dom.setAttribs(anchorElm, {
 							href: href,
-							target: data.target,
+							title: data.title ? data.title : null,
+							target: data.target ? data.target : null,
 							rel: data.rel ? data.rel : null
 						});
+
+						selection.select(anchorElm);
+					} else {
+						editor.insertContent(dom.createHTML('a', {
+							href: href,
+							title: data.title ? data.title : null,
+							target: data.target ? data.target : null,
+							rel: data.rel ? data.rel : null
+						}, data.text));
 					}
+				} else {
+					editor.execCommand('mceInsertLink', false, {
+						href: href,
+						title: data.title,
+						target: data.target ? data.target : null,
+						rel: data.rel ? data.rel : null
+					});
 				}
-
-				if (!href) {
-					editor.execCommand('unlink');
-					return;
-				}
-
-				// Is email and not //user@domain.com
-				if (href.indexOf('@') > 0 && href.indexOf('//') == -1 && href.indexOf('mailto:') == -1) {
-					delayedConfirm(
-						'The URL you entered seems to be an email address. Do you want to add the required mailto: prefix?',
-						function(state) {
-							if (state) {
-								href = 'mailto:' + href;
-							}
-
-							insertLink();
-						}
-					);
-
-					return;
-				}
-
-				// Is www. prefixed
-				if (/^\s*www\./i.test(href)) {
-					delayedConfirm(
-						'The URL you entered seems to be an external link. Do you want to add the required http:// prefix?',
-						function(state) {
-							if (state) {
-								href = 'http://' + href;
-							}
-
-							insertLink();
-						}
-					);
-
-					return;
-				}
-
-				insertLink();
 			}
-		});
-	}
 
+			if (!href) {
+				editor.execCommand('unlink');
+				return;
+			}
+
+			// Is email and not //user@domain.com
+			if (href.indexOf('@') > 0 && href.indexOf('//') == -1 && href.indexOf('mailto:') == -1) {
+				delayedConfirm(
+					'The URL you entered seems to be an email address. Do you want to add the required mailto: prefix?',
+					function(state) {
+						if (state) {
+							href = 'mailto:' + href;
+						}
+
+						insertLink();
+					}
+				);
+
+				return;
+			}
+
+			// Is www. prefixed
+			if (/^\s*www\./i.test(href)) {
+				delayedConfirm(
+					'The URL you entered seems to be an external link. Do you want to add the required http:// prefix?',
+					function(state) {
+						if (state) {
+							href = 'http://' + href;
+						}
+
+						insertLink();
+					}
+				);
+
+				return;
+			}
+
+			insertLink();
+		}
+
+		// General settings shared between simple and advanced dialogs
+		var generalFormItems = [
+			{name: 'text', type: 'textbox', size: 40, label: 'Text', onchange: function() {
+				data.text = this.value();
+			}},
+			{
+				name: 'href',
+				type: 'filepicker',
+				filetype: 'file',
+				size: 40,
+				autofocus: true,
+				label: 'Url',
+				onchange: updateText,
+				onkeyup: updateText
+			},
+			buildAnchorListControl(data.href),
+			linkListCtrl
+		];
+
+
+		if (editor.settings.link_advtab) {
+
+			// Advanced dialog shows general+advanced tabs
+			win = editor.windowManager.open({
+				title: 'Insert/edit link',
+				data: data,
+				bodyType: 'tabpanel',
+				body: [
+					{
+						title: 'General',
+						type: 'form',
+						items: generalFormItems
+					},
+
+					{
+						title: 'Advanced',
+						type: 'form',
+						pack: 'start',
+						items: [
+							{name: 'title', type: 'textbox', size: 40, label: 'Title', onchange: function() {
+								data.title = this.value();
+							}}
+							,
+							{name: 'target', type: 'textbox', size: 40, label: 'Target', onchange: function() {
+								data.target = this.value();
+							}},
+							targetListCtrl,
+							{name: 'rel', type: 'textbox', size: 40, label: 'Rel', onchange: function() {
+								data.rel = this.value();
+							}},
+							relListCtrl
+						]
+					}
+				],
+				onSubmit: onSubmitForm
+			});
+		} else {
+			// Simple default dialog
+			win = editor.windowManager.open({
+				title: 'Insert/edit link',
+				data: data,
+				body: generalFormItems,
+				onSubmit: onSubmitForm
+			});
+		}
+
+
+	}
 	editor.addButton('link', {
 		icon: 'link',
 		tooltip: 'Insert/edit link',


### PR DESCRIPTION
Some additions to help with using SEO and light boxes, etc.
Set "link_advtab: true" in your tinyMCE.init({}) to turn on the advanced link tab.

GENERAL tab
• Text
• URL
• Anchors (pulldown menu)
• Links (pulldown menu)

ADVANCED tab
• Title
• Target
• Targets (pulldown menu)
• Rel
• Rels (pulldown menu)

![screen shot 2013-08-19 at 11 33 20 am](https://f.cloud.github.com/assets/40175/987085/c02076c2-08e4-11e3-88f5-d32d3c14ef66.png)
![screen shot 2013-08-19 at 11 33 35 am](https://f.cloud.github.com/assets/40175/987088/c74c0588-08e4-11e3-9fc9-114b94542f4c.png)