### PR TITLE
Some non-breaking changes (preparation for Shadow DOM support)

### DIFF
--- a/js/tinymce/classes/dom/DomQuery.js
+++ b/js/tinymce/classes/dom/DomQuery.js
@@ -643,7 +643,8 @@ define("tinymce/dom/DomQuery", [
 		 */
 		append: function() {
 			return domManipulate(this, arguments, function(node) {
-				if (this.nodeType === 1) {
+				// Either element or Shadow Root
+				if (this.nodeType === 1 || (this.host && this.host.nodeType === 1)) {
 					this.appendChild(node);
 				}
 			});
@@ -658,7 +659,8 @@ define("tinymce/dom/DomQuery", [
 		 */
 		prepend: function() {
 			return domManipulate(this, arguments, function(node) {
-				if (this.nodeType === 1) {
+				// Either element or Shadow Root
+				if (this.nodeType === 1 || (this.host && this.host.nodeType === 1)) {
 					this.insertBefore(node, this.firstChild);
 				}
 			}, true);

--- a/js/tinymce/classes/dom/EventUtils.js
+++ b/js/tinymce/classes/dom/EventUtils.js
@@ -74,6 +74,19 @@ define("tinymce/dom/EventUtils", [], function() {
 			event.target = event.srcElement || document;
 		}
 
+		// When target element is inside Shadow DOM we need to take first element from path
+		// otherwise we'll get Shadow Root parent, not actual target element
+
+		// Normalize target for WebComponents v0 implementation (in Chrome)
+		if (event.path) {
+			event.target = event.path[0];
+		}
+
+		// Normalize target for WebComponents v1 implementation (standard)
+		if (event.deepPath) {
+			event.target = event.deepPath[0];
+		}
+
 		// Calculate pageX/Y if missing and clientX/Y available
 		if (originalEvent && mouseEventRe.test(originalEvent.type) && originalEvent.pageX === undef && originalEvent.clientX !== undef) {
 			var eventDoc = event.target.ownerDocument || document;

--- a/js/tinymce/classes/ui/FloatPanel.js
+++ b/js/tinymce/classes/ui/FloatPanel.js
@@ -43,9 +43,12 @@ define("tinymce/ui/FloatPanel", [
 		// Hide any float panel when a click/focus out is out side that float panel and the
 		// float panels direct parent for example a click on a menu button
 		var i = visiblePanels.length;
+		// When target element is inside Shadow DOM we need to take first element from path
+		// otherwise we'll get Shadow Root parent, not actual target element
+		var target = e.path ? e.path[0] : e.target;
 
 		while (i--) {
-			var panel = visiblePanels[i], clickCtrl = panel.getParentCtrl(e.target);
+			var panel = visiblePanels[i], clickCtrl = panel.getParentCtrl(target);
 
 			if (panel.settings.autohide) {
 				if (clickCtrl) {
@@ -54,7 +57,7 @@ define("tinymce/ui/FloatPanel", [
 					}
 				}
 
-				e = panel.fire('autohide', {target: e.target});
+				e = panel.fire('autohide', {target: target});
 				if (!e.isDefaultPrevented()) {
 					panel.hide();
 				}

--- a/js/tinymce/classes/ui/FloatPanel.js
+++ b/js/tinymce/classes/ui/FloatPanel.js
@@ -181,7 +181,7 @@ define("tinymce/ui/FloatPanel", [
 			}
 		}
 
-		var modalBlockEl = document.getElementById(ctrl.classPrefix + 'modal-block');
+		var modalBlockEl = $('#' + ctrl.classPrefix + 'modal-block', ctrl.getContainerElm())[0];
 
 		if (topModal) {
 			$(modalBlockEl).css('z-index', topModal.zIndex - 1);
@@ -231,7 +231,7 @@ define("tinymce/ui/FloatPanel", [
 					var $modalBlockEl, prefix = self.classPrefix;
 
 					if (self.modal && !hasModal) {
-						$modalBlockEl = $('#' + prefix + 'modal-block');
+						$modalBlockEl = $('#' + prefix + 'modal-block', self.getContainerElm());
 						if (!$modalBlockEl[0]) {
 							$modalBlockEl = $(
 								'<div id="' + prefix + 'modal-block" class="' + prefix + 'reset ' + prefix + 'fade"></div>'

--- a/js/tinymce/classes/ui/FloatPanel.js
+++ b/js/tinymce/classes/ui/FloatPanel.js
@@ -43,12 +43,9 @@ define("tinymce/ui/FloatPanel", [
 		// Hide any float panel when a click/focus out is out side that float panel and the
 		// float panels direct parent for example a click on a menu button
 		var i = visiblePanels.length;
-		// When target element is inside Shadow DOM we need to take first element from path
-		// otherwise we'll get Shadow Root parent, not actual target element
-		var target = e.path ? e.path[0] : e.target;
 
 		while (i--) {
-			var panel = visiblePanels[i], clickCtrl = panel.getParentCtrl(target);
+			var panel = visiblePanels[i], clickCtrl = panel.getParentCtrl(e.target);
 
 			if (panel.settings.autohide) {
 				if (clickCtrl) {
@@ -57,7 +54,7 @@ define("tinymce/ui/FloatPanel", [
 					}
 				}
 
-				e = panel.fire('autohide', {target: target});
+				e = panel.fire('autohide', {target: e.target});
 				if (!e.isDefaultPrevented()) {
 					panel.hide();
 				}


### PR DESCRIPTION
Some changes that break nothing and can be easily accepted, while help maturing Shadow DOM support in future (first 3 commits from #561).
Detailed description to suggested changed:
* Allow appending/prepending elements not only to regular elements (`element.nodeType == 1`), but also to Shadow Root (`element.host` is present and `element.host.nodeType == 1`)
* expect `event.path` to be present and picking first element from there instead of blindly picking `event.target` always; this helps with correct events targeting when target element is within Shadow Tree
* Modal block selection normalized like in other placed, also helps to find proper element when using Shadow DOM (previously it didn't really matter, because everything was withing main DOM Tree, but since it doesn't break anything, I think it can be accepted)