### PR TITLE
Add placeholder plugin

### DIFF
--- a/js/tinymce/plugins/placeholder/plugin.js
+++ b/js/tinymce/plugins/placeholder/plugin.js
@@ -1,0 +1,71 @@
+/**
+ * plugin.js
+ *
+ * Copyright, Moxiecode Systems AB
+ * Released under LGPL License.
+ *
+ * License: http://www.tinymce.com/license
+ * Contributing: http://www.tinymce.com/contributing
+ */
+
+/*jshint unused:false */
+/*global tinymce:true */
+/*global HTMLElement:true */
+/*global NodeList:true */
+/*global document:true */
+
+tinymce.PluginManager.add('placeholder', function(editor) {
+	var i, item, placeholders = [],
+		config = {
+			remove: editor.settings.ph_remove || false,
+			ph_items: editor.settings.placeholders,
+			ph_cb: typeof editor.settings.ph_callback === 'function' ? editor.settings.ph_callback : function() {
+				tinymce.activeEditor.insertContent(
+					this._value
+				);
+			}
+		};
+	if (typeof config.ph_items === 'string') {
+		config.ph_items = document.querySelectorAll(config.ph_items);
+	}
+	if (!(config instanceof NodeList) && typeof config.ph_items[0] !== 'object') {
+		throw new TypeError('placeholder items must be objects (pass either an array, a NodeList, a jQuery object or a selector string)');
+	}
+	for (i = 0; i < config.ph_items.length; ++i) {
+		if (config.ph_items[i] instanceof HTMLElement) {
+			item = {
+				text: config.ph_items[i].textContent,
+				value: config.ph_items[i].value || this.text,
+				onclick: config.ph_cb
+			};
+		} else {
+			item = config.ph_items[i];
+			if (!item.hasOwnProperty('value')) {
+				item.value = item.text || '';
+			}
+			if (!item.hasOwnProperty('text')) {
+				item.text = item.value;
+			}
+			if (!item.hasOwnProperty('onclick')) {
+				item.onclick = config.ph_cb;
+			}
+		}
+		placeholders.push(item);
+	}
+	if (config.remove) {
+		for (i = 0; i < config.ph_items.length; ++i) {
+			if (config.ph_items[i] instanceof HTMLElement) {
+				config.ph_items[i].parentNode.removeChild(
+					config.ph_items[i]
+				);
+			}
+		}
+	}
+	editor.addButton('placeholder', {
+		text: 'Placeholders',
+		type: 'menubutton',
+		name: 'placeholder',
+		icon: false,
+		menu: placeholders
+	});
+});

--- a/js/tinymce/plugins/placeholder/plugin.js
+++ b/js/tinymce/plugins/placeholder/plugin.js
@@ -11,7 +11,6 @@
 /*jshint unused:false */
 /*global tinymce:true */
 /*global HTMLElement:true */
-/*global NodeList:true */
 /*global document:true */
 
 tinymce.PluginManager.add('placeholder', function(editor) {
@@ -28,17 +27,19 @@ tinymce.PluginManager.add('placeholder', function(editor) {
 	if (typeof config.ph_items === 'string') {
 		config.ph_items = document.querySelectorAll(config.ph_items);
 	}
-	if (!(config instanceof NodeList) && typeof config.ph_items[0] !== 'object') {
-		throw new TypeError('placeholder items must be objects (pass either an array, a NodeList, a jQuery object or a selector string)');
+	if (typeof config.ph_items !== 'object' || typeof config.ph_items.length === 'undefined') {
+		throw new TypeError(
+			'placeholder items must be objects (pass either an array, a NodeList, a jQuery object or a selector string)'
+		);
 	}
-	for (i = 0; i < config.ph_items.length; ++i) {
+	for (i = 0;i < config.ph_items.length; ++i) {
 		if (config.ph_items[i] instanceof HTMLElement) {
 			item = {
 				text: config.ph_items[i].textContent,
 				value: config.ph_items[i].value || this.text,
 				onclick: config.ph_cb
 			};
-		} else {
+		} else if (typeof config.ph_items[i] === 'object') {
 			item = config.ph_items[i];
 			if (!item.hasOwnProperty('value')) {
 				item.value = item.text || '';
@@ -49,8 +50,12 @@ tinymce.PluginManager.add('placeholder', function(editor) {
 			if (!item.hasOwnProperty('onclick')) {
 				item.onclick = config.ph_cb;
 			}
+		} else {
+			item = false;
 		}
-		placeholders.push(item);
+		if (item) {
+			placeholders.push(item);
+		}
 	}
 	if (config.remove) {
 		for (i = 0; i < config.ph_items.length; ++i) {


### PR DESCRIPTION
I've created a placeholder plugin for TinyMCE. I believe this is a useful feature to have, whenever templates (eg email templates) should be editable for people who aren't too familiar with templating languages/engines. Its usage is pretty self-explanatory, but in case some thing is not quite clear, I first created a separate repo for this plugin here: https://github.com/EVODelavega/placeholder-plugin. 

Usage of the plugin is explained in the readme and the examples in that repo.