### PR TITLE
TINY-2194 Exception in Firefox if a file input element has focus when tinymce is initialized

### DIFF
--- a/src/core/main/ts/api/dom/Selection.ts
+++ b/src/core/main/ts/api/dom/Selection.ts
@@ -315,7 +315,7 @@ export const Selection = function (dom: DOMUtils, win: Window, serializer, edito
     }
 
     try {
-      if ((selection = getSel())) {
+      if ((selection = getSel()) && !Tools.isRestricted(selection.anchorNode)) {
         if (selection.rangeCount > 0) {
           rng = selection.getRangeAt(0);
         } else {

--- a/src/core/main/ts/api/util/Tools.ts
+++ b/src/core/main/ts/api/util/Tools.ts
@@ -90,6 +90,10 @@ const hasOwnProperty = function (obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 };
 
+const isRestricted = function (element) {
+  return !!element && !Object.getPrototypeOf(element);
+};
+
 /**
  * Creates a class, subclass or static singleton.
  * More details on this method can be found in the Wiki.
@@ -446,6 +450,15 @@ export default {
   inArray: ArrUtils.indexOf,
 
   hasOwn: hasOwnProperty,
+
+  /**
+   * Returns true if element is Restricted (due to cross origin limitation or not visible on quantum engine)
+   *
+   * @method isRestricted
+   * @param {any} a dom element, unassigned safe
+   * @return true if object is restricted, otherwise false
+  */
+  isRestricted,
 
   extend,
   create,

--- a/src/core/main/ts/selection/SelectionBookmark.ts
+++ b/src/core/main/ts/selection/SelectionBookmark.ts
@@ -9,6 +9,7 @@ import { Fun, Option } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Compare, Element, Node, Text, Traverse, Selection } from '@ephox/sugar';
 import { document } from '@ephox/dom-globals';
+import Tools from '../api/util/Tools';
 
 const browser = PlatformDetection.detect().browser;
 
@@ -34,7 +35,7 @@ const normalizeRng = function (rng) {
 };
 
 const isOrContains = function (root, elm) {
-  return Compare.contains(root, elm) || Compare.eq(root, elm);
+  return !(elm && Tools.isRestricted(elm.dom())) && (Compare.contains(root, elm) || Compare.eq(root, elm));
 };
 
 const isRngInRoot = function (root) {


### PR DESCRIPTION
I reproduced the issue to be present as well on numeric input field.
It is related to selectionchange event to which previously initialised tinymce instance is subscribed to.

In my case problem occurrs on tinymce component in the angular 6 application, no iframes are present.

Latest firefox browser has selection's nodes filled in with Restricted value, I implemented 2 checks for this which seem to be enough when handling selectionchange event causing the exceptions and thus it should not have negative impact on performance.

There seem to be no workaround - setting event_root would not make any difference for selectionchange handler.

I previously signed the agreement.