### PR TITLE
Fixes bug where as inline editors would select all page text when hidden or removed.

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1534,7 +1534,7 @@ define("tinymce/Editor", [
 			var self = this, doc = self.getDoc();
 
 			// Fixed bug where IE has a blinking cursor left from the editor
-			if (ie && doc) {
+			if (ie && doc && !self.inline) {
 				doc.execCommand('SelectAll');
 			}
 
@@ -2016,7 +2016,7 @@ define("tinymce/Editor", [
 
 				// Fixed bug where IE has a blinking cursor left from the editor
 				var doc = self.getDoc();
-				if (ie && doc) {
+				if (ie && doc && !self.inline) {
 					doc.execCommand('SelectAll');
 				}
 


### PR DESCRIPTION
By having the SelectAll workaround on hide and remove, all text on the site would be selected when a inline editor was hidden or removed.

As far as I can tell the blinking cursor bug isn't applicable for inline editors.
