### PR TITLE
Use tooltips for better consistency

### DIFF
--- a/js/tinymce/plugins/save/plugin.js
+++ b/js/tinymce/plugins/save/plugin.js
@@ -76,15 +76,15 @@ tinymce.PluginManager.add('save', function(editor) {
 
 	editor.addButton('save', {
 		icon: 'save',
-		text: 'Save',
+		tooltip: 'Save',
 		cmd: 'mceSave',
 		disabled: true,
 		onPostRender: stateToggle
 	});
 
 	editor.addButton('cancel', {
-		text: 'Cancel',
 		icon: false,
+		tooltip: 'Cancel',
 		cmd: 'mceCancel',
 		disabled: true,
 		onPostRender: stateToggle


### PR DESCRIPTION
Use tooltips instead of text buttons for better consistency with most toolbar buttons. Also changed order of entries for readability.
