### PR TITLE
Pasted numeric list regex

### DIFF
--- a/js/tinymce/plugins/paste/classes/WordFilter.js
+++ b/js/tinymce/plugins/paste/classes/WordFilter.js
@@ -196,7 +196,7 @@ define("tinymce/pasteplugin/WordFilter", [
 						// Detect ordered lists 1., a. or ixv.
 						if (isNumericList(nodeText)) {
 							// Parse OL start number
-							var matches = /([0-9])\./.exec(nodeText);
+							var matches = /([0-9]+)\./.exec(nodeText);
 							var start = 1;
 							if (matches) {
 								start = parseInt(matches[1], 10);


### PR DESCRIPTION
Fixes an issue where pasted numbered lists from Word do not increment past number 9 if newlines were added between the numbers in the list.

Note: The fix works for every browser but IE 11.
