### PR TITLE
Removed "MsoCaption" Node Class Filter

### DIFF
--- a/js/tinymce/plugins/paste/classes/WordFilter.js
+++ b/js/tinymce/plugins/paste/classes/WordFilter.js
@@ -419,7 +419,7 @@ define("tinymce/pasteplugin/WordFilter", [
 						node = nodes[i];
 
 						className = node.attr('class');
-						if (/^(MsoCommentReference|MsoCommentText|msoDel|MsoCaption)$/i.test(className)) {
+						if (/^(MsoCommentReference|MsoCommentText|msoDel)$/i.test(className)) {
 							node.remove();
 						}
 


### PR DESCRIPTION
While I agree that comment references, comment text and pre-marked "to be deleted" elements shouldn't be pasted into the editor, captions are visible elements in the document that are usually titles of figures or tables and should be able to be pasted.