### PR TITLE
Image resize handles are shown far below the edited image if fixed_toolbar_container is used

### DIFF
--- a/src/core/main/ts/dom/Position.ts
+++ b/src/core/main/ts/dom/Position.ts
@@ -1,3 +1,4 @@
+import { HTMLElement } from '@ephox/sand';
 /**
  * Copyright (c) Tiny Technologies, Inc. All rights reserved.
  * Licensed under the LGPL or a commercial license.
@@ -34,6 +35,18 @@ const getTableCaptionDeltaY = function (elm) {
   }
 };
 
+const hasChild = function (elm, child) {
+  if (elm && elm.children) {
+    for (let i = 0; i < elm.children.length; i++) {
+      if (elm.children[i] === child) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
 const getPos = function (body, elm, rootElm) {
   let x = 0, y = 0, offsetParent;
   const doc = body.ownerDocument;
@@ -56,14 +69,14 @@ const getPos = function (body, elm, rootElm) {
     }
 
     offsetParent = elm;
-    while (offsetParent && offsetParent !== rootElm && offsetParent.nodeType) {
+    while (offsetParent && offsetParent !== rootElm && offsetParent.nodeType && !hasChild(offsetParent, rootElm)) {
       x += offsetParent.offsetLeft || 0;
       y += offsetParent.offsetTop || 0;
       offsetParent = offsetParent.offsetParent;
     }
 
     offsetParent = elm.parentNode;
-    while (offsetParent && offsetParent !== rootElm && offsetParent.nodeType) {
+    while (offsetParent && offsetParent !== rootElm && offsetParent.nodeType && !hasChild(offsetParent, rootElm)) {
       x -= offsetParent.scrollLeft || 0;
       y -= offsetParent.scrollTop || 0;
       offsetParent = offsetParent.parentNode;


### PR DESCRIPTION
I have a scenario (angular 7) where the TinyMCE toolbar needs to be attached to the inline editing area if user scrolls up/down while the toolbar is only shown if the editor is focused.

This scenario requires placing a toolbar placeholder div (with position: absolute) just before tinymce div, both present in the angular component. When clicking on an image already present in the HTML editor, image resize handles are shown far below the edited image.

The reason for this is getPos function is skipping offsetParent div element for TinyMCE as it is a second child in a parent component which is not a part of DOM (angular element).

Since performance of this function is not critical (getPos is executed only when selecting an object), scanning for children when traversing parents won't affect the overall experience yet will provide an extra check if when searching for root we could have skipped it.
