### PR TITLE
Fixing bug #6628 and tests

### DIFF
--- a/js/tinymce/plugins/noneditable/plugin.js
+++ b/js/tinymce/plugins/noneditable/plugin.js
@@ -128,9 +128,9 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 			return caretContainer;
 		}
 
-		// Removes any caret container except the one we might be in
+		// Removes any caret container
 		function removeCaretContainer(caretContainer) {
-			var rng, child, currentCaretContainer, lastContainer;
+			var rng, child, lastContainer;
 
 			if (caretContainer) {
 				rng = selection.getRng(true);
@@ -146,16 +146,13 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 
 				selection.setRng(rng);
 			} else {
-				currentCaretContainer = getParentCaretContainer(selection.getStart());
 				while ((caretContainer = dom.get(caretContainerId)) && caretContainer !== lastContainer) {
-					if (currentCaretContainer !== caretContainer) {
-						child = findFirstTextNode(caretContainer);
-						if (child && child.nodeValue.charAt(0) == invisibleChar) {
-							child = child.deleteData(0, 1);
-						}
-
-						dom.remove(caretContainer, true);
+					child = findFirstTextNode(caretContainer);
+					if (child && child.nodeValue.charAt(0) == invisibleChar) {
+						child = child.deleteData(0, 1);
 					}
+
+					dom.remove(caretContainer, true);
 
 					lastContainer = caretContainer;
 				}
@@ -350,6 +347,8 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 				return true;
 			}
 
+			moveSelection();
+
 			startElement = selection.getStart();
 			endElement = selection.getEnd();
 
@@ -435,7 +434,6 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 			}
 		});
 
-		editor.on('mouseup keyup', moveSelection);
 		editor.on('keydown', handleKey);
 	}
 

--- a/js/tinymce/plugins/noneditable/plugin.js
+++ b/js/tinymce/plugins/noneditable/plugin.js
@@ -434,6 +434,8 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 			}
 		});
 
+		editor.on('mouseup', moveSelection);
+
 		editor.on('keydown', handleKey);
 	}
 

--- a/tests/plugins/noneditable.js
+++ b/tests/plugins/noneditable.js
@@ -33,7 +33,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		rng.setEnd(editor.getBody().firstChild.lastChild, 1);
 		editor.selection.setRng(rng);
 
-		Utils.type({keyCode: 18}); // ALT
+		editor.dom.fire(editor.getBody(), 'mouseup');
 		rng = Utils.normalizeRng(editor.selection.getRng(true));
 
 		equal(rng.startContainer.nodeName, 'P');
@@ -50,7 +50,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		rng.setEnd(editor.getBody().firstChild.lastChild.firstChild, 1);
 		editor.selection.setRng(rng);
 
-		Utils.type({keyCode: 18}); // ALT
+		editor.dom.fire(editor.getBody(), 'mouseup');
 		rng = Utils.normalizeRng(editor.selection.getRng(true));
 
 		equal(rng.startContainer.nodeName, '#text');
@@ -67,7 +67,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		rng.setEnd(editor.dom.select('span')[0].firstChild, 2);
 		editor.selection.setRng(rng);
 
-		Utils.type({keyCode: 18}); // ALT
+		editor.dom.fire(editor.getBody(), 'mouseup');
 		rng = Utils.normalizeRng(editor.selection.getRng(true));
 
 		equal(rng.startContainer.nodeName, 'P');
@@ -84,7 +84,6 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		rng.setEnd(editor.dom.select('span')[0].firstChild, 2);
 		editor.selection.setRng(rng);
 
-		editor.dom.fire(editor.getBody(), 'mouseup');
 		Utils.type('X');
 		rng = Utils.normalizeRng(editor.selection.getRng(true));
 
@@ -105,7 +104,6 @@ test('type between non editable', function() {
 	rng.setEnd(editor.dom.select('span')[0].firstChild, 2);
 	editor.selection.setRng(rng);
 
-	editor.dom.fire(editor.getBody(), 'mouseup');
 	Utils.type('X');
 	rng = Utils.normalizeRng(editor.selection.getRng(true));
 
@@ -125,7 +123,6 @@ test('type after last non editable', function() {
 	rng.setEnd(editor.dom.select('span')[0].firstChild, 2);
 	editor.selection.setRng(rng);
 
-	editor.dom.fire(editor.getBody(), 'mouseup');
 	Utils.type('X');
 	rng = Utils.normalizeRng(editor.selection.getRng(true));
 

--- a/tests/plugins/noneditable.js
+++ b/tests/plugins/noneditable.js
@@ -33,7 +33,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		rng.setEnd(editor.getBody().firstChild.lastChild, 1);
 		editor.selection.setRng(rng);
 
-		editor.dom.fire(editor.getBody(), 'mouseup');
+		Utils.type({keyCode: 18}); // ALT
 		rng = Utils.normalizeRng(editor.selection.getRng(true));
 
 		equal(rng.startContainer.nodeName, 'P');
@@ -50,7 +50,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		rng.setEnd(editor.getBody().firstChild.lastChild.firstChild, 1);
 		editor.selection.setRng(rng);
 
-		editor.dom.fire(editor.getBody(), 'mouseup');
+		Utils.type({keyCode: 18}); // ALT
 		rng = Utils.normalizeRng(editor.selection.getRng(true));
 
 		equal(rng.startContainer.nodeName, '#text');
@@ -67,7 +67,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		rng.setEnd(editor.dom.select('span')[0].firstChild, 2);
 		editor.selection.setRng(rng);
 
-		editor.dom.fire(editor.getBody(), 'mouseup');
+		Utils.type({keyCode: 18}); // ALT
 		rng = Utils.normalizeRng(editor.selection.getRng(true));
 
 		equal(rng.startContainer.nodeName, 'P');
@@ -148,10 +148,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 
 		Utils.type({keyCode: 37});
 		rng = Utils.normalizeRng(editor.selection.getRng(true));
-
-		equal(rng.startContainer.nodeName, 'SPAN');
-		equal(rng.startContainer.parentNode.nodeName, 'P');
-		equal(editor.dom.nodeIndex(rng.startContainer), 1);
+		equal(rng.startContainer.nodeName, 'P');
 		equal(rng.collapsed, true);
 	});
 }
@@ -166,9 +163,8 @@ test('escape noneditable inline element (right)', function() {
 	Utils.type({keyCode: 39});
 	rng = Utils.normalizeRng(editor.selection.getRng(true));
 
-	equal(rng.startContainer.nodeName, 'SPAN');
-	equal(rng.startContainer.parentNode.nodeName, 'P');
-	equal(editor.dom.nodeIndex(rng.startContainer), 2);
+	equal(rng.startContainer.nodeName, 'P');
+	equal(editor.dom.nodeIndex(rng.startContainer), 0);
 	equal(rng.collapsed, true);
 });
 


### PR DESCRIPTION
Fix bug #6628

* When inserting a noneditable block, first typing car just after insertion was never shown (because moveSelection was called on keyup event, and it has to be called before handlekey to act properly
* When typing some car after inserting a noneditable block, then pressing BACKSPACE, the wrong block was removed (not le last caracter)

See : http://www.tinymce.com/develop/bugtracker_view.php?id=6628 and associate fiddle
