### PR TITLE
add grunt-cli to list of dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	},
 	"devDependencies": {
 		"grunt": "~0.4.5",
+		"grunt-cli": "~0.1.13",
 		"grunt-contrib-clean": "~0.6.0",
 		"grunt-contrib-connect": "~0.8.0",
 		"grunt-contrib-jshint": "~0.10.0",


### PR DESCRIPTION
This allows a single 'npm install' to install everything required to
build TinyMCE.