### PR TITLE
Format menu shortcuts for the Mac

### DIFF
--- a/js/tinymce/classes/EditorCommands.js
+++ b/js/tinymce/classes/EditorCommands.js
@@ -171,7 +171,8 @@ define("tinymce/EditorCommands", [
 				if (failed || !doc.queryCommandSupported(command)) {
 					editor.windowManager.alert(
 						"Your browser doesn't support direct access to the clipboard. " +
-						"Please use the Ctrl+X/C/V keyboard shortcuts instead."
+						"Please use the " + (Env.mac ? 'Command' : 'Ctrl') +
+						"+X/C/V keyboard shortcuts instead."
 					);
 				}
 			},

--- a/js/tinymce/classes/ui/MenuItem.js
+++ b/js/tinymce/classes/ui/MenuItem.js
@@ -17,8 +17,9 @@
  */
 define("tinymce/ui/MenuItem", [
 	"tinymce/ui/Widget",
-	"tinymce/ui/Factory"
-], function(Widget, Factory) {
+	"tinymce/ui/Factory",
+	"tinymce/Env"
+], function(Widget, Factory, Env) {
 	"use strict";
 
 	return Widget.extend({
@@ -212,7 +213,7 @@ define("tinymce/ui/MenuItem", [
 		 */
 		renderHtml: function() {
 			var self = this, id = self._id, settings = self.settings, prefix = self.classPrefix, text = self.encode(self._text);
-			var icon = self.settings.icon, image = '';
+			var icon = self.settings.icon, image = '', shortcut = settings.shortcut;
 
 			if (icon) {
 				self.parent().addClass('menu-has-icons');
@@ -223,14 +224,22 @@ define("tinymce/ui/MenuItem", [
 				image = ' style="background-image: url(\'' + settings.image + '\')"';
 			}
 
+			if (shortcut && Env.mac) {
+				// format shortcut for Mac
+				shortcut = shortcut.replace(/ctrl\+alt\+/i, '&#x2325;&#x2318;'); // ctrl+cmd
+				shortcut = shortcut.replace(/ctrl\+/i, '&#x2318;'); // ctrl symbol
+				shortcut = shortcut.replace(/alt\+/i, '&#x2325;'); // cmd symbol
+				shortcut = shortcut.replace(/shift\+/i, '&#x21E7;'); // shift symbol
+			}
+
 			icon = prefix + 'ico ' + prefix + 'i-' + (self.settings.icon || 'none');
 
 			return (
 				'<div id="' + id + '" class="' + self.classes() + '" tabindex="-1">' +
 					(text !== '-' ? '<i class="' + icon + '"' + image + '></i>&nbsp;' : '') +
 					(text !== '-' ? '<span id="' + id + '-text" class="' + prefix + 'text">' + text + '</span>' : '') +
-					(settings.shortcut ? '<div id="' + id + '-shortcut" class="' + prefix + 'menu-shortcut">' +
-						settings.shortcut + '</div>' : '') +
+					(shortcut ? '<div id="' + id + '-shortcut" class="' + prefix + 'menu-shortcut">' +
+					 shortcut + '</div>' : '') +
 					(settings.menu ? '<div class="' + prefix + 'caret"></div>' : '') +
 				'</div>'
 			);


### PR DESCRIPTION
Also update the X/C/V dialog to use say Command for Mac.

Before: 

![screen shot 2013-11-06 at 9 02 33 am](https://f.cloud.github.com/assets/2660251/1482935/b82d8bca-46ed-11e3-95b6-fdec97354dd3.png)

![screen shot 2013-11-06 at 9 02 55 am](https://f.cloud.github.com/assets/2660251/1482940/cf333ce8-46ed-11e3-9c62-170e10ceff65.png)

After:

![screen shot 2013-11-06 at 9 04 12 am](https://f.cloud.github.com/assets/2660251/1482938/c451f828-46ed-11e3-828c-072d3f6ae7f2.png)

![screen shot 2013-11-06 at 9 04 27 am](https://f.cloud.github.com/assets/2660251/1482943/d3fd8e0e-46ed-11e3-8d6b-c70eb64be0b3.png)
