### PR TITLE
Fixing style bug in images plugin

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -117,6 +117,8 @@ tinymce.PluginManager.add('image', function(editor) {
 
 				imgElm.onerror = selectImage;
 			}
+			
+			updateStyle();
 
 			var data = win.toJSON();
 


### PR DESCRIPTION
Bug occurs when modifying the border or padding in the image advanced tab and clicking the "Ok" button before clicking anything else. This causes the onChange event to never fire for the field thus never calling updateStyle and causing TinyMCE to lose the data the user just entered. This patch adds a call to updateStyle into onSubmitForm so that the style is always recalculated.
