### PR TITLE
Prevent invalid markup error

### DIFF
--- a/js/tinymce/classes/dom/DOMUtils.js
+++ b/js/tinymce/classes/dom/DOMUtils.js
@@ -1166,7 +1166,7 @@ define("tinymce/dom/DOMUtils", [
 						target.removeChild(target.firstChild);
 					} catch (ex) {
 						// IE sometimes produces an unknown runtime error on innerHTML if it's a div inside a p
-						$('<div>').html('<br>' + html).contents().slice(1).appendTo(target);
+						$('<div></div>').html('<br>' + html).contents().slice(1).appendTo(target);
 					}
 
 					return html;
@@ -1190,7 +1190,7 @@ define("tinymce/dom/DOMUtils", [
 			elm = this.get(elm);
 
 			// Older FF doesn't have outerHTML 3.6 is still used by some orgaizations
-			return elm.nodeType == 1 && "outerHTML" in elm ? elm.outerHTML : $('<div>').append($(elm).clone()).html();
+			return elm.nodeType == 1 && "outerHTML" in elm ? elm.outerHTML : $('<div></div>').append($(elm).clone()).html();
 		},
 
 		/**

--- a/js/tinymce/classes/ui/DragHelper.js
+++ b/js/tinymce/classes/ui/DragHelper.js
@@ -89,7 +89,7 @@ define("tinymce/ui/DragHelper", [
 				cursor = handleElm.runtimeStyle.cursor;
 			}
 
-			$eventOverlay = $('<div>').css({
+			$eventOverlay = $('<div></div>').css({
 				position: "absolute",
 				top: 0, left: 0,
 				width: docSize.width,


### PR DESCRIPTION
I opened an issue some months ago but nobody answered to my example (#511).

The first link produces a DOMException, the second doesn't.
Both files are identical.

https://charlesbourasseau.com/invalid-markup-tinymce.xhtml
https://charlesbourasseau.com/invalid-markup-tinymce.html

Please consider to merge this pull request.