### PR TITLE
Add picture element support

### DIFF
--- a/js/tinymce/classes/html/Schema.js
+++ b/js/tinymce/classes/html/Schema.js
@@ -225,7 +225,7 @@ define("tinymce/html/Schema", [
 				"muted controls width height buffered", flowContent, "track source");
 			add("audio", "src crossorigin preload autoplay mediagroup loop muted controls buffered volume", flowContent, "track source");
 			add("picture", "", "img source");
-			add("source", "src type media sizes");
+			add("source", "src srcset type media sizes");
 			add("track", "kind src srclang label default");
 			add("datalist", "", phrasingContent, "option");
 			add("article section nav aside header footer", "", flowContent);


### PR DESCRIPTION
Related: https://github.com/tinymce/tinymce/pull/428

This pull request adds support for the picture element which has recently shipped in Chrome (and I think FF)

For reference see http://www.w3.org/html/wg/drafts/html/master/embedded-content.html#the-picture-element
