### PR TITLE
Change fontsizeselect menu so it previews the font-size values

### DIFF
--- a/js/tinymce/classes/ui/FormatControls.js
+++ b/js/tinymce/classes/ui/FormatControls.js
@@ -516,7 +516,7 @@ define("tinymce/ui/FormatControls", [
 					text = values[0];
 					value = values[1];
 				}
-				items.push({text: text, value: value});
+				items.push({text: text, value: value, textStyle: 'font-size:' + value});
 			});
 
 			return {


### PR DESCRIPTION
This pull request changes the styling of the list items in the fontsizeselect dropdown menu, so they preview the font-size which is to be selected, as shown in:

![fontsizeselect_preview](https://cloud.githubusercontent.com/assets/946583/3351189/53b14efa-f9fa-11e3-87e0-2053f13ca2ac.png)