### PR TITLE
Add paste_single_plaintext_block option to plugin

### DIFF
--- a/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
@@ -71,6 +71,10 @@ const shouldUseDefaultFilters = (editor: Editor): boolean => {
   return editor.getParam('paste_enable_default_filters', true);
 };
 
+const shouldUseSinglePlaintextBlock = (editor: Editor): boolean => {
+  return editor.getParam('paste_single_plaintext_block', false);
+};
+
 export default {
   shouldBlockDrop,
   shouldPasteDataImages,
@@ -85,5 +89,6 @@ export default {
   getRetainStyleProps,
   getWordValidElements,
   shouldConvertWordFakeLists,
-  shouldUseDefaultFilters
+  shouldUseDefaultFilters,
+  shouldUseSinglePlaintextBlock
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -14,6 +14,7 @@ import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Tools from 'tinymce/core/api/util/Tools';
 import VK from 'tinymce/core/api/util/VK';
 import Events from '../api/Events';
+import Settings from '../api/Settings';
 import InternalHtml from './InternalHtml';
 import Newlines from './Newlines';
 import { PasteBin } from './PasteBin';
@@ -50,7 +51,11 @@ const pasteHtml = (editor: Editor, html: string, internalFlag: boolean) => {
 const pasteText = (editor: Editor, text: string) => {
   const encodedText = editor.dom.encode(text).replace(/\r\n/g, '\n');
   const normalizedText = Whitespace.normalizeWhitespace(encodedText);
-  const html = Newlines.convert(normalizedText, editor.settings.forced_root_block, editor.settings.forced_root_block_attrs);
+  const html = Newlines.convert(
+      normalizedText,
+      editor.settings.forced_root_block,
+      editor.settings.forced_root_block_attrs,
+      Settings.shouldUseSinglePlaintextBlock(editor));
 
   pasteHtml(editor, html, false);
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Newlines.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Newlines.ts
@@ -47,8 +47,8 @@ const openContainer = function (rootTag: string, rootAttrs: RootAttrs) {
   return tag + '>';
 };
 
-const toBlockElements = function (text: string, rootTag: string, rootAttrs: RootAttrs) {
-  const blocks = text.split(/\n\n/);
+const toBlockElements = function (text: string, rootTag: string, rootAttrs: RootAttrs, useSingleBlock: boolean) {
+  const blocks = useSingleBlock ? [text] : text.split(/\n\n/);
   const tagOpen = openContainer(rootTag, rootAttrs);
   const tagClose = '</' + rootTag + '>';
 
@@ -63,8 +63,8 @@ const toBlockElements = function (text: string, rootTag: string, rootAttrs: Root
   return paragraphs.length === 1 ? paragraphs[0] : Tools.map(paragraphs, stitch).join('');
 };
 
-const convert = function (text: string, rootTag: string | boolean, rootAttrs: RootAttrs) {
-  return rootTag ? toBlockElements(text, rootTag === true ? 'p' : rootTag, rootAttrs) : toBRs(text);
+const convert = function (text: string, rootTag: string | boolean, rootAttrs: RootAttrs, useSingleBlock: boolean) {
+  return rootTag ? toBlockElements(text, rootTag === true ? 'p' : rootTag, rootAttrs, useSingleBlock) : toBRs(text);
 };
 
 export default {

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
@@ -102,6 +102,7 @@ UnitTest.asynctest('tinymce.plugins.paste.browser.PlainTextPaste', (success, fai
 
   const expectedWithRootBlock = '<p>one<br />two</p><p>three</p><p><br />four</p><p>&nbsp;</p><p>.</p>';
   const expectedWithRootBlockAndAttrs = '<p class="attr">one<br />two</p><p class="attr">three</p><p class="attr"><br />four</p><p class="attr">&nbsp;</p><p class="attr">.</p>';
+  const expectedWithSingleRootBlock = '<p>one<br />two<br /><br />three<br /><br /><br />four<br /><br /><br /><br />.</p>';
   const expectedWithoutRootBlock = 'one<br />two<br /><br />three<br /><br /><br />four<br /><br /><br /><br />.';
 
   Pipeline.async({}, [
@@ -122,6 +123,15 @@ UnitTest.asynctest('tinymce.plugins.paste.browser.PlainTextPaste', (success, fai
         }
       }),
       cAssertClipboardPaste(expectedWithRootBlockAndAttrs, pasteData),
+      cRemoveEditor()
+    ])),
+    Chain.asStep({}, Log.chains('TBA', 'Paste: Assert forced_root_block <p></p> is added only once to pasted data', [
+      cCreateEditorFromSettings({
+        plugins: 'paste',
+        forced_root_block: 'p',
+        paste_single_plaintext_block: true,
+      }),
+      cAssertClipboardPaste(expectedWithSingleRootBlock, pasteData),
       cRemoveEditor()
     ])),
     Chain.asStep({}, Log.chains('TBA', 'Paste: Assert forced_root_block is not added to the pasted data', [


### PR DESCRIPTION
By default, the TinyMCE paste plugin performs automatic smart blocking
of plaintext paste contents. It splits content on \n\n and puts each
new block into a new root-block tag, in cases where one is configured,
where &lt;p> is the default. This isn't always what you might want,
especially if the styling of &lt;p> tags in the application doesn't match
up with consecutive &lt;br> tags.

This adds a paste_single_plaintext_block option, which pastes
plaintext into a single root block, with \n\n being converted into
&lt;br>&lt;br> rather than a new block. This is similar to the functionality
when forced_root_block = false, except that there is still one outer
root block wrapping the entire paste contents.

Using this option means that plaintext is pasted exactly as-is, but
with the downside that any block formatting options (e.g., bullets)
are applied to the entire paste contents rather than individual
paragraphs. (Of course, this option is disabled by default.)