### PR TITLE
Spellchecker - 2 bugfixes and 1 update

### DIFF
--- a/src/plugins/spellchecker/main/ts/core/Actions.ts
+++ b/src/plugins/spellchecker/main/ts/core/Actions.ts
@@ -93,6 +93,7 @@ const spellcheck = function (editor: Editor, pluginUrl: string, startedState: Ce
   const errorCallback = function (message: string) {
     editor.notificationManager.open({ text: message, type: 'error' });
     editor.setProgressState(false);
+    editor.setMode('design');
     finish(editor, startedState, textMatcherState);
   };
 
@@ -103,6 +104,7 @@ const spellcheck = function (editor: Editor, pluginUrl: string, startedState: Ce
   editor.setProgressState(true);
   sendRpcCall(editor, pluginUrl, currentLanguageState, 'spellcheck', getTextMatcher(editor, textMatcherState).text, successCallback, errorCallback);
   editor.focus();
+  editor.setMode('readonly');
 };
 
 const checkIfFinished = function (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>) {
@@ -113,14 +115,16 @@ const checkIfFinished = function (editor: Editor, startedState: Cell<boolean>, t
 
 const addToDictionary = function (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, word: string, spans: Element[]) {
   editor.setProgressState(true);
-
+  editor.setMode('readonly');
   sendRpcCall(editor, pluginUrl, currentLanguageState, 'addToDictionary', word, () => {
     editor.setProgressState(false);
+    editor.setMode('design');
     editor.dom.remove(spans, true);
     checkIfFinished(editor, startedState, textMatcherState);
   }, (message) => {
     editor.notificationManager.open({ text: message, type: 'error' });
     editor.setProgressState(false);
+    editor.setMode('design');
   });
 };
 
@@ -200,7 +204,7 @@ const markErrors = function (editor: Editor, startedState: Cell<boolean>, textMa
   }
 
   editor.setProgressState(false);
-
+  editor.setMode('design');
   if (isEmpty(suggestions)) {
     const message = editor.translate('No misspellings found.');
     editor.notificationManager.open({ text: message, type: 'info' });

--- a/src/plugins/spellchecker/main/ts/ui/Buttons.ts
+++ b/src/plugins/spellchecker/main/ts/ui/Buttons.ts
@@ -74,6 +74,11 @@ const register = function (editor: Editor, pluginUrl: string, startedState: Cell
     buttonArgs.onshow = updateSelection(editor, currentLanguageState);
     buttonArgs.onselect = function (e) {
       currentLanguageState.set(e.control.settings.data);
+      if (startedState.get()==true)
+        {
+        startSpellchecking();
+        }
+      editor.focus();
     };
   }
 

--- a/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
+++ b/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
@@ -34,7 +34,7 @@ const showSuggestions = function (editor: Editor, pluginUrl: string, lastSuggest
   });
 
   if (suggestions.length==0) {
-  var message = editor.translate('(No suggestions)');
+  const message = editor.translate('(No suggestions)');
   items.push({text:message,disabled:true});
   } 
   items.push({ text: '-' });

--- a/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
+++ b/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
@@ -33,6 +33,10 @@ const showSuggestions = function (editor: Editor, pluginUrl: string, lastSuggest
     });
   });
 
+  if (suggestions.length==0) {
+  var message = editor.translate('(No suggestions)');
+  items.push({text:message,disabled:true});
+  } 
   items.push({ text: '-' });
 
   const hasDictionarySupport = lastSuggestionsState.get().hasDictionarySupport;


### PR DESCRIPTION
I modified the SpellChecker plugin in order to show in the suggestionsMenu a '(No suggestions)' disabled item over the separator instead of only showing a separator when no suggestions. Hope it may help.

![38496372-b0ac5ac2-3bd3-11e8-8ba9-e24fbf108d93](https://user-images.githubusercontent.com/11498901/44891295-e02df880-acb4-11e8-8724-2325fd5fa585.png)

Also, two bugs are fixed in the SpellChecker plugin with this pull request. 

BUG 1: While the spellchecking is working with a large document you will see the throbber, but meanwhile you can scroll up and down and move all arround the document with your keys (up/down/left/right), when you shouldn't be able to. This is fixed in this pull request.

BUG 2: When using several languages in the spellchecker, you will see the splitbutton that will show a dropdown menu with all the available languages. If you already activate the spellchecker and you already have all the marked words in your document with English (for example) as the selected language and then you change the language to French (for example), the marked words remains marked when it shouldn't because you select another language from the spellchecker menu. This is fixed in this pull request.