### PR TITLE
Add name/id settings flag to anchor plugin

### DIFF
--- a/js/tinymce/plugins/anchor/plugin.js
+++ b/js/tinymce/plugins/anchor/plugin.js
@@ -11,6 +11,8 @@
 /*global tinymce:true */
 
 tinymce.PluginManager.add('anchor', function(editor) {
+	var attrName = editor.settings.anchor_name_attr ? 'name' : 'id';
+
 	function showDialog() {
 		var selectedNode = editor.selection.getNode(), name = '';
 
@@ -22,9 +24,9 @@ tinymce.PluginManager.add('anchor', function(editor) {
 			title: 'Anchor',
 			body: {type: 'textbox', name: 'name', size: 40, label: 'Name', value: name},
 			onsubmit: function(e) {
-				editor.execCommand('mceInsertContent', false, editor.dom.createHTML('a', {
-					id: e.data.name
-				}));
+				var options = {};
+				options[attrName] = e.data.name;
+				editor.execCommand('mceInsertContent', false, editor.dom.createHTML('a', options));
 			}
 		});
 	}


### PR DESCRIPTION
This pull request adds new option `anchor_name_attr` for anchor plugin. If this option is set to `true` all new anchors will use attribute `name="..."` instead of `id="..."`.