### PR TITLE
bug 6331 : linked styles not rendering.  took a shot at fixing it

### DIFF
--- a/js/tinymce/plugins/fullpage/plugin.js
+++ b/js/tinymce/plugins/fullpage/plugin.js
@@ -355,6 +355,17 @@ tinymce.PluginManager.add('fullpage', function(editor) {
 			}
 		});
 
+        each(headerFragment.getAll('link'), function(node) {
+            if (node && node.attr('rel') == 'stylesheet' && node.attr('type') == 'text/css') {
+                try {
+                    editor.contentCSS.push(editor.documentBaseURI.toAbsolute(node.attr('href')));
+                }
+                catch(e) {
+                    /* bad uri; nothing to be done */
+                }
+            }
+        });
+
 		elm = headerFragment.getAll('body')[0];
 		if (elm) {
 			dom.setAttribs(editor.getBody(), {


### PR DESCRIPTION
Fullpage plugin : link tags are not read, editor does not render document's styling
