### PR TITLE
Add editor config param to disable loading of CSS in codesample plugin

### DIFF
--- a/js/tinymce/plugins/codesample/classes/Plugin.js
+++ b/js/tinymce/plugins/codesample/classes/Plugin.js
@@ -34,6 +34,10 @@ define("tinymce/codesampleplugin/Plugin", [
 		function loadCss() {
 			var linkElm;
 
+			if (!editor.loadCss) {
+				return;
+			}
+
 			if (editor.inline && addedInlineCss) {
 				return;
 			}


### PR DESCRIPTION
this is to disable codesample plugin from loading the default prism style and be able to customise it by just adding into the editor's content_css config parameter.