### PR TITLE
Tables: border spacing and width as CSS properties

### DIFF
--- a/js/tinymce/plugins/table/classes/Plugin.js
+++ b/js/tinymce/plugins/table/classes/Plugin.js
@@ -113,7 +113,9 @@ define("tinymce/tableplugin/Plugin", [
 
 						editor.dom.setStyles(tableElm, {
 							width: addSizeSuffix(data.width),
-							height: addSizeSuffix(data.height)
+							height: addSizeSuffix(data.height),
+							borderSpacing: addSizeSuffix(data.cellspacing),
+							borderWidth: addSizeSuffix(data.border)
 						});
 
 						// Toggle caption on/off


### PR DESCRIPTION
This fixes problems where a stylesheet sets border spacing and/or
width, which overrides the cellspacing and border attributes on
a table element.

See http://www.tinymce.com/develop/bugtracker_view.php?id=5835