### PR TITLE
Have the textarea scrolled to the top consistently in all browsers

### DIFF
--- a/js/tinymce/plugins/code/plugin.js
+++ b/js/tinymce/plugins/code/plugin.js
@@ -35,12 +35,15 @@ tinymce.PluginManager.add('code', function(editor) {
 
 				editor.selection.setCursorLocation();
 				editor.nodeChanged();
+			},
+			onPostRender: function(e) {
+				// Always open the source editor with scroll at the beginning
+				var textarea = $('textarea', e.target.getEl());
+				textarea.html(editor.getContent({source_view: true}));
+				textarea.scrollTop(0);
 			}
 		});
 
-		// Gecko has a major performance issue with textarea
-		// contents so we need to set it when all reflows are done
-		win.find('#code').value(editor.getContent({source_view: true}));
 	}
 
 	editor.addCommand("mceCodeEditor", showDialog);


### PR DESCRIPTION
I'm not sure if this triggers the performance issue with Gecko mentioned in the removed piece of code, but I couldn't find any other way to do this.

BTW, the problem this PR tries to solve is, when you open the "Source code", and there's enough content to scroll, it will start with the scroll at the top of the text area in Chrome, but on Firefox and IE, it will start with the scroll at the bottom.

This should make it so it always opens with the scroll at the top