### PR TITLE
Adding settings option for container element

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -495,6 +495,13 @@ define("tinymce/Editor", [
 
 			settings.aria_label = settings.aria_label || DOM.getAttrib(elm, 'aria-label', self.getLang('aria.rich_text_area'));
 
+            if (settings.container) {
+                var container = DOM.getParent(elm, settings.container);
+                if (container) {
+                    DOM.setContainer(container);
+                }
+            }
+
 			/**
 			 * Reference to the theme instance that was used to generate the UI.
 			 *
@@ -821,6 +828,7 @@ define("tinymce/Editor", [
 				class_filter: settings.class_filter,
 				update_styles: true,
 				root_element: self.inline ? self.getBody() : null,
+                container: settings.container,
 				collect: settings.content_editable,
 				schema: self.schema,
 				onSetAttrib: function(e) {

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -495,12 +495,12 @@ define("tinymce/Editor", [
 
 			settings.aria_label = settings.aria_label || DOM.getAttrib(elm, 'aria-label', self.getLang('aria.rich_text_area'));
 
-            if (settings.container) {
-                var container = DOM.getParent(elm, settings.container);
-                if (container) {
-                    DOM.setContainer(container);
-                }
-            }
+			if (settings.container) {
+				var container = DOM.getParent(elm, settings.container);
+				if (container) {
+					DOM.setContainer(container);
+				}
+			}
 
 			/**
 			 * Reference to the theme instance that was used to generate the UI.
@@ -828,7 +828,7 @@ define("tinymce/Editor", [
 				class_filter: settings.class_filter,
 				update_styles: true,
 				root_element: self.inline ? self.getBody() : null,
-                container: settings.container,
+				container: settings.container,
 				collect: settings.content_editable,
 				schema: self.schema,
 				onSetAttrib: function(e) {

--- a/js/tinymce/classes/dom/DOMUtils.js
+++ b/js/tinymce/classes/dom/DOMUtils.js
@@ -250,15 +250,15 @@ define("tinymce/dom/DOMUtils", [
 			return self.settings.root_element || self.doc.body;
 		},
 
-        setContainer: function(elm) {
-            if (elm) {
-                this.container = elm;
-            }
-        },
+		setContainer: function(elm) {
+			if (elm) {
+				this.container = elm;
+			}
+		},
 
-        getContainer: function() {
-            return this.container;
-        },
+		getContainer: function() {
+			return this.container;
+		},
 
 		/**
 		 * Returns the viewport of the window.
@@ -864,9 +864,9 @@ define("tinymce/dom/DOMUtils", [
 
 			elm = self.get(elm);
 
-            if (!rootElm) {
-                rootElm = self.container;
-            }
+			if (!rootElm) {
+				rootElm = self.container;
+			}
 
 			rootElm = rootElm || body;
 

--- a/js/tinymce/classes/dom/DOMUtils.js
+++ b/js/tinymce/classes/dom/DOMUtils.js
@@ -250,6 +250,16 @@ define("tinymce/dom/DOMUtils", [
 			return self.settings.root_element || self.doc.body;
 		},
 
+        setContainer: function(elm) {
+            if (elm) {
+                this.container = elm;
+            }
+        },
+
+        getContainer: function() {
+            return this.container;
+        },
+
 		/**
 		 * Returns the viewport of the window.
 		 *
@@ -853,6 +863,11 @@ define("tinymce/dom/DOMUtils", [
 			var self = this, x = 0, y = 0, offsetParent, doc = self.doc, body = doc.body, pos;
 
 			elm = self.get(elm);
+
+            if (!rootElm) {
+                rootElm = self.container;
+            }
+
 			rootElm = rootElm || body;
 
 			if (elm) {

--- a/js/tinymce/classes/ui/Control.js
+++ b/js/tinymce/classes/ui/Control.js
@@ -141,7 +141,7 @@ define("tinymce/ui/Control", [
 			self.borderBox = BoxUtils.parseBox(settings.border);
 			self.paddingBox = BoxUtils.parseBox(settings.padding);
 			self.marginBox = BoxUtils.parseBox(settings.margin);
-            self.container = DomUtils.getContainer();
+			self.container = DomUtils.getContainer();
 
 			if (settings.hidden) {
 				self.hide();
@@ -158,7 +158,7 @@ define("tinymce/ui/Control", [
 		 * @return {Element} HTML DOM element to render into.
 		 */
 		getContainerElm: function() {
-            return this.container || document.body;
+			return this.container || document.body;
 		},
 
 		/**

--- a/js/tinymce/classes/ui/Control.js
+++ b/js/tinymce/classes/ui/Control.js
@@ -141,6 +141,7 @@ define("tinymce/ui/Control", [
 			self.borderBox = BoxUtils.parseBox(settings.border);
 			self.paddingBox = BoxUtils.parseBox(settings.padding);
 			self.marginBox = BoxUtils.parseBox(settings.margin);
+            self.container = DomUtils.getContainer();
 
 			if (settings.hidden) {
 				self.hide();
@@ -157,7 +158,7 @@ define("tinymce/ui/Control", [
 		 * @return {Element} HTML DOM element to render into.
 		 */
 		getContainerElm: function() {
-			return document.body;
+            return this.container || document.body;
 		},
 
 		/**

--- a/js/tinymce/classes/ui/DomUtils.js
+++ b/js/tinymce/classes/ui/DomUtils.js
@@ -55,9 +55,9 @@ define("tinymce/ui/DomUtils", [
 			return DOMUtils.DOM.getPos(elm, root);
 		},
 
-        getContainer: function() {
-            return DOMUtils.DOM.getContainer();
-        },
+		getContainer: function() {
+			return DOMUtils.DOM.getContainer();
+		},
 
 		getViewPort: function(win) {
 			return DOMUtils.DOM.getViewPort(win);

--- a/js/tinymce/classes/ui/DomUtils.js
+++ b/js/tinymce/classes/ui/DomUtils.js
@@ -55,6 +55,10 @@ define("tinymce/ui/DomUtils", [
 			return DOMUtils.DOM.getPos(elm, root);
 		},
 
+        getContainer: function() {
+            return DOMUtils.DOM.getContainer();
+        },
+
 		getViewPort: function(win) {
 			return DOMUtils.DOM.getViewPort(win);
 		},

--- a/test_markup/index.html
+++ b/test_markup/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+        <script type="text/javascript" src="../js/tinymce/tinymce.dev.js"></script>
+        <script type="text/javascript">
+            tinymce.init({
+                selector: "textarea",
+                width: 600,
+                height: 150,
+                container: '.content'
+            });
+        </script>
+        <style media="screen">
+            .scrollable {
+                margin:20px;
+                padding:20px;
+                background:#eee;
+                overflow-y:scroll;
+                height:400px;
+            }
+            .content {
+                height:1000px;
+                background:#ccc;
+                padding:20px;
+                margin:20px;
+                position:relative;
+            }
+        </style>
+    </head>
+    <body>
+        <p>
+            Use the 'container' setting to contain tinymce and toolbar menus inside a specific container specified by a selector.
+        </p>
+        <p>
+            This allows the use of tinymce inside a scrollable area whereas before scrolling while having a toolbar menu open, the menu would always be positioned in relation to 'body'.
+        </p>
+        <p>
+            Note: Requires that the container element you define has position:relative
+        </p>
+        <div class="scrollable">
+            scrollable
+            <div class="content">
+                content
+                <textarea></textarea>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
I would like to add the option of containing TinyMce inside a parent element in the DOM, specified by a selector. 

We have the need to use TinyMCE inside a scrollable div (iframing is not an option) and currently all new DOM elements (like toolbar menus) are added to the `body` element. When scrolling the area while having a context/toolbar menu open, the menu is positioned absolute according to `body` and therefore will not scroll with the area.

My PR addresses this by allowing for a container element, which TinyMCE will operate inside. This container element needs to be styled `position: relative` and then specified as a settings parameter on init. You can see the issue in `test_markup/index.html` of my branch by adding/removing the `container` selector.

I tried figuring out if `root_element` could support some of what I needed to do, but the use of it seems a bit random and inconsistent - and also unfinished/unused in some places. I became a bit unsure if it was thought for something else, so decided to keep this a separate configuration setting. I'm also not very familiar with the codebase of tiny, so any suggestions on what could/should be done differently would be greatly appreciated!