### PR TITLE
Remove superfluous bogus BR elements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 Version 4.2.7 (2015-10-xx)
+	Fixed bug where empty elements were unnecessarily padded with BRs on IE
 	Fixed bug where backspace/delete would remove all formats on the last paragraph character in WebKit/Blink.
 	Fixed bug where backspace within a inline format element with a bogus caret container would move the caret.
 	Fixed bug where backspace/delete on selected table cells wouldn't add an undo level.

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -879,8 +879,9 @@ define("tinymce/Editor", [
 				}
 			});
 
-			if (!ie) {
-				// IE does not need br elements in empty blocks. See also EnterKey.js/emptyBlock()
+			if (!ie || ie >= 11) {
+				// Add BR elements to empty blocks to prevent them collapsing, except for IE < 11,
+				// which sizes the elements as expected WITHOUT the br. See also EnterKey.js/emptyBlock()
 				self.parser.addNodeFilter('p,h1,h2,h3,h4,h5,h6,div', function(nodes) {
 					var i = nodes.length, node, nonEmptyElements = self.schema.getNonEmptyElements();
 

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -888,7 +888,7 @@ define("tinymce/Editor", [
 					while (i--) {
 						node = nodes[i];
 
-						if (node.isEmpty(nonEmptyElements)) {
+						if (node.isEmpty(nonEmptyElements, {br: 1} /* Consider an existing br data-mce-bogus element as non-empty */)) {
 							var brNode = new Node('br', 1);
 							brNode.shortEnded = true;
 							brNode.attr('data-mce-bogus', '1');

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -879,17 +879,24 @@ define("tinymce/Editor", [
 				}
 			});
 
-			self.parser.addNodeFilter('p,h1,h2,h3,h4,h5,h6,div', function(nodes) {
-				var i = nodes.length, node, nonEmptyElements = self.schema.getNonEmptyElements();
+			if (!ie) {
+				// IE does not need br elements in empty blocks. See also EnterKey.js/emptyBlock()
+				self.parser.addNodeFilter('p,h1,h2,h3,h4,h5,h6,div', function(nodes) {
+					var i = nodes.length, node, nonEmptyElements = self.schema.getNonEmptyElements();
 
-				while (i--) {
-					node = nodes[i];
+					while (i--) {
+						node = nodes[i];
 
-					if (node.isEmpty(nonEmptyElements)) {
-						node.append(new Node('br', 1)).shortEnded = true;
+						if (node.isEmpty(nonEmptyElements)) {
+							var brNode = new Node('br', 1);
+							brNode.shortEnded = true;
+							brNode.attr('data-mce-bogus', '1');
+
+							node.append(brNode);
+						}
 					}
-				}
-			});
+				});
+			}
 
 			/**
 			 * DOM serializer for the editor. Will be used when contents is extracted from the editor.

--- a/js/tinymce/classes/EnterKey.js
+++ b/js/tinymce/classes/EnterKey.js
@@ -231,10 +231,7 @@ define("tinymce/EnterKey", [
 					} while ((node = node.parentNode));
 				}
 
-				// BR is needed in empty blocks on non IE browsers
-				if (!isIE) {
-					caretNode.innerHTML = '<br data-mce-bogus="1">';
-				}
+				emptyBlock(caretNode);
 
 				return block;
 			}

--- a/js/tinymce/classes/html/Node.js
+++ b/js/tinymce/classes/html/Node.js
@@ -413,16 +413,24 @@ define("tinymce/html/Node", [], function() {
 		 * node.isEmpty({img: true});
 		 * @method isEmpty
 		 * @param {Object} elements Name/value object with elements that are automatically treated as non empty elements.
+		 * @param {Object} bogusElements Name/value object with elements that are automatically treated as non-empty elements
+		 * even when marked as mce-bogus.
 		 * @return {Boolean} true/false if the node is empty or not.
 		 */
-		isEmpty: function(elements) {
+		isEmpty: function(elements, bogusElements) {
 			var self = this, node = self.firstChild, i, name;
+
+			bogusElements = bogusElements || [];
 
 			if (node) {
 				do {
 					if (node.type === 1) {
-						// Ignore bogus elements
+						// Ignore bogus elements, unless they are explicity to be treated as non-empty
 						if (node.attributes.map['data-mce-bogus']) {
+							if (bogusElements[node.name]) {
+								return false;
+							}
+
 							continue;
 						}
 

--- a/tests/tinymce/Editor.js
+++ b/tests/tinymce/Editor.js
@@ -14,7 +14,7 @@ module("tinymce.Editor", {
 				'*': 'color,font-size,font-family,background-color,font-weight,font-style,text-decoration,float,margin,margin-top,margin-right,margin-bottom,margin-left,display'
 			},
 			custom_elements: 'custom1,~custom2',
-			extended_valid_elements: 'custom1,custom2,script[*]',
+			extended_valid_elements: 'custom1,custom2,script[*],div[!class]',
 			init_instance_callback: function(ed) {
 				window.editor = ed;
 
@@ -224,6 +224,24 @@ test('setContent with comment bug #4409', function() {
 test('custom elements', function() {
 	editor.setContent('<custom1>c1</custom1><custom2>c1</custom2>');
 	equal(editor.getContent(), '<custom1>c1</custom1><p><custom2>c1</custom2></p>');
+});
+
+test('br in empty elements', function() {
+	expect(2);
+	editor.setContent('<p></p><h1></h1><h2></h2><h3></h3><h4></h4><h5></h5><h6></h6><div class="a"></div><div class="x"><div class="y"></div></div>');
+	
+	equal(editor.getContent({format: 'raw'}).toLowerCase(),
+			tinymce.isIE && tinymce.isIE < 11	? '<p>&nbsp;</p><h1>&nbsp;</h1><h2>&nbsp;</h2><h3>&nbsp;</h3><h4>&nbsp;</h4><h5>&nbsp;</h5><h6>&nbsp;</h6><div class="a"></div><div class="x"><div class="y"></div></div>'
+												: '<p>&nbsp;<br data-mce-bogus="1"></p><h1>&nbsp;<br data-mce-bogus="1"></h1><h2>&nbsp;<br data-mce-bogus="1"></h2><h3>&nbsp;<br data-mce-bogus="1"></h3><h4>&nbsp;<br data-mce-bogus="1"></h4><h5>&nbsp;<br data-mce-bogus="1"></h5><h6>&nbsp;<br data-mce-bogus="1"></h6><div class="a"><br data-mce-bogus="1"></div><div class="x"><div class="y"><br data-mce-bogus="1"></div></div>');
+	equal(editor.getContent(), '<p>\u00a0</p><h1>\u00a0</h1><h2>\u00a0</h2><h3>\u00a0</h3><h4>\u00a0</h4><h5>\u00a0</h5><h6>\u00a0</h6><div class="a"></div><div class="x"><div class="y"></div></div>');
+});
+
+test('No br in filled elements', function() {
+	expect(2);
+	editor.setContent('<p>a</p><h1>b</h1><h2>c</h2><h3>d</h3><h4>e</h4><h5>f</h5><h6>g</h6><div class="b">h</div>');
+	
+	equal(editor.getContent({format: 'raw'}).toLowerCase(), '<p>a</p><h1>b</h1><h2>c</h2><h3>d</h3><h4>e</h4><h5>f</h5><h6>g</h6><div class="b">h</div>');
+	equal(editor.getContent(), '<p>a</p><h1>b</h1><h2>c</h2><h3>d</h3><h4>e</h4><h5>f</h5><h6>g</h6><div class="b">h</div>');
 });
 
 test('Store/restore tabindex', function() {


### PR DESCRIPTION
- IE versions below 11 pad empty elements too much if a `<br data-mce-bogus="1">` element is automatically added; the empty element has a height of two lines, not one.
- Nested empty elements, e.g. `<div class="a"><div class="b"></div></div>` were transformed into `<div class="a"><div class="b"><br data-mce-bogus="1"></div><br data-mce-bogus="1"></div>`; the final `<br ...>` is unnecessary, and again pads the display too much - on all browsers. The extra parameter "bogusElements" to `Node.isEmpty()` allows elements marked as "data-mce-bogus" to also count as non-empty, and is used when setting the editor content to ensure that only the innermost empty element is padded in this way.
