### PR TITLE
Fix JSDoc mini typo.

### DIFF
--- a/js/tinymce/plugins/compat3x/tiny_mce_popup.js
+++ b/js/tinymce/plugins/compat3x/tiny_mce_popup.js
@@ -295,7 +295,7 @@ var tinyMCEPopup = {
 	 * native version use the callback method instead then it can be extended.
 	 *
 	 * @method alert
-	 * @param {String} t Title for the new alert dialog.
+	 * @param {String} tx Title for the new alert dialog.
 	 * @param {function} cb Callback function to be executed after the user has selected ok.
 	 * @param {Object} s Optional scope to execute the callback in.
 	 */


### PR DESCRIPTION
Fix JSDoc mini typo. Reported by @mauryaratan here https://core.trac.wordpress.org/ticket/27074. 
