### PR TITLE
Fix some WCAG2AA / US508 compliance issues with the iframe and buttons

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -601,7 +601,7 @@ define("tinymce/Editor", [
 				return self.initContentBody();
 			}
 
-			self.iframeHTML = settings.doctype + '<html><head>';
+			self.iframeHTML = settings.doctype + '<html lang="en"><head><title>TinyMCE Editor</title>';
 
 			// We only need to override paths if we have to
 			// IE has a bug where it remove site absolute urls to relative ones if this is specified

--- a/js/tinymce/classes/ui/Button.js
+++ b/js/tinymce/classes/ui/Button.js
@@ -159,7 +159,8 @@ define("tinymce/ui/Button", [
 
 			return (
 				'<div id="' + id + '" class="' + self.classes() + '" tabindex="-1" aria-labelledby="' + id + '">' +
-					'<button role="presentation" type="button" tabindex="-1">' +
+					'<button role="presentation" type="button" tabindex="-1" ' +
+					'title="' + self.encode(self._text || self.settings.tooltip) + '">' +
 						(icon ? '<i class="' + icon + '"' + image + '></i>' : '') +
 						(self._text ? (icon ? '\u00a0' : '') + self.encode(self._text) : '') +
 					'</button>' +

--- a/js/tinymce/classes/ui/SplitButton.js
+++ b/js/tinymce/classes/ui/SplitButton.js
@@ -89,11 +89,13 @@ define("tinymce/ui/SplitButton", [
 
 			return (
 				'<div id="' + id + '" class="' + self.classes() + '" role="button" tabindex="-1">' +
-					'<button type="button" hidefocus="1" tabindex="-1">' +
+					'<button type="button" hidefocus="1" tabindex="-1" ' +
+					'title="' + self.encode(self._text || self.settings.tooltip) + '">' +
 						(icon ? '<i class="' + icon + '"' + image + '></i>' : '') +
 						(self._text ? (icon ? ' ' : '') + self._text : '') +
 					'</button>' +
-					'<button type="button" class="' + prefix + 'open" hidefocus="1" tabindex="-1">' +
+					'<button type="button" class="' + prefix + 'open" hidefocus="1" tabindex="-1" ' +
+					'title="Options (' + self.encode(self._text || self.settings.tooltip) + ')">' +
 						//(icon ? '<i class="' + icon + '"></i>' : '') +
 						(self._menuBtnText ? (icon ? '\u00a0' : '') + self._menuBtnText : '') +
 						' <i class="' + prefix + 'caret"></i>' +


### PR DESCRIPTION
Buttons require a title attribute for screen-readers, and documents (in this case the iframe) require a title and lang attribute.