### PR TITLE
Link target fix

### DIFF
--- a/js/tinymce/plugins/link/plugin.js
+++ b/js/tinymce/plugins/link/plugin.js
@@ -152,7 +152,7 @@ tinymce.PluginManager.add('link', function(editor) {
 		data.text = initialText = anchorElm ? (anchorElm.innerText || anchorElm.textContent) : selection.getContent({format: 'text'});
 		data.href = anchorElm ? dom.getAttrib(anchorElm, 'href') : '';
 
-		if ((value = dom.getAttrib(anchorElm, 'target'))) {
+		if (anchorElm) {
 			data.target = value;
 		} else if (editor.settings.default_link_target) {
 			data.target = editor.settings.default_link_target;

--- a/js/tinymce/plugins/link/plugin.js
+++ b/js/tinymce/plugins/link/plugin.js
@@ -153,7 +153,7 @@ tinymce.PluginManager.add('link', function(editor) {
 		data.href = anchorElm ? dom.getAttrib(anchorElm, 'href') : '';
 
 		if (anchorElm) {
-			data.target = value;
+			data.target = dom.getAttrib(anchorElm, 'target');
 		} else if (editor.settings.default_link_target) {
 			data.target = editor.settings.default_link_target;
 		}


### PR DESCRIPTION
Set only to default_link_target if creating new link
If editing an existing link without target it is misleading to have the default_link_target selected as target