### PR TITLE
Security added in getRng method

### DIFF
--- a/js/tinymce/classes/dom/Selection.js
+++ b/js/tinymce/classes/dom/Selection.js
@@ -498,6 +498,10 @@ define("tinymce/dom/Selection", [
 
 			doc = self.win.document;
 
+			if (typeof doc === 'undefined' || doc === null) {
+				return null;
+			}
+
 			// Use last rng passed from FocusManager if it's available this enables
 			// calls to editor.selection.getStart() to work when caret focus is lost on IE
 			if (!w3c && self.lastFocusBookmark) {

--- a/tests/tinymce/dom/Selection.js
+++ b/tests/tinymce/dom/Selection.js
@@ -1055,5 +1055,28 @@ ModuleLoader.require([
 		equal(rng.endContainer.nodeName, '#text');
 		equal(rng.endOffset, 1);
 	});
+
+	test('getRng should return null if win.document is not defined or null', function() {
+		var win = editor.selection.win,
+			rng = editor.dom.createRng();
+
+		editor.setContent('<p>x</p>');
+
+		rng.setStart(editor.$('p')[0].firstChild, 0);
+		rng.setEnd(editor.$('p')[0].firstChild, 1);
+
+		editor.selection.setRng(rng);
+		editor.selection.setRng(null);
+
+		editor.selection.win = {};
+		rng = editor.selection.getRng(true);
+		equal(rng, null);
+
+		editor.selection.win = {document:null};
+		rng = editor.selection.getRng(true);
+		equal(rng, null);
+
+		editor.selection.win = win;
+	});
 });
 


### PR DESCRIPTION
Hello,

I fixed a bug that thrown an error if self.win.document was undefined or null in some cases.