### PR TITLE
Resolve clobbered image source when replacing blob URL

### DIFF
--- a/js/tinymce/classes/EditorUpload.js
+++ b/js/tinymce/classes/EditorUpload.js
@@ -129,7 +129,7 @@ define("tinymce/EditorUpload", [
 					return 'src="data:' + blobInfo.blob().type + ';base64,' + blobInfo.base64() + '"';
 				}
 
-				return match[0];
+				return match;
 			});
 		}
 


### PR DESCRIPTION
When replacing blob URLs with their base 64 equivalent in the EditorUpload module, a fallback was recently added to return a value when image information could not be found in the blob cache (11a7a98). However, while this no longer throws an error, it still results in a clobbered image `src` because the fallback should return the entire matched string, not only the first character.

The changes herein will return the entire match when failing to find info in the blob cache.

The problem (and resolution) is illustrated by the following JSBin: http://jsbin.com/vasufe/edit?js,console

See also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter