### PR TITLE
Global style overrides

### DIFF
--- a/modules/oxide/src/less/skins/ui/dark/content.less
+++ b/modules/oxide/src/less/skins/ui/dark/content.less
@@ -10,11 +10,3 @@
 @content-ui-darkmode: true;
 @resize-handle-color: #4099ff;
 @object-block-selected-color: @resize-handle-color;
-
-body {
-  font-family: sans-serif;
-}
-
-table {
-  border-collapse: collapse;
-}

--- a/modules/oxide/src/less/skins/ui/dark/content.mobile.less
+++ b/modules/oxide/src/less/skins/ui/dark/content.mobile.less
@@ -6,11 +6,3 @@
  */
 
 @import 'src/less/theme-mobile/content-ui-mobile';
-
-body {
-  font-family: sans-serif;
-}
-
-table {
-  border-collapse: collapse;
-}

--- a/modules/oxide/src/less/skins/ui/default/content.less
+++ b/modules/oxide/src/less/skins/ui/default/content.less
@@ -6,11 +6,3 @@
  */
 
 @import 'src/less/theme/content-ui';
-
-body {
-  font-family: sans-serif;
-}
-
-table {
-  border-collapse: collapse;
-}

--- a/modules/oxide/src/less/skins/ui/default/content.mobile.less
+++ b/modules/oxide/src/less/skins/ui/default/content.mobile.less
@@ -6,11 +6,3 @@
  */
 
 @import 'src/less/theme-mobile/content-ui-mobile';
-
-body {
-  font-family: sans-serif;
-}
-
-table {
-  border-collapse: collapse;
-}

--- a/modules/oxide/src/less/theme/globals/reset.less
+++ b/modules/oxide/src/less/theme/globals/reset.less
@@ -58,6 +58,10 @@
     position: static;
     width: auto;
   }
+
+  table {
+    border-collapse: collapse;
+  }
 }
 
 .tox:not([dir=rtl]) {


### PR DESCRIPTION
Most TinyMCE styles are self-contained and do not override global styles.

Except, font-family is being overwritten by generated styles so this PR removes that styles so it won't affect global application styles