### PR TITLE
Add CloseQuery event to FloatPanel

### DIFF
--- a/js/tinymce/classes/ui/FloatPanel.js
+++ b/js/tinymce/classes/ui/FloatPanel.js
@@ -330,9 +330,15 @@ define("tinymce/ui/FloatPanel", [
 		close: function() {
 			var self = this;
 
-			self.fire('close');
+			var evt = self.fire('closequery');
 
-			return self.remove();
+			if (!evt.isDefaultPrevented()) {
+
+				self.fire('close');
+
+				return self.remove();
+
+			}
 		},
 
 		/**


### PR DESCRIPTION
This event enables code, which creates a custom dialog, to prevent the user from closing the dialog window by calling `evt.preventDefault()`.
This can be useful to prohibit closing the dialog during critical sections of the process or to ask the user if they really want to close the window without submitting.
