### PR TITLE
Use `html` instead of `body`

### DIFF
--- a/js/tinymce/skins/lightgray/AbsoluteLayout.less
+++ b/js/tinymce/skins/lightgray/AbsoluteLayout.less
@@ -4,7 +4,7 @@
 	position: relative;
 }
 
-body .@{prefix}-abs-layout-item, .@{prefix}-abs-end {
+html .@{prefix}-abs-layout-item, .@{prefix}-abs-end {
 	position: absolute;
 }
 


### PR DESCRIPTION
This doesn't cause any issues and have the same specificity, but might be useful in certain scenarios.
#### My use case that is solved by this change

I'm creating modal on page and placing TinyMCE instance inside of it. The trick is that modal itself is in `html` root and `body` on background is blurred. In order to make TinyMCE's modals working I did following in runtime:

``` javascript
tinymce.ui.Control.prototype.getContainerElm = function () { return document.children[0]; };
```

Simple yet efficient, but now that one selector I've edited cause issue with position of various elements inside TinyMCE's modal.
