### PR TITLE
Add statusbar_size config option

### DIFF
--- a/js/tinymce/plugins/wordcount/plugin.js
+++ b/js/tinymce/plugins/wordcount/plugin.js
@@ -24,6 +24,7 @@ tinymce.PluginManager.add('wordcount', function(editor) {
 
 	editor.on('init', function() {
 		var statusbar = editor.theme.panel && editor.theme.panel.find('#statusbar')[0];
+		var offset = editor.settings.statusbar_size == 'small' && editor.settings.resize !== false;
 
 		if (statusbar) {
 			window.setTimeout(function() {
@@ -31,7 +32,7 @@ tinymce.PluginManager.add('wordcount', function(editor) {
 					type: 'label',
 					name: 'wordcount',
 					text: ['Words: {0}', self.getCount()],
-					classes: 'wordcount',
+					classes: 'wordcount' + ((offset) ? ' offset' : ''),
 					disabled: editor.settings.readonly
 				}, 0);
 

--- a/js/tinymce/skins/lightgray/Path.less
+++ b/js/tinymce/skins/lightgray/Path.less
@@ -6,6 +6,10 @@
 	white-space: normal;
 }
 
+.@{prefix}-statusbar.@{prefix}-small .@{prefix}-path {
+	padding: 2px;
+}
+
 .@{prefix}-path .@{prefix}-txt {
 	display: inline-block;
 	padding-right: 3px;

--- a/js/tinymce/skins/lightgray/ResizeHandle.less
+++ b/js/tinymce/skins/lightgray/ResizeHandle.less
@@ -16,3 +16,7 @@
 i.@{prefix}-i-resize {
 	color: @text;
 }
+
+.@{prefix}-statusbar.@{prefix}-small i.@{prefix}-i-resize {
+	font-size: @iconSize;
+}

--- a/js/tinymce/skins/lightgray/TinyMCE.less
+++ b/js/tinymce/skins/lightgray/TinyMCE.less
@@ -30,6 +30,14 @@ div.@{prefix}-fullscreen {
 	padding: 8px;
 }
 
+.@{prefix}-statusbar.@{prefix}-small .@{prefix}-wordcount {
+	padding: 2px 4px;
+}
+
+.@{prefix}-statusbar.@{prefix}-small .@{prefix}-wordcount.@{prefix}-offset {
+	padding-right: 16px;
+}
+
 div.@{prefix}-edit-area {
 	background: #FFF;
 	filter: none;
@@ -41,6 +49,10 @@ div.@{prefix}-edit-area {
 
 .@{prefix}-statusbar .@{prefix}-container-body {
 	position: relative;
+}
+
+.@{prefix}-statusbar.@{prefix}-small * {
+	font-size: 11px;
 }
 
 .@{prefix}-fullscreen .@{prefix}-resizehandle {

--- a/js/tinymce/themes/modern/theme.js
+++ b/js/tinymce/themes/modern/theme.js
@@ -532,10 +532,12 @@ tinymce.ThemeManager.add('modern', function(editor) {
 
 		// Add statusbar if needed
 		if (settings.statusbar !== false) {
-			panel.add({type: 'panel', name: 'statusbar', classes: 'statusbar', layout: 'flow', border: '1 0 0 0', ariaRoot: true, items: [
-				{type: 'elementpath'},
-				resizeHandleCtrl
-			]});
+			panel.add({type: 'panel', name: 'statusbar', layout: 'flow', border: '1 0 0 0', ariaRoot: true,
+				classes: 'statusbar' + ((settings.statusbar_size) ? ' ' + settings.statusbar_size : ''), items: [
+					{type: 'elementpath'},
+					resizeHandleCtrl
+				]
+			});
 		}
 
 		if (settings.readonly) {


### PR DESCRIPTION
Setting `statusbar_size` to 'small' will scale down the statusbar. May be used in combination with `toolbar_items_size` or stand-alone if the statusbar seems too large.