### PR TITLE
Fixed bug in paste filter for Word list detection

### DIFF
--- a/js/tinymce/plugins/paste/classes/WordFilter.js
+++ b/js/tinymce/plugins/paste/classes/WordFilter.js
@@ -62,7 +62,7 @@ define("tinymce/pasteplugin/WordFilter", [
 	}
 
 	function isBulletList(text) {
-		return /^[\s\u00a0]*[\u2022\u00b7\u00a7\u00d8\u25CF]\s*/.test(text);
+		return /^[\s\u00a0]*[\u2022\u00b7\u00a7\u25CF]\s*/.test(text);
 	}
 
 	function WordFilter(editor) {
@@ -174,7 +174,7 @@ define("tinymce/pasteplugin/WordFilter", [
 					// Remove start of list item "1. " or "&middot; " etc
 					removeIgnoredNodes(paragraphNode);
 					trimListStart(paragraphNode, /^\u00a0+/);
-					trimListStart(paragraphNode, /^\s*([\u2022\u00b7\u00a7\u00d8\u25CF]|\w+\.)/);
+					trimListStart(paragraphNode, /^\s*([\u2022\u00b7\u00a7\u25CF]|\w+\.)/);
 					trimListStart(paragraphNode, /^\u00a0+/);
 				}
 


### PR DESCRIPTION
One of the unicode characters in the list ('\u00d8') was the Norwegian and Danish letter 'Ø'.
This caused sentences starting with an Ø to become unordered lists when pasted from Word.