### PR TITLE
img.parentNode is null in IE10, viewed in IE8 Compatibility Mode

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -15,7 +15,8 @@ tinymce.PluginManager.add('image', function(editor) {
 		var img = document.createElement('img');
 
 		function done(width, height) {
-			img.parentNode.removeChild(img);
+			if(img.parentNode)
+				img.parentNode.removeChild(img);
 			callback({width: width, height: height});
 		}
 


### PR DESCRIPTION
We have a SAAS product where we are forced to use IE8 compatibility mode, since one of our JS components don't play nice in higher versions of IE. However, in this case the automatic image dimensions detection doesn't work now while inserting an image in a TinyMce editor. The proposed commit fixes this issue.
