### PR TITLE
TINY-4810: update range offsets when changing range containers

### DIFF
--- a/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
@@ -41,7 +41,7 @@ const excludeTrailingWhitespace = function (endContainer, endOffset) {
     }
 
     if (leaf.node && leaf.offset > 0 && leaf.node.nodeType === 3 &&
-        leaf.node.nodeValue.charAt(leaf.offset - 1) === ' ') {
+      leaf.node.nodeValue.charAt(leaf.offset - 1) === ' ') {
 
       if (leaf.offset > 1) {
         endContainer = leaf.node;
@@ -280,26 +280,34 @@ const expandRng = function (editor: Editor, rng, format, remove?) {
   if (isBookmarkNode(startContainer.parentNode) || isBookmarkNode(startContainer)) {
     startContainer = isBookmarkNode(startContainer) ? startContainer : startContainer.parentNode;
     if (rng.collapsed) {
-      startContainer = startContainer.previousSibling || startContainer;
-    } else {
-      startContainer = startContainer.nextSibling || startContainer;
-    }
-
-    if (startContainer.nodeType === 3) {
-      startOffset = rng.collapsed ? startContainer.length : 0;
+      if (startContainer.previousSibling) {
+        startContainer = startContainer.previousSibling;
+        if (startContainer.nodeType === 3) {
+          startOffset = startContainer.length;
+        } else if (startContainer.nodeType === 1) {
+          startOffset = startContainer.childNodes.length;
+        }
+      }
+    } else if (startContainer.nextSibling) {
+      startContainer = startContainer.nextSibling;
+      startOffset = 0;
     }
   }
 
   if (isBookmarkNode(endContainer.parentNode) || isBookmarkNode(endContainer)) {
     endContainer = isBookmarkNode(endContainer) ? endContainer : endContainer.parentNode;
     if (rng.collapsed) {
-      endContainer = endContainer.nextSibling || endContainer;
-    } else {
-      endContainer = endContainer.previousSibling || endContainer;
-    }
-
-    if (endContainer.nodeType === 3) {
-      endOffset = rng.collapsed ? 0 : endContainer.length;
+      if (endContainer.nextSibling) {
+        endContainer = endContainer.nextSibling;
+        endOffset = 0;
+      }
+    } else if (endContainer.previousSibling) {
+      endContainer = endContainer.previousSibling;
+      if (endContainer.nodeType === 3) {
+        endOffset = endContainer.length;
+      } else if (endContainer.nodeType === 1) {
+        endOffset = endContainer.childNodes.length;
+      }
     }
   }
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
@@ -141,6 +141,11 @@ UnitTest.asynctest('browser.tinymce.core.fmt.ExpandRangeTest', function () {
           cSetRawContent('<p><span data-mce-type="bookmark">ab cd ef</span></p>'),
           cExpandRng([0, 0, 0], 3, [0, 0, 0], 5, inlineFormat, false),
           cAssertRange(editor, [], 0, [], 1)
+        ])),
+        Logger.t('In selection with bookmarks, where the first child of endContainer.previousSibling is a text node that ends with space', Chain.asStep(editor, [
+          cSetRawContent('<p><span><span data-mce-type="bookmark">&#65279;</span>ab <span>cd</span>ef</span><span data-mce-type="bookmark">&#65279;</span><br/></p>'),
+          cExpandRng([0, 0, 0], 1, [0, 1], 1, inlineFormat, false),
+          cAssertRange(editor, [], 0, [0], 1)
         ]))
       ])),
 


### PR DESCRIPTION
This pull request fixes the issue #4810.

This issue has occurred because of following steps:
1. Create a paragraph and style it to achieve following html structure
`<p><style1> some text <style2> some text </style2> some text </style1><br></p>`
2. When you triple click on paragraph to select the paragraph, firefox ends the selection before `br` tag after `style1`.
3. In the code changed in commit, `endContainer` was being switched to `previousSibling` which is `style1` but not updating the `endOffset`, which is still 1.
4. When this `endOffset` is passed to `excludeTrailingWhitespace` method, it changes the `endContainer` to first childNode of `style1`. (this is the issue)

**PS:** Updating the `startOffset` also for consistency