### PR TITLE
Fixes an exception being thrown when attempting to remove formatting

### DIFF
--- a/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/src/core/main/ts/fmt/RemoveFormat.ts
@@ -380,6 +380,12 @@ const remove = function (ed: Editor, name: string, vars?, node?, similar?) {
     return wrapAndSplit(ed, formatList, formatRoot, container, container, true, format, vars);
   };
 
+  const isRemoveBookmarkNode = function (node: Node) {
+    // Make sure to only check for bookmarks created here (eg _start or _end)
+    // as there maybe nested bookmarks
+    return Bookmarks.isBookmarkNode(node) && NodeType.isElement(node) && (node.id === '_start' || node.id === '_end');
+  };
+
   // Merges the styles for each node
   const process = function (node) {
     let children, i, l, lastContentEditable, hasContentEditableState;
@@ -424,7 +430,7 @@ const remove = function (ed: Editor, name: string, vars?, node?, similar?) {
     // If the end is placed within the start the result will be removed
     // So this checks if the out node is a bookmark node if it is it
     // checks for another more suitable node
-    if (Bookmarks.isBookmarkNode(out)) {
+    if (isRemoveBookmarkNode(out)) {
       out = out[start ? 'firstChild' : 'lastChild'];
     }
 

--- a/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -23,6 +23,10 @@ UnitTest.asynctest('browser.tinymce.core.fmt.RemoveFormatTest', (success, failur
       split: true,
       expand: false
     }];
+    const boldFormat = [{
+      inline: 'strong',
+      remove: 'all'
+    }];
 
     Pipeline.async({}, [
       tinyApis.sFocus,
@@ -56,6 +60,15 @@ UnitTest.asynctest('browser.tinymce.core.fmt.RemoveFormatTest', (success, failur
           tinyApis.sAssertSelection([0, 0], 1, [0, 0], 1)
         ])),
       ])),
+      Logger.t('Remove single format with collapsed selection', GeneralSteps.sequence([
+        Logger.t('In middle of first of two words wrapped in strong and em', GeneralSteps.sequence([
+          tinyApis.sSetContent('<p><em><strong>ab cd</strong></em></p>'),
+          tinyApis.sSetCursor([0, 0, 0, 0], 1),
+          sRemoveFormat(editor, boldFormat),
+          tinyApis.sAssertContent('<p><em>ab<strong> cd</strong></em></p>'),
+          tinyApis.sAssertSelection([0, 0, 0], 1, [0, 0, 0], 1)
+        ])),
+      ]))
     ], onSuccess, onFailure);
   }, {
     plugins: '',


### PR DESCRIPTION
Fixes #4636 

Fixed an issue where trying to remove formatting with a collapsed selection range would throw an exception. This was caused because when a selection isn't made, it determines the range based on the caret position, which internally creates a persistent bookmark. However the remove format logic also uses it's own set of bookmarks and when trying to unwrap those bookmarks it checks to make sure it's not picking up it's own bookmark, but this logic was checking against all bookmark nodes and would therefore try to get a non existent child node.