### PR TITLE
Allow a dynamic class list for link plugin

### DIFF
--- a/src/plugins/link/main/ts/api/Settings.ts
+++ b/src/plugins/link/main/ts/api/Settings.ts
@@ -53,6 +53,14 @@ const hasLinkClassList = function (editorSettings) {
   return getLinkClassList(editorSettings) !== undefined;
 };
 
+const getLinkClassListSetup = function (editorSettings) {
+  return editorSettings.link_class_list_setup;
+};
+
+const hasLinkClassListSetup = function (editorSettings) {
+  return getLinkClassListSetup(editorSettings) !== undefined;
+};
+
 const shouldShowLinkTitle = function (editorSettings) {
   return editorSettings.link_title !== false;
 };
@@ -74,6 +82,8 @@ export default {
   hasRelList,
   getLinkClassList,
   hasLinkClassList,
+  getLinkClassListSetup,
+  hasLinkClassListSetup,
   shouldShowLinkTitle,
   allowUnsafeLinkTarget
 };

--- a/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/src/plugins/link/main/ts/ui/Dialog.ts
@@ -258,7 +258,10 @@ const showDialog = function (editor, linkList) {
               return editor.formatter.getCssText({ inline: 'a', classes: [item.value] });
             };
           }
-        }
+        },
+        Settings.hasLinkClassSetup(editor.settings)
+          ? Settings.getLinkClassSetup(editor.settings)(editor)
+          : []
       )
     };
   }


### PR DESCRIPTION
In a link modal, when saving, and when the selected link element has a class that is not defined in _link_class_list_ setting, the class attribute gets changed to the first listed in _link_class_list_ setting. This is expected behaviour, but is causing some issues. Same issue exists in image plugin.

It can be fixed in a dozen of ways, so here is one solution: a new _link_class_list_setup_ setting which is expected to be a function that accepts _editor_ and returns _array_ of default classes. This way we can add current classes added to the selected link on-fly by checking for values in _editor.dom.getParent(editor.selection.getNode(), 'a[href]')_.

Unfortunately, I do not have experence with yarn builds nor yarn tests, and am asking someone to build the thing, if this gets approved.