### PR TITLE
Fixed issue where images are selectable even with objects_resizing

### DIFF
--- a/js/tinymce/classes/dom/ControlSelection.js
+++ b/js/tinymce/classes/dom/ControlSelection.js
@@ -267,11 +267,13 @@ define("tinymce/dom/ControlSelection", [
 						top: (targetHeight * handle[1] + selectedElmY) - (handleElm.offsetHeight / 2)
 					});
 				});
+
+				// Only add the selected attribute if this is element is actually resizable
+				selectedElm.setAttribute('data-mce-selected', '1');
+
 			} else {
 				hideResizeRect();
 			}
-
-			selectedElm.setAttribute('data-mce-selected', '1');
 		}
 
 		function hideResizeRect() {


### PR DESCRIPTION
is set to false. 

In version 3.x if objects_resizing was set to false, the selection box was not drawn around a selected object. This code was changed in 4.x, so when an object is selected the data-mce-selected attribute IS being set, which is probably incorrect (based on the prior version).

This code change will only set the attribute if the object is able to be selected
