### PR TITLE
Add option to allow the link target to not show.

### DIFF
--- a/js/tinymce/plugins/autoresize/plugin.js
+++ b/js/tinymce/plugins/autoresize/plugin.js
@@ -64,6 +64,7 @@ tinymce.PluginManager.add('autoresize', function(editor) {
 		myHeight = body.offsetHeight + parseInt(marginTop, 10) + parseInt(marginBottom, 10) +
 			parseInt(paddingTop, 10) + parseInt(paddingBottom, 10) +
 			parseInt(borderTop, 10) + parseInt(borderBottom, 10);
+		//myHeight = body.offsetHeight;
 
 		// Make sure we have a valid height
 		if (isNaN(myHeight) || myHeight <= 0) {
@@ -127,11 +128,13 @@ tinymce.PluginManager.add('autoresize', function(editor) {
 	editor.on("init", function() {
 		var overflowPadding = editor.getParam('autoresize_overflow_padding', 1);
 
-		editor.dom.setStyles(editor.getBody(), {
-			paddingBottom: editor.getParam('autoresize_bottom_margin', 50),
-			paddingLeft: overflowPadding,
-			paddingRight: overflowPadding
-		});
+		if (editor.getParam('autoresize_bottom_margin', false)) {
+			editor.dom.setStyles(editor.getBody(), {
+				paddingBottom: editor.getParam('autoresize_bottom_margin', 50),
+				paddingLeft: overflowPadding,
+				paddingRight: overflowPadding
+			});
+		}
 	});
 
 	// Add appropriate listeners for resizing content area

--- a/js/tinymce/plugins/link/plugin.js
+++ b/js/tinymce/plugins/link/plugin.js
@@ -209,12 +209,14 @@ tinymce.PluginManager.add('link', function(editor) {
 				];
 			}
 
-			targetListCtrl = {
-				name: 'target',
-				type: 'listbox',
-				label: 'Target',
-				values: buildListItems(editor.settings.target_list)
-			};
+			if (editor.settings.show_link_target !== false) {
+				targetListCtrl = {
+					name: 'target',
+					type: 'listbox',
+					label: 'Target',
+					values: buildListItems(editor.settings.target_list)
+				};
+			}
 		}
 
 		if (editor.settings.rel_list) {


### PR DESCRIPTION
When the editor is set to scrub the target attribute from href links it makes no sense to give the use a dialog to add the attribute..