### PR TITLE
Fixed handling negative endOffset when endContainer is the same as startContainer

### DIFF
--- a/src/core/src/main/js/fmt/ExpandRange.js
+++ b/src/core/src/main/js/fmt/ExpandRange.js
@@ -123,7 +123,7 @@ define(
       // If index based end position then resolve it
       if (endContainer.nodeType === 1 && endContainer.hasChildNodes()) {
         lastIdx = endContainer.childNodes.length - 1;
-        endContainer = endContainer.childNodes[endOffset > lastIdx ? lastIdx : endOffset - 1];
+        endContainer = endContainer.childNodes[endOffset > lastIdx ? lastIdx : Math.max(endOffset - 1, 0)];
 
         if (endContainer.nodeType === 3) {
           endOffset = endContainer.nodeValue.length;


### PR DESCRIPTION
There is an issue on Safari and iOS browser when on init event some formats are updated and the contents of the editor are already initialised with an empty text. The bug looks obvious - if endOffset is 0 the code is trying to retrieve a child with index -1.
Initialization code which triggered the problem is:
```
        editor.on('init', () => {
          if ($this._html == undefined) {
            $this._html = '';
          }
          $this.editor.setContent($this._html);
          $this.editor.readonly = $this._disabled;
          $this.setEditorDisabled($this._disabled);

          let formats = [ 'alignleft', 'aligncenter', 'alignright', 'alignjustify' ];
          formats.forEach(format => {
            let formatter = $this.editor.formatter;
            let formatDetails = formatter.get(format);
            if (formatDetails) {
              formatter.remove(format);
              let newDetails = formatDetails.filter((details: any) => !(details.selector && details.selector.includes('img')));
              formatter.register(format, newDetails);
            }
          });
```

