### PR TITLE
Fix inline image dialog javascript error

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version 4.0.17 (2014-02-xx)
 	Added var,cite,dfn,code,mark,q,sup,sub to the list of elements that gets cloned on enter. Patch contributed by Naim Hammadi.
 	Added new visual_anchor_class option to specify a custom class for inline anchors. Patch contributed by Naim Hammadi.
 	Added support for paste_data_images on WebKit/Blink when the user pastes image data.
+	Added support for highlighting the video icon when a video is added that produces an iframe. Patch contributed by monkeydiane.
 	Fixed bug where the ObjectResizeStart event didn't get fired properly by the ControlSelection class.
 	Fixed bug where the autolink plugin would steal focus when loaded on IE 9+.
 	Fixed bug where the editor save method would remove the current selection when called on an inline editor.
@@ -17,7 +18,7 @@ Version 4.0.17 (2014-02-xx)
 	Fixed bug where the formatter would apply inline formatting outside the current word in if the selection was collapsed.
 	Fixed so pagebreak elements in the editor breaks pages when printing. Patch contributed by penc.
 	Fixed so UndoManager events pass though the original event that created the undo level such as a keydown, blur etc.
-	Added support for highlighting the video icon when a video is added that produces an iframe. Patch contributed by monkeydiane.
+	Fixed bug where the image dialog would get stuck if the src was removed. Patch contribued by monkeydiane.
 Version 4.0.16 (2014-01-31)
 	Fixed bug where the editor wouldn't be properly rendered on IE 10 depending on the document.readyState.
 Version 4.0.15 (2014-01-31)

--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -149,6 +149,7 @@ tinymce.PluginManager.add('image', function(editor) {
 				if (!data.src) {
 					if (imgElm) {
 						dom.remove(imgElm);
+						editor.focus();
 						editor.nodeChanged();
 					}
 


### PR DESCRIPTION
http://www.tinymce.com/develop/bugtracker_view.php?id=6717
Focus the editor after deleting the image so that the selection resets
and the old selection (where the image has the selection) isn't used,
which previously caused a javascript error on save.

Also moved the previous changelog entry I made to where all the other Adds are
