### PR TITLE
Keyboard paste detection

### DIFF
--- a/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -244,7 +244,7 @@ const isKeyboardPasteEvent = (e: KeyboardEvent) => {
 };
 
 const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: Cell<string>) => {
-  let keyboardPasteTimeStamp = 0;
+  let keyboardPasteEvent = null;
   let keyboardPastePlainTextState;
 
   editor.on('keydown', function (e) {
@@ -268,7 +268,12 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
       // Prevent undoManager keydown handler from making an undo level with the pastebin in it
       e.stopImmediatePropagation();
 
-      keyboardPasteTimeStamp = new Date().getTime();
+      // track that this is a keyboard paste event but remove it once the paste event
+      // has had enough time to be added to the stack first
+      keyboardPasteEvent = e;
+      window.setTimeout(() => {
+        keyboardPasteEvent = null;
+      }, 100);
 
       // IE doesn't support Ctrl+Shift+V and it doesn't even produce a paste event
       // so lets fake a paste event and let IE use the execCommand/dataTransfer methods
@@ -352,12 +357,9 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
   };
 
   editor.on('paste', function (e: EditorEvent<ClipboardEvent & { ieFake: boolean }>) {
-    // Getting content from the Clipboard can take some time
-    const clipboardTimer = new Date().getTime();
+    const isKeyBoardPaste = keyboardPasteEvent !== null;
     const clipboardContent = getClipboardContent(editor, e);
-    const clipboardDelay = new Date().getTime() - clipboardTimer;
 
-    const isKeyBoardPaste = (new Date().getTime() - keyboardPasteTimeStamp - clipboardDelay) < 1000;
     const plainTextMode = pasteFormat.get() === 'text' || keyboardPastePlainTextState;
     let internal = hasContentType(clipboardContent, InternalHtml.internalHtmlMime());
 


### PR DESCRIPTION
Resolves #4974

The previous implementation required the editor paste event to be processed within 1 second of the keyboard event. In IE11, the time for the paste event to be processed seemed to differ based on the content in the clipboard and was often > 1 second.

The new implementation only requires that the paste event is on the stack, to eventually be processed, within 100ms of the keyboard event. This approach might not be ideal but looks to be more reliable then the previous implementation.