### PR TITLE
prevents copying styles outside the editor

### DIFF
--- a/js/tinymce/classes/EnterKey.js
+++ b/js/tinymce/classes/EnterKey.js
@@ -220,7 +220,7 @@ define("tinymce/EnterKey", [
 								block.appendChild(clonedNode);
 							}
 						}
-					} while ((node = node.parentNode));
+					} while ((node = node.parentNode) && node != editableRoot);
 				}
 
 				// BR is needed in empty blocks on non IE browsers


### PR DESCRIPTION
Fixes Bug #7559

If an inline editor is wrapped in spans, the styles of those spans were
cloned when a new paragraph was created.
This commit fixes this problem.