### PR TITLE
Add get_content and set_content config options

### DIFF
--- a/js/tinymce/plugins/code/plugin.js
+++ b/js/tinymce/plugins/code/plugin.js
@@ -12,6 +12,9 @@
 
 tinymce.PluginManager.add('code', function(editor) {
 	function showDialog() {
+		function identity(value) {
+			return value;
+		}
 		var win = editor.windowManager.open({
 			title: "Source code",
 			body: {
@@ -30,7 +33,7 @@ tinymce.PluginManager.add('code', function(editor) {
 				editor.focus();
 
 				editor.undoManager.transact(function() {
-					editor.setContent(e.data.code);
+					editor.setContent(editor.getParam("code_get_content", identity)(e.data.code));
 				});
 
 				editor.selection.setCursorLocation();
@@ -40,7 +43,7 @@ tinymce.PluginManager.add('code', function(editor) {
 
 		// Gecko has a major performance issue with textarea
 		// contents so we need to set it when all reflows are done
-		win.find('#code').value(editor.getContent({source_view: true}));
+		win.find('#code').value(editor.getParam("code_set_content", identity)(editor.getContent({source_view: true})));
 	}
 
 	editor.addCommand("mceCodeEditor", showDialog);


### PR DESCRIPTION
This change would allow for some tidying or otherwise modifying content for the code editor. For example, my team uses `forced_root_block='p'` with `enter` activating a new RTE and `shift+enter` creating a new line within the same RTE. We have to wrap/unwrap with a root block (as required by tinyMCE) having a special class name, so that the resultant value can be rootless; however, we would like to remove this wrapper when exposing the content in the code editor.