### PR TITLE
When converting px to pt, add support for converting to half pt.

### DIFF
--- a/src/ui/src/main/js/fmt/FontInfo.js
+++ b/src/ui/src/main/js/fmt/FontInfo.js
@@ -37,7 +37,8 @@ define(
 
     var toPt = function (fontSize) {
       if (/[0-9.]+px$/.test(fontSize)) {
-        return Math.round(parseInt(fontSize, 10) * 72 / 96) + 'pt';
+        // Round to the nearest 0.5
+        return Math.round(parseInt(fontSize, 10) * 72 / 96 * 2) / 2 + 'pt';
       }
 
       return fontSize;


### PR DESCRIPTION
Currently, tinyMCE allows users to customize the list of font sizes to show via "fontsize_formats". In my case, I have 10.5pt as one of the options. (10.5pt = 14px) In tinyMCE's source code, the "toPt" function converts 14px to its pt value by using Math.round to round to the nearest whole number and does not support half pt. So, when tinyMCE loads, it defaults the selected font size to 11pt instead of 10.5pt. This is problematic because if you keep selecting the same 11pt option from the font size selector, the actual text size jumps between 10.5pt and 11pt while the selected font size stays at 11pt. This PR changes "toPt" to round to the nearest 0.5 instead of whole number.