### PR TITLE
Shadow DOM support (first attempt)

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1128,7 +1128,10 @@ define("tinymce/Editor", [
 							body.focus();
 						}
 					} else {
-						body.focus();
+						// Under native Shadow DOM body ==== self.targetElm and causes infinite loop
+						if (body !== self.targetElm || !Object.getPrototypeOf(document).registerElement) {
+							body.focus();
+						}
 					}
 
 					if (contentEditable) {

--- a/js/tinymce/classes/WindowManager.js
+++ b/js/tinymce/classes/WindowManager.js
@@ -85,6 +85,8 @@ define("tinymce/WindowManager", [
 		self.open = function(args, params) {
 			var win;
 
+			args.target = editor.targetElm;
+
 			editor.editorManager.setActive(editor);
 
 			args.title = args.title || ' ';

--- a/js/tinymce/classes/dom/DOMUtils.js
+++ b/js/tinymce/classes/dom/DOMUtils.js
@@ -396,19 +396,19 @@ define("tinymce/dom/DOMUtils", [
 		 * Returns the specified element by ID or the input element if it isn't a string.
 		 *
 		 * @method get
-		 * @param {String/Element} n Element id to look for or element to just pass though.
+		 * @param {String/Element} elm Element id to look for or element to just pass though.
 		 * @return {Element} Element matching the specified id or null if it wasn't found.
 		 */
 		get: function(elm) {
-			var name;
+			var name, root = this.settings.root_element || this.doc;
 
-			if (elm && this.doc && typeof elm == 'string') {
+			if (elm && root && typeof elm == 'string') {
 				name = elm;
-				elm = this.doc.getElementById(elm);
+				elm = root.querySelector('#' + elm);
 
 				// IE and Opera returns meta elements when they match the specified input ID, but getElementsByName seems to do the trick
 				if (elm && elm.id !== name) {
-					return this.doc.getElementsByName(name)[1];
+					return root.querySelector('[name=' + name + ']')[1];
 				}
 			}
 

--- a/js/tinymce/classes/dom/DomQuery.js
+++ b/js/tinymce/classes/dom/DomQuery.js
@@ -295,7 +295,8 @@ define("tinymce/dom/DomQuery", [
 							node = node.nextSibling;
 						}
 					} else {
-						node = getElementDocument(context).getElementById(match[2]);
+						// Element might be in global scope or inside current context (within Shadow DOM)
+						node = getElementDocument(context).getElementById(match[2]) || context.querySelector('#' + match[2]);
 
 						if (!node) {
 							return self;

--- a/js/tinymce/classes/dom/RangeUtils.js
+++ b/js/tinymce/classes/dom/RangeUtils.js
@@ -584,9 +584,24 @@ define("tinymce/dom/RangeUtils", [
 	 * @returns {Range} caret range
 	 */
 	RangeUtils.getCaretRangeFromPoint = function(clientX, clientY, doc) {
-		var rng, point;
+		var element, point, rect, rng;
 
-		if (doc.caretPositionFromPoint) {
+		// Check whether target point is under Shadow DOM
+		element = doc.elementFromPoint(clientX, clientY);
+		if (element && element.shadowRoot) {
+			// Under Shadow DOM the best thing we can do it to determine end or start of target place, not exact position
+			rng = doc.createRange();
+			while (element.shadowRoot) {
+				element = element.shadowRoot.elementFromPoint(clientX, clientY);
+			}
+			rect = element.getBoundingClientRect();
+			// 10px is limit where insertion point will be considered to be at start, otherwise at the end
+			if (clientX > doc.scrollingElement.scrollLeft + rect.left + 10) {
+				rng.setStart(element, 1);
+			} else {
+				rng.setStart(element, 0);
+			}
+		} else if (doc.caretPositionFromPoint) {
 			point = doc.caretPositionFromPoint(clientX, clientY);
 			rng = doc.createRange();
 			rng.setStart(point.offsetNode, point.offset);

--- a/js/tinymce/classes/dom/Selection.js
+++ b/js/tinymce/classes/dom/Selection.js
@@ -463,6 +463,23 @@ define("tinymce/dom/Selection", [
 		 */
 		getSel: function() {
 			var win = this.win;
+			try {
+				// We need to return Shadow Root if target element is under Shadow DOM and not using iframe
+				if (!this.editor.iframeElement && this.editor.targetElm.matches && this.editor.targetElm.matches(':host *')) {
+					(function(target) {
+						while (target.parentNode) {
+							target = target.parentNode;
+						}
+						// If there is no parent node, but there is `host` property - we've just found Shadow Root,
+						// where we'll get selection
+						if (target.host) {
+							win = target;
+						}
+					})(this.editor.targetElm);
+				}
+			} catch (err) {
+				// Nothing, even if `.matches` method is present - it doesn't mean that browsers understands ':host *' selector
+			}
 
 			return win.getSelection ? win.getSelection() : win.document.selection;
 		},

--- a/js/tinymce/classes/jquery.tinymce.js
+++ b/js/tinymce/classes/jquery.tinymce.js
@@ -50,6 +50,11 @@
 					node.id = id = tinymce.DOM.uniqueId();
 				}
 
+				// Set target if not specified, otherwise we'll not be able to find in by id under Shadow DOM
+				if (!settings.target) {
+					settings = self.extend(settings, {target: node});
+				}
+
 				// Only init the editor once
 				if (tinymce.get(id)) {
 					return;

--- a/js/tinymce/classes/ui/ComboBox.js
+++ b/js/tinymce/classes/ui/ComboBox.js
@@ -117,7 +117,7 @@ define("tinymce/ui/ComboBox", [
 					menu.type = menu.type || 'menu';
 				}
 
-				self.menu = Factory.create(menu).parent(self).renderTo(self.getContainerElm());
+				self.menu = Factory.create(menu, {target: self.settings.target}).parent(self).renderTo(self.getContainerElm());
 				self.fire('createmenu');
 				self.menu.reflow();
 				self.menu.on('cancel', function(e) {

--- a/js/tinymce/classes/ui/Container.js
+++ b/js/tinymce/classes/ui/Container.js
@@ -72,7 +72,7 @@ define("tinymce/ui/Container", [
 				self.classes.add(settings.containerCls);
 			}
 
-			self._layout = Factory.create((settings.layout || '') + 'layout');
+			self._layout = Factory.create((settings.layout || '') + 'layout', {target: settings.target});
 
 			if (self.settings.items) {
 				self.add(self.settings.items);
@@ -234,7 +234,7 @@ define("tinymce/ui/Container", [
 						settings = Tools.extend({}, self.settings.defaults, item);
 						item.type = settings.type = settings.type || item.type || self.settings.defaultType ||
 							(settings.defaults ? settings.defaults.type : null);
-						item = Factory.create(settings);
+						item = Factory.create(settings, {target: self.settings.target});
 					}
 
 					ctrlItems.push(item);

--- a/js/tinymce/classes/ui/Factory.js
+++ b/js/tinymce/classes/ui/Factory.js
@@ -75,12 +75,14 @@ define("tinymce/ui/Factory", [], function() {
 				namespaceInit = true;
 			}
 
+			settings = settings || {};
 			// If string is specified then use it as the type
 			if (typeof type == 'string') {
-				settings = settings || {};
 				settings.type = type;
 			} else {
-				settings = type;
+				for (var i in type) {
+					settings[i] = type[i];
+				}
 				type = settings.type;
 			}
 

--- a/js/tinymce/classes/ui/FloatPanel.js
+++ b/js/tinymce/classes/ui/FloatPanel.js
@@ -361,10 +361,10 @@ define("tinymce/ui/FloatPanel", [
 		},
 
 		postRender: function() {
-			var self = this;
+			var self = this, editor = editor;
 
 			if (self.settings.bodyRole) {
-				this.getEl('body').setAttribute('role', self.settings.bodyRole);
+				this.getEl('body', editor && editor.targetElm).setAttribute('role', self.settings.bodyRole);
 			}
 
 			return self._super();

--- a/js/tinymce/classes/ui/Form.js
+++ b/js/tinymce/classes/ui/Form.js
@@ -78,7 +78,8 @@ define("tinymce/ui/Form", [
 							flex: 0,
 							forId: ctrl._id,
 							disabled: ctrl.disabled()
-						}
+						},
+						target: self.settings.target
 					}, self.settings.formItemDefaults));
 
 					formItem.type = 'formitem';

--- a/js/tinymce/classes/ui/MenuButton.js
+++ b/js/tinymce/classes/ui/MenuButton.js
@@ -87,7 +87,7 @@ define("tinymce/ui/MenuButton", [
 				}
 
 				if (!menu.renderTo) {
-					self.menu = Factory.create(menu).parent(self).renderTo();
+					self.menu = Factory.create(menu, {target: self.settings.target}).parent(self).renderTo();
 				} else {
 					self.menu = menu.parent(self).show().renderTo();
 				}

--- a/js/tinymce/classes/ui/MenuItem.js
+++ b/js/tinymce/classes/ui/MenuItem.js
@@ -125,7 +125,7 @@ define("tinymce/ui/MenuItem", [
 						menu.itemDefaults = parent.settings.itemDefaults;
 					}
 
-					menu = self.menu = Factory.create(menu).parent(self).renderTo();
+					menu = self.menu = Factory.create(menu, {target: self.settings.target}).parent(self).renderTo();
 					menu.reflow();
 					menu.on('cancel', function(e) {
 						e.stopPropagation();

--- a/js/tinymce/classes/ui/MessageBox.js
+++ b/js/tinymce/classes/ui/MessageBox.js
@@ -158,7 +158,8 @@ define("tinymce/ui/MessageBox", [
 					onClose: settings.onClose,
 					onCancel: function() {
 						callback(false);
-					}
+					},
+					target: null
 				}).renderTo(document.body).reflow();
 			},
 

--- a/js/tinymce/classes/ui/PanelButton.js
+++ b/js/tinymce/classes/ui/PanelButton.js
@@ -47,6 +47,7 @@ define("tinymce/ui/PanelButton", [
 				panelSettings.popover = true;
 				panelSettings.autohide = true;
 				panelSettings.ariaRoot = true;
+				panelSettings.target = settings.target;
 
 				self.panel = new FloatPanel(panelSettings).on('hide', function() {
 					self.active(false);

--- a/js/tinymce/classes/ui/Widget.js
+++ b/js/tinymce/classes/ui/Widget.js
@@ -72,7 +72,10 @@ define("tinymce/ui/Widget", [
 		 */
 		tooltip: function() {
 			if (!tooltip) {
-				tooltip = new Tooltip({type: 'tooltip'});
+				tooltip = new Tooltip({
+					type: 'tooltip',
+					target: null
+				});
 				tooltip.renderTo();
 			}
 

--- a/js/tinymce/classes/ui/Window.js
+++ b/js/tinymce/classes/ui/Window.js
@@ -150,7 +150,8 @@ define("tinymce/ui/Window", [
 					defaults: {
 						type: 'button'
 					},
-					items: settings.buttons
+					items: settings.buttons,
+					target: settings.target
 				});
 
 				self.statusbar.classes.add('foot');

--- a/js/tinymce/plugins/contextmenu/plugin.js
+++ b/js/tinymce/plugins/contextmenu/plugin.js
@@ -63,7 +63,8 @@ tinymce.PluginManager.add('contextmenu', function(editor) {
 			menu = new tinymce.ui.Menu({
 				items: items,
 				context: 'contextmenu',
-				classes: 'contextmenu'
+				classes: 'contextmenu',
+				target: editor.targetElm
 			}).renderTo();
 
 			editor.on('remove', function() {

--- a/js/tinymce/plugins/searchreplace/plugin.js
+++ b/js/tinymce/plugins/searchreplace/plugin.js
@@ -371,7 +371,8 @@
 						{type: 'checkbox', name: 'case', text: 'Match case', label: ' '},
 						{type: 'checkbox', name: 'words', text: 'Whole words', label: ' '}
 					]
-				}
+				},
+				target: this.settings.target
 			});
 		}
 

--- a/js/tinymce/skins/lightgray/AbsoluteLayout.less
+++ b/js/tinymce/skins/lightgray/AbsoluteLayout.less
@@ -4,7 +4,7 @@
 	position: relative;
 }
 
-body .@{prefix}-abs-layout-item, .@{prefix}-abs-end {
+html .@{prefix}-abs-layout-item, .@{prefix}-abs-end {
 	position: absolute;
 }
 

--- a/js/tinymce/themes/modern/theme.js
+++ b/js/tinymce/themes/modern/theme.js
@@ -102,7 +102,7 @@ tinymce.ThemeManager.add('modern', function(editor) {
 						item.type = item.type || 'button';
 						item.size = size;
 
-						item = Factory.create(item);
+						item = Factory.create(item, {target: editor.targetElm});
 						buttonGroup.items.push(item);
 
 						if (editor.initialized) {
@@ -561,7 +561,8 @@ tinymce.ThemeManager.add('modern', function(editor) {
 				items: createToolbar(match.toolbar.items),
 				oncancel: function() {
 					editor.focus();
-				}
+				},
+				target: self.settings.target
 			});
 
 			match.toolbar.panel = panel;
@@ -730,7 +731,8 @@ tinymce.ThemeManager.add('modern', function(editor) {
 				items: [
 					settings.menubar === false ? null : {type: 'menubar', border: '0 0 1 0', items: createMenuButtons()},
 					createToolbars(settings.toolbar_items_size)
-				]
+				],
+				target: editor.targetElm
 			});
 
 			// Add statusbar
@@ -818,7 +820,8 @@ tinymce.ThemeManager.add('modern', function(editor) {
 				settings.menubar === false ? null : {type: 'menubar', border: '0 0 1 0', items: createMenuButtons()},
 				createToolbars(settings.toolbar_items_size),
 				{type: 'panel', name: 'iframe', layout: 'stack', classes: 'edit-area', html: '', border: '1 0 0 0'}
-			]
+			],
+			target: editor.targetElm
 		});
 
 		if (settings.resize !== false) {

--- a/tests/plugins/importcss.js
+++ b/tests/plugins/importcss.js
@@ -34,7 +34,8 @@
 
 	function fireFormatsMenuEvent(styleSheets, items) {
 		menuCtrl = tinymce.ui.Factory.create('menu', {
-			items: items
+			items: items,
+			target: null
 		}).renderTo(document.getElementById('view'));
 
 		return editor.fire('renderFormatsMenu', {

--- a/tests/tinymce/ui/AbsoluteLayout.js
+++ b/tests/tinymce/ui/AbsoluteLayout.js
@@ -14,7 +14,8 @@
 			type: 'panel',
 			layout: 'absolute',
 			width: 200,
-			height: 200
+			height: 200,
+			target: null
 		}, settings)).renderTo(document.getElementById('view')).reflow();
 	}
 

--- a/tests/tinymce/ui/Button.js
+++ b/tests/tinymce/ui/Button.js
@@ -11,7 +11,8 @@
 
 	function createButton(settings) {
 		return tinymce.ui.Factory.create(tinymce.extend({
-			type: 'button'
+			type: 'button',
+			target: null
 		}, settings)).renderTo(document.getElementById('view'));
 	}
 

--- a/tests/tinymce/ui/Collection.js
+++ b/tests/tinymce/ui/Collection.js
@@ -29,7 +29,8 @@
 							{type: 'button', name: 'button12', classes: 'class4'}
 						]}
 					]}
-				]
+				],
+				target: null
 			}).renderTo(document.getElementById('view'));
 		},
 

--- a/tests/tinymce/ui/ColorButton.js
+++ b/tests/tinymce/ui/ColorButton.js
@@ -11,7 +11,8 @@
 
 	function createColorButton(settings) {
 		return tinymce.ui.Factory.create(tinymce.extend({
-			type: 'colorbutton'
+			type: 'colorbutton',
+			target: null
 		}, settings)).renderTo(document.getElementById('view'));
 	}
 

--- a/tests/tinymce/ui/Control.js
+++ b/tests/tinymce/ui/Control.js
@@ -48,7 +48,9 @@
 	test("Properties", function() {
 		var ctrl, cont;
 
-		cont = new tinymce.ui.Container({});
+		cont = new tinymce.ui.Container({
+			target: null
+		});
 		ctrl = new tinymce.ui.Control({});
 
 		// Set all states
@@ -72,7 +74,9 @@
 	});
 
 	test("Chained methods", function() {
-		var ctrl = new tinymce.ui.Control({});
+		var ctrl = new tinymce.ui.Control({
+			target: null
+		});
 
 		// Set all states
 		ctrl = ctrl.

--- a/tests/tinymce/ui/FitLayout.js
+++ b/tests/tinymce/ui/FitLayout.js
@@ -17,7 +17,8 @@
 			layout: 'fit',
 			width: 200,
 			height: 200,
-			border: 1
+			border: 1,
+			target: null
 		}, settings)).renderTo(document.getElementById('view')).reflow();
 	}
 

--- a/tests/tinymce/ui/FlexLayout.js
+++ b/tests/tinymce/ui/FlexLayout.js
@@ -20,7 +20,8 @@
 				{type: 'spacer', classes: 'red'},
 				{type: 'spacer', classes: 'green'},
 				{type: 'spacer', classes: 'blue'}
-			]
+			],
+			target: null
 		}, settings)).renderTo(document.getElementById('view')).reflow();
 
 		Utils.resetScroll(panel.getEl('body'));
@@ -487,7 +488,8 @@
 					{type: 'spacer', classes: 'magenta'}
 				]},
 				{type: 'spacer', classes: 'green'}
-			]
+			],
+			target: null
 		}).renderTo(document.getElementById('view')).reflow();
 
 		Utils.nearlyEqualRects(Utils.rect(panel), [0, 0, 110, 40]);
@@ -510,7 +512,8 @@
 					{type: 'spacer', classes: 'magenta'}
 				]},
 				{type: 'spacer', classes: 'green'}
-			]
+			],
+			target: null
 		}).renderTo(document.getElementById('view')).reflow();
 
 		panel.find('spacer')[1].hide().parent().reflow();
@@ -871,7 +874,8 @@
 					{type: 'spacer', classes: 'magenta'}
 				]},
 				{type: 'spacer', classes: 'green'}
-			]
+			],
+			target: null
 		}).renderTo(document.getElementById('view')).reflow();
 
 		Utils.nearlyEqualRects(Utils.rect(panel), [0, 0, 110, 40]);

--- a/tests/tinymce/ui/GridLayout.js
+++ b/tests/tinymce/ui/GridLayout.js
@@ -13,7 +13,8 @@
 		var panel = tinymce.ui.Factory.create(tinymce.extend({
 			type: "panel",
 			layout: "grid",
-			defaults: {type: 'spacer'}
+			defaults: {type: 'spacer'},
+			target: null
 		}, settings)).renderTo(document.getElementById('view')).reflow();
 
 		Utils.resetScroll(panel.getEl('body'));

--- a/tests/tinymce/ui/MenuButton.js
+++ b/tests/tinymce/ui/MenuButton.js
@@ -16,7 +16,8 @@
 				{text: '1'},
 				{text: '2'},
 				{text: '3'}
-			]
+			],
+			target: null
 		}, settings)).renderTo(document.getElementById('view'));
 	}
 

--- a/tests/tinymce/ui/Panel.js
+++ b/tests/tinymce/ui/Panel.js
@@ -13,7 +13,8 @@
 
 	function createPanel(settings) {
 		return tinymce.ui.Factory.create(tinymce.extend({
-			type: 'panel'
+			type: 'panel',
+			target: null
 		}, settings)).renderTo(document.getElementById('view')).reflow();
 	}
 

--- a/tests/tinymce/ui/Selector.js
+++ b/tests/tinymce/ui/Selector.js
@@ -29,7 +29,8 @@
 							{type: 'button', name: 'button12', classes: 'class4'}
 						]}
 					]}
-				]
+				],
+				target: null
 			}).renderTo(document.getElementById('view'));
 		},
 

--- a/tests/tinymce/ui/SplitButton.js
+++ b/tests/tinymce/ui/SplitButton.js
@@ -11,7 +11,8 @@
 
 	function createSplitButton(settings) {
 		return tinymce.ui.Factory.create(tinymce.extend({
-			type: 'splitbutton'
+			type: 'splitbutton',
+			target: null
 		}, settings)).renderTo(document.getElementById('view'));
 	}
 

--- a/tests/tinymce/ui/TabPanel.js
+++ b/tests/tinymce/ui/TabPanel.js
@@ -16,7 +16,8 @@
 				{title: 'a', type: 'spacer', classes: 'red'},
 				{title: 'b', type: 'spacer', classes: 'green'},
 				{title: 'c', type: 'spacer', classes: 'blue'}
-			]
+			],
+			target: null
 		}, settings)).renderTo(document.getElementById('view')).reflow();
 	}
 

--- a/tests/tinymce/ui/TextBox.js
+++ b/tests/tinymce/ui/TextBox.js
@@ -11,7 +11,8 @@
 
 	function createTextBox(settings) {
 		return tinymce.ui.Factory.create(tinymce.extend({
-			type: 'textbox'
+			type: 'textbox',
+			target: null
 		}, settings)).renderTo(document.getElementById('view'));
 	}
 

--- a/tests/tinymce/ui/Window.js
+++ b/tests/tinymce/ui/Window.js
@@ -12,7 +12,8 @@
 
 	function createWindow(settings) {
 		return tinymce.ui.Factory.create(tinymce.extend({
-			type: 'window'
+			type: 'window',
+			target: null
 		}, settings)).renderTo(document.getElementById('view')).reflow();
 	}
 


### PR DESCRIPTION
The first attempt to bring TinyMCE under Shadow DOM and make it working there.
To be honest I'm not expecting this to be merged, but I want to show main issues in current architecture and demonstrate that this is indeed possible.
Related feature was requested here, this is just first essential step (and is more generic): http://www.tinymce.com/forum/viewtopic.php?pid=117628
#### What works

TinyMCE under native Shadow DOM (including inline mode) - selection, cut/paste, all buttons, dropdowns, modals, etc.
I've tested most of plugins, to be specific:

> advlist anchor charmap code colorpicker contextmenu fullscreen hr image link lists media nonbreaking noneditable pagebreak paste preview searchreplace tabfocus table textcolor visualblocks visualchars wordcount

This patch includes only JS part, CSS can be easily converted to such that penetrates Shadow Root and thus will work using [this script](https://github.com/nazar-pc/CleverStyle-CMS/blob/master/service_scripts/make_css_shadow_dom_ready.php) (ideally, we'll need to wrap everything into custom element to avoid using deprecated `/deep/`, but it works for now and will work for quite long time until we'll implement it properly).
#### What doesn't work

TinyMCE under Shadow DOM polyfill from WebComponents.js.
This is in progress, I'm planning to implement this as well, but changes in Shadow DOM polyfill will be necessary, so this will take some more time, hopefully not too much, PR will be updated.
Also 2 tests fail, don't know yet why exactly, but they don't seem to be critical indeed (help is welcomed).
#### Partially working features

`caretRangeFromPoint()` method is present only on `document`, but not on `shadowRoot` ([mailing list](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/Zn_Tri1nBQw), relevant [Chromium issue](http://crbug.com/388976), vote, please) and using `document.caretRangeFromPoint()` gives us just Shadow Root's host element.
Because of this we can't find exact position where content was dropped.
However, `shadowRoot.elementFromPoint()` method is present and is used as last resort to drop contents to the beginning or the end of string, this was the best alternative I was able to get working and it is not that bad actually.
#### BC breaks

Current design involves very, VERY bad, horrible idea to reference everything by ID.
Since some elements are under Shadow DOM we need to know where Shadow Root is, for this purpose `target` property should be passed in settings with `textarea` (or target element in inline mode), which involves trivial changes for many of TinyMCE's internals and some plugins/themes.
I had some idea about repository of elements like key-value storage `id:dom_node_reference` to make smaller changes to existing structure from one side and avoid problems with determining current document/shadow root to search for ID in from another side.
#### Implementation

First 3 commits might be actually separated since they are generic and will not break anything in existing code, the last is heavy with actually implementing all essential things. Please, refer to commit messages for details (tricky parts in code also commented).
#### What is next?

I expect feedback from core developers and those who are interested about how TinyMCE's core might be adjusted to make this patch less invasive and avoid breaking plugins/themes (`settings.target` is required now).
Also any other feedback about implementation and/or help with fixing those 2 tests and/or anything else - I'm open for discussion.
