### PR TITLE
IE: hide offscreen selection

### DIFF
--- a/js/tinymce/classes/SelectionOverrides.js
+++ b/js/tinymce/classes/SelectionOverrides.js
@@ -830,6 +830,7 @@ define("tinymce/SelectionOverrides", [
 				rootClass + ' .mce-offscreen-selection {' +
 					'position: absolute;' +
 					'left: -9999999999px;' +
+					'max-width: 1000000px;' +
 				'}' +
 				rootClass + ' *[contentEditable=false] {' +
 					'cursor: default;' +

--- a/tests/tinymce/SelectionOverrides.js
+++ b/tests/tinymce/SelectionOverrides.js
@@ -328,4 +328,29 @@ ModuleLoader.require([
 		// Since we can't do a real click we need to check if it gets sucked in towards the cE=false block
 		equal(editor.selection.getNode().nodeName !== 'P', true);
 	});
+
+	test('offscreen copy of cE=false block remains offscreen', function() {
+		if (tinymce.isIE || tinymce.isGecko || tinymce.isOpera) {
+			expect(3);
+			editor.setContent('<table contenteditable="false" style="width: 100%; table-layout: fixed">'
+						  + '<tbody><tr><td>1</td><td>2</td></tr></tbody>'
+						  + '</table>');
+
+			editor.selection.select(editor.getBody().ownerDocument.getElementsByTagName('table')[0]);
+			var offscreenSelection = editor.getBody().ownerDocument.getElementsByClassName('mce-offscreen-selection')[0];
+
+			ok(offscreenSelection.offsetLeft !== undefined, 'The offscreen selection\'s left border is undefined');
+			ok(offscreenSelection.offsetLeft < 0, 'The offscreen selection\'s left border is onscreen');
+			ok(offscreenSelection.offsetWidth+ offscreenSelection.offsetLeft < 0,
+			   'The cE=false offscreen selection is visible on-screen. Right edge: ' +
+			   offscreenSelection.offsetLeft + '+' + offscreenSelection.offsetWidth + '=' +
+			   (offscreenSelection.offsetLeft + offscreenSelection.offsetWidth) + 'px');
+		}
+		else {
+			// Chrome and Safari behave correctly, and PhantomJS also declares itself as WebKit but does not
+			// put the off-screen selection off-screen, so fails the above tests. However, it has no visible UI,
+			// so everything is off-screen anyway :-)
+			ok(true, 'Not a tested browser - Chrome & Safari work, PhantomJS does not put the selection off screen');
+		}
+	});
 });


### PR DESCRIPTION
When selecting a `cE=false` block containing a table with style `"width: 100%; table-layout: fixed"`, IE sizes the offscreen selection to the full width of the editor, making it visible and difficult to deal with. Limiting the width of the offscreen selection keeps it hidden, as intended.
