### PR TITLE
Update WindowManager.open() docs to reference autoScroll option.

### DIFF
--- a/js/tinymce/classes/WindowManager.js
+++ b/js/tinymce/classes/WindowManager.js
@@ -68,7 +68,7 @@ define("tinymce/WindowManager", [
 		 * @option {Number} height Height in pixels.
 		 * @option {Boolean} resizable Specifies whether the popup window is resizable or not.
 		 * @option {Boolean} maximizable Specifies whether the popup window has a "maximize" button and can get maximized or not.
-		 * @option {String/Boolean} scrollbars Specifies whether the popup window can have scrollbars if required (i.e. content
+		 * @option {Boolean} autoScroll Specifies whether the popup window can have scrollbars if required (i.e. content
 		 * larger than the popup size specified).
 		 */
 		self.open = function(args, params) {


### PR DESCRIPTION
The docs for the "resizeable" and "maximizable" options appear to also need updating.