### PR TITLE
Fixing #3213: Multibyte Characters Not Encoded Correctly in Named+Numeric

### DIFF
--- a/src/core/src/main/js/html/Entities.js
+++ b/src/core/src/main/js/html/Entities.js
@@ -201,7 +201,20 @@ define(
 
         function encodeNamedAndNumeric(text, attr) {
           return text.replace(attr ? attrsCharsRegExp : textCharsRegExp, function (chr) {
-            return baseEntities[chr] || entities[chr] || '&#' + chr.charCodeAt(0) + ';' || chr;
+            if (baseEntities[chr]) {
+              return baseEntities[chr];
+            }
+
+            if (entities[chr]) {
+              return entities[chr];
+            }
+
+            // Convert multi-byte sequences to a single entity.
+            if (chr.length > 1) {
+              return '&#' + (((chr.charCodeAt(0) - 0xD800) * 0x400) + (chr.charCodeAt(1) - 0xDC00) + 0x10000) + ';';
+            }
+
+            return '&#' + chr.charCodeAt(0) + ';';
           });
         }
 

--- a/src/core/src/test/js/browser/html/EntitiesTest.js
+++ b/src/core/src/test/js/browser/html/EntitiesTest.js
@@ -65,6 +65,8 @@ asynctest(
       encodeFunc = Entities.getEncodeFunc('raw');
       LegacyUnit.equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;\u00e5\u00e4\u00f6', 'Raw encoding text');
       LegacyUnit.equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6', true), '&lt;&gt;&quot;\'&amp;\u00e5\u00e4\u00f6', 'Raw encoding attribute');
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04'), '\ud87e\udc04', 'Raw high-byte encoding text');
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04', true), '\ud87e\udc04', 'Raw high-byte encoding attribute');
 
       encodeFunc = Entities.getEncodeFunc('named');
       LegacyUnit.equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&aring;&auml;&ouml;', 'Named encoding text');
@@ -73,10 +75,17 @@ asynctest(
         '&lt;&gt;&quot;\'&amp;&aring;&auml;&ouml;',
         'Named encoding attribute'
       );
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04'), '\ud87e\udc04', 'Named high-byte encoding text');
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04', true), '\ud87e\udc04', 'Named high-byte encoding attribute');
 
       encodeFunc = Entities.getEncodeFunc('numeric');
-      LegacyUnit.equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&#229;&#228;&#246;', 'Named encoding text');
-      LegacyUnit.equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6', true), '&lt;&gt;&quot;\'&amp;&#229;&#228;&#246;', 'Named encoding attribute');
+      LegacyUnit.equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&#229;&#228;&#246;', 'Numeric encoding text');
+      LegacyUnit.equal(
+        encodeFunc('<>"\'&\u00e5\u00e4\u00f6', true),
+        '&lt;&gt;&quot;\'&amp;&#229;&#228;&#246;',
+        'Numeric encoding attribute');
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04'), '&#194564;', 'Numeric high-byte encoding text');
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04', true), '&#194564;', 'Numeric high-byte encoding attribute');
 
       encodeFunc = Entities.getEncodeFunc('named+numeric', '229,aring');
       LegacyUnit.equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&aring;&#228;&#246;', 'Named+numeric encoding text');
@@ -85,6 +94,8 @@ asynctest(
         '&lt;&gt;&quot;\'&amp;&aring;&#228;&#246;',
         'Named+numeric encoding attribute'
       );
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04'), '&#194564;', 'Named+numeric high-byte encoding text');
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04', true), '&#194564;', 'Named+numeric high-byte encoding attribute');
 
       encodeFunc = Entities.getEncodeFunc('named,numeric', '229,aring');
       LegacyUnit.equal(encodeFunc('<>"\'&\u00e5\u00e4\u00f6'), '&lt;&gt;"\'&amp;&aring;&#228;&#246;', 'Named+numeric encoding text');
@@ -93,6 +104,8 @@ asynctest(
         '&lt;&gt;&quot;\'&amp;&aring;&#228;&#246;',
         'Named+numeric encoding attribute'
       );
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04'), '&#194564;', 'Named+numeric high-byte encoding text');
+      LegacyUnit.equal(encodeFunc('\ud87e\udc04', true), '&#194564;', 'Named+numeric high-byte encoding attribute');
     });
 
     suite.test('decode', function () {


### PR DESCRIPTION
Fixing issue #3213 where multibyte characters were not encoded correctly in Named+Numeric.

This also adds unit tests and fixes the messages for the numeric getEncodeFunc tests; they referred to named encoding tests rather than numeric encoding tests.