### PR TITLE
Adds the mac_ctrl_key=ctrl/cmd/both preference

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -155,6 +155,7 @@ define("tinymce/Editor", [
 			indent_after: 'p,h1,h2,h3,h4,h5,h6,blockquote,div,title,style,pre,script,td,ul,li,area,table,thead,' +
 				'tfoot,tbody,tr,section,article,hgroup,aside,figure,option,optgroup,datalist',
 			validate: true,
+			mac_ctrl_key: 'both',
 			entity_encoding: 'named',
 			url_converter: self.convertURL,
 			url_converter_scope: self,
@@ -1281,6 +1282,16 @@ define("tinymce/Editor", [
 				settings.onclick = function() {
 					self.execCommand(settings.cmd);
 				};
+			}
+
+			// format shortcut for the mac based on the mac_ctrl_key preference.
+			if (Env.mac && settings.shortcut) {
+				var shortcut = settings.shortcut, ctrl = (Env.mac && self.settings.mac_ctrl_key !== 'ctrl') ? '&#x2318;' : '&#x2303;';
+				shortcut = shortcut.replace(/ctrl\+alt\+/i, '&#x2325;' + ctrl);
+				shortcut = shortcut.replace(/ctrl\+/i, ctrl);
+				shortcut = shortcut.replace(/alt\+/i, '&#x2325;');
+				shortcut = shortcut.replace(/shift\+/i, '&#x21E7;');
+				settings.shortcut = shortcut;
 			}
 
 			self.menuItems = self.menuItems || {};

--- a/js/tinymce/classes/EditorCommands.js
+++ b/js/tinymce/classes/EditorCommands.js
@@ -171,7 +171,9 @@ define("tinymce/EditorCommands", [
 				if (failed || !doc.queryCommandSupported(command)) {
 					editor.windowManager.alert(
 						"Your browser doesn't support direct access to the clipboard. " +
-						"Please use the Ctrl+X/C/V keyboard shortcuts instead."
+						"Please use the " +
+						((Env.mac && editor.settings.mac_ctrl_key !== 'ctrl') ? 'Cmd+' : 'Ctrl+') +
+						"X/C/V keyboard shortcuts instead."
 					);
 				}
 			},

--- a/js/tinymce/classes/Shortcuts.js
+++ b/js/tinymce/classes/Shortcuts.js
@@ -13,8 +13,8 @@
  */
 define("tinymce/Shortcuts", [
 	"tinymce/util/Tools",
-	"tinymce/Env"
-], function(Tools, Env) {
+	"tinymce/util/VK"
+], function(Tools, VK) {
 	var each = Tools.each, explode = Tools.explode;
 
 	var keyCodeLookup = {
@@ -29,9 +29,8 @@ define("tinymce/Shortcuts", [
 		editor.on('keyup keypress keydown', function(e) {
 			if (e.altKey || e.ctrlKey || e.metaKey) {
 				each(shortcuts, function(shortcut) {
-					var ctrlKey = Env.mac ? (e.ctrlKey || e.metaKey) : e.ctrlKey;
 
-					if (shortcut.ctrl != ctrlKey || shortcut.alt != e.altKey || shortcut.shift != e.shiftKey) {
+					if (shortcut.ctrl != VK.ctrlKeyPressed(e, editor) || shortcut.alt != e.altKey || shortcut.shift != e.shiftKey) {
 						return;
 					}
 

--- a/js/tinymce/classes/util/Quirks.js
+++ b/js/tinymce/classes/util/Quirks.js
@@ -223,7 +223,7 @@ define("tinymce/util/Quirks", [
 		 */
 		function selectAll() {
 			editor.on('keydown', function(e) {
-				if (!isDefaultPrevented(e) && e.keyCode == 65 && VK.metaKeyPressed(e)) {
+				if (!isDefaultPrevented(e) && e.keyCode == 65 && VK.metaKeyPressed(e, editor)) {
 					e.preventDefault();
 					editor.execCommand('SelectAll');
 				}
@@ -889,7 +889,7 @@ define("tinymce/util/Quirks", [
 		function normalizeSelection() {
 			// Normalize selection for example <b>a</b><i>|a</i> becomes <b>a|</b><i>a</i> except for Ctrl+A since it selects everything
 			editor.on('keyup focusin', function(e) {
-				if (e.keyCode != 65 || !VK.metaKeyPressed(e)) {
+				if (e.keyCode != 65 || !VK.metaKeyPressed(e, editor)) {
 					selection.normalize();
 				}
 			});

--- a/js/tinymce/classes/util/VK.js
+++ b/js/tinymce/classes/util/VK.js
@@ -14,6 +14,20 @@
 define("tinymce/util/VK", [
 	"tinymce/Env"
 ], function(Env) {
+        
+	function ctrlKeyPressed(e, editor) {
+		if (Env.mac) {
+			if (editor) {
+				switch (editor.settings.mac_ctrl_key) {
+				case 'ctrl': return e.ctrlKey;
+				case 'cmd':  return e.metaKey;
+				}
+			}
+			return e.ctrlKey || e.metaKey;
+		}
+		return e.ctrlKey;
+	}
+
 	return {
 		BACKSPACE: 8,
 		DELETE: 46,
@@ -29,9 +43,15 @@ define("tinymce/util/VK", [
 			return e.shiftKey || e.ctrlKey || e.altKey;
 		},
 
-		metaKeyPressed: function(e) {
+		// Sensitive to the mac_ctrl_key preference
+		ctrlKeyPressed: ctrlKeyPressed,
+
+		// This name is misleading, but it is used in
+		// Quirks.js to detect when Cmd-A/Ctrl-A behavior
+		// should be modified.
+		metaKeyPressed: function(e, editor) {
 			// Check if ctrl or meta key is pressed also check if alt is false for Polish users
-			return (Env.mac ? e.ctrlKey || e.metaKey : e.ctrlKey) && !e.altKey;
+			return ctrlKeyPressed(e, editor) && !e.altKey;
 		}
 	};
 });


### PR DESCRIPTION
... so that mac users can have their ctrl keys back. The default is set to 'both' to match existing behavior, but 'cmd' will work like other editors on the mac. For example, Ctrl-A will move the cursor to the beginning of the line while Cmd-A will select the entire buffer.

I'm open to suggestions for an alternate setting name and set of values.
