### PR TITLE
Bind toolbar events to an editor's ui_container

### DIFF
--- a/src/themes/inlite/main/ts/alien/UiContainer.ts
+++ b/src/themes/inlite/main/ts/alien/UiContainer.ts
@@ -6,11 +6,9 @@
  */
 
 import { Option } from '@ephox/katamari';
-import Env from 'tinymce/core/api/Env';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 
-const getUiContainerDelta = function (): Option<{x: number, y: number}> {
-  const uiContainer = Env.container;
+const getUiContainerDelta = function (uiContainer): Option<{x: number, y: number}> {
   if (uiContainer && DOMUtils.DOM.getStyle(uiContainer, 'position', true) !== 'static') {
     const containerPos = DOMUtils.DOM.getPos(uiContainer);
     const dx = containerPos.x - uiContainer.scrollLeft;

--- a/src/themes/inlite/main/ts/core/Render.ts
+++ b/src/themes/inlite/main/ts/core/Render.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Env from 'tinymce/core/api/Env';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Delay from 'tinymce/core/api/util/Delay';
 import DeepFlatten from '../alien/DeepFlatten';
@@ -118,9 +117,9 @@ const bindContextualToolbarsEvents = function (editor: Editor, panel: InlitePane
   editor.on('ResizeEditor keyup', throttledTogglePanel);
   editor.on('ResizeWindow', reposition);
 
-  DOMUtils.DOM.bind(Env.container, 'scroll', reposition);
+  DOMUtils.DOM.bind(editor.settings.ui_container, 'scroll', reposition);
   editor.on('remove', function () {
-    DOMUtils.DOM.unbind(Env.container, 'scroll', reposition);
+    DOMUtils.DOM.unbind(editor.settings.ui_container, 'scroll', reposition);
     panel.remove();
   });
 

--- a/src/themes/inlite/main/ts/ui/Panel.ts
+++ b/src/themes/inlite/main/ts/ui/Panel.ts
@@ -130,7 +130,7 @@ export const create = (): InlitePanel => {
     }
 
     if (result) {
-      const delta = UiContainer.getUiContainerDelta().getOr({ x: 0, y: 0 });
+      const delta = UiContainer.getUiContainerDelta(editor.settings.ui_container).getOr({ x: 0, y: 0 });
       const transposedPanelRect = { x: result.rect.x - delta.x, y: result.rect.y - delta.y, w: result.rect.w, h: result.rect.h };
       currentRect = targetRect;
       movePanelTo(panel, Layout.userConstrain(userConstainHandler, targetRect, contentAreaRect, transposedPanelRect));


### PR DESCRIPTION
There is a bug in TinyMCE where if you create a new editor instance with the "ui_container" option, all previous instances behave as though they were given the same option.

This means that using "ui_container" doesn't fix the issue with colour-pickers and drop-downs becoming un-moored (https://github.com/tinymce/tinymce/issues/3592), if there are editors in different scrollable areas on a page.

By the looks of things this is not intentional because each editor has its own "ui_containter" property in addition to the shared "ui_container" environment variable. I've changed one place where the environment variable is used when I believe using the local container makes sense.

`grunt test` gives the same errors as master.
`grunt lint` passes.