### PR TITLE
Restore ability to set font sizes in text=value format

### DIFF
--- a/js/tinymce/classes/ui/FormatControls.js
+++ b/js/tinymce/classes/ui/FormatControls.js
@@ -509,7 +509,14 @@ define("tinymce/ui/FormatControls", [
 			var fontsize_formats = editor.settings.fontsize_formats || defaultFontsizeFormats;
 
 			each(fontsize_formats.split(' '), function(item) {
-				items.push({text: item, value: item});
+				var text = item, value = item;
+				// Allow text=value font sizes.
+				var values = item.split('=');
+				if (values.length > 1) {
+					text = values[0];
+					value = values[1];
+				}
+				items.push({text: text, value: value});
 			});
 
 			return {


### PR DESCRIPTION
In TinyMCE 3.x theme_advanced_font_sizes could be used to specify font sizes with text that differed from the value (e.g. '110=11px,120=12px' where 110 would appear in the font selection list and when applied 11px was the value used). fontsize_formats in 4.x doesn't support this.

This pull request adds support for specifying text=value font sizes in fontsize_formats.
