### PR TITLE
Fixed bug #6626

### DIFF
--- a/js/tinymce/skins/lightgray/Content.Objects.less
+++ b/js/tinymce/skins/lightgray/Content.Objects.less
@@ -13,6 +13,13 @@
 	height: 5px;
 	border: 1px dashed #666;
 	margin-top: 15px;
+	page-break-before: always;
+}
+
+@media print {
+  .mce-pagebreak {
+    border: 0px;
+  }
 }
 
 .mce-item-anchor {


### PR DESCRIPTION
We resolve this bug using property "page-break-before: always". We also add a rule for printing does not appear a "dash border" (with border: 0px).
