### PR TITLE
Fix for IE7

### DIFF
--- a/js/tinymce/plugins/spellchecker/classes/DomTextMatcher.js
+++ b/js/tinymce/plugins/spellchecker/classes/DomTextMatcher.js
@@ -244,9 +244,9 @@ define("tinymce/spellcheckerplugin/DomTextMatcher", [], function() {
 			index = typeof(index) == "number" ? "" + index : null;
 
 			for (var i = 0; i < elements.length; i++) {
-				var element = elements[i], dataIndex = element.getAttribute('data-mce-index');
+				var element = elements[i], dataIndex = (window.attachEvent && !window.addEventListener) ? element['data-mce-index'] : element.getAttribute('data-mce-index');
 
-				if (dataIndex !== null && dataIndex.length) {
+				if (dataIndex !== null && dataIndex !== undefined) {
 					if (dataIndex === index || index === null) {
 						wrappers.push(element);
 					}


### PR DESCRIPTION
getAttribute does not work properly in IE7. This fix uses array style access in IE8 and below (the spellchecker would not turn off in IE7, as there were no elements found to unwrap).