### PR TITLE
Prevent propagation of anchor click on table plugin

### DIFF
--- a/js/tinymce/plugins/table/classes/Plugin.js
+++ b/js/tinymce/plugins/table/classes/Plugin.js
@@ -523,6 +523,7 @@ define("tinymce/tableplugin/Plugin", [
 					onclick: function(e) {
 						if (e.target.nodeName == 'A' && this.lastPos) {
 							e.preventDefault();
+							e.stopPropagation();
 
 							insertTable(this.lastPos[0] + 1, this.lastPos[1] + 1);
 


### PR DESCRIPTION
This solve an anoying issue, when you integrate TinyMCE on single page applications.
