### PR TITLE
The advanced tab in the media plugin is only displayed if it has elements

### DIFF
--- a/src/plugins/media/main/ts/ui/Dialog.ts
+++ b/src/plugins/media/main/ts/ui/Dialog.ts
@@ -189,18 +189,13 @@ const showDialog = function (editor) {
 
   embedTextBox[embedChange] = updateValueOnChange;
 
-  win = editor.windowManager.open({
-    title: 'Insert/edit media',
-    data,
-    bodyType: 'tabpanel',
-    body: [
-      {
+  const body = [
+    {
         title: 'General',
         type: 'form',
         items: generalFormItems
-      },
-
-      {
+    },
+    {
         title: 'Embed',
         type: 'container',
         layout: 'flex',
@@ -216,14 +211,18 @@ const showDialog = function (editor) {
           },
           embedTextBox
         ]
-      },
-
-      {
-        title: 'Advanced',
-        type: 'form',
-        items: advancedFormItems
       }
-    ],
+  ];
+
+  if (advancedFormItems.length > 0) {
+    body.push({ title: 'Advanced', type: 'form', items: advancedFormItems });
+  }
+
+  win = editor.windowManager.open({
+    title: 'Insert/edit media',
+    data,
+    bodyType: 'tabpanel',
+    body,
     onSubmit () {
       SizeManager.updateSize(win);
       submitForm(win, editor);


### PR DESCRIPTION
If both the media_alt_source and the media_poster options are set to false, the Advanced tab is shown in the media dialog with nothing on it. With this change, the Advanced tab is displayed if it the amount of elements on it is greater than 0.