### PR TITLE
Fix for name="body" attributes

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1948,7 +1948,7 @@ define("tinymce/Editor", [
 		 * @return {Element} Iframe body element.
 		 */
 		getBody: function() {
-			return this.bodyElement || this.getDoc().body;
+			return this.bodyElement || this.getDoc().getElementsByTagName('body')[0] || this.getDoc().body;
 		},
 
 		/**

--- a/js/tinymce/classes/ForceBlocks.js
+++ b/js/tinymce/classes/ForceBlocks.js
@@ -51,7 +51,7 @@ define("tinymce/ForceBlocks", [], function() {
 				// Force control range into text range
 				if (rng.item) {
 					node = rng.item(0);
-					rng = editor.getDoc().body.createTextRange();
+					rng = editor.getBody().createTextRange();
 					rng.moveToElementText(node);
 				}
 
@@ -105,7 +105,7 @@ define("tinymce/ForceBlocks", [], function() {
 				} else {
 					// Only select if the previous selection was inside the document to prevent auto focus in quirks mode
 					try {
-						rng = editor.getDoc().body.createTextRange();
+						rng = editor.getBody().createTextRange();
 						rng.moveToElementText(rootNode);
 						rng.collapse(true);
 						rng.moveStart('character', startOffset);

--- a/js/tinymce/classes/dom/ControlSelection.js
+++ b/js/tinymce/classes/dom/ControlSelection.js
@@ -493,13 +493,14 @@ define("tinymce/dom/ControlSelection", [
 		}
 
 		function controlSelect(elm) {
-			var ctrlRng;
+			var editableBody, ctrlRng;
 
 			if (!isIE) {
 				return;
 			}
 
-			ctrlRng = editableDoc.body.createControlRange();
+			editableBody = editableDoc.getElementsByTagName('body')[0] || editableDoc.body;
+			ctrlRng = editableBody.createControlRange();
 
 			try {
 				ctrlRng.addElement(elm);

--- a/js/tinymce/classes/dom/DOMUtils.js
+++ b/js/tinymce/classes/dom/DOMUtils.js
@@ -214,7 +214,7 @@ define("tinymce/dom/DOMUtils", [
 		getRoot: function() {
 			var self = this;
 
-			return self.settings.root_element || self.doc.body;
+			return self.settings.root_element || self.doc.getElementsByTagName('body')[0] || self.doc.body;
 		},
 
 		/**
@@ -229,7 +229,7 @@ define("tinymce/dom/DOMUtils", [
 
 			win = !win ? this.win : win;
 			doc = win.document;
-			rootElm = this.boxModel ? doc.documentElement : doc.body;
+			rootElm = this.boxModel ? doc.documentElement : (document.getElementsByTagName('body')[0] || doc.body);
 
 			// Returns viewport size excluding scrollbars
 			return {
@@ -815,7 +815,7 @@ define("tinymce/dom/DOMUtils", [
 		 * @return {object} Absolute position of the specified element object with x, y fields.
 		 */
 		getPos: function(elm, rootElm) {
-			var self = this, x = 0, y = 0, offsetParent, doc = self.doc, body = doc.body, pos;
+			var self = this, x = 0, y = 0, offsetParent, doc = self.doc, body = (doc.getElementsByTagName('body')[0] || doc.body), pos;
 
 			elm = self.get(elm);
 			rootElm = rootElm || body;

--- a/js/tinymce/classes/dom/DomQuery.js
+++ b/js/tinymce/classes/dom/DomQuery.js
@@ -1069,7 +1069,7 @@ define("tinymce/dom/DomQuery", [
 		 * @return {Object/tinymce.dom.DomQuery} Returns the first element offset or the current set if you specified an offset.
 		 */
 		offset: function(offset) {
-			var elm, doc, docElm;
+			var elm, doc, docElm, docBody;
 			var x = 0, y = 0, pos;
 
 			if (!offset) {
@@ -1078,11 +1078,12 @@ define("tinymce/dom/DomQuery", [
 				if (elm) {
 					doc = elm.ownerDocument;
 					docElm = doc.documentElement;
+					docBody = doc.getElementsByTagName('body')[0] || doc.body;
 
 					if (elm.getBoundingClientRect) {
 						pos = elm.getBoundingClientRect();
-						x = pos.left + (docElm.scrollLeft || doc.body.scrollLeft) - docElm.clientLeft;
-						y = pos.top + (docElm.scrollTop || doc.body.scrollTop) - docElm.clientTop;
+						x = pos.left + (docElm.scrollLeft || docBody.scrollLeft) - docElm.clientLeft;
+						y = pos.top + (docElm.scrollTop || docBody.scrollTop) - docElm.clientTop;
 					}
 				}
 

--- a/js/tinymce/classes/dom/EventUtils.js
+++ b/js/tinymce/classes/dom/EventUtils.js
@@ -78,7 +78,7 @@ define("tinymce/dom/EventUtils", [], function() {
 		if (originalEvent && mouseEventRe.test(originalEvent.type) && originalEvent.pageX === undef && originalEvent.clientX !== undef) {
 			var eventDoc = event.target.ownerDocument || document;
 			var doc = eventDoc.documentElement;
-			var body = eventDoc.body;
+			var body = eventDoc.getElementsByTagName('body')[0] || eventDoc.body;
 
 			event.pageX = originalEvent.clientX + (doc && doc.scrollLeft || body && body.scrollLeft || 0) -
 				(doc && doc.clientLeft || body && body.clientLeft || 0);

--- a/js/tinymce/classes/dom/ScriptLoader.js
+++ b/js/tinymce/classes/dom/ScriptLoader.js
@@ -112,7 +112,7 @@ define("tinymce/dom/ScriptLoader", [
 			elm.onerror = error;
 
 			// Add script to document
-			(document.getElementsByTagName('head')[0] || document.body).appendChild(elm);
+			(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0] || document.body).appendChild(elm);
 		}
 
 		/**

--- a/js/tinymce/classes/dom/Selection.js
+++ b/js/tinymce/classes/dom/Selection.js
@@ -151,7 +151,8 @@ define("tinymce/dom/Selection", [
 		 * tinymce.activeEditor.selection.setContent('<strong>Some contents</strong>');
 		 */
 		setContent: function(content, args) {
-			var self = this, rng = self.getRng(), caretNode, doc = self.win.document, frag, temp;
+			var self = this, rng = self.getRng(), caretNode, doc = self.win.document,
+				body = (doc.getElementsByTagName('body')[0] || doc.body), frag, temp;
 
 			args = args || {format: 'html'};
 			args.set = true;
@@ -172,12 +173,12 @@ define("tinymce/dom/Selection", [
 				// Delete and insert new node
 				if (rng.startContainer == doc && rng.endContainer == doc) {
 					// WebKit will fail if the body is empty since the range is then invalid and it can't insert contents
-					doc.body.innerHTML = content;
+					body.innerHTML = content;
 				} else {
 					rng.deleteContents();
 
-					if (doc.body.childNodes.length === 0) {
-						doc.body.innerHTML = content;
+					if (body.childNodes.length === 0) {
+						body.innerHTML = content;
 					} else {
 						// createContextualFragment doesn't exists in IE 9 DOMRanges
 						if (rng.createContextualFragment) {
@@ -545,7 +546,7 @@ define("tinymce/dom/Selection", [
 			// This can occur when the editor is placed in a hidden container element on Gecko
 			// Or on IE when there was an exception
 			if (!rng) {
-				rng = doc.createRange ? doc.createRange() : doc.body.createTextRange();
+				rng = doc.createRange ? doc.createRange() : (doc.getElementsByTagName('body')[0] || doc.body).createTextRange();
 			}
 
 			// If range is at start of document then move it to start of body
@@ -903,7 +904,7 @@ define("tinymce/dom/Selection", [
 		},
 
 		placeCaretAt: function(clientX, clientY) {
-			var doc = this.editor.getDoc(), rng, point;
+			var doc = this.editor.getDoc(), body = this.editor.getBody(), rng, point;
 
 			if (doc.caretPositionFromPoint) {
 				point = doc.caretPositionFromPoint(clientX, clientY);
@@ -912,14 +913,14 @@ define("tinymce/dom/Selection", [
 				rng.collapse(true);
 			} else if (doc.caretRangeFromPoint) {
 				rng = doc.caretRangeFromPoint(clientX, clientY);
-			} else if (doc.body.createTextRange) {
-				rng = doc.body.createTextRange();
+			} else if (body.createTextRange) {
+				rng = body.createTextRange();
 
 				try {
 					rng.moveToPoint(clientX, clientY);
 					rng.collapse(true);
 				} catch (ex) {
-					rng.collapse(clientY < doc.body.clientHeight);
+					rng.collapse(clientY < body.clientHeight);
 				}
 			}
 

--- a/js/tinymce/classes/dom/Serializer.js
+++ b/js/tinymce/classes/dom/Serializer.js
@@ -284,7 +284,7 @@ define("tinymce/dom/Serializer", [
 			 * @param {Object} args Arguments option that gets passed to event handlers.
 			 */
 			serialize: function(node, args) {
-				var self = this, impl, doc, oldDoc, htmlSerializer, content;
+				var self = this, impl, doc, docBody, oldDoc, htmlSerializer, content;
 
 				// Explorer won't clone contents of script and style and the
 				// selected index of select elements are cleared on a clone operation.
@@ -302,17 +302,18 @@ define("tinymce/dom/Serializer", [
 				if (impl.createHTMLDocument) {
 					// Create an empty HTML document
 					doc = impl.createHTMLDocument("");
+					docBody = doc.body;
 
 					// Add the element or it's children if it's a body element to the new document
 					each(node.nodeName == 'BODY' ? node.childNodes : [node], function(node) {
-						doc.body.appendChild(doc.importNode(node, true));
+						docBody.appendChild(doc.importNode(node, true));
 					});
 
 					// Grab first child or body element for serialization
 					if (node.nodeName != 'BODY') {
-						node = doc.body.firstChild;
+						node = docBody.firstChild;
 					} else {
-						node = doc.body;
+						node = docBody;
 					}
 
 					// set the new document in DOMUtils so createElement etc works

--- a/js/tinymce/plugins/autoresize/plugin.js
+++ b/js/tinymce/plugins/autoresize/plugin.js
@@ -41,7 +41,7 @@ tinymce.PluginManager.add('autoresize', function(editor) {
 			return;
 		}
 
-		body = doc.body;
+		body = editor.getBody();
 		docElm = doc.documentElement;
 		resizeHeight = settings.autoresize_min_height;
 

--- a/js/tinymce/plugins/fullscreen/plugin.js
+++ b/js/tinymce/plugins/fullscreen/plugin.js
@@ -20,7 +20,7 @@ tinymce.PluginManager.add('fullscreen', function(editor) {
 
 	function getWindowSize() {
 		var w, h, win = window, doc = document;
-		var body = doc.body;
+		var body = doc.getElementsByTagName('body')[0] || doc.body;
 
 		// Old IE
 		if (body.offsetWidth) {
@@ -38,8 +38,8 @@ tinymce.PluginManager.add('fullscreen', function(editor) {
 	}
 
 	function toggleFullscreen() {
-		var body = document.body, documentElement = document.documentElement, editorContainerStyle;
-		var editorContainer, iframe, iframeStyle;
+		var body = document.getElementsByTagName('body')[0] || document.body, documentElement = document.documentElement;
+		var editorContainerStyle, editorContainer, iframe, iframeStyle;
 
 		function resize() {
 			DOM.setStyle(iframe, 'height', getWindowSize().h - (editorContainer.clientHeight - iframe.clientHeight));


### PR DESCRIPTION
If the document being edited contained a tag with a `name="body"` attribute, the editor would be broken, since `editor.getBody()` would then return that tag instead of the body. This should have been fixed in this pull request.

See also: http://www.tinymce.com/forum/viewtopic.php?id=35141