### PR TITLE
Update Window.less

### DIFF
--- a/js/tinymce/skins/lightgray/Window.less
+++ b/js/tinymce/skins/lightgray/Window.less
@@ -5,6 +5,7 @@
 	overflow: hidden;
 	background: @window-fullscreen-bg;
 	height: 100%;
+	z-index: 10000;
 }
 
 div.@{prefix}-fullscreen {


### PR DESCRIPTION
in some cases, fullscreen gets overlayed by other elements if the z-index is really high - so this should move the editor in front of the stuff