### PR TITLE
autosave plugin stores content only if it was really changed #6629

### DIFF
--- a/js/tinymce/plugins/autosave/plugin.js
+++ b/js/tinymce/plugins/autosave/plugin.js
@@ -50,7 +50,7 @@ tinymce.PluginManager.add('autosave', function(editor) {
 	}
 
 	function storeDraft() {
-		if (!isEmpty()) {
+		if (!isEmpty() && editor.isDirty()) {
 			LocalStorage.setItem(prefix + "draft", editor.getContent({format: 'raw', no_events: true}));
 			LocalStorage.setItem(prefix + "time", new Date().getTime());
 			editor.fire('StoreDraft');


### PR DESCRIPTION
This fixes problematic behavior when editing text as described in bug #6629 (http://www.tinymce.com/develop/bugtracker_view.php?id=6629)

Content was always auto-saved, which means if the editor is loaded with stored text from the server, eventually it would be auto-saved over any previous modifications that might exist, rendering the recovery button useless.

The solution is to auto-save only if the content was modified (editor is dirty).
