### PR TITLE
Fixed bug where single words got lost when pasting lists with formatted parts from MS Word

### DIFF
--- a/js/tinymce/plugins/paste/classes/WordFilter.js
+++ b/js/tinymce/plugins/paste/classes/WordFilter.js
@@ -108,8 +108,8 @@ define("tinymce/pasteplugin/WordFilter", [
 					if (node.type === 3) {
 						if (regExp.test(node.value)) {
 							node.value = node.value.replace(regExp, '');
-							return false;
 						}
+						return false;
 					}
 
 					if ((node = node.firstChild)) {


### PR DESCRIPTION
Fixed bug where single words got lost when pasting lists with formatted parts from MS Word
