### PR TITLE
Prevent tinyMCE from overwriting document.id

### DIFF
--- a/js/tinymce/classes/ui/ComboBox.js
+++ b/js/tinymce/classes/ui/ComboBox.js
@@ -49,7 +49,11 @@ define("tinymce/ui/ComboBox", [
 				var elm = e.target;
 
 				while (elm) {
-					if (elm.id && elm.id.indexOf('-open') != -1) {
+					var id = "";
+					if(elm.nodeType !== 9){ // Document node
+						elm.id = id = (elm.getAttribute && elm.getAttribute('id')) || "";
+					}
+					if (id.indexOf('-open') != -1) {
 						self.fire('action');
 
 						if (settings.menu) {


### PR DESCRIPTION
Mootools uses document.id as a longhand for $. When TinyMCE sets and searches for id in the document it gets overwritten.
