### PR TITLE
#6837 Allow flow content inside of anchors

### DIFF
--- a/js/tinymce/classes/html/Schema.js
+++ b/js/tinymce/classes/html/Schema.js
@@ -216,6 +216,7 @@ define("tinymce/html/Schema", [
 
 		// Extend with HTML5 elements
 		if (type != "html4") {
+			add("a", "href target rel media hreflang type", phrasingContent, flowContent);
 			add("wbr");
 			add("ruby", "", phrasingContent, "rt rp");
 			add("figcaption", "", flowContent);

--- a/tests/tinymce/html/Schema.js
+++ b/tests/tinymce/html/Schema.js
@@ -268,6 +268,18 @@ test('isValidChild', function() {
 	ok(!schema.isValidChild('p', 'body'));
 });
 
+test('isValidChild of anchor', function(){
+	var schemaHtml5, schemaHtml4;
+
+	expect(2);
+
+	schemaHtml5 = new tinymce.html.Schema({schema: "html5"});
+	schemaHtml4 = new tinymce.html.Schema({schema: "html4"});
+
+	ok(schemaHtml5.isValidChild('a', 'p'));
+	ok(!schemaHtml4.isValidChild('a', 'p'));
+});
+
 test('getElementRule', function() {
 	var schema;
 


### PR DESCRIPTION
This change allows flow content inside of anchor elements if mode is not HTML4. Since the HTML5 specification actually defines the anchors content model as transparent, this is technically not correct, but it is definately better to be more tolerant than the standard instead of being more strict. As far as I can tell, properly supporting transparent content model would require a lot of changes and I'm not sure if it is worth the effort.
See http://www.tinymce.com/develop/bugtracker_view.php?id=6837
