### PR TITLE
Avoid init-time exception for applewebdata: based URL found in native platform WebView

### DIFF
--- a/js/tinymce/classes/EditorManager.js
+++ b/js/tinymce/classes/EditorManager.js
@@ -127,8 +127,17 @@ define("tinymce/EditorManager", [
 		setup: function() {
 			var self = this, baseURL, documentBaseURL, suffix = "", preInit, src;
 
-			// Get base URL for the current document
-			documentBaseURL = document.location.href.replace(/[\?#].*$/, '').replace(/[\/\\][^\/]+$/, '');
+			// Get base URL for the current document, accommodating the possibility
+			// that we have a weird "applewebdata:" based URL e.g. if we are embedded
+			// in a native WebKit application on Mac or iOS.
+			var thisHref = document.location.href;
+			if (thisHref.indexOf("applewebdata:") === 0) {
+				documentBaseURL = thisHref;
+			}
+			else {
+				documentBaseURL = thisHref.replace(/[\?#].*$/, '').replace(/[\/\\][^\/]+$/, '');
+			}
+			
 			if (!/[\/\\]$/.test(documentBaseURL)) {
 				documentBaseURL += '/';
 			}


### PR DESCRIPTION
This affects apps that use TinyMCE embedded into a WebKit view in a native app where the content is not file based. In this scenario the base URL for a document is a custom Apple scheme like "applewebdata://5B6058BF-649C-431B-BF28-358D68108A9E" and the default behavior of TinyMCE strips this to just "applewebdata:/" which causes errors later in URI processing. 

The patch provided will special case applewebdata: URLs leaving them as-is, which I've tested over a couple years at least with TinyMCE3 and it seems to work well.

Unfortunately I couldn't see an obvious way to add a unit test for this scenario. The behavior without this patch is if you were to try loading TinyMCE into a WebKit based view on Mac or iOS, it will throw an exception in initializing EditorManager, and thus the whole load of TinyMCE ends up failing.
