### PR TITLE
Added the link_auto_add_protocol setting for the Link plugin

### DIFF
--- a/src/plugins/link/src/main/js/Plugin.js
+++ b/src/plugins/link/src/main/js/Plugin.js
@@ -542,16 +542,22 @@ define(
             // Is not protocol prefixed
             if ((editor.settings.link_assume_external_targets && !/^\w+:/i.test(href)) ||
               (!editor.settings.link_assume_external_targets && /^\s*www[\.|\d\.]/i.test(href))) {
-              delayedConfirm(
-                'The URL you entered seems to be an external link. Do you want to add the required http:// prefix?',
-                function (state) {
-                  if (state) {
-                    href = 'http://' + href;
-                  }
 
-                  insertLink();
-                }
-              );
+              if (editor.settings.link_auto_add_protocol) {
+                href = 'http://' + href;
+                insertLink();
+              } else {
+                delayedConfirm(
+                  'The URL you entered seems to be an external link. Do you want to add the required http:// prefix?',
+                  function (state) {
+                    if (state) {
+                      href = 'http://' + href;
+                    }
+
+                    insertLink();
+                  }
+                );
+              }
 
               return;
             }


### PR DESCRIPTION
When the link without the `http://` protocol is added to the editor via the `Link` plugin, the confirmation dialog shows up asking if the link should be prefixed with `http://`. I needed to spare the user the trouble of seeing this dialog, so I implemented the `link_auto_add_protocol` setting, `false` by default. When set to `true`, the confirmation dialog is not presented, and the link is corrected automatically. 

This setting does not relate to the [`link_assume_external_targets`](https://www.tinymce.com/docs/plugins/link/#link_assume_external_targets) setting. Currently the documentation for this setting is misleading. It implies that this setting controls if the confirmation dialog is presented or not (I believe the #2327 issue is related).

Actually the confirmation dialog is presented to the user in any case when the link should be corrected. The `link_assume_external_targets` setting only controls in which the cases the prefix should be added. There was no way of skipping the confirmation dialog and just adding the `http://` automatically. This is what the proposed `link_auto_add_protocol` setting is for.

The docs should also be corrected, I'll add the corresponding PR to [tinymce/tinymce-docs](https://github.com/tinymce/tinymce-docs) if this PR gets accepted.