### PR TITLE
Fixed issue where 'change' event is being fired before the isNotDirty

### DIFF
--- a/js/tinymce/classes/UndoManager.js
+++ b/js/tinymce/classes/UndoManager.js
@@ -220,8 +220,8 @@ define("tinymce/UndoManager", [
 				editor.fire('AddUndo', args);
 
 				if (index > 0) {
-					editor.fire('change', args);
 					editor.isNotDirty = false;
+					editor.fire('change', args);
 				}
 
 				return level;


### PR DESCRIPTION
property is updated. 

If you are relying on the 'change' event to do something, the 'isNotDirty' flag hasn't been updated yet so you cannot rely on the editor.isDirty() function to return the correct value. If my editor value has changed, isDirty() should be true...but in this case the flag hasn't flipped yet.
