### PR TITLE
Use editor.convertURL instead of manually converting the URL

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -221,14 +221,7 @@ tinymce.PluginManager.add('image', function(editor) {
 			});
 
 			if (!meta.width && !meta.height) {
-				var srcURL = this.value(),
-				absoluteURLPattern = new RegExp('^(?:[a-z]+:)?//', 'i'),
-				baseURL = editor.settings.document_base_url;
-
-				//Pattern test the src url and make sure we haven't already prepended the url
-				if (baseURL && !absoluteURLPattern.test(srcURL) && srcURL.substring(0, baseURL.length) !== baseURL) {
-					this.value(baseURL + srcURL);
-				}
+				this.value(editor.convertURL(this.value(), 'src'));
 
 				getImageSize(this.value(), function(data) {
 					if (data.width && data.height && imageDimensions) {


### PR DESCRIPTION
Do not merge yet - 2 tests are failing.

Previously, adding an image would always prepend the document_base_url,
which by default includes protocol and hostname, regardless of the
relative_urls setting. However, when relative_urls is set to true, this
is not desired.

WIP: I assume that convertURL does the right thing, and confirmed so
with manual testing, but I can't get the test setup changed so that it
works correctly. 2 tests are failing now:

```
tinymce.plugins.Image - Image recognizes relative src url and prepends relative document_base_url setting....ERROR
tinymce.plugins.Image - Image recognizes relative src url and prepends absolute document_base_url setting....ERROR
```