### PR TITLE
Keep style after pressing enter or return on samp tag

### DIFF
--- a/js/tinymce/classes/EnterKey.js
+++ b/js/tinymce/classes/EnterKey.js
@@ -188,7 +188,7 @@ define("tinymce/EnterKey", [
 				// Clone any parent styles
 				if (settings.keep_styles !== false) {
 					do {
-						if (/^(SPAN|STRONG|B|EM|I|FONT|STRIKE|U|VAR|CITE|DFN|CODE|MARK|Q|SUP|SUB)$/.test(node.nodeName)) {
+						if (/^(SPAN|STRONG|B|EM|I|FONT|STRIKE|U|VAR|CITE|DFN|CODE|MARK|Q|SUP|SUB|SAMP)$/.test(node.nodeName)) {
 							// Never clone a caret containers
 							if (node.id == '_mce_caret') {
 								continue;

--- a/js/tinymce/classes/html/Schema.js
+++ b/js/tinymce/classes/html/Schema.js
@@ -376,7 +376,7 @@ define("tinymce/html/Schema", [
 		textBlockElementsMap = createLookupTable('text_block_elements', 'h1 h2 h3 h4 h5 h6 p div address pre form ' +
 						'blockquote center dir fieldset header footer article section hgroup aside nav figure');
 		blockElementsMap = createLookupTable('block_elements', 'hr table tbody thead tfoot ' +
-						'th tr td li ol ul caption dl dt dd noscript menu isindex samp option ' +
+						'th tr td li ol ul caption dl dt dd noscript menu isindex option ' +
 						'datalist select optgroup', textBlockElementsMap);
 
 		each((settings.special || 'script noscript style textarea').split(' '), function(name) {


### PR DESCRIPTION
Unlike most inline and phrase elements, after pressing enter on a samp tag I don't get the expected result and the editor doesn't create a <p> tag with a <samp> inside of it but instead it create another <samp> after the first one

Senario:

1/ insert this  html content <p><samp>sample text</samp></p>
2/ put the cursor after the word "text" and press Enter

Expected:

<p><samp>sample text</samp></p>

<p><samp></samp></p>


Actual:

<p><samp>sample text</samp><samp></samp></p>
