### PR TITLE
Add extra classname to preview dialog

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Dialog.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Dialog.ts
@@ -117,6 +117,7 @@ export const dialogSchema = ValueSchema.objOf([
     tabpanel: tabPanelSchema
   })),
   FieldSchema.defaultedString('size', 'normal'),
+  FieldSchema.strictString('extraClasses'),
   FieldSchema.strictArrayOf('buttons', dialogButtonSchema),
   FieldSchema.defaulted('initialData', {}),
   FieldSchema.defaultedFunction('onAction', Fun.noop),

--- a/modules/tinymce/src/plugins/preview/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/api/Settings.ts
@@ -22,9 +22,14 @@ const shouldUseContentCssCors = (editor: Editor): boolean => {
   return editor.getParam('content_css_cors', false, 'boolean');
 };
 
+const getExtraClasses = function (editor) {
+  return editor.getParam('plugin_preview_classes', '');
+};
+
 export default {
   getPreviewDialogWidth,
   getPreviewDialogHeight,
   getContentStyle,
-  shouldUseContentCssCors
+  shouldUseContentCssCors,
+  getExtraClasses
 };

--- a/modules/tinymce/src/plugins/preview/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/ui/Dialog.ts
@@ -7,14 +7,17 @@
 
 import Editor from 'tinymce/core/api/Editor';
 import IframeContent from '../core/IframeContent';
+import Settings from '../api/Settings';
 
 export const open = (editor: Editor) => {
 
   const content = IframeContent.getPreviewHtml(editor);
+  const dialogClasses = Settings.getExtraClasses(editor);
 
   const dataApi = editor.windowManager.open({
     title: 'Preview',
     size: 'large',
+    extraClasses: dialogClasses,
     body: {
       type: 'panel',
       items: [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -33,11 +33,16 @@ const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverD
 
   const dialogEvents = SilverDialogEvents.initDialog(() => instanceApi, SilverDialogCommon.getEventExtras(() => dialog, extra));
 
-  const dialogSize = dialogInit.internalDialog.size !== 'normal'
+  let dialogSize = dialogInit.internalDialog.size !== 'normal'
     ? dialogInit.internalDialog.size === 'large'
       ? [ 'tox-dialog--width-lg' ]
       : [ 'tox-dialog--width-md' ]
     : [];
+
+  // if there is any extra classname
+  if (dialogInit.internalDialog.extraClasses) {
+    dialogSize = dialogSize.concat(dialogInit.internalDialog.extraClasses);
+  }
 
   const spec = {
     header,


### PR DESCRIPTION
### Situation:
> Background: Vue application

Due to the generated place of the preview dialog in HTML, which is outside the editor itself, we found it was difficult to apply the specific styles on the dialog('cause the scoped styles are only worked inside the component).

Apart from that, because this is A single page application, the styles are more likely to be polluted globally by setting styles to the default classname of the dialog.

Under this circumstance, we appreciate it if the **extra classes feature** could be patched for the preview dialog.

### Usage:
```javascript
<editor
  class="editor"
  initial-value=""
  :init="{
    // ...
    plugin_preview_classes: 'my-preview'
  }"
/>
```

### Result:
![image](https://user-images.githubusercontent.com/7589350/66738509-4bc72b00-eea1-11e9-912e-6dc07d03cb1a.png)
