### PR TITLE
Fix for Window does not get focus on IE8

### DIFF
--- a/js/tinymce/classes/ui/Window.js
+++ b/js/tinymce/classes/ui/Window.js
@@ -314,7 +314,9 @@ define("tinymce/ui/Window", [
 				self.statusbar.postRender();
 			}
 
-			self.focus();
+	            	setTimeout(function() {
+	               		self.focus();
+	            	}, 0);
 
 			this.dragHelper = new DragHelper(self._id + '-dragh', {
 				start: function() {


### PR DESCRIPTION
Added a Timeout to fix IE8 issue: on IE8 the dialog did not get focus, adding the timeout fixes the problem.