### PR TITLE
Active tab option for image plugin

### DIFF
--- a/src/plugins/image/src/main/js/ui/Dialog.js
+++ b/src/plugins/image/src/main/js/ui/Dialog.js
@@ -588,6 +588,11 @@ define(
             body: body,
             onSubmit: onSubmitForm
           });
+
+          // Set the active tab to the images_active_tab, if exists
+          var activeTab = editor.settings.images_active_tab || 0;
+          win.find('tabpanel')[0].activateTab(activeTab);
+
         } else {
           // Simple default dialog
           win = editor.windowManager.open({


### PR DESCRIPTION
Currently you can't set the default (active) tab on the image plugin.
That is, you can't have `Upload` or `Advanced` as the default selected tab.
Using the added setting (`images_active_tab`), users would be able to indicate which tab to be activated by default. Note that this number for the first tab is zero (this value starts from zero).

For example, if user wants to show all of the tabs in the dialog and set `images_active_tab` to `2`, the following would be the result:
![image](https://user-images.githubusercontent.com/23480946/30779491-dd3c791a-a0af-11e7-8f63-bc8d8cc5e86d.png)


