### PR TITLE
Issue #2278

### DIFF
--- a/js/tinymce/plugins/paste/classes/Plugin.js
+++ b/js/tinymce/plugins/paste/classes/Plugin.js
@@ -86,7 +86,7 @@ define("tinymce/pasteplugin/Plugin", [
 		});
 
 		// Block all drag/drop events
-		if (editor.paste_block_drop) {
+		if (editor.settings.paste_block_drop) {
 			editor.on('dragend dragover draggesture dragdrop drop drag', function(e) {
 				e.preventDefault();
 				e.stopPropagation();


### PR DESCRIPTION
paste plugin doesn't use paste_block_drop setting. Fixing small typo to allow for the use of the paste_block_drop setting.