### PR TITLE
added undo event to a change in anchor tag

### DIFF
--- a/src/plugins/anchor/main/ts/core/Anchor.ts
+++ b/src/plugins/anchor/main/ts/core/Anchor.ts
@@ -26,6 +26,7 @@ const insert = function (editor, id) {
   if (isAnchor) {
     selectedNode.removeAttribute('name');
     selectedNode.id = id;
+    editor.undoManager.add();
   } else {
     editor.focus();
     editor.selection.collapse(true);


### PR DESCRIPTION
Changing an existing anchor does not fire any change events. Adds undo event to anchor update.