### PR TITLE
Add event which fires before inserting content via the code editor

### DIFF
--- a/src/plugins/code/main/ts/core/Content.ts
+++ b/src/plugins/code/main/ts/core/Content.ts
@@ -14,12 +14,17 @@ const setContent = function (editor, html) {
   // transation since it tries to make a bookmark for the current selection
   editor.focus();
 
-  editor.undoManager.transact(function () {
-    editor.setContent(html);
-  });
+  const args = editor.fire('PreCodeEditorInsert', {content: html});
 
-  editor.selection.setCursorLocation();
-  editor.nodeChanged();
+  if (!args.isDefaultPrevented()) {
+
+      editor.undoManager.transact(function () {
+          editor.setContent(html);
+      });
+
+      editor.selection.setCursorLocation();
+      editor.nodeChanged();
+  }
 };
 
 const getContent = function (editor) {

--- a/src/plugins/code/main/ts/core/Content.ts
+++ b/src/plugins/code/main/ts/core/Content.ts
@@ -19,7 +19,7 @@ const setContent = function (editor, html) {
   if (!args.isDefaultPrevented()) {
 
       editor.undoManager.transact(function () {
-          editor.setContent(html);
+          editor.setContent(args.content);
       });
 
       editor.selection.setCursorLocation();


### PR DESCRIPTION
Related to #4377

This event allows the content to be altered or the insert cancelled.

I've tested the following scenarios:

- Callback supplied which calls e.preventDefault() - content is not inserted
- Callback supplied which changes the content - altered content is inserted
- No callback supplied - original content inserted