### PR TITLE
Exit Shadow DOM when detecting if an element is located in the document body

### DIFF
--- a/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
@@ -8,6 +8,7 @@ import * as InsertAll from './dom/InsertAll';
 import * as Link from './dom/Link';
 import * as Remove from './dom/Remove';
 import * as Replication from './dom/Replication';
+import * as ShadowDom from './dom/ShadowDom';
 import { EventArgs, EventFilter, EventHandler, EventUnbinder } from './events/Types';
 import * as DomEvent from './events/DomEvent';
 import * as MouseEvent from './events/MouseEvent';
@@ -82,6 +83,7 @@ export {
   Link,
   Remove,
   Replication,
+  ShadowDom,
   EventArgs,
   EventFilter,
   EventHandler,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/ShadowDom.ts
@@ -1,0 +1,26 @@
+import Element from '../node/Element';
+import { Selectors } from '@ephox/sugar';
+import * as Traverse from '../search/Traverse';
+import { Element as DomElement, Node as DomNode, ShadowRoot, ShadowRootInit } from '@ephox/dom-globals';
+
+const escapeShadowDom = function (element: Element<DomNode>) {
+  if (Selectors.is(element, ':host *')) {
+    return Traverse.parent(element).map(escapeShadowDom).getOr(element);
+  } else {
+    const host = (<ShadowRoot> element.dom()).host;
+    if (host && host instanceof DomNode) {
+      return escapeShadowDom(Element.fromDom(host));
+    }
+  }
+
+  return element;
+};
+
+const attachShadow = function (element: Element<DomElement>, shadowRootInitDict: ShadowRootInit) {
+  return Element.fromDom(element.dom().attachShadow(shadowRootInitDict));
+};
+
+export {
+  escapeShadowDom,
+  attachShadow
+};

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Body.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Body.ts
@@ -2,13 +2,21 @@ import { Thunk } from '@ephox/katamari';
 import Element from './Element';
 import * as Node from './Node';
 import { document, Document, Node as DomNode, HTMLElement } from '@ephox/dom-globals';
+import * as ShadowDom from '../dom/ShadowDom';
+import * as Traverse from '../search/Traverse';
 
 // Node.contains() is very, very, very good performance
 // http://jsperf.com/closest-vs-contains/5
 const inBody = function (element: Element<DomNode>) {
   // Technically this is only required on IE, where contains() returns false for text nodes.
   // But it's cheap enough to run everywhere and Sugar doesn't have platform detection (yet).
-  const dom = Node.isText(element) ? element.dom().parentNode : element.dom();
+  if (Node.isText(element)) {
+    element = Traverse.parent(element).getOr(element);
+  }
+
+  // Try to find the first parent node that's not contained within a shadow dom.
+  // Otherwise, body.contains() will always return false.
+  const dom = ShadowDom.escapeShadowDom(element).dom();
 
   // use ownerDocument.body to ensure this works inside iframes.
   // Normally contains is bad because an element "contains" itself, but here we want that.

--- a/modules/sugar/src/test/ts/browser/BodyTest.ts
+++ b/modules/sugar/src/test/ts/browser/BodyTest.ts
@@ -4,6 +4,7 @@ import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as SelectorFind from 'ephox/sugar/api/search/SelectorFind';
 import { UnitTest, assert } from '@ephox/bedrock';
+import { attachShadow } from 'ephox/sugar/api/dom/ShadowDom';
 
 UnitTest.test('BodyTest', function () {
   const body = SelectorFind.first('body').getOrDie();
@@ -11,17 +12,28 @@ UnitTest.test('BodyTest', function () {
   const div = Element.fromTag('div');
   const child = Element.fromTag('span');
   const text = Element.fromText('hi');
+  const shadowDom = Element.fromTag('div');
+  const shadowRoot = attachShadow(shadowDom, { mode: 'open' });
+  const shadowItem = Element.fromTag('span');
   Insert.append(child, text);
   Insert.append(div, child);
+  Insert.append(div, shadowDom);
+  Insert.append(shadowRoot, shadowItem);
   assert.eq(false, Body.inBody(div));
   assert.eq(false, Body.inBody(child));
   assert.eq(false, Body.inBody(text));
+  assert.eq(false, Body.inBody(shadowDom));
+  assert.eq(false, Body.inBody(shadowRoot));
+  assert.eq(false, Body.inBody(shadowItem));
 
   Insert.append(body, div);
   assert.eq(true, Body.inBody(div));
   assert.eq(true, Body.inBody(child));
   assert.eq(true, Body.inBody(text));
   assert.eq(true, Body.inBody(body));
+  assert.eq(true, Body.inBody(shadowDom));
+  assert.eq(true, Body.inBody(shadowRoot));
+  assert.eq(true, Body.inBody(shadowItem));
 
   Remove.remove(div);
 });

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -1,0 +1,24 @@
+import Element from 'ephox/sugar/api/node/Element';
+import { UnitTest, assert } from '@ephox/bedrock';
+import { attachShadow, escapeShadowDom } from 'ephox/sugar/api/dom/ShadowDom';
+import { Insert, Selectors } from '@ephox/sugar';
+
+UnitTest.test('ShadowDomTest', function () {
+  const root = Element.fromHtml(`<div id="root">
+    <div id="inner">
+        <a id="link"></a>
+        <div id="shadow-dom"></div>
+    </div>
+  </div>`);
+
+  const shadowDom = Selectors.one('#shadow-dom', root).getOrDie();
+  const shadowRoot = attachShadow(shadowDom, { mode: 'open' });
+  const shadowItem = Element.fromHtml(`<div id="shadow-item"></div>`);
+  Insert.append(shadowRoot, shadowItem);
+
+  assert.eq('root', escapeShadowDom(root).dom().id);
+  assert.eq('inner', escapeShadowDom(Selectors.one('#inner', root).getOrDie()).dom().id);
+  assert.eq('link', escapeShadowDom(Selectors.one('#link', root).getOrDie()).dom().id);
+  assert.eq('shadow-dom', escapeShadowDom(shadowDom).dom().id);
+  assert.eq('shadow-dom', escapeShadowDom(shadowItem).dom().id);
+});


### PR DESCRIPTION
ephox/sugar's Body.inBody currently doesn't support elements that are located within the shadow DOM. It returns false for such elements, even though the element is located in the body. This results in buggy behavior for some features such as the quickbar.

This pull request fixes Body.inBody so that it supports shadow DOM inhabitants.