### PR TITLE
Fixed advanced space not submitting.

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -123,6 +123,8 @@ tinymce.PluginManager.add('image', function(editor) {
 		}
 
 		function onSubmitForm() {
+			updateStyle();
+
 			function waitLoad(imgElm) {
 				function selectImage() {
 					imgElm.onload = imgElm.onerror = null;
@@ -144,7 +146,6 @@ tinymce.PluginManager.add('image', function(editor) {
 				imgElm.onerror = selectImage;
 			}
 			
-			updateStyle();
 			recalcSize();
 
 			data = tinymce.extend(data, win.toJSON());


### PR DESCRIPTION
If 'OK' or Enter were pressed before leaving the advanced horizontal or vertical space textboxes, their values weren't submitted. Fixed by moving updateStyle() above waitLoad() in onSubmitForm().
