### PR TITLE
Fixed panel compatibility with responsive frameworks

### DIFF
--- a/js/tinymce/skins/lightgray/Panel.less
+++ b/js/tinymce/skins/lightgray/Panel.less
@@ -4,4 +4,5 @@
 	border: 0 solid mix(rgb(red(@panel-border), green(@panel-border), blue(@panel-border)), @panel-bg, 20%); 
 	border: 0 solid @panel-border;
 	.vertical-gradient(@panel-bg, @panel-bg-hlight);
+	input:not([type]) { width: auto !important; };
 }


### PR DESCRIPTION
Frameworks like foundation have the width on input fields set to 100%. This causes a problem where the panel is unable to properly calculate it's width before it is displayed.