### PR TITLE
mceInsertLink converts only first space in link

### DIFF
--- a/src/core/main/ts/api/EditorCommands.ts
+++ b/src/core/main/ts/api/EditorCommands.ts
@@ -485,7 +485,7 @@ class EditorCommands {
         anchor = editor.dom.getParent(editor.selection.getNode(), 'a');
 
         // Spaces are never valid in URLs and it's a very common mistake for people to make so we fix it here.
-        value.href = value.href.replace(' ', '%20');
+        value.href = value.href.replace(/ /g, '%20');
 
         // Remove existing links if there could be child links or that the href isn't specified
         if (!anchor || !value.href) {


### PR DESCRIPTION
String.prototype.replace takes a regex. The 'g' flag must be explicitly provided.

Feel free to re-write this pull request since I'm not about to sign a CLA.