### PR TITLE
feature: config max size for images uploaded/pasted/dragged-in

### DIFF
--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -161,6 +161,13 @@ const pasteImage = (editor: Editor, imageItem) => {
       blobInfo = existingBlobInfo;
     }
 
+    // Config max size for images uploaded/pasted/dragged-in
+    if (editor.settings.paste_image_maxsize && blobInfo.blob().size > editor.settings.paste_image_maxsize * 1024 * 1024) {
+      // code...
+      editor.windowManager.alert('Image size exceeds maxImageFileSize.');
+      return false;
+    }
+
     pasteHtml(editor, '<img src="' + blobInfo.blobUri() + '">', false);
   } else {
     pasteHtml(editor, '<img src="' + imageItem.uri + '">', false);


### PR DESCRIPTION
Config max size for images uploaded/pasted/dragged-in

Feature for issue [#4897](https://github.com/tinymce/tinymce/issues/4897)

Add `paste_image_maxsize` option for paste plugin

- Usage
```
tinymce.init({
  // .....
  plugins: 'paste',
  paste_data_images: true,
  paste_image_maxsize: 10 // (unit: MB)
});
```