### PR TITLE
improving validation of external links to accept a number after 'www'

### DIFF
--- a/js/tinymce/plugins/link/plugin.js
+++ b/js/tinymce/plugins/link/plugin.js
@@ -350,7 +350,7 @@ tinymce.PluginManager.add('link', function(editor) {
 
 				// Is not protocol prefixed
 				if ((editor.settings.link_assume_external_targets && !/^\w+:/i.test(href)) ||
-					(!editor.settings.link_assume_external_targets && /^\s*www\./i.test(href))) {
+					(!editor.settings.link_assume_external_targets && /^\s*www[\.|\d\.]/i.test(href))) {
 					delayedConfirm(
 						'The URL you entered seems to be an external link. Do you want to add the required http:// prefix?',
 						function(state) {


### PR DESCRIPTION
The `link` plugin shows a message when the user forget to put the 'http://' before the link. 
But when the user put something like "www2.walmart.com.br" the plugin don't shows the message. 