### PR TITLE
Prevent exception in table plugin

### DIFF
--- a/js/tinymce/plugins/table/classes/Plugin.js
+++ b/js/tinymce/plugins/table/classes/Plugin.js
@@ -346,7 +346,7 @@ define("tinymce/tableplugin/Plugin", [
 
 		editor.on('Init', function() {
 			self.cellSelection = new CellSelection(editor, function (selecting) {
-				if (selecting) {
+				if (selecting && resizeBars) {
 					resizeBars.clearBars();
 				}
 			});


### PR DESCRIPTION
Somehow I've got the line `resizeBars.clearBars();` called with an undefined `resizeBars`.
This just prevent `clearBars` on undefined.
