### PR TITLE
trimListStart should remove only start children

### DIFF
--- a/js/tinymce/plugins/paste/classes/WordFilter.js
+++ b/js/tinymce/plugins/paste/classes/WordFilter.js
@@ -112,12 +112,11 @@ define("tinymce/pasteplugin/WordFilter", [
 						}
 					}
 
-					if ((node = node.firstChild)) {
-						do {
-							if (!trimListStart(node, regExp)) {
-								return false;
-							}
-						} while ((node = node.next));
+					while ((node = node.firstChild)) 
+					{
+						if (!trimListStart(node, regExp)) {
+							return false;
+						}
 					}
 
 					return true;


### PR DESCRIPTION
Hello, this is fix for deleting trailing words with dot at the end 
(i didnt create a bug report for this)

original:
https://goo.gl/SgvYEc
after paste result:
https://goo.gl/xqJi2c

test document: https://1drv.ms/w/s!At0QPhta5WNQgq4FYRNbdFsxLK0xAA
steps: try paste this document into tinymce (win10 office2016)
used tinymce version: 4.5.2 (2017-01-04)

wrong enter point:
https://goo.gl/098Vi4

Thanx