### PR TITLE
Add file_browser_callback_enabled setting to enable file browser icon regarding filetype

### DIFF
--- a/js/tinymce/classes/ui/FilePicker.js
+++ b/js/tinymce/classes/ui/FilePicker.js
@@ -29,22 +29,37 @@ define("tinymce/ui/FilePicker", [
 		 * @param {Object} settings Name/value object with settings.
 		 */
 		init: function(settings) {
-			var self = this, editor = tinymce.activeEditor, fileBrowserCallback;
+			var self = this, editor = tinymce.activeEditor, fileBrowserCallback, fileBrowserCallbackEnabled;
 
 			settings.spellcheck = false;
 
 			fileBrowserCallback = editor.settings.file_browser_callback;
 			if (fileBrowserCallback) {
-				settings.icon = 'browse';
+			
+				fileBrowserCallbackEnabled = editor.settings.file_browser_callback_enabled;
+				
+				if (fileBrowserCallbackEnabled && typeof(fileBrowserCallbackEnabled) == 'string') {
+					// Option enabled set to a string, check if the current fileBrowser match the setting
+					// Current filetype possible values are file, image, and media
+					// file_browser_callback_enabled should be set to something like file|image
+					fileBrowserCallbackEnabled = fileBrowserCallbackEnabled.indexOf(settings.filetype) !== -1;
+				} else if (typeof(fileBrowserCallbackEnabled) == 'undefined') {
+					// Option not set, consider it enabled
+					fileBrowserCallbackEnabled = true;
+				}
+				
+				if (fileBrowserCallbackEnabled) {
+					settings.icon = 'browse';
 
-				settings.onaction = function() {
-					fileBrowserCallback(
-						self.getEl('inp').id,
-						self.getEl('inp').value,
-						settings.filetype,
-						window
-					);
-				};
+					settings.onaction = function() {
+						fileBrowserCallback(
+							self.getEl('inp').id,
+							self.getEl('inp').value,
+							settings.filetype,
+							window
+						);
+					};
+				}
 			}
 
 			self._super(settings);


### PR DESCRIPTION
See http://www.tinymce.com/develop/bugtracker_view.php?id=6047

A new option file_browser_callback_enabled is created to determine if the browser icon should be shown or not.

For now, the filetype possible are : 
- file (used in link panel)
- image (used in image panel and poster in video panel)
- media (used in 2 times in media panel)

the file_browser_callback_enabled settings could be set to : 
- undefined (default) or true : enabled file_browser_callback if provided everywhere
- false : disable file_browser_callback everywhere
- string : enable file_browser_callback when the filetype is containing in the string.

Exemple : in order to allow only image and file browser : 
- Set file_browser_callback like before
- set file_browser_callback_enabled to "file|image"

I didn't find any place to add automatic documentation for this new setting. Did I miss somthing?
