### PR TITLE
Template classes bug

### DIFF
--- a/jscripts/tiny_mce/plugins/template/editor_plugin_src.js
+++ b/jscripts/tiny_mce/plugins/template/editor_plugin_src.js
@@ -93,8 +93,11 @@
 					n.innerHTML = t._getDateTime(new Date(), ed.getParam("template_mdate_format", ed.getLang("template.mdate_format")));
 
 				// Replace selection
-				if (hasClass(n, ed.getParam('template_selected_content_classes', 'selcontent').replace(/\s+/g, '|')))
-					n.innerHTML = sel;
+				var replClass = ed.getParam('template_selected_content_classes', 'selcontent');
+				if ('' != replClass.replace(/\s+/g, '')) {
+					if (hasClass(n, replClass.replace(/\s+/g, '|')))
+						n.innerHTML = sel;
+				}
 			});
 
 			t._replaceVals(el);


### PR DESCRIPTION
In the TinyMCE plugin for MODX Revolution (uses TinyMCE 3.5.4.1) I encountered the following bug:

Using TinyMCE's template plugin, I tried to insert a snippet where the outmost tag was a DIV with a class:

``` html
<div class="ym-grid">
    <div class="ym-g50 ym-gl">
        <div class="ym-gbox">
            <p>Content of the left column</p>
        </div>
    </div>
    <div class="ym-g50 ym-gr">
        <div class="ym-gbox">
            <p>Content of the right column</p>
        </div>
    </div>
</div>
```

After adding it, only the outmost DIV was inserted, the other elements just disappeared.

I found out that this happened because my template_selected_content_classes list was empty. In the jscripts\tiny_mce\plugins\template\editor_plugin_src.js there needs to be a test if it is empty before replacing, otherwise every time a construct like this is inserted, the inner HTML will be replaced (with the empty string if nothing is selected in the editor).

This should also apply to the "standalone" TinyMCE at least up to the current 3.x version - the template plugin hasn't changed in the meantime.
