### PR TITLE
#6051 - Safari needs contentEditable for selection

### DIFF
--- a/js/tinymce/plugins/paste/classes/Clipboard.js
+++ b/js/tinymce/plugins/paste/classes/Clipboard.js
@@ -105,7 +105,7 @@ define("tinymce/pasteplugin/Clipboard", [
 
 			// Create a pastebin and move the selection into the bin
 			var pastebinElm = editor.dom.add(editor.getBody(), 'div', {
-				contentEditable: false,
+				contentEditable: true,
 				"data-mce-bogus": "1",
 				style: 'position: absolute; top: ' + scrollTop + 'px; left: 0; width: 1px; height: 1px; overflow: hidden'
 			}, '<div contentEditable="true" data-mce-bogus="1">X</div>');


### PR DESCRIPTION
For issue: http://www.tinymce.com/develop/bugtracker_view.php?id=6051

I've put a thorough description of what's happening and why it's going wrong in the bug tracker. It seems that the pastebinElm needs to be contentEditable for Safari to be able to focus on its contents properly. This change allows for that.
