### PR TITLE
Fix dragging and dropping issue inside of the noneditable plugin

### DIFF
--- a/js/tinymce/plugins/noneditable/plugin.js
+++ b/js/tinymce/plugins/noneditable/plugin.js
@@ -424,13 +424,13 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 				}
 			}
 		}
-        //This prevents a user from dropping content into a noneditable,
+        //This prevents a user from dropping content into a noneditable.
+        // ToDo: Add intelligence to move cursor to proper position and insert current dragged element.
         function handleDrop(e){
-           var contenteditablemce = e.target.getAttribute("data-mce-contenteditable");
+           var contenteditablemce = getContentEditable(e.target);
             if(contenteditablemce !== null){
                 return contenteditablemce === "true";
             }
-            return true;
         }
 
 		editor.on('mousedown', function(e) {


### PR DESCRIPTION
Quick fix for drag and dropping content inside of a tag marked as non contenteditable by the noneditable plugin. Without the fix content can be dragged and dropped into an element that is marked as noneditable by the noneditable plugin. This quick fix prevents the final drop from happening, there is a lot of room for improvement aka making it intelligent so that it puts the content on either side of the element that is marked as noneditable.
