### PR TITLE
Fixing typo which breaks auto-generated docs

### DIFF
--- a/js/tinymce/classes/ui/MessageBox.js
+++ b/js/tinymce/classes/ui/MessageBox.js
@@ -11,7 +11,7 @@
 /**
  * This class is used to create MessageBoxes like alerts/confirms etc.
  *
- * @class tinymce.ui.Window
+ * @class tinymce.ui.MessageBox
  * @extends tinymce.ui.FloatPanel
  */
 define("tinymce/ui/MessageBox", [


### PR DESCRIPTION
You can see the broken docs online by looking at http://www.tinymce.com/wiki.php/api4:namespace.tinymce.ui and seeing the fact that tinymce.ui.Window shows up where MessageBox ought to be, and it is a broken link.