### PR TITLE
Select all and cut removes focus from editor in WebKit browsers

### DIFF
--- a/js/tinymce/classes/util/Quirks.js
+++ b/js/tinymce/classes/util/Quirks.js
@@ -244,7 +244,7 @@ define("tinymce/util/Quirks", [
 				// Protect against the possibility we are asked to find a caret node relative
 				// to a node that is no longer in the DOM tree. In this case attempting to
 				// select on any match leads to a scenario where selection is completely removed
-				// from the editor. This scenario is met in real world at a minimum on 
+				// from the editor. This scenario is met in real world at a minimum on
 				// WebKit browsers when selecting all and Cmd-X cutting to delete content.
 				if (!dom.isChildOf(node, editor.getBody())) {
 					return;

--- a/js/tinymce/classes/util/Quirks.js
+++ b/js/tinymce/classes/util/Quirks.js
@@ -241,6 +241,15 @@ define("tinymce/util/Quirks", [
 			function findCaretNode(node, forward, startNode) {
 				var walker, current, nonEmptyElements;
 
+				// Protect against the possibility we are asked to find a caret node relative
+				// to a node that is no longer in the DOM tree. In this case attempting to
+				// select on any match leads to a scenario where selection is completely removed
+				// from the editor. This scenario is met in real world at a minimum on 
+				// WebKit browsers when selecting all and Cmd-X cutting to delete content.
+				if (!dom.isChildOf(node, editor.getBody())) {
+					return;
+				}
+
 				nonEmptyElements = dom.schema.getNonEmptyElements();
 
 				walker = new TreeWalker(startNode || node, node);


### PR DESCRIPTION
This patch prevents a situation in which for example selecting all and cutting in a WebKit browser will remove typing focus. Whenever a caret node is sought, it should be a pre-requisite that the node in question is still part of the editor's DOM. In some circumstances where the start or end block for a deletion is completely removed, it is still considered as a viable block for restoring caret.

I was not able to come up with a unit test to cover this change because I think the "unfocused" state reached in a side-effect of setting the selection to a DOM node that has been removed from the tree, but the selection "fixes itself up" at least as far as the DOM is concerned. So although from a practical point of view the editor has lost focus, testing the selection with getRng() shows that it has a reasonable selection as 0-index relative to the editor body.

For clarity about the nature of the bug, here are precise instruction for reproducing it from a WebKit browser:

1. Open http://fiddle.tinymce.com/1vfaab
2. Click into the editor and select all (Cmd-A)
3. Cut (Cmd-X)

Note that the insertion caret disappears and typing has no effect.

The circumstances that lead to this bug require that the customDelete method be reached while the current selected range encompasses the whole document. For some reason when the "Cut" command is used these conditions are met, but when "Delete" is used e.g. by the delete key, the current selected range is instead represented as a text container range not encompassing the container nodes, so the bug is not exhibited.

I hope this helps! Let me know if you have questions or concerns. Thanks.