### PR TITLE
Handle null computedStyle when rendered in Firefox hidden iframe.

### DIFF
--- a/src/ui/src/main/js/BoxUtils.js
+++ b/src/ui/src/main/js/BoxUtils.js
@@ -74,12 +74,17 @@ define(
           var defaultView = document.defaultView;
 
           if (defaultView) {
-            // Remove camelcase
-            name = name.replace(/[A-Z]/g, function (a) {
-              return '-' + a;
-            });
+            var computedStyle = defaultView.getComputedStyle(elm, null);
+            if (computedStyle) {
+              // Remove camelcase
+              name = name.replace(/[A-Z]/g, function (a) {
+                return '-' + a;
+              });
 
-            return defaultView.getComputedStyle(elm, null).getPropertyValue(name);
+              return computedStyle.getPropertyValue(name);
+            } else {
+              return null;
+            }
           }
 
           return elm.currentStyle[name];


### PR DESCRIPTION
Fix for when editor is rendered in Firefox in hidden iframe ( #4075 )

In this scenario "getComputedStyle(...)" returns null, so this code handles that null response.