### PR TITLE
TINY-2194 Exception in Firefox if a file input element has focus when tinymce is initialized (4.9.4)

### DIFF
--- a/src/core/main/ts/api/dom/Selection.ts
+++ b/src/core/main/ts/api/dom/Selection.ts
@@ -315,7 +315,7 @@ export const Selection = function (dom: DOMUtils, win: Window, serializer, edito
     }
 
     try {
-      if ((selection = getSel())) {
+      if ((selection = getSel()) && !Tools.isRestricted(selection.anchorNode)) {
         if (selection.rangeCount > 0) {
           rng = selection.getRangeAt(0);
         } else {

--- a/src/core/main/ts/api/util/Tools.ts
+++ b/src/core/main/ts/api/util/Tools.ts
@@ -90,6 +90,10 @@ const hasOwnProperty = function (obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 };
 
+const isRestricted = function (element) {
+  return !!element && !Object.getPrototypeOf(element);
+};
+
 /**
  * Creates a class, subclass or static singleton.
  * More details on this method can be found in the Wiki.
@@ -446,6 +450,15 @@ export default {
   inArray: ArrUtils.indexOf,
 
   hasOwn: hasOwnProperty,
+
+  /**
+   * Returns true if element is Restricted (due to cross origin limitation or not visible on quantum engine)
+   *
+   * @method isRestricted
+   * @param {any} a dom element, unassigned safe
+   * @return true if object is restricted, otherwise false
+  */
+  isRestricted,
 
   extend,
   create,

--- a/src/core/main/ts/selection/SelectionBookmark.ts
+++ b/src/core/main/ts/selection/SelectionBookmark.ts
@@ -9,6 +9,7 @@ import { Fun, Option } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Compare, Element, Node, Text, Traverse, Selection } from '@ephox/sugar';
 import { document } from '@ephox/dom-globals';
+import Tools from '../api/util/Tools';
 
 const browser = PlatformDetection.detect().browser;
 
@@ -34,7 +35,7 @@ const normalizeRng = function (rng) {
 };
 
 const isOrContains = function (root, elm) {
-  return Compare.contains(root, elm) || Compare.eq(root, elm);
+  return !(elm && Tools.isRestricted(elm.dom())) && (Compare.contains(root, elm) || Compare.eq(root, elm));
 };
 
 const isRngInRoot = function (root) {


### PR DESCRIPTION
Please refer to TINY-2194 for more information. The issue still persists in 4.x branch, I was not able to check 5.x.

Firefox and edge are only browsers affected, issue is related to tinymce subscribing to whole document events while tinymce editors are removed from DOM by angular framework (invisible).

There is no workaround.