### PR TITLE
Fix/remove superfluous bogus brs 4.3.8

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 4.3.9 (2016-0x-xx)
+	Fixed bug where empty elements were unnecessarily padded with BRs on IE
 Version 4.3.8 (2016-03-15)
 	Fixed bug where inserting HR at the end of a block element would produce an extra empty block.
 	Fixed bug where links would be clickable when readonly mode was enabled.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,3 @@
-Version 4.3.9 (2016-0x-xx)
-	Fixed bug where empty elements were unnecessarily padded with BRs on IE
 Version 4.3.8 (2016-03-15)
 	Fixed bug where inserting HR at the end of a block element would produce an extra empty block.
 	Fixed bug where links would be clickable when readonly mode was enabled.

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -901,17 +901,25 @@ define("tinymce/Editor", [
 				}
 			});
 
-			self.parser.addNodeFilter('p,h1,h2,h3,h4,h5,h6,div', function(nodes) {
-				var i = nodes.length, node, nonEmptyElements = self.schema.getNonEmptyElements();
+			if (!ie || ie >= 11) {
+				// Add BR elements to empty blocks to prevent them collapsing, except for IE < 11,
+				// which size the elements as expected WITHOUT the br. See also EnterKey.js/emptyBlock()
+				self.parser.addNodeFilter('p,h1,h2,h3,h4,h5,h6,div', function(nodes) {
+					var i = nodes.length, node, nonEmptyElements = self.schema.getNonEmptyElements();
 
-				while (i--) {
-					node = nodes[i];
+					while (i--) {
+						node = nodes[i];
 
-					if (node.isEmpty(nonEmptyElements)) {
-						node.append(new Node('br', 1)).shortEnded = true;
+						if (node.isEmpty(nonEmptyElements)) {
+							var brNode = new Node('br', 1);
+							brNode.shortEnded = true;
+							brNode.attr('data-mce-bogus', '1');
+
+							node.append(brNode);
+						}
 					}
-				}
-			});
+				});
+			}
 
 			/**
 			 * DOM serializer for the editor. Will be used when contents is extracted from the editor.

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -910,7 +910,7 @@ define("tinymce/Editor", [
 					while (i--) {
 						node = nodes[i];
 
-						if (node.isEmpty(nonEmptyElements)) {
+						if (node.isEmpty(nonEmptyElements, {br: 1} /* Consider an existing br data-mce-bogus element as non-empty */)) {
 							var brNode = new Node('br', 1);
 							brNode.shortEnded = true;
 							brNode.attr('data-mce-bogus', '1');

--- a/js/tinymce/classes/EnterKey.js
+++ b/js/tinymce/classes/EnterKey.js
@@ -235,10 +235,7 @@ define("tinymce/EnterKey", [
 					} while ((node = node.parentNode) && node != editableRoot);
 				}
 
-				// BR is needed in empty blocks on non IE browsers
-				if (!isIE) {
-					caretNode.innerHTML = '<br data-mce-bogus="1">';
-				}
+				emptyBlock(caretNode);
 
 				return block;
 			}

--- a/js/tinymce/classes/html/Node.js
+++ b/js/tinymce/classes/html/Node.js
@@ -413,16 +413,24 @@ define("tinymce/html/Node", [], function() {
 		 * node.isEmpty({img: true});
 		 * @method isEmpty
 		 * @param {Object} elements Name/value object with elements that are automatically treated as non empty elements.
+		 * @param {Object} bogusElements Name/value object with elements that are automatically treated as non-empty elements
+		 * even when marked as mce-bogus.
 		 * @return {Boolean} true/false if the node is empty or not.
 		 */
-		isEmpty: function(elements) {
+		isEmpty: function(elements, bogusElements) {
 			var self = this, node = self.firstChild, i, name;
+
+			bogusElements = bogusElements || [];
 
 			if (node) {
 				do {
 					if (node.type === 1) {
-						// Ignore bogus elements
+						// Ignore bogus elements, unless they are explicity to be treated as non-empty
 						if (node.attributes.map['data-mce-bogus']) {
+							if (bogusElements[node.name]) {
+								return false;
+							}
+
 							continue;
 						}
 

--- a/tests/tinymce/Editor.js
+++ b/tests/tinymce/Editor.js
@@ -14,7 +14,7 @@ module("tinymce.Editor", {
 				'*': 'color,font-size,font-family,background-color,font-weight,font-style,text-decoration,float,margin,margin-top,margin-right,margin-bottom,margin-left,display'
 			},
 			custom_elements: 'custom1,~custom2',
-			extended_valid_elements: 'custom1,custom2,script[*]',
+			extended_valid_elements: 'custom1,custom2,script[*],div[!class]',
 			init_instance_callback: function(ed) {
 				window.editor = ed;
 
@@ -224,6 +224,24 @@ test('setContent with comment bug #4409', function() {
 test('custom elements', function() {
 	editor.setContent('<custom1>c1</custom1><custom2>c1</custom2>');
 	equal(editor.getContent(), '<custom1>c1</custom1><p><custom2>c1</custom2></p>');
+});
+
+test('br in empty elements', function() {
+	expect(2);
+	editor.setContent('<p></p><h1></h1><h2></h2><h3></h3><h4></h4><h5></h5><h6></h6><div class="a"></div><div class="x"><div class="y"></div></div>');
+	
+	equal(editor.getContent({format: 'raw'}).toLowerCase(),
+			tinymce.isIE && tinymce.isIE < 11	? '<p>&nbsp;</p><h1>&nbsp;</h1><h2>&nbsp;</h2><h3>&nbsp;</h3><h4>&nbsp;</h4><h5>&nbsp;</h5><h6>&nbsp;</h6><div class="a"></div><div class="x"><div class="y"></div></div>'
+												: '<p>&nbsp;<br data-mce-bogus="1"></p><h1>&nbsp;<br data-mce-bogus="1"></h1><h2>&nbsp;<br data-mce-bogus="1"></h2><h3>&nbsp;<br data-mce-bogus="1"></h3><h4>&nbsp;<br data-mce-bogus="1"></h4><h5>&nbsp;<br data-mce-bogus="1"></h5><h6>&nbsp;<br data-mce-bogus="1"></h6><div class="a"><br data-mce-bogus="1"></div><div class="x"><div class="y"><br data-mce-bogus="1"></div></div>');
+	equal(editor.getContent(), '<p>\u00a0</p><h1>\u00a0</h1><h2>\u00a0</h2><h3>\u00a0</h3><h4>\u00a0</h4><h5>\u00a0</h5><h6>\u00a0</h6><div class="a"></div><div class="x"><div class="y"></div></div>');
+});
+
+test('No br in filled elements', function() {
+	expect(2);
+	editor.setContent('<p>a</p><h1>b</h1><h2>c</h2><h3>d</h3><h4>e</h4><h5>f</h5><h6>g</h6><div class="b">h</div>');
+	
+	equal(editor.getContent({format: 'raw'}).toLowerCase(), '<p>a</p><h1>b</h1><h2>c</h2><h3>d</h3><h4>e</h4><h5>f</h5><h6>g</h6><div class="b">h</div>');
+	equal(editor.getContent(), '<p>a</p><h1>b</h1><h2>c</h2><h3>d</h3><h4>e</h4><h5>f</h5><h6>g</h6><div class="b">h</div>');
 });
 
 test('Store/restore tabindex', function() {


### PR DESCRIPTION
Only fill empty block elements with br elements when running in non-IE browsers before IE 11; the <br> expands the block size unnecessarily in IE < 11.

(This is an updated version of pull request #559)
