### PR TITLE
Sandbox mode

### DIFF
--- a/html/sandbox.html
+++ b/html/sandbox.html
@@ -1,0 +1,35 @@
+<html>
+<head>
+	<script type="text/javascript" src="tinymce/js/tinymce/tinymce.min.js"></script>
+	<script type="text/javascript">
+		(function () {
+			var proxy = new tinymce.Proxy(parent, "*", false);
+
+			proxy.on("init", function (settings, content) {
+				document.getElementById("content").value = content;
+				document.getElementById("content").style.height = document.body.offsetHeight + "px";
+
+				tinymce.init(tinymce.extend(settings, {
+					selector: "textarea",
+					setup: function(ed) {
+						ed.on('change', function(e) {
+							proxy.send("newContent", [ed.getContent()]);
+						});
+
+						ed.on('loadContent', function (e) {
+							proxy.send("setHeight", [document.body.offsetHeight + "px"]);
+						})
+					},
+					sandbox: false,
+					content_element: "content"
+				}));
+
+
+			});
+		}());
+	</script>
+</head>
+<body>
+<textarea id="content"></textarea>
+</body>
+</html>

--- a/js/tinymce/classes/EditorManager.js
+++ b/js/tinymce/classes/EditorManager.js
@@ -27,8 +27,9 @@ define("tinymce/EditorManager", [
 	"tinymce/util/Tools",
 	"tinymce/util/Observable",
 	"tinymce/util/I18n",
-	"tinymce/FocusManager"
-], function(Editor, DomQuery, DOMUtils, URI, Env, Tools, Observable, I18n, FocusManager) {
+	"tinymce/FocusManager",
+	"tinymce/ProxyEditor"
+], function(Editor, DomQuery, DOMUtils, URI, Env, Tools, Observable, I18n, FocusManager, ProxyEditor) {
 	var DOM = DOMUtils.DOM;
 	var explode = Tools.explode, each = Tools.each, extend = Tools.extend;
 	var instanceCounter = 0, beforeUnloadDelegate, EditorManager;
@@ -262,8 +263,15 @@ define("tinymce/EditorManager", [
 			}
 
 			function createEditor(id, settings) {
+				var editor;
+
 				if (!purgeDestroyedEditor(self.get(id))) {
-					var editor = new Editor(id, settings, self);
+					if (settings.sandbox && Env.postMessage) {
+						editor = new ProxyEditor(id, settings, self);
+					} else {
+						editor = new Editor(id, settings, self);
+					}
+
 					editors.push(editor);
 					editor.render();
 				}

--- a/js/tinymce/classes/Env.js
+++ b/js/tinymce/classes/Env.js
@@ -130,6 +130,14 @@ define("tinymce/Env", [], function() {
 		 * @property documentMode
 		 * @type Number
 		 */
-		documentMode: ie ? (document.documentMode || 7) : 10
+		documentMode: ie ? (document.documentMode || 7) : 10,
+
+		/**
+		 * Returns true/false if the browser supports message passing between iframe.
+		 *
+		 * @property postMessage
+		 * @type Boolean
+		 */
+		postMessage: !!window.postMessage
 	};
 });

--- a/js/tinymce/classes/Proxy.js
+++ b/js/tinymce/classes/Proxy.js
@@ -1,0 +1,159 @@
+/**
+ * Proxy.js
+ *
+ * Copyright, Moxiecode Systems AB
+ * Released under LGPL License.
+ *
+ * License: http://www.tinymce.com/license
+ * Contributing: http://www.tinymce.com/contributing
+ */
+
+/**
+ * This class enables you to proxy command to an iframe located on an other domain.
+ *
+ * @class tinymce.Proxy
+ */
+define("tinymce/Proxy", [
+	"tinymce/util/Tools"
+], function(Tools) {
+
+	return function (win, domain, isParent) {
+		var handlers = {},
+
+			// Unique id of the communication to make sure we only receive information of the good iframe.
+			// Without this we would receive message from other iframe RTE
+			uniqueIdentifier = (isParent) ? createUniqueIdentifier() : "",
+			ready = false,
+			initInterval,
+			extend = Tools.extend,
+			callbackCache = {};
+
+		function on(eventName, callback) {
+			if (!handlers[eventName]) {
+				handlers[eventName]= [];
+			}
+
+			handlers[eventName].push(callback);
+		}
+
+		function send(eventName, params, callback) {
+			var eventObj = {
+				eventName : eventName,
+				params : params,
+				source : uniqueIdentifier,
+				callId : createUniqueIdentifier()
+			};
+
+			if (eventName !== "__callback") {
+				callbackCache[eventObj.callId] = callback;
+			}
+
+			try {
+				var strObj = JSON.stringify(eventObj);
+				win.postMessage(strObj, "*");
+			} catch (e) {
+				console.error(e);
+				// Communication channel may not be ready yet, no need for exception.
+			}
+		}
+
+		extend(this, {
+			on : on,
+			send : send
+		});
+
+		window.addEventListener("message", messageHandle, false);
+
+		// Set the internal callback
+		on("__setIdentifier", function (identifier) {
+
+			if (!uniqueIdentifier) { 
+				uniqueIdentifier = identifier;
+			}
+
+			if (!ready) {
+				ready = true;
+				send("__setIdentifier", [identifier]);
+				trigger("ready", []);
+
+				if (initInterval) {
+					clearInterval(initInterval);
+				}
+			}
+		});
+
+		on("__callback", function (callbackId, returnValue) {
+			if (typeof callbackCache[callbackId] == "function") {
+				callbackCache[callbackId](returnValue);
+			}
+
+			delete callbackCache[callbackId];
+		});
+		
+		// Parent decides the ID of the communication channel and sends it to the iframe.
+		if (isParent) {
+			initInterval = setInterval(function () {
+				send("__setIdentifier", [uniqueIdentifier]);
+			}, 500);
+		}
+
+		// Private functions
+
+		function messageHandle(event) {
+			// We need to ignore message from domain that we do not expect. //
+			if (event.origin !== domain && domain !== "*") {
+				return;
+			}
+
+			var jsonData = event.data,
+			    obj = JSON.parse(jsonData),
+			    i,
+			    returnValues;
+
+			console.log("[" + document.domain + "] " + event.data);
+
+			// Make sure we only handle message of the good iframe.
+			if (obj.source == uniqueIdentifier || obj.eventName == "__setIdentifier") {
+				returnValues = trigger(obj.eventName, obj.params);
+
+				if (obj.eventName !== "__callback") {
+					send("__callback", [obj.callId, returnValues]);
+				}
+			}
+		}
+
+		function trigger(eventName, params) {
+			var returnValues = [],
+				returnValue,
+				i;
+
+			if (handlers[eventName]) {
+				for (i=0; i<handlers[eventName].length; i++) {
+					try {
+						returnValue = handlers[eventName][i].apply(null, params);
+
+						if (typeof returnValue !== "undefined") {
+							returnValues.push(returnValue);
+						}
+					} catch (e) {
+						console.error(e);
+						// Make sure callback failure don't crash everything
+					}
+				}
+			}
+
+			if (returnValues.length <= 1) {
+				returnValues = returnValues[0];
+			}
+
+			return returnValues;
+		}
+
+		function createUniqueIdentifier() {
+			return "" + 
+				(Math.random().toString(16)+"000000000").substr(2,8) + 
+				(Math.random().toString(16)+"000000000").substr(2,8);
+		}
+	};
+
+});

--- a/js/tinymce/classes/ProxyEditor.js
+++ b/js/tinymce/classes/ProxyEditor.js
@@ -1,0 +1,73 @@
+define("tinymce/ProxyEditor", [
+	"tinymce/dom/DOMUtils",
+	"tinymce/Editor",
+	"tinymce/Proxy"
+], function (DOMUtils, Editor, Proxy) {
+	var DOM = DOMUtils.DOM;
+
+	function ProxyEditor(id, settings, editorManager) {
+		var self = this;
+
+		self.settings = settings;
+		self.settings.content_element = self.settings.content_element || id;
+
+		self.iframe = createIframe();
+		var proxy = new Proxy(self.iframe.contentWindow, "*", true);
+
+		proxy.on("ready", function () {
+			proxy.send("init", [settings, self.getElement().value]);
+		});
+
+		proxy.on("newContent", function (value) {
+			self.getElement().value = value;
+		});
+
+		proxy.on("setHeight", function (value) {
+			self.iframe.style.height = value;
+		});
+
+		self.getElement().style.visibility = "hidden";
+		self.getElement().style.display = "none";
+
+		function createContainer() {
+			var element = self.getElement();
+			var container = document.createElement("div");
+			element.parentNode.insertBefore(container, element);
+
+			self.container = container;
+			return container;
+		}
+
+		function createIframe() {
+			var elm = self.getElement();
+			var w = settings.width || elm.style.width || elm.offsetWidth;
+			var h = settings.height || elm.style.height || elm.offsetHeight;
+			var container = createContainer();
+
+			return DOM.add(container, 'iframe', {
+				id: id + "_ifr",
+				src: settings.sandbox,
+				frameBorder: '0',
+				allowTransparency: "true",
+				style: {
+					width: '100%',
+					height: h,
+					display: 'block' // Important for Gecko to render the iframe correctly
+				}
+			});
+		}
+
+		function getURIDomain(uri) {
+			var a = document.createElement("a");
+			a.href = uri;
+
+			var domain = a.hostname;
+			return domain;
+		}
+	}
+
+	ProxyEditor.prototype.getElement = Editor.prototype.getElement;
+	ProxyEditor.prototype.render = function () {};
+
+	return ProxyEditor;
+});


### PR DESCRIPTION
**What is the "sandbox" mode ?**

The purpose of this pull request is to have an option to sandbox the execution of anything being executed in the iframe of the RTE on a domain other than the one where the editor is being embedded. This is mostly to mitigate permanent XSS attack while allowing script tags, "on" attributes, etc. 

This features should be 100% backward compatible (it will simply not use it, if the browser doesn't support postMessage) and shouldn't affect anything if there is no "sandbox" parameter.

**How to test ?**
1. Host on a CDN the following structure
   - sandbox.html
   - tinymce/js/tinymce/tinymce.min.js
2. Use the following configuration for the TinyMCE 

```
tinymce.init({
    selector: "textarea",
    sandbox: "http://[CDN-DOMAIN]/sandbox.html"
});
```

Note : I have hosted a version of the sandbox on `agile-beyond-2236.herokuapp.com`, so you can use `http://agile-beyond-2236.herokuapp.com/sandbox.html` as a sandbox parameter to save you the trouble of hosting it.

**What I'd like to get feedback for**
- Is this the best way to integrate such feature ?
- What kind of test should I include ?
- What is potentially broken in this mode ?
