### PR TITLE
[image-plugin] Added check for undefined for data.width, data.height, data[class]

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -157,16 +157,20 @@ tinymce.PluginManager.add('image', function(editor) {
 				data.title = '';
 			}
 
-			if (data.width === '') {
+			if (data.width === '' || data.width === undefined) {
 				data.width = null;
 			}
 
-			if (data.height === '') {
+			if (data.height === '' || data.height === undefined) {
 				data.height = null;
 			}
 
 			if (!data.style) {
 				data.style = null;
+			}
+
+			if (data["class"] === undefined) {
+				data["class"]= null;
 			}
 
 			// Setup new data excluding style properties


### PR DESCRIPTION
On image inserts with 'image_dimensions: false', the generated html tags contain ' class="undefined" width="undefined" height="undefined" '.
