### PR TITLE
Replace parseInt with parseFloat for Indent/Outdent

### DIFF
--- a/src/core/src/main/js/EditorCommands.js
+++ b/src/core/src/main/js/EditorCommands.js
@@ -477,7 +477,7 @@ define(
           // Setup indent level
           intentValue = settings.indentation;
           indentUnit = /[a-z%]+$/i.exec(intentValue);
-          intentValue = parseInt(intentValue, 10);
+          intentValue = parseFloat(intentValue);
 
           if (!queryCommandState('InsertUnorderedList') && !queryCommandState('InsertOrderedList')) {
             // If forced_root_blocks is set to false we don't have a block to indent so lets create a div
@@ -496,10 +496,10 @@ define(
                 indentStyleName += dom.getStyle(element, 'direction', true) == 'rtl' ? 'Right' : 'Left';
 
                 if (command == 'outdent') {
-                  value = Math.max(0, parseInt(element.style[indentStyleName] || 0, 10) - intentValue);
+                  value = Math.max(0, parseFloat(element.style[indentStyleName] || 0) - intentValue);
                   dom.setStyle(element, indentStyleName, value ? value + indentUnit : '');
                 } else {
-                  value = (parseInt(element.style[indentStyleName] || 0, 10) + intentValue) + indentUnit;
+                  value = (parseFloat(element.style[indentStyleName] || 0) + intentValue) + indentUnit;
                   dom.setStyle(element, indentStyleName, value);
                 }
               }
@@ -695,11 +695,11 @@ define(
           var node;
 
           if (settings.inline_styles) {
-            if ((node = dom.getParent(selection.getStart(), dom.isBlock)) && parseInt(node.style.paddingLeft, 10) > 0) {
+            if ((node = dom.getParent(selection.getStart(), dom.isBlock)) && parseFloat(node.style.paddingLeft) > 0) {
               return TRUE;
             }
 
-            if ((node = dom.getParent(selection.getEnd(), dom.isBlock)) && parseInt(node.style.paddingLeft, 10) > 0) {
+            if ((node = dom.getParent(selection.getEnd(), dom.isBlock)) && parseFloat(node.style.paddingLeft) > 0) {
               return TRUE;
             }
           }


### PR DESCRIPTION
I was writing some custom code to indent the first line of paragraphs and was reusing the `indentation` setting when I noticed that if I used floating point values for my css, the decimal was ignored.  Since I was using 0.5in, essentially nothing happened.  The problem was with using `parseInt` to determine the numerical piece of the setting rather than `parseFloat`.  The change is simple enough and allows the setting to work as specified by css standards.