### PR TITLE
Fix up/down movement and delete/backspace handling for complex nonEditables

### DIFF
--- a/js/tinymce/plugins/noneditable/plugin.js
+++ b/js/tinymce/plugins/noneditable/plugin.js
@@ -419,7 +419,16 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 							}
 						}
 					} else {
-						// remove block-level domNode but no container around on delete/backspace
+						var rng = selection.getRng(true);
+						var container = rng.endContainer;
+
+						// FIX: If end of node is selected, check wether next sibling is nonEditable to correctly remove it
+						// 			(else would break for more complex nonEditables, their content would get moved to the current node)
+						if (dom.isBlock(container) && dom.isBlock(container.nextSibling) && rng.endOffset == 1 && keyCode == VK.DELETE) {
+							nonEditableParent = getNonEditableParent(container.nextSibling);
+						}
+
+						// correctly remove block-level nonEditable domNode on delete/backspace
 						if (nonEditableParent && (keyCode == VK.DELETE || keyCode == VK.BACKSPACE) && dom.isBlock(nonEditableParent)) {
 							e.preventDefault();
 							dom.remove(nonEditableParent);

--- a/js/tinymce/plugins/noneditable/plugin.js
+++ b/js/tinymce/plugins/noneditable/plugin.js
@@ -418,6 +418,13 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 								removeCaretContainer(caretContainer);
 							}
 						}
+					} else {
+						// remove block-level domNode but no container around on delete/backspace
+						if (nonEditableParent && (keyCode == VK.DELETE || keyCode == VK.BACKSPACE) && dom.isBlock(nonEditableParent)) {
+							e.preventDefault();
+							dom.remove(nonEditableParent);
+							return;
+						}
 					}
 
 					if ((keyCode == VK.BACKSPACE || keyCode == VK.DELETE) && !canDelete(keyCode == VK.BACKSPACE)) {

--- a/js/tinymce/plugins/noneditable/plugin.js
+++ b/js/tinymce/plugins/noneditable/plugin.js
@@ -356,6 +356,7 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 			// Disable all key presses in contentEditable=false except delete or backspace
 			nonEditableParent = getNonEditableParent(startElement) || getNonEditableParent(endElement);
 			if (nonEditableParent && (keyCode < 112 || keyCode > 124) && keyCode != VK.DELETE && keyCode != VK.BACKSPACE) {
+
 				// Is Ctrl+c, Ctrl+v or Ctrl+x then use default browser behavior
 				if ((tinymce.isMac ? e.metaKey : e.ctrlKey) && (keyCode == 67 || keyCode == 88 || keyCode == 86)) {
 					return;
@@ -364,8 +365,8 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 				e.preventDefault();
 
 				// Arrow left/right select the element and collapse left/right
-				if (keyCode == VK.LEFT || keyCode == VK.RIGHT) {
-					var left = keyCode == VK.LEFT;
+				if (keyCode == VK.LEFT || keyCode == VK.RIGHT || keyCode == VK.UP || keyCode == VK.DOWN) {
+					var left = keyCode == VK.LEFT || keyCode == VK.UP;
 					// If a block element find previous or next element to position the caret
 					if (editor.dom.isBlock(nonEditableParent)) {
 						var targetElement = left ? nonEditableParent.previousSibling : nonEditableParent.nextSibling;
@@ -379,6 +380,7 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 			} else {
 				// Is arrow left/right, backspace or delete
 				if (keyCode == VK.LEFT || keyCode == VK.RIGHT || keyCode == VK.BACKSPACE || keyCode == VK.DELETE) {
+
 					caretContainer = getParentCaretContainer(startElement);
 					if (caretContainer) {
 						// Arrow left or backspace
@@ -401,7 +403,7 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 
 						// Arrow right or delete
 						if (keyCode == VK.RIGHT || keyCode == VK.DELETE) {
-							nonEditableParent = getNonEmptyTextNodeSibling(caretContainer);
+							nonEditableParent = getNonEmptyTextNodeSibling(caretContainer, true);
 
 							if (nonEditableParent && getContentEditable(nonEditableParent) === "false") {
 								e.preventDefault();

--- a/js/tinymce/plugins/noneditable/plugin.js
+++ b/js/tinymce/plugins/noneditable/plugin.js
@@ -492,6 +492,17 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 		editor.on('mousedown', function(e) {
 			var node = editor.selection.getNode();
 
+			// Also remove separator lines when clicking on another node
+			if (node && node.className.indexOf('mceTmpParagraph') !== -1 && node !== e.target) {
+				// current node is still empty and a separator -> remove it
+				// else: remove the separator class, as it now includes content
+				if (node.innerHTML === '&nbsp;' || node.innerHTML === '' || node.innerHTML === ' ') {
+					dom.remove(node);
+				} else {
+					node.className = node.className.replace('mceTmpParagraph', '');
+				}
+			}
+
 			if (getContentEditable(node) === "false" && node == e.target) {
 				// Expand selection on mouse down we can't block the default event since it's used for drag/drop
 				moveSelection();

--- a/js/tinymce/plugins/noneditable/plugin.js
+++ b/js/tinymce/plugins/noneditable/plugin.js
@@ -383,12 +383,12 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 							var p = dom.create('p', null, '&nbsp;');
 							p.className = 'mceTmpParagraph';
 
-							var insertElement = left ? editor.selection.getNode() : targetElement;
+							var insertElement = left ? nonEditableParent : targetElement;
 
 							if (insertElement && insertElement.parentNode) {
 								insertElement.parentNode.insertBefore(p, insertElement);
 							} else if (!targetElement && !left) {
-								currentNode.parentNode.appendChild(p);
+								nonEditableParent.parentNode.appendChild(p);
 							}
 
 							targetElement = p;


### PR DESCRIPTION
These bugs occured for complex, block-level nonEditables (meaning they have child nodes which are not non-editable themselves):

1. Before it was not possible to move over/through nonEditables using up and down.
2. It was possible to remove parts (child nodes) of nonEditables, rather than the complete nonEditable, as it would be expected.
3. If one nonEditable was followed by another, there was no way to navigate between them.

There is still a bug when dropping/pasting on nonEditables, which can be fixed using the paste-plugin preprocess function (select the whole nonEditable and replace it with the drop/paste content)