### PR TITLE
fix bugs 7412 and 7413 related to the valid_styles setting

### DIFF
--- a/js/tinymce/classes/dom/DOMUtils.js
+++ b/js/tinymce/classes/dom/DOMUtils.js
@@ -72,7 +72,7 @@ define("tinymce/dom/DOMUtils", [
 				get: function($elm) {
 					var value = $elm.attr('data-mce-style') || $elm.attr('style');
 
-					value = domUtils.serializeStyle(domUtils.parseStyle(value), $elm[0].nodeName);
+					value = domUtils.serializeStyle(domUtils.parseStyle(value), $elm[0].nodeName.toLowerCase());
 
 					return value;
 				}

--- a/tests/tinymce/Formatter_apply.js
+++ b/tests/tinymce/Formatter_apply.js
@@ -1615,3 +1615,29 @@ test('Bug #6518 - Apply div blocks to inline editor paragraph', function() {
 	inlineEditor.formatter.apply('format');
 	equal(inlineEditor.getContent(), '<div>a</div><p>b</p>');
 });
+
+asyncTest('Bug #7412 - valid_styles affects the Bold and Italic buttons, although it shouldn\'t', function() {
+    tinymce.remove();
+
+    document.getElementById('view').innerHTML = '<textarea id="elm1"></textarea>';
+
+    tinymce.init({
+        selector: "#elm1",
+        add_unload_trigger: false,
+        valid_styles: {
+            span: 'color,background-color,font-size,text-decoration,padding-left'
+        },
+        init_instance_callback: function(ed) {
+            window.editor = ed;
+            QUnit.start();
+
+            editor.getBody().innerHTML = '<p>1 <span style="text-decoration: underline;">1234</span> 1</p>';
+            var rng = editor.dom.createRng();
+            rng.setStart(editor.dom.select('span')[0], 0);
+            rng.setEnd(editor.dom.select('span')[0], 1);
+            editor.selection.setRng(rng);
+            editor.formatter.toggle('bold');
+            equal(getContent(), '<p>1 <strong><span style="text-decoration: underline;">1234</span></strong> 1</p>');
+        }
+    });
+});


### PR DESCRIPTION
- [#7412](http://www.tinymce.com/develop/bugtracker_view.php?id=7412): valid_styles affects the Bold and Italic buttons, although it shouldn't
- [#7413](http://www.tinymce.com/develop/bugtracker_view.php?id=7413): valid_styles breaks the Strike-through button in IE

This fix might be not optimal from the performance point of view. It might make sense instead to preprocess the `valid_styles` map to add uppercase values there as I did in #487.
I'm submitting both options for the project team to decide.