### PR TITLE
Update autoresize plugin with option to prevent extending height beyond browser viewport

### DIFF
--- a/js/tinymce/plugins/autoresize/plugin.js
+++ b/js/tinymce/plugins/autoresize/plugin.js
@@ -34,7 +34,8 @@ tinymce.PluginManager.add('autoresize', function(editor) {
 	 */
 	function resize(e) {
 		var deltaSize, doc, body, docElm, DOM = tinymce.DOM, resizeHeight, myHeight,
-			marginTop, marginBottom, paddingTop, paddingBottom, borderTop, borderBottom;
+			marginTop, marginBottom, paddingTop, paddingBottom, borderTop, borderBottom,
+			currentMaxHeight = settings.autoresize_max_height, viewPortHeight;
 
 		doc = editor.getDoc();
 		if (!doc) {
@@ -76,9 +77,24 @@ tinymce.PluginManager.add('autoresize', function(editor) {
 			resizeHeight = myHeight;
 		}
 
+		// If user wants to keep within browser viewport height, set max_height if needed
+		if (settings.autoresize_viewport_offset) {
+			// Old IE
+			if (body.offsetHeight) {
+				viewPortHeight = body.offsetHeight;
+			}
+
+			// Modern browsers
+			if (window.innerHeight) {
+				viewPortHeight = window.innerHeight;
+			}
+
+			currentMaxHeight = Math.min(viewPortHeight - settings.autoresize_viewport_offset, currentMaxHeight);
+		}
+
 		// If a maximum height has been defined don't exceed this height
-		if (settings.autoresize_max_height && myHeight > settings.autoresize_max_height) {
-			resizeHeight = settings.autoresize_max_height;
+		if ((currentMaxHeight > 0) && myHeight > currentMaxHeight) {
+			resizeHeight = currentMaxHeight;
 			body.style.overflowY = "auto";
 			docElm.style.overflowY = "auto"; // Old IE
 		} else {
@@ -122,6 +138,9 @@ tinymce.PluginManager.add('autoresize', function(editor) {
 
 	// Define maximum height
 	settings.autoresize_max_height = parseInt(editor.getParam('autoresize_max_height', 0), 10);
+
+	// Define don't exceed browser viewport height
+	settings.autoresize_viewport_offset = parseInt(editor.getParam('autoresize_viewport_offset', 0), 10);
 
 	// Add padding at the bottom for better UX
 	editor.on("init", function() {


### PR DESCRIPTION
If optional `autoresize_viewport_offset` is non-zero make sure editor is not autoresized beyond the current browser viewport height taking the offset into consideration (ie. viewport-height minus viewport-offset).
