### PR TITLE
Rewrite TextBox.renderHtml to accept html5 atts

### DIFF
--- a/js/tinymce/classes/ui/Checkbox.js
+++ b/js/tinymce/classes/ui/Checkbox.js
@@ -101,14 +101,27 @@ define("tinymce/ui/Checkbox", [
 		 * @return {String} HTML representing the control.
 		 */
 		renderHtml: function() {
-			var self = this, id = self._id, prefix = self.classPrefix;
+			var self = this, id = self._id, prefix = self.classPrefix,
+				element = document.createElement('div'),
+				i = document.createElement('i'),
+				span = document.createElement('span');
 
-			return (
-				'<div id="' + id + '" class="' + self.classes + '" unselectable="on" aria-labelledby="' + id + '-al" tabindex="-1">' +
-					'<i class="' + prefix + 'ico ' + prefix + 'i-checkbox"></i>' +
-					'<span id="' + id + '-al" class="' + prefix + 'label">' + self.encode(self.state.get('text')) + '</span>' +
-				'</div>'
-			);
+			element.id = id;
+			element.className = self.classes;
+			element.setAttribute('unselectable', 'on');
+			element.setAttribute('aria-labelledby', id + '-al');
+			element.setAttribute('tabindex', '-1');
+
+			i.className = prefix + 'ico ' + prefix + 'i-checkbox';
+
+			span.id = id + '-al';
+			span.className = prefix + label;
+			span.innerText = self.state.get('text');
+
+			element.appendChild(i);
+			element.appendChild(span);
+
+			return element.outerHTML;
 		},
 
 		bindStates: function() {

--- a/js/tinymce/classes/ui/TextBox.js
+++ b/js/tinymce/classes/ui/TextBox.js
@@ -129,7 +129,6 @@ define("tinymce/ui/TextBox", [
 				 * keys to values, like subtype maps to html input type.
 				 */
 				extraAttrs = {
-					subtype : 'type',
 					rows : 'rows',
 					spellcheck : 'spellcheck',
 					maxLength : 'maxLength',
@@ -154,6 +153,7 @@ define("tinymce/ui/TextBox", [
 			if (settings.multiline) {
 				element.innerText = self.state.get('value');
 			} else {
+				element.setAttribute('type', settings.subtype ? settings.subtype : 'text');
 				element.setAttribute('value', self.state.get('value'));
 			}
 

--- a/js/tinymce/classes/ui/TextBox.js
+++ b/js/tinymce/classes/ui/TextBox.js
@@ -120,38 +120,46 @@ define("tinymce/ui/TextBox", [
 		 * @return {String} HTML representing the control.
 		 */
 		renderHtml: function() {
-			var self = this, id = self._id, settings = self.settings, value = self.encode(self.state.get('value'), false), extraAttrs = '';
+			var self = this,
+				settings = self.settings,
+				element = document.createElement( settings.multiline ? 'textarea' : 'input' ),
+				/*
+				 * For these, the key is what is set, the value is the html attribute
+				 * it will go into.  This will make it easier for legacy or shifting
+				 * keys to values, like subtype maps to html input type.
+				 */
+				extraAttrs = {
+					subtype : 'type',
+					rows : 'rows',
+					spellcheck : 'spellcheck',
+					maxLength : 'maxLength',
+					size : 'size',
+					readonly : 'readonly',
+					min : 'min',
+					max : 'max',
+					step : 'step',
+					list : 'list',
+					pattern : 'pattern',
+					placeholder : 'placeholder',
+					required : 'required',
+					multiple : 'multiple' // Multiple may be used with the `email` subtype
+				};
 
-			if ("spellcheck" in settings) {
-				extraAttrs += ' spellcheck="' + settings.spellcheck + '"';
+			for (var key in extraAttrs) {
+				if (typeof settings[ key ] !== 'undefined') {
+					element.setAttribute(extraAttrs[ key ], settings[ key ]);
+				}
 			}
 
-			if (settings.maxLength) {
-				extraAttrs += ' maxlength="' + settings.maxLength + '"';
-			}
-
-			if (settings.size) {
-				extraAttrs += ' size="' + settings.size + '"';
-			}
-
-			if (settings.subtype) {
-				extraAttrs += ' type="' + settings.subtype + '"';
-			}
-
+			element.value = self.state.get('value');
+			element.id = self._id;
+			element.className = self.classes;
+			element.setAttribute( 'hidefocus', 1 );
 			if (self.disabled()) {
-				extraAttrs += ' disabled="disabled"';
+				element.disabled = true;
 			}
 
-			if (settings.multiline) {
-				return (
-					'<textarea id="' + id + '" class="' + self.classes + '" ' +
-					(settings.rows ? ' rows="' + settings.rows + '"' : '') +
-					' hidefocus="1"' + extraAttrs + '>' + value +
-					'</textarea>'
-				);
-			}
-
-			return '<input id="' + id + '" class="' + self.classes + '" value="' + value + '" hidefocus="1"' + extraAttrs + ' />';
+			return element.outerHTML;
 		},
 
 		value: function(value) {

--- a/js/tinymce/classes/ui/TextBox.js
+++ b/js/tinymce/classes/ui/TextBox.js
@@ -123,30 +123,26 @@ define("tinymce/ui/TextBox", [
 			var self = this,
 				settings = self.settings,
 				element = document.createElement( settings.multiline ? 'textarea' : 'input' ),
-				/*
-				 * For these, the key is what is set, the value is the html attribute
-				 * it will go into.  This will make it easier for legacy or shifting
-				 * keys to values, like subtype maps to html input type.
-				 */
-				extraAttrs = {
-					rows : 'rows',
-					spellcheck : 'spellcheck',
-					maxLength : 'maxLength',
-					size : 'size',
-					readonly : 'readonly',
-					min : 'min',
-					max : 'max',
-					step : 'step',
-					list : 'list',
-					pattern : 'pattern',
-					placeholder : 'placeholder',
-					required : 'required',
-					multiple : 'multiple' // Multiple may be used with the `email` subtype
-				};
+				extraAttrs = [
+					'rows',
+					'spellcheck',
+					'maxLength',
+					'size',
+					'readonly',
+					'min',
+					'max',
+					'step',
+					'list',
+					'pattern',
+					'placeholder',
+					'required',
+					'multiple'
+				];
 
-			for (var key in extraAttrs) {
+			for (var i = 0; i < extraAttrs.length; i++) {
+				var key = extraAttrs[ i ];
 				if (typeof settings[ key ] !== 'undefined') {
-					element.setAttribute(extraAttrs[ key ], settings[ key ]);
+					element.setAttribute(key, settings[ key ]);
 				}
 			}
 

--- a/js/tinymce/classes/ui/TextBox.js
+++ b/js/tinymce/classes/ui/TextBox.js
@@ -151,7 +151,12 @@ define("tinymce/ui/TextBox", [
 				}
 			}
 
-			element.value = self.state.get('value');
+			if (settings.multiline) {
+				element.innerText = self.state.get('value');
+			} else {
+				element.setAttribute('value', self.state.get('value'));
+			}
+
 			element.id = self._id;
 			element.className = self.classes;
 			element.setAttribute( 'hidefocus', 1 );


### PR DESCRIPTION
Also, by using native JS APIs instead of creating our own html string by
concatenation, we are more resilient to hacky/bad ways of doing things,
like `subtype : 'number" min="60',`