### PR TITLE
Allow suppression of alt and dimension fields in image plugin.

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -288,11 +288,11 @@ tinymce.PluginManager.add('image', function(editor) {
 			imageListCtrl
 		];
 
-		if (!editor.settings.image_hide_alt) {
+		if (editor.settings.image_description !== false) {
 			generalFormItems.push({name: 'alt', type: 'textbox', label: 'Image description'});
 		}
 
-		if (!editor.settings.image_hide_dimensions) {
+		if (editor.settings.image_dimensions !== false) {
 			generalFormItems.push({
 				type: 'container',
 				label: 'Dimensions',


### PR DESCRIPTION
This allows implementations of the image plugin to suppress the `alt` and Dimensions fields.
