### PR TITLE
compatible with 3.x

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1152,7 +1152,7 @@ define("tinymce/Editor", [
 		 */
 		getLang: function(name, defaultVal) {
 			return (
-				this.editorManager.i18n.data[(this.settings.language || 'en') + '.' + name] ||
+				(this.editorManager.i18n.data[(this.settings.language || 'en')] && this.editorManager.i18n.data[(this.settings.language || 'en')][name]) ||
 				(defaultVal !== undefined ? defaultVal : '{#' + name + '}')
 			);
 		},


### PR DESCRIPTION
tinymce 3.x has "a.b.c" key for getLang function, which is not work well in 4x.

this code fix the bug in my problem.