### PR TITLE
Fullscreen plugin displays one shortcut but listens for another

### DIFF
--- a/js/tinymce/plugins/fullscreen/plugin.js
+++ b/js/tinymce/plugins/fullscreen/plugin.js
@@ -104,7 +104,7 @@ tinymce.PluginManager.add('fullscreen', function(editor) {
 	}
 
 	editor.on('init', function() {
-		editor.addShortcut('Ctrl+Shift+F', '', toggleFullscreen);
+		editor.addShortcut('Ctrl+Alt+F', '', toggleFullscreen);
 	});
 
 	editor.on('remove', function() {


### PR DESCRIPTION
Fullscreen plugin displays Ctrl+Alt+F as the shortcut in the menu option, but listens for Ctrl+Shift+F.

Updated the shortcut to match the menu item (alternatively if you wish you could change the shortcut displayed instead, depending on which shortcut you prefer/intended).