### PR TITLE
Restore historic behavior of setStyle to imply pixel suffix for appropri...

### DIFF
--- a/js/tinymce/classes/dom/DomQuery.js
+++ b/js/tinymce/classes/dom/DomQuery.js
@@ -488,7 +488,7 @@ define("tinymce/dom/DomQuery", [
 					name = camel(name);
 
 					// Default px suffix on these
-					if (typeof(value) === 'number' && !numericCssMap[name]) {
+					if (((typeof(value) === 'number' ) || /^[\-0-9\.]+$/.test(value)) && !numericCssMap[name]) {
 						value += 'px';
 					}
 

--- a/tests/tinymce/dom/DOMUtils.js
+++ b/tests/tinymce/dom/DOMUtils.js
@@ -313,6 +313,9 @@
 		DOM.setStyle('test', 'fontSize', 23);
 		equal(DOM.getStyle('test', 'fontSize'), '23px');
 
+		DOM.setStyle('test', 'fontSize', '24')
+		equal(DOM.getStyle('test', 'fontSize'), '24px');
+
 		DOM.setStyle('test', 'fontSize', 23);
 		DOM.setStyle('test', 'fontSize', '');
 		equal(DOM.getStyle('test', 'fontSize'), '');


### PR DESCRIPTION
...ate attributes even if they are supplied as instead of as numbers. This was previously addressed in Pull request #376 but has since fallen out of proper functioning again, presumably when stuff moved from DomUtils.js to DomQuery.js.