### PR TITLE
fix control characters deleting selection

### DIFF
--- a/js/tinymce/classes/util/Quirks.js
+++ b/js/tinymce/classes/util/Quirks.js
@@ -499,7 +499,7 @@ define("tinymce/util/Quirks", [
 
 			// Handle case where text is deleted by typing over
 			editor.on('keypress', function(e) {
-				if (!isDefaultPrevented(e) && !selection.isCollapsed() && e.charCode && !VK.metaKeyPressed(e)) {
+				if (!isDefaultPrevented(e) && !selection.isCollapsed() && e.charCode > 31 && !VK.metaKeyPressed(e)) {
 					var rng, currentFormatNodes, fragmentNode, blockParent, caretNode, charText;
 
 					rng = editor.selection.getRng();


### PR DESCRIPTION
Mac OS X Chrome: non printable control characters are sent as keypress events
https://jsfiddle.net/19foy6oz/

Try typing in Ctrl+C, Ctrl+Q, Ctrl+R

This makes the webkit quirk handler of customDelete trigger deleting the selection.