### PR TITLE
Fix internationalization when using multiple languages

### DIFF
--- a/js/tinymce/classes/EditorManager.js
+++ b/js/tinymce/classes/EditorManager.js
@@ -619,7 +619,8 @@ define("tinymce/EditorManager", [
 		 * @return {String} Translated string.
 		 */
 		translate: function(text) {
-			return I18n.translate(text);
+			var code = (this.activeEditor ? this.activeEditor.settings.language : null) || 'en';
+			return I18n.translate(text, code);
 		},
 
 		/**

--- a/js/tinymce/classes/util/I18n.js
+++ b/js/tinymce/classes/util/I18n.js
@@ -17,7 +17,7 @@
 define("tinymce/util/I18n", [], function() {
 	"use strict";
 
-	var data = {};
+	var data = {}, lastAddedCode = null;
 
 	return {
 		/**
@@ -37,10 +37,11 @@ define("tinymce/util/I18n", [], function() {
 		 */
 		add: function(code, items) {
 			for (var name in items) {
-				data[name] = items[name];
+				data[code + '.' + name] = items[name];
 			}
 
 			this.rtl = this.rtl || data._dir === 'rtl';
+			lastAddedCode = code;
 		},
 
 		/**
@@ -55,7 +56,9 @@ define("tinymce/util/I18n", [], function() {
 		 * @param {String/Object/Array} text Text to translate.
 		 * @return {String} String that got translated.
 		 */
-		translate: function(text) {
+		translate: function(text, code) {
+			code = code || lastAddedCode || 'en';
+
 			if (typeof(text) == "undefined") {
 				return text;
 			}
@@ -67,12 +70,12 @@ define("tinymce/util/I18n", [], function() {
 			if (text.push) {
 				var values = text.slice(1);
 
-				text = (data[text[0]] || text[0]).replace(/\{([^\}]+)\}/g, function(match1, match2) {
+				text = (data[code + '.' + text[0]] || text[0]).replace(/\{([^\}]+)\}/g, function(match1, match2) {
 					return values[match2];
 				});
 			}
 
-			return data[text] || text;
+			return data[code + '.' + text] || text;
 		},
 
 		data: data


### PR DESCRIPTION
Fixes http://www.tinymce.com/develop/bugtracker_view.php?id=7207

I did not come up with the language code + '.' prefix in `i18n.data`, this is already code used in Editor's translate function, which tries to find a specific language's translation by prefixing the language code and dot. Somewhere along the way, there was a mismatch in expectations of what is stored in `i18n.data` between `Editor.js` and `I18n.js`, and this fixes that.