### PR TITLE
Fixup uncaught TypeError in DOMUtils.isEmpty

### DIFF
--- a/js/tinymce/classes/dom/DOMUtils.js
+++ b/js/tinymce/classes/dom/DOMUtils.js
@@ -1415,7 +1415,7 @@ define("tinymce/dom/DOMUtils", [
 			node = node.firstChild;
 			if (node) {
 				walker = new TreeWalker(node, node.parentNode);
-				elements = elements || self.schema ? self.schema.getNonEmptyElements() : null;
+				elements = elements || (self.schema ? self.schema.getNonEmptyElements() : null);
 
 				do {
 					type = node.nodeType;

--- a/tests/tinymce/dom/DOMUtils.js
+++ b/tests/tinymce/dom/DOMUtils.js
@@ -629,6 +629,18 @@
 		DOM.remove('test');
 	});
 
+	test('isEmpty with list of elements considered non-empty', function() {
+		var elm = DOM.create('p', null, '<img>');
+		equal(false, DOM.isEmpty(elm, {img: true}));
+	});
+
+	test('isEmpty with list of elements considered non-empty without schema', function() {
+		var domWithoutSchema = new tinymce.dom.DOMUtils(document, {keep_values: true});
+
+		var elm = domWithoutSchema.create('p', null, '<img>');
+		equal(false, domWithoutSchema.isEmpty(elm, {img: true}));
+	});
+
 	test('isEmpty on P with BR in EM', function() {
 		var elm = DOM.create('p', null, '<em><br></em>');
 		ok(DOM.isEmpty(elm, 'No children'));


### PR DESCRIPTION
this is caused by missing braces which ends up in a different evaluated operator precedence
this bug only occurs if no schema was set, have a look at the unit tests

cc @robertkowalski

```
Uncaught TypeError: Cannot read property 'getNonEmptyElements' of undefined 
```
