### PR TITLE
Added test case for expected browser execCommand "true" return

### DIFF
--- a/tests/tinymce/Editor.js
+++ b/tests/tinymce/Editor.js
@@ -294,7 +294,7 @@ test('execCommand return values', function() {
 	var expectedSuccess = editor.execCommand("SelectAll");
 	strictEqual(expectedSuccess, true, "Return value for an editor handled command");
 
-	// Would be nice to have a test here for a command that WILL be passed to the Browser
-	// and will return true, but I can't easily find/think of one that will make it to
-	// the browser and be handled with true on all platforms?
+	// At least on WebKit/Mac, this falls through to the browser case and does return true
+	var expectedSuccess = editor.execCommand("InsertLineBreak");
+	strictEqual(expectedSuccess, true, "Return value for a browser-handled command");
 });


### PR DESCRIPTION
Thank you for taking the other pull requests I sent. I discovered that (for now?) TinyMCE doesn't implement "InsertLineBreak" on its own and it ultimately passes through to the browser where it is handled with "true" return value, at least on WebKit. In case this is helpful it would supercede my comment in the previous tests that lamented the lack of such an example. I'm not sure though how it behaves for other platforms.
