### PR TITLE
TINY-4710: Reduced bundle size of a few plugins by switching to Promises instead of Futures

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.3.0 (TBD)
-
+    Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
 Version 5.2.1 (TBD)
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948
     Fixed the editor incorrectly stealing focus during initialization in IE 11 #TINY-4697

--- a/modules/tinymce/src/plugins/image/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/Utils.ts
@@ -5,13 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { document, Element, Blob, HTMLElement, FileReader } from '@ephox/dom-globals';
-import { Result } from '@ephox/katamari';
+import { Blob, document, Element, FileReader, HTMLElement } from '@ephox/dom-globals';
+import Editor from 'tinymce/core/api/Editor';
+import { StyleMap } from 'tinymce/core/api/html/Styles';
 import Promise from 'tinymce/core/api/util/Promise';
 import XHR from 'tinymce/core/api/util/XHR';
 import Settings from '../api/Settings';
-import { StyleMap } from 'tinymce/core/api/html/Styles';
-import Editor from 'tinymce/core/api/Editor';
 import { ImageData } from './ImageData';
 
 export interface ImageDimensions {
@@ -24,36 +23,38 @@ const parseIntAndGetMax = (val1: any, val2: any) => {
   return Math.max(parseInt(val1, 10), parseInt(val2, 10));
 };
 
-const getImageSize = (url: string, callback: (dimensions: Result<ImageDimensions, string>) => void) => {
-  const img = document.createElement('img');
+const getImageSize = (url: string): Promise<ImageDimensions> => {
+  return new Promise((callback) => {
+    const img = document.createElement('img');
 
-  const done = (dimensions: Result<ImageDimensions, string>) => {
-    if (img.parentNode) {
-      img.parentNode.removeChild(img);
-    }
+    const done = (dimensions: Promise<ImageDimensions>) => {
+      if (img.parentNode) {
+        img.parentNode.removeChild(img);
+      }
 
-    callback(dimensions);
-  };
+      callback(dimensions);
+    };
 
-  img.onload = () => {
-    const width = parseIntAndGetMax(img.width, img.clientWidth);
-    const height = parseIntAndGetMax(img.height, img.clientHeight);
-    const dimensions = { width, height };
-    done(Result.value(dimensions));
-  };
+    img.onload = () => {
+      const width = parseIntAndGetMax(img.width, img.clientWidth);
+      const height = parseIntAndGetMax(img.height, img.clientHeight);
+      const dimensions = { width, height };
+      done(Promise.resolve(dimensions));
+    };
 
-  img.onerror = () => {
-    done(Result.error(`Failed to get image dimensions for: ${url}`));
-  };
+    img.onerror = () => {
+      done(Promise.reject(`Failed to get image dimensions for: ${url}`));
+    };
 
-  const style = img.style;
-  style.visibility = 'hidden';
-  style.position = 'fixed';
-  style.bottom = style.left = '0px';
-  style.width = style.height = 'auto';
+    const style = img.style;
+    style.visibility = 'hidden';
+    style.position = 'fixed';
+    style.bottom = style.left = '0px';
+    style.width = style.height = 'auto';
 
-  document.body.appendChild(img);
-  img.src = url;
+    document.body.appendChild(img);
+    img.src = url;
+  });
 };
 
 const removePixelSuffix = (value: string): string => {

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
@@ -7,7 +7,7 @@
 
 import { Types } from '@ephox/bridge';
 import { File, URL } from '@ephox/dom-globals';
-import { Arr, FutureResult, Merger, Option, Type } from '@ephox/katamari';
+import { Arr, Merger, Option, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { BlobInfo } from 'tinymce/core/api/file/BlobCache';
@@ -34,7 +34,7 @@ interface Size {
 
 interface Helpers {
   onSubmit: (info: ImageDialogInfo) => (api: API) => void;
-  imageSize: (url: string) => FutureResult<Size, string>;
+  imageSize: (url: string) => Promise<Size>;
   addToBlobCache: (blobInfo: BlobInfo) => void;
   createBlobCache: (file: File, blobUri: string, dataUrl: string) => BlobInfo;
   alertErr: (api: API, message: string) => void;
@@ -176,12 +176,10 @@ const calculateImageSize = (helpers: Helpers, info: ImageDialogInfo, state: Imag
   const url = data.src.value;
   const meta = data.src.meta || {};
   if (!meta.width && !meta.height && info.hasDimensions) {
-    helpers.imageSize(url).get((result) => {
-      result.each((size) => {
-        if (state.open) {
-          api.setData({ dimensions: size });
-        }
-      });
+    helpers.imageSize(url).then((size) => {
+      if (state.open) {
+        api.setData({ dimensions: size });
+      }
     });
   }
 };
@@ -401,18 +399,12 @@ const submitHandler = (editor: Editor) => (info: ImageDialogInfo) => (api: API) 
   api.close();
 };
 
-const imageSize = (editor: Editor) => (url: string): FutureResult<Size, string> => {
-  return FutureResult.nu((completer) => {
-    Utils.getImageSize(editor.documentBaseURI.toAbsolute(url), (data) => {
-      const result = data.map((dimensions) => {
-        return {
-          width: String(dimensions.width),
-          height: String(dimensions.height)
-        };
-      });
-
-      completer(result);
-    });
+const imageSize = (editor: Editor) => (url: string): Promise<Size> => {
+  return Utils.getImageSize(editor.documentBaseURI.toAbsolute(url)).then((dimensions) => {
+    return {
+      width: String(dimensions.width),
+      height: String(dimensions.height)
+    };
   });
 };
 
@@ -457,7 +449,7 @@ export const Dialog = (editor: Editor) => {
     parseStyle: parseStyle(editor),
     serializeStyle: serializeStyle(editor),
   };
-  const open = () => collect(editor).map(makeDialog(helpers)).get((spec) => {
+  const open = () => collect(editor).then(makeDialog(helpers)).then((spec) => {
     editor.windowManager.open(spec);
   });
 

--- a/modules/tinymce/src/plugins/image/main/ts/ui/DialogInfo.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/DialogInfo.ts
@@ -5,8 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Future, Option, Type } from '@ephox/katamari';
+import { Arr, Option, Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
+import Promise from 'tinymce/core/api/util/Promise';
 
 import Settings from '../api/Settings';
 import { readImageDataFromSelection } from '../core/ImageSelection';
@@ -14,12 +15,12 @@ import { ListUtils } from '../core/ListUtils';
 import Utils from '../core/Utils';
 import { ImageDialogInfo, ListItem } from './DialogTypes';
 
-const collect = (editor: Editor): Future<ImageDialogInfo> => {
+const collect = (editor: Editor): Promise<ImageDialogInfo> => {
   const urlListSanitizer = ListUtils.sanitizer((item) => {
     return editor.convertURL(item.value || item.url, 'src');
   });
 
-  const futureImageList = Future.nu<Option<ListItem[]>>((completer) => {
+  const futureImageList = new Promise<Option<ListItem[]>>((completer) => {
     Utils.createImageList(editor, (imageList) => {
       completer(
         urlListSanitizer(imageList).map(
@@ -51,7 +52,7 @@ const collect = (editor: Editor): Future<ImageDialogInfo> => {
   const prependURL: Option<string> = Option.some(Settings.getPrependUrl(editor)).filter(
     (preUrl) => Type.isString(preUrl) && preUrl.length > 0);
 
-  return futureImageList.map((imageList): ImageDialogInfo => {
+  return futureImageList.then((imageList): ImageDialogInfo => {
     return {
       image,
       imageList,

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
@@ -7,7 +7,7 @@
 
 import { Types } from '@ephox/bridge';
 import { HTMLAnchorElement } from '@ephox/dom-globals';
-import { Arr, Future, Option, Options } from '@ephox/katamari';
+import { Arr, Option, Options } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 import Settings from '../api/Settings';
@@ -48,14 +48,14 @@ const handleSubmit = (editor: Editor, info: LinkDialogInfo) => (api: Types.Dialo
     attach: data.url.meta !== undefined && data.url.meta.attach ? data.url.meta.attach : () => {}
   };
 
-  DialogConfirms.preprocess(editor, changedData).get((pData) => {
+  DialogConfirms.preprocess(editor, changedData).then((pData) => {
     Utils.link(editor, attachState, pData);
   });
 
   api.close();
 };
 
-const collectData = (editor): Future<LinkDialogInfo> => {
+const collectData = (editor): Promise<LinkDialogInfo> => {
   const anchorNode: HTMLAnchorElement = Utils.getAnchorElement(editor);
   return DialogInfo.collect(editor, anchorNode);
 };
@@ -160,10 +160,10 @@ const makeDialog = (settings: LinkDialogInfo, onSubmit, editor: Editor): Types.D
 
 const open = function (editor: Editor) {
   const data = collectData(editor);
-  data.map((info) => {
+  data.then((info) => {
     const onSubmit = handleSubmit(editor, info);
     return makeDialog(info, onSubmit, editor);
-  }).get((spec) => {
+  }).then((spec) => {
     editor.windowManager.open(spec);
   });
 };

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogConfirms.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogConfirms.ts
@@ -5,9 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Future, Option } from '@ephox/katamari';
-import Delay from 'tinymce/core/api/util/Delay';
+import { Arr, Option } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
+import Delay from 'tinymce/core/api/util/Delay';
+import Promise from 'tinymce/core/api/util/Promise';
 
 import Settings from '../api/Settings';
 import { AssumeExternalTargets } from '../api/Types';
@@ -53,13 +54,13 @@ const tryProtocolTransform = (assumeExternalTargets: AssumeExternalTargets, defa
   }) : Option.none();
 };
 
-const preprocess = (editor: Editor, data: LinkDialogOutput): Future<LinkDialogOutput> => {
+const preprocess = (editor: Editor, data: LinkDialogOutput): Promise<LinkDialogOutput> => {
   return Arr.findMap(
     [ tryEmailTransform, tryProtocolTransform(Settings.assumeExternalTargets(editor),  Settings.getDefaultLinkProtocol(editor)) ],
     (f) => f(data)
   ).fold(
-    () => Future.pure(data),
-    (transform) => Future.nu((callback) => {
+    () => Promise.resolve(data),
+    (transform) => new Promise((callback) => {
       delayedConfirm(editor, transform.message, (state) => {
         callback(state ? transform.preprocess(data) : data);
       });

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
@@ -5,8 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { HTMLAnchorElement, Element } from '@ephox/dom-globals';
-import { Future, Option } from '@ephox/katamari';
+import { Element, HTMLAnchorElement } from '@ephox/dom-globals';
+import { Option } from '@ephox/katamari';
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import Editor from 'tinymce/core/api/Editor';
 
 import Settings from '../api/Settings';
 import Utils from '../core/Utils';
@@ -16,8 +18,6 @@ import { ClassListOptions } from './sections/ClassListOptions';
 import { LinkListOptions } from './sections/LinkListOptions';
 import { RelOptions } from './sections/RelOptions';
 import { TargetOptions } from './sections/TargetOptions';
-import Editor from 'tinymce/core/api/Editor';
-import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 
 const nonEmptyAttr = (dom: DOMUtils, elem: string | Element, name: string): Option<string> => {
   const val: string | null = dom.getAttrib(elem, name);
@@ -44,8 +44,8 @@ const extractFromAnchor = (editor: Editor, anchor: HTMLAnchorElement) => {
   };
 };
 
-const collect = (editor: Editor, linkNode: HTMLAnchorElement): Future<LinkDialogInfo> => {
-  return LinkListOptions.getLinks(editor).map((links) => {
+const collect = (editor: Editor, linkNode: HTMLAnchorElement): Promise<LinkDialogInfo> => {
+  return LinkListOptions.getLinks(editor).then((links) => {
     const anchor = extractFromAnchor(editor, linkNode);
     return {
       anchor,

--- a/modules/tinymce/src/plugins/link/main/ts/ui/sections/LinkListOptions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/sections/LinkListOptions.ts
@@ -5,11 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Settings from '../../api/Settings';
-import { Future, Option, Type } from '@ephox/katamari';
+import { Option, Type } from '@ephox/katamari';
+import Promise from 'tinymce/core/api/util/Promise';
 import XHR from 'tinymce/core/api/util/XHR';
-import { ListItem } from '../DialogTypes';
+import Settings from '../../api/Settings';
 import { ListOptions } from '../../core/ListOptions';
+import { ListItem } from '../DialogTypes';
 
 const parseJson = (text: string): Option<ListItem[]> => {
   // Do some proper modelling.
@@ -20,11 +21,11 @@ const parseJson = (text: string): Option<ListItem[]> => {
   }
 };
 
-const getLinks = (editor): Future<Option<ListItem[]>> => {
+const getLinks = (editor): Promise<Option<ListItem[]>> => {
   const extractor = (item) => editor.convertURL(item.value || item.url, 'href');
 
   const linkList = Settings.getLinkList(editor);
-  return Future.nu<Option<ListItem[]>>((callback) => {
+  return new Promise<Option<ListItem[]>>((callback) => {
     // TODO - better handling of failure
     if (Type.isString(linkList)) {
       XHR.send({
@@ -37,7 +38,7 @@ const getLinks = (editor): Future<Option<ListItem[]>> => {
     } else {
       callback(Option.from(linkList as ListItem[]));
     }
-  }).map((optItems) => {
+  }).then((optItems) => {
     return optItems.bind(ListOptions.sanitizeWith(extractor)).map((items) => {
       if (items.length > 0) {
         return [{ text: 'None', value: '' }].concat(items);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
@@ -1,15 +1,15 @@
-import { Assertions, Pipeline, Step, Log } from '@ephox/agar';
+import { Assertions, Log, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Option } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
 
 import { AnchorListOptions } from 'tinymce/plugins/link/ui/sections/AnchorListOptions';
 import { ClassListOptions } from 'tinymce/plugins/link/ui/sections/ClassListOptions';
 import { LinkListOptions } from 'tinymce/plugins/link/ui/sections/LinkListOptions';
 import { RelOptions } from 'tinymce/plugins/link/ui/sections/RelOptions';
 import { TargetOptions } from 'tinymce/plugins/link/ui/sections/TargetOptions';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 import { TestLinkUi } from '../module/TestLinkUi';
 
 UnitTest.asynctest('browser.tinymce.plugins.link.ListOptionsTest', (success, failure) => {
@@ -79,7 +79,7 @@ UnitTest.asynctest('browser.tinymce.plugins.link.ListOptionsTest', (success, fai
           ]);
         }),
         Step.async((next, die) => {
-          LinkListOptions.getLinks(editor).get((links) => {
+          LinkListOptions.getLinks(editor).then((links) => {
             try {
               Assertions.assertEq(
                 'Checking link_list',

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -5,12 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { DataTransfer, ClipboardEvent, HTMLImageElement, Range, Image, Event, DragEvent, navigator, KeyboardEvent, File } from '@ephox/dom-globals';
-import { Cell, Futures, Future, Arr, Singleton } from '@ephox/katamari';
+import { ClipboardEvent, DataTransfer, DragEvent, Event, File, HTMLImageElement, Image, KeyboardEvent, navigator, Range } from '@ephox/dom-globals';
+import { Arr, Cell, Singleton } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Delay from 'tinymce/core/api/util/Delay';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import Promise from 'tinymce/core/api/util/Promise';
 import Tools from 'tinymce/core/api/util/Tools';
 import VK from 'tinymce/core/api/util/VK';
 import Events from '../api/Events';
@@ -19,8 +20,8 @@ import Newlines from './Newlines';
 import { PasteBin } from './PasteBin';
 import ProcessFilters from './ProcessFilters';
 import SmartPaste from './SmartPaste';
-import * as Whitespace from './Whitespace';
 import Utils from './Utils';
+import * as Whitespace from './Whitespace';
 
 declare let window: any;
 
@@ -175,8 +176,8 @@ const pasteImage = (editor: Editor, imageItem) => {
 const isClipboardEvent = (event: Event): event is ClipboardEvent => event.type === 'paste';
 
 const readBlobsAsDataUris = (items: File[]) => {
-  return Futures.traverse(items, (item: any) => {
-    return Future.nu((resolve) => {
+  return Promise.all(Arr.map(items, (item: any) => {
+    return new Promise((resolve) => {
       const blob = item.getAsFile ? item.getAsFile() : item;
 
       const reader = new window.FileReader();
@@ -188,7 +189,7 @@ const readBlobsAsDataUris = (items: File[]) => {
       };
       reader.readAsDataURL(blob);
     });
-  });
+  }));
 };
 
 const getImagesFromDataTransfer = (dataTransfer: DataTransfer) => {
@@ -215,7 +216,7 @@ const pasteImageData = (editor, e: ClipboardEvent | DragEvent, rng: Range) => {
     if (images.length > 0) {
       e.preventDefault();
 
-      readBlobsAsDataUris(images).get((blobResults) => {
+      readBlobsAsDataUris(images).then((blobResults) => {
         if (rng) {
           editor.selection.setRng(rng);
         }


### PR DESCRIPTION
Just something I threw together while in transit, but this should reduce the minified size of the 3 affected plugins by ~7kb each.