### PR TITLE
Fixes #3900. Saving a single editor instead of all.

### DIFF
--- a/src/plugins/save/src/main/js/Plugin.js
+++ b/src/plugins/save/src/main/js/Plugin.js
@@ -19,10 +19,9 @@ define(
   [
     'tinymce.core.PluginManager',
     'tinymce.core.dom.DOMUtils',
-    'tinymce.core.EditorManager',
     'tinymce.core.util.Tools'
   ],
-  function (PluginManager, DOMUtils, EditorManager, Tools) {
+  function (PluginManager, DOMUtils, Tools) {
     PluginManager.add('save', function (editor) {
       function save() {
         var formObj;
@@ -33,7 +32,7 @@ define(
           return;
         }
 
-        EditorManager.triggerSave();
+        editor.save();
 
         // Use callback instead
         if (editor.getParam("save_onsavecallback")) {


### PR DESCRIPTION
Fixes #3900. Saving a single editor instead of all. 

I removed the unused EditorManager parameter.




