### PR TITLE
Fire dragend event before removing dragging state

### DIFF
--- a/src/core/main/ts/DragDropOverrides.ts
+++ b/src/core/main/ts/DragDropOverrides.ts
@@ -219,10 +219,10 @@ const drop = function (state, editor) {
 
 const stop = function (state, editor) {
   return function () {
-    removeDragState(state);
     if (state.dragging) {
       editor.fire('dragend');
     }
+    removeDragState(state);
   };
 };
 

--- a/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -1,0 +1,38 @@
+import { Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { Hierarchy, Element } from '@ephox/sugar';
+import Theme from 'tinymce/themes/modern/Theme';
+import { UnitTest } from '@ephox/bedrock';
+
+UnitTest.asynctest('browser.tinymce.core.DragDropOverridesTest', function () {
+  const success = arguments[arguments.length - 2];
+  const failure = arguments[arguments.length - 1];
+
+  Theme();
+
+  TinyLoader.setup(function (editor, onSuccess, onFailure) {
+    const tinyApis = TinyApis(editor);
+
+    Pipeline.async({}, [
+      Logger.t('Drop draggable element outside of editor', GeneralSteps.sequence([
+        tinyApis.sSetContent('<p contenteditable="false">a</p>'),
+        Step.sync(function () {
+          let fired = false;
+          editor.on('dragend', function () {
+            fired = true;
+          });
+          const target = Hierarchy.follow(Element.fromDom(editor.getBody()), [0]).getOrDie().dom();
+          const rect = target.getBoundingClientRect();
+          const button = 0, screenX = (rect.left + rect.width / 2), screenY = (rect.top + rect.height / 2);
+          editor.fire('mousedown', { button, screenX, screenY, target });
+          editor.fire('mousemove', { button, screenX: screenX + 20, screenY: screenY + 20, target });
+          editor.dom.fire(document.body, 'mouseup');
+          Assertions.assertEq('Should fire dragend event', true, fired);
+        })
+      ])),
+    ], onSuccess, onFailure);
+  }, {
+    indent: false,
+    skin_url: '/project/js/tinymce/skins/lightgray'
+  }, success, failure);
+});


### PR DESCRIPTION
Moved the removeDragState method after the dragging check. Previously
the dragging check was always evaluating to false since the dragging
state was being removed before the check, meaning the dragend event
would never be fired.

Fixes: #4026