### PR TITLE
Webkit image selection bugfix

### DIFF
--- a/jscripts/tiny_mce/classes/dom/DOMUtils.js
+++ b/jscripts/tiny_mce/classes/dom/DOMUtils.js
@@ -73,7 +73,7 @@
 				keep_values : false,
 				hex_colors : 1
 			}, s);
-			
+
 			t.schema = s.schema;
 			t.styles = new tinymce.html.Styles({
 				url_converter : s.url_converter,
@@ -595,7 +595,7 @@
 					case 'float':
 						(isIE && ! tinymce.isIE11) ? s.styleFloat = v : s.cssFloat = v;
 						break;
-					
+
 					default:
 						s[na] = v || '';
 				}
@@ -1920,6 +1920,20 @@
 
 			// Check for real content editable
 			return node.contentEditable !== "inherit" ? node.contentEditable : null;
+		},
+
+		getContentEditableParent: function (node) {
+			var root = this.getRoot(), state = null;
+
+			for (; node && node !== root; node = node.parentNode) {
+				state = this.getContentEditable(node);
+
+				if (state !== null) {
+		  			break;
+				}
+			}
+
+			return state;
 		},
 
 		// #ifdef debug

--- a/jscripts/tiny_mce/classes/util/Quirks.js
+++ b/jscripts/tiny_mce/classes/util/Quirks.js
@@ -140,7 +140,7 @@ tinymce.util.Quirks = function(editor) {
 
 		editor.addCommand('Delete', function() {removeMergedFormatSpans();});
 	};
-	
+
 	/**
 	 * Makes sure that the editor body becomes empty when backspace or delete is pressed in empty editors.
 	 *
@@ -295,20 +295,21 @@ tinymce.util.Quirks = function(editor) {
 	 */
 	function selectControlElements() {
 		editor.onClick.add(function(editor, e) {
-			e = e.target;
+		target = e.target;
 
-			// Workaround for bug, http://bugs.webkit.org/show_bug.cgi?id=12250
-			// WebKit can't even do simple things like selecting an image
-			// Needs tobe the setBaseAndExtend or it will fail to select floated images
-			if (/^(IMG|HR)$/.test(e.nodeName)) {
-				selection.getSel().setBaseAndExtent(e, 0, e, 1);
-			}
-
-			if (e.nodeName == 'A' && dom.hasClass(e, 'mceItemAnchor')) {
-				selection.select(e);
-			}
-
+		// Workaround for bug, http://bugs.webkit.org/show_bug.cgi?id=12250
+		// WebKit can't even do simple things like selecting an image
+		// Needs tobe the setBaseAndExtend or it will fail to select floated images
+		if (/^(IMG|HR)$/.test(target.nodeName) && dom.getContentEditableParent(target) !== "false") {
+			e.preventDefault();
+			editor.selection.select(target);
 			editor.nodeChanged();
+		}
+
+		if (target.nodeName == 'A' && dom.hasClass(target, 'mceItemAnchor')) {
+			e.preventDefault();
+			selection.select(target);
+		}
 		});
 	};
 


### PR DESCRIPTION
Please merge this changes.

It will fix the image selection problem under chrome browser (Webkit webengine)
The solution moved from the latest tinymce version.