### PR TITLE
Added option to disable the alert in the paste plugin

### DIFF
--- a/js/tinymce/plugins/paste/classes/Plugin.js
+++ b/js/tinymce/plugins/paste/classes/Plugin.js
@@ -33,6 +33,9 @@ define("tinymce/pasteplugin/Plugin", [
 				clipboard.pasteFormat = "text";
 				this.active(true);
 
+				if (settings.paste_informUser === false)
+					return;
+
 				if (!userIsInformed) {
 					editor.windowManager.alert(
 						'Paste is now in plain text mode. Contents will now ' +


### PR DESCRIPTION
This patch adds an option to disable the dialog that informs the user about the paste in plain text mode consequences. Feel free to change the name of the option.