### PR TITLE
[ShadowDOM] add invalid_classes setting

### DIFF
--- a/src/core/main/ts/api/html/Schema.ts
+++ b/src/core/main/ts/api/html/Schema.ts
@@ -14,6 +14,7 @@ interface Schema {
   elements: { [name: string]: ElementRule; };
   getValidStyles: () => SchemaMap;
   getValidClasses: () => SchemaMap;
+  getInvalidClasses: () => SchemaMap;
   getBlockElements: () => SchemaMap;
   getInvalidStyles: () => SchemaMap;
   getShortEndedElements: () => SchemaMap;
@@ -387,7 +388,7 @@ function Schema(settings?) {
   let validStyles;
   let invalidStyles;
   let schemaItems;
-  let whiteSpaceElementsMap, selfClosingElementsMap, shortEndedElementsMap, boolAttrMap, validClasses;
+  let whiteSpaceElementsMap, selfClosingElementsMap, shortEndedElementsMap, boolAttrMap, validClasses, invalidClasses;
   let blockElementsMap, nonEmptyElementsMap, moveCaretBeforeOnEnterElementsMap, textBlockElementsMap, textInlineElementsMap;
   const customElementsMap = {}, specialElements = {} as SchemaRegExpMap;
 
@@ -424,6 +425,7 @@ function Schema(settings?) {
   validStyles = compileElementMap(settings.valid_styles);
   invalidStyles = compileElementMap(settings.invalid_styles, 'map');
   validClasses = compileElementMap(settings.valid_classes, 'map');
+  invalidClasses = compileElementMap(settings.invalid_classes, 'map');
 
   // Setup map objects
   whiteSpaceElementsMap = createLookupTable(
@@ -840,6 +842,14 @@ function Schema(settings?) {
   const getValidClasses = (): SchemaMap => validClasses;
 
   /**
+   * Name/value map object with invalid classes for each element.
+   *
+   * @method getInvalidClasses
+   * @type Object
+   */
+  const getInvalidClasses = (): SchemaMap => invalidClasses;
+
+  /**
    * Returns a map with boolean attributes.
    *
    * @method getBoolAttrs
@@ -1032,6 +1042,7 @@ function Schema(settings?) {
     elements,
     getValidStyles,
     getValidClasses,
+    getInvalidClasses,
     getBlockElements,
     getInvalidStyles,
     getShortEndedElements,

--- a/src/core/main/ts/html/ParserFilters.ts
+++ b/src/core/main/ts/html/ParserFilters.ts
@@ -171,11 +171,12 @@ const register = (parser, settings: any): void => {
     });
   }
 
-  if (settings.validate && schema.getValidClasses()) {
+  if (settings.validate && (schema.getValidClasses() || schema.getInvalidClasses())) {
     parser.addAttributeFilter('class', function (nodes) {
       let i = nodes.length, node, classList, ci, className, classValue;
       const validClasses = schema.getValidClasses();
-      let validClassesMap, valid;
+      const invalidClasses = schema.getInvalidClasses();
+      let validClassesMap, invalidClassesMap, valid;
 
       while (i--) {
         node = nodes[i];
@@ -186,14 +187,30 @@ const register = (parser, settings: any): void => {
           className = classList[ci];
           valid = false;
 
-          validClassesMap = validClasses['*'];
-          if (validClassesMap && validClassesMap[className]) {
+          if (validClasses) {
+            validClassesMap = validClasses['*'];
+            if (validClassesMap && validClassesMap[className]) {
+              valid = true;
+            }
+
+            validClassesMap = validClasses[node.name];
+            if (!valid && validClassesMap && validClassesMap[className]) {
+              valid = true;
+            }
+          } else {
             valid = true;
           }
 
-          validClassesMap = validClasses[node.name];
-          if (!valid && validClassesMap && validClassesMap[className]) {
-            valid = true;
+          if (valid && invalidClasses) {
+            invalidClassesMap = invalidClasses['*'];
+            if (invalidClassesMap && invalidClassesMap[className]) {
+              valid = false;
+            }
+
+            invalidClassesMap = invalidClasses[node.name];
+            if (valid && invalidClassesMap && invalidClassesMap[className]) {
+              valid = false;
+            }
           }
 
           if (valid) {

--- a/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/src/core/test/ts/browser/html/DomParserTest.ts
@@ -626,6 +626,48 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function () {
     LegacyUnit.equal(serializer.serialize(root), '<p class="classA classB"><strong class="classA classB classC">a</strong></p>');
   });
 
+  suite.test('Invalid classes', function () {
+    let parser, root;
+    const schema = Schema({ invalid_classes: 'classA classB' });
+
+    parser = DomParser({}, schema);
+    root = parser.parse('<p class="classA classB classC">a</p>');
+    LegacyUnit.equal(serializer.serialize(root), '<p class="classC">a</p>');
+  });
+
+  suite.test('Invalid classes multiple elements', function () {
+    let parser, root;
+    const schema = Schema({ invalid_classes: { '*': 'classA classB', 'strong': 'classC' } });
+
+    parser = DomParser({}, schema);
+    root = parser.parse('<p class="classA classB classC"><strong class="classA classB classC classD">a</strong></p>');
+    LegacyUnit.equal(serializer.serialize(root), '<p class="classC"><strong class="classD">a</strong></p>');
+  });
+
+  suite.test('Global invalid classes take precedence', function () {
+    let parser, root;
+    const schema = Schema({
+      valid_classes: { strong: 'classA classB' },
+      invalid_classes: { '*': 'classA' }
+    });
+
+    parser = DomParser({}, schema);
+    root = parser.parse('<p class="classA classB classC"><strong class="classA classB classC classD">a</strong></p>');
+    LegacyUnit.equal(serializer.serialize(root), '<p><strong class="classB">a</strong></p>');
+  });
+
+  suite.test('Element invalid classes take precedence', function () {
+    let parser, root;
+    const schema = Schema({
+      valid_classes: { '*': 'classA classB' },
+      invalid_classes: { strong: 'classA' }
+    });
+
+    parser = DomParser({}, schema);
+    root = parser.parse('<p class="classA classB classC"><strong class="classA classB classC classD">a</strong></p>');
+    LegacyUnit.equal(serializer.serialize(root), '<p class="classA classB"><strong class="classB">a</strong></p>');
+  });
+
   suite.test('Pad empty list blocks', function () {
     let parser, root;
     const schema = Schema();

--- a/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/src/core/test/ts/browser/html/SchemaTest.ts
@@ -573,6 +573,49 @@ UnitTest.asynctest('browser.tinymce.core.html.SchemaTest', function () {
     });
   });
 
+  suite.test('invalidClasses', function () {
+    let schema;
+
+    schema = Schema({ invalid_classes: 'classA,classB' });
+    LegacyUnit.deepEqual(schema.getInvalidClasses(), {
+      '*': {
+        classA: {},
+        classB: {}
+      }
+    });
+
+    schema = Schema({ invalid_classes: 'classA classB' });
+    LegacyUnit.deepEqual(schema.getInvalidClasses(), {
+      '*': {
+        classA: {},
+        classB: {}
+      }
+    });
+
+    schema = Schema({
+      invalid_classes: {
+        '*': 'classA classB',
+        'a': 'classC classD'
+      }
+    });
+    LegacyUnit.deepEqual(schema.getInvalidClasses(), {
+      '*': {
+        classA: {},
+        classB: {}
+      },
+
+      'a': {
+        classC: {},
+        classD: {}
+      },
+
+      'A': {
+        classC: {},
+        classD: {}
+      }
+    });
+  });
+
   Pipeline.async({}, suite.toSteps({}), function () {
     success();
   }, failure);


### PR DESCRIPTION
Add an invalid_classes setting similar to invalid_styles etc.

This was added to make it easy to remove the scope classes added by ShadyCSS when using tinymce in an encapsulated shadow root.