### PR TITLE
Prevent ForceBlocks processing elements with data-mce-type attribute

### DIFF
--- a/js/tinymce/classes/ForceBlocks.js
+++ b/js/tinymce/classes/ForceBlocks.js
@@ -72,7 +72,7 @@ define("tinymce/ForceBlocks", [], function() {
 			rootNodeName = rootNode.nodeName.toLowerCase();
 			while (node) {
 				// TODO: Break this up, too complex
-				if (((node.nodeType === 3 || (node.nodeType == 1 && !blockElements[node.nodeName]))) &&
+				if (((node.nodeType === 3 || (node.nodeType == 1 && !blockElements[node.nodeName] && !node.getAttribute('data-mce-type')))) &&
 					schema.isValidChild(rootNodeName, forcedRootBlock.toLowerCase())) {
 					// Remove empty text nodes
 					if (node.nodeType === 3 && node.nodeValue.length === 0) {


### PR DESCRIPTION
As in - https://github.com/tinymce/tinymce/blob/master/js/tinymce/classes/html/DomParser.js#L318 - prevent ForceBlocks from processing nodes that have a data-mce-type attribute.