### PR TITLE
Fixed some outstanding issues with drag and drop:

### DIFF
--- a/js/tinymce/classes/dom/RangeUtils.js
+++ b/js/tinymce/classes/dom/RangeUtils.js
@@ -12,7 +12,6 @@
  * This class contains a few utility methods for ranges.
  *
  * @class tinymce.dom.RangeUtils
- * @private
  */
 define("tinymce/dom/RangeUtils", [
 	"tinymce/util/Tools",
@@ -488,6 +487,41 @@ define("tinymce/dom/RangeUtils", [
 		}
 
 		return false;
+	};
+
+	/**
+	 * Gets the caret range for the given x/y location.
+	 *
+	 * @static
+	 * @method getCaretRangeFromPoint
+	 * @param {Number} x X coordinate for range
+	 * @param {Number} y Y coordinate for range
+	 * @param {Document} doc Document that x/y are relative to
+	 * @returns {Range} caret range
+	 */
+	RangeUtils.getCaretRangeFromPoint = function(x, y, doc) {
+		var rng, point;
+
+		if (doc.caretPositionFromPoint) {
+			point = doc.caretPositionFromPoint(x, y);
+			rng = doc.createRange();
+			rng.setStart(point.offsetNode, point.offset);
+			rng.collapse(true);
+		} else if (doc.caretRangeFromPoint) {
+			rng = doc.caretRangeFromPoint(x, y);
+		} else if (doc.body.createTextRange) {
+			rng = doc.body.createTextRange();
+
+			try {
+				rng.moveToPoint(x, y);
+				rng.collapse(true);
+			} catch (ex) {
+				// Append to top or bottom depending on drop location
+				rng.collapse(y < doc.body.clientHeight);
+			}
+		}
+
+		return rng;
 	};
 
 	return RangeUtils;

--- a/js/tinymce/plugins/paste/classes/Utils.js
+++ b/js/tinymce/plugins/paste/classes/Utils.js
@@ -11,7 +11,7 @@
 /**
  * This class contails various utility functions for the paste plugin.
  *
- * @class tinymce.pasteplugin.Clipboard
+ * @class tinymce.pasteplugin.Utils
  * @private
  */
 define("tinymce/pasteplugin/Utils", [

--- a/js/tinymce/plugins/paste/classes/WordFilter.js
+++ b/js/tinymce/plugins/paste/classes/WordFilter.js
@@ -11,7 +11,7 @@
 /**
  * This class parses word HTML into proper TinyMCE markup.
  *
- * @class tinymce.pasteplugin.Quirks
+ * @class tinymce.pasteplugin.WordFilter
  * @private
  */
 define("tinymce/pasteplugin/WordFilter", [


### PR DESCRIPTION
1. The Safari quirks code for drag and drop was using editor.insertContent.
   This bypassed the PastePreProcess and PastePostProcess events. Switched
   this to use the mceInsertClipboardContent command instead, which goes
   through the paste plugin and fires the correct events.
2. IE does not support setting custom contentType in the dataTransfer
   object, which meant drag and drop between editors did not work at all on
   IE. I extended the existing use of the special data:text/mce-internal url
   to IE so that it can now work.
3. Fixed a couple issues in the paste plugin:
   - BMP images are now allowed.
   - Multiple images can be dropped in one drag.
