### PR TITLE
PRE tag not selected while selecting all the content by pressing Ctrl + A

### DIFF
--- a/src/core/src/main/js/dom/RangeUtils.js
+++ b/src/core/src/main/js/dom/RangeUtils.js
@@ -471,8 +471,8 @@ define(
                     offset = dom.nodeIndex(node);
                     container = node.parentNode;
 
-                    // Put caret after image when moving the end point
-                    if (node.nodeName == "IMG" && !directionLeft) {
+                    // Put caret after image and pre tag when moving the end point
+                    if ((node.nodeName == "IMG" || node.nodeName == "PRE") && !directionLeft) {
                       offset++;
                     }
 


### PR DESCRIPTION
**Bug**

While we have PRE tag at the end of body and when we try to select all the content by pressing Ctrl + A
then some how PRE will not select.

Check on fiddle http://fiddle.tinymce.com/5Tfaab/2

**Environment :**
version : tinymce 4.6.4
Browser : Chrome , Firefox , IE and Safari