### PR TITLE
Write custom URL patterns from main editor config

### DIFF
--- a/js/tinymce/plugins/media/plugin.js
+++ b/js/tinymce/plugins/media/plugin.js
@@ -248,6 +248,11 @@ tinymce.PluginManager.add('media', function(editor, url) {
 		data.source2mime = guessMime(data.source2);
 		data.poster = editor.convertURL(data.poster, "poster");
 		data.flashPlayerUrl = editor.convertURL(url + '/moxieplayer.swf', "movie");
+		if(!!editor.settings.media_urlPatterns){
+			if(Array.isArray(editor.settings.media_urlPatterns)){
+				urlPatterns = urlPatterns.concat(editor.settings.media_urlPatterns);
+			}
+		}
 
 		tinymce.each(urlPatterns, function(pattern) {
 			var match, i, url;


### PR DESCRIPTION
Custom url patterns are written in main editor config into 'media_urlPatterns' param and are appended to default urlPatterns from media plugin