### PR TITLE
TINY-4564: Fixed `forced_root_block_attrs` setting not applying to new blocks consistently

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.2.1 (TBD)
-    Fixed `forced_root_block_attrs` setting not being applied to new blocks in certain cases #TINY-4564
+    Fixed `forced_root_block_attrs` setting not applying to new blocks in certain cases #TINY-4564
     Fixed `readonly` mode not returning appropriate boolean value. #TINY-3948
 Version 5.2.0 (2020-02-13)
     Added the ability to apply formats to spaces #TINY-4200

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.2.1 (TBD)
-    Fixed `forced_root_block_attrs` setting not applying to new blocks in certain cases #TINY-4564
+    Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
     Fixed `readonly` mode not returning appropriate boolean value. #TINY-3948
 Version 5.2.0 (2020-02-13)
     Added the ability to apply formats to spaces #TINY-4200

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.2.1 (TBD)
+    Fixed `forced_root_block_attrs` setting not being applied to new blocks in certain cases #TINY-4564
     Fixed `readonly` mode not returning appropriate boolean value. #TINY-3948
 Version 5.2.0 (2020-02-13)
     Added the ability to apply formats to spaces #TINY-4200

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -138,8 +138,8 @@ const applyAttributes = (editor: Editor, node: DomElement, forcedRootBlockAttrs:
   Option.from(forcedRootBlockAttrs.style)
     .map(editor.dom.parseStyle)
     .each((attrStyles) => {
-      const currentStyles = Css.getRaw(Element.fromDom(node), '');
-      const newStyles = { ...currentStyles.getOrNull, ...attrStyles };
+      const currentStyles = Css.getAllRaw(Element.fromDom(node));
+      const newStyles = { ...currentStyles, ...attrStyles };
       editor.dom.setStyles(node, newStyles);
     });
 

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -483,6 +483,7 @@ const insert = function (editor: Editor, evt?: EditorEvent<KeyboardEvent>) {
       dom.remove(newBlock);
       insertNewBlockAfter();
     } else {
+      setForcedBlockAttrs(editor, newBlock);
       NewLineUtils.moveToCaretPosition(editor, newBlock);
     }
   }

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -6,7 +6,7 @@
  */
 
 import { Element as DomElement, DocumentFragment, KeyboardEvent } from '@ephox/dom-globals';
-import { Arr, Option, Obj } from '@ephox/katamari';
+import { Arr, Option, Obj, Options } from '@ephox/katamari';
 import { PredicateFilter, Element, Css, Node } from '@ephox/sugar';
 import Settings from '../api/Settings';
 import * as CaretContainer from '../caret/CaretContainer';
@@ -144,14 +144,12 @@ const applyAttributes = (editor: Editor, node: DomElement, forcedRootBlockAttrs:
     });
 
   // Merge and apply class attribute
-  Option.from(forcedRootBlockAttrs.class).map((attrClasses) => attrClasses.split(/\s+/)).each((attrClasses) => {
-    Option.from(node.className)
-      .map((currentClasses) => Arr.filter(currentClasses.split(/\s+/), (c) => c !== ''))
-      .each((currentClasses) => {
-        const filteredClasses = Arr.filter(currentClasses, (c) => !Arr.contains(attrClasses, c));
-        const newClasses = [...attrClasses, ...filteredClasses];
-        editor.dom.setAttrib(node, 'class', newClasses.join(' '));
-      });
+  const attrClasses = Option.from(forcedRootBlockAttrs.class).map((attrC) => attrC.split(/\s+/));
+  const currentClasses = Option.from(node.className).map((currentC) => Arr.filter(currentC.split(/\s+/), (c) => c !== ''));
+  Options.lift2(attrClasses, currentClasses, (attrC, currentC) => {
+    const filteredClasses = Arr.filter(currentC, (c) => !Arr.contains(attrC, c));
+    const newClasses = [...attrC, ...filteredClasses];
+    editor.dom.setAttrib(node, 'class', newClasses.join(' '));
   });
 
   // Apply any remaining forced root block attributes

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -144,11 +144,11 @@ const applyAttributes = (editor: Editor, node: DomElement, forcedRootBlockAttrs:
     });
 
   // Merge and apply class attribute
-  const attrClasses = Option.from(forcedRootBlockAttrs.class).map((attrC) => attrC.split(/\s+/));
-  const currentClasses = Option.from(node.className).map((currentC) => Arr.filter(currentC.split(/\s+/), (c) => c !== ''));
-  Options.lift2(attrClasses, currentClasses, (attrC, currentC) => {
-    const filteredClasses = Arr.filter(currentC, (c) => !Arr.contains(attrC, c));
-    const newClasses = [...attrC, ...filteredClasses];
+  const attrClassesOpt = Option.from(forcedRootBlockAttrs.class).map((attrClasses) => attrClasses.split(/\s+/));
+  const currentClassesOpt = Option.from(node.className).map((currentClasses) => Arr.filter(currentClasses.split(/\s+/), (clazz) => clazz !== ''));
+  Options.lift2(attrClassesOpt, currentClassesOpt, (attrClasses, currentClasses) => {
+    const filteredClasses = Arr.filter(currentClasses, (clazz) => !Arr.contains(attrClasses, clazz));
+    const newClasses = [...attrClasses, ...filteredClasses];
     editor.dom.setAttrib(node, 'class', newClasses.join(' '));
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
@@ -1,0 +1,163 @@
+import { ApproxStructure, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { Obj } from '@ephox/katamari';
+import Editor from 'tinymce/core/api/Editor';
+import InsertNewLine from 'tinymce/core/newline/InsertNewLine';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.core.newline.ForcedRootBlockTest', (success, failure) => {
+  Theme();
+
+  const bookmarkSpan = '<span data-mce-type="bookmark" id="mce_2_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px"></span>';
+  const forcedRootBlock = 'p';
+  const forcedRootBlockAttrs = { style: 'border: 1px solid red;', class: 'abc def' };
+
+  const baseExpectedHTML = (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}">${innerHTML}</p>`;
+
+  const sInsertNewline = (editor: Editor, args) => {
+    return Step.sync(function () {
+      InsertNewLine.insert(editor, args);
+    });
+  };
+
+  TinyLoader.setupLight(function (editor: Editor, onSuccess, onFailure) {
+    const tinyApis = TinyApis(editor);
+
+    const sAssertNewLine = (label: string, rootBlock: string, initalHTML: string, expectedHTML: (innerHTML: string) => string) => Logger.t(label, GeneralSteps.sequence([
+      Logger.t('Insert block before', GeneralSteps.sequence([
+        tinyApis.sSetContent(initalHTML),
+        tinyApis.sSetCursor([0, 0], 0),
+        sInsertNewline(editor, {}),
+        tinyApis.sAssertContentStructure(
+          ApproxStructure.build((s, str, arr) => {
+            return s.element('body', {
+              children: [
+                ApproxStructure.fromHtml(expectedHTML('<br data-mce-bogus="1">')),
+                s.element(rootBlock, {})
+              ]
+            });
+          })
+        ),
+        tinyApis.sAssertSelection([1, 0], 0, [1, 0], 0)
+      ])),
+      Logger.t('Split block in the middle', GeneralSteps.sequence([
+        tinyApis.sSetContent(initalHTML),
+        tinyApis.sSetCursor([0, 0], 1),
+        sInsertNewline(editor, {}),
+        tinyApis.sAssertContentStructure(
+          ApproxStructure.build((s, str, arr) => {
+            return s.element('body', {
+              children: [
+                s.element(rootBlock, {}),
+                ApproxStructure.fromHtml(expectedHTML('b'))
+              ]
+            });
+          })
+        ),
+        tinyApis.sAssertSelection([1, 0], 0, [1, 0], 0)
+      ])),
+      Logger.t('Insert block after', GeneralSteps.sequence([
+        tinyApis.sSetContent(initalHTML),
+        tinyApis.sSetCursor([0, 0], 2),
+        sInsertNewline(editor, {}),
+        tinyApis.sAssertContentStructure(
+          ApproxStructure.build((s, str, arr) => {
+            return s.element('body', {
+              children: [
+                s.element(rootBlock, {}),
+                ApproxStructure.fromHtml(expectedHTML('<br data-mce-bogus="1">')),
+              ]
+            });
+          })
+        ),
+        tinyApis.sAssertSelection([1], 0, [1], 0)
+      ])),
+      Logger.t('Insert block after bookmark', GeneralSteps.sequence([
+        tinyApis.sSetRawContent(`<${rootBlock}>${bookmarkSpan}<br data-mce-bogus="1"></${rootBlock}>`),
+        tinyApis.sSetCursor([0], 1),
+        sInsertNewline(editor, {}),
+        tinyApis.sAssertContentStructure(
+          ApproxStructure.build((s, str) => {
+            return s.element('body', {
+              children: [
+                s.element(rootBlock, {
+                  children: [
+                    ApproxStructure.fromHtml(bookmarkSpan),
+                    s.element('br', {
+                      attrs: {
+                        'data-mce-bogus': str.is('1')
+                      }
+                    })
+                  ]
+                }),
+                s.element(rootBlock, {
+                  attrs: Obj.map(editor.settings.forced_root_block_attrs, (val) => str.is(val)),
+                  children: [
+                    s.element('br', {
+                      attrs: {
+                        'data-mce-bogus': str.is('1')
+                      }
+                    })
+                  ]
+                })
+              ]
+            });
+          })),
+        tinyApis.sAssertSelection([1], 0, [1], 0)
+      ]))
+    ]));
+
+    Pipeline.async({}, [
+      tinyApis.sFocus(),
+      sAssertNewLine('paragraph, plain', 'p', `<p>ab</p>`, baseExpectedHTML),
+      sAssertNewLine('paragraph, same attributes as forced_root_block_attrs', 'p', `<p class=${forcedRootBlockAttrs.class} style=${forcedRootBlockAttrs.style}>ab</p>`, baseExpectedHTML),
+      sAssertNewLine('paragraph, only style attribute', 'p', `<p style=${forcedRootBlockAttrs.style}>ab</p>`, baseExpectedHTML),
+      sAssertNewLine('paragraph, only class attribute', 'p', `<p class=${forcedRootBlockAttrs.class}>ab</p>`, baseExpectedHTML),
+      sAssertNewLine(
+        'paragraph, additional attribute',
+        'p',
+        `<p data-test="1">ab</p>`,
+        (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}" data-test="1">${innerHTML}</p>`
+      ),
+      sAssertNewLine(
+        'paragraph, custom class attribute',
+        'p',
+        `<p class="c1">ab</p>`,
+        (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class + ' c1'}" style="${forcedRootBlockAttrs.style}">${innerHTML}</p>`
+      ),
+      sAssertNewLine(
+        'paragraph, custom style attribute',
+        'p',
+        `<p style="padding-left: 40px;">ab</p>`,
+        (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style + ' padding-left: 40px;'}">${innerHTML}</p>`
+      ),
+      tinyApis.sSetSetting('forced_root_block_attrs', { ...forcedRootBlockAttrs, 'data-test': '1' }),
+      sAssertNewLine(
+        'paragraph, additional attribute in forced_root_block_attrs',
+        'p',
+        `<p>ab</p>`,
+        (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}" data-test="1">${innerHTML}</p>`
+      ),
+      sAssertNewLine(
+        'paragraph, common attribute',
+        'p',
+        `<p data-test="0">ab</p>`,
+        (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}" data-test="1">${innerHTML}</p>`
+      ),
+      tinyApis.sSetSetting('forced_root_block_atrrs', forcedRootBlockAttrs),
+      tinyApis.sSetSetting('forced_root_block', 'div'),
+      sAssertNewLine(
+        'div, plain',
+        'div',
+        `<div>ab</div>`,
+        (innerHTML: string) => `<div class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}">${innerHTML}</div>`
+      )
+    ], onSuccess, onFailure);
+  }, {
+    forced_root_block: forcedRootBlock,
+    forced_root_block_attrs: forcedRootBlockAttrs,
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, success, failure);
+});

--- a/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
@@ -11,7 +11,7 @@ UnitTest.asynctest('browser.tinymce.core.newline.ForcedRootBlockTest', (success,
 
   const bookmarkSpan = '<span data-mce-type="bookmark" id="mce_2_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px"></span>';
   const forcedRootBlock = 'p';
-  const forcedRootBlockAttrs = { style: 'border: 1px solid red;', class: 'abc def' };
+  const forcedRootBlockAttrs = { style: 'color: red;', class: 'abc def' };
 
   const baseExpectedHTML = (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}">${innerHTML}</p>`;
 

--- a/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
@@ -1,9 +1,8 @@
-import { ApproxStructure, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
+import { ApproxStructure, GeneralSteps, Logger, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Obj } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
-import InsertNewLine from 'tinymce/core/newline/InsertNewLine';
 import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.core.newline.ForcedRootBlockTest', (success, failure) => {
@@ -12,123 +11,120 @@ UnitTest.asynctest('browser.tinymce.core.newline.ForcedRootBlockTest', (success,
   const bookmarkSpan = '<span data-mce-type="bookmark" id="mce_2_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px"></span>';
   const forcedRootBlock = 'p';
   const forcedRootBlockAttrs = { style: 'color: red;', class: 'abc def' };
-
   const baseExpectedHTML = (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}">${innerHTML}</p>`;
 
-  const sInsertNewline = (editor: Editor, args) => {
-    return Step.sync(function () {
-      InsertNewLine.insert(editor, args);
-    });
-  };
-
-  TinyLoader.setupLight(function (editor: Editor, onSuccess, onFailure) {
+  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
 
-    const sAssertNewLine = (label: string, rootBlock: string, initalHTML: string, expectedHTML: (innerHTML: string) => string) => Logger.t(label, GeneralSteps.sequence([
-      Logger.t('Insert block before', GeneralSteps.sequence([
-        tinyApis.sSetContent(initalHTML),
-        tinyApis.sSetCursor([0, 0], 0),
-        sInsertNewline(editor, {}),
-        tinyApis.sAssertContentStructure(
-          ApproxStructure.build((s, str, arr) => {
-            return s.element('body', {
-              children: [
-                ApproxStructure.fromHtml(expectedHTML('<br data-mce-bogus="1">')),
-                s.element(rootBlock, {})
-              ]
-            });
-          })
-        ),
-        tinyApis.sAssertSelection([1, 0], 0, [1, 0], 0)
-      ])),
-      Logger.t('Split block in the middle', GeneralSteps.sequence([
-        tinyApis.sSetContent(initalHTML),
-        tinyApis.sSetCursor([0, 0], 1),
-        sInsertNewline(editor, {}),
-        tinyApis.sAssertContentStructure(
-          ApproxStructure.build((s, str, arr) => {
-            return s.element('body', {
-              children: [
-                s.element(rootBlock, {}),
-                ApproxStructure.fromHtml(expectedHTML('b'))
-              ]
-            });
-          })
-        ),
-        tinyApis.sAssertSelection([1, 0], 0, [1, 0], 0)
-      ])),
-      Logger.t('Insert block after', GeneralSteps.sequence([
-        tinyApis.sSetContent(initalHTML),
-        tinyApis.sSetCursor([0, 0], 2),
-        sInsertNewline(editor, {}),
-        tinyApis.sAssertContentStructure(
-          ApproxStructure.build((s, str, arr) => {
-            return s.element('body', {
-              children: [
-                s.element(rootBlock, {}),
-                ApproxStructure.fromHtml(expectedHTML('<br data-mce-bogus="1">')),
-              ]
-            });
-          })
-        ),
-        tinyApis.sAssertSelection([1], 0, [1], 0)
-      ])),
-      Logger.t('Insert block after bookmark', GeneralSteps.sequence([
-        tinyApis.sSetRawContent(`<${rootBlock}>${bookmarkSpan}<br data-mce-bogus="1"></${rootBlock}>`),
-        tinyApis.sSetCursor([0], 1),
-        sInsertNewline(editor, {}),
-        tinyApis.sAssertContentStructure(
-          ApproxStructure.build((s, str) => {
-            return s.element('body', {
-              children: [
-                s.element(rootBlock, {
-                  children: [
-                    ApproxStructure.fromHtml(bookmarkSpan),
-                    s.element('br', {
-                      attrs: {
-                        'data-mce-bogus': str.is('1')
-                      }
-                    })
-                  ]
-                }),
-                s.element(rootBlock, {
-                  attrs: Obj.map(editor.settings.forced_root_block_attrs, (val) => str.is(val)),
-                  children: [
-                    s.element('br', {
-                      attrs: {
-                        'data-mce-bogus': str.is('1')
-                      }
-                    })
-                  ]
-                })
-              ]
-            });
-          })),
-        tinyApis.sAssertSelection([1], 0, [1], 0)
-      ]))
-    ]));
+    const sAssertNewLine = (label: string, rootBlock: string, rootBlockAttrs: Record<string, string>, initalHTML: string, expectedHTML: (innerHTML: string) => string) =>
+      Logger.t(label, GeneralSteps.sequence([
+        Logger.t('Insert block before', GeneralSteps.sequence([
+          tinyApis.sSetContent(initalHTML),
+          tinyApis.sSetCursor([0, 0], 0),
+          tinyApis.sExecCommand('mceInsertNewLine'),
+          tinyApis.sAssertContentStructure(
+            ApproxStructure.build((s, str, arr) => {
+              return s.element('body', {
+                children: [
+                  ApproxStructure.fromHtml(expectedHTML('<br data-mce-bogus="1">')),
+                  s.element(rootBlock, {})
+                ]
+              });
+            })
+          ),
+          tinyApis.sAssertSelection([1, 0], 0, [1, 0], 0)
+        ])),
+        Logger.t('Split block in the middle', GeneralSteps.sequence([
+          tinyApis.sSetContent(initalHTML),
+          tinyApis.sSetCursor([0, 0], 1),
+          tinyApis.sExecCommand('mceInsertNewLine'),
+          tinyApis.sAssertContentStructure(
+            ApproxStructure.build((s, str, arr) => {
+              return s.element('body', {
+                children: [
+                  s.element(rootBlock, {}),
+                  ApproxStructure.fromHtml(expectedHTML('b'))
+                ]
+              });
+            })
+          ),
+          tinyApis.sAssertSelection([1, 0], 0, [1, 0], 0)
+        ])),
+        Logger.t('Insert block after', GeneralSteps.sequence([
+          tinyApis.sSetContent(initalHTML),
+          tinyApis.sSetCursor([0, 0], 2),
+          tinyApis.sExecCommand('mceInsertNewLine'),
+          tinyApis.sAssertContentStructure(
+            ApproxStructure.build((s, str, arr) => {
+              return s.element('body', {
+                children: [
+                  s.element(rootBlock, {}),
+                  ApproxStructure.fromHtml(expectedHTML('<br data-mce-bogus="1">')),
+                ]
+              });
+            })
+          ),
+          tinyApis.sAssertSelection([1], 0, [1], 0)
+        ])),
+        Logger.t('Insert block after bookmark', GeneralSteps.sequence([
+          tinyApis.sSetRawContent(`<${rootBlock}>${bookmarkSpan}<br data-mce-bogus="1"></${rootBlock}>`),
+          tinyApis.sSetCursor([0], 1),
+          tinyApis.sExecCommand('mceInsertNewLine'),
+          tinyApis.sAssertContentStructure(
+            ApproxStructure.build((s, str) => {
+              return s.element('body', {
+                children: [
+                  s.element(rootBlock, {
+                    children: [
+                      ApproxStructure.fromHtml(bookmarkSpan),
+                      s.element('br', {
+                        attrs: {
+                          'data-mce-bogus': str.is('1')
+                        }
+                      })
+                    ]
+                  }),
+                  s.element(rootBlock, {
+                    attrs: Obj.map(rootBlockAttrs, (val) => str.is(val)),
+                    children: [
+                      s.element('br', {
+                        attrs: {
+                          'data-mce-bogus': str.is('1')
+                        }
+                      })
+                    ]
+                  })
+                ]
+              });
+            })),
+          tinyApis.sAssertSelection([1], 0, [1], 0)
+        ]))
+      ]));
 
     Pipeline.async({}, [
       tinyApis.sFocus(),
-      sAssertNewLine('paragraph, plain', 'p', `<p>ab</p>`, baseExpectedHTML),
-      sAssertNewLine('paragraph, same attributes as forced_root_block_attrs', 'p', `<p class=${forcedRootBlockAttrs.class} style=${forcedRootBlockAttrs.style}>ab</p>`, baseExpectedHTML),
-      sAssertNewLine('paragraph, only style attribute', 'p', `<p style=${forcedRootBlockAttrs.style}>ab</p>`, baseExpectedHTML),
-      sAssertNewLine('paragraph, only class attribute', 'p', `<p class=${forcedRootBlockAttrs.class}>ab</p>`, baseExpectedHTML),
+      sAssertNewLine('paragraph, plain', 'p', forcedRootBlockAttrs, `<p>ab</p>`, baseExpectedHTML),
+      sAssertNewLine('paragraph, same attributes as forced_root_block_attrs', 'p', forcedRootBlockAttrs, `<p class=${forcedRootBlockAttrs.class} style=${forcedRootBlockAttrs.style}>ab</p>`, baseExpectedHTML),
+      sAssertNewLine('paragraph, only style attribute', 'p', forcedRootBlockAttrs, `<p style=${forcedRootBlockAttrs.style}>ab</p>`, baseExpectedHTML),
+      sAssertNewLine('paragraph, only class attribute', 'p', forcedRootBlockAttrs, `<p class=${forcedRootBlockAttrs.class}>ab</p>`, baseExpectedHTML),
       sAssertNewLine(
         'paragraph, additional attribute',
         'p',
+        forcedRootBlockAttrs,
         `<p data-test="1">ab</p>`,
         (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}" data-test="1">${innerHTML}</p>`
       ),
       sAssertNewLine(
         'paragraph, custom class attribute',
         'p',
+        forcedRootBlockAttrs,
         `<p class="c1">ab</p>`,
         (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class + ' c1'}" style="${forcedRootBlockAttrs.style}">${innerHTML}</p>`
       ),
       sAssertNewLine(
         'paragraph, custom style attribute',
         'p',
+        forcedRootBlockAttrs,
         `<p style="padding-left: 40px;">ab</p>`,
         (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style + ' padding-left: 40px;'}">${innerHTML}</p>`
       ),
@@ -136,12 +132,14 @@ UnitTest.asynctest('browser.tinymce.core.newline.ForcedRootBlockTest', (success,
       sAssertNewLine(
         'paragraph, additional attribute in forced_root_block_attrs',
         'p',
+        { ...forcedRootBlockAttrs, 'data-test': '1' },
         `<p>ab</p>`,
         (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}" data-test="1">${innerHTML}</p>`
       ),
       sAssertNewLine(
         'paragraph, common attribute',
         'p',
+        { ...forcedRootBlockAttrs, 'data-test': '1' },
         `<p data-test="0">ab</p>`,
         (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}" data-test="1">${innerHTML}</p>`
       ),
@@ -150,6 +148,7 @@ UnitTest.asynctest('browser.tinymce.core.newline.ForcedRootBlockTest', (success,
       sAssertNewLine(
         'div, plain',
         'div',
+        forcedRootBlockAttrs,
         `<div>ab</div>`,
         (innerHTML: string) => `<div class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}">${innerHTML}</div>`
       )


### PR DESCRIPTION
These changes improve the behaviour of applying forced root block attributes to a new block when the previous block has modified or missing attributes.