### PR TITLE
Fixed regular expression for removing paste_data_images

### DIFF
--- a/js/tinymce/plugins/paste/classes/Clipboard.js
+++ b/js/tinymce/plugins/paste/classes/Clipboard.js
@@ -123,7 +123,7 @@ define("tinymce/pasteplugin/Clipboard", [
 
 			// Remove all data images from paste for example from Gecko
 			if (!editor.settings.paste_data_images) {
-				html = html.replace(/<img src=\"data:image[^>]+>/g, '');
+				html = html.replace(/<img[^>]+src=\"data:image[^>]+>/g, '');
 			}
 
 			if (editor.settings.paste_remove_styles || (editor.settings.paste_remove_styles_if_webkit !== false && Env.webkit)) {


### PR DESCRIPTION
The existing regex only picked up images where the src attribute immediately followed the tag opening. However, you could have an image tag like <img alt="something" src="data:image...">.
