### PR TITLE
Fixed potential crash with lastFocusBookmark during focusin event

### DIFF
--- a/js/tinymce/classes/FocusManager.js
+++ b/js/tinymce/classes/FocusManager.js
@@ -192,7 +192,11 @@ define("tinymce/FocusManager", [
 			var activeEditor = editorManager.activeEditor;
 
 			if (activeEditor && e.target.ownerDocument == document) {
-				activeEditor.selection.lastFocusBookmark = createBookmark(activeEditor.lastRng);
+
+				// Check to make sure we have a valid selection
+				if (activeEditor.selection) {
+					activeEditor.selection.lastFocusBookmark = createBookmark(activeEditor.lastRng);
+				}
 
 				// Fire a blur event if the element isn't a UI element
 				if (!isUIElement(e.target) && editorManager.focusedEditor == activeEditor) {


### PR DESCRIPTION
This is likely related to the same cause as https://github.com/tinymce/tinymce/pull/306

I can't come up with good steps to reproduce, but there are times when my editor(s) aren't visible, which is sometimes causing bad things to happen (like crashes).
