### PR TITLE
Use tinymce import alias

### DIFF
--- a/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
+++ b/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Element } from '@ephox/sugar';
 import { document } from '@ephox/dom-globals';
-import Theme from '../../../../../themes/silver/main/ts/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 import HelpPlugin from 'tinymce/plugins/help/Plugin';
 
 UnitTest.asynctest('browser.tinymce.plugins.help.DialogKeyboardNavTest', (success, failure) => {

--- a/src/plugins/help/test/ts/browser/PluginTest.ts
+++ b/src/plugins/help/test/ts/browser/PluginTest.ts
@@ -4,7 +4,7 @@ import { TinyLoader, TinyUi } from '@ephox/mcagar';
 import { Element } from '@ephox/sugar';
 
 import HelpPlugin from 'tinymce/plugins/help/Plugin';
-import Theme from '../../../../../themes/silver/main/ts/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import PluginAssert from '../module/PluginAssert';
 import Selectors from '../module/Selectors';

--- a/src/plugins/link/test/ts/atomic/DialogChangesTest.ts
+++ b/src/plugins/link/test/ts/atomic/DialogChangesTest.ts
@@ -1,7 +1,7 @@
 import { Logger, RawAssertions, UnitTest } from '@ephox/agar';
 
-import { DialogChanges, DialogDelta } from '../../../main/ts/ui/DialogChanges';
-import { ListItem, LinkDialogData } from '../../../main/ts/ui/DialogTypes';
+import { DialogChanges, DialogDelta } from 'tinymce/plugins/link/ui/DialogChanges';
+import { ListItem, LinkDialogData } from 'tinymce/plugins/link/ui/DialogTypes';
 import { Fun } from '@ephox/katamari';
 
 UnitTest.test('DialogChanges', () => {

--- a/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
+++ b/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
@@ -1,4 +1,4 @@
-import '../../../../../themes/silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 
 import { Pipeline, Log } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';

--- a/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -1,4 +1,4 @@
-import '../../../../../themes/silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 
 import { Pipeline, Log } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';

--- a/src/plugins/link/test/ts/browser/DialogFlowTest.ts
+++ b/src/plugins/link/test/ts/browser/DialogFlowTest.ts
@@ -1,4 +1,4 @@
-import '../../../../../themes/silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 
 import {
   ApproxStructure,

--- a/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
+++ b/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
@@ -1,4 +1,4 @@
-import '../../../../../themes/silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 
 import { Assertions, Logger, Log, Pipeline, Step, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';

--- a/src/plugins/link/test/ts/browser/LinkJustFirstFieldTest.ts
+++ b/src/plugins/link/test/ts/browser/LinkJustFirstFieldTest.ts
@@ -1,4 +1,4 @@
-import '../../../../../themes/silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 
 import { Chain, FocusTools, Keyboard, Keys, Log, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';

--- a/src/plugins/link/test/ts/browser/ListOptionsTest.ts
+++ b/src/plugins/link/test/ts/browser/ListOptionsTest.ts
@@ -6,11 +6,11 @@ import { Option } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 
-import { AnchorListOptions } from '../../../main/ts/ui/sections/AnchorListOptions';
-import { ClassListOptions } from '../../../main/ts/ui/sections/ClassListOptions';
-import { LinkListOptions } from '../../../main/ts/ui/sections/LinkListOptions';
-import { RelOptions } from '../../../main/ts/ui/sections/RelOptions';
-import { TargetOptions } from '../../../main/ts/ui/sections/TargetOptions';
+import { AnchorListOptions } from 'tinymce/plugins/link/ui/sections/AnchorListOptions';
+import { ClassListOptions } from 'tinymce/plugins/link/ui/sections/ClassListOptions';
+import { LinkListOptions } from 'tinymce/plugins/link/ui/sections/LinkListOptions';
+import { RelOptions } from 'tinymce/plugins/link/ui/sections/RelOptions';
+import { TargetOptions } from 'tinymce/plugins/link/ui/sections/TargetOptions';
 import { TestLinkUi } from '../module/TestLinkUi';
 
 UnitTest.asynctest('browser.tinymce.plugins.link.ListOptionsTest', (success, failure) => {

--- a/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
+++ b/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
@@ -1,4 +1,4 @@
-import '../../../../../themes/silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 
 import { Pipeline, Log } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';

--- a/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -1,4 +1,4 @@
-import '../../../../../themes/silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 
 import { FocusTools, Keyboard, Keys, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';

--- a/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
+++ b/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
@@ -1,4 +1,4 @@
-import '../../../../../themes/silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 
 import { Pipeline, Log, FocusTools, Keyboard, Keys, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';

--- a/src/plugins/lists/test/ts/browser/ListModelTest.ts
+++ b/src/plugins/lists/test/ts/browser/ListModelTest.ts
@@ -4,10 +4,10 @@ import { document } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
 import { Element } from '@ephox/sugar';
 import Jsc from '@ephox/wrap-jsverify';
-import { composeList } from '../../../main/ts/listModel/ComposeList';
-import { Entry } from '../../../main/ts/listModel/Entry';
-import { normalizeEntries } from '../../../main/ts/listModel/NormalizeEntries';
-import { parseLists } from '../../../main/ts/listModel/ParseLists';
+import { composeList } from 'tinymce/plugins/lists/listModel/ComposeList';
+import { Entry } from 'tinymce/plugins/lists/listModel/Entry';
+import { normalizeEntries } from 'tinymce/plugins/lists/listModel/NormalizeEntries';
+import { parseLists } from 'tinymce/plugins/lists/listModel/ParseLists';
 import { ListType } from 'tinymce/plugins/lists/listModel/Util';
 
 UnitTest.test('tinymce.lists.browser.ListModelTest', () => {

--- a/src/plugins/quickbars/test/ts/atomic/EditorSettingsTest.ts
+++ b/src/plugins/quickbars/test/ts/atomic/EditorSettingsTest.ts
@@ -1,7 +1,7 @@
 import { Logger, RawAssertions, UnitTest } from '@ephox/agar';
 import { Obj } from '@ephox/katamari';
-import Settings from '../../../main/ts/api/Settings';
 import Editor from 'tinymce/core/api/Editor';
+import Settings from 'tinymce/plugins/quickbars/api/Settings';
 
 UnitTest.test('DialogChanges', () => {
   Logger.sync(

--- a/src/plugins/spellchecker/test/ts/browser/SpellcheckerKeyboardNavigationTest.ts
+++ b/src/plugins/spellchecker/test/ts/browser/SpellcheckerKeyboardNavigationTest.ts
@@ -7,7 +7,7 @@ import SpellcheckerPlugin from 'tinymce/plugins/spellchecker/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 import { document } from '@ephox/dom-globals';
 import { Element } from '@ephox/sugar';
-import Tools from '../../../../../core/main/ts/api/util/Tools';
+import Tools from 'tinymce/core/api/util/Tools';
 
 UnitTest.asynctest('browser.tinymce.plugins.spellchecker.SpellcheckerTest', function () {
   const success = arguments[arguments.length - 2];

--- a/src/plugins/table/test/ts/browser/AlignedCellRowStyleChangeTest.ts
+++ b/src/plugins/table/test/ts/browser/AlignedCellRowStyleChangeTest.ts
@@ -5,7 +5,7 @@ import { TinyApis, TinyDom, TinyLoader } from '@ephox/mcagar';
 import { Element } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.AlignedCellRowStyleChangeTest', (success, failure) => {

--- a/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -4,7 +4,7 @@ import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
 import Tools from 'tinymce/core/api/util/Tools';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, failure) => {
   const suite = LegacyUnit.createSuite();

--- a/src/plugins/table/test/ts/browser/DragResizeTest.ts
+++ b/src/plugins/table/test/ts/browser/DragResizeTest.ts
@@ -7,7 +7,7 @@ import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Element, Height, Hierarchy, Width, Attr } from '@ephox/sugar';
 
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.DragResizeTest', (success, failure) => {
   SilverTheme();

--- a/src/plugins/table/test/ts/browser/GridSelectionTest.ts
+++ b/src/plugins/table/test/ts/browser/GridSelectionTest.ts
@@ -5,7 +5,7 @@ import { LegacyUnit, TinyLoader, TinyApis } from '@ephox/mcagar';
 
 import Tools from 'tinymce/core/api/util/Tools';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.GridSelectionTest', (success, failure) => {
 

--- a/src/plugins/table/test/ts/browser/HelpersTest.ts
+++ b/src/plugins/table/test/ts/browser/HelpersTest.ts
@@ -4,8 +4,8 @@ import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Element } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
-import Helpers from '../../../main/ts/ui/Helpers';
+import Helpers from 'tinymce/plugins/table/ui/Helpers';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.HelpersTest', (success, failure) => {
   Plugin();

--- a/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
+++ b/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
@@ -4,7 +4,7 @@ import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
 
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('tinymce.plugins.table.IndentListsInTableTest', (success, failure) => {
   SilverTheme();

--- a/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
+++ b/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { Editor, TinyDom } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import { SelectorFind } from '@ephox/sugar';
 import TableTestUtils from '../module/test/TableTestUtils';
 

--- a/src/plugins/table/test/ts/browser/InsertCommandsTest.ts
+++ b/src/plugins/table/test/ts/browser/InsertCommandsTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.InsertCommandsTest', (success, failure) => {
 

--- a/src/plugins/table/test/ts/browser/InsertTableTest.ts
+++ b/src/plugins/table/test/ts/browser/InsertTableTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.InsertTableTest', (success, failure) => {
   Plugin();

--- a/src/plugins/table/test/ts/browser/KeyboardCellNavigationTest.ts
+++ b/src/plugins/table/test/ts/browser/KeyboardCellNavigationTest.ts
@@ -5,7 +5,7 @@ import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
 
 import Env from 'tinymce/core/api/Env';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.quirks.KeyboardCellNavigationTest', (success, failure) => {
     TablePlugin();

--- a/src/plugins/table/test/ts/browser/MergeCellCommandTest.ts
+++ b/src/plugins/table/test/ts/browser/MergeCellCommandTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.MergeCellCommandTest', (success, failure) => {
   const suite = LegacyUnit.createSuite();

--- a/src/plugins/table/test/ts/browser/NewCellRowEventsTest.ts
+++ b/src/plugins/table/test/ts/browser/NewCellRowEventsTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.NewCellRowEventsTest', (success, failure) => {
   const suite = LegacyUnit.createSuite();

--- a/src/plugins/table/test/ts/browser/ResizeTableTest.ts
+++ b/src/plugins/table/test/ts/browser/ResizeTableTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { Editor, ApiChains } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import { Cell } from '@ephox/katamari';
 import TableTestUtils from '../module/test/TableTestUtils';
 

--- a/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
+++ b/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.TabKeyNavigationTest', (success, failure) => {
   const suite = LegacyUnit.createSuite();

--- a/src/plugins/table/test/ts/browser/TableCellPropsStyleTest.ts
+++ b/src/plugins/table/test/ts/browser/TableCellPropsStyleTest.ts
@@ -4,7 +4,7 @@ import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.TableCellPropsStyleTest', (success, failure) => {

--- a/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
+++ b/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { Editor, TinyDom } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import { SelectorFind } from '@ephox/sugar';
 import TableTestUtils from '../module/test/TableTestUtils';
 

--- a/src/plugins/table/test/ts/browser/settings/CustomTableToolbarTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/CustomTableToolbarTest.ts
@@ -4,7 +4,7 @@ import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import { SelectorFilter } from '@ephox/sugar';
 
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from '../../../../../../themes/silver/main/ts/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import TableTestUtils from '../../module/test/TableTestUtils';
 

--- a/src/plugins/table/test/ts/browser/settings/DefaultTableToolbarTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/DefaultTableToolbarTest.ts
@@ -4,7 +4,7 @@ import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import { SelectorFilter } from '@ephox/sugar';
 
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from '../../../../../../themes/silver/main/ts/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import TableTestUtils from '../../module/test/TableTestUtils';
 

--- a/src/plugins/table/test/ts/browser/settings/DisabledTableToolbarTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/DisabledTableToolbarTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyDom, TinyLoader } from '@ephox/mcagar';
 
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from '../../../../../../themes/silver/main/ts/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 import { document } from '@ephox/dom-globals';
 
 /*

--- a/src/plugins/table/test/ts/browser/settings/TableAppearanceOptionsTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/TableAppearanceOptionsTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.TableAppearanceTest', (success, failure) => {

--- a/src/plugins/table/test/ts/browser/settings/TableCellClassListTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/TableCellClassListTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.TableCellClassListTest', (success, failure) => {

--- a/src/plugins/table/test/ts/browser/settings/TableClassListTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/TableClassListTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.TableClassListTest', (success, failure) => {

--- a/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesTest.ts
@@ -2,7 +2,7 @@ import { GeneralSteps, Logger, Pipeline, ApproxStructure, Waiter } from '@ephox/
 import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../../module/test/TableTestUtils';
 
 /* This requires a menubar. Cannot migrate yet. */

--- a/src/plugins/table/test/ts/browser/settings/TableDefaultStylesTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/TableDefaultStylesTest.ts
@@ -2,7 +2,7 @@ import { GeneralSteps, Logger, Pipeline, ApproxStructure, Waiter } from '@ephox/
 import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../../module/test/TableTestUtils';
 
 /* This requires a menubar. Cannot migrate yet. */

--- a/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 /* This test requires a menubar. It is testing a setting which means that the table picker is replaced by just a dialog. */
 UnitTest.asynctest('browser.tinymce.plugins.table.TableGridFalse', (success, failure) => {

--- a/src/plugins/table/test/ts/browser/settings/TableRowClassListTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/TableRowClassListTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.TableRowClassListTest', (success, failure) => {

--- a/src/plugins/table/test/ts/browser/settings/TableTabNavigationDisabledTest.ts
+++ b/src/plugins/table/test/ts/browser/settings/TableTabNavigationDisabledTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
 
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 import TableTestUtils from '../../module/test/TableTestUtils';
 

--- a/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -2,7 +2,7 @@ import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.TableCellDialogTest', (success, failure) => {

--- a/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
+++ b/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
@@ -1,8 +1,8 @@
 import { Pipeline, Log, FocusTools, Keyboard, Keys } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import Plugin from '../../../../main/ts/Plugin';
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import Plugin from 'tinymce/plugins/table/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import { Element } from '@ephox/sugar';
 import { document } from '@ephox/dom-globals';
 

--- a/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
+++ b/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
@@ -2,7 +2,7 @@ import { Log, Pipeline, ApproxStructure } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.TableDialogGeneralTest', (success, failure) => {

--- a/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -4,7 +4,7 @@ import { document } from '@ephox/dom-globals';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Element } from '@ephox/sugar';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from '../../../../../../themes/silver/main/ts/Theme';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import TableTestUtils from '../../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.TableRowDialogTest', (success, failure) => {

--- a/src/themes/silver/demo/ts/demo/ToolbarComponentsDemo.ts
+++ b/src/themes/silver/demo/ts/demo/ToolbarComponentsDemo.ts
@@ -2,7 +2,7 @@ import { GuiFactory } from '@ephox/alloy';
 import { console } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
 
-import { identifyButtons } from '../../../main/ts/ui/toolbar/Integration';
+import { identifyButtons } from 'tinymce/themes/silver/ui/toolbar/Integration';
 import { setupDemo } from '../components/DemoHelpers';
 import Editor from 'tinymce/core/api/Editor';
 

--- a/src/themes/silver/main/ts/backstage/Anchors.ts
+++ b/src/themes/silver/main/ts/backstage/Anchors.ts
@@ -1,7 +1,7 @@
 import { AlloyComponent, AnchorSpec, Bubble, Layout, LayoutInside } from '@ephox/alloy';
 import { Option } from '@ephox/katamari';
 import { Element, Selection } from '@ephox/sugar';
-import Editor from '../../../../../core/main/ts/api/Editor';
+import Editor from 'tinymce/core/api/Editor';
 import { useFixedContainer } from '../api/Settings';
 
 const bubbleAlignments = {

--- a/src/themes/silver/main/ts/backstage/ColorInputBackstage.ts
+++ b/src/themes/silver/main/ts/backstage/ColorInputBackstage.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Editor from '../../../../../core/main/ts/api/Editor';
+import Editor from 'tinymce/core/api/Editor';
 import ColorSwatch from '../ui/core/color/ColorSwatch';
 import Settings from '../ui/core/color/Settings';
 import { Menu } from '@ephox/bridge';

--- a/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
+++ b/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
@@ -7,8 +7,8 @@
 
 import { Future, Obj, Option, Type } from '@ephox/katamari';
 
-import Editor from '../../../../../core/main/ts/api/Editor';
-import Tools from '../../../../../core/main/ts/api/util/Tools';
+import Editor from 'tinymce/core/api/Editor';
+import Tools from 'tinymce/core/api/util/Tools';
 import { LinkTarget, LinkTargets } from '../ui/core/LinkTargets';
 import { addToHistory, getHistory } from './UrlInputHistory';
 import { Types } from '@ephox/bridge';

--- a/src/themes/silver/main/ts/ui/core/ComplexControls.ts
+++ b/src/themes/silver/main/ts/ui/core/ComplexControls.ts
@@ -1,4 +1,4 @@
-import Editor from '../../../../../../core/main/ts/api/Editor';
+import Editor from 'tinymce/core/api/Editor';
 import { fontSelectMenu } from './complex/FontSelect';
 import { styleSelectMenu } from './complex/StyleSelect';
 import { formatSelectMenu } from './complex/FormatSelect';

--- a/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
+++ b/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
@@ -7,7 +7,7 @@
 
 import { Arr, Obj } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
-import { getUserStyleFormats, isMergeStyleFormats } from '../../../api/Settings';
+import { getUserStyleFormats, isMergeStyleFormats } from 'tinymce/themes/silver/api/Settings';
 import { AllowedFormat, BlockStyleFormat, FormatReference, InlineStyleFormat, NestedFormatting, SelectorStyleFormat, Separator, StyleFormat } from 'tinymce/core/api/fmt/StyleFormat';
 
 export const defaultStyleFormats: AllowedFormat[] = [

--- a/src/themes/silver/main/ts/ui/dialog/imagetools/EditPanel.ts
+++ b/src/themes/silver/main/ts/ui/dialog/imagetools/EditPanel.ts
@@ -24,7 +24,7 @@ import {
 import { ImageResult, ImageTransformations } from '@ephox/imagetools';
 import { Fun, Option } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../../backstage/Backstage';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderButton, renderIconButton } from '../../general/Button';
 import { renderSizeInput } from '../SizeInput';
 import * as ImageToolsEvents from './ImageToolsEvents';

--- a/src/themes/silver/main/ts/ui/dialog/imagetools/ImageTools.ts
+++ b/src/themes/silver/main/ts/ui/dialog/imagetools/ImageTools.ts
@@ -23,7 +23,7 @@ import { Fun, Option } from '@ephox/katamari';
 import { Element } from '@ephox/sugar';
 import { ComposingConfigs } from 'tinymce/themes/silver/ui/alien/ComposingConfigs';
 
-import { UiFactoryBackstageProviders } from '../../../backstage/Backstage';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import * as EditPanel from './EditPanel';
 import * as ImagePanel from './ImagePanel';
 import * as ImageToolsEvents from './ImageToolsEvents';

--- a/src/themes/silver/main/ts/ui/dialog/imagetools/SideBar.ts
+++ b/src/themes/silver/main/ts/ui/dialog/imagetools/SideBar.ts
@@ -8,7 +8,7 @@
 import { AlloyComponent, AlloyTriggers, Container, Disabling, Memento, SketchSpec } from '@ephox/alloy';
 import { Option } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../../backstage/Backstage';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderIconButton } from '../../general/Button';
 import * as ImageToolsEvents from './ImageToolsEvents';
 

--- a/src/themes/silver/main/ts/ui/menus/contextmenu/SilverContextMenu.ts
+++ b/src/themes/silver/main/ts/ui/menus/contextmenu/SilverContextMenu.ts
@@ -14,7 +14,7 @@ import * as MenuParts from '../menu/MenuParts';
 import * as NestedMenus from '../menu/NestedMenus';
 import { getPointAnchor, getNodeAnchor } from './Coords';
 import Settings from './Settings';
-import { UiFactoryBackstage } from '../../../backstage/Backstage';
+import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import ItemResponse from '../item/ItemResponse';
 
 type MenuItem =  string | Menu.MenuItemApi | Menu.NestedMenuItemApi | Menu.SeparatorMenuItemApi;

--- a/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
+++ b/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
@@ -8,7 +8,7 @@
 import { Disabling, Toggling } from '@ephox/alloy';
 import { Menu, Types } from '@ephox/bridge';
 import { Merger, Option } from '@ephox/katamari';
-import { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import * as ItemClasses from '../ItemClasses';
 import ItemResponse from '../ItemResponse';
 import { renderCheckmark } from '../structure/ItemSlices';

--- a/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
+++ b/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
@@ -9,8 +9,8 @@ import { ItemTypes, ItemWidget, Menu as AlloyMenu } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
 import { Id, Merger } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../../../backstage/Backstage';
-import ColorSwatch from '../../../core/color/ColorSwatch';
+import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
 import { createPartialChoiceMenu } from '../../menu/MenuChoice';
 import { deriveMenuMovement } from '../../menu/MenuMovement';
 import * as MenuParts from '../../menu/MenuParts';

--- a/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
+++ b/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
@@ -19,8 +19,8 @@ import {
 } from '@ephox/alloy';
 import { Arr, Cell, Fun, Merger, Option } from '@ephox/katamari';
 
-import { DisablingConfigs } from '../../../alien/DisablingConfigs';
-import { onControlAttached, onControlDetached, OnDestroy } from '../../../controls/Controls';
+import { DisablingConfigs } from 'tinymce/themes/silver/ui/alien/DisablingConfigs';
+import { onControlAttached, onControlDetached, OnDestroy } from 'tinymce/themes/silver/ui/controls/Controls';
 import { menuItemEventOrder, onMenuItemExecute } from '../ItemEvents';
 import { ItemStructure } from '../structure/ItemStructure';
 import ItemResponse from '../ItemResponse';

--- a/src/themes/silver/main/ts/ui/menus/item/build/FancyMenuItem.ts
+++ b/src/themes/silver/main/ts/ui/menus/item/build/FancyMenuItem.ts
@@ -9,7 +9,7 @@ import { Menu } from '@ephox/bridge';
 import { renderInsertTableMenuItem } from './InsertTableMenuItem';
 import { Option } from '@ephox/katamari';
 import { ItemTypes } from '@ephox/alloy';
-import { UiFactoryBackstage } from '../../../../backstage/Backstage';
+import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderColorSwatchItem } from './ColorSwatchItem';
 
 const fancyMenuItems: Record<keyof Menu.FancyActionArgsMap, (mi: Menu.FancyMenuItem, bs: UiFactoryBackstage) => ItemTypes.WidgetItemSpec> = {

--- a/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
+++ b/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
@@ -1,7 +1,7 @@
 import { AlloyComponent, Disabling, ItemTypes } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
 import { Fun, Option } from '@ephox/katamari';
-import { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import ItemResponse from '../ItemResponse';
 import { renderSubmenuCaret } from '../structure/ItemSlices';
 import { renderItemStructure } from '../structure/ItemStructure';

--- a/src/themes/silver/main/ts/ui/menus/item/build/NormalMenuItem.ts
+++ b/src/themes/silver/main/ts/ui/menus/item/build/NormalMenuItem.ts
@@ -8,7 +8,7 @@
 import { AlloyComponent, Disabling, ItemTypes } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
 import { Option } from '@ephox/katamari';
-import { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import ItemResponse from '../ItemResponse';
 import { renderItemStructure } from '../structure/ItemStructure';
 import { buildData, renderCommonItem } from './CommonMenuItem';

--- a/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
+++ b/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
@@ -8,7 +8,7 @@
 import { Disabling, Toggling, ItemTypes } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
 import { Merger, Option } from '@ephox/katamari';
-import { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import * as ItemClasses from '../ItemClasses';
 import ItemResponse from '../ItemResponse';
 import { renderCheckmark } from '../structure/ItemSlices';

--- a/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -9,7 +9,7 @@ import { AlloySpec, DomFactory, RawDomSchema } from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
 import { Fun, Merger, Obj, Option, Arr } from '@ephox/katamari';
 import I18n from 'tinymce/core/api/util/I18n';
-import { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import * as Icons from '../../../icons/Icons';
 import * as ItemClasses from '../ItemClasses';
 import { renderIcon, renderShortcut, renderStyledText, renderText, renderHtml } from './ItemSlices';

--- a/src/themes/silver/main/ts/ui/menus/menu/MenuChoice.ts
+++ b/src/themes/silver/main/ts/ui/menus/menu/MenuChoice.ts
@@ -2,7 +2,7 @@ import { MenuTypes } from '@ephox/alloy';
 import { Menu as BridgeMenu, Types } from '@ephox/bridge';
 import { Arr, Option, Options } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../../backstage/Backstage';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderChoiceItem } from '../item/build/ChoiceItem';
 import ItemResponse from '../item/ItemResponse';
 import { createPartialMenuWithAlloyItems, handleError, menuHasIcons } from './MenuUtils';

--- a/src/themes/silver/main/ts/ui/menus/menu/NestedMenus.ts
+++ b/src/themes/silver/main/ts/ui/menus/menu/NestedMenus.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { UiFactoryBackstage } from '../../../backstage/Backstage';
+import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import { TieredData, TieredMenu } from '@ephox/alloy';
 import { Objects } from '@ephox/boulder';
 import { Id, Merger, Obj, Option } from '@ephox/katamari';

--- a/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
+++ b/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
@@ -9,7 +9,7 @@ import { AlloyEvents, FocusManagers, ItemTypes, Keying, MenuTypes, TieredMenu } 
 import { InlineContent, Menu as BridgeMenu, Types } from '@ephox/bridge';
 import { console } from '@ephox/dom-globals';
 import { Arr, Merger, Option, Options } from '@ephox/katamari';
-import { UiFactoryBackstage, UiFactoryBackstageShared } from '../../../backstage/Backstage';
+import { UiFactoryBackstage, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { detectSize } from '../../alien/FlatgridAutodetect';
 import { SimpleBehaviours } from '../../alien/SimpleBehaviours';
 import ItemResponse from '../item/ItemResponse';

--- a/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -7,7 +7,7 @@
 
 import { Arr, Merger, Obj } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
-import { getRemovedMenuItems } from '../../../api/Settings';
+import { getRemovedMenuItems } from 'tinymce/themes/silver/api/Settings';
 import { MenubarItemSpec } from './SilverMenubar';
 
 export interface MenuRegistry {

--- a/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
+++ b/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
@@ -27,7 +27,7 @@ import { Arr, Fun, Option } from '@ephox/katamari';
 import { Compare, SelectorFind } from '@ephox/sugar';
 import { TranslatedString } from 'tinymce/core/api/util/I18n';
 
-import { UiFactoryBackstage } from '../../../backstage/Backstage';
+import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import { MenuButtonClasses } from '../../toolbar/button/ButtonClasses';
 import { renderMenuButton } from '../../toolbar/button/ToolbarButtons';
 import { SingleMenuItemApi } from '../menu/SingleMenuTypes';

--- a/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -29,7 +29,7 @@ import { Toolbar, Types } from '@ephox/bridge';
 import { Arr, Cell, Fun, Future, Id, Merger, Option } from '@ephox/katamari';
 import { Attr, Class, SelectorFind } from '@ephox/sugar';
 
-import { UiFactoryBackstage, UiFactoryBackstageProviders, UiFactoryBackstageShared } from '../../../backstage/Backstage';
+import { UiFactoryBackstage, UiFactoryBackstageProviders, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { DisablingConfigs } from '../../alien/DisablingConfigs';
 import { detectSize } from '../../alien/FlatgridAutodetect';
 import { SimpleBehaviours } from '../../alien/SimpleBehaviours';

--- a/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConvertTest.ts
+++ b/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConvertTest.ts
@@ -1,7 +1,7 @@
 import { UnitTest, assert } from '@ephox/bedrock';
 import Jsc from '@ephox/wrap-jsverify';
 
-import { convertUnit, nuSize, SizeUnit, Size } from '../../../../../main/ts/ui/sizeinput/SizeInputModel';
+import { convertUnit, nuSize, SizeUnit, Size } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 import { convertableUnits, largeSensible, units } from './SizeInputShared';
 import { Option, Arr } from '@ephox/katamari';
 

--- a/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConverterTest.ts
+++ b/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConverterTest.ts
@@ -1,5 +1,5 @@
 import { UnitTest, assert } from '@ephox/bedrock';
-import { SizeConversion, Size, noSizeConversion, SizeUnit, ratioSizeConversion, nuSize, makeRatioConverter } from '../../../../../main/ts/ui/sizeinput/SizeInputModel';
+import { SizeConversion, Size, noSizeConversion, SizeUnit, ratioSizeConversion, nuSize, makeRatioConverter } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 import { Option } from '@ephox/katamari';
 import Jsc from '@ephox/wrap-jsverify';
 import { largeSensible, units } from './SizeInputShared';

--- a/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputFormatTest.ts
+++ b/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputFormatTest.ts
@@ -1,5 +1,5 @@
 import { UnitTest, assert } from '@ephox/bedrock';
-import { formatSize } from '../../../../../main/ts/ui/sizeinput/SizeInputModel';
+import { formatSize } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 
 UnitTest.test('SizeInputFormatTest', function () {
   // pixel measurements do not get decimals

--- a/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputNuTest.ts
+++ b/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputNuTest.ts
@@ -1,5 +1,5 @@
 import { UnitTest, assert } from '@ephox/bedrock';
-import { nuSize } from '../../../../../main/ts/ui/sizeinput/SizeInputModel';
+import { nuSize } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 
 UnitTest.test('SizeInputNuTest', () => {
   assert.eq({value: 4, unit: 'px'}, nuSize(4, 'px'));

--- a/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputParsingTest.ts
+++ b/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputParsingTest.ts
@@ -2,7 +2,7 @@ import { UnitTest, assert } from '@ephox/bedrock';
 import { Result, Arr } from '@ephox/katamari';
 import Jsc from '@ephox/wrap-jsverify';
 
-import { parseSize, Size, nuSize, SizeUnit } from '../../../../../main/ts/ui/sizeinput/SizeInputModel';
+import { parseSize, Size, nuSize, SizeUnit } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 import { units, largeSensible } from './SizeInputShared';
 
 UnitTest.test('SizeInputParsingTest', () => {

--- a/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputShared.ts
+++ b/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputShared.ts
@@ -1,4 +1,4 @@
-import { SizeUnit } from '../../../../../main/ts/ui/sizeinput/SizeInputModel';
+import { SizeUnit } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 
 export const units: SizeUnit[] = ['', 'cm', 'mm', 'in', 'px', 'pt', 'pc', 'em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', '%'];
 export const convertableUnits: SizeUnit[] = ['', 'cm', 'mm', 'in', 'px', 'pt', 'pc'];

--- a/src/themes/silver/test/ts/atomic/icons/IconsTest.ts
+++ b/src/themes/silver/test/ts/atomic/icons/IconsTest.ts
@@ -1,5 +1,5 @@
 import { UnitTest } from '@ephox/bedrock';
-import { IconProvider, get } from '../../../../main/ts/ui/icons/Icons';
+import { IconProvider, get } from 'tinymce/themes/silver/ui/icons/Icons';
 import { Assertions, Pipeline, Step } from '@ephox/agar';
 import { getAll as getAllOxide } from '@tinymce/oxide-icons-default';
 import { TinyLoader } from '@ephox/mcagar';

--- a/src/themes/silver/test/ts/atomic/sizing/ResizeTest.ts
+++ b/src/themes/silver/test/ts/atomic/sizing/ResizeTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Log, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock';
 import { Option } from '@ephox/katamari';
-import { calcCappedSize, getDimensions, ResizeTypes } from '../../../../main/ts/ui/sizing/Resize';
+import { calcCappedSize, getDimensions, ResizeTypes } from 'tinymce/themes/silver/ui/sizing/Resize';
 
 const mockEditor = (containerHeight, contentAreaHeight) => {
   const settings = {

--- a/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
+++ b/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Chain, Log, Logger, Mouse, Pipeline, UiFinder, UnitTest } from '@ephox/agar';
 import { TinyLoader, TinyUi } from '@ephox/mcagar';
 import { Body, Element } from '@ephox/sugar';
-import Theme from '../../../../main/ts/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('Menu group heading test', (success, failure) => {
   Theme();

--- a/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -5,9 +5,9 @@ import { Cell } from '@ephox/katamari';
 import { TinyLoader } from '@ephox/mcagar';
 import { Element, Body } from '@ephox/sugar';
 
-import Theme from '../../../../../silver/main/ts/Theme';
 import Env from 'tinymce/core/api/Env';
 import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('Editor (Silver) test', (success, failure) => {
   Theme();

--- a/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -5,9 +5,9 @@ import { Cell, Arr } from '@ephox/katamari';
 import { TinyLoader, TinyApis } from '@ephox/mcagar';
 import { Element, Body, Css } from '@ephox/sugar';
 
-import Theme from '../../../../main/ts/Theme';
 import Env from 'tinymce/core/api/Env';
 import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('Inline Editor (Silver) test', (success, failure) => {
   Theme();

--- a/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
+++ b/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
@@ -3,8 +3,8 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyLoader } from '@ephox/mcagar';
 import { Element, Body, Attr, Traverse, Class } from '@ephox/sugar';
 
-import Theme from '../../../../../silver/main/ts/Theme';
 import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
 import { Result } from '@ephox/katamari';
 
 UnitTest.asynctest('Editor (Silver) test', (success, failure) => {

--- a/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -6,7 +6,7 @@ import 'tinymce/themes/silver/Theme';
 
 import { Element, SelectorFilter } from '@ephox/sugar';
 import { document } from '@ephox/dom-globals';
-import ColorSwatch from '../../../../../main/ts/ui/core/color/ColorSwatch';
+import ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
 
 UnitTest.asynctest('ColorPickerSanityTest', (success, failure) => {
   // mutation is yummy

--- a/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
+++ b/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
@@ -2,9 +2,9 @@ import { Logger, Pipeline, RawAssertions, Step, Log } from '@ephox/agar';
 import { TinyLoader } from '@ephox/mcagar';
 import 'tinymce/themes/silver/Theme';
 import { UnitTest } from '@ephox/bedrock';
-import ColorSwatch from '../../../../../main/ts/ui/core/color/ColorSwatch';
-import Settings from '../../../../../main/ts/ui/core/color/Settings';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
+import ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
+import Settings from 'tinymce/themes/silver/ui/core/color/Settings';
 
 UnitTest.asynctest('ColorSettingsTest', (success, failure) => {
 

--- a/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
+++ b/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
@@ -3,7 +3,7 @@ import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import 'tinymce/themes/silver/Theme';
 import { UnitTest } from '@ephox/bedrock';
 import { PlatformDetection } from '@ephox/sand';
-import ColorSwatch from '../../../../../main/ts/ui/core/color/ColorSwatch';
+import ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
 
 UnitTest.asynctest('GetCurrentColorTest', (success, failure) => {
     const browser = PlatformDetection.detect().browser;

--- a/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarSettingsTest.ts
+++ b/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarSettingsTest.ts
@@ -2,7 +2,7 @@ import { Log, Pipeline, UiFinder, NamedChain, Assertions, ApproxStructure } from
 import { UnitTest } from '@ephox/bedrock';
 import { Editor as McagarEditor } from '@ephox/mcagar';
 
-import '../../../../../../silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 import { Body } from '@ephox/sugar';
 import { Result, Arr, Id } from '@ephox/katamari';
 import { cExtractOnlyOne, cCountNumber } from '../../../module/UiChainUtils';

--- a/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarSettingsTest.ts
+++ b/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarSettingsTest.ts
@@ -2,7 +2,7 @@ import { Log, Pipeline, UiFinder, NamedChain, Assertions, ApproxStructure } from
 import { UnitTest } from '@ephox/bedrock';
 import { Editor as McagarEditor } from '@ephox/mcagar';
 
-import '../../../../../../silver/main/ts/Theme';
+import 'tinymce/themes/silver/Theme';
 import { Body } from '@ephox/sugar';
 import { Result, Arr, Id } from '@ephox/katamari';
 import { cCountNumber, cExtractOnlyOne } from '../../../module/UiChainUtils';

--- a/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
+++ b/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
@@ -4,8 +4,8 @@ import { Cell } from '@ephox/katamari';
 import { TinyLoader } from '@ephox/mcagar';
 import { Body } from '@ephox/sugar';
 
-import Theme from '../../../../../silver/main/ts/Theme';
 import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('OxideBlockedDialogTest', (success, failure) => {
 

--- a/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
+++ b/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
@@ -18,8 +18,8 @@ import { Arr, Option, Options, Result } from '@ephox/katamari';
 import { TinyLoader } from '@ephox/mcagar';
 import { Body, Element, Attr } from '@ephox/sugar';
 
-import Theme from '../../../../../silver/main/ts/Theme';
 import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
 import { TestHelpers } from '@ephox/alloy';
 
 UnitTest.asynctest('OxideCollectionComponentTest', (success, failure) => {

--- a/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
+++ b/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
@@ -17,7 +17,7 @@ import { document } from '@ephox/dom-globals';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Body, Element } from '@ephox/sugar';
 
-import Theme from '../../../../../silver/main/ts/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 import { PlatformDetection } from '@ephox/sand';
 import { TestHelpers } from '@ephox/alloy';
 

--- a/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
+++ b/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
@@ -18,8 +18,8 @@ import { Arr } from '@ephox/katamari';
 import { TinyLoader } from '@ephox/mcagar';
 import { Body, Element } from '@ephox/sugar';
 
-import Theme from '../../../../../silver/main/ts/Theme';
 import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
 import { Menu } from '@ephox/bridge';
 import { TestHelpers } from '@ephox/alloy';
 

--- a/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
+++ b/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
@@ -15,8 +15,8 @@ import { document } from '@ephox/dom-globals';
 import { TinyLoader } from '@ephox/mcagar';
 import { Body, Element } from '@ephox/sugar';
 
-import Theme from '../../../../../silver/main/ts/Theme';
 import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
 import { Menu } from '@ephox/bridge';
 import { TestHelpers } from '@ephox/alloy';
 

--- a/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock';
 import { TinyLoader } from '@ephox/mcagar';
 import { document } from '@ephox/dom-globals';
 
-import Theme from '../../../../../silver/main/ts/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 import { Body, Element } from '@ephox/sugar';
 import { Menu } from '@ephox/bridge';
 

--- a/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, Chain, Log, Mouse, NamedChain, Pipeline, U
 import { UnitTest } from '@ephox/bedrock';
 import { Editor } from '@ephox/mcagar';
 import { Element } from '@ephox/sugar';
-import Wordcount from '../../../../../../plugins/wordcount/main/ts/Plugin';
-import Theme from '../../../../main/ts/Theme';
+import Wordcount from 'tinymce/plugins/wordcount/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('Statusbar Structure Test', (success, failure) => {
 

--- a/src/themes/silver/test/ts/phantom/components/dialogbutton/DialogButtonTest.ts
+++ b/src/themes/silver/test/ts/phantom/components/dialogbutton/DialogButtonTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions, Mouse } from '@ephox/agar';
 import { GuiFactory, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock';
 
-import { renderButton } from '../../../../../main/ts/ui/general/Button';
+import { renderButton } from 'tinymce/themes/silver/ui/general/Button';
 import { Option } from '@ephox/katamari';
 import TestProviders from '../../../module/TestProviders';
 

--- a/src/themes/silver/test/ts/phantom/components/selectbox/SelectboxTest.ts
+++ b/src/themes/silver/test/ts/phantom/components/selectbox/SelectboxTest.ts
@@ -3,7 +3,7 @@ import { GuiFactory, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock';
 import { Option } from '@ephox/katamari';
 
-import { renderSelectBox } from '../../../../../main/ts/ui/dialog/SelectBox';
+import { renderSelectBox } from 'tinymce/themes/silver/ui/dialog/SelectBox';
 import { DomSteps } from '../../../module/DomSteps';
 import { RepresentingSteps } from '../../../module/ReperesentingSteps';
 import TestProviders from '../../../module/TestProviders';

--- a/src/themes/silver/test/ts/phantom/components/urlinput/HistoryTest.ts
+++ b/src/themes/silver/test/ts/phantom/components/urlinput/HistoryTest.ts
@@ -1,6 +1,6 @@
 import { assert, UnitTest } from '@ephox/bedrock';
 
-import { addToHistory, clearHistory, getHistory } from '../../../../../main/ts/backstage/UrlInputHistory';
+import { addToHistory, clearHistory, getHistory } from 'tinymce/themes/silver/backstage/UrlInputHistory';
 
 UnitTest.test('HistoryTest', () => {
   const filetype = 'test';

--- a/src/themes/silver/test/ts/phantom/configs/ControlOnSetupTest.ts
+++ b/src/themes/silver/test/ts/phantom/configs/ControlOnSetupTest.ts
@@ -2,8 +2,8 @@ import { Log, Step, Logger } from '@ephox/agar';
 import { Behaviour, GuiFactory, Replacing, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock';
 
-import { SimpleBehaviours } from '../../../../main/ts/ui/alien/SimpleBehaviours';
-import { onControlAttached, onControlDetached } from '../../../../main/ts/ui/controls/Controls';
+import { SimpleBehaviours } from 'tinymce/themes/silver/ui/alien/SimpleBehaviours';
+import { onControlAttached, onControlDetached } from 'tinymce/themes/silver/ui/controls/Controls';
 import { Cell } from '@ephox/katamari';
 
 UnitTest.asynctest('ControlOnSetup Test', (success, failure) => {

--- a/src/themes/silver/test/ts/phantom/toolbar/ToolbarTest.ts
+++ b/src/themes/silver/test/ts/phantom/toolbar/ToolbarTest.ts
@@ -1,7 +1,7 @@
 import { AlloyComponent, GuiFactory, Behaviour, Focusing, Keying, Toolbar, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock';
 
-import { renderToolbar, renderToolbarGroup } from '../../../../main/ts/ui/toolbar/CommonToolbar';
+import { renderToolbar, renderToolbarGroup } from 'tinymce/themes/silver/ui/toolbar/CommonToolbar';
 import { Step, Assertions, ApproxStructure, FocusTools, Keyboard, Keys, GeneralSteps, Logger } from '@ephox/agar';
 import { Arr, Option, Result } from '@ephox/katamari';
 import TestBackstage from '../../module/TestBackstage';

--- a/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
+++ b/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
@@ -5,7 +5,7 @@ import { ValueSchema } from '@ephox/boulder';
 import { Types, DialogManager } from '@ephox/bridge';
 import { Fun, Result, Option } from '@ephox/katamari';
 
-import { renderDialog } from '../../../../main/ts/ui/window/SilverDialog';
+import { renderDialog } from 'tinymce/themes/silver/ui/window/SilverDialog';
 import I18n from 'tinymce/core/api/util/I18n';
 import { Body } from '@ephox/sugar';
 


### PR DESCRIPTION
Facilitates reading where resources are imported from.

---
Upon opportunity, imports were sorted to follow alphabetical order of import location.