### PR TITLE
Keep style for other inline html tags after pressing enter or return 

### DIFF
--- a/js/tinymce/classes/EnterKey.js
+++ b/js/tinymce/classes/EnterKey.js
@@ -187,7 +187,7 @@ define("tinymce/EnterKey", [
 				// Clone any parent styles
 				if (settings.keep_styles !== false) {
 					do {
-						if (/^(SPAN|STRONG|B|EM|I|FONT|STRIKE|U)$/.test(node.nodeName)) {
+						if (/^(SPAN|STRONG|B|EM|I|FONT|STRIKE|U|VAR|CITE|DFN|CODE|MARK|Q|SUP|SUB)$/.test(node.nodeName)) {
 							// Never clone a caret containers
 							if (node.id == '_mce_caret') {
 								continue;


### PR DESCRIPTION
Keep styles for these HTML tags: var, cite, dfn, code, mark, q, sub, sup
