### PR TITLE
spellchecker bug fix

### DIFF
--- a/js/tinymce/plugins/spellchecker/classes/DomTextMatcher.js
+++ b/js/tinymce/plugins/spellchecker/classes/DomTextMatcher.js
@@ -244,7 +244,9 @@ define("tinymce/spellcheckerplugin/DomTextMatcher", [], function() {
 
 		function unwrapElement(element) {
 			var parentNode = element.parentNode;
-			parentNode.insertBefore(element.firstChild, element);
+			while(element.childNodes.length > 0) {
+				parentNode.insertBefore(element.childNodes[0], element);
+			}
 			element.parentNode.removeChild(element);
 		}
 


### PR DESCRIPTION
When spellchecking, if the user clicks in the middle of an underlined word to see options, the element is split into two spans to drive the positioning of the option menu. Then, if the user toggles the spellcheck button again without choosing an option, unwrapElement function removes the wrapper element and moves the first span, but not the second, to the parent element. This causes the part of the word after the spot where the user clicked to disappear.

It's an obscure flow of events, but it has been happening to some of our users who wonder why half of the word is disappearing. This fix modifies the unwrapElement function to move all child nodes to the parent element, not just the first.