### PR TITLE
Add option to render HTML for autocomplete item

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/Autocompleter.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/Autocompleter.ts
@@ -7,6 +7,7 @@ import { ColumnTypes } from '../toolbar/ToolbarSplitButton';
 export interface AutocompleterItemApi {
   value: string;
   text?: string;
+  html?: string;
   icon?: string;
   meta?: Record<string, any>;
 }
@@ -14,6 +15,7 @@ export interface AutocompleterItemApi {
 export interface AutocompleterItem {
   type: 'autocompleteitem';
   value: string;
+  html: Option<string>;
   text: Option<string>;
   icon: Option<string>;
   active: boolean;
@@ -55,6 +57,7 @@ const autocompleterItemSchema = ValueSchema.objOf([
   FieldSchema.defaulted('meta', {}),
   FieldSchema.strictString('value'),
   FieldSchema.optionString('text'),
+  FieldSchema.optionString('html'),
   FieldSchema.optionString('icon')
 ]);
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
@@ -71,7 +71,7 @@ const renderAutocompleteItem = (spec: InlineContent.AutocompleterItem, matchText
   const structure = renderItemStructure({
     presets,
     textContent: Option.none(),
-    htmlContent: useText ? spec.text.map((text) => replaceText(text, matchText)) : Option.none(),
+    htmlContent: spec.html || useText ? spec.text.map((text) => replaceText(text, matchText)) : Option.none(),
     ariaLabel: spec.text,
     iconContent: spec.icon,
     shortcutContent: Option.none(),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
@@ -71,7 +71,7 @@ const renderAutocompleteItem = (spec: InlineContent.AutocompleterItem, matchText
   const structure = renderItemStructure({
     presets,
     textContent: Option.none(),
-    htmlContent: spec.html || useText ? spec.text.map((text) => replaceText(text, matchText)) : Option.none(),
+    htmlContent: spec.html || (useText ? spec.text.map((text) => replaceText(text, matchText)) : Option.none()),
     ariaLabel: spec.text,
     iconContent: spec.icon,
     shortcutContent: Option.none(),


### PR DESCRIPTION
Currently the autocomplete can only render text or icons. This adds support to render arbitrary HTML.