### PR TITLE
Fix bug for domains containing ".min"

### DIFF
--- a/js/tinymce/classes/EditorManager.js
+++ b/js/tinymce/classes/EditorManager.js
@@ -183,8 +183,9 @@ define("tinymce/EditorManager", [
 					// tinymce.js tinymce.min.js tinymce.dev.js
 					// tinymce.jquery.js tinymce.jquery.min.js tinymce.jquery.dev.js
 					// tinymce.full.js tinymce.full.min.js tinymce.full.dev.js
+					var srcScript = src.substring(src.lastIndexOf('/'));
 					if (/tinymce(\.full|\.jquery|)(\.min|\.dev|)\.js/.test(src)) {
-						if (src.indexOf('.min') != -1) {
+						if (srcScript.indexOf('.min') != -1) {
 							suffix = '.min';
 						}
 


### PR DESCRIPTION
For the domain
dev.minesplus.netanswer.fr
the 
   src.indexOf('.min') != -1
does not work because the domain contains ".min".

With this commit, only the filename is tested, not the whole path