### PR TITLE
Fix Uncaught TypeError: Cannot read property 'ownerDocument' of undefined

### DIFF
--- a/js/tinymce/classes/dom/DomQuery.js
+++ b/js/tinymce/classes/dom/DomQuery.js
@@ -520,19 +520,21 @@ define("tinymce/dom/DomQuery", [
 				} else {
 					elm = self[0];
 
-					hook = cssHooks[name];
-					if (hook && hook.get) {
-						return hook.get(elm);
-					}
-
-					if (elm.ownerDocument.defaultView) {
-						try {
-							return elm.ownerDocument.defaultView.getComputedStyle(elm, null).getPropertyValue(dashed(name));
-						} catch (ex) {
-							return undef;
+					if (elm != undefined) {
+						hook = cssHooks[name];
+						if (hook && hook.get) {
+							return hook.get(elm);
 						}
-					} else if (elm.currentStyle) {
-						return elm.currentStyle[camel(name)];
+
+						if (elm.ownerDocument.defaultView) {
+							try {
+								return elm.ownerDocument.defaultView.getComputedStyle(elm, null).getPropertyValue(dashed(name));
+							} catch (ex) {
+								return undef;
+							}
+						} else if (elm.currentStyle) {
+							return elm.currentStyle[camel(name)];
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The error was especially irritating when using several tinymce editors on one page - because of the error toolbar wouldn't hide when editor lost focus on Chrome. This resulted in multiple toolbars on one page where it should be just one at once (one that is a part of currently active editor).
Error reported in browser console was `Uncaught TypeError: Cannot read property 'ownerDocument' of undefined`.
