### PR TITLE
fixes error thrown in firefox

### DIFF
--- a/js/tinymce/classes/util/LocalStorage.js
+++ b/js/tinymce/classes/util/LocalStorage.js
@@ -31,8 +31,12 @@ define("tinymce/util/LocalStorage", [], function() {
 	var LocalStorage, storageElm, items, keys, userDataKey, hasOldIEDataSupport;
 
 	// Check for native support
-	if (window.localStorage) {
-		return localStorage;
+	try {
+		if (window.localStorage) {
+			return localStorage;
+		}
+	} catch (ex) {
+		// Ignore
 	}
 
 	userDataKey = "tinymce";


### PR DESCRIPTION
window.localStorage is throwing an error in Firefox 23. Wrapping in a try/catch handler, so it'll fallback to the simulated LocalStorage.
