### PR TITLE
Allow word formating of international words

### DIFF
--- a/js/tinymce/classes/Formatter.js
+++ b/js/tinymce/classes/Formatter.js
@@ -2256,7 +2256,9 @@ define("tinymce/Formatter", [
 				}
 
 				// Expand to word is caret is in the middle of a text node and the char before/after is a alpha numeric character
-				if (text && offset > 0 && offset < text.length && /\w/.test(text.charAt(offset)) && /\w/.test(text.charAt(offset - 1))) {
+				var wordcharRegex = /^[A-Za-z0-9\u00C0-\u017F]+$/;
+				if (text && offset > 0 && offset < text.length &&
+					wordcharRegex.test(text.charAt(offset)) && wordcharRegex.test(text.charAt(offset - 1))) {
 					// Get bookmark of caret position
 					bookmark = selection.getBookmark();
 

--- a/tests/tinymce/Formatter_apply.js
+++ b/tests/tinymce/Formatter_apply.js
@@ -1291,6 +1291,16 @@ test('Caret format inside single block word', function() {
 	equal(editor.getContent(), '<p><b>abc</b></p>');
 });
 
+test('Caret format inside non-ascii single block word', function() {
+	editor.setContent('<p>noël</p>');
+	editor.formatter.register('format', {
+		inline: 'b'
+	});
+	Utils.setSelection('p', 2, 'p', 2);
+	editor.formatter.apply('format');
+	equal(editor.getContent(), '<p><b>noël</b></p>');
+});
+
 test('Caret format inside first block word', function() {
 	editor.setContent('<p>abc 123</p>');
 	editor.formatter.register('format', {


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Words with non ascii characters as "Noël" can't be formatted without selecting the full word if the caret is before or after the non ascii character as ë

**How is this accomplished?** 

Use a custom regex that extends the built in \w word character match

Added support for words with unicode characters from À to ſ
http://unicode-table.com/en/#latin-1-supplement
