### PR TITLE
Allow templates option to be a callback

### DIFF
--- a/js/tinymce/plugins/template/plugin.js
+++ b/js/tinymce/plugins/template/plugin.js
@@ -17,6 +17,10 @@ tinymce.PluginManager.add('template', function(editor) {
 		return function() {
 			var templateList = editor.settings.templates;
 
+			if (typeof templateList == "function") {
+				templateList = templateList.call();
+			}
+
 			if (typeof templateList == "string") {
 				tinymce.util.XHR.send({
 					url: templateList,


### PR DESCRIPTION
Sometimes the URL or list of templates needs to be defined dynamically at the time the user clicks the `Insert Template` button/menu-item.

This commit adds the ability for the user to pass a callback to the `templates` config option.

This callback allows the user to dynamically generate a url, or template list at the time the `Insert Template` action is performed.

```
editor.tinymce({
        plugins: ['template'],
        templates: function() { return 'my_dynamic_url/' + $('#some_id').val(); }
});
```

OR

```
editor.tinymce({
        plugins: ['template'],
        templates: function() { return [{ ... ... }]; }
});
```