### PR TITLE
Conditional comments in IE are case-insensitive

### DIFF
--- a/js/tinymce/classes/html/SaxParser.js
+++ b/js/tinymce/classes/html/SaxParser.js
@@ -436,7 +436,7 @@ define("tinymce/html/SaxParser", [
 						value = ' ' + value;
 					}
 
-					if (!settings.allow_conditional_comments && value.substr(0, 3) === '[if') {
+					if (!settings.allow_conditional_comments && value.substr(0, 3).toLowerCase() === '[if') {
 						value = ' ' + value;
 					}
 

--- a/tests/tinymce/html/SaxParser.js
+++ b/tests/tinymce/html/SaxParser.js
@@ -604,6 +604,10 @@
 		writer.reset();
 		parser.parse('<!--[if !IE]>alert(1)<![endif]-->');
 		equal(writer.getContent(), '<!-- [if !IE]>alert(1)<![endif]-->');
+
+		writer.reset();
+		parser.parse('<!--[iF !IE]>alert(1)<![endif]-->');
+		equal(writer.getContent(), '<!-- [iF !IE]>alert(1)<![endif]-->');
 	});
 
 	test('Parse script urls (allowed)', function() {


### PR DESCRIPTION
This prevents XSS like https://html5sec.org/#115