### PR TITLE
Make bullet list works with IE11 compatibility mode less than 10

### DIFF
--- a/js/tinymce/classes/dom/ControlSelection.js
+++ b/js/tinymce/classes/dom/ControlSelection.js
@@ -533,6 +533,25 @@ define("tinymce/dom/ControlSelection", [
 
 			if (!isIE) {
 				return;
+			} else {
+				var ieVersion;
+				var ieCompatibilityModeVersion;
+				
+				var trident = navigator.userAgent.match(/Trident\/(\d+)/);
+				if (trident) {
+					ieVersion = parseInt(trident[1], 10) + 4;
+				}
+				
+				var msie = navigator.userAgent.match(/MSIE (\d+)/);
+				if (msie) {
+					ieCompatibilityModeVersion = parseInt(msie[1]);
+				} else {
+					ieCompatibilityModeVersion = ieVersion;
+				}
+				
+				if ( ieVersion == 11 && ieCompatibilityModeVersion <= 10) {
+					return;
+				}
 			}
 
 			ctrlRng = editableDoc.body.createControlRange();


### PR DESCRIPTION
[test.txt](https://github.com/tinymce/tinymce/files/1031529/test.txt)

Open attached html file (test.txt) with "tinymce-dist-4.5.7" in IE11. Then, press the enter button on the bullet list "list2" twice. IE will be crashed.

**Before submitting a pull request** please do the following:

1. Fork [the repository](https://github.com/tinymce/tinymce) and create your branch from `master`
2. Have you added some code that should be tested? Write some tests! (Are you unsure how to write the test you want to write, ask us for help!)
3. Ensure that the tests pass: `grunt test`
4. Ensure that your code passes the linter: `grunt lint`
5. Make sure to sign the CLA.