### PR TITLE
fixed issue with @ephox/alloy@2.0.6

### DIFF
--- a/src/themes/mobile/main/ts/ui/StylesMenu.ts
+++ b/src/themes/mobile/main/ts/ui/StylesMenu.ts
@@ -37,7 +37,7 @@ const convert = function (formats, memMenuThunk) {
 
   const menus = Merger.deepMerge(submenus, Objects.wrap('styles', mainMenu));
 
-  const tmenu = TieredMenu.tieredMenu.tieredData('styles', menus, formats.expansions);
+  const tmenu = TieredMenu.tieredData('styles', menus, formats.expansions);
 
   return {
     tmenu
@@ -104,7 +104,7 @@ const makeMenu = function (value, items, memMenuThunk, collapsable) {
         action (item) {
           if (collapsable) {
             const comp = memMenuThunk().get(item);
-            TieredMenu.tieredMenu.collapseMenu(comp);
+            TieredMenu.collapseMenu(comp);
           }
         }
       }),
@@ -155,7 +155,7 @@ const sketch = function (settings) {
   });
   // Turn settings into a tiered menu data.
 
-  const memMenu = Memento.record(TieredMenu.tieredMenu.sketch({
+  const memMenu = Memento.record(TieredMenu.sketch({
     dom: {
       tag: 'div',
       classes: [ Styles.resolve('styles-menu') ]


### PR DESCRIPTION
tsc failed because `@ephox/alloy`'s changes.

```
// @ephox/alloy@2.0.5
import * as TieredMenu from './ui/TieredMenu';

// @ephox/alloy@2.0.6
import { tieredMenu as TieredMenu, TieredMenuSketch, TieredData } from './ui/TieredMenu';
```

so I fixed it.

Why don't you use '^2.0.6' not 'latest'?