### PR TITLE
Fixed default value of toStart in Selection.collapse.

### DIFF
--- a/js/tinymce/classes/dom/Selection.js
+++ b/js/tinymce/classes/dom/Selection.js
@@ -448,7 +448,7 @@ define("tinymce/dom/Selection", [
 				rng.moveToElementText(node);
 			}
 
-			rng.collapse(!!toStart);
+			rng.collapse(toStart !== undefined ? toStart : true);
 			self.setRng(rng);
 		},
 

--- a/js/tinymce/plugins/anchor/plugin.js
+++ b/js/tinymce/plugins/anchor/plugin.js
@@ -13,18 +13,25 @@
 tinymce.PluginManager.add('anchor', function(editor) {
 	function showDialog() {
 		var selectedNode = editor.selection.getNode(), name = '';
+		var isAnchor = selectedNode.tagName == 'A' && editor.dom.getAttrib(selectedNode, 'href') === '';
 
-		if (selectedNode.tagName == 'A') {
+		if (isAnchor)
 			name = selectedNode.name || selectedNode.id || '';
-		}
 
 		editor.windowManager.open({
 			title: 'Anchor',
 			body: {type: 'textbox', name: 'name', size: 40, label: 'Name', value: name},
 			onsubmit: function(e) {
-				editor.execCommand('mceInsertContent', false, editor.dom.createHTML('a', {
-					id: e.data.name
-				}));
+				var id = e.data.name;
+
+				if (isAnchor)
+					selectedNode.id = id;
+				else {
+					editor.selection.collapse(true);
+					editor.execCommand('mceInsertContent', false, editor.dom.createHTML('a', {
+						id: id
+					}));
+				}
 			}
 		});
 	}


### PR DESCRIPTION
This is a patch that fixes the default value of Selection.collapse. According to the documentation the default value should be true but `!!undefined` will become `false`.