### PR TITLE
Added editor.mode.focusOnChange(boolean) option allowing to prevent focusing

### DIFF
--- a/src/core/main/ts/Mode.ts
+++ b/src/core/main/ts/Mode.ts
@@ -44,6 +44,14 @@ export interface Mode {
    * @param {ModeApi} api Activation and Deactivation API for the new mode.
    */
   register: (mode: string, api: ModeApi) => void;
+
+  /**
+   * If true, focus will be altered on mode changes
+   *
+   * @method focusOnChange
+   * @param {Boolean} focus If true, focus should not be altered on mode changes, default false
+   */
+  focusOnChange: (focus: boolean) => void;
 }
 
 export interface ModeApi {
@@ -81,6 +89,7 @@ const toggleClass = (elm, cls, state: boolean) => {
 
 export const create = (editor: Editor): Mode => {
   let activeMode = 'design';
+  let changeFocus = true;
   const defaultModes = ['design', 'readonly'];
 
   const availableModes: Record<string, ModeApi> = {
@@ -117,7 +126,9 @@ export const create = (editor: Editor): Mode => {
       setEditorCommandState('StyleWithCSS', false);
       setEditorCommandState('enableInlineTableEditing', false);
       setEditorCommandState('enableObjectResizing', false);
-      editor.focus();
+      if (changeFocus) {
+        editor.focus();
+      }
       editor.nodeChanged();
     }
   };
@@ -177,10 +188,15 @@ export const create = (editor: Editor): Mode => {
     };
   };
 
+  const focusOnChange = (focus: boolean) => {
+    changeFocus = focus;
+  };
+
   return {
     isReadOnly,
     set,
     get,
-    register
+    register,
+    focusOnChange
   };
 };


### PR DESCRIPTION
In our application we separate view and edit mode which can be changed using edit and save buttons.
Switching editor from read-only mode to design mode enforces focus change to the TinyMCE editor.
If the mode change is applied to multiple editors on the same page, last editor receives focus causing page to scroll down to the last editor which is undesired, focus should not be forcibly changed and implementing hacks like saving focus and then restoring it after mode change would be undesired as well.

I implemented a new feature on the Mode class, a write-only function focusOnChange(boolean) allowing to easily disable this behavior without any obvious drawbacks.

To use it, after instantiating the editor just call editor.mode.focusOnChange(false) and subsequent mode changes won't affect the focus.

This is a non-breaking change, state is kept together with mode instance which makes most sense as it is the only object affected by a new feature.