### PR TITLE
Fix issue in fullpage plugin

### DIFF
--- a/js/tinymce/plugins/fullpage/plugin.js
+++ b/js/tinymce/plugins/fullpage/plugin.js
@@ -194,7 +194,7 @@ tinymce.PluginManager.add('fullpage', function(editor) {
 			}
 
 			elm.attr('content', 'text/html; charset=' + data.docencoding);
-		} else {
+		} else if(elm) {
 			elm.remove();
 		}
 


### PR DESCRIPTION
There might  be some cases in the fullpage code where elm is null. Don't call remove on it if it not there to start with.
