### PR TITLE
Fixed auto resize plugin to resize iframe and <body> correctly

### DIFF
--- a/js/tinymce/plugins/autoresize/plugin.js
+++ b/js/tinymce/plugins/autoresize/plugin.js
@@ -28,15 +28,24 @@ tinymce.PluginManager.add('autoresize', function(editor) {
 	 * This method gets executed each time the editor needs to resize.
 	 */
 	function resize(e) {
-		var deltaSize, d = editor.getDoc(), body = d.body, de = d.documentElement, DOM = tinymce.DOM;
-		var resizeHeight = settings.autoresize_min_height, myHeight;
+		var deltaSize, d = editor.getDoc(), body = d.body, de = d.documentElement, DOM = tinymce.DOM,
+			resizeHeight = settings.autoresize_min_height, myHeight, marginTop, marginBottom;
 
-		if ((e.type == "setcontent" && e.initial) || (editor.plugins.fullscreen && editor.plugins.fullscreen.isFullscreen())) {
+		if (!body || !e || (e.type === "setcontent" && e.initial) ||
+				(editor.plugins.fullscreen && editor.plugins.fullscreen.isFullscreen())) {
 			return;
 		}
 
-		// Get height differently depending on the browser used
-		myHeight = tinymce.Env.ie ? body.scrollHeight : (tinymce.Env.webkit && body.clientHeight === 0 ? 0 : body.offsetHeight);
+		// Calculate outer height of the body element using CSS styles
+		marginTop = editor.dom.getStyle(body, 'margin-top', true);
+		marginBottom = editor.dom.getStyle(body, 'margin-bottom', true);
+		myHeight = body.offsetHeight + parseInt(marginTop, 10) + parseInt(marginBottom, 10);
+
+		// Make sure we have a valid height
+		if (isNaN(myHeight) || myHeight <= 0) {
+			// Get height differently depending on the browser used
+			myHeight = tinymce.Env.ie ? body.scrollHeight : (tinymce.Env.webkit && body.clientHeight === 0 ? 0 : body.offsetHeight);
+		}
 
 		// Don't make it smaller than the minimum height
 		if (myHeight > settings.autoresize_min_height) {


### PR DESCRIPTION
The <body> height was not being calculated correctly because it was not taking the margins into account. This fix will handle everything across browsers correctly.
