### PR TITLE
Quote usage of reserved word float

### DIFF
--- a/js/tinymce/classes/dom/DomQuery.js
+++ b/js/tinymce/classes/dom/DomQuery.js
@@ -126,7 +126,7 @@ define("tinymce/dom/DomQuery", [
 		'readonly': 'readOnly'
 	};
 	var cssFix = {
-		float: 'cssFloat'
+		'float': 'cssFloat'
 	};
 
 	var attrHooks = {}, cssHooks = {};


### PR DESCRIPTION
A user of tinymce-rails has posted an issue (spohlenz/tinymce-rails#148) due to the unquoted use of the JavaScript reserved word `float` when using the YUI compiler.

This PR simply wraps the key in quotes.
