### PR TITLE
[Shadow DOM] Modify DOMUtils.get to use query selector rather than getElementById

### DIFF
--- a/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/src/core/main/ts/api/dom/DOMUtils.ts
@@ -285,12 +285,13 @@ export function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}
   };
 
   const get = (elm: Node | string): HTMLElement => {
-    if (elm && doc && typeof elm === 'string') {
-      const node = doc.getElementById(elm);
+    const root = settings.root_element || doc;
+    if (elm && root && typeof elm === 'string') {
+      const node = root.querySelector(`#${elm}`) as HTMLElement;
 
       // IE and Opera returns meta elements when they match the specified input ID, but getElementsByName seems to do the trick
       if (node && node.id !== elm) {
-        return doc.getElementsByName(elm)[1];
+        return root.querySelector(`[name='${elm}']`)[1];
       } else {
         return node;
       }

--- a/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -191,6 +191,29 @@ UnitTest.asynctest('browser.tinymce.core.dom.DomUtilsTest', function () {
     LegacyUnit.equal(DOM.createHTML('span', null, 'content <b>abc</b>'), '<span>content <b>abc</b></span>');
   });
 
+  suite.test('get', function () {
+    DOM.add(document.body, 'div', { id : 'test', class: 'abc 123' });
+    LegacyUnit.equal(DOM.get('test').className, 'abc 123');
+
+    DOM.remove('test');
+  });
+
+  suite.test('get (shadow root)', function () {
+    const host = DOM.add(document.body, 'div', { id : 'test' });
+    if (host.attachShadow) {
+      const shadow = host.attachShadow({mode: 'open'});
+      const rootElement = DOM.add(shadow, 'p', { class : 'abc 123' }, '<span id="local" class="shadowy"><b>abc</b></span>');
+
+      let localDom = DOM.get('local');
+      LegacyUnit.equal(localDom, null, 'Should not be found unless set root element');
+
+      const domWithRootElement = DOMUtils(document, { root_element: rootElement });
+      localDom = domWithRootElement.get('local');
+      LegacyUnit.equal(localDom.className, 'shadowy', 'Should be found via root element');
+    }
+    DOM.remove('test');
+  });
+
   suite.test('uniqueId', function () {
     LegacyUnit.equal(DOM.uniqueId(), 'mce_0');
     LegacyUnit.equal(DOM.uniqueId(), 'mce_1');


### PR DESCRIPTION
…to support shadow roots

We're trying to get tinymce working in web components that utilize shadow DOM. Our initial usage of tinymce is for an inline editor with a simple toolbar.

My intent is to create a number of small PRs that progressively fix more issues required in order to make our use cases work, rather than one big blanket PR that makes all tinymce use cases support shadow DOM.

This PR enhances DOMUtil.get so that it will use a querySelector rather than getElementById so that it can find elements contained in shadow roots. It uses the root element of the editor as the target for the querySelector.

[Resubmitted to clean up commits and fix assignment to const issue]