### PR TITLE
Underline on the menu was missing its associated keyboard shortcut label

### DIFF
--- a/js/tinymce/classes/ui/FormatControls.js
+++ b/js/tinymce/classes/ui/FormatControls.js
@@ -481,7 +481,7 @@ define("tinymce/ui/FormatControls", [
 			selectall: ['Select all', 'SelectAll', 'Meta+A'],
 			bold: ['Bold', 'Bold', 'Meta+B'],
 			italic: ['Italic', 'Italic', 'Meta+I'],
-			underline: ['Underline', 'Underline'],
+			underline: ['Underline', 'Underline', 'Meta+U'],
 			strikethrough: ['Strikethrough', 'Strikethrough'],
 			subscript: ['Subscript', 'Subscript'],
 			superscript: ['Superscript', 'Superscript'],


### PR DESCRIPTION
From the official documentation: https://www.tinymce.com/docs/advanced/keyboard-shortcuts/

The functionality already exists, this is just tidiness. 