### PR TITLE
Added nullcheck on ul when outdenting a list

### DIFF
--- a/src/plugins/lists/src/main/js/actions/Outdent.js
+++ b/src/plugins/lists/src/main/js/actions/Outdent.js
@@ -29,7 +29,14 @@ define(
     };
 
     var outdent = function (editor, li) {
-      var ul = li.parentNode, ulParent = ul.parentNode, newBlock;
+      var ul = li.parentNode, ulParent, newBlock;
+
+      if (ul) {
+        ulParent = ul.parentNode;
+      } else {
+        removeEmptyLi(editor.dom, li);
+        return true;
+      }
 
       if (ul === editor.getBody()) {
         return true;


### PR DESCRIPTION
This corrects an issue in Firefox (observed in 53.0). If you have several lines of text entered and new lines at the end and select all (including new lines) and apply an unordered/ordered list it works as expected (list items are created for the newlines). When de-listing the selection an exception is thrown.