### PR TITLE
Only add None target option when no target_list configuration found

### DIFF
--- a/js/tinymce/plugins/link/plugin.js
+++ b/js/tinymce/plugins/link/plugin.js
@@ -71,9 +71,10 @@ tinymce.PluginManager.add('link', function(editor) {
 		}
 
 		function buildTargetList(targetValue) {
-			var targetListItems = [{text: 'None', value: ''}];
+			var targetListItems = [];
 
 			if (!editor.settings.target_list) {
+				targetListItems.push({text: 'None', value: ''});
 				targetListItems.push({text: 'New window', value: '_blank'});
 			}
 


### PR DESCRIPTION
It's not possible right now if you want to force all links to be opened in external windows.

I change the link plugin a little bit, so that when the target_list configuration is explicitly defined, the "None target" option will not be included in the target dropdown list.
