### PR TITLE
[3.x] Fix DomUtils.getClasses error handling on @import nodes

### DIFF
--- a/jscripts/tiny_mce/classes/dom/DOMUtils.js
+++ b/jscripts/tiny_mce/classes/dom/DOMUtils.js
@@ -1555,7 +1555,12 @@
 
 						// Import
 						case 3:
-							addClasses(r.styleSheet);
+							try {
+								addClasses(r.styleSheet);
+							} catch (ex) {
+								// Ignore
+							}
+
 							break;
 					}
 				});


### PR DESCRIPTION
This fixes a bug in the `getClasses()` method of `tinymce.dom.DomUtils` that prevented the advanced theme's style selector from being populated when an exception is raised while processing an @import'ed CSS file linked from the `content_css` stylesheet.

You can reproduce this issue by using the following stylesheet as the `content_css` in combination with the latest versions of Firefox (24.0):

```
@import url(//fonts.googleapis.com/css?family=Pathway+Gothic+One);

p.introduction {
  font-size: 110%;
  font-weight: bold;
}
```

The cross-site @import causes Firefox to raise an InvalidAccessError and stops any other classes in the file from being processed.

The problem is solved by simply wrapping the recursive call to addClasses with a try/catch statement.
