### PR TITLE
Remove the 'width' attribute when table_style_by_css is enabled.

### DIFF
--- a/js/tinymce/plugins/table/classes/CellSelection.js
+++ b/js/tinymce/plugins/table/classes/CellSelection.js
@@ -75,6 +75,16 @@ define("tinymce/tableplugin/CellSelection", [
 			}
 		}
 
+		function setStyleWidth(elm)
+		{
+			if (!editor.settings.table_style_by_css)
+				return;
+
+			var width = editor.dom.getAttrib(elm, 'width');
+			editor.dom.setAttrib(elm, 'width', null);
+			dom.setStyle(elm, 'width', width + 'px');
+		}
+
 		// Add cell selection logic
 		editor.on('MouseDown', function(e) {
 			if (e.button != 2 && !resizing) {
@@ -167,6 +177,9 @@ define("tinymce/tableplugin/CellSelection", [
 
 		editor.on('ObjectResizeStart ObjectResized', function(e) {
 			resizing = e.type != 'objectresized';
+
+			if (!resizing)
+				setStyleWidth(e.target);
 		});
 
 		return {

--- a/js/tinymce/plugins/table/classes/Dialogs.js
+++ b/js/tinymce/plugins/table/classes/Dialogs.js
@@ -247,6 +247,7 @@ define("tinymce/tableplugin/Dialogs", [
 						dom.setAttrib(tableElm, 'width', removePxSuffix(data.width));
 					} else {
 						dom.setStyle(tableElm, 'width', addSizeSuffix(data.width));
+						dom.setAttrib(tableElm, 'width', null);
 					}
 
 					dom.setStyle(tableElm, 'height', addSizeSuffix(data.height));
@@ -463,6 +464,10 @@ define("tinymce/tableplugin/Dialogs", [
 							width: addSizeSuffix(data.width),
 							height: addSizeSuffix(data.height)
 						});
+
+						// Remove width attribute
+						if (editor.settings.table_style_by_css)
+							dom.setAttrib(cellElm, 'width', null);
 
 						// Switch cell type
 						if (data.type && cellElm.nodeName.toLowerCase() != data.type) {


### PR DESCRIPTION
This patch removes the 'width' attribute from the table and cell when table_style_by_css is enabled. The current code keeps the 'width' attribute and this takes precedence over the 'width' style.

I am not sure if the changes to CellSelection are the correct way to do this. Not sure which part of the code sets the 'width' attribute on the table node.