### PR TITLE
fix bug with pasting leading zeros from word

### DIFF
--- a/js/tinymce/plugins/paste/classes/WordFilter.js
+++ b/js/tinymce/plugins/paste/classes/WordFilter.js
@@ -178,7 +178,7 @@ define("tinymce/pasteplugin/WordFilter", [
 					// Remove start of list item "1. " or "&middot; " etc
 					removeIgnoredNodes(paragraphNode);
 					trimListStart(paragraphNode, /^\u00a0+/);
-					trimListStart(paragraphNode, /^\s*([\u2022\u00b7\u00a7\u25CF]|\w+\.)/);
+					trimListStart(paragraphNode, /^\s*([\u2022\u00b7\u00a7\u25CF]|\w+\.\s)/);
 					trimListStart(paragraphNode, /^\u00a0+/);
 				}
 


### PR DESCRIPTION
To reproduce the bug that this change should fix:
1. Create a Word document and add a bulleted list. 
2. For one of the items in the list start the line with a decimal with a leading zero like: 0.5
3. Copy that list and paste it into TinyMCE

Notice that the leading zero and decimal point are removed. 

I've updated the regular expression to look for whitespace after the decimal before trimming.