### PR TITLE
Conform dropdown menu's scrollbar to the one used in content area and source code viewer

### DIFF
--- a/js/tinymce/skins/lightgray/Menu.less
+++ b/js/tinymce/skins/lightgray/Menu.less
@@ -19,6 +19,22 @@
 	overflow-x: hidden;
 }
 
+.mce-menu::-webkit-scrollbar {
+	width: 8px; height: 8px;
+	-webkit-border-radius: 4px;
+}
+
+.mce-menu::-webkit-scrollbar-track,
+.mce-menu::-webkit-scrollbar-track-piece {
+	background-color:transparent;
+}
+
+.mce-menu::-webkit-scrollbar-thumb {
+	background-color: rgba(053, 057, 071, 0.3);
+	width: 6px; height: 6px;
+	-webkit-border-radius: 4px;
+}
+
 .mce-menu i {
 	display: none;
 }


### PR DESCRIPTION
Assuming that there are no immediate plans to change the scrollbar to a more conventional one in Chrome.
