### PR TITLE
Avoid returning an undefined value from editor.execCommand when a comman...

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1424,8 +1424,12 @@ define("tinymce/Editor", [
 			}
 
 			// Browser commands
-			self.getDoc().execCommand(cmd, ui, value);
-			self.fire('ExecCommand', {command: cmd, ui: ui, value: value});
+			if (self.getDoc().execCommand(cmd, ui, value)) {
+				self.fire('ExecCommand', {command: cmd, ui: ui, value: value});
+				return true;
+			}
+
+			return false;
 		},
 
 		/**

--- a/tests/tinymce/Editor.js
+++ b/tests/tinymce/Editor.js
@@ -286,3 +286,15 @@ test('insertContent merge', function() {
 	editor.insertContent('<em><strong>b</strong></em>', {merge: true});
 	equal(editor.getContent(), '<p><strong>a<em>b</em></strong></p>');
 });
+
+test('execCommand return values', function() {
+	var expectedFailure = editor.execCommand("Bogus");
+	strictEqual(expectedFailure, false, "Return value for a completely unhandled command");
+
+	var expectedSuccess = editor.execCommand("SelectAll");
+	strictEqual(expectedSuccess, true, "Return value for an editor handled command");
+
+	// Would be nice to have a test here for a command that WILL be passed to the Browser
+	// and will return true, but I can't easily find/think of one that will make it to
+	// the browser and be handled with true on all platforms?
+});


### PR DESCRIPTION
...d reaches the browser.

This may be a somewhat contrived scenario but for any client who depends upon the accuracy of execCommand's boolean return value, it seems best to formalize and guarantee that it will be true or false and not undefined. Do you have any misgivings about e.g. the possibility that the ExecCommand event would not be fired when the browser returns false to execCommand? In any case it seems that if control reaches the end of the method then false should be returned.
