### PR TITLE
Added webkit clipboard html decode on paste

### DIFF
--- a/src/plugins/paste/src/main/js/core/Quirks.js
+++ b/src/plugins/paste/src/main/js/core/Quirks.js
@@ -117,6 +117,9 @@ define(
           var dom = editor.dom, node = editor.selection.getNode();
 
           content = content.replace(/(<[^>]+) style="([^"]*)"([^>]*>)/gi, function (all, before, value, after) {
+            // Newer Chrome clipboard data already encodes the clipboard data so " will be &quote;
+            // This needs to be decoded so TinyMCE can do its own encoding when parsing the style.
+            value = dom.decode(value);
             var inputStyles = dom.parseStyle(value, 'span'), outputStyles = {};
 
             if (webKitStyles === "none") {


### PR DESCRIPTION
Newer Chrome already encodes the clipboard data so " will be &quote;
This needs to be decoded so TinyMCE can do its own encoding when parsing
the style.

For example, when pasting with font-family as a webkit style to keep in Chrome 58, the clipboard content for the style will already be encoded, i.e. `value` would be `"font-family: SFMono-Regular, Consolas, &quot;Liberation Mono&quot;, Menlo, Courier, monospace;"`

If this is not decoded before attempting to parse the style some of the styling information will be lost.