### PR TITLE
Public Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+
+os: linux
+
+node_js:
+  - node
+
+addons:
+  chrome: stable
+
+before_script:
+  - npm install -g chromedriver
+
+script:
+  - yarn tslint
+  - yarn build
+  - yarn phantomjs-test
+  - yarn browser-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os: linux
 node_js:
   - node
 
+cache: yarn
+
 addons:
   chrome: stable
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,7 +97,7 @@ const fetchLernaProjects = (log, runAllTests) => {
   // if JSON parse fails, well, grunt will just fail /shrug
   const parseLernaList = (cmd) => {
     try {
-      return JSON.parse(exec(`yarn -s lerna ${cmd} -a --no-ignore-changes --json --loglevel warn 2>&1`));
+      return JSON.parse(exec(`yarn -s lerna ${cmd} -a --json --loglevel warn 2>&1`));
     } catch (e) {
       // If no changes are found, then lerna returns an exit code of 1, so deal with that gracefully
       if (e.status === 1) {
@@ -108,7 +108,7 @@ const fetchLernaProjects = (log, runAllTests) => {
     }
   };
 
-  const changes = runAllTests ? [] : parseLernaList('changed');
+  const changes = runAllTests ? [] : parseLernaList('changed --no-ignore-changes');
 
   if (changes.length === 0) {
     log.writeln('No changes found, testing all projects');


### PR DESCRIPTION
While testings for all browsers currently requires the Tiny private CI infrastructure, we are able to run style checks and the TinyMCE bedrock test suite against Chrome Headless & PhantomJS.

This should provide useful feedback for community PRs ahead of any internal testing at Tiny.