### PR TITLE
Added visual_anchor_class configuration option

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1979,8 +1979,8 @@ define("tinymce/Editor", [
 
 					case 'A':
 						if (!dom.getAttrib(elm, 'href', false)) {
-							value = dom.getAttrib(elm, 'name') || elm.id;
-							cls = 'mce-item-anchor';
+						    value = dom.getAttrib(elm, 'name') || elm.id;
+						    cls = settings.visual_anchor_class || 'mce-item-anchor';
 
 							if (value) {
 								if (self.hasVisual) {


### PR DESCRIPTION
This option enables you to configure a custom class to be added to anchors, if not configured the 'mce-item-anchor' will be used instead
