### PR TITLE
Add Dailymotion short domain to urlPatterns

### DIFF
--- a/js/tinymce/plugins/media/plugin.js
+++ b/js/tinymce/plugins/media/plugin.js
@@ -20,7 +20,8 @@ tinymce.PluginManager.add('media', function(editor, url) {
 		{regex: /vimeo\.com\/([0-9]+)/, type: 'iframe', w: 425, h: 350, url: '//player.vimeo.com/video/$1?title=0&byline=0&portrait=0&color=8dc7dc', allowfullscreen: true},
 		{regex: /vimeo\.com\/(.*)\/([0-9]+)/, type: "iframe", w: 425, h: 350, url: "//player.vimeo.com/video/$2?title=0&amp;byline=0", allowfullscreen: true},
 		{regex: /maps\.google\.([a-z]{2,3})\/maps\/(.+)msid=(.+)/, type: 'iframe', w: 425, h: 350, url: '//maps.google.com/maps/ms?msid=$2&output=embed"', allowFullscreen: false},
-		{regex: /dailymotion\.com\/video\/([^_]+)/, type: 'iframe', w: 480, h: 270, url: '//www.dailymotion.com/embed/video/$1', allowFullscreen: true}
+		{regex: /dailymotion\.com\/video\/([^_]+)/, type: 'iframe', w: 480, h: 270, url: '//www.dailymotion.com/embed/video/$1', allowFullscreen: true},
+		{regex: /dai\.ly\/([^_]+)/, type: 'iframe', w: 480, h: 270, url: '//www.dailymotion.com/embed/video/$1', allowFullscreen: true}
 	];
 
 	var embedChange = (tinymce.Env.ie && tinymce.Env.ie <= 8) ? 'onChange' : 'onInput';


### PR DESCRIPTION
Hi,

Currently Dailymotion videos are handled by media plugin, but mini-urls (from short domain dai.ly) are not recognized. It displays a generic <video> instead of loading iframe from dailymotion.

This PR would allow to have a video preview when a mini-url is entered.
