### PR TITLE
Add global hook into XRH setup of each request

### DIFF
--- a/js/tinymce/classes/util/XHR.js
+++ b/js/tinymce/classes/util/XHR.js
@@ -55,6 +55,8 @@ define("tinymce/util/XHR", [
 					setTimeout(ready, 10);
 				}
 			}
+			
+			
 
 			// Default settings
 			settings.scope = settings.scope || this;
@@ -62,6 +64,8 @@ define("tinymce/util/XHR", [
 			settings.error_scope = settings.error_scope || settings.scope;
 			settings.async = settings.async === false ? false : true;
 			settings.data = settings.data || '';
+			
+			XHR.fire('beforeInitialize', {settings: settings});
 
 			xhr = new XMLHttpRequest();
 

--- a/js/tinymce/classes/util/XHR.js
+++ b/js/tinymce/classes/util/XHR.js
@@ -55,8 +55,6 @@ define("tinymce/util/XHR", [
 					setTimeout(ready, 10);
 				}
 			}
-			
-			
 
 			// Default settings
 			settings.scope = settings.scope || this;


### PR DESCRIPTION
There are times where the data sent in the XHR request needs to be modified.

An example of where this is needed can be seen in pull request, #498.  In this example, the plugin does't currently allow the URL to be defined at the time an XHR request is made.  Having a global hook, is a way to access the request even if the plugin hasn't provided for it.

This commit adds a hook before the XHR object is initialised, allowing for the settings to be modified at the time of the request.

```
tinymce.util.XHR.on('beforeInitialize', function(settings) {
    if (settings.data) settings.data = settings.data + '&';
    settings.data = settings.data + 'foo=bar';
});
```