### PR TITLE
Changes in isEqual()

### DIFF
--- a/js/tinymce/classes/data/ObservableObject.js
+++ b/js/tinymce/classes/data/ObservableObject.js
@@ -54,7 +54,11 @@ define("tinymce/data/ObservableObject", [
 		// Compare objects
 		checked = {};
 		for (k in b) {
-			if (!isEqual(a[k], b[k])) {
+		
+			if (
+				b.hasOwnProperty(k) &&
+				!isEqual(a[k], b[k])
+			) {
 				return false;
 			}
 
@@ -62,7 +66,11 @@ define("tinymce/data/ObservableObject", [
 		}
 
 		for (k in a) {
-			if (!checked[k] && !isEqual(a[k], b[k])) {
+			if (
+				!checked[k] && 
+				a.hasOwnProperty(k) &&
+				!isEqual(a[k], b[k])
+			) {
 				return false;
 			}
 		}


### PR DESCRIPTION
It is not necessary to check all object properties. This results in a "too much recursion" error in really big html tables.I added a hasOwnProperty check.