### PR TITLE
Fixed default value of toStart in Selection.collapse.

### DIFF
--- a/js/tinymce/classes/dom/Selection.js
+++ b/js/tinymce/classes/dom/Selection.js
@@ -448,7 +448,7 @@ define("tinymce/dom/Selection", [
 				rng.moveToElementText(node);
 			}
 
-			rng.collapse(!!toStart);
+			rng.collapse(toStart !== undefined ? toStart : true);
 			self.setRng(rng);
 		},
 


### PR DESCRIPTION
This is a patch that fixes the default value of Selection.collapse. According to the documentation the default value should be true but !!undefined will become false.