### PR TITLE
Update plugin.js, the noneditable element cannot be deleted with the 'delete' key.

### DIFF
--- a/js/tinymce/plugins/noneditable/plugin.js
+++ b/js/tinymce/plugins/noneditable/plugin.js
@@ -427,7 +427,7 @@ tinymce.PluginManager.add('noneditable', function(editor) {
 
 						// Arrow right or delete
 						if (keyCode == VK.RIGHT || keyCode == VK.DELETE) {
-							nonEditableParent = getNonEmptyTextNodeSibling(caretContainer, true);
+							nonEditableParent = getNonEmptyTextNodeSibling(caretContainer, false);
 
 							if (nonEditableParent && getContentEditable(nonEditableParent) === "false") {
 								e.preventDefault();


### PR DESCRIPTION
On right press or delete key, the NEXT non-empty node sibling must be picked instead of the previous one.