### PR TITLE
Fix bug to fire postprocess and other save events right before remove()

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -2041,8 +2041,8 @@ define("tinymce/Editor", [
 			var self = this;
 
 			if (!self.removed) {
-				self.removed = 1;
 				self.save();
+				self.removed = 1;
 
 				// Remove any hidden input
 				if (self.hasHiddenInput) {


### PR DESCRIPTION
Fixes issue possibly introduced in 8a0136c0ed where editor.removed is set to true
before it runs save().  This blocks postprocess and other events from firing
properly during the save.

For instance, the default content `<p>&nbsp;</p>` would remain after running
tinymce.remove() instead of being cleaned up.
