### PR TITLE
Add splitTableAfterRow action for tables

### DIFF
--- a/js/tinymce/plugins/table/classes/Plugin.js
+++ b/js/tinymce/plugins/table/classes/Plugin.js
@@ -249,6 +249,7 @@ define("tinymce/tableplugin/Plugin", [
 			menu: [
 				{text: 'Insert row before', onclick: cmd('mceTableInsertRowBefore'), onPostRender: postRenderCell},
 				{text: 'Insert row after', onclick: cmd('mceTableInsertRowAfter'), onPostRender: postRenderCell},
+				{text: 'Start new table', onclick: cmd('mceTableSplitTableAfterRow'), onPostRender: postRenderCell},
 				{text: 'Delete row', onclick: cmd('mceTableDeleteRow'), onPostRender: postRenderCell},
 				{text: 'Row properties', onclick: cmd('mceTableRowProps'), onPostRender: postRenderCell},
 				{text: '-'},
@@ -326,6 +327,10 @@ define("tinymce/tableplugin/Plugin", [
 
 			mceTableInsertRowAfter: function(grid) {
 				grid.insertRow();
+			},
+
+			mceTableSplitTableAfterRow: function(grid) {
+				grid.splitTableAfterRow();
 			},
 
 			mceTableInsertColBefore: function(grid) {

--- a/js/tinymce/plugins/table/classes/TableGrid.js
+++ b/js/tinymce/plugins/table/classes/TableGrid.js
@@ -380,6 +380,50 @@ define("tinymce/tableplugin/TableGrid", [
 			}
 		}
 
+
+		function splitTableAfterRow() {
+			var cell, x, y, rowElm, tableElm, newTableElm, newRow, brElm, thead, newThead, bodyElm;
+			// Find first/last row
+			each(grid, function(row, y) {
+				each(row, function(cell, x) {
+					if (isCellSelected(cell)) {
+						cell = cell.elm;
+						rowElm = cell.parentNode;
+					}
+				});
+			});
+		
+			// Get this row's parent table element 
+			tableElm = dom.getParent(rowElm, 'table');
+
+			// Insert a blank row to split on (Tiny will clean this up)
+			newRow = cloneNode(rowElm, false);
+			rowElm.parentNode.insertBefore(newRow, rowElm);
+
+			// If original table has a thead row, copy that here
+			thead = dom.select('thead', tableElm);
+			if (thead.length > 0) {
+				newThead = cloneNode(thead[0], true);
+			} 
+
+			// Create new table splitting on current row
+			dom.split(tableElm, newRow); 
+
+			newTableElm = dom.getParent(rowElm, 'table');
+
+			// If original table has a thead row, copy that here
+			if (newThead) {
+				bodyElm = dom.select('tbody', newTableElm);
+				if (bodyElm.length > 0) {
+					bodyElm[0].parentNode.insertBefore(newThead, bodyElm[0]);
+				}
+			}
+
+			// Insert BR before tableElm
+			brElm = editor.getDoc().createElement('BR');
+			newTableElm.parentNode.insertBefore(brElm, newTableElm);
+ 		}
+
 		function insertRow(before) {
 			var posY, cell, lastCell, x, rowElm, newRow, newCell, otherCell, rowSpan;
 

--- a/tests/plugins/table.js
+++ b/tests/plugins/table.js
@@ -423,6 +423,13 @@
 		);
 	});
 
+	test("mceTableSplitTableAfterRow command", function() {
+		editor.setContent('<table><thead><tr><td>1</td><td>2</td></tr></thead><tbody><tr><td>3</td><td>4</td></tr></tbody></table>');
+		Utils.setSelection('tbody tr', 0);
+		editor.execCommand('mceTableSplitTableAfterRow');
+		equal(cleanTableHtml(editor.getContent()), '<table><thead><tr><td>1</td><td>2</td></tr></thead></table><p>&nbsp;</p><table><thead><tr><td>1</td><td>2</td></tr></thead><tbody><tr><td>3</td><td>4</td></tr></tbody></table>');
+	});
+
 	test("Tab key navigation", function() {
 		editor.setContent('<table><tbody><tr><td>A1</td><td>A2</td></tr><tr><td>B1</td><td>B2</td></tr></tbody></table><p>x</p>');
 


### PR DESCRIPTION
Add a new splitTableAfterRow action in table plugin so that users can
split long tables at a specific row and replicate any thead from
original table.
