### PR TITLE
Extends codesample with plugins from Prismjs

### DIFF
--- a/codesample-plugin.md
+++ b/codesample-plugin.md
@@ -1,0 +1,17 @@
+# Codesample plugin
+
+The plugin was updated with the following options from [Prismjs](http://prismjs.com/) :
+
+* [line-highlight](http://prismjs.com/plugins/line-highlight/)
+* [line-numbers](http://prismjs.com/plugins/line-numbers/)
+* [autolinker](http://prismjs.com/plugins/autolinker/)
+* [file-highlight](http://prismjs.com/plugins/file-highlight/)
+* [jsonp-highlight](http://prismjs.com/plugins/jsonp-highlight/)
+* [autoloader](http://prismjs.com/plugins/autoloader/)
+* [show-language](http://prismjs.com/plugins/show-language/)
+
+For adding more languages, read the following files :
+js/tinymce/plugins/codesample/components/readme.md
+
+But if you prefer to include more languages in the plugin, read this file :
+src/plugins/codesample/src/main/js/core/Prism.js

--- a/src/plugins/codesample/Gruntfile.js
+++ b/src/plugins/codesample/Gruntfile.js
@@ -34,6 +34,10 @@ module.exports = function (grunt) {
           {
             src: "src/main/css/prism.css",
             dest: "dist/codesample/css/prism.css"
+          },
+          {
+            src: "src/main/components/readme.md",
+            dest: "dist/codesample/components/readme.md"
           }
         ]
       }

--- a/src/plugins/codesample/src/main/components/readme.md
+++ b/src/plugins/codesample/src/main/components/readme.md
@@ -1,0 +1,7 @@
+This is where additional languages for Prism should be placed.
+
+Download files from https://github.com/PrismJS/prism/tree/gh-pages/components and store here.
+
+Or store in an other location and add codesample_autoloader_path option with full path for tinymce.
+
+Languages must be listed in codesample_languages option for tinymce.

--- a/src/plugins/codesample/src/main/css/prism.css
+++ b/src/plugins/codesample/src/main/css/prism.css
@@ -1,83 +1,77 @@
-/* http://prismjs.com/download.html?themes=prism&languages=markup+css+clike+javascript */
+/* http://test.lan/PluXml-2017/plugins/prismJS/working/prism/download.html?themes=prism-dark&languages=markup+css+clike+javascript+c+cpp+csharp+ruby+java+php+python&plugins=line-highlight+line-numbers+autolinker+file-highlight+toolbar+jsonp-highlight+autoloader+show-language */
 /**
- * prism.js default theme for JavaScript, CSS and HTML
- * Based on dabblet (http://dabblet.com)
+ * prism.js Dark theme for JavaScript, CSS and HTML
+ * Based on the slides of the talk “/Reg(exp){2}lained/”
  * @author Lea Verou
  */
 
 code[class*="language-"],
 pre[class*="language-"] {
-  color: black;
-  text-shadow: 0 1px white;
-  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  word-wrap: normal;
-  line-height: 1.5;
+	color: white;
+	background: none;
+	text-shadow: 0 -.1em .2em black;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-}
-
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #b3d4fc;
-}
-
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
-code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #b3d4fc;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
 }
 
 @media print {
-  code[class*="language-"],
-  pre[class*="language-"] {
-    text-shadow: none;
-  }
+	code[class*="language-"],
+	pre[class*="language-"] {
+		text-shadow: none;
+	}
+}
+
+pre[class*="language-"],
+:not(pre) > code[class*="language-"] {
+	background: hsl(30, 20%, 25%);
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
-}
-
-:not(pre) > code[class*="language-"],
-pre[class*="language-"] {
-  background: #f5f2f0;
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+	border: .3em solid hsl(30, 20%, 40%);
+	border-radius: .5em;
+	box-shadow: 1px 1px .5em black inset;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+	padding: .15em .2em .05em;
+	border-radius: .3em;
+	border: .13em solid hsl(30, 20%, 40%);
+	box-shadow: 1px 1px .3em -.1em black inset;
+	white-space: normal;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: slategray;
+	color: hsl(30, 20%, 50%);
 }
 
 .token.punctuation {
-  color: #999;
+	opacity: .7;
 }
 
 .namespace {
-  opacity: .7;
+	opacity: .7;
 }
 
 .token.property,
@@ -85,9 +79,8 @@ pre[class*="language-"] {
 .token.boolean,
 .token.number,
 .token.constant,
-.token.symbol,
-.token.deleted {
-  color: #905;
+.token.symbol {
+	color: hsl(350, 40%, 70%);
 }
 
 .token.selector,
@@ -96,43 +89,190 @@ pre[class*="language-"] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #690;
+	color: hsl(75, 70%, 60%);
 }
 
 .token.operator,
 .token.entity,
 .token.url,
 .language-css .token.string,
-.style .token.string {
-  color: #a67f59;
-  background: hsla(0, 0%, 100%, .5);
+.style .token.string,
+.token.variable {
+	color: hsl(40, 90%, 60%);
 }
 
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-  color: #07a;
-}
-
-.token.function {
-  color: #DD4A68;
+	color: hsl(350, 40%, 70%);
 }
 
 .token.regex,
-.token.important,
-.token.variable {
-  color: #e90;
+.token.important {
+	color: #e90;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+	font-weight: bold;
 }
 .token.italic {
-  font-style: italic;
+	font-style: italic;
 }
 
 .token.entity {
-  cursor: help;
+	cursor: help;
+}
+
+.token.deleted {
+	color: red;
+}
+
+pre[data-line] {
+	position: relative;
+	padding: 1em 0 1em 3em;
+}
+
+.line-highlight {
+	position: absolute;
+	left: 0;
+	right: 0;
+	padding: inherit 0;
+	margin-top: 1em; /* Same as .prism’s padding-top */
+
+	background: hsla(24, 20%, 50%,.08);
+	background: linear-gradient(to right, hsla(24, 20%, 50%,.1) 70%, hsla(24, 20%, 50%,0));
+
+	pointer-events: none;
+
+	line-height: inherit;
+	white-space: pre;
+}
+
+	.line-highlight:before,
+	.line-highlight[data-end]:after {
+		content: attr(data-start);
+		position: absolute;
+		top: .4em;
+		left: .6em;
+		min-width: 1em;
+		padding: 0 .5em;
+		background-color: hsla(24, 20%, 50%,.4);
+		color: hsl(24, 20%, 95%);
+		font: bold 65%/1.5 sans-serif;
+		text-align: center;
+		vertical-align: .3em;
+		border-radius: 999px;
+		text-shadow: none;
+		box-shadow: 0 1px white;
+	}
+
+	.line-highlight[data-end]:after {
+		content: attr(data-end);
+		top: auto;
+		bottom: .4em;
+	}
+
+pre.line-numbers {
+	position: relative;
+	padding-left: 3.8em;
+	counter-reset: linenumber;
+}
+
+pre.line-numbers > code {
+	position: relative;
+    white-space: inherit;
+}
+
+.line-numbers .line-numbers-rows {
+	position: absolute;
+	pointer-events: none;
+	top: 0;
+	font-size: 100%;
+	left: -3.8em;
+	width: 3em; /* works for line-numbers below 1000 lines */
+	letter-spacing: -1px;
+	border-right: 1px solid #999;
+
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+
+}
+
+	.line-numbers-rows > span {
+		pointer-events: none;
+		display: block;
+		counter-increment: linenumber;
+	}
+
+		.line-numbers-rows > span:before {
+			content: counter(linenumber);
+			color: #999;
+			display: block;
+			padding-right: 0.8em;
+			text-align: right;
+		}
+.token a {
+	color: inherit;
+}
+pre.code-toolbar {
+	position: relative;
+}
+
+pre.code-toolbar > .toolbar {
+	position: absolute;
+	top: .3em;
+	right: .2em;
+	transition: opacity 0.3s ease-in-out;
+	opacity: 0;
+}
+
+pre.code-toolbar:hover > .toolbar {
+	opacity: 1;
+}
+
+pre.code-toolbar > .toolbar .toolbar-item {
+	display: inline-block;
+}
+
+pre.code-toolbar > .toolbar a {
+	cursor: pointer;
+}
+
+pre.code-toolbar > .toolbar button {
+	background: none;
+	border: 0;
+	color: inherit;
+	font: inherit;
+	line-height: normal;
+	overflow: visible;
+	padding: 0;
+	-webkit-user-select: none; /* for button */
+	-moz-user-select: none;
+	-ms-user-select: none;
+}
+
+pre.code-toolbar > .toolbar a,
+pre.code-toolbar > .toolbar button,
+pre.code-toolbar > .toolbar span {
+	color: #bbb;
+	font-size: .8em;
+	padding: 0 .5em;
+	background: #f5f2f0;
+	background: rgba(224, 224, 224, 0.2);
+	box-shadow: 0 2px 0 0 rgba(0,0,0,0.2);
+	border-radius: .5em;
+}
+
+pre.code-toolbar > .toolbar a:hover,
+pre.code-toolbar > .toolbar a:focus,
+pre.code-toolbar > .toolbar button:hover,
+pre.code-toolbar > .toolbar button:focus,
+pre.code-toolbar > .toolbar span:hover,
+pre.code-toolbar > .toolbar span:focus {
+	color: inherit;
+	text-decoration: none;
 }
 

--- a/src/plugins/codesample/src/main/js/Plugin.js
+++ b/src/plugins/codesample/src/main/js/Plugin.js
@@ -24,7 +24,7 @@ define(
     PluginManager.add('codesample', function (editor, pluginUrl) {
       var addedCss = Cell(false);
 
-      FilterContent.setup(editor);
+      FilterContent.setup(editor, pluginUrl);
       Buttons.register(editor);
       Commands.register(editor);
 

--- a/src/plugins/codesample/src/main/js/core/FilterContent.js
+++ b/src/plugins/codesample/src/main/js/core/FilterContent.js
@@ -15,22 +15,38 @@ define(
     'tinymce.plugins.codesample.util.Utils'
   ],
   function (Prism, Utils) {
-    var setup = function (editor) {
+    var setup = function (editor, pluginUrl) {
       var $ = editor.$;
 
       editor.on('PreProcess', function (e) {
         $('pre[contenteditable=false]', e.node).
           filter(Utils.trimArg(Utils.isCodeSample)).
           each(function (idx, elm) {
-            var $elm = $(elm), code = elm.textContent;
+            var $elm = $(elm);
 
-            $elm.attr('class', $.trim($elm.attr('class')));
+            var className = (!elm.hasAttribute('data-src')) ? elm.className.replace(/^.*\blang(?:uage)-(\w+)\b.*$/, 'language-$1') : '';
+            if (/line-numbers/.test(elm.className)) {
+              className += ' line-numbers';
+            }
+            if (className != '') {
+              $elm.attr('class', className.trim());
+            } else {
+              $elm.removeClass();
+            }
+
+            if (!elm.hasAttribute('data-src') && !elm.hasAttribute('data-jsonp')) {
+              var node = elm.querySelector('code');
+              var code = (node != null) ? node.textContent : '';
+              $elm.empty().append($('<code></code>').each(function () {
+                // Needs to be textContent since innerText produces BR:s
+                this.textContent = code;
+              }));
+            } else {
+              $elm.empty();
+            }
+
             $elm.removeAttr('contentEditable');
 
-            $elm.empty().append($('<code></code>').each(function () {
-              // Needs to be textContent since innerText produces BR:s
-              this.textContent = code;
-            }));
           });
       });
 
@@ -47,13 +63,33 @@ define(
               });
 
               elm.contentEditable = false;
-              elm.innerHTML = editor.dom.encode(elm.textContent);
-              Prism.highlightElement(elm);
               elm.className = $.trim(elm.className);
+              var code = null;
+              if (elm.hasAttribute('data-src')) {
+                elm.classList.add('language-text');
+                code = Utils.pseudoCode({ File: elm.getAttribute('data-src') });
+              } else if (elm.hasAttribute('data-jsonp')) {
+                code = Utils.pseudoCode({ Url: elm.getAttribute('data-jsonp'), Language: elm.className.replace(/^.*lang(?:uage)?-(\w+).*$/, '$1') });
+              } else {
+                elm.innerHTML = '<code>' + editor.dom.encode(elm.textContent) + '</code>';
+                code = elm.querySelector('code');
+                Prism.highlightElement(code);
+              }
+
+              if (typeof code === 'string') {
+                code += Utils.lineNumbers(code);
+                elm.innerHTML = '<code class="language-text">' + code + '</code>';
+              }
+
             });
           });
         }
       });
+
+      if (typeof Prism.plugins.autoloader != 'undefined') {
+        var autoloaderPath = editor.settings.codesample_autoloader_path;
+        Prism.plugins.autoloader.languages_path = (typeof autoloaderPath != 'undefined') ? autoloaderPath : pluginUrl + '/components/';
+      }
     };
 
     return {

--- a/src/plugins/codesample/src/main/js/core/Prism.js
+++ b/src/plugins/codesample/src/main/js/core/Prism.js
@@ -7,7 +7,17 @@
  * License: http://www.tinymce.com/license
  * Contributing: http://www.tinymce.com/contributing
  *
- * Import of prism. Disabled DOMContentLoaded event listener.
+ * Import of prism :
+ * Download prism.js and prism.css from http://prismjs.com/download.html
+ * Select "Development version"
+ * Choose Languages as you want
+ * Choose one theme
+ * Select the plugins : line-highlight, line-numbers, autolinker ,file-highlight, jsonp-highlight, autoloader ,show-language
+ * Don't use clipboard plugin. That doesn't work !
+ * insert content of prism.js between the "Start wrap" and "End wrap" tags
+ * Disabled DOMContentLoaded event listener.
+ * Update the Languages.getLanguages() function as you choose the languages.
+ * Store prism.css in the plugins/codesample/src/main/css/ folder.
  */
 
 /*eslint-disable*/
@@ -17,926 +27,2047 @@ define(
   [
   ],
   function () {
-    var window = {};
+
     // ------------------ Start wrap
 
-    /* http://prismjs.com/download.html?themes=prism-dark&languages=markup+css+clike+javascript+c+csharp+cpp+java+php+python+ruby */
-    var _self = (typeof window !== 'undefined')
-      ? window   // if in browser
-      : (
-        (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope)
-          ? self // if in worker
-          : {}   // if in node js
-      );
-
-    /**
-     * Prism: Lightweight, robust, elegant syntax highlighting
-     * MIT license http://www.opensource.org/licenses/mit-license.php/
-     * @author Lea Verou http://lea.verou.me
-     */
-
-    var Prism = (function () {
-
-      // Private helper vars
-      var lang = /\blang(?:uage)?-(?!\*)(\w+)\b/i;
-
-      var _ = _self.Prism = {
-        util: {
-          encode: function (tokens) {
-            if (tokens instanceof Token) {
-              return new Token(tokens.type, _.util.encode(tokens.content), tokens.alias);
-            } else if (_.util.type(tokens) === 'Array') {
-              return tokens.map(_.util.encode);
-            } else {
-              return tokens.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\u00a0/g, ' ');
-            }
-          },
-
-          type: function (o) {
-            return Object.prototype.toString.call(o).match(/\[object (\w+)\]/)[1];
-          },
-
-          // Deep clone a language definition (e.g. to extend it)
-          clone: function (o) {
-            var type = _.util.type(o);
-
-            switch (type) {
-              case 'Object':
-                var clone = {};
-
-                for (var key in o) {
-                  if (o.hasOwnProperty(key)) {
-                    clone[key] = _.util.clone(o[key]);
-                  }
-                }
-
-                return clone;
-
-              case 'Array':
-                // Check for existence for IE8
-                return o.map && o.map(function (v) { return _.util.clone(v); });
-            }
-
-            return o;
-          }
-        },
-
-        languages: {
-          extend: function (id, redef) {
-            var lang = _.util.clone(_.languages[id]);
-
-            for (var key in redef) {
-              lang[key] = redef[key];
-            }
-
-            return lang;
-          },
-
-          /**
-           * Insert a token before another token in a language literal
-           * As this needs to recreate the object (we cannot actually insert before keys in object literals),
-           * we cannot just provide an object, we need anobject and a key.
-           * @param inside The key (or language id) of the parent
-           * @param before The key to insert before. If not provided, the function appends instead.
-           * @param insert Object with the key/value pairs to insert
-           * @param root The object that contains `inside`. If equal to Prism.languages, it can be omitted.
-           */
-          insertBefore: function (inside, before, insert, root) {
-            root = root || _.languages;
-            var grammar = root[inside];
-
-            if (arguments.length == 2) {
-              insert = arguments[1];
-
-              for (var newToken in insert) {
-                if (insert.hasOwnProperty(newToken)) {
-                  grammar[newToken] = insert[newToken];
-                }
-              }
-
-              return grammar;
-            }
-
-            var ret = {};
-
-            for (var token in grammar) {
-
-              if (grammar.hasOwnProperty(token)) {
-
-                if (token == before) {
-
-                  for (var newToken in insert) {
-
-                    if (insert.hasOwnProperty(newToken)) {
-                      ret[newToken] = insert[newToken];
-                    }
-                  }
-                }
-
-                ret[token] = grammar[token];
-              }
-            }
-
-            // Update references in other language definitions
-            _.languages.DFS(_.languages, function (key, value) {
-              if (value === root[inside] && key != inside) {
-                this[key] = ret;
-              }
-            });
-
-            return root[inside] = ret;
-          },
-
-          // Traverse a language definition with Depth First Search
-          DFS: function (o, callback, type) {
-            for (var i in o) {
-              if (o.hasOwnProperty(i)) {
-                callback.call(o, i, o[i], type || i);
-
-                if (_.util.type(o[i]) === 'Object') {
-                  _.languages.DFS(o[i], callback);
-                }
-                else if (_.util.type(o[i]) === 'Array') {
-                  _.languages.DFS(o[i], callback, i);
-                }
-              }
-            }
-          }
-        },
-        plugins: {},
-
-        highlightAll: function (async, callback) {
-          var elements = document.querySelectorAll('code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code');
-
-          for (var i = 0, element; element = elements[i++];) {
-            _.highlightElement(element, async === true, callback);
-          }
-        },
-
-        highlightElement: function (element, async, callback) {
-          // Find language
-          var language, grammar, parent = element;
-
-          while (parent && !lang.test(parent.className)) {
-            parent = parent.parentNode;
-          }
-
-          if (parent) {
-            language = (parent.className.match(lang) || [, ''])[1];
-            grammar = _.languages[language];
-          }
-
-          // Set language on the element, if not present
-          element.className = element.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
-
-          // Set language on the parent, for styling
-          parent = element.parentNode;
-
-          if (/pre/i.test(parent.nodeName)) {
-            parent.className = parent.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
-          }
-
-          var code = element.textContent;
-
-          var env = {
-            element: element,
-            language: language,
-            grammar: grammar,
-            code: code
-          };
-
-          if (!code || !grammar) {
-            _.hooks.run('complete', env);
-            return;
-          }
-
-          _.hooks.run('before-highlight', env);
-
-          if (async && _self.Worker) {
-            var worker = new Worker(_.filename);
-
-            worker.onmessage = function (evt) {
-              env.highlightedCode = evt.data;
-
-              _.hooks.run('before-insert', env);
-
-              env.element.innerHTML = env.highlightedCode;
-
-              callback && callback.call(env.element);
-              _.hooks.run('after-highlight', env);
-              _.hooks.run('complete', env);
-            };
-
-            worker.postMessage(JSON.stringify({
-              language: env.language,
-              code: env.code,
-              immediateClose: true
-            }));
-          }
-          else {
-            env.highlightedCode = _.highlight(env.code, env.grammar, env.language);
-
-            _.hooks.run('before-insert', env);
-
-            env.element.innerHTML = env.highlightedCode;
-
-            callback && callback.call(element);
-
-            _.hooks.run('after-highlight', env);
-            _.hooks.run('complete', env);
-          }
-        },
-
-        highlight: function (text, grammar, language) {
-          var tokens = _.tokenize(text, grammar);
-          return Token.stringify(_.util.encode(tokens), language);
-        },
-
-        tokenize: function (text, grammar, language) {
-          var Token = _.Token;
-
-          var strarr = [text];
-
-          var rest = grammar.rest;
-
-          if (rest) {
-            for (var token in rest) {
-              grammar[token] = rest[token];
-            }
-
-            delete grammar.rest;
-          }
-
-          tokenloop: for (var token in grammar) {
-            if (!grammar.hasOwnProperty(token) || !grammar[token]) {
-              continue;
-            }
-
-            var patterns = grammar[token];
-            patterns = (_.util.type(patterns) === "Array") ? patterns : [patterns];
-
-            for (var j = 0; j < patterns.length; ++j) {
-              var pattern = patterns[j],
-                inside = pattern.inside,
-                lookbehind = !!pattern.lookbehind,
-                lookbehindLength = 0,
-                alias = pattern.alias;
-
-              pattern = pattern.pattern || pattern;
-
-              for (var i = 0; i < strarr.length; i++) { // Don’t cache length as it changes during the loop
-
-                var str = strarr[i];
-
-                if (strarr.length > text.length) {
-                  // Something went terribly wrong, ABORT, ABORT!
-                  break tokenloop;
-                }
-
-                if (str instanceof Token) {
-                  continue;
-                }
-
-                pattern.lastIndex = 0;
-
-                var match = pattern.exec(str);
-
-                if (match) {
-                  if (lookbehind) {
-                    lookbehindLength = match[1].length;
-                  }
-
-                  var from = match.index - 1 + lookbehindLength,
-                    match = match[0].slice(lookbehindLength),
-                    len = match.length,
-                    to = from + len,
-                    before = str.slice(0, from + 1),
-                    after = str.slice(to + 1);
-
-                  var args = [i, 1];
-
-                  if (before) {
-                    args.push(before);
-                  }
-
-                  var wrapped = new Token(token, inside ? _.tokenize(match, inside) : match, alias);
-
-                  args.push(wrapped);
-
-                  if (after) {
-                    args.push(after);
-                  }
-
-                  Array.prototype.splice.apply(strarr, args);
-                }
-              }
-            }
-          }
-
-          return strarr;
-        },
-
-        hooks: {
-          all: {},
-
-          add: function (name, callback) {
-            var hooks = _.hooks.all;
-
-            hooks[name] = hooks[name] || [];
-
-            hooks[name].push(callback);
-          },
-
-          run: function (name, env) {
-            var callbacks = _.hooks.all[name];
-
-            if (!callbacks || !callbacks.length) {
-              return;
-            }
-
-            for (var i = 0, callback; callback = callbacks[i++];) {
-              callback(env);
-            }
-          }
-        }
-      };
-
-      var Token = _.Token = function (type, content, alias) {
-        this.type = type;
-        this.content = content;
-        this.alias = alias;
-      };
-
-      Token.stringify = function (o, language, parent) {
-        if (typeof o == 'string') {
-          return o;
-        }
-
-        if (_.util.type(o) === 'Array') {
-          return o.map(function (element) {
-            return Token.stringify(element, language, o);
-          }).join('');
-        }
-
-        var env = {
-          type: o.type,
-          content: Token.stringify(o.content, language, parent),
-          tag: 'span',
-          classes: ['token', o.type],
-          attributes: {},
-          language: language,
-          parent: parent
-        };
-
-        if (env.type == 'comment') {
-          env.attributes['spellcheck'] = 'true';
-        }
-
-        if (o.alias) {
-          var aliases = _.util.type(o.alias) === 'Array' ? o.alias : [o.alias];
-          Array.prototype.push.apply(env.classes, aliases);
-        }
-
-        _.hooks.run('wrap', env);
-
-        var attributes = '';
-
-        for (var name in env.attributes) {
-          attributes += (attributes ? ' ' : '') + name + '="' + (env.attributes[name] || '') + '"';
-        }
-
-        return '<' + env.tag + ' class="' + env.classes.join(' ') + '" ' + attributes + '>' + env.content + '</' + env.tag + '>';
-
-      };
-
-      if (!_self.document) {
-        if (!_self.addEventListener) {
-          // in Node.js
-          return _self.Prism;
-        }
-        // In worker
-        _self.addEventListener('message', function (evt) {
-          var message = JSON.parse(evt.data),
-            lang = message.language,
-            code = message.code,
-            immediateClose = message.immediateClose;
-
-          _self.postMessage(_.highlight(code, _.languages[lang], lang));
-          if (immediateClose) {
-            _self.close();
-          }
-        }, false);
-
-        return _self.Prism;
-      }
-      /*
-      // Get current script and highlight
-      var script = document.getElementsByTagName('script');
-
-      script = script[script.length - 1];
-
-      if (script) {
-        _.filename = script.src;
-
-        if (document.addEventListener && !script.hasAttribute('data-manual')) {
-          document.addEventListener('DOMContentLoaded', _.highlightAll);
-        }
-      }
-
-      return _self.Prism;
-      */
-    })();
-
-    if (typeof module !== 'undefined' && module.exports) {
-      module.exports = Prism;
-    }
-
-    // hack for components to work correctly in node.js
-    if (typeof global !== 'undefined') {
-      global.Prism = Prism;
-    }
-    ;
-    Prism.languages.markup = {
-      'comment': /<!--[\w\W]*?-->/,
-      'prolog': /<\?[\w\W]+?\?>/,
-      'doctype': /<!DOCTYPE[\w\W]+?>/,
-      'cdata': /<!\[CDATA\[[\w\W]*?]]>/i,
-      'tag': {
-        pattern: /<\/?[^\s>\/=.]+(?:\s+[^\s>\/=]+(?:=(?:("|')(?:\\\1|\\?(?!\1)[\w\W])*\1|[^\s'">=]+))?)*\s*\/?>/i,
-        inside: {
-          'tag': {
-            pattern: /^<\/?[^\s>\/]+/i,
-            inside: {
-              'punctuation': /^<\/?/,
-              'namespace': /^[^\s>\/:]+:/
-            }
-          },
-          'attr-value': {
-            pattern: /=(?:('|")[\w\W]*?(\1)|[^\s>]+)/i,
-            inside: {
-              'punctuation': /[=>"']/
-            }
-          },
-          'punctuation': /\/?>/,
-          'attr-name': {
-            pattern: /[^\s>\/]+/,
-            inside: {
-              'namespace': /^[^\s>\/:]+:/
-            }
-          }
-
-        }
-      },
-      'entity': /&#?[\da-z]{1,8};/i
-    };
-
-    // Plugin to make entity title show the real entity, idea by Roman Komarov
-    Prism.hooks.add('wrap', function (env) {
-
-      if (env.type === 'entity') {
-        env.attributes['title'] = env.content.replace(/&amp;/, '&');
-      }
-    });
-
-    Prism.languages.xml = Prism.languages.markup;
-    Prism.languages.html = Prism.languages.markup;
-    Prism.languages.mathml = Prism.languages.markup;
-    Prism.languages.svg = Prism.languages.markup;
-
-    Prism.languages.css = {
-      'comment': /\/\*[\w\W]*?\*\//,
-      'atrule': {
-        pattern: /@[\w-]+?.*?(;|(?=\s*\{))/i,
-        inside: {
-          'rule': /@[\w-]+/
-          // See rest below
-        }
-      },
-      'url': /url\((?:(["'])(\\(?:\r\n|[\w\W])|(?!\1)[^\\\r\n])*\1|.*?)\)/i,
-      'selector': /[^\{\}\s][^\{\};]*?(?=\s*\{)/,
-      'string': /("|')(\\(?:\r\n|[\w\W])|(?!\1)[^\\\r\n])*\1/,
-      'property': /(\b|\B)[\w-]+(?=\s*:)/i,
-      'important': /\B!important\b/i,
-      'function': /[-a-z0-9]+(?=\()/i,
-      'punctuation': /[(){};:]/
-    };
-
-    Prism.languages.css['atrule'].inside.rest = Prism.util.clone(Prism.languages.css);
-
-    if (Prism.languages.markup) {
-      Prism.languages.insertBefore('markup', 'tag', {
-        'style': {
-          pattern: /<style[\w\W]*?>[\w\W]*?<\/style>/i,
-          inside: {
-            'tag': {
-              pattern: /<style[\w\W]*?>|<\/style>/i,
-              inside: Prism.languages.markup.tag.inside
-            },
-            rest: Prism.languages.css
-          },
-          alias: 'language-css'
-        }
-      });
-
-      Prism.languages.insertBefore('inside', 'attr-value', {
-        'style-attr': {
-          pattern: /\s*style=("|').*?\1/i,
-          inside: {
-            'attr-name': {
-              pattern: /^\s*style/i,
-              inside: Prism.languages.markup.tag.inside
-            },
-            'punctuation': /^\s*=\s*['"]|['"]\s*$/,
-            'attr-value': {
-              pattern: /.+/i,
-              inside: Prism.languages.css
-            }
-          },
-          alias: 'language-css'
-        }
-      }, Prism.languages.markup.tag);
-    };
-    Prism.languages.clike = {
-      'comment': [
-        {
-          pattern: /(^|[^\\])\/\*[\w\W]*?\*\//,
-          lookbehind: true
-        },
-        {
-          pattern: /(^|[^\\:])\/\/.*/,
-          lookbehind: true
-        }
-      ],
-      'string': /(["'])(\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
-      'class-name': {
-        pattern: /((?:\b(?:class|interface|extends|implements|trait|instanceof|new)\s+)|(?:catch\s+\())[a-z0-9_\.\\]+/i,
-        lookbehind: true,
-        inside: {
-          punctuation: /(\.|\\)/
-        }
-      },
-      'keyword': /\b(if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\b/,
-      'boolean': /\b(true|false)\b/,
-      'function': /[a-z0-9_]+(?=\()/i,
-      'number': /\b-?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)\b/i,
-      'operator': /--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&?|\|\|?|\?|\*|\/|~|\^|%/,
-      'punctuation': /[{}[\];(),.:]/
-    };
-
-    Prism.languages.javascript = Prism.languages.extend('clike', {
-      'keyword': /\b(as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|true|try|typeof|var|void|while|with|yield)\b/,
-      'number': /\b-?(0x[\dA-Fa-f]+|0b[01]+|0o[0-7]+|\d*\.?\d+([Ee][+-]?\d+)?|NaN|Infinity)\b/,
-      // Allow for all non-ASCII characters (See http://stackoverflow.com/a/2008444)
-      'function': /[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*(?=\()/i
-    });
-
-    Prism.languages.insertBefore('javascript', 'keyword', {
-      'regex': {
-        pattern: /(^|[^/])\/(?!\/)(\[.+?]|\\.|[^/\\\r\n])+\/[gimyu]{0,5}(?=\s*($|[\r\n,.;})]))/,
-        lookbehind: true
-      }
-    });
-
-    Prism.languages.insertBefore('javascript', 'class-name', {
-      'template-string': {
-        pattern: /`(?:\\`|\\?[^`])*`/,
-        inside: {
-          'interpolation': {
-            pattern: /\$\{[^}]+\}/,
-            inside: {
-              'interpolation-punctuation': {
-                pattern: /^\$\{|\}$/,
-                alias: 'punctuation'
-              },
-              rest: Prism.languages.javascript
-            }
-          },
-          'string': /[\s\S]+/
-        }
-      }
-    });
-
-    if (Prism.languages.markup) {
-      Prism.languages.insertBefore('markup', 'tag', {
-        'script': {
-          pattern: /<script[\w\W]*?>[\w\W]*?<\/script>/i,
-          inside: {
-            'tag': {
-              pattern: /<script[\w\W]*?>|<\/script>/i,
-              inside: Prism.languages.markup.tag.inside
-            },
-            rest: Prism.languages.javascript
-          },
-          alias: 'language-javascript'
-        }
-      });
-    }
-
-    Prism.languages.js = Prism.languages.javascript;
-    Prism.languages.c = Prism.languages.extend('clike', {
-      'keyword': /\b(asm|typeof|inline|auto|break|case|char|const|continue|default|do|double|else|enum|extern|float|for|goto|if|int|long|register|return|short|signed|sizeof|static|struct|switch|typedef|union|unsigned|void|volatile|while)\b/,
-      'operator': /\-[>-]?|\+\+?|!=?|<<?=?|>>?=?|==?|&&?|\|?\||[~^%?*\/]/,
-      'number': /\b-?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)[ful]*\b/i
-    });
-
-    Prism.languages.insertBefore('c', 'string', {
-      'macro': {
-        // allow for multiline macro definitions
-        // spaces after the # character compile fine with gcc
-        pattern: /(^\s*)#\s*[a-z]+([^\r\n\\]|\\.|\\(?:\r\n?|\n))*/im,
-        lookbehind: true,
-        alias: 'property',
-        inside: {
-          // highlight the path of the include statement as a string
-          'string': {
-            pattern: /(#\s*include\s*)(<.+?>|("|')(\\?.)+?\3)/,
-            lookbehind: true
-          }
-        }
-      }
-    });
-
-    delete Prism.languages.c['class-name'];
-    delete Prism.languages.c['boolean'];
-
-    Prism.languages.csharp = Prism.languages.extend('clike', {
-      'keyword': /\b(abstract|as|async|await|base|bool|break|byte|case|catch|char|checked|class|const|continue|decimal|default|delegate|do|double|else|enum|event|explicit|extern|false|finally|fixed|float|for|foreach|goto|if|implicit|in|int|interface|internal|is|lock|long|namespace|new|null|object|operator|out|override|params|private|protected|public|readonly|ref|return|sbyte|sealed|short|sizeof|stackalloc|static|string|struct|switch|this|throw|true|try|typeof|uint|ulong|unchecked|unsafe|ushort|using|virtual|void|volatile|while|add|alias|ascending|async|await|descending|dynamic|from|get|global|group|into|join|let|orderby|partial|remove|select|set|value|var|where|yield)\b/,
-      'string': [
-        /@("|')(\1\1|\\\1|\\?(?!\1)[\s\S])*\1/,
-        /("|')(\\?.)*?\1/
-      ],
-      'number': /\b-?(0x[\da-f]+|\d*\.?\d+)\b/i
-    });
-
-    Prism.languages.insertBefore('csharp', 'keyword', {
-      'preprocessor': {
-        pattern: /(^\s*)#.*/m,
-        lookbehind: true
-      }
-    });
-
-    Prism.languages.cpp = Prism.languages.extend('c', {
-      'keyword': /\b(alignas|alignof|asm|auto|bool|break|case|catch|char|char16_t|char32_t|class|compl|const|constexpr|const_cast|continue|decltype|default|delete|do|double|dynamic_cast|else|enum|explicit|export|extern|float|for|friend|goto|if|inline|int|long|mutable|namespace|new|noexcept|nullptr|operator|private|protected|public|register|reinterpret_cast|return|short|signed|sizeof|static|static_assert|static_cast|struct|switch|template|this|thread_local|throw|try|typedef|typeid|typename|union|unsigned|using|virtual|void|volatile|wchar_t|while)\b/,
-      'boolean': /\b(true|false)\b/,
-      'operator': /[-+]{1,2}|!=?|<{1,2}=?|>{1,2}=?|\->|:{1,2}|={1,2}|\^|~|%|&{1,2}|\|?\||\?|\*|\/|\b(and|and_eq|bitand|bitor|not|not_eq|or|or_eq|xor|xor_eq)\b/
-    });
-
-    Prism.languages.insertBefore('cpp', 'keyword', {
-      'class-name': {
-        pattern: /(class\s+)[a-z0-9_]+/i,
-        lookbehind: true
-      }
-    });
-    Prism.languages.java = Prism.languages.extend('clike', {
-      'keyword': /\b(abstract|continue|for|new|switch|assert|default|goto|package|synchronized|boolean|do|if|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while)\b/,
-      'number': /\b0b[01]+\b|\b0x[\da-f]*\.?[\da-fp\-]+\b|\b\d*\.?\d+(?:e[+-]?\d+)?[df]?\b/i,
-      'operator': {
-        pattern: /(^|[^.])(?:\+[+=]?|-[-=]?|!=?|<<?=?|>>?>?=?|==?|&[&=]?|\|[|=]?|\*=?|\/=?|%=?|\^=?|[?:~])/m,
-        lookbehind: true
-      }
-    });
-    /**
-     * Original by Aaron Harun: http://aahacreative.com/2012/07/31/php-syntax-highlighting-prism/
-     * Modified by Miles Johnson: http://milesj.me
-     *
-     * Supports the following:
-     *  - Extends clike syntax
-     *  - Support for PHP 5.3+ (namespaces, traits, generators, etc)
-     *  - Smarter constant and function matching
-     *
-     * Adds the following new token classes:
-     *  constant, delimiter, variable, function, package
-     */
-
-    Prism.languages.php = Prism.languages.extend('clike', {
-      'keyword': /\b(and|or|xor|array|as|break|case|cfunction|class|const|continue|declare|default|die|do|else|elseif|enddeclare|endfor|endforeach|endif|endswitch|endwhile|extends|for|foreach|function|include|include_once|global|if|new|return|static|switch|use|require|require_once|var|while|abstract|interface|public|implements|private|protected|parent|throw|null|echo|print|trait|namespace|final|yield|goto|instanceof|finally|try|catch)\b/i,
-      'constant': /\b[A-Z0-9_]{2,}\b/,
-      'comment': {
-        pattern: /(^|[^\\])(?:\/\*[\w\W]*?\*\/|\/\/.*)/,
-        lookbehind: true
-      }
-    });
-
-    // Shell-like comments are matched after strings, because they are less
-    // common than strings containing hashes...
-    Prism.languages.insertBefore('php', 'class-name', {
-      'shell-comment': {
-        pattern: /(^|[^\\])#.*/,
-        lookbehind: true,
-        alias: 'comment'
-      }
-    });
-
-    Prism.languages.insertBefore('php', 'keyword', {
-      'delimiter': /\?>|<\?(?:php)?/i,
-      'variable': /\$\w+\b/i,
-      'package': {
-        pattern: /(\\|namespace\s+|use\s+)[\w\\]+/,
-        lookbehind: true,
-        inside: {
-          punctuation: /\\/
-        }
-      }
-    });
-
-    // Must be defined after the function pattern
-    Prism.languages.insertBefore('php', 'operator', {
-      'property': {
-        pattern: /(->)[\w]+/,
-        lookbehind: true
-      }
-    });
-
-    // Add HTML support of the markup language exists
-    if (Prism.languages.markup) {
-
-      // Tokenize all inline PHP blocks that are wrapped in <?php ?>
-      // This allows for easy PHP + markup highlighting
-      Prism.hooks.add('before-highlight', function (env) {
-        if (env.language !== 'php') {
-          return;
-        }
-
-        env.tokenStack = [];
-
-        env.backupCode = env.code;
-        env.code = env.code.replace(/(?:<\?php|<\?)[\w\W]*?(?:\?>)/ig, function (match) {
-          env.tokenStack.push(match);
-
-          return '{{{PHP' + env.tokenStack.length + '}}}';
-        });
-      });
-
-      // Restore env.code for other plugins (e.g. line-numbers)
-      Prism.hooks.add('before-insert', function (env) {
-        if (env.language === 'php') {
-          env.code = env.backupCode;
-          delete env.backupCode;
-        }
-      });
-
-      // Re-insert the tokens after highlighting
-      Prism.hooks.add('after-highlight', function (env) {
-        if (env.language !== 'php') {
-          return;
-        }
-
-        for (var i = 0, t; t = env.tokenStack[i]; i++) {
-          // The replace prevents $$, $&, $`, $', $n, $nn from being interpreted as special patterns
-          env.highlightedCode = env.highlightedCode.replace('{{{PHP' + (i + 1) + '}}}', Prism.highlight(t, env.grammar, 'php').replace(/\$/g, '$$$$'));
-        }
-
-        env.element.innerHTML = env.highlightedCode;
-      });
-
-      // Wrap tokens in classes that are missing them
-      Prism.hooks.add('wrap', function (env) {
-        if (env.language === 'php' && env.type === 'markup') {
-          env.content = env.content.replace(/(\{\{\{PHP[0-9]+\}\}\})/g, "<span class=\"token php\">$1</span>");
-        }
-      });
-
-      // Add the rules before all others
-      Prism.languages.insertBefore('php', 'comment', {
-        'markup': {
-          pattern: /<[^?]\/?(.*?)>/,
-          inside: Prism.languages.markup
-        },
-        'php': /\{\{\{PHP[0-9]+\}\}\}/
-      });
-    }
-    ;
-    Prism.languages.python = {
-      'comment': {
-        pattern: /(^|[^\\])#.*/,
-        lookbehind: true
-      },
-      'string': /"""[\s\S]+?"""|'''[\s\S]+?'''|("|')(?:\\?.)*?\1/,
-      'function': {
-        pattern: /((?:^|\s)def[ \t]+)[a-zA-Z_][a-zA-Z0-9_]*(?=\()/g,
-        lookbehind: true
-      },
-      'class-name': {
-        pattern: /(\bclass\s+)[a-z0-9_]+/i,
-        lookbehind: true
-      },
-      'keyword': /\b(?:as|assert|async|await|break|class|continue|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|pass|print|raise|return|try|while|with|yield)\b/,
-      'boolean': /\b(?:True|False)\b/,
-      'number': /\b-?(?:0[bo])?(?:(?:\d|0x[\da-f])[\da-f]*\.?\d*|\.\d+)(?:e[+-]?\d+)?j?\b/i,
-      'operator': /[-+%=]=?|!=|\*\*?=?|\/\/?=?|<[<=>]?|>[=>]?|[&|^~]|\b(?:or|and|not)\b/,
-      'punctuation': /[{}[\];(),.:]/
-    };
-
-    /**
-     * Original by Samuel Flores
-     *
-     * Adds the following new token classes:
-     *  constant, builtin, variable, symbol, regex
-     */
-    (function (Prism) {
-      Prism.languages.ruby = Prism.languages.extend('clike', {
-        'comment': /#(?!\{[^\r\n]*?\}).*/,
-        'keyword': /\b(alias|and|BEGIN|begin|break|case|class|def|define_method|defined|do|each|else|elsif|END|end|ensure|false|for|if|in|module|new|next|nil|not|or|raise|redo|require|rescue|retry|return|self|super|then|throw|true|undef|unless|until|when|while|yield)\b/
-      });
-
-      var interpolation = {
-        pattern: /#\{[^}]+\}/,
-        inside: {
-          'delimiter': {
-            pattern: /^#\{|\}$/,
-            alias: 'tag'
-          },
-          rest: Prism.util.clone(Prism.languages.ruby)
-        }
-      };
-
-      Prism.languages.insertBefore('ruby', 'keyword', {
-        'regex': [
-          {
-            pattern: /%r([^a-zA-Z0-9\s\{\(\[<])(?:[^\\]|\\[\s\S])*?\1[gim]{0,3}/,
-            inside: {
-              'interpolation': interpolation
-            }
-          },
-          {
-            pattern: /%r\((?:[^()\\]|\\[\s\S])*\)[gim]{0,3}/,
-            inside: {
-              'interpolation': interpolation
-            }
-          },
-          {
-            // Here we need to specifically allow interpolation
-            pattern: /%r\{(?:[^#{}\\]|#(?:\{[^}]+\})?|\\[\s\S])*\}[gim]{0,3}/,
-            inside: {
-              'interpolation': interpolation
-            }
-          },
-          {
-            pattern: /%r\[(?:[^\[\]\\]|\\[\s\S])*\][gim]{0,3}/,
-            inside: {
-              'interpolation': interpolation
-            }
-          },
-          {
-            pattern: /%r<(?:[^<>\\]|\\[\s\S])*>[gim]{0,3}/,
-            inside: {
-              'interpolation': interpolation
-            }
-          },
-          {
-            pattern: /(^|[^/])\/(?!\/)(\[.+?]|\\.|[^/\r\n])+\/[gim]{0,3}(?=\s*($|[\r\n,.;})]))/,
-            lookbehind: true
-          }
-        ],
-        'variable': /[@$]+[a-zA-Z_][a-zA-Z_0-9]*(?:[?!]|\b)/,
-        'symbol': /:[a-zA-Z_][a-zA-Z_0-9]*(?:[?!]|\b)/
-      });
-
-      Prism.languages.insertBefore('ruby', 'number', {
-        'builtin': /\b(Array|Bignum|Binding|Class|Continuation|Dir|Exception|FalseClass|File|Stat|File|Fixnum|Fload|Hash|Integer|IO|MatchData|Method|Module|NilClass|Numeric|Object|Proc|Range|Regexp|String|Struct|TMS|Symbol|ThreadGroup|Thread|Time|TrueClass)\b/,
-        'constant': /\b[A-Z][a-zA-Z_0-9]*(?:[?!]|\b)/
-      });
-
-      Prism.languages.ruby.string = [
-        {
-          pattern: /%[qQiIwWxs]?([^a-zA-Z0-9\s\{\(\[<])(?:[^\\]|\\[\s\S])*?\1/,
-          inside: {
-            'interpolation': interpolation
-          }
-        },
-        {
-          pattern: /%[qQiIwWxs]?\((?:[^()\\]|\\[\s\S])*\)/,
-          inside: {
-            'interpolation': interpolation
-          }
-        },
-        {
-          // Here we need to specifically allow interpolation
-          pattern: /%[qQiIwWxs]?\{(?:[^#{}\\]|#(?:\{[^}]+\})?|\\[\s\S])*\}/,
-          inside: {
-            'interpolation': interpolation
-          }
-        },
-        {
-          pattern: /%[qQiIwWxs]?\[(?:[^\[\]\\]|\\[\s\S])*\]/,
-          inside: {
-            'interpolation': interpolation
-          }
-        },
-        {
-          pattern: /%[qQiIwWxs]?<(?:[^<>\\]|\\[\s\S])*>/,
-          inside: {
-            'interpolation': interpolation
-          }
-        },
-        {
-          pattern: /("|')(#\{[^}]+\}|\\(?:\r?\n|\r)|\\?.)*?\1/,
-          inside: {
-            'interpolation': interpolation
-          }
-        }
-      ];
-    }(Prism));
+/* http://test.lan/PluXml-2017/plugins/prismJS/working/prism/download.html?themes=prism-dark&languages=markup+css+clike+javascript+c+cpp+csharp+ruby+java+php+python&plugins=line-highlight+line-numbers+autolinker+file-highlight+toolbar+jsonp-highlight+autoloader+show-language */
+var _self = (typeof window !== 'undefined')
+	? window   // if in browser
+	: (
+		(typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope)
+		? self // if in worker
+		: {}   // if in node js
+	);
+
+/**
+ * Prism: Lightweight, robust, elegant syntax highlighting
+ * MIT license http://www.opensource.org/licenses/mit-license.php/
+ * @author Lea Verou http://lea.verou.me
+ */
+
+var Prism = (function(){
+
+// Private helper vars
+var lang = /\blang(?:uage)?-(\w+)\b/i;
+var uniqueId = 0;
+
+var _ = _self.Prism = {
+	manual: _self.Prism && _self.Prism.manual,
+	disableWorkerMessageHandler: _self.Prism && _self.Prism.disableWorkerMessageHandler,
+	util: {
+		encode: function (tokens) {
+			if (tokens instanceof Token) {
+				return new Token(tokens.type, _.util.encode(tokens.content), tokens.alias);
+			} else if (_.util.type(tokens) === 'Array') {
+				return tokens.map(_.util.encode);
+			} else {
+				return tokens.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\u00a0/g, ' ');
+			}
+		},
+
+		type: function (o) {
+			return Object.prototype.toString.call(o).match(/\[object (\w+)\]/)[1];
+		},
+
+		objId: function (obj) {
+			if (!obj['__id']) {
+				Object.defineProperty(obj, '__id', { value: ++uniqueId });
+			}
+			return obj['__id'];
+		},
+
+		// Deep clone a language definition (e.g. to extend it)
+		clone: function (o) {
+			var type = _.util.type(o);
+
+			switch (type) {
+				case 'Object':
+					var clone = {};
+
+					for (var key in o) {
+						if (o.hasOwnProperty(key)) {
+							clone[key] = _.util.clone(o[key]);
+						}
+					}
+
+					return clone;
+
+				case 'Array':
+					return o.map(function(v) { return _.util.clone(v); });
+			}
+
+			return o;
+		}
+	},
+
+	languages: {
+		extend: function (id, redef) {
+			var lang = _.util.clone(_.languages[id]);
+
+			for (var key in redef) {
+				lang[key] = redef[key];
+			}
+
+			return lang;
+		},
+
+		/**
+		 * Insert a token before another token in a language literal
+		 * As this needs to recreate the object (we cannot actually insert before keys in object literals),
+		 * we cannot just provide an object, we need anobject and a key.
+		 * @param inside The key (or language id) of the parent
+		 * @param before The key to insert before. If not provided, the function appends instead.
+		 * @param insert Object with the key/value pairs to insert
+		 * @param root The object that contains `inside`. If equal to Prism.languages, it can be omitted.
+		 */
+		insertBefore: function (inside, before, insert, root) {
+			root = root || _.languages;
+			var grammar = root[inside];
+
+			if (arguments.length == 2) {
+				insert = arguments[1];
+
+				for (var newToken in insert) {
+					if (insert.hasOwnProperty(newToken)) {
+						grammar[newToken] = insert[newToken];
+					}
+				}
+
+				return grammar;
+			}
+
+			var ret = {};
+
+			for (var token in grammar) {
+
+				if (grammar.hasOwnProperty(token)) {
+
+					if (token == before) {
+
+						for (var newToken in insert) {
+
+							if (insert.hasOwnProperty(newToken)) {
+								ret[newToken] = insert[newToken];
+							}
+						}
+					}
+
+					ret[token] = grammar[token];
+				}
+			}
+
+			// Update references in other language definitions
+			_.languages.DFS(_.languages, function(key, value) {
+				if (value === root[inside] && key != inside) {
+					this[key] = ret;
+				}
+			});
+
+			return root[inside] = ret;
+		},
+
+		// Traverse a language definition with Depth First Search
+		DFS: function(o, callback, type, visited) {
+			visited = visited || {};
+			for (var i in o) {
+				if (o.hasOwnProperty(i)) {
+					callback.call(o, i, o[i], type || i);
+
+					if (_.util.type(o[i]) === 'Object' && !visited[_.util.objId(o[i])]) {
+						visited[_.util.objId(o[i])] = true;
+						_.languages.DFS(o[i], callback, null, visited);
+					}
+					else if (_.util.type(o[i]) === 'Array' && !visited[_.util.objId(o[i])]) {
+						visited[_.util.objId(o[i])] = true;
+						_.languages.DFS(o[i], callback, i, visited);
+					}
+				}
+			}
+		}
+	},
+	plugins: {},
+
+	highlightAll: function(async, callback) {
+		var env = {
+			callback: callback,
+			selector: 'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code'
+		};
+
+		_.hooks.run("before-highlightall", env);
+
+		var elements = env.elements || document.querySelectorAll(env.selector);
+
+		for (var i=0, element; element = elements[i++];) {
+			_.highlightElement(element, async === true, env.callback);
+		}
+	},
+
+	highlightElement: function(element, async, callback) {
+		// Find language
+		var language, grammar, parent = element;
+
+		while (parent && !lang.test(parent.className)) {
+			parent = parent.parentNode;
+		}
+
+		if (parent) {
+			language = (parent.className.match(lang) || [,''])[1].toLowerCase();
+			grammar = _.languages[language];
+		}
+
+		// Set language on the element, if not present
+		element.className = element.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+
+		if (element.parentNode) {
+			// Set language on the parent, for styling
+			parent = element.parentNode;
+
+			if (/pre/i.test(parent.nodeName)) {
+				parent.className = parent.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+			}
+		}
+
+		var code = element.textContent;
+
+		var env = {
+			element: element,
+			language: language,
+			grammar: grammar,
+			code: code
+		};
+
+		_.hooks.run('before-sanity-check', env);
+
+		if (!env.code || !env.grammar) {
+			if (env.code) {
+				_.hooks.run('before-highlight', env);
+				env.element.textContent = env.code;
+				_.hooks.run('after-highlight', env);
+			}
+			_.hooks.run('complete', env);
+			return;
+		}
+
+		_.hooks.run('before-highlight', env);
+
+		if (async && _self.Worker) {
+			var worker = new Worker(_.filename);
+
+			worker.onmessage = function(evt) {
+				env.highlightedCode = evt.data;
+
+				_.hooks.run('before-insert', env);
+
+				env.element.innerHTML = env.highlightedCode;
+
+				callback && callback.call(env.element);
+				_.hooks.run('after-highlight', env);
+				_.hooks.run('complete', env);
+			};
+
+			worker.postMessage(JSON.stringify({
+				language: env.language,
+				code: env.code,
+				immediateClose: true
+			}));
+		}
+		else {
+			env.highlightedCode = _.highlight(env.code, env.grammar, env.language);
+
+			_.hooks.run('before-insert', env);
+
+			env.element.innerHTML = env.highlightedCode;
+
+			callback && callback.call(element);
+
+			_.hooks.run('after-highlight', env);
+			_.hooks.run('complete', env);
+		}
+	},
+
+	highlight: function (text, grammar, language) {
+		var tokens = _.tokenize(text, grammar);
+		return Token.stringify(_.util.encode(tokens), language);
+	},
+
+	matchGrammar: function (text, strarr, grammar, index, startPos, oneshot, target) {
+		var Token = _.Token;
+
+		for (var token in grammar) {
+			if(!grammar.hasOwnProperty(token) || !grammar[token]) {
+				continue;
+			}
+
+			if (token == target) {
+				return;
+			}
+
+			var patterns = grammar[token];
+			patterns = (_.util.type(patterns) === "Array") ? patterns : [patterns];
+
+			for (var j = 0; j < patterns.length; ++j) {
+				var pattern = patterns[j],
+					inside = pattern.inside,
+					lookbehind = !!pattern.lookbehind,
+					greedy = !!pattern.greedy,
+					lookbehindLength = 0,
+					alias = pattern.alias;
+
+				if (greedy && !pattern.pattern.global) {
+					// Without the global flag, lastIndex won't work
+					var flags = pattern.pattern.toString().match(/[imuy]*$/)[0];
+					pattern.pattern = RegExp(pattern.pattern.source, flags + "g");
+				}
+
+				pattern = pattern.pattern || pattern;
+
+				// Don’t cache length as it changes during the loop
+				for (var i = index, pos = startPos; i < strarr.length; pos += strarr[i].length, ++i) {
+
+					var str = strarr[i];
+
+					if (strarr.length > text.length) {
+						// Something went terribly wrong, ABORT, ABORT!
+						return;
+					}
+
+					if (str instanceof Token) {
+						continue;
+					}
+
+					pattern.lastIndex = 0;
+
+					var match = pattern.exec(str),
+					    delNum = 1;
+
+					// Greedy patterns can override/remove up to two previously matched tokens
+					if (!match && greedy && i != strarr.length - 1) {
+						pattern.lastIndex = pos;
+						match = pattern.exec(text);
+						if (!match) {
+							break;
+						}
+
+						var from = match.index + (lookbehind ? match[1].length : 0),
+						    to = match.index + match[0].length,
+						    k = i,
+						    p = pos;
+
+						for (var len = strarr.length; k < len && (p < to || (!strarr[k].type && !strarr[k - 1].greedy)); ++k) {
+							p += strarr[k].length;
+							// Move the index i to the element in strarr that is closest to from
+							if (from >= p) {
+								++i;
+								pos = p;
+							}
+						}
+
+						/*
+						 * If strarr[i] is a Token, then the match starts inside another Token, which is invalid
+						 * If strarr[k - 1] is greedy we are in conflict with another greedy pattern
+						 */
+						if (strarr[i] instanceof Token || strarr[k - 1].greedy) {
+							continue;
+						}
+
+						// Number of tokens to delete and replace with the new match
+						delNum = k - i;
+						str = text.slice(pos, p);
+						match.index -= pos;
+					}
+
+					if (!match) {
+						if (oneshot) {
+							break;
+						}
+
+						continue;
+					}
+
+					if(lookbehind) {
+						lookbehindLength = match[1].length;
+					}
+
+					var from = match.index + lookbehindLength,
+					    match = match[0].slice(lookbehindLength),
+					    to = from + match.length,
+					    before = str.slice(0, from),
+					    after = str.slice(to);
+
+					var args = [i, delNum];
+
+					if (before) {
+						++i;
+						pos += before.length;
+						args.push(before);
+					}
+
+					var wrapped = new Token(token, inside? _.tokenize(match, inside) : match, alias, match, greedy);
+
+					args.push(wrapped);
+
+					if (after) {
+						args.push(after);
+					}
+
+					Array.prototype.splice.apply(strarr, args);
+
+					if (delNum != 1)
+						_.matchGrammar(text, strarr, grammar, i, pos, true, token);
+
+					if (oneshot)
+						break;
+				}
+			}
+		}
+	},
+
+	tokenize: function(text, grammar, language) {
+		var strarr = [text];
+
+		var rest = grammar.rest;
+
+		if (rest) {
+			for (var token in rest) {
+				grammar[token] = rest[token];
+			}
+
+			delete grammar.rest;
+		}
+
+		_.matchGrammar(text, strarr, grammar, 0, 0, false);
+
+		return strarr;
+	},
+
+	hooks: {
+		all: {},
+
+		add: function (name, callback) {
+			var hooks = _.hooks.all;
+
+			hooks[name] = hooks[name] || [];
+
+			hooks[name].push(callback);
+		},
+
+		run: function (name, env) {
+			var callbacks = _.hooks.all[name];
+
+			if (!callbacks || !callbacks.length) {
+				return;
+			}
+
+			for (var i=0, callback; callback = callbacks[i++];) {
+				callback(env);
+			}
+		}
+	}
+};
+
+var Token = _.Token = function(type, content, alias, matchedStr, greedy) {
+	this.type = type;
+	this.content = content;
+	this.alias = alias;
+	// Copy of the full string this token was created from
+	this.length = (matchedStr || "").length|0;
+	this.greedy = !!greedy;
+};
+
+Token.stringify = function(o, language, parent) {
+	if (typeof o == 'string') {
+		return o;
+	}
+
+	if (_.util.type(o) === 'Array') {
+		return o.map(function(element) {
+			return Token.stringify(element, language, o);
+		}).join('');
+	}
+
+	var env = {
+		type: o.type,
+		content: Token.stringify(o.content, language, parent),
+		tag: 'span',
+		classes: ['token', o.type],
+		attributes: {},
+		language: language,
+		parent: parent
+	};
+
+	if (o.alias) {
+		var aliases = _.util.type(o.alias) === 'Array' ? o.alias : [o.alias];
+		Array.prototype.push.apply(env.classes, aliases);
+	}
+
+	_.hooks.run('wrap', env);
+
+	var attributes = Object.keys(env.attributes).map(function(name) {
+		return name + '="' + (env.attributes[name] || '').replace(/"/g, '&quot;') + '"';
+	}).join(' ');
+
+	return '<' + env.tag + ' class="' + env.classes.join(' ') + '"' + (attributes ? ' ' + attributes : '') + '>' + env.content + '</' + env.tag + '>';
+
+};
+
+if (!_self.document) {
+	if (!_self.addEventListener) {
+		// in Node.js
+		return _self.Prism;
+	}
+
+	if (!_.disableWorkerMessageHandler) {
+		// In worker
+		_self.addEventListener('message', function (evt) {
+			var message = JSON.parse(evt.data),
+				lang = message.language,
+				code = message.code,
+				immediateClose = message.immediateClose;
+
+			_self.postMessage(_.highlight(code, _.languages[lang], lang));
+			if (immediateClose) {
+				_self.close();
+			}
+		}, false);
+	}
+
+	return _self.Prism;
+}
+
+//Get current script and highlight
+var script = document.currentScript || [].slice.call(document.getElementsByTagName("script")).pop();
+
+if (script) {
+	_.filename = script.src;
+
+	if (!_.manual && !script.hasAttribute('data-manual')) {
+		if(document.readyState !== "loading") {
+			if (window.requestAnimationFrame) {
+				window.requestAnimationFrame(_.highlightAll);
+			} else {
+				window.setTimeout(_.highlightAll, 16);
+			}
+		}
+		else {
+			// document.addEventListener('DOMContentLoaded', _.highlightAll);
+		}
+	}
+}
+
+return _self.Prism;
+
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = Prism;
+}
+
+// hack for components to work correctly in node.js
+if (typeof global !== 'undefined') {
+	global.Prism = Prism;
+}
+;
+Prism.languages.markup = {
+	'comment': /<!--[\s\S]*?-->/,
+	'prolog': /<\?[\s\S]+?\?>/,
+	'doctype': /<!DOCTYPE[\s\S]+?>/i,
+	'cdata': /<!\[CDATA\[[\s\S]*?]]>/i,
+	'tag': {
+		pattern: /<\/?(?!\d)[^\s>\/=$<]+(?:\s+[^\s>\/=]+(?:=(?:("|')(?:\\[\s\S]|(?!\1)[^\\])*\1|[^\s'">=]+))?)*\s*\/?>/i,
+		inside: {
+			'tag': {
+				pattern: /^<\/?[^\s>\/]+/i,
+				inside: {
+					'punctuation': /^<\/?/,
+					'namespace': /^[^\s>\/:]+:/
+				}
+			},
+			'attr-value': {
+				pattern: /=(?:("|')(?:\\[\s\S]|(?!\1)[^\\])*\1|[^\s'">=]+)/i,
+				inside: {
+					'punctuation': [
+						/^=/,
+						{
+							pattern: /(^|[^\\])["']/,
+							lookbehind: true
+						}
+					]
+				}
+			},
+			'punctuation': /\/?>/,
+			'attr-name': {
+				pattern: /[^\s>\/]+/,
+				inside: {
+					'namespace': /^[^\s>\/:]+:/
+				}
+			}
+
+		}
+	},
+	'entity': /&#?[\da-z]{1,8};/i
+};
+
+Prism.languages.markup['tag'].inside['attr-value'].inside['entity'] =
+	Prism.languages.markup['entity'];
+
+// Plugin to make entity title show the real entity, idea by Roman Komarov
+Prism.hooks.add('wrap', function(env) {
+
+	if (env.type === 'entity') {
+		env.attributes['title'] = env.content.replace(/&amp;/, '&');
+	}
+});
+
+Prism.languages.xml = Prism.languages.markup;
+Prism.languages.html = Prism.languages.markup;
+Prism.languages.mathml = Prism.languages.markup;
+Prism.languages.svg = Prism.languages.markup;
+
+Prism.languages.css = {
+	'comment': /\/\*[\s\S]*?\*\//,
+	'atrule': {
+		pattern: /@[\w-]+?.*?(?:;|(?=\s*\{))/i,
+		inside: {
+			'rule': /@[\w-]+/
+			// See rest below
+		}
+	},
+	'url': /url\((?:(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1|.*?)\)/i,
+	'selector': /[^{}\s][^{};]*?(?=\s*\{)/,
+	'string': {
+		pattern: /("|')(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+		greedy: true
+	},
+	'property': /[\w-]+(?=\s*:)/i,
+	'important': /\B!important\b/i,
+	'function': /[-a-z0-9]+(?=\()/i,
+	'punctuation': /[(){};:]/
+};
+
+Prism.languages.css['atrule'].inside.rest = Prism.util.clone(Prism.languages.css);
+
+if (Prism.languages.markup) {
+	Prism.languages.insertBefore('markup', 'tag', {
+		'style': {
+			pattern: /(<style[\s\S]*?>)[\s\S]*?(?=<\/style>)/i,
+			lookbehind: true,
+			inside: Prism.languages.css,
+			alias: 'language-css'
+		}
+	});
+
+	Prism.languages.insertBefore('inside', 'attr-value', {
+		'style-attr': {
+			pattern: /\s*style=("|')(?:\\[\s\S]|(?!\1)[^\\])*\1/i,
+			inside: {
+				'attr-name': {
+					pattern: /^\s*style/i,
+					inside: Prism.languages.markup.tag.inside
+				},
+				'punctuation': /^\s*=\s*['"]|['"]\s*$/,
+				'attr-value': {
+					pattern: /.+/i,
+					inside: Prism.languages.css
+				}
+			},
+			alias: 'language-css'
+		}
+	}, Prism.languages.markup.tag);
+};
+Prism.languages.clike = {
+	'comment': [
+		{
+			pattern: /(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,
+			lookbehind: true
+		},
+		{
+			pattern: /(^|[^\\:])\/\/.*/,
+			lookbehind: true
+		}
+	],
+	'string': {
+		pattern: /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+		greedy: true
+	},
+	'class-name': {
+		pattern: /((?:\b(?:class|interface|extends|implements|trait|instanceof|new)\s+)|(?:catch\s+\())[\w.\\]+/i,
+		lookbehind: true,
+		inside: {
+			punctuation: /[.\\]/
+		}
+	},
+	'keyword': /\b(?:if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\b/,
+	'boolean': /\b(?:true|false)\b/,
+	'function': /[a-z0-9_]+(?=\()/i,
+	'number': /\b-?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)\b/i,
+	'operator': /--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&?|\|\|?|\?|\*|\/|~|\^|%/,
+	'punctuation': /[{}[\];(),.:]/
+};
+
+Prism.languages.javascript = Prism.languages.extend('clike', {
+	'keyword': /\b(?:as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|var|void|while|with|yield)\b/,
+	'number': /\b-?(?:0[xX][\dA-Fa-f]+|0[bB][01]+|0[oO][0-7]+|\d*\.?\d+(?:[Ee][+-]?\d+)?|NaN|Infinity)\b/,
+	// Allow for all non-ASCII characters (See http://stackoverflow.com/a/2008444)
+	'function': /[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*(?=\s*\()/i,
+	'operator': /-[-=]?|\+[+=]?|!=?=?|<<?=?|>>?>?=?|=(?:==?|>)?|&[&=]?|\|[|=]?|\*\*?=?|\/=?|~|\^=?|%=?|\?|\.{3}/
+});
+
+Prism.languages.insertBefore('javascript', 'keyword', {
+	'regex': {
+		pattern: /(^|[^/])\/(?!\/)(\[[^\]\r\n]+]|\\.|[^/\\\[\r\n])+\/[gimyu]{0,5}(?=\s*($|[\r\n,.;})]))/,
+		lookbehind: true,
+		greedy: true
+	},
+	// This must be declared before keyword because we use "function" inside the look-forward
+	'function-variable': {
+		pattern: /[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*(?=\s*=\s*(?:function\b|(?:\([^()]*\)|[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*)\s*=>))/i,
+		alias: 'function'
+	}
+});
+
+Prism.languages.insertBefore('javascript', 'string', {
+	'template-string': {
+		pattern: /`(?:\\[\s\S]|[^\\`])*`/,
+		greedy: true,
+		inside: {
+			'interpolation': {
+				pattern: /\$\{[^}]+\}/,
+				inside: {
+					'interpolation-punctuation': {
+						pattern: /^\$\{|\}$/,
+						alias: 'punctuation'
+					},
+					rest: Prism.languages.javascript
+				}
+			},
+			'string': /[\s\S]+/
+		}
+	}
+});
+
+if (Prism.languages.markup) {
+	Prism.languages.insertBefore('markup', 'tag', {
+		'script': {
+			pattern: /(<script[\s\S]*?>)[\s\S]*?(?=<\/script>)/i,
+			lookbehind: true,
+			inside: Prism.languages.javascript,
+			alias: 'language-javascript'
+		}
+	});
+}
+
+Prism.languages.js = Prism.languages.javascript;
+
+Prism.languages.c = Prism.languages.extend('clike', {
+	'keyword': /\b(?:_Alignas|_Alignof|_Atomic|_Bool|_Complex|_Generic|_Imaginary|_Noreturn|_Static_assert|_Thread_local|asm|typeof|inline|auto|break|case|char|const|continue|default|do|double|else|enum|extern|float|for|goto|if|int|long|register|return|short|signed|sizeof|static|struct|switch|typedef|union|unsigned|void|volatile|while)\b/,
+	'operator': /-[>-]?|\+\+?|!=?|<<?=?|>>?=?|==?|&&?|\|\|?|[~^%?*\/]/,
+	'number': /\b-?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)[ful]*\b/i
+});
+
+Prism.languages.insertBefore('c', 'string', {
+	'macro': {
+		// allow for multiline macro definitions
+		// spaces after the # character compile fine with gcc
+		pattern: /(^\s*)#\s*[a-z]+(?:[^\r\n\\]|\\(?:\r\n|[\s\S]))*/im,
+		lookbehind: true,
+		alias: 'property',
+		inside: {
+			// highlight the path of the include statement as a string
+			'string': {
+				pattern: /(#\s*include\s*)(?:<.+?>|("|')(?:\\?.)+?\2)/,
+				lookbehind: true
+			},
+			// highlight macro directives as keywords
+			'directive': {
+				pattern: /(#\s*)\b(?:define|defined|elif|else|endif|error|ifdef|ifndef|if|import|include|line|pragma|undef|using)\b/,
+				lookbehind: true,
+				alias: 'keyword'
+			}
+		}
+	},
+	// highlight predefined macros as constants
+	'constant': /\b(?:__FILE__|__LINE__|__DATE__|__TIME__|__TIMESTAMP__|__func__|EOF|NULL|SEEK_CUR|SEEK_END|SEEK_SET|stdin|stdout|stderr)\b/
+});
+
+delete Prism.languages.c['class-name'];
+delete Prism.languages.c['boolean'];
+
+Prism.languages.cpp = Prism.languages.extend('c', {
+	'keyword': /\b(?:alignas|alignof|asm|auto|bool|break|case|catch|char|char16_t|char32_t|class|compl|const|constexpr|const_cast|continue|decltype|default|delete|do|double|dynamic_cast|else|enum|explicit|export|extern|float|for|friend|goto|if|inline|int|long|mutable|namespace|new|noexcept|nullptr|operator|private|protected|public|register|reinterpret_cast|return|short|signed|sizeof|static|static_assert|static_cast|struct|switch|template|this|thread_local|throw|try|typedef|typeid|typename|union|unsigned|using|virtual|void|volatile|wchar_t|while)\b/,
+	'boolean': /\b(?:true|false)\b/,
+	'operator': /--?|\+\+?|!=?|<{1,2}=?|>{1,2}=?|->|:{1,2}|={1,2}|\^|~|%|&{1,2}|\|\|?|\?|\*|\/|\b(?:and|and_eq|bitand|bitor|not|not_eq|or|or_eq|xor|xor_eq)\b/
+});
+
+Prism.languages.insertBefore('cpp', 'keyword', {
+	'class-name': {
+		pattern: /(class\s+)\w+/i,
+		lookbehind: true
+	}
+});
+Prism.languages.csharp = Prism.languages.extend('clike', {
+	'keyword': /\b(abstract|as|async|await|base|bool|break|byte|case|catch|char|checked|class|const|continue|decimal|default|delegate|do|double|else|enum|event|explicit|extern|false|finally|fixed|float|for|foreach|goto|if|implicit|in|int|interface|internal|is|lock|long|namespace|new|null|object|operator|out|override|params|private|protected|public|readonly|ref|return|sbyte|sealed|short|sizeof|stackalloc|static|string|struct|switch|this|throw|true|try|typeof|uint|ulong|unchecked|unsafe|ushort|using|virtual|void|volatile|while|add|alias|ascending|async|await|descending|dynamic|from|get|global|group|into|join|let|orderby|partial|remove|select|set|value|var|where|yield)\b/,
+	'string': [
+		{
+			pattern: /@("|')(?:\1\1|\\[\s\S]|(?!\1)[^\\])*\1/,
+			greedy: true
+		},
+		{
+			pattern: /("|')(?:\\.|(?!\1)[^\\\r\n])*?\1/,
+			greedy: true
+		}
+	],
+	'number': /\b-?(?:0x[\da-f]+|\d*\.?\d+f?)\b/i
+});
+
+Prism.languages.insertBefore('csharp', 'keyword', {
+	'generic-method': {
+		pattern: /[a-z0-9_]+\s*<[^>\r\n]+?>\s*(?=\()/i,
+		alias: 'function',
+		inside: {
+			keyword: Prism.languages.csharp.keyword,
+			punctuation: /[<>(),.:]/
+		}
+	},
+	'preprocessor': {
+		pattern: /(^\s*)#.*/m,
+		lookbehind: true,
+		alias: 'property',
+		inside: {
+			// highlight preprocessor directives as keywords
+			'directive': {
+				pattern: /(\s*#)\b(?:define|elif|else|endif|endregion|error|if|line|pragma|region|undef|warning)\b/,
+				lookbehind: true,
+				alias: 'keyword'
+			}
+		}
+	}
+});
+
+/**
+ * Original by Samuel Flores
+ *
+ * Adds the following new token classes:
+ * 		constant, builtin, variable, symbol, regex
+ */
+(function(Prism) {
+	Prism.languages.ruby = Prism.languages.extend('clike', {
+		'comment': [
+			/#(?!\{[^\r\n]*?\}).*/,
+			/^=begin(?:\r?\n|\r)(?:.*(?:\r?\n|\r))*?=end/m
+		],
+		'keyword': /\b(?:alias|and|BEGIN|begin|break|case|class|def|define_method|defined|do|each|else|elsif|END|end|ensure|false|for|if|in|module|new|next|nil|not|or|raise|redo|require|rescue|retry|return|self|super|then|throw|true|undef|unless|until|when|while|yield)\b/
+	});
+
+	var interpolation = {
+		pattern: /#\{[^}]+\}/,
+		inside: {
+			'delimiter': {
+				pattern: /^#\{|\}$/,
+				alias: 'tag'
+			},
+			rest: Prism.util.clone(Prism.languages.ruby)
+		}
+	};
+
+	Prism.languages.insertBefore('ruby', 'keyword', {
+		'regex': [
+			{
+				pattern: /%r([^a-zA-Z0-9\s{(\[<])(?:(?!\1)[^\\]|\\[\s\S])*\1[gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				pattern: /%r\((?:[^()\\]|\\[\s\S])*\)[gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				// Here we need to specifically allow interpolation
+				pattern: /%r\{(?:[^#{}\\]|#(?:\{[^}]+\})?|\\[\s\S])*\}[gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				pattern: /%r\[(?:[^\[\]\\]|\\[\s\S])*\][gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				pattern: /%r<(?:[^<>\\]|\\[\s\S])*>[gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				pattern: /(^|[^/])\/(?!\/)(\[.+?]|\\.|[^/\\\r\n])+\/[gim]{0,3}(?=\s*($|[\r\n,.;})]))/,
+				lookbehind: true,
+				greedy: true
+			}
+		],
+		'variable': /[@$]+[a-zA-Z_]\w*(?:[?!]|\b)/,
+		'symbol': /:[a-zA-Z_]\w*(?:[?!]|\b)/
+	});
+
+	Prism.languages.insertBefore('ruby', 'number', {
+		'builtin': /\b(?:Array|Bignum|Binding|Class|Continuation|Dir|Exception|FalseClass|File|Stat|Fixnum|Float|Hash|Integer|IO|MatchData|Method|Module|NilClass|Numeric|Object|Proc|Range|Regexp|String|Struct|TMS|Symbol|ThreadGroup|Thread|Time|TrueClass)\b/,
+		'constant': /\b[A-Z]\w*(?:[?!]|\b)/
+	});
+
+	Prism.languages.ruby.string = [
+		{
+			pattern: /%[qQiIwWxs]?([^a-zA-Z0-9\s{(\[<])(?:(?!\1)[^\\]|\\[\s\S])*\1/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			pattern: /%[qQiIwWxs]?\((?:[^()\\]|\\[\s\S])*\)/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			// Here we need to specifically allow interpolation
+			pattern: /%[qQiIwWxs]?\{(?:[^#{}\\]|#(?:\{[^}]+\})?|\\[\s\S])*\}/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			pattern: /%[qQiIwWxs]?\[(?:[^\[\]\\]|\\[\s\S])*\]/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			pattern: /%[qQiIwWxs]?<(?:[^<>\\]|\\[\s\S])*>/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			pattern: /("|')(?:#\{[^}]+\}|\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		}
+	];
+}(Prism));
+Prism.languages.java = Prism.languages.extend('clike', {
+	'keyword': /\b(?:abstract|continue|for|new|switch|assert|default|goto|package|synchronized|boolean|do|if|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while)\b/,
+	'number': /\b0b[01]+\b|\b0x[\da-f]*\.?[\da-fp\-]+\b|\b\d*\.?\d+(?:e[+-]?\d+)?[df]?\b/i,
+	'operator': {
+		pattern: /(^|[^.])(?:\+[+=]?|-[-=]?|!=?|<<?=?|>>?>?=?|==?|&[&=]?|\|[|=]?|\*=?|\/=?|%=?|\^=?|[?:~])/m,
+		lookbehind: true
+	}
+});
+
+Prism.languages.insertBefore('java','function', {
+	'annotation': {
+		alias: 'punctuation',
+		pattern: /(^|[^.])@\w+/,
+		lookbehind: true
+	}
+});
+
+/**
+ * Original by Aaron Harun: http://aahacreative.com/2012/07/31/php-syntax-highlighting-prism/
+ * Modified by Miles Johnson: http://milesj.me
+ *
+ * Supports the following:
+ * 		- Extends clike syntax
+ * 		- Support for PHP 5.3+ (namespaces, traits, generators, etc)
+ * 		- Smarter constant and function matching
+ *
+ * Adds the following new token classes:
+ * 		constant, delimiter, variable, function, package
+ */
+
+Prism.languages.php = Prism.languages.extend('clike', {
+	'keyword': /\b(?:and|or|xor|array|as|break|case|cfunction|class|const|continue|declare|default|die|do|else|elseif|enddeclare|endfor|endforeach|endif|endswitch|endwhile|extends|for|foreach|function|include|include_once|global|if|new|return|static|switch|use|require|require_once|var|while|abstract|interface|public|implements|private|protected|parent|throw|null|echo|print|trait|namespace|final|yield|goto|instanceof|finally|try|catch)\b/i,
+	'constant': /\b[A-Z0-9_]{2,}\b/,
+	'comment': {
+		pattern: /(^|[^\\])(?:\/\*[\s\S]*?\*\/|\/\/.*)/,
+		lookbehind: true
+	}
+});
+
+// Shell-like comments are matched after strings, because they are less
+// common than strings containing hashes...
+Prism.languages.insertBefore('php', 'class-name', {
+	'shell-comment': {
+		pattern: /(^|[^\\])#.*/,
+		lookbehind: true,
+		alias: 'comment'
+	}
+});
+
+Prism.languages.insertBefore('php', 'keyword', {
+	'delimiter': {
+		pattern: /\?>|<\?(?:php|=)?/i,
+		alias: 'important'
+	},
+	'variable': /\$\w+\b/i,
+	'package': {
+		pattern: /(\\|namespace\s+|use\s+)[\w\\]+/,
+		lookbehind: true,
+		inside: {
+			punctuation: /\\/
+		}
+	}
+});
+
+// Must be defined after the function pattern
+Prism.languages.insertBefore('php', 'operator', {
+	'property': {
+		pattern: /(->)[\w]+/,
+		lookbehind: true
+	}
+});
+
+// Add HTML support if the markup language exists
+if (Prism.languages.markup) {
+
+	// Tokenize all inline PHP blocks that are wrapped in <?php ?>
+	// This allows for easy PHP + markup highlighting
+	Prism.hooks.add('before-highlight', function(env) {
+		if (env.language !== 'php' || !/(?:<\?php|<\?)/ig.test(env.code)) {
+			return;
+		}
+
+		env.tokenStack = [];
+
+		env.backupCode = env.code;
+		env.code = env.code.replace(/(?:<\?php|<\?)[\s\S]*?(?:\?>|$)/ig, function(match) {
+			var i = env.tokenStack.length;
+			// Check for existing strings
+			while (env.backupCode.indexOf('___PHP' + i + '___') !== -1)
+				++i;
+
+			// Create a sparse array
+			env.tokenStack[i] = match;
+
+			return '___PHP' + i + '___';
+		});
+
+		// Switch the grammar to markup
+		env.grammar = Prism.languages.markup;
+	});
+
+	// Restore env.code for other plugins (e.g. line-numbers)
+	Prism.hooks.add('before-insert', function(env) {
+		if (env.language === 'php' && env.backupCode) {
+			env.code = env.backupCode;
+			delete env.backupCode;
+		}
+	});
+
+	// Re-insert the tokens after highlighting
+	Prism.hooks.add('after-highlight', function(env) {
+		if (env.language !== 'php' || !env.tokenStack) {
+			return;
+		}
+
+		// Switch the grammar back
+		env.grammar = Prism.languages.php;
+
+		for (var i = 0, keys = Object.keys(env.tokenStack); i < keys.length; ++i) {
+			var k = keys[i];
+			var t = env.tokenStack[k];
+
+			// The replace prevents $$, $&, $`, $', $n, $nn from being interpreted as special patterns
+			env.highlightedCode = env.highlightedCode.replace('___PHP' + k + '___',
+					"<span class=\"token php language-php\">" +
+					Prism.highlight(t, env.grammar, 'php').replace(/\$/g, '$$$$') +
+					"</span>");
+		}
+
+		env.element.innerHTML = env.highlightedCode;
+	});
+}
+;
+Prism.languages.python = {
+	'comment': {
+		pattern: /(^|[^\\])#.*/,
+		lookbehind: true
+	},
+	'triple-quoted-string': {
+		pattern: /("""|''')[\s\S]+?\1/,
+		greedy: true,
+		alias: 'string'
+	},
+	'string': {
+		pattern: /("|')(?:\\.|(?!\1)[^\\\r\n])*\1/,
+		greedy: true
+	},
+	'function': {
+		pattern: /((?:^|\s)def[ \t]+)[a-zA-Z_]\w*(?=\s*\()/g,
+		lookbehind: true
+	},
+	'class-name': {
+		pattern: /(\bclass\s+)\w+/i,
+		lookbehind: true
+	},
+	'keyword': /\b(?:as|assert|async|await|break|class|continue|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|nonlocal|pass|print|raise|return|try|while|with|yield)\b/,
+	'builtin':/\b(?:__import__|abs|all|any|apply|ascii|basestring|bin|bool|buffer|bytearray|bytes|callable|chr|classmethod|cmp|coerce|compile|complex|delattr|dict|dir|divmod|enumerate|eval|execfile|file|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|intern|isinstance|issubclass|iter|len|list|locals|long|map|max|memoryview|min|next|object|oct|open|ord|pow|property|range|raw_input|reduce|reload|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|unichr|unicode|vars|xrange|zip)\b/,
+	'boolean': /\b(?:True|False|None)\b/,
+	'number': /\b-?(?:0[bo])?(?:(?:\d|0x[\da-f])[\da-f]*\.?\d*|\.\d+)(?:e[+-]?\d+)?j?\b/i,
+	'operator': /[-+%=]=?|!=|\*\*?=?|\/\/?=?|<[<=>]?|>[=>]?|[&|^~]|\b(?:or|and|not)\b/,
+	'punctuation': /[{}[\];(),.:]/
+};
+
+(function(){
+
+if (typeof self === 'undefined' || !self.Prism || !self.document || !document.querySelector) {
+	return;
+}
+
+function $$(expr, con) {
+	return Array.prototype.slice.call((con || document).querySelectorAll(expr));
+}
+
+function hasClass(element, className) {
+  className = " " + className + " ";
+  return (" " + element.className + " ").replace(/[\n\t]/g, " ").indexOf(className) > -1
+}
+
+// Some browsers round the line-height, others don't.
+// We need to test for it to position the elements properly.
+var isLineHeightRounded = (function() {
+	var res;
+	return function() {
+		if(typeof res === 'undefined') {
+			var d = document.createElement('div');
+			d.style.fontSize = '13px';
+			d.style.lineHeight = '1.5';
+			d.style.padding = 0;
+			d.style.border = 0;
+			d.innerHTML = '&nbsp;<br />&nbsp;';
+			document.body.appendChild(d);
+			// Browsers that round the line-height should have offsetHeight === 38
+			// The others should have 39.
+			res = d.offsetHeight === 38;
+			document.body.removeChild(d);
+		}
+		return res;
+	}
+}());
+
+function highlightLines(pre, lines, classes) {
+	var ranges = lines.replace(/\s+/g, '').split(','),
+	    offset = +pre.getAttribute('data-line-offset') || 0;
+
+	var parseMethod = isLineHeightRounded() ? parseInt : parseFloat;
+	var lineHeight = parseMethod(getComputedStyle(pre).lineHeight);
+
+	for (var i=0, range; range = ranges[i++];) {
+		range = range.split('-');
+
+		var start = +range[0],
+		    end = +range[1] || start;
+
+		var line = document.createElement('div');
+
+		line.textContent = Array(end - start + 2).join(' \n');
+		line.setAttribute('aria-hidden', 'true');
+		line.className = (classes || '') + ' line-highlight';
+
+		//if the line-numbers plugin is enabled, then there is no reason for this plugin to display the line numbers
+		if(!hasClass(pre, 'line-numbers')) {
+			line.setAttribute('data-start', start);
+
+			if(end > start) {
+				line.setAttribute('data-end', end);
+			}
+		}
+
+		line.style.top = (start - offset - 1) * lineHeight + 'px';
+
+		//allow this to play nicely with the line-numbers plugin
+		if(hasClass(pre, 'line-numbers')) {
+			//need to attack to pre as when line-numbers is enabled, the code tag is relatively which screws up the positioning
+			pre.appendChild(line);
+		} else {
+			(pre.querySelector('code') || pre).appendChild(line);
+		}
+	}
+}
+
+function applyHash() {
+	var hash = location.hash.slice(1);
+
+	// Remove pre-existing temporary lines
+	$$('.temporary.line-highlight').forEach(function (line) {
+		line.parentNode.removeChild(line);
+	});
+
+	var range = (hash.match(/\.([\d,-]+)$/) || [,''])[1];
+
+	if (!range || document.getElementById(hash)) {
+		return;
+	}
+
+	var id = hash.slice(0, hash.lastIndexOf('.')),
+	    pre = document.getElementById(id);
+
+	if (!pre) {
+		return;
+	}
+
+	if (!pre.hasAttribute('data-line')) {
+		pre.setAttribute('data-line', '');
+	}
+
+	highlightLines(pre, range, 'temporary ');
+
+	document.querySelector('.temporary.line-highlight').scrollIntoView();
+}
+
+var fakeTimer = 0; // Hack to limit the number of times applyHash() runs
+
+Prism.hooks.add('before-sanity-check', function(env) {
+	var pre = env.element.parentNode;
+	var lines = pre && pre.getAttribute('data-line');
+
+	if (!pre || !lines || !/pre/i.test(pre.nodeName)) {
+		return;
+	}
+
+	/*
+	* Cleanup for other plugins (e.g. autoloader).
+	 *
+	 * Sometimes <code> blocks are highlighted multiple times. It is necessary
+	 * to cleanup any left-over tags, because the whitespace inside of the <div>
+	 * tags change the content of the <code> tag.
+	 */
+	var num = 0;
+	$$('.line-highlight', pre).forEach(function (line) {
+		num += line.textContent.length;
+		line.parentNode.removeChild(line);
+	});
+	// Remove extra whitespace
+	if (num && /^( \n)+$/.test(env.code.slice(-num))) {
+		env.code = env.code.slice(0, -num);
+	}
+});
+
+Prism.hooks.add('complete', function(env) {
+	var pre = env.element.parentNode;
+	var lines = pre && pre.getAttribute('data-line');
+
+	if (!pre || !lines || !/pre/i.test(pre.nodeName)) {
+		return;
+	}
+
+	clearTimeout(fakeTimer);
+	highlightLines(pre, lines);
+
+	fakeTimer = setTimeout(applyHash, 1);
+});
+
+	window.addEventListener('hashchange', applyHash);
+
+})();
+
+(function () {
+
+	if (typeof self === 'undefined' || !self.Prism || !self.document) {
+		return;
+	}
+
+	/**
+	 * Class name for <pre> which is activating the plugin
+	 * @type {String}
+	 */
+	var PLUGIN_CLASS = 'line-numbers';
+
+	/**
+	 * Resizes line numbers spans according to height of line of code
+	 * @param  {Element} element <pre> element
+	 */
+	var _resizeElement = function (element) {
+		var codeStyles = getStyles(element);
+		var whiteSpace = codeStyles['white-space'];
+
+		if (whiteSpace === 'pre-wrap' || whiteSpace === 'pre-line') {
+			var codeElement = element.querySelector('code');
+			var lineNumbersWrapper = element.querySelector('.line-numbers-rows');
+			var lineNumberSizer = element.querySelector('.line-numbers-sizer');
+			var codeLines = element.textContent.split('\n');
+
+			if (!lineNumberSizer) {
+				lineNumberSizer = document.createElement('span');
+				lineNumberSizer.className = 'line-numbers-sizer';
+
+				codeElement.appendChild(lineNumberSizer);
+			}
+
+			lineNumberSizer.style.display = 'block';
+
+			codeLines.forEach(function (line, lineNumber) {
+				lineNumberSizer.textContent = line || '\n';
+				var lineSize = lineNumberSizer.getBoundingClientRect().height;
+				lineNumbersWrapper.children[lineNumber].style.height = lineSize + 'px';
+			});
+
+			lineNumberSizer.textContent = '';
+			lineNumberSizer.style.display = 'none';
+		}
+	};
+
+	/**
+	 * Returns style declarations for the element
+	 * @param {Element} element
+	 */
+	var getStyles = function (element) {
+		if (!element) {
+			return null;
+		}
+
+		return window.getComputedStyle ? getComputedStyle(element) : (element.currentStyle || null);
+	};
+
+	window.addEventListener('resize', function () {
+		Array.prototype.forEach.call(document.querySelectorAll('pre.' + PLUGIN_CLASS), _resizeElement);
+	});
+
+	Prism.hooks.add('complete', function (env) {
+		if (!env.code) {
+			return;
+		}
+
+		// works only for <code> wrapped inside <pre> (not inline)
+		var pre = env.element.parentNode;
+		var clsReg = /\s*\bline-numbers\b\s*/;
+		if (
+			!pre || !/pre/i.test(pre.nodeName) ||
+			// Abort only if nor the <pre> nor the <code> have the class
+			(!clsReg.test(pre.className) && !clsReg.test(env.element.className))
+		) {
+			return;
+		}
+
+		if (env.element.querySelector(".line-numbers-rows")) {
+			// Abort if line numbers already exists
+			return;
+		}
+
+		if (clsReg.test(env.element.className)) {
+			// Remove the class "line-numbers" from the <code>
+			env.element.className = env.element.className.replace(clsReg, ' ');
+		}
+		if (!clsReg.test(pre.className)) {
+			// Add the class "line-numbers" to the <pre>
+			pre.className += ' line-numbers';
+		}
+
+		var match = env.code.match(/\n(?!$)/g);
+		var linesNum = match ? match.length + 1 : 1;
+		var lineNumbersWrapper;
+
+		var lines = new Array(linesNum + 1);
+		lines = lines.join('<span></span>');
+
+		lineNumbersWrapper = document.createElement('span');
+		lineNumbersWrapper.setAttribute('aria-hidden', 'true');
+		lineNumbersWrapper.className = 'line-numbers-rows';
+		lineNumbersWrapper.innerHTML = lines;
+
+		if (pre.hasAttribute('data-start')) {
+			pre.style.counterReset = 'linenumber ' + (parseInt(pre.getAttribute('data-start'), 10) - 1);
+		}
+
+		env.element.appendChild(lineNumbersWrapper);
+
+		_resizeElement(pre);
+	});
+
+}());
+(function(){
+
+if (
+	typeof self !== 'undefined' && !self.Prism ||
+	typeof global !== 'undefined' && !global.Prism
+) {
+	return;
+}
+
+var url = /\b([a-z]{3,7}:\/\/|tel:)[\w\-+%~/.:#=?&amp;]+/,
+    email = /\b\S+@[\w.]+[a-z]{2}/,
+    linkMd = /\[([^\]]+)]\(([^)]+)\)/,
+
+	// Tokens that may contain URLs and emails
+    candidates = ['comment', 'url', 'attr-value', 'string'];
+
+Prism.plugins.autolinker = {
+	processGrammar: function (grammar) {
+		// Abort if grammar has already been processed
+		if (!grammar || grammar['url-link']) {
+			return;
+		}
+		Prism.languages.DFS(grammar, function (key, def, type) {
+			if (candidates.indexOf(type) > -1 && Prism.util.type(def) !== 'Array') {
+				if (!def.pattern) {
+					def = this[key] = {
+						pattern: def
+					};
+				}
+
+				def.inside = def.inside || {};
+
+				if (type == 'comment') {
+					def.inside['md-link'] = linkMd;
+				}
+				if (type == 'attr-value') {
+					Prism.languages.insertBefore('inside', 'punctuation', { 'url-link': url }, def);
+				}
+				else {
+					def.inside['url-link'] = url;
+				}
+
+				def.inside['email-link'] = email;
+			}
+		});
+		grammar['url-link'] = url;
+		grammar['email-link'] = email;
+	}
+};
+
+Prism.hooks.add('before-highlight', function(env) {
+	Prism.plugins.autolinker.processGrammar(env.grammar);
+});
+
+Prism.hooks.add('wrap', function(env) {
+	if (/-link$/.test(env.type)) {
+		env.tag = 'a';
+
+		var href = env.content;
+
+		if (env.type == 'email-link' && href.indexOf('mailto:') != 0) {
+			href = 'mailto:' + href;
+		}
+		else if (env.type == 'md-link') {
+			// Markdown
+			var match = env.content.match(linkMd);
+
+			href = match[2];
+			env.content = match[1];
+		}
+
+		env.attributes.href = href;
+	}
+
+	// Silently catch any error thrown by decodeURIComponent (#1186)
+	try {
+		env.content = decodeURIComponent(env.content);
+	} catch(e) {}
+});
+
+})();
+
+(function () {
+	if (typeof self === 'undefined' || !self.Prism || !self.document || !document.querySelector) {
+		return;
+	}
+
+	self.Prism.fileHighlight = function() {
+
+		var Extensions = {
+			'js': 'javascript',
+			'py': 'python',
+			'rb': 'ruby',
+			'ps1': 'powershell',
+			'psm1': 'powershell',
+			'sh': 'bash',
+			'bat': 'batch',
+			'h': 'c',
+			'tex': 'latex'
+		};
+
+		Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach(function (pre) {
+			var src = pre.getAttribute('data-src');
+
+			var language, parent = pre;
+			var lang = /\blang(?:uage)?-(?!\*)(\w+)\b/i;
+			while (parent && !lang.test(parent.className)) {
+				parent = parent.parentNode;
+			}
+
+			if (parent) {
+				language = (pre.className.match(lang) || [, ''])[1];
+			}
+
+			if (!language) {
+				var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+				language = Extensions[extension] || extension;
+			}
+
+			var code = document.createElement('code');
+			code.className = 'language-' + language;
+
+			pre.textContent = '';
+
+			code.textContent = 'Loading…';
+
+			pre.appendChild(code);
+
+			var xhr = new XMLHttpRequest();
+
+			xhr.open('GET', src, true);
+
+			xhr.onreadystatechange = function () {
+				if (xhr.readyState == 4) {
+
+					if (xhr.status < 400 && xhr.responseText) {
+						code.textContent = xhr.responseText;
+
+						Prism.highlightElement(code);
+					}
+					else if (xhr.status >= 400) {
+						code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+					}
+					else {
+						code.textContent = '✖ Error: File does not exist or is empty';
+					}
+				}
+			};
+
+			xhr.send(null);
+		});
+
+	};
+
+	// document.addEventListener('DOMContentLoaded', self.Prism.fileHighlight);
+
+})();
+
+(function(){
+	if (typeof self === 'undefined' || !self.Prism || !self.document) {
+		return;
+	}
+
+	var callbacks = [];
+	var map = {};
+	var noop = function() {};
+
+	Prism.plugins.toolbar = {};
+
+	/**
+	 * Register a button callback with the toolbar.
+	 *
+	 * @param {string} key
+	 * @param {Object|Function} opts
+	 */
+	var registerButton = Prism.plugins.toolbar.registerButton = function (key, opts) {
+		var callback;
+
+		if (typeof opts === 'function') {
+			callback = opts;
+		} else {
+			callback = function (env) {
+				var element;
+
+				if (typeof opts.onClick === 'function') {
+					element = document.createElement('button');
+					element.type = 'button';
+					element.addEventListener('click', function () {
+						opts.onClick.call(this, env);
+					});
+				} else if (typeof opts.url === 'string') {
+					element = document.createElement('a');
+					element.href = opts.url;
+				} else {
+					element = document.createElement('span');
+				}
+
+				element.textContent = opts.text;
+
+				return element;
+			};
+		}
+
+		callbacks.push(map[key] = callback);
+	};
+
+	/**
+	 * Post-highlight Prism hook callback.
+	 *
+	 * @param env
+	 */
+	var hook = Prism.plugins.toolbar.hook = function (env) {
+		// Check if inline or actual code block (credit to line-numbers plugin)
+		var pre = env.element.parentNode;
+		if (!pre || !/pre/i.test(pre.nodeName)) {
+			return;
+		}
+
+		// Autoloader rehighlights, so only do this once.
+		if (pre.classList.contains('code-toolbar')) {
+			return;
+		}
+
+		pre.classList.add('code-toolbar');
+
+		// Setup the toolbar
+		var toolbar = document.createElement('div');
+		toolbar.classList.add('toolbar');
+
+		if (document.body.hasAttribute('data-toolbar-order')) {
+			callbacks = document.body.getAttribute('data-toolbar-order').split(',').map(function(key) {
+				return map[key] || noop;
+			});
+		}
+
+		callbacks.forEach(function(callback) {
+			var element = callback(env);
+
+			if (!element) {
+				return;
+			}
+
+			var item = document.createElement('div');
+			item.classList.add('toolbar-item');
+
+			item.appendChild(element);
+			toolbar.appendChild(item);
+		});
+
+		// Add our toolbar to the <pre> tag
+		pre.appendChild(toolbar);
+	};
+
+	registerButton('label', function(env) {
+		var pre = env.element.parentNode;
+		if (!pre || !/pre/i.test(pre.nodeName)) {
+			return;
+		}
+
+		if (!pre.hasAttribute('data-label')) {
+			return;
+		}
+
+		var element, template;
+		var text = pre.getAttribute('data-label');
+		try {
+			// Any normal text will blow up this selector.
+			template = document.querySelector('template#' + text);
+		} catch (e) {}
+
+		if (template) {
+			element = template.content;
+		} else {
+			if (pre.hasAttribute('data-url')) {
+				element = document.createElement('a');
+				element.href = pre.getAttribute('data-url');
+			} else {
+				element = document.createElement('span');
+			}
+
+			element.textContent = text;
+		}
+
+		return element;
+	});
+
+	/**
+	 * Register the toolbar with Prism.
+	 */
+	Prism.hooks.add('complete', hook);
+})();
+
+(function() {
+	if ( !self.Prism || !self.document || !document.querySelectorAll || ![].filter) return;
+
+	var adapters = [];
+	function registerAdapter(adapter) {
+		if (typeof adapter === "function" && !getAdapter(adapter)) {
+			adapters.push(adapter);
+		}
+	}
+	function getAdapter(adapter) {
+		if (typeof adapter === "function") {
+			return adapters.filter(function(fn) { return fn.valueOf() === adapter.valueOf()})[0];
+		}
+		else if (typeof adapter === "string" && adapter.length > 0) {
+			return adapters.filter(function(fn) { return fn.name === adapter})[0];
+		}
+		return null;
+	}
+	function removeAdapter(adapter) {
+		if (typeof adapter === "string")
+			adapter = getAdapter(adapter);
+		if (typeof adapter === "function") {
+			var index = adapters.indexOf(adapter);
+			if (index >=0) {
+				adapters.splice(index,1);
+			}
+		}
+	}
+
+	Prism.plugins.jsonphighlight = {
+		registerAdapter: registerAdapter,
+		removeAdapter: removeAdapter,
+		highlight: highlight
+	};
+	registerAdapter(function github(rsp, el) {
+		if ( rsp && rsp.meta && rsp.data ) {
+			if ( rsp.meta.status && rsp.meta.status >= 400 ) {
+				return "Error: " + ( rsp.data.message || rsp.meta.status );
+			}
+			else if ( typeof(rsp.data.content) === "string" ) {
+				return typeof(atob) === "function"
+					? atob(rsp.data.content.replace(/\s/g, ""))
+					: "Your browser cannot decode base64";
+			}
+		}
+		return null;
+	});
+	registerAdapter(function gist(rsp, el) {
+		if ( rsp && rsp.meta && rsp.data && rsp.data.files ) {
+			if ( rsp.meta.status && rsp.meta.status >= 400 ) {
+				return "Error: " + ( rsp.data.message || rsp.meta.status );
+			}
+			else {
+				var filename = el.getAttribute("data-filename");
+				if (filename == null) {
+					// Maybe in the future we can somehow render all files
+					// But the standard <script> include for gists does that nicely already,
+					// so that might be getting beyond the scope of this plugin
+					for (var key in rsp.data.files) {
+						if (rsp.data.files.hasOwnProperty(key)) {
+							filename = key;
+							break;
+						}
+					}
+				}
+				if (rsp.data.files[filename] !== undefined) {
+					return rsp.data.files[filename].content;
+				}
+				else {
+					return "Error: unknown or missing gist file " + filename;
+				}
+			}
+		}
+		return null;
+	});
+	registerAdapter(function bitbucket(rsp, el) {
+		return rsp && rsp.node && typeof(rsp.data) === "string"
+			? rsp.data
+			: null;
+	});
+
+	var jsonpcb = 0,
+	    loadstr = "Loading…";
+
+	function highlight() {
+		Array.prototype.slice.call(document.querySelectorAll("pre[data-jsonp]")).forEach(function(pre) {
+			pre.textContent = "";
+
+			var code = document.createElement("code");
+			code.textContent = loadstr;
+			pre.appendChild(code);
+
+			var adapterfn = pre.getAttribute("data-adapter");
+			var adapter = null;
+			if ( adapterfn ) {
+				if ( typeof(window[adapterfn]) === "function" ) {
+					adapter = window[adapterfn];
+				}
+				else {
+					code.textContent = "JSONP adapter function '" + adapterfn + "' doesn't exist";
+					return;
+				}
+			}
+
+			var cb = "prismjsonp" + ( jsonpcb++ );
+
+			var uri = document.createElement("a");
+			var src = uri.href = pre.getAttribute("data-jsonp");
+			uri.href += ( uri.search ? "&" : "?" ) + ( pre.getAttribute("data-callback") || "callback" ) + "=" + cb;
+
+			var timeout = setTimeout(function() {
+				// we could clean up window[cb], but if the request finally succeeds, keeping it around is a good thing
+				if ( code.textContent === loadstr )
+					code.textContent = "Timeout loading '" + src + "'";
+			}, 5000);
+
+			var script = document.createElement("script");
+			script.src = uri.href;
+
+			window[cb] = function(rsp) {
+				document.head.removeChild(script);
+				clearTimeout(timeout);
+				delete window[cb];
+
+				var data = "";
+
+				if ( adapter ) {
+					data = adapter(rsp, pre);
+				}
+				else {
+					for ( var p in adapters ) {
+						data = adapters[p](rsp, pre);
+						if ( data !== null ) break;
+					}
+				}
+
+				if (data === null) {
+					code.textContent = "Cannot parse response (perhaps you need an adapter function?)";
+				}
+				else {
+					code.textContent = data;
+					Prism.highlightElement(code);
+				}
+			};
+
+			document.head.appendChild(script);
+		});
+	}
+
+	highlight();
+})();
+(function () {
+	if (typeof self === 'undefined' || !self.Prism || !self.document || !document.createElement) {
+		return;
+	}
+
+	// The dependencies map is built automatically with gulp
+	var lang_dependencies = /*languages_placeholder[*/{"javascript":"clike","actionscript":"javascript","arduino":"cpp","aspnet":"markup","bison":"c","c":"clike","csharp":"clike","cpp":"c","coffeescript":"javascript","crystal":"ruby","css-extras":"css","d":"clike","dart":"clike","django":"markup","fsharp":"clike","flow":"javascript","glsl":"clike","go":"clike","groovy":"clike","haml":"ruby","handlebars":"markup","haxe":"clike","java":"clike","jolie":"clike","kotlin":"clike","less":"css","markdown":"markup","n4js":"javascript","nginx":"clike","objectivec":"c","opencl":"cpp","parser":"markup","php":"clike","php-extras":"php","processing":"clike","protobuf":"clike","pug":"javascript","qore":"clike","jsx":["markup","javascript"],"reason":"clike","ruby":"clike","sass":"css","scss":"css","scala":"java","smarty":"markup","swift":"clike","textile":"markup","twig":"markup","typescript":"javascript","vbnet":"basic","wiki":"markup"}/*]*/;
+
+	var lang_data = {};
+
+	var ignored_language = 'none';
+
+	var config = Prism.plugins.autoloader = {
+		languages_path: 'components/',
+		use_minified: true
+	};
+
+	/**
+	 * Lazy loads an external script
+	 * @param {string} src
+	 * @param {function=} success
+	 * @param {function=} error
+	 */
+	var script = function (src, success, error) {
+		var s = document.createElement('script');
+		s.src = src;
+		s.async = true;
+		s.onload = function() {
+			document.body.removeChild(s);
+			success && success();
+		};
+		s.onerror = function() {
+			document.body.removeChild(s);
+			error && error();
+		};
+		document.body.appendChild(s);
+	};
+
+	/**
+	 * Returns the path to a grammar, using the language_path and use_minified config keys.
+	 * @param {string} lang
+	 * @returns {string}
+	 */
+	var getLanguagePath = function (lang) {
+		return config.languages_path +
+			'prism-' + lang
+			+ (config.use_minified ? '.min' : '') + '.js'
+	};
+
+	/**
+	 * Tries to load a grammar and
+	 * highlight again the given element once loaded.
+	 * @param {string} lang
+	 * @param {HTMLElement} elt
+	 */
+	var registerElement = function (lang, elt) {
+		var data = lang_data[lang];
+		if (!data) {
+			data = lang_data[lang] = {};
+		}
+
+		// Look for additional dependencies defined on the <code> or <pre> tags
+		var deps = elt.getAttribute('data-dependencies');
+		if (!deps && elt.parentNode && elt.parentNode.tagName.toLowerCase() === 'pre') {
+			deps = elt.parentNode.getAttribute('data-dependencies');
+		}
+
+		if (deps) {
+			deps = deps.split(/\s*,\s*/g);
+		} else {
+			deps = [];
+		}
+
+		loadLanguages(deps, function () {
+			loadLanguage(lang, function () {
+				Prism.highlightElement(elt);
+			});
+		});
+	};
+
+	/**
+	 * Sequentially loads an array of grammars.
+	 * @param {string[]|string} langs
+	 * @param {function=} success
+	 * @param {function=} error
+	 */
+	var loadLanguages = function (langs, success, error) {
+		if (typeof langs === 'string') {
+			langs = [langs];
+		}
+		var i = 0;
+		var l = langs.length;
+		var f = function () {
+			if (i < l) {
+				loadLanguage(langs[i], function () {
+					i++;
+					f();
+				}, function () {
+					error && error(langs[i]);
+				});
+			} else if (i === l) {
+				success && success(langs);
+			}
+		};
+		f();
+	};
+
+	/**
+	 * Load a grammar with its dependencies
+	 * @param {string} lang
+	 * @param {function=} success
+	 * @param {function=} error
+	 */
+	var loadLanguage = function (lang, success, error) {
+		var load = function () {
+			var force = false;
+			// Do we want to force reload the grammar?
+			if (lang.indexOf('!') >= 0) {
+				force = true;
+				lang = lang.replace('!', '');
+			}
+
+			var data = lang_data[lang];
+			if (!data) {
+				data = lang_data[lang] = {};
+			}
+			if (success) {
+				if (!data.success_callbacks) {
+					data.success_callbacks = [];
+				}
+				data.success_callbacks.push(success);
+			}
+			if (error) {
+				if (!data.error_callbacks) {
+					data.error_callbacks = [];
+				}
+				data.error_callbacks.push(error);
+			}
+
+			if (!force && Prism.languages[lang]) {
+				languageSuccess(lang);
+			} else if (!force && data.error) {
+				languageError(lang);
+			} else if (force || !data.loading) {
+				data.loading = true;
+				var src = getLanguagePath(lang);
+				script(src, function () {
+					data.loading = false;
+					languageSuccess(lang);
+
+				}, function () {
+					data.loading = false;
+					data.error = true;
+					languageError(lang);
+				});
+			}
+		};
+		var dependencies = lang_dependencies[lang];
+		if(dependencies && dependencies.length) {
+			loadLanguages(dependencies, load);
+		} else {
+			load();
+		}
+	};
+
+	/**
+	 * Runs all success callbacks for this language.
+	 * @param {string} lang
+	 */
+	var languageSuccess = function (lang) {
+		if (lang_data[lang] && lang_data[lang].success_callbacks && lang_data[lang].success_callbacks.length) {
+			lang_data[lang].success_callbacks.forEach(function (f) {
+				f(lang);
+			});
+		}
+	};
+
+	/**
+	 * Runs all error callbacks for this language.
+	 * @param {string} lang
+	 */
+	var languageError = function (lang) {
+		if (lang_data[lang] && lang_data[lang].error_callbacks && lang_data[lang].error_callbacks.length) {
+			lang_data[lang].error_callbacks.forEach(function (f) {
+				f(lang);
+			});
+		}
+	};
+
+	Prism.hooks.add('complete', function (env) {
+		if (env.element && env.language && !env.grammar) {
+			if (env.language !== ignored_language) {
+				registerElement(env.language, env.element);
+			}
+		}
+	});
+
+}());
+
+(function(){
+
+if (typeof self === 'undefined' || !self.Prism || !self.document) {
+	return;
+}
+
+if (!Prism.plugins.toolbar) {
+	console.warn('Show Languages plugin loaded before Toolbar plugin.');
+
+	return;
+}
+
+// The languages map is built automatically with gulp
+var Languages = /*languages_placeholder[*/{"html":"HTML","xml":"XML","svg":"SVG","mathml":"MathML","css":"CSS","clike":"C-like","javascript":"JavaScript","abap":"ABAP","actionscript":"ActionScript","apacheconf":"Apache Configuration","apl":"APL","applescript":"AppleScript","asciidoc":"AsciiDoc","aspnet":"ASP.NET (C#)","autohotkey":"AutoHotkey","autoit":"AutoIt","basic":"BASIC","csharp":"C#","cpp":"C++","coffeescript":"CoffeeScript","css-extras":"CSS Extras","django":"Django/Jinja2","fsharp":"F#","glsl":"GLSL","graphql":"GraphQL","http":"HTTP","inform7":"Inform 7","json":"JSON","latex":"LaTeX","livescript":"LiveScript","lolcode":"LOLCODE","matlab":"MATLAB","mel":"MEL","n4js":"N4JS","nasm":"NASM","nginx":"nginx","nsis":"NSIS","objectivec":"Objective-C","ocaml":"OCaml","opencl":"OpenCL","parigp":"PARI/GP","php":"PHP","php-extras":"PHP Extras","powershell":"PowerShell","properties":".properties","protobuf":"Protocol Buffers","jsx":"React JSX","renpy":"Ren'py","rest":"reST (reStructuredText)","sas":"SAS","sass":"Sass (Sass)","scss":"Sass (Scss)","sql":"SQL","typescript":"TypeScript","vbnet":"VB.Net","vhdl":"VHDL","vim":"vim","wiki":"Wiki markup","xojo":"Xojo (REALbasic)","yaml":"YAML"}/*]*/;
+Prism.plugins.toolbar.registerButton('show-language', function(env) {
+	var pre = env.element.parentNode;
+	if (!pre || !/pre/i.test(pre.nodeName)) {
+		return;
+	}
+	var language = pre.getAttribute('data-language') || Languages[env.language] || (env.language.substring(0, 1).toUpperCase() + env.language.substring(1));
+
+	var element = document.createElement('span');
+	element.textContent = language;
+
+	return element;
+});
+
+})();
 
     // ------------------ End wrap
     return Prism;

--- a/src/plugins/codesample/src/main/js/ui/Dialog.js
+++ b/src/plugins/codesample/src/main/js/ui/Dialog.js
@@ -20,9 +20,10 @@ define(
       open: function (editor) {
         var minWidth = Settings.getDialogMinWidth(editor);
         var minHeight = Settings.getDialogMinHeight(editor);
-        var currentLanguage = Languages.getCurrentLanguage(editor);
+        // var currentLanguage = Languages.getCurrentLanguage(editor);
         var currentLanguages = Languages.getLanguages(editor);
-        var currentCode = CodeSample.getCurrentCode(editor);
+        // var currentCode = CodeSample.getCurrentCode(editor);
+        var datas = CodeSample.getDatas(editor);
 
         editor.windowManager.open({
           title: "Insert/Edit code sample",
@@ -37,8 +38,58 @@ define(
               name: 'language',
               label: 'Language',
               maxWidth: 200,
-              value: currentLanguage,
+              value: datas.language,
               values: currentLanguages
+            },
+
+            {
+              type: 'checkbox',
+              name: 'isLineNumbers',
+              label: 'Line numbers',
+              checked: datas.isLineNumbers,
+              values: currentLanguages
+            },
+
+            {
+              type: 'textbox',
+              name: 'highlightedLines',
+              label: 'Highligth lines',
+              placeholder: 'For example:  2,5-8,12, ...',
+              multiline: false,
+              spellcheck: false,
+              classes: 'monospace',
+              value: datas.highlightedLines
+            },
+
+            /*
+            {
+              type: 'textbox',
+              name: 'dataSrc',
+              label: 'File',
+              multiline: false,
+              spellcheck: false,
+              classes: 'monospace',
+              value: datas.dataSrc
+            },
+             * */
+            {
+              type: 'filepicker',
+              filetype: 'codesample',
+              name: 'dataSrc',
+              label: 'File',
+              placeholder: 'On this server',
+              value: datas.dataSrc
+            },
+
+            {
+              type: 'textbox',
+              name: 'url',
+              label: 'Url',
+              placeholder: 'From Github, Gist, Bitbucket,...',
+              multiline: false,
+              spellcheck: false,
+              classes: 'monospace',
+              value: datas.url
             },
 
             {
@@ -50,12 +101,12 @@ define(
               flex: 1,
               style: 'direction: ltr; text-align: left',
               classes: 'monospace',
-              value: currentCode,
+              value: datas.code,
               autofocus: true
             }
           ],
           onSubmit: function (e) {
-            CodeSample.insertCodeSample(editor, e.data.language, e.data.code);
+            CodeSample.insertCodeSample(editor, e.data);
           }
         });
       }

--- a/src/plugins/codesample/src/main/js/util/Utils.js
+++ b/src/plugins/codesample/src/main/js/util/Utils.js
@@ -14,7 +14,7 @@ define(
   ],
   function () {
     function isCodeSample(elm) {
-      return elm && elm.nodeName === 'PRE' && elm.className.indexOf('language-') !== -1;
+      return elm && elm.nodeName === 'PRE' && (elm.className.indexOf('language-') !== -1 || elm.hasAttribute('data-src'));
     }
 
     function trimArg(predicateFn) {
@@ -23,9 +23,27 @@ define(
       };
     }
 
+    function lineNumbers(code) {
+      var match = code.match(/\n(?!$)/g);
+      var linesNum = match ? match.length + 1 : 1;
+      var lines = new Array(linesNum + 1);
+
+      return '<div aria-hidden="true" class="line-numbers-rows">' + lines.join('<span></span>') + '</div>';
+    }
+
+    function pseudoCode(params) {
+      var code = '<span class="token comment">/* ---- Codesample ---- */</span>\n';
+      for (var field in params) {
+        code += '<span class="token property">' + field + '</span><span class="token punctuation">:</span> ' + params[field].trim() + "\n";
+      }
+      return code;
+    }
+
     return {
       isCodeSample: isCodeSample,
-      trimArg: trimArg
+      trimArg: trimArg,
+      lineNumbers: lineNumbers,
+      pseudoCode: pseudoCode
     };
   }
 );


### PR DESCRIPTION
This is an upgrade for codesample plugin.
It's use more options from PrismJs :
* line numbers
* highlighted  lines
* auto-loader for missing languages
* displays language on overflow event
* download sources for displaying from local server, github, bitbucket,
Read the following file for more information :
https://github.com/bazooka07/tinymce/blob/codesample/codesample-plugin.md
Perhaps controls are missing for the dialog box but it's works