### PR TITLE
Show selected state for video iframe elements (#6564)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 4.0.17 (2014-02-xx)
 	Added dfn,code,samp,kbd,var,cite,mark,q elements to the default remove formats list. Patch contributed by Naim Hammadi.
 	Fixed bug where the autolink plugin would steal focus when loaded on IE 9+.
 	Fixed so pagebreak elements in the editor breaks pages when printing. Patch contributed by penc.
+	Added support for highlighting the video icon when a video is added that produces an iframe. Patch contributed by monkeydiane.
 Version 4.0.16 (2014-01-31)
 	Fixed bug where the editor wouldn't be properly rendered on IE 10 depending on the document.readyState.
 Version 4.0.15 (2014-01-31)

--- a/js/tinymce/plugins/media/plugin.js
+++ b/js/tinymce/plugins/media/plugin.js
@@ -641,7 +641,7 @@ tinymce.PluginManager.add('media', function(editor, url) {
 	editor.addButton('media', {
 		tooltip: 'Insert/edit video',
 		onclick: showDialog,
-		stateSelector: 'img[data-mce-object=video]'
+		stateSelector: ['img[data-mce-object=video]', 'img[data-mce-object=iframe]']
 	});
 
 	editor.addMenuItem('media', {


### PR DESCRIPTION
http://www.tinymce.com/develop/bugtracker_view.php?id=6564
Added iframes get edited/added with the media plugin but aren't getting added to the selector which triggers the highlight for the menu button. Added in the iframe selector so that when you click on an added
video/iframe, the media button highlights.
