### PR TITLE
Fix for issue 3185: drag and drop noneditable elements

### DIFF
--- a/js/tinymce/classes/DragDropOverrides.js
+++ b/js/tinymce/classes/DragDropOverrides.js
@@ -187,7 +187,7 @@ define("tinymce/DragDropOverrides", [
 	var drop = function (state, editor) {
 		return function (e) {
 			if (state.dragging) {
-				if (isValidDropTarget(editor, editor.selection.getNode(), state.element)) {
+				if (isValidDropTarget(editor, editor.getDoc().getSelection().focusNode, state.element)) {
 					var targetClone = cloneElement(state.element);
 
 					var args = editor.fire('drop', {

--- a/js/tinymce/classes/DragDropOverrides.js
+++ b/js/tinymce/classes/DragDropOverrides.js
@@ -36,7 +36,7 @@ define("tinymce/DragDropOverrides", [
 			return false;
 		}
 
-		if (isContentEditableFalse(targetElement)) {
+		if (isContentEditableFalse(targetElement) || editor.dom.getContentEditableParent(targetElement) === "false") {
 			return false;
 		}
 
@@ -255,7 +255,7 @@ define("tinymce/DragDropOverrides", [
 			// FF doesn't pass out clientX/clientY for drop since this is for IE we just use null instead
 			var realTarget = typeof e.clientX !== 'undefined' ? editor.getDoc().elementFromPoint(e.clientX, e.clientY) : null;
 
-			if (isContentEditableFalse(realTarget) || isContentEditableFalse(editor.dom.getContentEditableParent(realTarget))) {
+			if (isContentEditableFalse(realTarget) || editor.dom.getContentEditableParent(realTarget) === 'false') {
 				e.preventDefault();
 			}
 		});


### PR DESCRIPTION
A fix for https://github.com/tinymce/tinymce/issues/3185:
- The TinyMCE selection is apparently not updated during a drag operation, so it is necessary to use the native selection to determine the drag target element
- `DomUtils.getContentEditableParent()` returns the _state_ of contentEditable on the first ancestor node which specifies it, not the ancestor node, so its return value must be used directly.
- `isValidDropTarget()` must also check that the ancestor nodes are editable, so that it is not possible to drag a cE=false element into a cE=false block.
