### PR TITLE
Fix issue 2642.

### DIFF
--- a/js/tinymce/classes/dom/Sizzle.js
+++ b/js/tinymce/classes/dom/Sizzle.js
@@ -491,7 +491,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	// If iframe document is assigned to "document" variable and if iframe has been reloaded,
 	// IE will throw "permission denied" error when accessing "document" variable, see jQuery #13936
 	// IE6-8 do not support the defaultView property so parent will be undefined
-	if ( parent && parent !== parent.top ) {
+	if ( window.parent && window.parent !== window.parent.top ) {
 		// IE11 does not have attachEvent, so all must suffer
 		if ( parent.addEventListener ) {
 			parent.addEventListener( "unload", function() {


### PR DESCRIPTION
IE doesnt have parent in window scope. When call without variable "window" Edge throw error, because its normal. When called window.parent, the are have undefined value and worked fine

Issue link https://github.com/tinymce/tinymce/issues/2642