### PR TITLE
Fixed missing text color in default skin

### DIFF
--- a/js/tinymce/skins/lightgray/Content.less
+++ b/js/tinymce/skins/lightgray/Content.less
@@ -5,6 +5,7 @@
 
 body {
 	background-color: #FFFFFF;
+	color: #000000;
 	font-family: @font-family;
 	font-size: @font-size;
 	scrollbar-3dlight-color: #F0F0EE;


### PR DESCRIPTION
Fix invisible text for users with alternative color scheme (dark background os theme). 

White (undefined) text on white (defined) background is hard to read.
