### PR TITLE
remove previous color when select another one

### DIFF
--- a/src/plugins/textcolor/src/main/js/Plugin.js
+++ b/src/plugins/textcolor/src/main/js/Plugin.js
@@ -205,6 +205,7 @@ define(
         type = buttonCtrl.settings.origin;
 
         function selectColor(value) {
+          removeFormat(buttonCtrl.settings.format);
           buttonCtrl.hidePanel();
           buttonCtrl.color(value);
           applyFormat(buttonCtrl.settings.format, value);


### PR DESCRIPTION
It fixes the following bug:

When change "forecolor" or "backcolor" at first, and then change font size,
after that, you cannot change color to other color
