### PR TITLE
plugin fullscreen: remove invalid button setting

### DIFF
--- a/src/plugins/fullscreen/src/main/js/ui/Buttons.js
+++ b/src/plugins/fullscreen/src/main/js/ui/Buttons.js
@@ -35,7 +35,6 @@ define(
 
       editor.addButton('fullscreen', {
         tooltip: 'Fullscreen',
-        shortcut: 'Ctrl+Shift+F',
         cmd: 'mceFullScreen',
         onPostRender: postRender(editor)
       });


### PR DESCRIPTION
Buttons don't have the `shortcut` setting.