### PR TITLE
Adding text-transform to buttons in variables

### DIFF
--- a/src/skins/lightgray/main/less/desktop/Button.less
+++ b/src/skins/lightgray/main/less/desktop/Button.less
@@ -61,6 +61,7 @@
   cursor: pointer;
   color: @btn-text;
   text-align: center;
+  text-transform: @btn-text-transform;
 
   // Fixes for default inner padding of button
   overflow: visible; // IE7

--- a/src/skins/lightgray/main/less/desktop/Variables.less
+++ b/src/skins/lightgray/main/less/desktop/Variables.less
@@ -46,6 +46,7 @@
 @btn-box-disabled-opacity:       0.4;
 @btn-padding:                    4px 6px;
 @btn-chevron:                    #b5bcc2;
+@btn-text-transform:             none;
 
 // Button:hover
 @btn-bg-hover:                   @btn-bg;


### PR DESCRIPTION
To conform better with in house styles buttons may be required to be all capital text. This can be easily accomplished with a text-transform. I added it as a variable in the variables.less file so that it can be easily assigned. Default is none. 