### PR TITLE
new option `indent_use_margin: bool` [false]

### DIFF
--- a/js/tinymce/classes/EditorCommands.js
+++ b/js/tinymce/classes/EditorCommands.js
@@ -526,7 +526,8 @@ define("tinymce/EditorCommands", [
 
 						if (element.nodeName != "LI") {
 							indentStyleDir = dom.getStyle(element, 'direction', true) == 'rtl' ? 'Right' : 'Left';
-                            indentStyleName = (editor.getParam('indent_use_margin', false)) ? "margin" + indentStyleDir : "padding" + indentStyleDir;
+                            indentStyleName = (editor.getParam(
+                                'indent_use_margin', false)) ? "margin" + indentStyleDir : "padding" + indentStyleDir;
 
 							if (command == 'outdent') {
 								value = Math.max(0, parseInt(element.style[indentStyleName] || 0, 10) - intentValue);


### PR DESCRIPTION
if false use padding for indent/outdent otherwise use margin.
(re bug#6553: http://www.tinymce.com/develop/bugtracker_view.php?id=6553)
