### PR TITLE
Changed postProcessHooks from array to object.

### DIFF
--- a/js/tinymce/classes/fmt/Hooks.js
+++ b/js/tinymce/classes/fmt/Hooks.js
@@ -19,7 +19,7 @@ define("tinymce/fmt/Hooks", [
 	"tinymce/dom/NodeType",
 	"tinymce/dom/DomQuery"
 ], function(Arr, NodeType, $) {
-	var postProcessHooks = [], filter = Arr.filter, each = Arr.each;
+	var postProcessHooks = {}, filter = Arr.filter, each = Arr.each;
 
 	function addPostProcessHook(name, hook) {
 		var hooks = postProcessHooks[name];


### PR DESCRIPTION
Fixed an issue where Array properties would conflict with hook names and cause unexpected results.  Since it is only used as an object, postProcessHooks does not need to be an Array.