### PR TITLE
Fixed issue with loading remote image with proxy in Imagetools plugin

### DIFF
--- a/js/tinymce/plugins/imagetools/classes/Plugin.js
+++ b/js/tinymce/plugins/imagetools/classes/Plugin.js
@@ -173,9 +173,10 @@ define("tinymce/imagetoolsplugin/Plugin", [
 			}
 
 			if (!isLocalImage(img)) {
-				img = new Image();
 				src = editor.settings.imagetools_proxy;
-				img.src += (src.indexOf('?') === -1 ? '?' : '&') + 'url=' + encodeURIComponent(img.src);
+				src += (src.indexOf('?') === -1 ? '?' : '&') + 'url=' + encodeURIComponent(img.src);
+				img = new Image();
+				img.src = src;
 			}
 
 			return Conversions.imageToBlob(img);


### PR DESCRIPTION
In the Imagetools plugin, the remote image loading part seems to be broken. It always attempt to request `?url=` instead of `<imagetools_proxy>?url=<img.src>`. This pull request fixes the issue by correcting the proxied image url.