### PR TITLE
Touch events not working when the editor in a read-only mode

### DIFF
--- a/src/core/main/ts/api/EditorObservable.ts
+++ b/src/core/main/ts/api/EditorObservable.ts
@@ -61,7 +61,9 @@ const fireEvent = (editor: Editor, eventName: string, e: Event) => {
   if (isListening(editor)) {
     editor.fire(eventName, e);
   } else if (editor.readonly) {
-    e.preventDefault();
+    if (!(eventName === 'touchstart' || eventName === 'touchmove' || eventName === 'touchend')) {
+      e.preventDefault();
+    }
   }
 };
 
@@ -85,6 +87,13 @@ const bindEventDelegate = function (editor: Editor, eventName: string) {
   }
 
   eventRootElm = getEventTarget(editor, eventName);
+
+  let options: any;
+  if (eventName === 'touchstart' || eventName === 'touchmove' || eventName === 'touchend') {
+    options = {
+      passive: true
+    };
+  }
 
   if (editor.settings.event_root) {
     if (!customEventRootDelegates) {
@@ -123,13 +132,13 @@ const bindEventDelegate = function (editor: Editor, eventName: string) {
     };
 
     customEventRootDelegates[eventName] = delegate;
-    DOM.bind(eventRootElm, eventName, delegate);
+    DOM.bind(eventRootElm, eventName, delegate, null, options);
   } else {
     delegate = function (e) {
       fireEvent(editor, eventName, e);
     };
 
-    DOM.bind(eventRootElm, eventName, delegate);
+    DOM.bind(eventRootElm, eventName, delegate, null, options);
     editor.delegates[eventName] = delegate;
   }
 };

--- a/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/src/core/main/ts/api/dom/DOMUtils.ts
@@ -233,8 +233,8 @@ interface DOMUtils {
   createRng (): Range;
   nodeIndex (node: Node, normalized?: boolean): number;
   split (parentElm: Node, splitElm: Node, replacementElm?: Node): Node;
-  bind <K extends keyof HTMLElementEventMap>(target: Target, name: K, func: EventUtilsCallback<HTMLElementEventMap[K]>, scope?: {}): any;
-  bind <T = any>(target: Target, name: string, func: EventUtilsCallback<T>, scope?: {}): any;
+  bind <K extends keyof HTMLElementEventMap>(target: Target, name: K, func: EventUtilsCallback<HTMLElementEventMap[K]>, scope?: {}, options?: any): any;
+  bind <T = any>(target: Target, name: string, func: EventUtilsCallback<T>, scope?: {}, options?: any): any;
   unbind <K extends keyof HTMLElementEventMap>(target: Target, name: K, func: EventUtilsCallback<HTMLElementEventMap[K]>): any;
   unbind <T = any>(target: Target, name?: string, func?: EventUtilsCallback<T>): any;
   fire (target: Target, name: string, evt?: {}): EventUtils;
@@ -1105,13 +1105,13 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     }
   };
 
-  const bind = (target: Target, name: string, func: EventUtilsCallback<any>, scope?: any) => {
+  const bind = (target: Target, name: string, func: EventUtilsCallback<any>, scope?: any, options?: any) => {
     if (Tools.isArray(target)) {
       let i = target.length;
       const rv = [];
 
       while (i--) {
-        rv[i] = bind(target[i], name, func, scope);
+        rv[i] = bind(target[i], name, func, scope, options);
       }
 
       return rv;
@@ -1122,7 +1122,7 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
       boundEvents.push([target, name, func, scope]);
     }
 
-    return events.bind(target, name, func, scope || self);
+    return events.bind(target, name, func, scope || self, options);
   };
 
   const unbind = (target: Target, name?: string, func?: EventUtilsCallback<any>) => {

--- a/src/core/main/ts/api/dom/EventUtils.ts
+++ b/src/core/main/ts/api/dom/EventUtils.ts
@@ -286,9 +286,9 @@ class EventUtils {
    * @param {Object} scope Scope to call the callback function on, defaults to target.
    * @return {function} Callback function that got bound.
    */
-  public bind <K extends keyof HTMLElementEventMap>(target: any, name: K, callback: EventUtilsCallback<HTMLElementEventMap[K]>, scope?: {}): EventUtilsCallback<HTMLElementEventMap[K]>;
-  public bind <T = any>(target: any, names: string, callback: EventUtilsCallback<T>, scope?: {}): EventUtilsCallback<T>;
-  public bind (target: any, names: string, callback: EventUtilsCallback<any>, scope?: {}): EventUtilsCallback<any> {
+  public bind <K extends keyof HTMLElementEventMap>(target: any, name: K, callback: EventUtilsCallback<HTMLElementEventMap[K]>, scope?: {}, options?: any): EventUtilsCallback<HTMLElementEventMap[K]>;
+  public bind <T = any>(target: any, names: string, callback: EventUtilsCallback<T>, scope?: {}, options?: any): EventUtilsCallback<T>;
+  public bind (target: any, names: string, callback: EventUtilsCallback<any>, scope?: {}, options?: any): EventUtilsCallback<any> {
     const self = this;
     let id, callbackList, i, name, fakeName, nativeHandler, capture;
     const win = window;
@@ -394,7 +394,12 @@ class EventUtils {
         if (name === 'ready') {
           bindOnReady(target, nativeHandler, self);
         } else {
-          addEvent(target, fakeName || name, nativeHandler, capture);
+          if (options) {
+            options.capture = capture;
+            addEvent(target, fakeName || name, nativeHandler, options);
+          } else {
+            addEvent(target, fakeName || name, nativeHandler, capture);
+          }
         }
       } else {
         if (name === 'ready' && self.domLoaded) {


### PR DESCRIPTION
There are few issues with all recent versions of tinymce I tested on mobile devices - when editor is in the read only mode - editor.mode.set('readonly'), preventDefault is called on touch events and touch events are not bound using a passive flag causing warnings in the console (already reported bug).

There are multiple places touch events are registered without passive option (needs fixing) but editor.on EditorObservable used by both editor and theme is causing an issue on mobile devices where user cannot scroll up or down if editor uses most or all of the screen (only tapping on borders and outside the editor works).

To fix it I implemented a generic fix allowing passing of addEventListener options in DOMUtils and EventUtils and used by the EditorObservable only for touchstart, touchmove and touchend events allowing these to be registered with passive option and disallowing preventDefault on these events.

Fix partially improved Chrome console warnings about touch events and fixed the main problem of not being able to drag a readonly TinyMCE.

Hope you can include it in the latest version among my other 2 pull requests.