### PR TITLE
Fixed issue where the autoresize plugin wouldn't work if it was missing a valid event object.

### DIFF
--- a/js/tinymce/plugins/autoresize/plugin.js
+++ b/js/tinymce/plugins/autoresize/plugin.js
@@ -31,7 +31,7 @@ tinymce.PluginManager.add('autoresize', function(editor) {
 		var deltaSize, d = editor.getDoc(), body = d.body, de = d.documentElement, DOM = tinymce.DOM,
 			resizeHeight = settings.autoresize_min_height, myHeight, marginTop, marginBottom;
 
-		if (!body || !e || (e.type === "setcontent" && e.initial) ||
+		if (!body || (e && e.type === "setcontent" && e.initial) ||
 				(editor.plugins.fullscreen && editor.plugins.fullscreen.isFullscreen())) {
 			return;
 		}


### PR DESCRIPTION
A crash was fixed earlier when 'e' was null (accessing was crashing), but a valid event isn't necessary for the resize function to work. If you called
editor.execCommand('mceAutoResize') the editor would not resize because the initial null check on 'e' was false and the rest of the resize code was not executed.
