### PR TITLE
Show native contextmenu with ctrl key

### DIFF
--- a/js/tinymce/plugins/contextmenu/plugin.js
+++ b/js/tinymce/plugins/contextmenu/plugin.js
@@ -11,10 +11,15 @@
 /*global tinymce:true */
 
 tinymce.PluginManager.add('contextmenu', function(editor) {
-	var menu;
+	var menu, contextmenuNeverUseNative = editor.settings.contextmenu_never_use_native;
 
 	editor.on('contextmenu', function(e) {
 		var contextmenu;
+
+		// Block TinyMCE menu on ctrlKey
+		if (e.ctrlKey && !contextmenuNeverUseNative) {
+			return;
+		}
 
 		e.preventDefault();
 


### PR DESCRIPTION
This restores TinyMCE 3.x behavior which allows Safari (and other) spell suggestions on the native contextmenu to be used. Set "contextmenu_never_use_native: true" in settings to preserve new 4.x behavior. I'm open to changing the default, but not being able to get to the native contextmenu is not ideal.
