### PR TITLE
[template-plugin] Add a class to iframe body of the preview popup 

### DIFF
--- a/js/tinymce/plugins/template/plugin.js
+++ b/js/tinymce/plugins/template/plugin.js
@@ -62,18 +62,18 @@ tinymce.PluginManager.add('template', function(editor) {
 			function insertIframeHtml(html) {
 				if (html.indexOf('<html>') == -1) {
 					var contentCssLinks = '';
-
+					var bodyClass = editor.getParam('template_popup_content_class', 'mce-abs-layout-item-preview');
 					tinymce.each(editor.contentCSS, function(url) {
 						contentCssLinks += '<link type="text/css" rel="stylesheet" href="' + editor.documentBaseURI.toAbsolute(url) + '">';
 					});
-
+				        
 					html = (
 						'<!DOCTYPE html>' +
 						'<html>' +
 							'<head>' +
 								contentCssLinks +
 							'</head>' +
-							'<body>' +
+							'<body class="'+bodyClass+'">' +
 								html +
 							'</body>' +
 						'</html>'


### PR DESCRIPTION
With a class on body of the preview popup we are able to apply specific CSS style on the preview content (ex for wordpress via style_editor.css)
this add the template_popup_content_class parameter with the default class name 'mce-abs-layout-item-preview'