### PR TITLE
Editor.addButtons: Add various buttons at once with a single toolbar setting string.

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1241,6 +1241,8 @@ define("tinymce/Editor", [
 				settings.icon = name;
 			}
 
+			settings.name = settings.name || name;
+
 			self.buttons = self.buttons || {};
 			settings.tooltip = settings.tooltip || settings.title;
 			self.buttons[name] = settings;
@@ -1277,15 +1279,28 @@ define("tinymce/Editor", [
 		 *    }
 		 * });
 		 */
-	    addButtons: function(name, buttonsSettings){
-	      var self = this;
+		addButtons: function(name, buttonsSettings){
+			var self = this;
+			var buttonConfigs = [];
 
-	      each(buttonsSettings, function(settings, idx){
-	      	settings.name = settings.name || String(idx);
+			self.buttons = self.buttons || {};
 
-	        self.addButton(name + settings.name, settings);
-	      });
-	    },
+			each(buttonsSettings, function(settings, idx){
+				settings.name = settings.name || (name + String(idx));
+
+				if(!self.buttons[settings.name]){
+					self.addButton(settings.name, settings)
+				} else {
+					settings = self.buttons[settings.name];
+				}
+
+				buttonConfigs.push(settings);
+			});
+
+			self.addButton(name, function(){
+				return buttonConfigs.slice();
+			});
+		},
 
 		/**
 		 * Adds a menu item to be used in the menus of the theme. There might be multiple instances

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1283,7 +1283,7 @@ define("tinymce/Editor", [
 	      each(buttonsSettings, function(settings, idx){
 	      	settings.name = settings.name || String(idx);
 
-	        this.addButton(name + settings.name, settings);
+	        self.addButton(name + settings.name, settings);
 	      });
 	    },
 

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1247,6 +1247,47 @@ define("tinymce/Editor", [
 		},
 
 		/**
+		 * Adds various buttons at once to the same button group that later gets created by the theme in the editors toolbars.
+		 *
+		 * @method addButtons
+		 * @param {String} name Button namespace to add.
+		 * @param {Array} settings Array of settings objects with title, cmd etc.
+		 * @example
+		 * // Adds a custom button to the editor that inserts contents when clicked
+		 * tinymce.init({
+		 *    ...
+		 *
+		 *    toolbar: 'example'
+		 *
+		 *    setup: function(ed) {
+		 *       ed.addButtons('example', [
+		 *          {
+		 *             title: 'First',
+		 *             onclick: function(){
+		 *                ed.insertContent('First hello world!!');
+		 *             }
+		 *          },
+		 *          {
+		 *             title: 'Second',
+		 *             onclick: function(){
+		 *                ed.insertContent('Second hello world!!');
+		 *             }
+		 *          }
+		 *       ]);
+		 *    }
+		 * });
+		 */
+	    addButtons: function(name, buttonsSettings){
+	      var self = this;
+
+	      each(buttonsSettings, function(buttonSetting, idx){
+	      	buttonSetting.name = buttonSetting.name || String(idx);
+
+	        this.addButton(name + buttonSetting.name, buttonSetting);
+	      });
+	    },
+
+		/**
 		 * Adds a menu item to be used in the menus of the theme. There might be multiple instances
 		 * of this menu item for example it might be used in the main menus of the theme but also in
 		 * the context menu so make sure that it's self contained and supports multiple instances.

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1280,10 +1280,10 @@ define("tinymce/Editor", [
 	    addButtons: function(name, buttonsSettings){
 	      var self = this;
 
-	      each(buttonsSettings, function(buttonSetting, idx){
-	      	buttonSetting.name = buttonSetting.name || String(idx);
+	      each(buttonsSettings, function(settings, idx){
+	      	settings.name = settings.name || String(idx);
 
-	        this.addButton(name + buttonSetting.name, buttonSetting);
+	        this.addButton(name + settings.name, settings);
 	      });
 	    },
 

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1250,17 +1250,17 @@ define("tinymce/Editor", [
 		 * Adds various buttons at once to the same button group that later gets created by the theme in the editors toolbars.
 		 *
 		 * @method addButtons
-		 * @param {String} name Button namespace to add.
+		 * @param {String} name Namespace to add to buttons.
 		 * @param {Array} settings Array of settings objects with title, cmd etc.
 		 * @example
-		 * // Adds a custom button to the editor that inserts contents when clicked
+		 * // Adds custom buttons to the editor that inserts contents when clicked
 		 * tinymce.init({
 		 *    ...
 		 *
-		 *    toolbar: 'example'
+		 *    toolbar: 'examples'
 		 *
 		 *    setup: function(ed) {
-		 *       ed.addButtons('example', [
+		 *       ed.addButtons('examples', [
 		 *          {
 		 *             title: 'First',
 		 *             onclick: function(){

--- a/js/tinymce/themes/modern/theme.js
+++ b/js/tinymce/themes/modern/theme.js
@@ -48,47 +48,49 @@ tinymce.ThemeManager.add('modern', function(editor) {
 				function bindSelectorChanged() {
 					var selection = editor.selection;
 
-					if (itemName == "bullist") {
-						selection.selectorChanged('ul > li', function(state, args) {
-							var nodeName, i = args.parents.length;
+					each(tinymce.isArray(item) ? item : [item], function(item, j){
+						if (itemName == "bullist") {
+							selection.selectorChanged('ul > li', function(state, args) {
+								var nodeName, i = args.parents.length;
 
-							while (i--) {
-								nodeName = args.parents[i].nodeName;
-								if (nodeName == "OL" || nodeName == "UL") {
-									break;
+								while (i--) {
+									nodeName = args.parents[i].nodeName;
+									if (nodeName == "OL" || nodeName == "UL") {
+										break;
+									}
 								}
-							}
 
-							item.active(state && nodeName == "UL");
-						});
-					}
+								item.active(state && nodeName == "UL");
+							});
+						}
 
-					if (itemName == "numlist") {
-						selection.selectorChanged('ol > li', function(state, args) {
-							var nodeName, i = args.parents.length;
+						if (itemName == "numlist") {
+							selection.selectorChanged('ol > li', function(state, args) {
+								var nodeName, i = args.parents.length;
 
-							while (i--) {
-								nodeName = args.parents[i].nodeName;
-								if (nodeName == "OL" || nodeName == "UL") {
-									break;
+								while (i--) {
+									nodeName = args.parents[i].nodeName;
+									if (nodeName == "OL" || nodeName == "UL") {
+										break;
+									}
 								}
-							}
 
-							item.active(state && nodeName == "OL");
-						});
-					}
+								item.active(state && nodeName == "OL");
+							});
+						}
 
-					if (item.settings.stateSelector) {
-						selection.selectorChanged(item.settings.stateSelector, function(state) {
-							item.active(state);
-						}, true);
-					}
+						if (item.settings.stateSelector) {
+							selection.selectorChanged(item.settings.stateSelector, function(state) {
+								item.active(state);
+							}, true);
+						}
 
-					if (item.settings.disabledStateSelector) {
-						selection.selectorChanged(item.settings.disabledStateSelector, function(state) {
-							item.disabled(state);
-						});
-					}
+						if (item.settings.disabledStateSelector) {
+							selection.selectorChanged(item.settings.disabledStateSelector, function(state) {
+								item.disabled(state);
+							});
+						}
+					});
 				}
 
 				if (item == "|") {
@@ -118,14 +120,37 @@ tinymce.ThemeManager.add('modern', function(editor) {
 								item = item();
 							}
 
+							if(tinymce.isArray(item)){
+								item = {
+									type: 'buttongroup',
+									items: item
+								};
+							}
+
 							item.type = item.type || 'button';
 
 							if (settings.toolbar_items_size) {
 								item.size = settings.toolbar_items_size;
 							}
 
-							item = Factory.create(item);
-							buttonGroup.items.push(item);
+							if(item.type !== 'buttongroup'){
+								item = Factory.create(item);
+								buttonGroup.items.push(item);
+							} else {
+								each(item.items, function(it, j){
+									it.type = it.type || 'button';
+
+									if (settings.toolbar_items_size) {
+										it.size = settings.toolbar_items_size;
+									}
+
+									item.items[j] = Factory.create(it);
+
+									buttonGroup.items.push(item.items[j]);
+								})
+
+								item = item.items;
+							}
 
 							if (editor.initialized) {
 								bindSelectorChanged();


### PR DESCRIPTION
The idea is to be able to add various buttons but only declaring one setting in the toolbar. As per the example in the comment of addButtons if in a toolbar you would place something like: '... | example | ...', in it's place would be a button group with two buttons instead of just one. You can still tack on another option next to "example" to add more buttons to the group. This should be useful for creating default button groups or various buttons at once instead of having to call addButton any number of times.

What I don't like with this code:
I had to alter theme.js to get this to work properly... Functions within functions within functions within... It starts to get a bit messy imho. Frankly I don't know how to make the code cleaner at this point.

I added a property to the button declarations called "name" to be used in addButton, not sure if this is optimal or not or if this will affect the editor negatively in someway? Maybe problems with the selector?

Does anyone have any suggestions/criticisms? 
I'm currently using this code in a project I'm working on atm.