### PR TITLE
Replace internal table function with mceTableProps command for button and menu item

### DIFF
--- a/src/plugins/table/main/ts/ui/Buttons.ts
+++ b/src/plugins/table/main/ts/ui/Buttons.ts
@@ -9,11 +9,7 @@
  */
 
 import Tools from 'tinymce/core/api/util/Tools';
-<<<<<<< HEAD
-=======
-import TableDialog from './TableDialog';
 import { getToolbar } from '../api/Settings';
->>>>>>> upstream/master
 
 const each = Tools.each;
 

--- a/src/plugins/table/main/ts/ui/Buttons.ts
+++ b/src/plugins/table/main/ts/ui/Buttons.ts
@@ -8,9 +8,7 @@
  * Contributing: http://www.tinymce.com/contributing
  */
 
-import { Fun } from '@ephox/katamari';
 import Tools from 'tinymce/core/api/util/Tools';
-import TableDialog from './TableDialog';
 
 const each = Tools.each;
 
@@ -38,7 +36,7 @@ const addButtons = function (editor) {
 
   editor.addButton('tableprops', {
     title: 'Table properties',
-    onclick: Fun.curry(TableDialog.open, editor, true),
+    onclick: cmd('mceTableProps'),
     icon: 'table'
   });
 

--- a/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -14,11 +14,7 @@ import { Element } from '@ephox/sugar';
 
 import InsertTable from '../actions/InsertTable';
 import TableTargets from '../queries/TableTargets';
-<<<<<<< HEAD
-=======
-import TableDialog from './TableDialog';
 import { hasTableGrid } from '../api/Settings';
->>>>>>> upstream/master
 
 const addMenuItems = function (editor, selections) {
   let targets = Option.none();

--- a/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -8,13 +8,12 @@
  * Contributing: http://www.tinymce.com/contributing
  */
 
-import { Arr, Fun, Option } from '@ephox/katamari';
+import { Arr, Option } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
 import { Element } from '@ephox/sugar';
 
 import InsertTable from '../actions/InsertTable';
 import TableTargets from '../queries/TableTargets';
-import TableDialog from './TableDialog';
 
 const addMenuItems = function (editor, selections) {
   let targets = Option.none();
@@ -159,7 +158,7 @@ const addMenuItems = function (editor, selections) {
     text: 'Table',
     icon: 'table',
     context: 'table',
-    onclick: Fun.curry(TableDialog.open, editor)
+    onclick: cmd('mceInsertTable')
   } : {
     text: 'Table',
     icon: 'table',
@@ -169,7 +168,7 @@ const addMenuItems = function (editor, selections) {
       if (e.aria) {
         this.parent().hideAll();
         e.stopImmediatePropagation();
-        TableDialog.open(editor);
+        editor.execCommand('mceInsertTable');
       }
     },
     onshow () {
@@ -239,7 +238,7 @@ const addMenuItems = function (editor, selections) {
     text: 'Table properties',
     context: 'table',
     onPostRender: pushTable,
-    onclick: Fun.curry(TableDialog.open, editor, true)
+    onclick: cmd('mceTableProps')
   };
 
   const deleteTable = {


### PR DESCRIPTION
The Table plugin uses a direct call to an internal function to open the Table dialog for inserting a table and editing table properties, instead of via the mceInsertTable or mceTableProps commands, preventing these methods from being overridden, which is required for creating a custom Table dialog.

This PR replaces those function calls with a call to the appropriate command.

The PR has passed `grunt test` and `grunt lint`