### PR TITLE
Fix missing call of the custom url converter in the image plugin

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -168,6 +168,8 @@ tinymce.PluginManager.add('image', function(editor) {
 			if (!data.style) {
 				data.style = null;
 			}
+			
+			data.src = editor.convertURL(data.src, 'src');
 
 			// Setup new data excluding style properties
 			/*eslint dot-notation: 0*/


### PR DESCRIPTION
Bugfix for the image plugin. If a custom URL converter is configured (configuration option "convert_urls"), it will be called after changes of the source field in the "insert/edit image" dialog. 
Unfortunately the url converter is not called if the user clicks the "Ok" button directly (form submission).
The problem occured with the Internet Explorer 9.
