### PR TITLE
Updated parser to scope match nodes/attributes to the parsing function

### DIFF
--- a/js/tinymce/classes/html/DomParser.js
+++ b/js/tinymce/classes/html/DomParser.js
@@ -37,14 +37,14 @@ define("tinymce/html/DomParser", [
 	 * @param {tinymce.html.Schema} schema HTML Schema class to use when parsing.
 	 */
 	return function(settings, schema) {
-		var self = this, nodeFilters = {}, attributeFilters = [], matchedNodes = {}, matchedAttributes = {};
+		var self = this, nodeFilters = {}, attributeFilters = [];
 
 		settings = settings || {};
 		settings.validate = "validate" in settings ? settings.validate : true;
 		settings.root_name = settings.root_name || 'body';
 		self.schema = schema = schema || new Schema();
 
-		function fixInvalidChildren(nodes) {
+		function fixInvalidChildren(nodes, matchedNodes, matchedAttributes) {
 			var ni, node, parent, parents, newParent, currentNode, tempNode, childNode, i;
 			var nonEmptyElements, nonSplitableElements, textBlockElements, specialElements, sibling, nextNode;
 
@@ -96,12 +96,12 @@ define("tinymce/html/DomParser", [
 					parents.reverse();
 
 					// Clone the related parent and insert that after the moved node
-					newParent = currentNode = self.filterNode(parents[0].clone());
+					newParent = currentNode = self.filterNode(parents[0].clone(), matchedNodes, matchedAttributes);
 
 					// Start cloning and moving children on the left side of the target node
 					for (i = 0; i < parents.length - 1; i++) {
 						if (schema.isValidChild(currentNode.name, parents[i].name)) {
-							tempNode = self.filterNode(parents[i].clone());
+							tempNode = self.filterNode(parents[i].clone(), matchedNodes, matchedAttributes);
 							currentNode.append(tempNode);
 						} else {
 							tempNode = currentNode;
@@ -143,13 +143,13 @@ define("tinymce/html/DomParser", [
 							continue;
 						}
 
-						node.wrap(self.filterNode(new Node('ul', 1)));
+						node.wrap(self.filterNode(new Node('ul', 1), matchedNodes, matchedAttributes));
 						continue;
 					}
 
 					// Try wrapping the element in a DIV
 					if (schema.isValidChild(node.parent.name, 'div') && schema.isValidChild('div', node.name)) {
-						node.wrap(self.filterNode(new Node('div', 1)));
+						node.wrap(self.filterNode(new Node('div', 1), matchedNodes, matchedAttributes));
 					} else {
 						// We failed wrapping it, then remove or unwrap it
 						if (specialElements[node.name]) {
@@ -169,7 +169,7 @@ define("tinymce/html/DomParser", [
 		 * @param {tinymce.html.Node} Node the node to run filters on.
 		 * @return {tinymce.html.Node} The passed in node.
 		 */
-		self.filterNode = function(node) {
+		self.filterNode = function(node, matchedNodes, matchedAttributes) {
 			var i, name, list;
 
 			// Run element filters
@@ -271,7 +271,7 @@ define("tinymce/html/DomParser", [
 			var parser, rootNode, node, nodes, i, l, fi, fl, list, name, validate;
 			var blockElements, startWhiteSpaceRegExp, invalidChildren = [], isInWhiteSpacePreservedElement;
 			var endWhiteSpaceRegExp, allWhiteSpaceRegExp, isAllWhiteSpaceRegExp, whiteSpaceElements;
-			var children, nonEmptyElements, rootBlockName;
+			var children, nonEmptyElements, rootBlockName, matchedNodes, matchedAttributes;
 
 			args = args || {};
 			matchedNodes = {};
@@ -617,7 +617,7 @@ define("tinymce/html/DomParser", [
 			// Fix invalid children or report invalid children in a contextual parsing
 			if (validate && invalidChildren.length) {
 				if (!args.context) {
-					fixInvalidChildren(invalidChildren);
+					fixInvalidChildren(invalidChildren, matchedNodes, matchedAttributes);
 				} else {
 					args.invalid = true;
 				}

--- a/js/tinymce/plugins/autolink/plugin.js
+++ b/js/tinymce/plugins/autolink/plugin.js
@@ -12,6 +12,11 @@
 
 tinymce.PluginManager.add('autolink', function(editor) {
 	var AutoUrlDetectState;
+	var AutoLinkPattern = /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+\-]+@)(.+)$/i;
+
+	if (editor.settings.autolink_pattern) {
+		AutoLinkPattern = editor.settings.autolink_pattern;
+	}
 
 	editor.on("keydown", function(e) {
 		if (e.keyCode == 13) {
@@ -179,7 +184,7 @@ tinymce.PluginManager.add('autolink', function(editor) {
 		}
 
 		text = rng.toString();
-		matches = text.match(/^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+\-]+@)(.+)$/i);
+		matches = text.match(AutoLinkPattern);
 
 		if (matches) {
 			if (matches[1] == 'www.') {

--- a/js/tinymce/plugins/autolink/plugin.js
+++ b/js/tinymce/plugins/autolink/plugin.js
@@ -12,11 +12,6 @@
 
 tinymce.PluginManager.add('autolink', function(editor) {
 	var AutoUrlDetectState;
-	var AutoLinkPattern = /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+\-]+@)(.+)$/i;
-
-	if (editor.settings.autolink_pattern) {
-		AutoLinkPattern = editor.settings.autolink_pattern;
-	}
 
 	editor.on("keydown", function(e) {
 		if (e.keyCode == 13) {
@@ -184,7 +179,7 @@ tinymce.PluginManager.add('autolink', function(editor) {
 		}
 
 		text = rng.toString();
-		matches = text.match(AutoLinkPattern);
+		matches = text.match(/^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+\-]+@)(.+)$/i);
 
 		if (matches) {
 			if (matches[1] == 'www.') {


### PR DESCRIPTION
In TinyMCE 3.x and 4.x, the matched nodes/attributes of the parser are scoped to the parser and not the parse call which causes the matchedNodes value to be corrupted by plugins that must use the editor's parser within a node filter to modify a node (and still cause the modifications to be run through the parser and other editor-parser-registered node filters).