### PR TITLE
Create plugin.selected.js

### DIFF
--- a/js/tinymce/plugins/code/plugin.selected.js
+++ b/js/tinymce/plugins/code/plugin.selected.js
@@ -1,0 +1,29 @@
+tinymce.PluginManager.add("htmleditor", function (e) {
+    e.addButton("htmleditor", {
+        text: "HTML Editor",
+        icon: !1,
+        onclick: function () {
+            e.windowManager.open({
+                title: "HTML Editor",
+                body: [{
+					type: "textbox",
+					name: "html_source",
+					label: "HTML",
+					value: e.selection.getContent( { format : 'html' } ),
+					multiline: !0,
+					minWidth: e.getParam("code_dialog_width", 600),
+					minHeight: e.getParam("code_dialog_height", Math.min(tinymce.DOM.getViewPort().h - 200, 500)),
+					spellcheck: !1,
+					style: "direction: ltr; text-align: left"
+                }],
+                onsubmit: function (t) {
+					// Set focus and set an undo point
+					e.focus(), e.undoManager.transact(function () {
+						// Update the selected text
+						e.execCommand('mceReplaceContent', false, t.data.html_source)
+					}), e.focus(), e.nodeChanged()
+                }
+            })
+        }
+    })
+});


### PR DESCRIPTION
This version of the existing code plugin will allow a selection of editor source to be edited rather than the entire source which is unwieldy if editing a large content item, email etc.

Possibly this "idea" could be merged into the existing plugin whereby someone could modify my sample code to allow a selection to be edited if a selection is active, otherwise default to all source.

Food for thought. Alternatively simply add this as a separate plugin and use as desired.

Richard Hetherington
