### PR TITLE
Bug fix for Preview.js

### DIFF
--- a/js/tinymce/classes/fmt/Preview.js
+++ b/js/tinymce/classes/fmt/Preview.js
@@ -117,7 +117,7 @@ define("tinymce/fmt/Preview", [
 
 
 	function selectorToHtml(selector, editor) {
-		return parsedSelectorToHtml(parseSelector(selector, editor));
+		return parsedSelectorToHtml(parseSelector(selector), editor);
 	}
 
 
@@ -240,9 +240,9 @@ define("tinymce/fmt/Preview", [
 				items[0].name = name;
 			}
 			name = format.selector;
-			previewFrag = parsedSelectorToHtml(items);
+			previewFrag = parsedSelectorToHtml(items, editor);
 		} else {
-			previewFrag = parsedSelectorToHtml([name]);
+			previewFrag = parsedSelectorToHtml([name], editor);
 		}
 
 		previewElm = dom.select(name, previewFrag)[0] || previewFrag.firstChild;


### PR DESCRIPTION
I found an error in "js/tinymce/classes/fmt/Preview.js" whereby the editor instance is not passed to the "parsedSelectorToHtml" function.

This prevented me from adding my own custom element as a "style_formats" option.