### PR TITLE
Fix table row type select text attribute

### DIFF
--- a/js/tinymce/plugins/table/classes/Dialogs.js
+++ b/js/tinymce/plugins/table/classes/Dialogs.js
@@ -767,7 +767,7 @@ define("tinymce/tableplugin/Dialogs", [
 						type: 'listbox',
 						name: 'type',
 						label: 'Row type',
-						text: 'None',
+						text: 'Header',
 						maxWidth: null,
 						values: [
 							{text: 'Header', value: 'thead'},


### PR DESCRIPTION
Fix for issue #2889.

Listbox seems to have an issue when the text attribute is set to a text which is not included in the values. It seems to recognize "Header" as the first entry and doesn't update the text accordingly (because the actual row type is "Header" which is the first item in values). This pull request sets the text to "Header" which seems to solve the issue with the non updating text.