### PR TITLE
Restore support for adding "px" to non-numeric setStyle arguments

### DIFF
--- a/js/tinymce/classes/dom/DOMUtils.js
+++ b/js/tinymce/classes/dom/DOMUtils.js
@@ -617,7 +617,7 @@ define("tinymce/dom/DOMUtils", [
 						});
 
 						// Default px suffix on these
-						if (typeof(value) === 'number' && !numericCssMap[name]) {
+						if (((typeof(value) === 'number') || /^[\-0-9\.]+$/.test(value)) && !numericCssMap[name]) {
 							value += 'px';
 						}
 

--- a/tests/tinymce/dom/DOMUtils.js
+++ b/tests/tinymce/dom/DOMUtils.js
@@ -313,7 +313,7 @@
 		DOM.remove('test');
 	});
 
-	test('setGetStyles', 7, function() {
+	test('setGetStyles', 9, function() {
 		DOM.add(document.body, 'div', {id : 'test'});
 
 		DOM.setStyle('test', 'font-size', '20px');
@@ -331,6 +331,12 @@
 		equal(DOM.getStyle('test2', 'fontSize'), '22px');
 		equal(DOM.getStyle('test3', 'fontSize'), '22px');
 		equal(DOM.getStyle('test4', 'fontSize'), '22px');
+
+		DOM.setStyle('test', 'fontSize', 23);
+		equal(DOM.getStyle('test', 'fontSize'), '23px', null, tinymce.isWebKit);
+
+		DOM.setStyle('test', 'fontSize', '24');
+		equal(DOM.getStyle('test', 'fontSize'), '24px', null, tinymce.isWebKit);
 
 		DOM.setAttrib('test', 'style', '');
 


### PR DESCRIPTION
Unless you had a specific reason to drop support for this, this just restores the TinyMCE3 behavior of dom.setStyle that would accept a non-numeric string e.g. "32" and convert it to a "32px" as TinyMCE4 currently does for pure numeric values. I also added tests to cover expected behavior of adding px both for a string and a numeric value that doesn't include px already.
