### PR TITLE
Prevent setting dropdown to an empty value.

### DIFF
--- a/src/ui/src/main/js/FormatControls.js
+++ b/src/ui/src/main/js/FormatControls.js
@@ -152,7 +152,7 @@ define(
 
             self.value(value);
 
-            if (!value) {
+            if (!value && pt) {
               self.text(pt);
             }
           });


### PR DESCRIPTION
Consistent with how the Font Family dropdown is set, only set the text if pt has a value.

**Before submitting a pull request** please do the following:

1. Fork [the repository](https://github.com/tinymce/tinymce) and create your branch from `master`
2. Have you added some code that should be tested? Write some tests! (Are you unsure how to write the test you want to write, ask us for help!)
3. Ensure that the tests pass: `grunt test`
4. Ensure that your code passes the linter: `grunt lint`
5. Make sure to sign the CLA.