### PR TITLE
Only apply the jQuery patch once

### DIFF
--- a/js/tinymce/classes/jquery.tinymce.js
+++ b/js/tinymce/classes/jquery.tinymce.js
@@ -13,11 +13,12 @@
 (function($) {
 	var undef,
 		lazyLoading,
+		patchApplied,
 		delayedInits = [],
 		win = window;
 
 	$.fn.tinymce = function(settings) {
-		var self = this, url, base, lang, suffix = "", patchApplied;
+		var self = this, url, base, lang, suffix = "";
 
 		// No match then just ignore the call
 		if (!self.length) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -92,6 +92,7 @@
 	<script src="plugins/image.js"></script>
 	<script src="plugins/importcss.js"></script>
 	<script src="plugins/jquery_plugin.js"></script>
+	<script src="plugins/jquery_initialization.js"></script>
 	<script src="plugins/legacyoutput.js"></script>
 	<script src="plugins/link.js"></script>
 	<script src="plugins/lists.js"></script>

--- a/tests/plugins/jquery_initialization.js
+++ b/tests/plugins/jquery_initialization.js
@@ -1,0 +1,40 @@
+module("tinymce.plugins.jQueryInitialization", {
+	setupModule: function() {
+		document.getElementById('view').innerHTML = (
+			'<textarea id="elm1"></textarea>' +
+			'<textarea id="elm2"></textarea>'
+		);
+
+		this.val = $.fn.val;
+
+		QUnit.stop();
+
+		$(function() {
+			QUnit.start();
+		});
+	},
+
+	teardown: function() {
+		$.fn.val = this.val;
+	}
+});
+
+test("applyPatch is only called once", function() {
+	expect(1);
+
+	var options = {plugins: [
+				"pagebreak,layer,table,save,emoticons,insertdatetime,preview,media,searchreplace",
+				"print,contextmenu,paste,directionality,fullscreen,noneditable,visualchars,nonbreaking,template"
+			]},
+		oldValFn;
+
+	$('#elm1').tinymce(options);
+
+	oldValFn = $.fn.val = function() {
+		// no-op
+	};
+
+	$('#elm2').tinymce(options);
+
+	equal($.fn.val, oldValFn);
+});


### PR DESCRIPTION
If you initialize multiple instances of tinymce separately with jQuery each one is causing various methods in jQuery to be wrapped, which causes re-wrapping of already-wrapped functions. Repeated enough this can have a severe performance hit.

With this change the jQuery patch will only be applied once.