### PR TITLE
Reduce use of javascript: URLs to avoid CSP issues

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -666,7 +666,6 @@ define("tinymce/Editor", [
 			// TODO: ACC add the appropriate description on this.
 			var ifr = DOM.create('iframe', {
 				id: self.id + "_ifr",
-				//src: url || 'javascript:""', // Workaround for HTTPS warning in IE6/7
 				frameBorder: '0',
 				allowTransparency: "true",
 				title: self.editorManager.translate(
@@ -685,7 +684,10 @@ define("tinymce/Editor", [
 				self.fire("load");
 			};
 
-			DOM.setAttrib(ifr, "src", url || 'javascript:""');
+			if (url)
+				DOM.setAttrib(ifr, "src", url);
+			else if (ie && ie < 8)
+				DOM.setAttrib(ifr, "src", 'javascript:""'); // Workaround for HTTPS warning in IE6/7
 
 			self.contentAreaContainer = o.iframeContainer;
 			self.iframeElement = ifr;


### PR DESCRIPTION
IE6/7 needs "javascript:" as the iframe src to avoid an HTTPS warning, but modern browsers (or at least Chrome 40) will complain about such URLs if there is a strict Content-Security-Policy.

These changes resolve the following error I am getting in a Chrome extension: "Refused to execute JavaScript URL because it violates the following Content Security Policy directive: "script-src 'self' chrome-extension-resource:". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution."

I have not tested this change in other browsers.