### PR TITLE
Fix for bug 7045: check whether a selector matches a non-editor

### DIFF
--- a/js/tinymce/classes/EditorManager.js
+++ b/js/tinymce/classes/EditorManager.js
@@ -491,7 +491,9 @@ define("tinymce/EditorManager", [
 				selector = selector.selector || selector;
 
 				each(DOM.select(selector), function(elm) {
-					self.remove(editors[elm.id]);
+					var editor = editors[elm.id];
+					if(editor)
+						self.remove(editor);
 				});
 
 				return;


### PR DESCRIPTION
check whether a selector matches a non-editor to prevent removing all editors in that case
