### PR TITLE
Movable.calcualteRelativePosition() can be overriden for better positioning

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -546,7 +546,8 @@ module.exports = function(grunt) {
 					"js/tinymce/tinymce.min.js",
 					"js/tinymce/jquery.tinymce.min.js",
 					"js/tinymce/license.txt",
-					"changelog.txt"
+					"changelog.txt",
+					"readme.md"
 				]
 			}
 		},

--- a/js/tinymce/classes/ui/Movable.js
+++ b/js/tinymce/classes/ui/Movable.js
@@ -21,6 +21,15 @@ define("tinymce/ui/Movable", [
 	function calculateRelativePosition(ctrl, targetElm, rel) {
 		var ctrlElm, pos, x, y, selfW, selfH, targetW, targetH, viewport, size;
 
+		// can override the calculateRelativePosition setting the new function on Env.calculateRelativePosition
+		if (typeof Env.calculateRelativePosition === "function") {
+			var result = Env.calculateRelativePosition(ctrl, targetElm, rel, DomUtils);
+			// fall back to default if this returns null
+			if (result != null) {
+				return result;
+			}
+		}
+
 		viewport = DomUtils.getViewPort();
 
 		// Get pos of target

--- a/js/tinymce/plugins/paste/classes/Plugin.js
+++ b/js/tinymce/plugins/paste/classes/Plugin.js
@@ -37,6 +37,7 @@ define("tinymce/pasteplugin/Plugin", [
 			} else {
 				clipboard.pasteFormat = "text";
 				this.active(true);
+				editor.fire('PastePlainTextToggle', {state: true});
 
 				if (!isUserInformedAboutPlainText()) {
 					var message = editor.translate('Paste is now in plain text mode. Contents will now ' +
@@ -48,7 +49,6 @@ define("tinymce/pasteplugin/Plugin", [
 					});
 
 					userIsInformed = true;
-					editor.fire('PastePlainTextToggle', {state: true});
 				}
 			}
 


### PR DESCRIPTION
I had a similar situation to what described in  https://github.com/tinymce/tinymce/pull/2653, except that the tinymce 4 editor was placed inside of a scrollable container, plus we have added a feature that the toolbar of the editor got "sticky" to the top of its container when it has been scrolled out from the screen. 

In this patch I've added a new option that by defining a new method on the Env object I was able to override the calculateRelativePosition() method of the Movable object, so then I could use JQuery UI's positioning for the tinymce panels and alike.

Is there some better way to achieve this?

This is the example of the using the JQuery ui positioning. The editor's setup looks like:

<pre>
editor.editorManager.Env.calculateRelativePosition = function(ctrl, targetElm, rel, DomUtils) {
        // Parse align string
        rel = (rel || '').split('');

        // Target corners
        function relConvert(rel, defvalue) {
            switch (rel) {
                case 'l': return "left";
                case 'r': return "right";
                case 'c': return "center";
                case 't': return "top";
                case 'b': return "bottom";
            }
            return defvalue;
        }
        var atY = relConvert(rel[0], "left");
        var atX = relConvert(rel[1], "bottom");
        var myY = relConvert(rel[3], "left");
        var myX = relConvert(rel[4], "top");

        // using JQUERY UI's for positioning
        var target = $(targetElm);
        var control = ctrl.getEl();

        var my = myX +" " + myY;
        var at = atX +" " + atY;
        console.log("Using positioning my:" + my +", at:" + at +" for rel:" + rel);
        var pos = {
            w: $(control).width(),
            h: $(control).height()
        };

        // call jquery ui to calculate the position
        $(control).position({
            my: my,
            at: at,
            of: target,
            using: function(calculatedPos) {
                pos.x = calculatedPos.left;
                pos.y = calculatedPos.top;
            }
        });
        // console.log("Position calculated:" + pos);

        return pos;
    }
</pre>

