### PR TITLE
[Shadow DOM] Allow selection from target encapsulated by a shadow root

### DIFF
--- a/src/core/test/ts/browser/api/dom/SelectionTest.ts
+++ b/src/core/test/ts/browser/api/dom/SelectionTest.ts
@@ -1,0 +1,65 @@
+import { Assertions, Logger, Pipeline, Step } from '@ephox/agar';
+import { TinyLoader } from '@ephox/mcagar';
+import { Selection } from 'tinymce/core/api/dom/Selection';
+import Theme from 'tinymce/themes/modern/Theme';
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import ViewBlock from '../../../module/test/ViewBlock';
+import { UnitTest } from '@ephox/bedrock';
+import { document } from '@ephox/dom-globals';
+
+UnitTest.asynctest('browser.tinymce.core.api.dom.SelectionTest', function () {
+  const success = arguments[arguments.length - 2];
+  const failure = arguments[arguments.length - 1];
+
+  Theme();
+
+  const DOM = DOMUtils.DOM;
+  const viewBlock = ViewBlock();
+
+  TinyLoader.setup(function (editor, onSuccess, onFailure) {
+
+    const sTestEmptyDocumentSelection = Logger.t('Returns empty document selection', Step.sync(function () {
+      document.getSelection().removeAllRanges();
+      const selection = Selection(DOM, DOM.win, null, editor);
+      Assertions.assertEq('empty selection', null, selection.getSel().anchorNode);
+    }));
+
+    const sTestSimpleDocumentSelection = Logger.t('Returns document selection', Step.sync(function () {
+      viewBlock.attach();
+      document.getSelection().selectAllChildren(viewBlock.get());
+
+      const selection = Selection(DOM, DOM.win, null, editor);
+      Assertions.assertEq('document selection', 'DIV', selection.getSel().anchorNode.nodeName);
+    }));
+
+    const sTestSimpleShadowSelection = Logger.t('Returns shadow root selection', Step.sync(function () {
+      const div = viewBlock.get();
+      if (div.attachShadow) {
+        const shadow = div.attachShadow({mode: 'open'});
+        shadow.appendChild(editor.targetElm);
+        const para = document.createElement('p');
+        para.textContent = 'how now brown cow';
+        editor.targetElm.appendChild(para);
+        viewBlock.attach();
+        const selectionRoot = shadow.getSelection ? shadow : document;
+        selectionRoot.getSelection().selectAllChildren(editor.targetElm);
+
+        const selection = Selection(DOM, DOM.win, null, editor);
+        Assertions.assertEq('shadow selection', true, selection.getSel().containsNode(para.firstChild, false));
+    }
+
+    }));
+
+    Pipeline.async({}, [
+      sTestEmptyDocumentSelection,
+      sTestSimpleDocumentSelection,
+      sTestSimpleShadowSelection
+    ], onSuccess, onFailure);
+  }, {
+    skin_url: '/project/js/tinymce/skins/lightgray',
+    inline: true
+  }, function () {
+    viewBlock.detach();
+    success();
+  }, failure);
+});


### PR DESCRIPTION
Extracting ideas from PR #561 that was never merged, to begin adding support for Shadow DOM:

Re-submit of #4720 with tweaks to support shadow DOM in browsers other than Chrome where the DocumentOrShadowRoot mixin is still implemented on the document interface.

We're trying to get tinymce working in web components that utilize shadow DOM. Our initial usage of tinymce is for an inline editor with a simple toolbar.

My intent is to create a number of small PRs that progressively fix more issues required in order to make our use cases work, rather than one big blanket PR that makes all tinymce use cases support shadow DOM.

This PR fixes the selection so that if an editor is encapsulated by a shadow root, the current selection is obtained from the shadow root's selection rather than the window selection.

Also attempted to add some tests, (there were previously no tests for the Selection function.
Tried to glean what I could from reading other tinymce tests, but not sure if what I have come up with is particularly clean or standard for writing tinymce tests.