### PR TITLE
Ensure that the offscreen selection remains offscreen.

### DIFF
--- a/js/tinymce/classes/SelectionOverrides.js
+++ b/js/tinymce/classes/SelectionOverrides.js
@@ -667,8 +667,8 @@ define("tinymce/SelectionOverrides", [
 				rootClass + ' .mce-offscreen-selection {' +
 					'position: absolute;' +
 					'left: -9999999999px;' +
-					'width: 100px' +
-					'height: 100px' +
+					'width: 100px;' +
+					'height: 100px;' +
 				'}' +
 				rootClass + ' *[contentEditable=false] {' +
 					'cursor: default;' +


### PR DESCRIPTION
When selecting a non-editable block containing a table with styles specifying "width: 100%; table-layout:fixed;", the table extends into the visible area on Internet Explorer 11. (Firefox and Chrome appear to limit the width of elements to 1 million pixels, which remains off-screen)

Correcting the height and width specification of the mce-offscreen-selection block ensures that the non-editable table remains offscreen.

The fiddle at https://jsfiddle.net/f6be4b5r/1/ makes the current problem visible.