### PR TITLE
Fix regexp for hasClass() test in insertTemplate()

### DIFF
--- a/js/tinymce/plugins/template/plugin.js
+++ b/js/tinymce/plugins/template/plugin.js
@@ -207,7 +207,7 @@ tinymce.PluginManager.add('template', function(editor) {
 		}
 
 		function hasClass(n, c) {
-			return new RegExp('\\b' + c + '\\b', 'g').test(n.className);
+			return new RegExp('(?:^|\\s)(?:' + c + ')(?:\\s|$)', 'g').test(n.className);
 		}
 
 		each(dom.select('*', el), function(n) {


### PR DESCRIPTION
The regexp test against [DOMnode].className was using \b to delimit the class names, but this could fail for class names containing '-'. The hyphen character is considered a word boundary in regexp. So a test for the class name 'example' would have incorrectly matched 'my-example'.