### PR TITLE
TINY-4711: Fixed the `colorinput` popup appearing offscreen on mobile devices

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,33 +127,21 @@ node("primary") {
       }
     }
 
-    // No actual code runs between SCM checkout and here, just function definition
-    notifyBitbucket()
-    try {
-      // our linux nodes have multiple executors, sometimes yarn creates conflicts
-      lock("Don't run yarn simultaneously") {
-        stage ("Install tools") {
-          cleanAndInstall()
-        }
+    // our linux nodes have multiple executors, sometimes yarn creates conflicts
+    lock("Don't run yarn simultaneously") {
+      stage ("Install tools") {
+        cleanAndInstall()
       }
-
-      stage ("Type check") {
-        exec("yarn ci-all")
-      }
-
-      stage ("Run Tests") {
-        grunt("list-changed-phantom list-changed-browser")
-        // Run all the tests in parallel
-        parallel processes
-      }
-
-      // bitbucket plugin requires the result to explicitly be success
-      if (currentBuild.resultIsBetterOrEqualTo("SUCCESS")) {
-        currentBuild.result = "SUCCESS"
-      }
-    } catch (err) {
-      currentBuild.result = "FAILED"
     }
-    notifyBitbucket()
+
+    stage ("Type check") {
+      exec("yarn ci-all")
+    }
+
+    stage ("Run Tests") {
+      grunt("list-changed-phantom list-changed-browser")
+      // Run all the tests in parallel
+      parallel processes
+    }
   }
 }

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.2.1 (TBD)
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948
     Fixed the editor incorrectly stealing focus during initialization in IE 11 #TINY-4697
+    Fixed the `colorinput` popup appearing offscreen on mobile devices #TINY-4711
 Version 5.2.0 (2020-02-13)
     Added the ability to apply formats to spaces #TINY-4200
     Added new `toolbar_location` setting to allow for positioning the menu and toolbar at the bottom of the editor #TINY-4210

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
@@ -142,8 +142,8 @@ export const renderColorInput = (spec: ColorInputSpec, sharedBackstage: UiFactor
         }
       },
       layouts: {
-        onRtl: () => [ Layout.southeast ],
-        onLtr: () => [ Layout.southwest ]
+        onRtl: () => [ Layout.southwest, Layout.southeast, Layout.south ],
+        onLtr: () => [ Layout.southeast, Layout.southwest, Layout.south ]
       },
       components: [],
       fetch: ColorSwatch.getFetch(colorInputBackstage.getColors(), colorInputBackstage.hasCustomColors()),


### PR DESCRIPTION
This was causing the colorinput popup to show in the wrong direction, since the button got moved from the right side to the left side in 5.2.0. This also meant that since it only had one direction, the popup would appear offscreen on small screens (eg mobile).