### PR TITLE
[Shadow DOM] Enhance range validation to support ranges encapsulated by shadow roots

### DIFF
--- a/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/src/core/main/ts/api/dom/DOMUtils.ts
@@ -224,6 +224,7 @@ export interface DOMUtils {
   destroy: () => void;
   isChildOf: (node: Node, parent: Node) => boolean;
   dumpRng: (r: Range) => string;
+  getTopLevelShadowHost: (node: Node) => Node;
 }
 
 /**
@@ -1198,6 +1199,26 @@ export function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}
     return false;
   };
 
+  const getTopLevelShadowHost = (node: Node): Node => {
+    let topShadowHost = null;
+    let shadowHost = node;
+    while (shadowHost = getParentShadowHost(shadowHost)) {
+      topShadowHost = shadowHost;
+    }
+    return topShadowHost;
+  };
+
+  const getElementShadowHost = (element: any): Node => {
+    return element.host;
+  };
+
+  const getParentShadowHost = (node: Node): Node => {
+    while (node.parentNode) {
+      node = node.parentNode;
+    }
+    return getElementShadowHost(node);
+  };
+
   const dumpRng = (r: Range) => {
     return (
       'startContainer: ' + r.startContainer.nodeName +
@@ -1891,7 +1912,8 @@ export function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}
      */
     destroy,
     isChildOf,
-    dumpRng
+    dumpRng,
+    getTopLevelShadowHost
   };
 
   attrHooks = setupAttrHooks(styles, settings, () => self);

--- a/src/core/main/ts/api/dom/Selection.ts
+++ b/src/core/main/ts/api/dom/Selection.ts
@@ -82,9 +82,9 @@ export interface Selection {
   getSelectedBlocks: (startElm?: Element, endElm?: Element) => Element[];
   normalize: () => Range;
   selectorChanged: (selector: string, callback: (active: boolean, args: {
-      node: Node;
-      selector: String;
-      parents: Element[];
+    node: Node;
+    selector: String;
+    parents: Element[];
   }) => void) => any;
   getScrollContainer: () => HTMLElement;
   scrollIntoView: (elm: Element, alignToTop?: boolean) => void;
@@ -270,7 +270,28 @@ export const Selection = function (dom: DOMUtils, win: Window, serializer, edito
    * @method getSel
    * @return {Selection} Internal browser selection object.
    */
-  const getSel = (): NativeSelection => win.getSelection ? win.getSelection() : (<any> win.document).selection;
+  const getSel = (): NativeSelection => {
+    let selectionRoot: any = win;
+    try {
+      // We need to return Shadow Root if target element is under Shadow DOM and not using iframe
+      if (!editor.iframeElement && editor.targetElm.matches && editor.targetElm.matches(':host *')) {
+        (function (target: any) {
+          while (target.parentNode) {
+            target = target.parentNode;
+          }
+          // If there is no parent node, but there is `host` property - we've just found Shadow Root,
+          // where we'll get selection
+          if (target.host) {
+            selectionRoot = target;
+          }
+        })(editor.targetElm);
+      }
+    } catch (err) {
+      // Nothing, even if `.matches` method is present - it doesn't mean that browsers understands ':host *' selector
+    }
+
+    return selectionRoot.getSelection ? selectionRoot.getSelection() : (<any>win.document).selection;
+  }
 
   /**
    * Returns the browsers internal range object.

--- a/src/core/test/ts/browser/api/dom/DOMUtilsTest.ts
+++ b/src/core/test/ts/browser/api/dom/DOMUtilsTest.ts
@@ -1,0 +1,57 @@
+import { Assertions, Logger, Pipeline, Step } from '@ephox/agar';
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import ViewBlock from '../../../module/test/ViewBlock';
+import { UnitTest } from '@ephox/bedrock';
+import { document } from '@ephox/dom-globals';
+
+UnitTest.asynctest('browser.tinymce.core.api.dom.DOMUtilsTest', function () {
+  const success = arguments[arguments.length - 2];
+  const failure = arguments[arguments.length - 1];
+
+  const DOM = DOMUtils.DOM;
+
+  const viewBlock = ViewBlock();
+
+  const sTestNotShadowHost = Logger.t('No shadow host returns null', Step.sync(function () {
+    viewBlock.update('<div></div>');
+    Assertions.assertEq('label', null, DOM.getTopLevelShadowHost(viewBlock.get()));
+  }));
+
+  const sTestSingleShadowHost = Logger.t('Single level returns shadow host', Step.sync(function () {
+    viewBlock.update('<div></div>');
+    const div = viewBlock.get().firstElementChild;
+    if (div.attachShadow) {
+      const shadow = div.attachShadow({mode: 'open'});
+      const para = document.createElement('p');
+      shadow.appendChild(para);
+
+      Assertions.assertEq('label', div, DOM.getTopLevelShadowHost(para));
+    }
+  }));
+
+  const sTestMultiShadowHost = Logger.t('Multi level returns shadow host', Step.sync(function () {
+    viewBlock.update('<div></div>');
+    const div = viewBlock.get().firstElementChild;
+    if (div.attachShadow) {
+      const shadow = div.attachShadow({mode: 'open'});
+      const para = document.createElement('p');
+      shadow.appendChild(para);
+
+      const shadow2 = para.attachShadow({mode: 'open'});
+      const para2 = document.createElement('p');
+      shadow2.appendChild(para2);
+
+      Assertions.assertEq('label', div, DOM.getTopLevelShadowHost(para2));
+    }
+  }));
+
+  viewBlock.attach();
+  Pipeline.async({}, [
+    sTestNotShadowHost,
+    sTestSingleShadowHost,
+    sTestMultiShadowHost,
+  ], function () {
+    viewBlock.detach();
+    success();
+  }, failure);
+});

--- a/src/core/test/ts/browser/api/dom/SelectionRangeTest.ts
+++ b/src/core/test/ts/browser/api/dom/SelectionRangeTest.ts
@@ -1,0 +1,86 @@
+import { Assertions, Logger, Pipeline, Step } from '@ephox/agar';
+import { TinyLoader } from '@ephox/mcagar';
+import { Selection } from 'tinymce/core/api/dom/Selection';
+import Theme from 'tinymce/themes/modern/Theme';
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import ViewBlock from '../../../module/test/ViewBlock';
+import { UnitTest } from '@ephox/bedrock';
+import { document } from '@ephox/dom-globals';
+
+UnitTest.asynctest('browser.tinymce.core.api.dom.SelectionRangeTest', function () {
+  const success = arguments[arguments.length - 2];
+  const failure = arguments[arguments.length - 1];
+
+  const validateRangeTest = function (root, shouldSetRange, editor) {
+
+      const selection = Selection(DOM, DOM.win, null, editor);
+      const rng = document.createRange();
+      rng.setStartBefore(root.firstElementChild.firstElementChild);
+      rng.setEndAfter(root.firstElementChild.firstElementChild);
+
+      selection.setRng(rng);
+      const selected = selection.getRng();
+      Assertions.assertEq('range set', shouldSetRange, root.firstElementChild === selected.startContainer);
+  };
+
+  const innerHtml = '<p><span>Blue</span><span>Orange</span></p>';
+
+  Theme();
+
+  const DOM = DOMUtils.DOM;
+  const viewBlock = ViewBlock();
+
+  TinyLoader.setup(function (editor, onSuccess, onFailure) {
+
+    const sTestSimpleDocumentRange = Logger.t('Sets simple range in document', Step.sync(function () {
+      viewBlock.update(innerHtml);
+      const div = viewBlock.get();
+
+      validateRangeTest(div, true, editor);
+    }));
+
+    const sTestSimpleDocumentRangeNotAttached = Logger.t('Unattached simple range not set', Step.sync(function () {
+      const div = document.createElement('div');
+      DOMUtils.DOM.setHTML(div, innerHtml);
+
+      validateRangeTest(div, false, editor);
+    }));
+
+    const sTestShadowRootRange = Logger.t('Sets shadow range in document', Step.sync(function () {
+      viewBlock.update('<div></div>');
+      const div = viewBlock.get().firstElementChild;
+
+      if (div.attachShadow) {
+        const shadow = div.attachShadow({mode: 'open'});
+        DOMUtils.DOM.setHTML(shadow, innerHtml);
+
+        validateRangeTest(shadow, true, editor);
+      }
+    }));
+
+    const sTestShadowRootRangeNotAttached = Logger.t('Unattached shadow range not set', Step.sync(function () {
+      const div = document.createElement('div');
+      if (div.attachShadow) {
+        const shadow = div.attachShadow({mode: 'open'});
+        DOMUtils.DOM.setHTML(shadow, innerHtml);
+
+        validateRangeTest(shadow, false, editor);
+      }
+    }));
+
+    viewBlock.attach();
+
+    Pipeline.async({}, [
+      sTestSimpleDocumentRange,
+      sTestSimpleDocumentRangeNotAttached,
+      sTestShadowRootRange,
+      sTestShadowRootRangeNotAttached
+    ], onSuccess, onFailure);
+  }, {
+    skin_url: '/project/js/tinymce/skins/lightgray',
+    inline: true
+  }, function () {
+    viewBlock.detach();
+    success();
+  }, failure);
+});


### PR DESCRIPTION
We're trying to get tinymce working in web components that utilize shadow DOM. Our initial usage of tinymce is for an inline editor with a simple toolbar.

My intent is to create a number of small PRs that progressively fix more issues required in order to make our use cases work, rather than one big blanket PR that makes all tinymce use cases support shadow DOM.

This PR fixes the range validation so that if the range is encapsulated by a shadow root the range still validates as being contained by the document. It finds the top level shadow hosts for the start and end of the selection and validates that they are contained by the document.