### PR TITLE
Fix crash when accessing lastFocusBookmark if editor is not visible

### DIFF
--- a/js/tinymce/classes/FocusManager.js
+++ b/js/tinymce/classes/FocusManager.js
@@ -176,7 +176,11 @@ define("tinymce/FocusManager", [
 					if (!isUIElement(getActiveElement()) && focusedEditor == editor) {
 						editor.fire('blur', {focusedEditor: null});
 						editorManager.focusedEditor = null;
-						editor.selection.lastFocusBookmark = null;
+
+						// Make sure selection is valid
+						if (editor.selection) {
+							editor.selection.lastFocusBookmark = null;
+						}
 					}
 				}, 0);
 			});


### PR DESCRIPTION
In certain circumstances the editor is not visible when this function is called, which results in a crash. Added a null check to fix this issue.
