### PR TITLE
Remove spans before inserting content

### DIFF
--- a/js/tinymce/plugins/spellchecker/classes/Plugin.js
+++ b/js/tinymce/plugins/spellchecker/classes/Plugin.js
@@ -87,8 +87,8 @@ define("tinymce/spellcheckerplugin/Plugin", [
 				items.push({
 					text: suggestion,
 					onclick: function() {
-						editor.insertContent(editor.dom.encode(suggestion));
 						editor.dom.remove(spans);
+						editor.insertContent(editor.dom.encode(suggestion));
 						checkIfFinished();
 					}
 				});


### PR DESCRIPTION
In IE8 and below the content seems to get inserted into the spans and therefore is removed when the spans are removed. This fix removes the spans before inserting the new word.