### PR TITLE
Fix selected item when no settings.value provided

### DIFF
--- a/js/tinymce/classes/ui/ListBox.js
+++ b/js/tinymce/classes/ui/ListBox.js
@@ -51,9 +51,7 @@ define("tinymce/ui/ListBox", [
 
 			self._values = values = settings.values;
 			if (values) {
-				if (typeof settings.value != "undefined") {
-					setSelected(values);
-				}
+				setSelected(values);
 
 				// Default with first item
 				if (!selected && values.length > 0) {


### PR DESCRIPTION
I think the test on settings.value is useless.
It broke my own code, because I'm providing a full list of items, one having the 'selected' flag to true, but I don't provide a settings.value