### PR TITLE
add settings to anchor plugin for web based mailer

### DIFF
--- a/js/tinymce/plugins/anchor/plugin.js
+++ b/js/tinymce/plugins/anchor/plugin.js
@@ -28,10 +28,11 @@ tinymce.PluginManager.add('anchor', function(editor) {
 				if (isAnchor) {
 					selectedNode.id = id;
 				} else {
+					var attr = editor.settings.use_anchor_name_attr ? 'name' : 'id';
+					var opt = {};
+					opt[attr] = e.data.name;
 					editor.selection.collapse(true);
-					editor.execCommand('mceInsertContent', false, editor.dom.createHTML('a', {
-						id: id
-					}));
+					editor.execCommand('mceInsertContent', false, editor.dom.createHTML('a', opt));
 				}
 			}
 		});


### PR DESCRIPTION
Anchor plugin sets `<a id="foo">` but Gmail omits id attribute.
Name attribute (`<a name="foo">`) is not modified by Gmail but not provided from anchor plugin.
This pull request adds new option to enable anchor plugin provide name attribute.

see also:
http://archive.tinymce.com/forum/viewtopic.php?id=36544
