### PR TITLE
Wrap padded empty contenteditable with forced root block

### DIFF
--- a/src/core/src/main/js/SelectionOverrides.js
+++ b/src/core/src/main/js/SelectionOverrides.js
@@ -722,12 +722,15 @@ define(
         });
 
         function paddEmptyContentEditableArea() {
-          var br, ceRoot = getContentEditableRoot(editor.selection.getNode());
+          var content, ceRoot = getContentEditableRoot(editor.selection.getNode());
 
           if (isContentEditableTrue(ceRoot) && isBlock(ceRoot) && editor.dom.isEmpty(ceRoot)) {
-            br = editor.dom.create('br', { "data-mce-bogus": "1" });
-            editor.$(ceRoot).empty().append(br);
-            editor.selection.setRng(CaretPosition.before(br).toRange());
+            content = editor.dom.create('br', { "data-mce-bogus": "1" });
+            if (editor.settings.forced_root_block) {
+              content = editor.dom.create(editor.settings.forced_root_block, editor.settings.forced_root_block_attrs, content);
+            }
+            editor.$(ceRoot).empty().append(content);
+            editor.selection.setRng(CaretPosition.before(content).toRange());
           }
         }
 


### PR DESCRIPTION
This pull request seeks to resolve an issue demonstrated in the below fiddle, where attempting to remove all text from the nested contenteditable will not enforce `forced_root_block` behavior for the empty node:

http://fiddle.tinymce.com/dLfaab

The changes here seem to correctly reinstate a wrapping paragraph block to the empty contenteditable, but is not yet perfect in that the user can still backspace once more at this point to remove both the paragraph and bogus line break.