### PR TITLE
Fix find and replace not working properly with spaces

### DIFF
--- a/src/plugins/searchreplace/main/ts/core/Actions.ts
+++ b/src/plugins/searchreplace/main/ts/core/Actions.ts
@@ -104,7 +104,7 @@ const removeNode = function (dom, node) {
 
 const find = function (editor, currentIndexState, text, matchCase, wholeWord) {
   text = text.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
-  text = text.replace(/\s/g, '\\s');
+  text = text.replace(/\s/g, '[^\\S\\r\\n]');
   text = wholeWord ? '\\b' + text + '\\b' : text;
 
   const count = markAllMatches(editor, currentIndexState, new RegExp(text, matchCase ? 'g' : 'gi'));

--- a/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
+++ b/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
@@ -80,6 +80,13 @@ UnitTest.asynctest(
       LegacyUnit.equal('<p>x b x</p>', editor.getContent());
     });
 
+    suite.test('Find and replace all spaces with new lines', function (editor) {
+      editor.setContent('a&nbsp; &nbsp;b<br/><br/>ab&nbsp;c');
+      editor.plugins.searchreplace.find(' ');
+      LegacyUnit.equal(editor.plugins.searchreplace.replace('x', true, true), false);
+      LegacyUnit.equal('<p>axxxb<br /><br />abxc</p>', editor.getContent());
+    });
+
     suite.test('Find multiple matches, move to next and replace', function (editor) {
       editor.setContent('a a');
       LegacyUnit.equal(2, editor.plugins.searchreplace.find('a'));
@@ -133,7 +140,7 @@ UnitTest.asynctest(
       Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
     }, {
       plugins: 'searchreplace',
-      valid_elements: 'b,i',
+      valid_elements: 'b,i,br',
       indent: false,
       skin_url: '/project/js/tinymce/skins/lightgray'
     }, success, failure);


### PR DESCRIPTION
Fixes #4602 

If a line contained new chars (eg &lt;br /&gt;), then if a search was done with one or more space chars, the find and replace would incorrectly match to those new line chars. This was because find was replacing any whitespace chars in the entered text and replacing them with the '\s' regex matcher (which included matching new lines). That would then cause the find logic to remove the chars after the new lines from view when doing a find and then add additional chars when replacing.

So the fix I've made preserves the logic of replacing whitespace chars, but instead it now only match against whitespaces chars without matching on new line chars.

Note: Not 100% sure it should be replacing whitespace input text with '\s', but I've played it safe and left that alone with the exception of new line chars. If I had to guess why it's doing '\s' matches, I believe it may be to handle the fact that spaces could be a regular space or a non breaking space (or other unicode space chars), in which case we may be better just searching for that (eg `text.replace(/ /g, '[ \u00a0]')`), instead of all whitespace chars.

