### PR TITLE
Prevent SkinLoader dynamically load css files when option skin is false

### DIFF
--- a/src/themes/inlite/src/main/js/core/SkinLoader.js
+++ b/src/themes/inlite/src/main/js/core/SkinLoader.js
@@ -46,6 +46,11 @@ define(
         fireSkinLoaded(editor, callback);
       };
 
+      if (settings.skin === false) {
+        done();
+        return;
+      }
+
       DOMUtils.DOM.styleSheetLoader.load(skinUrl + '/skin.min.css', done);
       editor.contentCSS.push(skinUrl + '/content.inline.min.css');
     };


### PR DESCRIPTION
I want resolve #3500 (also expected in #2836 ) that let the option skin:false will prevent dynamically load css files. This useful when all skin & theme css files are already loaded to the page that no need to be loaded again, especially when we have many tinymce instance on the samepage.