### PR TITLE
alternative fix for bugs 7412 and 7413 related to valid_styles

### DIFF
--- a/js/tinymce/classes/html/Schema.js
+++ b/js/tinymce/classes/html/Schema.js
@@ -329,7 +329,7 @@ define("tinymce/html/Schema", [
 
 			// Convert styles into a rule list
 			each(value, function(value, key) {
-				styles[key] = mode == 'map' ? makeMap(value, /[, ]/) : explode(value, /[, ]/);
+				styles[key] = styles[key.toUpperCase()] = mode == 'map' ? makeMap(value, /[, ]/) : explode(value, /[, ]/);
 			});
 		}
 

--- a/tests/tinymce/Formatter_apply.js
+++ b/tests/tinymce/Formatter_apply.js
@@ -1615,3 +1615,29 @@ test('Bug #6518 - Apply div blocks to inline editor paragraph', function() {
 	inlineEditor.formatter.apply('format');
 	equal(inlineEditor.getContent(), '<div>a</div><p>b</p>');
 });
+
+asyncTest('Bug #7412 - valid_styles affects the Bold and Italic buttons, although it shouldn\'t', function() {
+    tinymce.remove();
+
+    document.getElementById('view').innerHTML = '<textarea id="elm1"></textarea>';
+
+    tinymce.init({
+        selector: "#elm1",
+        add_unload_trigger: false,
+        valid_styles: {
+            span: 'color,background-color,font-size,text-decoration,padding-left'
+        },
+        init_instance_callback: function(ed) {
+            window.editor = ed;
+            QUnit.start();
+
+            editor.getBody().innerHTML = '<p>1 <span style="text-decoration: underline;">1234</span> 1</p>';
+            var rng = editor.dom.createRng();
+            rng.setStart(editor.dom.select('span')[0], 0);
+            rng.setEnd(editor.dom.select('span')[0], 1);
+            editor.selection.setRng(rng);
+            editor.formatter.toggle('bold');
+            equal(getContent(), '<p>1 <strong><span style="text-decoration: underline;">1234</span></strong> 1</p>');
+        }
+    });
+});

--- a/tests/tinymce/html/Schema.js
+++ b/tests/tinymce/html/Schema.js
@@ -455,6 +455,11 @@ test('validStyles', function() {
 		"a": [
 			"background",
 			"font-family"
+		],
+
+		"A": [
+			"background",
+			"font-family"
 		]
 	});
 });
@@ -493,6 +498,11 @@ test('invalidStyles', function() {
 		'a': {
 			'background': {},
 			'font-family': {}
+		},
+
+		'A': {
+			'background': {},
+			'font-family': {}
 		}
 	});
 });
@@ -529,6 +539,11 @@ test('validClasses', function() {
 		},
 
 		'a': {
+			'classC': {},
+			'classD': {}
+		},
+
+		'A': {
 			'classC': {},
 			'classD': {}
 		}


### PR DESCRIPTION
- [#7412](http://www.tinymce.com/develop/bugtracker_view.php?id=7412): valid_styles affects the Bold and Italic buttons, although it shouldn't
- [#7413](http://www.tinymce.com/develop/bugtracker_view.php?id=7413): valid_styles breaks the Strike-through button in IE

This fix should be better from the performance point of view than #486.
I'm submitting both options for the project team to decide.