### PR TITLE
Link: Add options 'http' and 'https' to link_assume_external_targets

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 5.0.7 (TBD)
     Added highlighting of matched text in autocompleter items #TINY-3687
     Added the ability for autocompleters to work with matches that include spaces #TINY-3704
     Added a new imagetools_fetch_image callback to allow custom implementations for cors loading of images. #TINY-3658
+    Added `'http'` and `https` options to `link_assume_external_targets` to prepend `http://` or `https://` prefixes when URL does not contain a protocol prefix. Patch contributed by francoisfreitag. #GH-4335
     Changed annotations navigation to work the same as inline boundaries #TINY-3396
     Fixed the autocompleter not working with fragmented text #TINY-3459
     Fixed the autosave plugin no longer overwrites window.onbeforeunload #TINY-3688

--- a/src/plugins/link/main/ts/api/Settings.ts
+++ b/src/plugins/link/main/ts/api/Settings.ts
@@ -5,8 +5,18 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const assumeExternalTargets = function (editorSettings) {
-  return typeof editorSettings.link_assume_external_targets === 'boolean' ? editorSettings.link_assume_external_targets : false;
+import { AssumeExternalTargets } from './Types';
+
+const assumeExternalTargets = function (editorSettings): AssumeExternalTargets {
+  const externalTargets = editorSettings.link_assume_external_targets;
+  if (typeof externalTargets === 'boolean' && externalTargets) {
+    return AssumeExternalTargets.WARN;
+  } else if (typeof externalTargets === 'string'
+      && (externalTargets === AssumeExternalTargets.ALWAYS_HTTP
+        || externalTargets === AssumeExternalTargets.ALWAYS_HTTPS)) {
+    return externalTargets;
+  }
+  return AssumeExternalTargets.OFF;
 };
 
 const hasContextToolbar = function (editorSettings) {

--- a/src/plugins/link/main/ts/api/Types.ts
+++ b/src/plugins/link/main/ts/api/Types.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+export const enum AssumeExternalTargets {
+  OFF,
+  WARN,
+  ALWAYS_HTTP = 'http',
+  ALWAYS_HTTPS = 'https'
+}

--- a/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/src/plugins/link/main/ts/ui/Dialog.ts
@@ -11,6 +11,7 @@ import { Arr, Future, Option, Options } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 import Settings from '../api/Settings';
+import { AssumeExternalTargets } from '../api/Types';
 import { ListOptions } from '../core/ListOptions';
 import Utils from '../core/Utils';
 import { DialogChanges } from './DialogChanges';
@@ -18,7 +19,7 @@ import { DialogConfirms } from './DialogConfirms';
 import { DialogInfo } from './DialogInfo';
 import { LinkDialogData, LinkDialogInfo } from './DialogTypes';
 
-const handleSubmit = (editor: Editor, info: LinkDialogInfo, assumeExternalTargets: boolean) => (api: Types.Dialog.DialogInstanceApi<LinkDialogData>) => {
+const handleSubmit = (editor: Editor, info: LinkDialogInfo, assumeExternalTargets: AssumeExternalTargets) => (api: Types.Dialog.DialogInstanceApi<LinkDialogData>) => {
   const data: LinkDialogData = api.getData();
 
   if (!data.url.value) {

--- a/src/plugins/link/main/ts/ui/DialogConfirms.ts
+++ b/src/plugins/link/main/ts/ui/DialogConfirms.ts
@@ -10,6 +10,8 @@ import { Future, Option, Options } from '@ephox/katamari';
 import Delay from 'tinymce/core/api/util/Delay';
 import Editor from 'tinymce/core/api/Editor';
 
+import { AssumeExternalTargets } from '../api/Types';
+import Utils from '../core/Utils';
 import { LinkDialogOutput } from './DialogTypes';
 
 // Delay confirm since onSubmit will move focus
@@ -38,11 +40,11 @@ const tryEmailTransform = (data: LinkDialogOutput): Option<Transformer> => {
   }) : Option.none();
 };
 
-const tryProtocolTransform = (assumeExternalTargets: boolean) => (data: LinkDialogOutput): Option<Transformer> => {
+const tryProtocolTransform = (assumeExternalTargets: AssumeExternalTargets) => (data: LinkDialogOutput): Option<Transformer> => {
   const url = data.href;
   const suggestProtocol = (
-    assumeExternalTargets === true && !/^\w+:/i.test(url) ||
-    assumeExternalTargets === false && /^\s*www[\.|\d\.]/i.test(url)
+    assumeExternalTargets === AssumeExternalTargets.WARN && !Utils.hasProtocol(url) ||
+    assumeExternalTargets === AssumeExternalTargets.OFF && /^\s*www[\.|\d\.]/i.test(url)
   );
 
   return suggestProtocol ? Option.some({
@@ -51,7 +53,7 @@ const tryProtocolTransform = (assumeExternalTargets: boolean) => (data: LinkDial
   }) : Option.none();
 };
 
-const preprocess = (editor: Editor, assumeExternalTargets: boolean, data: LinkDialogOutput): Future<LinkDialogOutput> => {
+const preprocess = (editor: Editor, assumeExternalTargets: AssumeExternalTargets, data: LinkDialogOutput): Future<LinkDialogOutput> => {
   return Options.findMap(
     [ tryEmailTransform, tryProtocolTransform(assumeExternalTargets) ],
     (f) => f(data)

--- a/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -1,6 +1,6 @@
 import 'tinymce/themes/silver/Theme';
 
-import { Pipeline, Log } from '@ephox/agar';
+import { GeneralSteps, Logger, Pipeline, Log } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
@@ -14,45 +14,48 @@ UnitTest.asynctest('browser.tinymce.plugins.link.AssumeExternalTargetsTest', (su
   TinyLoader.setup(function (editor, onSuccess, onFailure) {
     const tinyApis = TinyApis(editor);
 
-    Pipeline.async({},
-      Log.steps('TBA', 'Link: Test that with default setting, only www.-urls are prompted to add http:// prefix and with link_assume_external_targets: true, all urls are prompted', [
-        TestLinkUi.sClearHistory,
-        // with default setting, always prompts www.-urls, not other without protocol
-        TestLinkUi.sInsertLink('www.google.com'),
-        TestLinkUi.sWaitForUi(
-          'wait for dialog',
-          'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-        ),
-        TestLinkUi.sClickConfirmYes,
-        TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1}),
-        tinyApis.sSetContent(''),
+    Pipeline.async({}, [
+      Log.stepsAsStep('TBA', 'Default setting', [
+        Logger.t('www-urls are prompted to add http:// prefix', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('www.google.com'),
+          TestLinkUi.sWaitForUi(
+            'wait for dialog',
+            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
+          ),
+          TestLinkUi.sClickConfirmYes,
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1}),
+        ])),
 
-        TestLinkUi.sInsertLink('google.com'),
-        TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="google.com"]': 1 }),
-        tinyApis.sSetContent(''),
+        Logger.t('others urls are not prompted' , GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('google.com'),
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="google.com"]': 1 }),
+        ])),
+      ]),
 
-        // with link_assume_external_targets: true, prompts on all, even without protocol
+      Log.stepsAsStep('TBA', 'link_assume_external_targets: true', [
         tinyApis.sSetSetting('link_assume_external_targets', true),
-        TestLinkUi.sInsertLink('www.google.com'),
-        TestLinkUi.sWaitForUi(
-          'wait for dialog',
-          'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-        ),
-        TestLinkUi.sClickConfirmYes,
-        TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1 }),
-        tinyApis.sSetContent(''),
 
-        TestLinkUi.sInsertLink('google.com'),
-        TestLinkUi.sWaitForUi(
-          'wait for dialog',
-          'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-        ),
-        TestLinkUi.sClickConfirmYes,
-        TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://google.com"]': 1 }),
-        tinyApis.sSetContent(''),
-        TestLinkUi.sClearHistory,
-      ])
-    , onSuccess, onFailure);
+        Logger.t('www-urls are prompted to add http:// prefix', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('www.google.com'),
+          TestLinkUi.sWaitForUi(
+            'wait for dialog',
+            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
+          ),
+          TestLinkUi.sClickConfirmYes,
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1 }),
+        ])),
+
+        Logger.t('other urls are prompted to add http:// prefix', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('google.com'),
+          TestLinkUi.sWaitForUi(
+            'wait for dialog',
+            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
+          ),
+          TestLinkUi.sClickConfirmYes,
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://google.com"]': 1 }),
+        ])),
+      ]),
+    ], onSuccess, onFailure);
   }, {
     plugins: 'link',
     toolbar: 'link',

--- a/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -75,6 +75,34 @@ UnitTest.asynctest('browser.tinymce.plugins.link.AssumeExternalTargetsTest', (su
           TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="google.com"]': 1 }),
         ])),
       ]),
+
+      Log.stepsAsStep('TBA', 'link_assume_external_targets: http', [
+        tinyApis.sSetSetting('link_assume_external_targets', 'http'),
+
+        Logger.t('add http:// prefix to www-urls', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('www.google.com'),
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1 }),
+        ])),
+
+        Logger.t('add http:// prefix to other urls', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('google.com'),
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://google.com"]': 1 }),
+        ])),
+      ]),
+
+      Log.stepsAsStep('TBA', 'link_assume_external_targets: https', [
+        tinyApis.sSetSetting('link_assume_external_targets', 'https'),
+
+        Logger.t('add https:// prefix to www-urls', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('www.google.com'),
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="https://www.google.com"]': 1 }),
+        ])),
+
+        Logger.t('add https:// prefix to other urls', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('google.com'),
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="https://google.com"]': 1 }),
+        ])),
+      ]),
     ], onSuccess, onFailure);
   }, {
     plugins: 'link',

--- a/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -16,7 +16,7 @@ UnitTest.asynctest('browser.tinymce.plugins.link.AssumeExternalTargetsTest', (su
 
     Pipeline.async({}, [
       Log.stepsAsStep('TBA', 'Default setting', [
-        Logger.t('www-urls are prompted to add http:// prefix', GeneralSteps.sequence([
+        Logger.t('www-urls are prompted to add http:// prefix, accept', GeneralSteps.sequence([
           TestLinkUi.sInsertLink('www.google.com'),
           TestLinkUi.sWaitForUi(
             'wait for dialog',
@@ -24,6 +24,16 @@ UnitTest.asynctest('browser.tinymce.plugins.link.AssumeExternalTargetsTest', (su
           ),
           TestLinkUi.sClickConfirmYes,
           TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1}),
+        ])),
+
+        Logger.t('www-urls are prompted to add http:// prefix, cancel', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('www.google.com'),
+          TestLinkUi.sWaitForUi(
+            'wait for dialog',
+            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
+          ),
+          TestLinkUi.sClickConfirmNo,
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="www.google.com"]': 1}),
         ])),
 
         Logger.t('others urls are not prompted' , GeneralSteps.sequence([
@@ -53,6 +63,16 @@ UnitTest.asynctest('browser.tinymce.plugins.link.AssumeExternalTargetsTest', (su
           ),
           TestLinkUi.sClickConfirmYes,
           TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://google.com"]': 1 }),
+        ])),
+
+        Logger.t('url not updated when prompt canceled', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('google.com'),
+          TestLinkUi.sWaitForUi(
+            'wait for dialog',
+            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
+          ),
+          TestLinkUi.sClickConfirmNo,
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="google.com"]': 1 }),
         ])),
       ]),
     ], onSuccess, onFailure);

--- a/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -24,11 +24,11 @@ UnitTest.asynctest('browser.tinymce.plugins.link.AssumeExternalTargetsTest', (su
           'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
         ),
         TestLinkUi.sClickConfirmYes,
-        TestLinkUi.sAssertContentPresence(tinyApis, { a: 1 }),
+        TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1}),
         tinyApis.sSetContent(''),
 
         TestLinkUi.sInsertLink('google.com'),
-        TestLinkUi.sAssertContentPresence(tinyApis, { a: 1 }),
+        TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="google.com"]': 1 }),
         tinyApis.sSetContent(''),
 
         // with link_assume_external_targets: true, prompts on all, even without protocol
@@ -39,7 +39,7 @@ UnitTest.asynctest('browser.tinymce.plugins.link.AssumeExternalTargetsTest', (su
           'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
         ),
         TestLinkUi.sClickConfirmYes,
-        TestLinkUi.sAssertContentPresence(tinyApis, { a: 1 }),
+        TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1 }),
         tinyApis.sSetContent(''),
 
         TestLinkUi.sInsertLink('google.com'),


### PR DESCRIPTION
Instead of overloading `link_assume_external_targets`, as suggested in the issue, a new configuration option is added in order to benefit from TypeScript validation.

Fixes #4335

---

Corresponding documentation PR: https://github.com/tinymce/tinymce-docs/pull/1053.

---

**I am not able to run `grunt test` successfully locally.**
```
$ node_modules/.bin/grunt test
Running "bedrock-auto:phantomjs" (bedrock-auto) task
Verifying property bedrock-auto.phantomjs exists in config...ERROR
>> Unable to process task.
Warning: Required config property "bedrock-auto.phantomjs" missing. Use --force to continue.

Aborted due to warnings.
```