### PR TITLE
Fix setting format inconsistent

### DIFF
--- a/js/tinymce/classes/html/Schema.js
+++ b/js/tinymce/classes/html/Schema.js
@@ -341,7 +341,7 @@ define("tinymce/html/Schema", [
 				}
 			} else {
 				// Create custom map
-				value = makeMap(value, ',', makeMap(value.toUpperCase(), ' '));
+				value = makeMap(value, ' ', makeMap(value.toUpperCase(), ' '));
 			}
 
 			return value;


### PR DESCRIPTION
Schema setting value should be split with spacing not comma.
