### PR TITLE
Use 'exports' instead of 'window'

### DIFF
--- a/js/tinymce/classes/Compat.js
+++ b/js/tinymce/classes/Compat.js
@@ -24,7 +24,7 @@ define("tinymce/Compat", [
 	"tinymce/util/Tools",
 	"tinymce/Env"
 ], function(DOMUtils, EventUtils, ScriptLoader, AddOnManager, Tools, Env) {
-	var tinymce = exports.tinymce;
+	var tinymce = exports.tinymce || window.tinymce;
 
 	/**
 	 * @property {tinymce.dom.DOMUtils} DOM Global DOM instance.

--- a/js/tinymce/classes/Compat.js
+++ b/js/tinymce/classes/Compat.js
@@ -24,7 +24,7 @@ define("tinymce/Compat", [
 	"tinymce/util/Tools",
 	"tinymce/Env"
 ], function(DOMUtils, EventUtils, ScriptLoader, AddOnManager, Tools, Env) {
-	var tinymce = window.tinymce;
+	var tinymce = exports.tinymce;
 
 	/**
 	 * @property {tinymce.dom.DOMUtils} DOM Global DOM instance.

--- a/js/tinymce/classes/Compat.js
+++ b/js/tinymce/classes/Compat.js
@@ -16,6 +16,8 @@
  * @borrow-members tinymce.EditorManager
  * @borrow-members tinymce.util.Tools
  */
+
+/*global exports:false */
 define("tinymce/Compat", [
 	"tinymce/dom/DOMUtils",
 	"tinymce/dom/EventUtils",

--- a/js/tinymce/classes/EditorManager.js
+++ b/js/tinymce/classes/EditorManager.js
@@ -151,7 +151,7 @@ define("tinymce/EditorManager", [
 			}
 
 			// If tinymce is defined and has a base use that or use the old tinyMCEPreInit
-			preInit = window.tinymce || window.tinyMCEPreInit;
+			preInit = exports.tinymce || exports.tinyMCEPreInit;
 			if (preInit) {
 				baseURL = preInit.base || preInit.baseURL;
 				suffix = preInit.suffix;
@@ -648,7 +648,7 @@ define("tinymce/EditorManager", [
 	EditorManager.setup();
 
 	// Export EditorManager as tinymce/tinymce in global namespace
-	window.tinymce = window.tinyMCE = EditorManager;
+	exports.tinymce = exports.tinyMCE = EditorManager;
 
 	return EditorManager;
 });

--- a/js/tinymce/classes/EditorManager.js
+++ b/js/tinymce/classes/EditorManager.js
@@ -18,6 +18,8 @@
  * @mixes tinymce.util.Observable
  * @static
  */
+
+/*global exports:false */
 define("tinymce/EditorManager", [
 	"tinymce/Editor",
 	"tinymce/dom/DomQuery",

--- a/js/tinymce/classes/EditorManager.js
+++ b/js/tinymce/classes/EditorManager.js
@@ -151,7 +151,7 @@ define("tinymce/EditorManager", [
 			}
 
 			// If tinymce is defined and has a base use that or use the old tinyMCEPreInit
-			preInit = exports.tinymce || exports.tinyMCEPreInit;
+			preInit = exports.tinymce || exports.tinyMCEPreInit || window.tinymce || window.tinyMCEPreInit;
 			if (preInit) {
 				baseURL = preInit.base || preInit.baseURL;
 				suffix = preInit.suffix;


### PR DESCRIPTION
Use 'exports.tinymce' instead of 'window.tinymce'
This is very useful for the protection of `tinymce`