### PR TITLE
fix whiteSpaceRegExp so slow problem

### DIFF
--- a/src/core/main/ts/api/dom/DomQuery.ts
+++ b/src/core/main/ts/api/dom/DomQuery.ts
@@ -158,10 +158,10 @@ const inArray = function (item, array) {
   return -1;
 };
 
-const whiteSpaceRegExp = /^\s*|\s*$/g;
+// const whiteSpaceRegExp = /^\s*|\s*$/g;
 
 const trim = function (str) {
-  return (str === null || str === undefined) ? '' : ('' + str).replace(whiteSpaceRegExp, '');
+  return (str === null || str === undefined) ? '' : ('' + str).replace(/^\s\s*/, '').replace(/^\s\s*$/, '');
 };
 
 const each = function (obj, callback) {

--- a/src/core/main/ts/api/util/Tools.ts
+++ b/src/core/main/ts/api/util/Tools.ts
@@ -22,13 +22,13 @@ import Arr from '../../util/Arr';
  * Removes whitespace from the beginning and end of a string.
  *
  * @method trim
- * @param {String} s String to remove whitespace from.
+ * @param {String} str String to remove whitespace from.
  * @return {String} New string with removed whitespace.
  */
-const whiteSpaceRegExp = /^\s*|\s*$/g;
+// const whiteSpaceRegExp = /^\s*|\s*$/g;
 
 const trim = function (str) {
-  return (str === null || str === undefined) ? '' : ('' + str).replace(whiteSpaceRegExp, '');
+  return (str === null || str === undefined) ? '' : ('' + str).replace(/^\s\s*/, '').replace(/^\s\s*$/, '');
 };
 
 /**

--- a/src/ui/main/ts/Selector.ts
+++ b/src/ui/main/ts/Selector.ts
@@ -75,7 +75,7 @@ const expression = /^([\w\\*]+)?(?:#([\w\-\\]+))?(?:\.([\w\\\.]+))?(?:\[\@?([\w\
 /*jshint maxlen:255 */
 /*eslint max-len:0 */
 const chunker = /((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[^\[\]'"]+)+\]|\\.|[^ >+~,(\[\\]+)+|[>+~])(\s*,\s*)?((?:.|\r|\n)*)/g;
-const whiteSpace = /^\s*|\s*$/g;
+// const whiteSpace = /^\s*|\s*$/g;
 let Collection;
 
 const Selector = Class.extend({
@@ -180,7 +180,7 @@ const Selector = Class.extend({
       }
 
       // Parse expression into parts
-      parts = expression.exec(selector.replace(whiteSpace, ''));
+      parts = expression.exec(selector.replace(/^\s\s*/, '').replace(/^\s\s*$/, ''));
 
       add(compileNameFilter(parts[1]));
       add(compileIdFilter(parts[2]));


### PR DESCRIPTION
hello

because this is real customer email, so i will take it replace to "w"（privacy policy）
the str length is 31754

![image](https://user-images.githubusercontent.com/2436993/40843618-2f90ccf8-65e4-11e8-8e46-3f8093259539.png)


chrome Version 66.0.3359.181 (Official Build) (64-bit)
Speed is as follows: 
![image](https://user-images.githubusercontent.com/2436993/40843564-f7714708-65e3-11e8-81a0-e950b88d64f4.png)

Faster JavaScript Trim
http://blog.stevenlevithan.com/archives/faster-trim-javascript

by the way， should be abstracted into util methods
