### PR TITLE
(MODE-9408) custom setting to conditionate logic that restricts styli…

### DIFF
--- a/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/src/core/main/ts/fmt/ApplyFormat.ts
@@ -12,6 +12,7 @@ import Bookmarks from '../dom/Bookmarks';
 import NodeType from '../dom/NodeType';
 import CaretFormat from './CaretFormat';
 import ExpandRange from './ExpandRange';
+import EditorManager from '../api/EditorManager';
 import FormatUtils from './FormatUtils';
 import Hooks from './Hooks';
 import MatchFormat from './MatchFormat';
@@ -156,7 +157,7 @@ const applyFormat = function (ed, name, vars?, node?) {
 
         // Can we rename the block
         // TODO: Break this if up, too complex
-        if (contentEditable && !hasContentEditableState && format.block &&
+        if (/*contentEditable && !hasContentEditableState &&*/  format.block &&
           !format.wrapper && FormatUtils.isTextBlock(ed, nodeName) && FormatUtils.isValid(ed, parentName, wrapName)) {
           node = dom.rename(node, wrapName);
           setElementFormat(node);
@@ -178,7 +179,7 @@ const applyFormat = function (ed, name, vars?, node?) {
 
         // Is it valid to wrap this item
         // TODO: Break this if up, too complex
-        if (contentEditable && !hasContentEditableState && FormatUtils.isValid(ed, wrapName, nodeName) && FormatUtils.isValid(ed, parentName, wrapName) &&
+        if (/*contentEditable && !hasContentEditableState && */ FormatUtils.isValid(ed, wrapName, nodeName) && FormatUtils.isValid(ed, parentName, wrapName) &&
           !(!nodeSpecific && node.nodeType === 3 &&
             node.nodeValue.length === 1 &&
             node.nodeValue.charCodeAt(0) === 65279) &&
@@ -296,7 +297,7 @@ const applyFormat = function (ed, name, vars?, node?) {
     });
   };
 
-  if (dom.getContentEditable(selection.getNode()) === 'false') {
+  if (dom.getContentEditable(selection.getNode()) === 'false' && EditorManager.settings.makeNonEditableStylable == 'undefined') {
     node = selection.getNode();
     for (let i = 0, l = formatList.length; i < l; i++) {
       if (formatList[i].ceFalseOverride && dom.is(node, formatList[i].selector)) {

--- a/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/src/core/main/ts/fmt/RemoveFormat.ts
@@ -13,6 +13,7 @@ import NodeType from '../dom/NodeType';
 import TreeWalker from '../api/dom/TreeWalker';
 import CaretFormat from './CaretFormat';
 import ExpandRange from './ExpandRange';
+import EditorManager from '../api/EditorManager';
 import FormatUtils from './FormatUtils';
 import MatchFormat from './MatchFormat';
 import RangeWalk from '../selection/RangeWalk';
@@ -510,7 +511,7 @@ const remove = function (ed, name, vars?, node?, similar?) {
     return;
   }
 
-  if (dom.getContentEditable(selection.getNode()) === 'false') {
+  if (dom.getContentEditable(selection.getNode()) === 'false' && EditorManager.settings.makeNonEditableStylable == 'undefined') {
     node = selection.getNode();
     for (let i = 0, l = formatList.length; i < l; i++) {
       if (formatList[i].ceFalseOverride) {


### PR DESCRIPTION
This PR allows us to pass an extra config that avoids the initial behaviour of TinyMCE which restricts styling of non editable text.
Also 2 conditions were commented since i didn't know how to avoid them. Having the variable in place must be easy to extend on this at a later time.
Licensing must be figured out.
Known error: Clicking on non editable element will not select the text therefore the text can be selected in a batch or manipulating the selector with arrows using CMD+ SHIFT + arrows left/right.

https://monosupport.atlassian.net/browse/MODE-9408
