### PR TITLE
if the user specifies settings.language_load === false then dont load the language pack

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -417,7 +417,7 @@ define("tinymce/Editor", [
 					settings.language_url = self.editorManager.baseURL + '/langs/' + settings.language + '.js';
 				}
 
-				if (settings.language_url  && AddOnManager.languageLoad !== false) {
+				if (settings.language_url  && !tinymce.i18n.data[settings.language]) {
 					scriptLoader.add(settings.language_url);
 				}
 

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -417,7 +417,7 @@ define("tinymce/Editor", [
 					settings.language_url = self.editorManager.baseURL + '/langs/' + settings.language + '.js';
 				}
 
-				if (settings.language_url) {
+				if (settings.language_url  && AddOnManager.languageLoad !== false) {
 					scriptLoader.add(settings.language_url);
 				}
 


### PR DESCRIPTION
this option is used in requireLangPack function (which doesn't appear to be used anywhere), we load the tinymce plugins and our language pack file in our own module loading code, so we don't want tinymce reloading it a second time