### PR TITLE
Fixed Bug #7137 reported here http://www.tinymce.com/develop/bugtracker_...

### DIFF
--- a/js/tinymce/classes/WindowManager.js
+++ b/js/tinymce/classes/WindowManager.js
@@ -197,6 +197,7 @@ define("tinymce/WindowManager", [
 		self.close = function() {
 			if (getTopMostWindow()) {
 				getTopMostWindow().close();
+				editor.nodeChanged();
 			}
 		};
 


### PR DESCRIPTION
Fixed Bug #7137 reported here http://www.tinymce.com/develop/bugtracker_view.php?id=7137

A call to editor.nodeChanged() was required after the window closes.
