### PR TITLE
Added nullcheck on ul when outdenting a list

### DIFF
--- a/src/plugins/lists/main/ts/actions/Outdent.ts
+++ b/src/plugins/lists/main/ts/actions/Outdent.ts
@@ -26,8 +26,14 @@ const removeEmptyLi = function (dom, li) {
 
 const outdent = function (editor, li) {
   let ul = li.parentNode;
-  const ulParent = ul.parentNode;
-  let newBlock;
+  let ulParent, newBlock;
+
+  if (ul) {
+    ulParent = ul.parentNode;
+  } else {
+    removeEmptyLi(editor.dom, li);
+    return true;
+  }
 
   if (ul === editor.getBody()) {
     return true;


### PR DESCRIPTION
This can be reproduced on the public TinyMCE demo with Firefox 59.0.2. 

1. Enter multiple lines of text pressing enter between the lines.
2. Hit enter several times afterwards to create some blank lines.
3. Select all, hit list, then unlist. An exception will be thrown.