### PR TITLE
Fixed the mceInsertRawHTML editor command

### DIFF
--- a/src/core/main/ts/api/EditorCommands.ts
+++ b/src/core/main/ts/api/EditorCommands.ts
@@ -448,8 +448,8 @@ export default function (editor: Editor) {
     },
 
     'mceInsertRawHTML' (command, ui, value) {
-      const content = editor.getContent() as string;
       selection.setContent('tiny_mce_marker');
+      const content = editor.getContent() as string;
       editor.setContent(content.replace(/tiny_mce_marker/g, () => value));
     },
 

--- a/src/core/test/ts/browser/content/InsertContentCommandTest.ts
+++ b/src/core/test/ts/browser/content/InsertContentCommandTest.ts
@@ -402,6 +402,26 @@ UnitTest.asynctest('browser.tinymce.core.content.InsertContentCommandTest', (suc
     LegacyUnit.equal(JSON.serialize(editor.getContent()), '"<p>a X c</p>"');
   });
 
+  suite.test('mceInsertRawHTML - insert p at start', function (editor) {
+    editor.setContent('<p>abc</p>');
+    editor.execCommand('mceInsertRawHTML', false, '<p>Hello world!</p>');
+    LegacyUnit.equal(editor.getContent(), '<p>Hello world!</p><p>abc</p>');
+  });
+
+  suite.test('mceInsertRawHTML - insert link inside p', function (editor) {
+    editor.setContent('<p>abc</p>');
+    LegacyUnit.setSelection(editor, 'p', 3);
+    editor.execCommand('mceInsertRawHTML', false, ' <a href="#">Hello world!</a>');
+    LegacyUnit.equal(editor.getContent(), '<p>abc <a href="#">Hello world!</a></p>');
+  });
+
+  suite.test('mceInsertRawHTML - insert char at char surrounded by spaces', function (editor) {
+    editor.setContent('<p>a b c</p>');
+    LegacyUnit.setSelection(editor, 'p', 2, 'p', 3);
+    editor.execCommand('mceInsertRawHTML', false, '<strong>X</strong>');
+    LegacyUnit.equal(JSON.serialize(editor.getContent()), '"<p>a <strong>X</strong> c</p>"');
+  });
+
   TinyLoader.setup(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
   }, {


### PR DESCRIPTION
Relates to issue #4401

This takes the fix @mwilliamson created in https://github.com/tinymce/tinymce/pull/4402 and adds some basic tests for the insert raw HTML editor command.

Note: Not sure if where I placed the tests is the best location, but it seemed relevant as it's related to inserting content.