### PR TITLE
Fix the memory leak in the DragHelper

### DIFF
--- a/src/ui/main/ts/DragHelper.ts
+++ b/src/ui/main/ts/DragHelper.ts
@@ -69,9 +69,7 @@ export default function (id, settings) {
 
   settings = settings || {};
 
-  function getHandleElm() {
-    return doc.getElementById(settings.handle || id);
-  }
+  const handleElement = doc.getElementById(settings.handle || id);
 
   start = function (e) {
     const docSize = getDocumentSize(doc);
@@ -81,7 +79,7 @@ export default function (id, settings) {
 
     e.preventDefault();
     downButton = e.button;
-    handleElm = getHandleElm();
+    handleElm = handleElement;
     startX = e.screenX;
     startY = e.screenY;
 
@@ -139,8 +137,8 @@ export default function (id, settings) {
    * @method destroy
    */
   this.destroy = function () {
-    DomQuery(getHandleElm()).off();
+    DomQuery(handleElement).off();
   };
 
-  DomQuery(getHandleElm()).on('mousedown touchstart', start);
+  DomQuery(handleElement).on('mousedown touchstart', start);
 }


### PR DESCRIPTION
Refactored the DragHelper to calculate the handleElement once at startup
and maintain a reference to that element. This stops a memory leak that
would occur if the handle element was no longer in the DOM when destroy
was called.

Fixes: #4139