### PR TITLE
Fixed issue with a delay in getting clipboard contents causing keyboard paste warning

### DIFF
--- a/js/tinymce/plugins/paste/classes/Clipboard.js
+++ b/js/tinymce/plugins/paste/classes/Clipboard.js
@@ -403,10 +403,10 @@ define("tinymce/pasteplugin/Clipboard", [
 			});
 
 			editor.on('paste', function(e) {
-			        // Getting content from the Clipboard can take some time 
-			        var clipboardTimer = new Date().getTime();
+				// Getting content from the Clipboard can take some time 
+				var clipboardTimer = new Date().getTime();
 				var clipboardContent = getClipboardContent(e);
-			        var clipboardDelay = new Date().getTime() - clipboardTimer;
+				var clipboardDelay = new Date().getTime() - clipboardTimer;
 
 				var isKeyBoardPaste = (new Date().getTime() - keyboardPasteTimeStamp - clipboardDelay) < 1000;
 				var plainTextMode = self.pasteFormat == "text" || keyboardPastePlainTextState;


### PR DESCRIPTION
I noticed in our instance that on a sufficiently large document the "Please use keyboard shortcuts" error warning was displayed. Even with a small document depending on the load of the machine this error could be displayed (very intermittently). 

This fix simply times how long it takes to get the content from the clipboard and ignores this in the calculation. Works to fix our issues, but I cannot seem to run the tests as they are taking forever to run. 
