### PR TITLE
AssumeExternalTargetsTest: Use stepsAsStep for better reporting

### DIFF
--- a/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -1,6 +1,6 @@
 import '../../../../../themes/silver/main/ts/Theme';
 
-import { Pipeline, Log } from '@ephox/agar';
+import { GeneralSteps, Logger, Pipeline, Log } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
@@ -14,45 +14,48 @@ UnitTest.asynctest('browser.tinymce.plugins.link.AssumeExternalTargetsTest', (su
   TinyLoader.setup(function (editor, onSuccess, onFailure) {
     const tinyApis = TinyApis(editor);
 
-    Pipeline.async({},
-      Log.steps('TBA', 'Link: Test that with default setting, only www.-urls are prompted to add http:// prefix and with link_assume_external_targets: true, all urls are prompted', [
-        TestLinkUi.sClearHistory,
-        // with default setting, always prompts www.-urls, not other without protocol
-        TestLinkUi.sInsertLink('www.google.com'),
-        TestLinkUi.sWaitForUi(
-          'wait for dialog',
-          'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-        ),
-        TestLinkUi.sClickConfirmYes,
-        TestLinkUi.sAssertContentPresence(tinyApis, { a: 1 }),
-        tinyApis.sSetContent(''),
+    Pipeline.async({}, [
+      Log.stepsAsStep('TBA', 'Default setting', [
+        Logger.t('www-urls are prompted to add http:// prefix', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('www.google.com'),
+          TestLinkUi.sWaitForUi(
+            'wait for dialog',
+            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
+          ),
+          TestLinkUi.sClickConfirmYes,
+          TestLinkUi.sAssertContentPresence(tinyApis, { a: 1 }),
+        ])),
 
-        TestLinkUi.sInsertLink('google.com'),
-        TestLinkUi.sAssertContentPresence(tinyApis, { a: 1 }),
-        tinyApis.sSetContent(''),
+        Logger.t('others urls are not prompted' , GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('google.com'),
+          TestLinkUi.sAssertContentPresence(tinyApis, { a: 1 }),
+        ])),
+      ]),
 
-        // with link_assume_external_targets: true, prompts on all, even without protocol
+      Log.stepsAsStep('TBA', 'link_assume_external_targets: true', [
         tinyApis.sSetSetting('link_assume_external_targets', true),
-        TestLinkUi.sInsertLink('www.google.com'),
-        TestLinkUi.sWaitForUi(
-          'wait for dialog',
-          'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-        ),
-        TestLinkUi.sClickConfirmYes,
-        TestLinkUi.sAssertContentPresence(tinyApis, { a: 1 }),
-        tinyApis.sSetContent(''),
 
-        TestLinkUi.sInsertLink('google.com'),
-        TestLinkUi.sWaitForUi(
-          'wait for dialog',
-          'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-        ),
-        TestLinkUi.sClickConfirmYes,
-        TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://google.com"]': 1 }),
-        tinyApis.sSetContent(''),
-        TestLinkUi.sClearHistory,
-      ])
-    , onSuccess, onFailure);
+        Logger.t('www-urls are prompted to add http:// prefix', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('www.google.com'),
+          TestLinkUi.sWaitForUi(
+            'wait for dialog',
+            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
+          ),
+          TestLinkUi.sClickConfirmYes,
+          TestLinkUi.sAssertContentPresence(tinyApis, { a: 1 }),
+        ])),
+
+        Logger.t('other urls are prompted to add http:// prefix', GeneralSteps.sequence([
+          TestLinkUi.sInsertLink('google.com'),
+          TestLinkUi.sWaitForUi(
+            'wait for dialog',
+            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
+          ),
+          TestLinkUi.sClickConfirmYes,
+          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://google.com"]': 1 }),
+        ])),
+      ]),
+    ], onSuccess, onFailure);
   }, {
     plugins: 'link',
     toolbar: 'link',


### PR DESCRIPTION
Splitting tests grants more isolation and better reporting.