### PR TITLE
Added an error if there arent any themes

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -510,6 +510,10 @@ define("tinymce/Editor", [
 					Theme = ThemeManager.get(settings.theme);
 					self.theme = new Theme(self, ThemeManager.urls[settings.theme]);
 
+					if (!self.theme) {
+						throw new Error("You do not have any themes loaded.");
+					}
+
 					if (self.theme.init) {
 						self.theme.init(self, ThemeManager.urls[settings.theme] || self.documentBaseUrl.replace(/\/$/, ''), self.$);
 					}


### PR DESCRIPTION
I was running into issues where I forgot to load in a theme before the tinymce.min.js file. This gave me an odd error. It might be nice to give developers a friendly reminder when they forget.
