### PR TITLE
Textcolor: Treat removal like color selection

### DIFF
--- a/js/tinymce/classes/ui/ColorButton.js
+++ b/js/tinymce/classes/ui/ColorButton.js
@@ -55,6 +55,18 @@ define("tinymce/ui/ColorButton", [
 		},
 
 		/**
+		 * Resets the current color.
+		 *
+		 * @method resetColor
+		 * @return {tinymce.ui.ColorButton} Current instance.
+		 */
+		resetColor: function() {
+			this._color = null;
+			this.getEl('preview').style.backgroundColor = null;
+			return this;
+		},
+
+		/**
 		 * Renders the control as a HTML string.
 		 *
 		 * @method renderHtml

--- a/js/tinymce/plugins/textcolor/plugin.js
+++ b/js/tinymce/plugins/textcolor/plugin.js
@@ -183,6 +183,12 @@ tinymce.PluginManager.add('textcolor', function(editor) {
 			applyFormat(buttonCtrl.settings.format, value);
 		}
 
+		function resetColor() {
+			buttonCtrl.hidePanel();
+			buttonCtrl.resetColor();
+			removeFormat(buttonCtrl.settings.format);
+		}
+
 		function setDivColor(div, value) {
 			div.style.background = value;
 			div.setAttribute('data-mce-color', value);
@@ -229,12 +235,10 @@ tinymce.PluginManager.add('textcolor', function(editor) {
 			this.lastId = e.target.id;
 
 			if (value == 'transparent') {
-				removeFormat(buttonCtrl.settings.format);
-				buttonCtrl.hidePanel();
-				return;
+				resetColor();
+			} else {
+				selectColor(value);
 			}
-
-			selectColor(value);
 		} else if (value !== null) {
 			buttonCtrl.hidePanel();
 		}
@@ -245,6 +249,8 @@ tinymce.PluginManager.add('textcolor', function(editor) {
 
 		if (self._color) {
 			applyFormat(self.settings.format, self._color);
+		} else {
+			removeFormat(self.settings.format);
 		}
 	}
 


### PR DESCRIPTION
There's somewhat confusing behavior if you select "no color", because the preview element keeps the previously selected color.

I don't know whether this was done by design but the fix is trivial (if one is needed at all).
Maybe the default style for the preview element's background color will have to be updated to 'transparent' as well.