### PR TITLE
reverts onPostRender to the state before 4.5.3 as e is undefined

### DIFF
--- a/src/plugins/lists/src/main/js/Plugin.js
+++ b/src/plugins/lists/src/main/js/Plugin.js
@@ -122,8 +122,8 @@ define(
         icon: 'indent',
         title: 'Increase indent',
         cmd: 'Indent',
-        onPostRender: function (e) {
-          var ctrl = e.control;
+        onPostRender: function () {
+          var ctrl = this;
 
           editor.on('nodechange', function () {
             var blocks = editor.selection.getSelectedBlocks();


### PR DESCRIPTION
fixes #3531
