### PR TITLE
Add aria-hidden to editor resize handle

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
@@ -22,7 +22,8 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
         tag: 'div',
         classes: [ 'tox-statusbar__resize-handle' ],
         attributes: {
-          title: providersBackstage.translate('Resize') // TODO: tooltips AP-213
+          'title': providersBackstage.translate('Resize'), // TODO: tooltips AP-213
+          'aria-hidden': 'true',
         },
         innerHtml: getIcon('resize-handle', providersBackstage.icons),
       },


### PR DESCRIPTION
The resize handle on the editor is just a &lt;div>, so it's read to a screen-reader, but the user can't take any action on it. It's possible to use a combination of ARIA attributes and dynamic live-text to allow the user to drag-and-drop the resize handle. But, this is not very useful since a screen-reader user wouldn't have much of a reason to resize the editor in the first place.

This adds aria-hidden to the resize handler so it isn't read aloud and doesn't confuse the user since they cannot interact with it.