### PR TITLE
Selection.getContent issue in Chrome fix

### DIFF
--- a/js/tinymce/classes/dom/Selection.js
+++ b/js/tinymce/classes/dom/Selection.js
@@ -102,7 +102,7 @@ define("tinymce/dom/Selection", [
 			self.editor.fire('BeforeGetContent', args);
 
 			if (args.format == 'text') {
-				return self.isCollapsed() ? '' : (rng.text || (se.toString ? se.toString() : ''));
+				return self.isCollapsed() ? '' : (rng.text || (se.toString ? se.toString() : '') || rng.toString());
 			}
 
 			if (rng.cloneContents) {


### PR DESCRIPTION
Fixes an issue in Chrome where Selection.getContent does not always return selected text

Given:
* The inline editor is opened in Chrome
* A piece of text (text only!) is selected
* A button within a menubutton is clicked
Then:
* editor.selection.getContent({format: 'text'}) returns an empty string

This commit fixes the issue, but I am not certain rng.toString will never produce any gibberish.