### PR TITLE
check if editor is unassigned before trying to fire an event

### DIFF
--- a/src/core/src/main/js/EditorManager.js
+++ b/src/core/src/main/js/EditorManager.js
@@ -42,6 +42,10 @@ define(
 
     function globalEventDelegate(e) {
       each(EditorManager.editors, function (editor) {
+        if (!editor || !editor.fire) {
+          return;
+        }
+
         if (e.type === 'scroll') {
           editor.fire('ScrollWindow', e);
         } else {


### PR DESCRIPTION
if you add an editor with a number for an id, the add method will create
several undefined editors up to the id number to the editors variable. when the
event delegator then fires, it excepts trying to access 'fire' on 'unassigned'.

**Before submitting a pull request** please do the following:

1. Fork [the repository](https://github.com/tinymce/tinymce) and create your branch from `master`
2. Have you added some code that should be tested? Write some tests! (Are you unsure how to write the test you want to write, ask us for help!)
3. Ensure that the tests pass: `grunt test`
4. Ensure that your code passes the linter: `grunt lint`
5. Make sure to sign the CLA.