### PR TITLE
Default value wrong if submenus used in images list

### DIFF
--- a/js/tinymce/plugins/image/plugin.js
+++ b/js/tinymce/plugins/image/plugin.js
@@ -280,7 +280,7 @@ tinymce.PluginManager.add('image', function(editor) {
 					},
 					[{text: 'None', value: ''}]
 				),
-				value: data.src && editor.convertURL(data.src, 'src'),
+				value: data.src ? editor.convertURL(data.src, 'src') : '',
 				onselect: function(e) {
 					var altCtrl = win.find('#alt');
 


### PR DESCRIPTION
Fixed a bug, when submenus are used in the images list and no image is set as default, it defaults to the first of the sub menus (not the "None" item).

Example:

```
image_list: [
        {title: 'Favorites', menu: [
          {title: 'Foo 1', value: 'https://i.chzbgr.com/maxW500/8495890944/hB0969D4D/'},
          {title: 'Bar 2', value: 'https://i.chzbgr.com/maxW500/8495576832/h48CC8D78/'},
          {title: 'Baz 3', value: 'https://i.chzbgr.com/maxW500/8491557632/h7D0F6254/'}
        ]},
        {title: 'Shared', menu: [
          {title: 'Foo 11', value: 'https://i.chzbgr.com/maxW500/8495839744/h52B33840/'},
          {title: 'Bar 22', value: 'https://i.chzbgr.com/maxW500/8495521280/hDFE78113/'},
          {title: 'Baz 33', value: 'https://i.chzbgr.com/maxW500/8495847936/h41110593/'}
        ]},
        {title: 'Dog 11', value: 'https://i.chzbgr.com/maxW500/6258364416/h3DCB0C00/'},
        {title: 'Cat 22', value: 'https://i.chzbgr.com/maxW500/8495002624/h925C5C45/'}
      ],
```

In this case the menu "Favorites" is selected as default value.