### PR TITLE
Stop THEAD from inserting above CAPTION

### DIFF
--- a/js/tinymce/plugins/table/classes/Dialogs.js
+++ b/js/tinymce/plugins/table/classes/Dialogs.js
@@ -711,7 +711,11 @@ define("tinymce/tableplugin/Dialogs", [
 							if (!parentElm) {
 								parentElm = dom.create(toType);
 								if (tableElm.firstChild) {
-									tableElm.insertBefore(parentElm, tableElm.firstChild);
+									if (dom.select('caption', tableElm)[0]) {
+										tableElm.insertBefore(parentElm, tableElm.children[1]);
+									} else {
+										tableElm.insertBefore(parentElm, tableElm.firstChild);
+									}
 								} else {
 									tableElm.appendChild(parentElm);
 								}


### PR DESCRIPTION
When adding a thead check to see if a caption exists first, so that the caption is always the first child of the table.