### PR TITLE
Added missing period to hover text.

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -693,7 +693,7 @@ define("tinymce/Editor", [
 				allowTransparency: "true",
 				title: self.editorManager.translate(
 						"Rich Text Area. Press ALT-F9 for menu. " +
-						"Press ALT-F10 for toolbar. Press ALT-0 for help"
+						"Press ALT-F10 for toolbar. Press ALT-0 for help."
 				),
 				style: {
 					width: '100%',


### PR DESCRIPTION
All the phrases/sentences in the "Rich Text Area" hover text end with a period except for the final sentence. This pull request will remedy that.

Current hover text appearance:
![missing-period](https://cloud.githubusercontent.com/assets/4522761/20695990/21b50158-b5be-11e6-949f-ad2d0f082804.png)
