### PR TITLE
Add optional content security policy header

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -635,6 +635,10 @@ define("tinymce/Editor", [
 				bodyClass = bodyClass[self.id] || '';
 			}
 
+			if (settings.content_security_policy) {
+				self.iframeHTML += '<meta http-equiv="Content-Security-Policy" content="' + settings.content_security_policy +'" />'
+			}
+
 			self.iframeHTML += '</head><body id="' + bodyId +
 				'" class="mce-content-body ' + bodyClass +
 				'" data-id="' + self.id + '"><br></body></html>';


### PR DESCRIPTION
Add an optional `settings.content_security_policy` which allows the caller to set a [content security policy](http://www.w3.org/TR/CSP11/#delivery-html-meta-element) meta-tag in the iframe. 

**Why?**
This is useful to prevent the user from loading unwanted content while using the editor, for example it can be used as extra measure to prevent XSS issues in the client browser.

An example of such a policy would be: `script-src 'none'; img-src *; style-src * 'unsafe-inline'; default-src 'self';`. This will allow any image and style to be used, but deny any javascript from executing in the iframe.

Before:
![5ff7c5e4-1bca-11e4-9e81-d9f175b39897](https://cloud.githubusercontent.com/assets/2053039/3895028/7d0d4862-224a-11e4-8d86-23fa61f7cd38.png)

and after:
![813b6094-1bca-11e4-91df-6b5c4f6f79f6](https://cloud.githubusercontent.com/assets/2053039/3895031/820d7efe-224a-11e4-8f83-0fed6c426c3f.png)

Another useful example would be to disallow insecure `http:` resources from being loaded in the iframe. This is useful to avoid "mixed content" when the editor is being used on a HTTPS site. An example of such a policy would be: `default-src 'self' https: data: wss: 'unsafe-inline' 'unsafe-eval';`.
