### PR TITLE
bug trying to set startContainer on an enpty text node

### DIFF
--- a/js/tinymce/classes/Formatter.js
+++ b/js/tinymce/classes/Formatter.js
@@ -791,6 +791,11 @@ define("tinymce/Formatter", [
 							} else {
 								startContainer = startContainer.firstChild || startContainer;
 							}
+							// later, "unwrap" will clean an empty text node and we will stay with a detached reference,
+							// if this is the case, get the next element.
+							if (!startContainer.textContent) {
+								startContainer = startContainer.nextSibling;
+							}
 						}
 
 						// Try to adjust endContainer as well if cells on the same row were selected - bug #6410


### PR DESCRIPTION
Reproduce:
Select a TD element (e.g. double click on the text inside a cell with only one text node in a table - not selecting the text but the whole td) from a table created with the tinymce table plugin.
Make an action on the selected text (e.g. trigger mceInsertLink).
The action wont be executed and the browser will throw "Uncaught TypeError: Cannot read property 'nodeType' of null" (Chrome).

The cause:
We call removeRngStyle that at some point will call startContainer = unwrap(TRUE);
In our case, the first child in the td is an empty text node.
in the method unwrap() we are going to save a reference to it (out = out[start ? 'firstChild' : 'lastChild'];), but than later remove it (dom.remove(node, true)).
later in unwrap() we are returning "out", which is a detached from the DOM, and setting it as startContainer's value.
This will cause later rng.startContainer to be null (rng.startContainer = startContainer.parentNode   -  startContainer have no parent node because its detached. )
Later in line 1406 in startContainer.nodeType will blow because startContainer is null. ( Uncaught TypeError: Cannot read property 'nodeType' of null).