### PR TITLE
Fixed various issues with Table plugin API not doing null checks.

### DIFF
--- a/js/tinymce/plugins/table/classes/Plugin.js
+++ b/js/tinymce/plugins/table/classes/Plugin.js
@@ -170,6 +170,11 @@ define("tinymce/tableplugin/Plugin", [
 
 			cellElm = cellElm || cells[0];
 
+			if (!cellElm) {
+				// If this element is null, return now to avoid crashing.
+				return;
+			}
+
 			data = {
 				width: removePxSuffix(dom.getStyle(cellElm, 'width') || dom.getAttrib(cellElm, 'width')),
 				height: removePxSuffix(dom.getStyle(cellElm, 'height') || dom.getAttrib(cellElm, 'height')),
@@ -288,6 +293,10 @@ define("tinymce/tableplugin/Plugin", [
 			});
 
 			rowElm = rows[0];
+			if (!rowElm) {
+				// If this element is null, return now to avoid crashing.
+				return;
+			}
 
 			data = {
 				height: removePxSuffix(dom.getStyle(rowElm, 'height') || dom.getAttrib(rowElm, 'height')),

--- a/js/tinymce/plugins/table/classes/TableGrid.js
+++ b/js/tinymce/plugins/table/classes/TableGrid.js
@@ -114,7 +114,7 @@ define("tinymce/tableplugin/TableGrid", [
 
 			each(table.rows, function(row) {
 				each(row.cells, function(cell) {
-					if (dom.hasClass(cell, 'mce-item-selected') || cell == selectedCell.elm) {
+					if (dom.hasClass(cell, 'mce-item-selected') || (selectedCell && cell == selectedCell.elm)) {
 						rows.push(row);
 						return false;
 					}
@@ -219,11 +219,14 @@ define("tinymce/tableplugin/TableGrid", [
 			// Restore selection to start position if it still exists
 			buildGrid();
 
-			// Restore the selection to the closest table position
-			row = grid[Math.min(grid.length - 1, startPos.y)];
-			if (row) {
-				selection.select(row[Math.min(row.length - 1, startPos.x)].elm, true);
-				selection.collapse(true);
+			// If we have a valid startPos object
+			if (startPos) {
+				// Restore the selection to the closest table position
+				row = grid[Math.min(grid.length - 1, startPos.y)];
+				if (row) {
+					selection.select(row[Math.min(row.length - 1, startPos.x)].elm, true);
+					selection.collapse(true);
+				}
 			}
 		}
 
@@ -311,11 +314,13 @@ define("tinymce/tableplugin/TableGrid", [
 					});
 				});
 
-				// Use selection
-				startX = startPos.x;
-				startY = startPos.y;
-				endX = endPos.x;
-				endY = endPos.y;
+				// Use selection, but make sure startPos is valid before accessing
+				if (startPos) {
+					startX = startPos.x;
+					startY = startPos.y;
+					endX = endPos.x;
+					endY = endPos.y;
+				}
 			}
 
 			// Find start/end cells
@@ -393,6 +398,11 @@ define("tinymce/tableplugin/TableGrid", [
 					return !posY;
 				}
 			});
+
+			// If posY is undefined there is nothing for us to do here...just return to avoid crashing below
+			if (posY === undefined) {
+				return;
+			}
 
 			for (x = 0; x < grid[0].length; x++) {
 				// Cell not found could be because of an invalid table structure


### PR DESCRIPTION
The Table plugin API fails in various situations when calling execCommand without a valid table/cell selection. This is easily reproducible in the TinyMCE demo, ex: 
1)Open the TinyMCE demo, don't select a table
2a)tinymce.activeEditor.execCommand('mceTableRowProps')
2b)tinymce.activeEditor.execCommand('mceTableDeleteRow')
etc.
I won't list all situations where the plugin crashes here. 

I also realize that I probably should not be making these API calls without a valid table/cell selection, but at the same time if TinyMCE is going to support an API it should except to handle fail conditions.
