### PR TITLE
Fix "Powered by TinyMCE" breaking XHTML pages

### DIFF
--- a/src/themes/modern/main/ts/modes/Iframe.ts
+++ b/src/themes/modern/main/ts/modes/Iframe.ts
@@ -110,7 +110,7 @@ const render = function (editor, theme, args) {
   }
 
   if (Settings.hasStatusbar(editor)) {
-    const linkHtml = '<a href="https://www.tinymce.com/?utm_campaign=editor_referral&utm_medium=poweredby&utm_source=tinymce" rel="noopener" target="_blank" role="presentation" tabindex="-1">tinymce</a>';
+    const linkHtml = '<a href="https://www.tinymce.com/?utm_campaign=editor_referral&amp;utm_medium=poweredby&amp;utm_source=tinymce" rel="noopener" target="_blank" role="presentation" tabindex="-1">tinymce</a>';
     const html = I18n.translate(['Powered by {0}', linkHtml]);
     const brandingLabel = Settings.isBrandingEnabled(editor) ? { type: 'label', classes: 'branding', html: ' ' + html } : null;
 


### PR DESCRIPTION
The “Powered by TinyMCE” link breaks XHTML pages when inserted into the page (“not well-formed” XML processing error reported by Firefox) because ampersands are not properly escaped.