### PR TITLE
Cut does not work correctly on iOS

### DIFF
--- a/js/tinymce/classes/util/Quirks.js
+++ b/js/tinymce/classes/util/Quirks.js
@@ -747,21 +747,25 @@ define("tinymce/util/Quirks", [
 				}
 			});
 
-			editor.on('cut', function(e) {
-				if (!isDefaultPrevented(e) && e.clipboardData && !editor.selection.isCollapsed()) {
-					e.preventDefault();
-					e.clipboardData.clearData();
-					e.clipboardData.setData('text/html', editor.selection.getContent());
-					e.clipboardData.setData('text/plain', editor.selection.getContent({format: 'text'}));
+			// iOS Safari has an issue where setting data to the clipboard so we can't handle the cut event
+			// See: https://bugs.webkit.org/show_bug.cgi?id=143776
+			if (!Env.iOS) {
+				editor.on('cut', function (e) {
+					if (!isDefaultPrevented(e) && e.clipboardData && !editor.selection.isCollapsed()) {
+						e.preventDefault();
+						e.clipboardData.clearData();
+						e.clipboardData.setData('text/html', editor.selection.getContent());
+						e.clipboardData.setData('text/plain', editor.selection.getContent({format: 'text'}));
 
-					// Needed delay for https://code.google.com/p/chromium/issues/detail?id=363288#c3
-					// Nested delete/forwardDelete not allowed on execCommand("cut")
-					// This is ugly but not sure how to work around it otherwise
-					Delay.setEditorTimeout(editor, function() {
-						transactCustomDelete(true);
-					});
-				}
-			});
+						// Needed delay for https://code.google.com/p/chromium/issues/detail?id=363288#c3
+						// Nested delete/forwardDelete not allowed on execCommand("cut")
+						// This is ugly but not sure how to work around it otherwise
+						Delay.setEditorTimeout(editor, function () {
+							transactCustomDelete(true);
+						});
+					}
+				});
+			}
 		}
 
 		/**


### PR DESCRIPTION
iOS Safari has an issue where setting data to the clipboard.

https://bugs.webkit.org/show_bug.cgi?id=143776

I think it would be better to exclude the browser from the `cut` event handler in `cleanupStylesWhenDeleting` until this issue is fixed.
