### PR TITLE
Fixes: Table plugin: simple clicking on drag-handles in table will add width or height css to cells

### DIFF
--- a/js/tinymce/plugins/table/classes/ResizeBars.js
+++ b/js/tinymce/plugins/table/classes/ResizeBars.js
@@ -830,13 +830,17 @@ define("tinymce/tableplugin/ResizeBars", [
 					var newLeft = editor.dom.getPos(dragBar).x;
 					index = parseInt(editor.dom.getAttrib(dragBar, RESIZE_BAR_COL_DATA_ATTRIBUTE), 10);
 					delta = isRtl() ? initialLeft - newLeft : newLeft - initialLeft;
-					adjustWidth(hoverTable, delta, index);
+					if (Math.abs(delta) >= 1) {			// simple click with no real resize (<1px) must not add CSS properties
+						adjustWidth(hoverTable, delta, index);
+					}
 				} else if (isRow(dragBar)) {
 					var initialTop = parseInt(editor.dom.getAttrib(dragBar, RESIZE_BAR_ROW_DATA_INITIAL_TOP_ATTRIBUTE), 10);
 					var newTop = editor.dom.getPos(dragBar).y;
 					index = parseInt(editor.dom.getAttrib(dragBar, RESIZE_BAR_ROW_DATA_ATTRIBUTE), 10);
 					delta = newTop - initialTop;
-					adjustHeight(hoverTable, delta, index);
+					if (Math.abs(delta) >= 1) {			// simple click with no real resize (<1px) must not add CSS properties
+						adjustHeight(hoverTable, delta, index);
+					}
 				}
 				refreshBars(hoverTable);
 				editor.nodeChanged();


### PR DESCRIPTION
This bug appears when you simply click on the drag-handles in the table plugin which are used to resize the columns or rows of a table. The problem there is that when clicking there is no real resize is happening, the drag-delta is practically 0, but the Table plugin adds lots of with and height css properties to table columns/rows. This should not happen: just producing some garbage css.

The fix is to ignore "drags"/clicks with less than 1 px distance.