### PR TITLE
Fix for resize handle under Shadow DOM

### DIFF
--- a/js/tinymce/classes/ui/DragHelper.js
+++ b/js/tinymce/classes/ui/DragHelper.js
@@ -68,7 +68,8 @@ define("tinymce/ui/DragHelper", [
 		settings = settings || {};
 
 		function getHandleElm() {
-			return doc.getElementById(settings.handle || id);
+			var id_ = settings.handle || id;
+			return typeof id_ == 'object' ? id_ : doc.getElementById(id_);
 		}
 
 		start = function(e) {

--- a/js/tinymce/classes/ui/ResizeHandle.js
+++ b/js/tinymce/classes/ui/ResizeHandle.js
@@ -56,7 +56,7 @@ define("tinymce/ui/ResizeHandle", [
 
 			self._super();
 
-			self.resizeDragHelper = new DragHelper(this._id, {
+			self.resizeDragHelper = new DragHelper(self.getEl(), {
 				start: function() {
 					self.fire('ResizeStart');
 				},


### PR DESCRIPTION
Add support for passing DOM objects directly instead of selectors in `new DragHelper()` call.
Use new feature in ResizeHandle in order to avoid later DOM element searching by ID that will not work easily under Shadow DOM.

Tests are good, should not have any regressions.
