### PR TITLE
Fix Bug: Init When Textarea Starts with Comment

### DIFF
--- a/js/tinymce/classes/Formatter.js
+++ b/js/tinymce/classes/Formatter.js
@@ -1114,6 +1114,10 @@ define("tinymce/Formatter", [
 
 					// Ignore bogus nodes like the <a> tag created by moveStart()
 					parents = Tools.grep(parents, function(node) {
+					if (typeof(node.getAttribute) === 'undefined') {
+						// Comment nodes have no method .getAttribute()
+						return true;
+					}
 						return !node.getAttribute('data-mce-bogus');
 					});
 

--- a/tests/tinymce/Editor.js
+++ b/tests/tinymce/Editor.js
@@ -350,3 +350,20 @@ test('execCommand return values for native commands', function() {
 	strictEqual(editor.execCommand("ExistingCommand"), true, "Return value for an editor handled command");
 	strictEqual(lastCmd, "ExistingCommand");
 });
+
+asyncTest('initialize with comments', function() {
+	// Create a textarea with a comment in it
+	document.getElementById('view').appendChild(tinymce.DOM.create('textarea', {id: 'elmcomment'}, '<!-- comment -->'));
+
+	// initialize tinymce on that test area
+	tinymce.init({
+		selector: "#elmcomment",
+		init_instance_callback: function(editor) {
+			window.setTimeout(function() {
+				QUnit.start();
+				// we should be able to load the comment out of the tinymce editor
+				strictEqual(document.getElementById('elmcomment').value, '<!-- comment -->');
+			}, 0);
+		}
+	});
+});


### PR DESCRIPTION
Closes issue #4409

It looks like the check for "bogus-node" was calling getAttribute on the
node, but comment DOM nodes don't have attributes, so this check was
failing.  This commit adds a test for the problem (the test will throw
an exception on failure) and a fix for the problem.

Link to issue:  http://www.tinymce.com/develop/bugtracker_view.php?id=4409
Other possibly related issues: 

http://www.tinymce.com/develop/bugtracker_view.php?id=4340
http://www.tinymce.com/develop/bugtracker_view.php?id=5925
