### PR TITLE
set baseURL with document.currentScript if available 

### DIFF
--- a/js/tinymce/classes/EditorManager.js
+++ b/js/tinymce/classes/EditorManager.js
@@ -101,23 +101,34 @@ define("tinymce/EditorManager", [
 			if (preInit) {
 				baseURL = preInit.base || preInit.baseURL;
 				suffix = preInit.suffix;
-			} else {
-				// Get base where the tinymce script is located
-				var scripts = document.getElementsByTagName('script');
-				for (var i = 0; i < scripts.length; i++) {
-					var src = scripts[i].src;
-
-					// Script types supported:
-					// tinymce.js tinymce.min.js tinymce.dev.js
-					// tinymce.jquery.js tinymce.jquery.min.js tinymce.jquery.dev.js
-					// tinymce.full.js tinymce.full.min.js tinymce.full.dev.js
-					if (/tinymce(\.full|\.jquery|)(\.min|\.dev|)\.js/.test(src)) {
-						if (src.indexOf('.min') != -1) {
-							suffix = '.min';
+			} 
+			else {
+				// use document.currentScript if available ( https://developer.mozilla.org/en/docs/Web/API/document.currentScript )
+				if ( typeof document.currentScript == 'string' ) {
+					var src = document.currentScript;
+					if (src.indexOf('.min') != -1) {
+						suffix = '.min';
+					}
+					baseURL = src.substring(0, src.lastIndexOf('/'));
+				}
+				else {
+					// Get base where the tinymce script is located
+					var scripts = document.getElementsByTagName('script');
+					for (var i = 0; i < scripts.length; i++) {
+						var src = scripts[i].src;
+	
+						// Script types supported:
+						// tinymce.js tinymce.min.js tinymce.dev.js
+						// tinymce.jquery.js tinymce.jquery.min.js tinymce.jquery.dev.js
+						// tinymce.full.js tinymce.full.min.js tinymce.full.dev.js
+						if (/tinymce(\.full|\.jquery|)(\.min|\.dev|)\.js/.test(src)) {
+							if (src.indexOf('.min') != -1) {
+								suffix = '.min';
+							}
+	
+							baseURL = src.substring(0, src.lastIndexOf('/'));
+							break;
 						}
-
-						baseURL = src.substring(0, src.lastIndexOf('/'));
-						break;
 					}
 				}
 			}


### PR DESCRIPTION
use document.currentScript if available 

we use a js file compressor, so user dowload only one compacted js file with all script needed (there is many raisons for doing that)
for tinymce the path is wrong because the regex not match the path and is not the real path of script.

so in our compressor each script is preceded by this declaration:
`var src = "real/path/to/script.js";
( typeof document.currentScript == 'string' ) ? document.currentScript.src = src : document.currentScript = { 'src' : src };`

in this case document.currentScript is always set on all browser and we have no issue.

https://developer.mozilla.org/en/docs/Web/API/document.currentScript

i have read this code and know this can be fixed with preInit.baseURL, but document.currentScript is a more efficent way to get base Url.

Regards
