### PR TITLE
Set url property for item if available.

### DIFF
--- a/js/tinymce/plugins/link/plugin.js
+++ b/js/tinymce/plugins/link/plugin.js
@@ -41,6 +41,9 @@ tinymce.PluginManager.add('link', function(editor) {
 					menuItem.menu = appendItems(item.menu);
 				} else {
 					menuItem.value = item.value;
+					if (item.url) {
+						menuItem.url = item.url;
+					}
 
 					if (itemCallback) {
 						itemCallback(menuItem);


### PR DESCRIPTION
This fix allows link list items to have "url" key instead of "value" as it was possible in 4.0.

Currently the `item.value || item.url` on line 192 is pointless as `buildListItems` never sets the `url` property for `menuItem`.
