### PR TITLE
charmap-plugin: extended in order to add combined Unicode signs

### DIFF
--- a/src/plugins/charmap/main/ts/core/CharMap.ts
+++ b/src/plugins/charmap/main/ts/core/CharMap.ts
@@ -290,7 +290,7 @@ const getDefaultCharMap = function () {
 
 const charmapFilter = function (charmap) {
   return Tools.grep(charmap, function (item) {
-    return isArray(item) && item.length === 2;
+    return isArray(item) && (item.length === 2 || item.length === 3);
   });
 };
 

--- a/src/plugins/charmap/main/ts/ui/Dialog.ts
+++ b/src/plugins/charmap/main/ts/ui/Dialog.ts
@@ -35,17 +35,22 @@ const open = function (editor) {
         const charDiv = getParentTd(target).firstChild;
         if (charDiv && charDiv.hasAttribute('data-chr')) {
           const charCodeString = charDiv.getAttribute('data-chr');
-          const charCode = parseInt(charCodeString, 10);
+          const arr = charCodeString.split(';');
+          let char4Insert = '';
 
-          if (!isNaN(charCode)) {
-            Actions.insertChar(editor, String.fromCharCode(charCode));
+          for (let i = 0; i < arr.length; i++) {
+            const charCode = parseInt(arr[i], 10);
+            if (!isNaN(charCode)) {
+              char4Insert += String.fromCharCode(charCode);
+            }
           }
+          Actions.insertChar(editor, char4Insert);
 
           if (!e.ctrlKey) {
             win.close();
           }
         }
-      }
+    }
     },
     onmouseover (e) {
       const td = getParentTd(e.target);

--- a/src/plugins/charmap/main/ts/ui/GridHtml.ts
+++ b/src/plugins/charmap/main/ts/ui/GridHtml.ts
@@ -37,7 +37,7 @@ const getHtml = function (charmap) {
           chrText = chr ? String.fromCharCode(charCode) : '&nbsp;';
         }
 
-        const title = chr[2] && chr[2] instanceof String ? chr[2] : chr[1];
+        const title = chr[2] && typeof chr[2] === 'string' ? chr[2] : '';
         gridHtml += (
           '<td title="' + title + '">' +
           '<div tabindex="-1" title="' + title + '" role="button" data-chr="' + charCode4DataAttr.join(';') + '">' +

--- a/src/plugins/charmap/main/ts/ui/GridHtml.ts
+++ b/src/plugins/charmap/main/ts/ui/GridHtml.ts
@@ -22,12 +22,25 @@ const getHtml = function (charmap) {
       const index = y * width + x;
       if (index < charmap.length) {
         const chr = charmap[index];
-        const charCode = parseInt(chr[0], 10);
-        const chrText = chr ? String.fromCharCode(charCode) : '&nbsp;';
+        let chrText = '';
+        let charCode = 0;
+        const charCode4DataAttr = [];
+        if (chr[0] instanceof Array || chr[0] instanceof Object) {
+          for (let c = 0; c < chr[0].length; c++) {
+            charCode = parseInt(chr[0][c], 10);
+            charCode4DataAttr.push(charCode.toString());
+            chrText += chr[0] ? String.fromCharCode(charCode) : '&nbsp;';
+          }
+        } else {
+          charCode = parseInt(chr[0], 10);
+          charCode4DataAttr.push(charCode.toString());
+          chrText = chr ? String.fromCharCode(charCode) : '&nbsp;';
+        }
 
+        const title = chr[2] && chr[2] instanceof String ? chr[2] : chr[1];
         gridHtml += (
-          '<td title="' + chr[1] + '">' +
-          '<div tabindex="-1" title="' + chr[1] + '" role="button" data-chr="' + charCode + '">' +
+          '<td title="' + title + '">' +
+          '<div tabindex="-1" title="' + title + '" role="button" data-chr="' + charCode4DataAttr.join(';') + '">' +
           chrText +
           '</div>' +
           '</td>'


### PR DESCRIPTION
Extending the plugin charmap in order to be able to **add combined Unicode signs** instead of adding only one pointcode, as before. 
The reason for the modification: linguists need this feature quite often for annotating spoken language.

The plugin now accepts either a number (which has been standard so far) or an array consisting of numbers as first argument. Using the array allows us to combine diacritics, etc. with characters (please see examples below). 
A third argument was introduced as well for describing/explaining the particular character that will be inserted. This might help editors to understand the meaning of a "heavily loaded" character with three or more diacritics.

**Examples:**

The "old" way to add a character via charmap is still working, of course:
[ 0x0133, 'ē' ]

For combining characters and diacritics (e.g.), one can pass an array as first parameter:
[ [0x0113 , 0x0303 ], 'ē̃' ]

The third, new parameter should be a string that will be used as attribute _title_ in the HTML-output
[ [0x014D , 0x0307, 0x0303 , 0x031C], 'ō̜̃', 'half rounded, nasalized, long [o]']
