### PR TITLE
Image plugin: call the URL converter in all cases

### DIFF
--- a/src/plugins/image/src/main/js/ui/Dialog.js
+++ b/src/plugins/image/src/main/js/ui/Dialog.js
@@ -81,6 +81,8 @@ define(
           if (!data.style) {
             data.style = null;
           }
+          
+          data.src = editor.convertURL(data.src, 'src');
 
           // Setup new data excluding style properties
           /*eslint dot-notation: 0*/


### PR DESCRIPTION
Re-open #4065
The example http://fiddle.tinymce.com/hfgaab shows, that the URL converter is NOT called, if the OK button is clicked. The URL converter is only called, if you press for example the tabulator key.