### PR TITLE
TINY-4715: Fixed quickimage not restricting the file types to images

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.3.0 (TBD)
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
+    Fixed the `quickimage` button not restricting the file types to images #TINY-4715
 Version 5.2.1 (TBD)
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948
     Fixed the editor incorrectly stealing focus during initialization in IE 11 #TINY-4697

--- a/modules/tinymce/src/plugins/quickbars/main/ts/insert/Picker.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/insert/Picker.ts
@@ -15,6 +15,7 @@ const pickFile = (editor: Editor) => {
   return new Promise((resolve: (files: File[]) => void) => {
     const fileInput: HTMLInputElement = document.createElement('input');
     fileInput.type = 'file';
+    fileInput.accept = 'image/*';
     fileInput.style.position = 'fixed';
     fileInput.style.left = '0';
     fileInput.style.top = '0';


### PR DESCRIPTION
Just a quick issue that was very easy to fix, as we were just missing the `accept` attribute on the file input. Fixes #5415 

Note: No tests, as this relies on the native file input so we can't check what it's showing.