### PR TITLE
Namespace figure "image" class

### DIFF
--- a/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/src/core/main/ts/api/dom/ControlSelection.ts
@@ -120,7 +120,7 @@ const ControlSelection = (selection: Selection, editor: Editor): ControlSelectio
   );
 
   const isImage = function (elm) {
-    return elm && (elm.nodeName === 'IMG' || editor.dom.is(elm, 'figure.image'));
+    return elm && (elm.nodeName === 'IMG' || editor.dom.is(elm, 'figure.mce-image'));
   };
 
   const isEventOnImageOutsideRange = function (evt, range) {
@@ -137,7 +137,7 @@ const ControlSelection = (selection: Selection, editor: Editor): ControlSelectio
   };
 
   const getResizeTarget = function (elm) {
-    return editor.dom.is(elm, 'figure.image') ? elm.querySelector('img') : elm;
+    return editor.dom.is(elm, 'figure.mce-image') ? elm.querySelector('img') : elm;
   };
 
   const isResizable = function (elm) {
@@ -148,7 +148,7 @@ const ControlSelection = (selection: Selection, editor: Editor): ControlSelectio
     }
 
     if (typeof selector !== 'string') {
-      selector = 'table,img,figure.image,div';
+      selector = 'table,img,figure.mce-image,div';
     }
 
     if (elm.getAttribute('data-mce-resize') === 'false') {
@@ -435,7 +435,7 @@ const ControlSelection = (selection: Selection, editor: Editor): ControlSelectio
     });
 
     controlElm = e.type === 'mousedown' ? e.target : selection.getNode();
-    controlElm = dom.$(controlElm).closest('table,img,figure.image,hr')[0];
+    controlElm = dom.$(controlElm).closest('table,img,figure.mce-image,hr')[0];
 
     if (isChildOrEqual(controlElm, rootElement)) {
       disableGeckoResize();

--- a/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/src/core/main/ts/fmt/DefaultFormats.ts
@@ -23,9 +23,9 @@ const get = function (dom) {
 
     alignleft: [
       {
-        selector: 'figure.image',
+        selector: 'figure.mce-image',
         collapsed: false,
-        classes: 'align-left',
+        classes: 'mce-align-left',
         ceFalseOverride: true,
         preview: 'font-family font-size'
       },
@@ -59,9 +59,9 @@ const get = function (dom) {
         defaultBlock: 'div'
       },
       {
-        selector: 'figure.image',
+        selector: 'figure.mce-image',
         collapsed: false,
-        classes: 'align-center',
+        classes: 'mce-align-center',
         ceFalseOverride: true,
         preview: 'font-family font-size'
       },
@@ -88,9 +88,9 @@ const get = function (dom) {
 
     alignright: [
       {
-        selector: 'figure.image',
+        selector: 'figure.mce-image',
         collapsed: false,
-        classes: 'align-right',
+        classes: 'mce-align-right',
         ceFalseOverride: true,
         preview: 'font-family font-size'
       },

--- a/src/plugins/image/main/ts/core/ImageData.ts
+++ b/src/plugins/image/main/ts/core/ImageData.ts
@@ -202,7 +202,7 @@ const create = (normalizeCss: CssNormalizer, data: ImageData): HTMLElement => {
   setAttrib(image, 'alt', data.alt);
 
   if (data.caption) {
-    const figure = DOM.create('figure', { class: 'image' });
+    const figure = DOM.create('figure', { class: 'mce-image' });
 
     figure.appendChild(image);
     figure.appendChild(DOM.create('figcaption', { contentEditable: true }, 'Caption'));

--- a/src/plugins/image/main/ts/core/ImageSelection.ts
+++ b/src/plugins/image/main/ts/core/ImageSelection.ts
@@ -19,7 +19,7 @@ const normalizeCss = (editor: Editor, cssText: string): string => {
 
 const getSelectedImage = (editor: Editor): HTMLElement => {
   const imgElm = editor.selection.getNode() as HTMLElement;
-  const figureElm = editor.dom.getParent(imgElm, 'figure.image') as HTMLElement;
+  const figureElm = editor.dom.getParent(imgElm, 'figure.mce-image') as HTMLElement;
 
   if (figureElm) {
     return editor.dom.select('img', figureElm)[0];
@@ -78,7 +78,7 @@ const syncSrcAttr = (editor: Editor, image: HTMLElement) => {
 
 const deleteImage = (editor: Editor, image: HTMLElement) => {
   if (image) {
-    const elm = editor.dom.is(image.parentNode, 'figure.image') ? image.parentNode : image;
+    const elm = editor.dom.is(image.parentNode, 'figure.mce-image') ? image.parentNode : image;
 
     editor.dom.remove(elm);
     editor.focus();

--- a/src/skins/lightgray/main/less/desktop/Content.Objects.less
+++ b/src/skins/lightgray/main/less/desktop/Content.Objects.less
@@ -42,32 +42,32 @@
   background: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
 }
 
-figure.align-left {
+figure.mce-align-left {
   float: left;
 }
 
-figure.align-right {
+figure.mce-align-right {
   float: right;
 }
 
-figure.image.align-center {
+figure.mce-image.mce-align-center {
   display: table;
   margin-left: auto;
   margin-right: auto;
 }
 
-figure.image {
+figure.mce-image {
   display: inline-block;
   border: 1px solid gray;
   margin: 0 2px 0 1px;
   background: #f5f2f0;
 }
 
-figure.image img {
+figure.mce-image img {
   margin: 8px 8px 0 8px;
 }
 
-figure.image figcaption {
+figure.mce-image figcaption {
   margin: 6px 8px 6px 8px;
   text-align: center;
 }


### PR DESCRIPTION
When inserting an image with the Image plugin, and adding a caption, a class of "image" is added to the <figure> tag that is wrapped around the image.

This class is used to style the <figure>, <img> and <figcaption> tags, and used as a selector for formatting and for control selection / resize.

As this is in some ways an internal class name, and could theoretically conflict with a class of the same name in a CMS or CSS framework, the <figure> class names should be namespaced with an "mce-" prefix, eg: "mce-image"