### PR TITLE
Fix wbr elements when paste_as_text is enabled

### DIFF
--- a/src/plugins/paste/main/ts/core/Utils.ts
+++ b/src/plugins/paste/main/ts/core/Utils.ts
@@ -54,12 +54,17 @@ function innerText(html: string) {
       return;
     }
 
-    // img/input/hr
+    // Ignore wbr, to replicate innerText on Chrome/Firefox
+    if (name === 'wbr') {
+      return;
+    }
+
+    // img/input/hr but ignore wbr as it's just a potential word break
     if (shortEndedElements[name]) {
       text += ' ';
     }
 
-    // Ingore script, video contents
+    // Ignore script, video contents
     if (ignoreElements[name]) {
       text += ' ';
       return;

--- a/src/plugins/paste/test/ts/browser/PasteTest.ts
+++ b/src/plugins/paste/test/ts/browser/PasteTest.ts
@@ -674,6 +674,11 @@ UnitTest.asynctest('tinymce.plugins.paste.browser.ImagePasteTest', function () {
     LegacyUnit.equal(Utils.innerText(editor.getBody().innerHTML), 'a\nb');
   });
 
+  suite.test('paste innerText of P with WBR', function (editor) {
+    editor.setContent('<p>a<wbr>b</p>');
+    LegacyUnit.equal(Utils.innerText(editor.getBody().innerHTML), 'ab');
+  });
+
   suite.test('paste innerText of P with VIDEO', function (editor) {
     editor.setContent('<p>a<video>b<br>c</video>d</p>');
     LegacyUnit.equal(Utils.innerText(editor.getBody().innerHTML), 'a d');


### PR DESCRIPTION
Fixes #4559 

Fixed an issue where "wbr" elements were being transformed into a space when pasting as text, when it should have just been ignored (or at least that's the behaviour Opera, Firefox and Chrome for innerText).