### PR TITLE
Fix regexp for hasClass() test in insertTemplate()

### DIFF
--- a/js/tinymce/plugins/template/plugin.js
+++ b/js/tinymce/plugins/template/plugin.js
@@ -207,7 +207,7 @@ tinymce.PluginManager.add('template', function(editor) {
 		}
 
 		function hasClass(n, c) {
-			return new RegExp('\\b' + c + '\\b', 'g').test(n.className);
+			return new RegExp('(?:^|\\s)(?:' + c + ')(?:\\s|$)', 'g').test(n.className);
 		}
 
 		each(dom.select('*', el), function(n) {


### PR DESCRIPTION
Regexp test using \b 'word boundary' metacharacter could cause false positives, because \b will match at a '-' (hyphen). For example, a test for class 'foo' would have returned TRUE for class="foo-bar".
