### PR TITLE
Fix bug #6528: Infinite loop in 3.x searchreplace plugin in MSIE 9/10

### DIFF
--- a/jscripts/tiny_mce/plugins/searchreplace/js/searchreplace.js
+++ b/jscripts/tiny_mce/plugins/searchreplace/js/searchreplace.js
@@ -93,6 +93,10 @@ var SearchReplaceDialog = {
 
 						if (b) {
 							r.moveEnd("character", -(rs.length)); // Otherwise will loop forever
+						} else {
+							// to avoid looping for ever in MSIE 9/10 when just
+							// changing the case
+							r.moveStart("character", rs.length);
 						}
 					}
 


### PR DESCRIPTION
This patch fixes a potential infinite loop in MSIE 9/10 while using the searchreplace plugin to change the case.

See http://www.tinymce.com/develop/bugtracker_view.php?id=6528
