### PR TITLE
Remove invisible characters from link text that were preventing autolink plugin to auto create hyperlinks

### DIFF
--- a/src/plugins/autolink/src/main/js/Plugin.js
+++ b/src/plugins/autolink/src/main/js/Plugin.js
@@ -198,7 +198,7 @@ define(
           setEnd(endContainer, start - 1);
         }
 
-        text = rng.toString();
+        text = rng.toString().replace(/^[\u200B-\u200F\uFEFF]/g, '');
         matches = text.match(AutoLinkPattern);
 
         if (matches) {


### PR DESCRIPTION
Some characters that are automatically added to the DOM are making the
autolink regex fail to recognize links
example: ZERO WIDTH NO-BREAK SPACE -> http://www.fileformat.info/info/unicode/char/feff/index.htm

Signed-off-by: Thiago Lacerda <thiagotbl@gmail.com>