### PR TITLE
Fix for named+numeric entity encoding issue

### DIFF
--- a/js/tinymce/classes/html/Entities.js
+++ b/js/tinymce/classes/html/Entities.js
@@ -198,9 +198,20 @@ define("tinymce/html/Entities", [
 
 			function encodeNamedAndNumeric(text, attr) {
 				return text.replace(attr ? attrsCharsRegExp : textCharsRegExp, function(chr) {
-					return baseEntities[chr] || entities[chr] || (chr.length > 1
-				        ? '&#' + (((chr.charCodeAt(0) - 0xD800) * 0x400) + (chr.charCodeAt(1) - 0xDC00) + 0x10000) + ';'
-				        : '&#' + chr.charCodeAt(0) + ';');
+					if (baseEntities[chr]) {
+						return baseEntities[chr];
+					}
+
+					if (entities[chr]) {
+						return entities[chr];
+					}
+
+					// Convert multi-byte sequences to a single entity.
+					if (chr.length > 1) {
+						return '&#' + (((chr.charCodeAt(0) - 0xD800) * 0x400) + (chr.charCodeAt(1) - 0xDC00) + 0x10000) + ';';
+					}
+
+					return '&#' + chr.charCodeAt(0) + ';';
 				});
 			}
 

--- a/js/tinymce/classes/html/Entities.js
+++ b/js/tinymce/classes/html/Entities.js
@@ -198,7 +198,9 @@ define("tinymce/html/Entities", [
 
 			function encodeNamedAndNumeric(text, attr) {
 				return text.replace(attr ? attrsCharsRegExp : textCharsRegExp, function(chr) {
-					return baseEntities[chr] || entities[chr] || '&#' + chr.charCodeAt(0) + ';' || chr;
+					return baseEntities[chr] || entities[chr] || (chr.length > 1
+				        ? '&#' + (((chr.charCodeAt(0) - 0xD800) * 0x400) + (chr.charCodeAt(1) - 0xDC00) + 0x10000) + ';'
+				        : '&#' + chr.charCodeAt(0) + ';');
 				});
 			}
 

--- a/tests/tinymce/html/Entities.js
+++ b/tests/tinymce/html/Entities.js
@@ -14,10 +14,12 @@ test('encodeAllRaw', function() {
 });
 
 test('encodeNumeric', function() {
-	expect(2);
+	expect(4);
 
 	equal(tinymce.html.Entities.encodeNumeric('<>"\'&\u00e5\u00e4\u00f6\u03b8\u2170\ufa11'), '&lt;&gt;"\'&amp;&#229;&#228;&#246;&#952;&#8560;&#64017;', 'Numeric encoding text');
 	equal(tinymce.html.Entities.encodeNumeric('<>"\'&\u00e5\u00e4\u00f6', true), '&lt;&gt;&quot;\'&amp;&#229;&#228;&#246;', 'Numeric encoding attribute');
+	equal(tinymce.html.Entities.encodeNumeric('\ud87e\udc04'), '&#194564;', 'Numeric high-byte encoding text');
+	equal(tinymce.html.Entities.encodeNumeric('\ud87e\udc04', true), '&#194564;', 'Numeric high-byte encoding attribute');
 });
 
 test('encodeNamed', function() {
@@ -32,30 +34,42 @@ test('encodeNamed', function() {
 test('getEncodeFunc', function() {
 	var encodeFunc;
 
-	expect(10);
+	expect(20);
 
 	encodeFunc = tinymce.html.Entities.getEncodeFunc('raw');
 	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;\u00e5\u00e4\u00f6', 'Raw encoding text');
 	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6', true), '&lt;&gt;&quot;\'&amp;\u00e5\u00e4\u00f6', 'Raw encoding attribute');
+	equal(encodeFunc('\ud87e\udc04'), '\ud87e\udc04', 'Raw high-byte encoding text');
+	equal(encodeFunc('\ud87e\udc04', true), '\ud87e\udc04', 'Raw high-byte encoding attribute');
 
 	encodeFunc = tinymce.html.Entities.getEncodeFunc('named');
 	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&aring;&auml;&ouml;', 'Named encoding text');
 	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6', true), '&lt;&gt;&quot;\'&amp;&aring;&auml;&ouml;', 'Named encoding attribute');
+	equal(encodeFunc('\ud87e\udc04'), '\ud87e\udc04', 'Named high-byte encoding text');
+	equal(encodeFunc('\ud87e\udc04', true), '\ud87e\udc04', 'Named high-byte encoding attribute');
 
 	encodeFunc = tinymce.html.Entities.getEncodeFunc('numeric');
-	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&#229;&#228;&#246;', 'Named encoding text');
-	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6', true), '&lt;&gt;&quot;\'&amp;&#229;&#228;&#246;', 'Named encoding attribute');
+	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&#229;&#228;&#246;', 'Numeric encoding text');
+	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6', true), '&lt;&gt;&quot;\'&amp;&#229;&#228;&#246;', 'Numeric encoding attribute');
+	equal(encodeFunc('\ud87e\udc04'), '&#194564;', 'Numeric high-byte encoding text');
+	equal(encodeFunc('\ud87e\udc04', true), '&#194564;', 'Numeric high-byte encoding attribute');
 
 	encodeFunc = tinymce.html.Entities.getEncodeFunc('named+numeric', '229,aring');
 	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&aring;&#228;&#246;', 'Named+numeric encoding text');
 	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6', true), '&lt;&gt;&quot;\'&amp;&aring;&#228;&#246;', 'Named+numeric encoding attribute');
+	equal(encodeFunc('\ud87e\udc04'), '&#194564;', 'Named+numeric high-byte encoding text');
+	equal(encodeFunc('\ud87e\udc04', true), '&#194564;', 'Named+numeric high-byte encoding attribute');
 
 	encodeFunc = tinymce.html.Entities.getEncodeFunc('named,numeric', '229,aring');
 	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&aring;&#228;&#246;', 'Named+numeric encoding text');
 	equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6', true), '&lt;&gt;&quot;\'&amp;&aring;&#228;&#246;', 'Named+numeric encoding attribute');
+	equal(encodeFunc('\ud87e\udc04'), '&#194564;', 'Named+numeric high-byte encoding text');
+	equal(encodeFunc('\ud87e\udc04', true), '&#194564;', 'Named+numeric high-byte encoding attribute');
 });
 
 test('decode', function() {
+	expect(7);
+
 	equal(tinymce.html.Entities.decode('&lt;&gt;&quot;&#39;&amp;&aring;&auml;&ouml;&unknown;'), '<>"\'&\u00e5\u00e4\u00f6&unknown;', 'Decode text with various entities');
 	equal(tinymce.html.Entities.decode('&#65;&#66;&#039;'), 'AB\'', 'Decode numeric entities');
 	equal(tinymce.html.Entities.decode('&#x4F;&#X4F;&#x27;'), 'OO\'', 'Decode hexanumeric entities');


### PR DESCRIPTION
I found a bug where setting `entity_encoding: 'named+numeric'` did not properly encode Unicode characters outside of the basic multilingual plane (e.g., U+2F804).

I used the code in Entities.encodeNumeric as the basis for the fix and added some unit tests.

Let me know if any changes need to be made, stylistic or otherwise.