### PR TITLE
Exception in Firefox if a file input element has focus when tinymce is initialized (5.0.4)

### DIFF
--- a/src/core/main/ts/api/dom/Selection.ts
+++ b/src/core/main/ts/api/dom/Selection.ts
@@ -25,6 +25,7 @@ import { moveEndPoint, hasAnyRanges } from '../../selection/SelectionUtils';
 import Editor from '../Editor';
 import DOMUtils from './DOMUtils';
 import SelectorChanged from './SelectorChanged';
+import Tools from '../util/Tools';
 
 /**
  * This class handles text and control selection it's an crossbrowser utility class.
@@ -320,7 +321,7 @@ const Selection = function (dom: DOMUtils, win: Window, serializer, editor: Edit
     }
 
     try {
-      if ((selection = getSel())) {
+      if ((selection = getSel()) && !Tools.isRestricted(selection.anchorNode)) {
         if (selection.rangeCount > 0) {
           rng = selection.getRangeAt(0);
         } else {

--- a/src/core/main/ts/api/util/Tools.ts
+++ b/src/core/main/ts/api/util/Tools.ts
@@ -21,6 +21,7 @@ interface Tools {
   toArray <T>(obj: ArrayLike<T>): T[];
   hasOwn (obj: any, name: string): boolean;
   makeMap <T>(items: ArrayLike<T> | string, delim?: string | RegExp, map?: Record<string, T | string>): Record<string, T | string>;
+  isRestricted (element: any): boolean;
   each <T>(arr: ReadonlyArray<T>, cb: ArrayCallback<T, any>, scope?: any): void;
   each <T>(obj: T, cb: ObjCallback<T, any>, scope?: any): void;
   map <T, U>(arr: ReadonlyArray<T>, cb: ArrayCallback<T, U>, scope?: any): Array<U>;
@@ -113,6 +114,10 @@ const makeMap = function (items, delim?, map?) {
  */
 const hasOwnProperty = function (obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
+};
+
+const isRestricted = function (element) {
+  return !!element && !Object.getPrototypeOf(element);
 };
 
 /**
@@ -471,6 +476,15 @@ const Tools: Tools = {
   inArray: ArrUtils.indexOf,
 
   hasOwn: hasOwnProperty,
+
+  /**
+   * Returns true if element is Restricted (due to cross origin limitation or not visible on quantum engine)
+   *
+   * @method isRestricted
+   * @param {any} a dom element, unassigned safe
+   * @return true if object is restricted, otherwise false
+  */
+  isRestricted,
 
   extend,
   create,

--- a/src/core/main/ts/selection/SelectionBookmark.ts
+++ b/src/core/main/ts/selection/SelectionBookmark.ts
@@ -10,6 +10,7 @@ import { Fun, Option } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Compare, Element, Node, Text, Traverse, Selection } from '@ephox/sugar';
 import Editor from '../api/Editor';
+import Tools from '../api/util/Tools';
 
 const browser = PlatformDetection.detect().browser;
 
@@ -35,7 +36,7 @@ const normalizeRng = function (rng) {
 };
 
 const isOrContains = function (root, elm) {
-  return Compare.contains(root, elm) || Compare.eq(root, elm);
+  return !(elm && Tools.isRestricted(elm.dom())) && (Compare.contains(root, elm) || Compare.eq(root, elm));
 };
 
 const isRngInRoot = function (root) {


### PR DESCRIPTION
The previous PR fix migrated to 5.x and checked in the angular 7 application.

Please refer to pull requests https://github.com/tinymce/tinymce/pull/4732 and https://github.com/tinymce/tinymce/pull/4908 for more information.
