### PR TITLE
Fix filter parameter shadowing on locateIn

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/DomPinpoint.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/DomPinpoint.ts
@@ -11,7 +11,7 @@ const locateVisible = (container, current, selector) => {
 const locateIn = (container, current, selector, filter) => {
   const predicate = Fun.curry(Compare.eq, current);
   const candidates = SelectorFilter.descendants(container, selector);
-  const visible = Arr.filter(candidates, Visibility.isVisible);
+  const visible = Arr.filter(candidates, filter);
   return ArrPinpoint.locate(visible, predicate);
 };
 


### PR DESCRIPTION
The signature of `locateIn` includes a `filter` that is not used in the current definition of the function. This is causing some issues during the bundling on `master` for me. This is what `locateIn` and `locate ends up looking like:

```
    var locateVisible = function (container, current, selector) {
      return locateIn(container, current, selector);
    };
    var locateIn = function (container, current, selector, filter) {
      var predicate = curry(eq, current);
      var candidates = descendants(container, selector);
      var visible = filter(candidates, isVisible);
      return locate$2(visible, predicate);
    };
```

Note that the `filter` argument in `locateVisible` is removed, probably because the bundler can tell that the argument goes unused. Then `locateIn` calls `filter` from its argument list, which shadows the original `Arr.filter`, causing a `filter is not a function` error.

This is what the same block looks like from this branch:

```
    var locateVisible = function (container, current, selector) {
      var filter = isVisible;
      return locateIn(container, current, selector, filter);
    };
    var locateIn = function (container, current, selector, filter$1) {
      var predicate = curry(eq, current);
      var candidates = descendants(container, selector);
      var visible = filter(candidates, filter$1);
      return locate$2(visible, predicate);
    };
```