### PR TITLE
Fixed IE8 bug in image plugin - parentNode is undefined

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -19,23 +19,23 @@ tinymce.PluginManager.add('image', function(editor) {
 			callback({width: width, height: height});
 		}
 
-		img.onload = function() {
-			done(img.clientWidth, img.clientHeight);
-		};
-
-		img.onerror = function() {
-			done();
-		};
-
-		img.src = url;
-
 		var style = img.style;
-		style.visibility = 'hidden';
-		style.position = 'fixed';
-		style.bottom = style.left = 0;
-		style.width = style.height = 'auto';
-
-		document.body.appendChild(img);
+	        style.visibility = 'hidden';
+	        style.position = 'fixed';
+	        style.bottom = style.left = 0;
+	        style.width = style.height = 'auto';
+	
+	        document.body.appendChild(img);
+	
+	        img.onload = function () {
+	          done(img.clientWidth, img.clientHeight);
+	        };
+	
+	        img.onerror = function () {
+	          done();
+	        };
+	
+	       img.src = url;
 	}
 
 	function createImageList(callback) {


### PR DESCRIPTION
In IE8 the "done" function in the "getImageSize" function was firing before it was attached to the dom.  This was throwing a js error when trying to access the parentNode.removeChild method.  Reordering the events to be attached after the image is appended to the dom fixes this problem, since the image will now be in the dom when the done method is triggered.
