### PR TITLE
Fix for bug #6561, TinyMCE 3.5.9 and IE11, multi textareas additional line breaks

### DIFF
--- a/jscripts/tiny_mce/classes/EnterKey.js
+++ b/jscripts/tiny_mce/classes/EnterKey.js
@@ -169,7 +169,7 @@
 				}
 
 				// BR is needed in empty blocks on non IE browsers
-				if (!tinymce.isIE || tinymce.isIE11) {
+				if (!tinymce.isIE || !tinymce.isIE11) {
 					caretNode.innerHTML = '<br data-mce-bogus="1">';
 				}
 


### PR DESCRIPTION
This fixes the bug where TinyMCE 3.x adds extra <br /> elements at the end of a document in IE11
