### PR TITLE
Fire the PastePlainTextToggle event even if the user's notification is off

### DIFF
--- a/js/tinymce/plugins/paste/classes/Plugin.js
+++ b/js/tinymce/plugins/paste/classes/Plugin.js
@@ -37,6 +37,7 @@ define("tinymce/pasteplugin/Plugin", [
 			} else {
 				clipboard.pasteFormat = "text";
 				this.active(true);
+				editor.fire('PastePlainTextToggle', {state: true});
 
 				if (!isUserInformedAboutPlainText()) {
 					var message = editor.translate('Paste is now in plain text mode. Contents will now ' +
@@ -48,7 +49,6 @@ define("tinymce/pasteplugin/Plugin", [
 					});
 
 					userIsInformed = true;
-					editor.fire('PastePlainTextToggle', {state: true});
 				}
 			}
 


### PR DESCRIPTION
Hi,

I've added a paste-as-plain-text button to the toolbar and wanted to persist the state of this to a database. Having the "PastePlainTextToggle" event of the paste plugin is perfect for this, however that event is not fired when the user's notification is off or the user is already notified.

This patch fixes this so the "PastePlainTextToggle" will always fire.