### PR TITLE
request animation frame before updating resize rect in tables

### DIFF
--- a/js/tinymce/classes/dom/ControlSelection.js
+++ b/js/tinymce/classes/dom/ControlSelection.js
@@ -598,7 +598,9 @@ define("tinymce/dom/ControlSelection", [
 			// Update resize rect while typing in a table
 			editor.on('keydown keyup', function(e) {
 				if (selectedElm && selectedElm.nodeName == "TABLE") {
-					updateResizeRect(e);
+					Delay.requestAnimationFrame(function() {
+						updateResizeRect(e);
+					});
 				}
 			});
 


### PR DESCRIPTION
in order to not break the input of japanese characters on ie11

similar to french accents or german umlauts, most of the japanese
characters are inserted by pressing two keys (`h` + `o` for example)

when we add a dom node synchronously on keydown, this "combined input"
breaks apart, resulting in two single inputs.

fix #2479, #2371 

#### Steps to reproduce on Windows + IE11

 - Install Japanese keyboard
 - use Hiragana input method
 - add a table in tinymce
 - press keys `h` and `o`
 - see `h` + `お` (`ほ` would be correct)
 - use any other input to see the correct behaviour

#### Trivia:

 - this _could_ also be fixed, by wrapping the `updateResizeRect` call with `window.setTimeout`
 - root cause seems to be the [insert of the `mceResizeHandle`](https://github.com/tinymce/tinymce/blob/master/js/tinymce/classes/dom/ControlSelection.js#L319-L325)
 - i also got it to work by removing the [`keydown` listener in line `L599`](https://github.com/tinymce/tinymce/blob/master/js/tinymce/classes/dom/ControlSelection.js#L599)