### PR TITLE
docs: Fix misleading info in SelectBox documentation

### DIFF
--- a/js/tinymce/classes/ui/SelectBox.js
+++ b/js/tinymce/classes/ui/SelectBox.js
@@ -41,7 +41,7 @@ define("tinymce/ui/SelectBox", [
 		 *
 		 * @constructor
 		 * @param {Object} settings Name/value object with settings.
-		 * @setting {Array} values Array with values to add to list box.
+		 * @setting {Array} options Array with options to add to the select box.
 		 */
 		init: function(settings) {
 			var self = this;


### PR DESCRIPTION
The SelectBox documentation stated that in order to provide
values to serve as options when the HTML component would be rendered,
a `values` array should be passed, and its items would be used
as option values.
In the code, in `SelectBox.js:55` the property being checked is
`self.options` and there is no occurrence of `self.values` which
probably means that the documentation part was an unfortunate
copy+paste.

Signed-off-by: Adrian Oprea <adrian@codesi.nz>