### PR TITLE
Fix for images inserted with blob uri

### DIFF
--- a/js/tinymce/classes/file/ImageScanner.js
+++ b/js/tinymce/classes/file/ImageScanner.js
@@ -43,18 +43,18 @@ define("tinymce/file/ImageScanner", [
 					} else {
 						Conversions.uriToBlob(img.src).then(function (blob) {
 							Conversions.blobToDataUri(blob).then(function (dataUri) {
-                                base64 = Conversions.parseDataUri(dataUri).data;
-                                var blobInfoId = 'blobid' + (count++),
-                                    blobInfo = blobCache.create(blobInfoId, blob, base64);
+								base64 = Conversions.parseDataUri(dataUri).data;
+								var blobInfoId = 'blobid' + (count++),
+									blobInfo = blobCache.create(blobInfoId, blob, base64);
 
-                                blobCache.add(blobInfo);
+								blobCache.add(blobInfo);
 
-                                resolve({
-                                    image: img,
-                                    blobInfo: blobInfo
-                                });
-                            });
-                        });
+								resolve({
+									image: img,
+									blobInfo: blobInfo
+								});
+							});
+						});
 					}
 
 					return;

--- a/js/tinymce/classes/file/ImageScanner.js
+++ b/js/tinymce/classes/file/ImageScanner.js
@@ -40,6 +40,21 @@ define("tinymce/file/ImageScanner", [
 							image: img,
 							blobInfo: blobInfo
 						});
+					} else {
+						Conversions.uriToBlob(img.src).then(function (blob) {
+							Conversions.blobToDataUri(blob).then(function (dataUri) {
+                                base64 = Conversions.parseDataUri(dataUri).data;
+                                var blobInfoId = 'blobid' + (count++),
+                                    blobInfo = blobCache.create(blobInfoId, blob, base64);
+
+                                blobCache.add(blobInfo);
+
+                                resolve({
+                                    image: img,
+                                    blobInfo: blobInfo
+                                });
+                            });
+                        });
 					}
 
 					return;


### PR DESCRIPTION
Basically, the image scanner assumes that any image with `src="blob:..."` has been already processed by tinymce, but that's not have to be the case. That will lead to unfulfilled promises and stalled execution, as mentioned on issue #3357 

This fix seems sensible to me, but I'm not familiarized with the project, so better review it.