### PR TITLE
Being consistent with self vs. this

### DIFF
--- a/js/tinymce/classes/UndoManager.js
+++ b/js/tinymce/classes/UndoManager.js
@@ -316,7 +316,7 @@ define("tinymce/UndoManager", [
 			 * @return {Boolean} true/false if the undo manager has any redo levels.
 			 */
 			hasRedo: function() {
-				return index < data.length - 1 && !this.typing;
+				return index < data.length - 1 && !self.typing;
 			},
 
 			/**


### PR DESCRIPTION
Not sure if this is a bug or just a coding style issue, since I'm not familiar with the class-defining framework you're using in this codebase.  But nowhere else do you use `this`, not even in `hasUndo()`, so it would seem that in line 319 it should be `self` also.