### PR TITLE
Character Map Plugin: Support supplementary characters

### DIFF
--- a/modules/tinymce/src/plugins/charmap/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/charmap/demo/ts/demo/Demo.ts
@@ -5,7 +5,7 @@ tinymce.init({
   plugins: 'charmap',
   toolbar: 'charmap',
   height: 600,
-  charmap_append: [['A'.charCodeAt(0), 'A'], ['B'.charCodeAt(0), 'B'], ['C'.charCodeAt(0), 'C']],
+  charmap_append: [['A'.charCodeAt(0), 'A'], ['B'.charCodeAt(0), 'B'], ['C'.charCodeAt(0), 'C'], [0x1d160, 'note']],
 });
 
 export {};

--- a/modules/tinymce/src/plugins/charmap/main/ts/core/Scan.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/Scan.ts
@@ -14,8 +14,41 @@ export interface CharItem {
   text: string;
 }
 
+// Extract codepoint a la ES2015 String.fromCodePoint
+// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
+// Unwrapped the polyfill into a local function. typescript and lint.
+function stringfromCodePoint(_): string {
+  const codeUnits = [];
+  let codeLen = 0;
+  let result = '';
+  for (let index = 0, len = arguments.length; index !== len; ++index) {
+    let codePoint = +arguments[index];
+    // correctly handles all cases including `NaN`, `-Infinity`, `+Infinity`
+    // The surrounding `!(...)` is required to correctly handle `NaN` cases
+    // The (codePoint>>>0) === codePoint clause handles decimals and negatives
+    if (!(codePoint < 0x10FFFF && (codePoint >>> 0) === codePoint)) {
+      throw RangeError('Invalid code point: ' + codePoint);
+    }
+    if (codePoint <= 0xFFFF) { // BMP code point
+      codeLen = codeUnits.push(codePoint);
+    } else { // Astral code point; split in surrogate halves
+      // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+      codePoint -= 0x10000;
+      codeLen = codeUnits.push(
+        (codePoint >> 10) + 0xD800,  // highSurrogate
+        (codePoint % 0x400) + 0xDC00 // lowSurrogate
+      );
+    }
+    if (codeLen >= 0x3fff) {
+      result += String.fromCharCode.apply(null, codeUnits);
+      codeUnits.length = 0;
+    }
+  }
+  return result + String.fromCharCode.apply(null, codeUnits);
+}
+
 const charMatches = (charCode: number, name: string, lowerCasePattern: string): boolean => {
-  if (Strings.contains(String.fromCharCode(charCode).toLowerCase(), lowerCasePattern)) {
+  if (Strings.contains(stringfromCodePoint(charCode).toLowerCase(), lowerCasePattern)) {
     return true;
   } else {
     return Strings.contains(name.toLowerCase(), lowerCasePattern) || Strings.contains(name.toLowerCase().replace(/\s+/g, ''), lowerCasePattern);
@@ -34,8 +67,8 @@ const scan = (group: CharMap, pattern: string): CharItem[] => {
   return Arr.map(matches, (m) => {
     return {
       text: m[1],
-      value: String.fromCharCode(m[0]),
-      icon: String.fromCharCode(m[0])
+      value: stringfromCodePoint(m[0]),
+      icon: stringfromCodePoint(m[0])
     };
   });
 };

--- a/modules/tinymce/src/plugins/charmap/test/ts/atomic/ScanTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/atomic/ScanTest.ts
@@ -11,13 +11,15 @@ UnitTest.test('atomic.tinymce.plugins.charmap.ScanTest', () => {
       [8364, 'euro sign'],
       [402, 'function / florin'],
       [192, 'A - grave'],
-      [224, 'a - grave']
+      [224, 'a - grave'],
+      [0x1d160, 'Musical Symbol Eighth Note']
     ]
   };
 
   const testCharCode = () => {
     Assertions.assertEq('$ should match the dollar sign', [ { value: '$', icon: '$', text: 'dollar sign' } ], Scan.scan(charMap, '$'));
     Assertions.assertEq('À should match the "A - grave" and "a - grave"', [ { value: 'À', icon: 'À', text: 'A - grave' }, { value: 'à', icon: 'à', text: 'a - grave' } ], Scan.scan(charMap, 'À'));
+    Assertions.assertEq('𝅘𝅥𝅮 should match "Musical Symbol Eighth Note"', [ { value: '𝅘𝅥𝅮', icon: '𝅘𝅥𝅮', text: 'Musical Symbol Eighth Note' } ], Scan.scan(charMap, '𝅘𝅥𝅮'));
   };
 
   const testNames = () => {


### PR DESCRIPTION
Supplementary characters (Unicode characters greater than U+FFFF) are truncated
when adding them to the charmap.

Thus a character like 𝅘𝅥𝅮 (0x1d160 "Musical Symbol Eighth Note"), is displayed and entered into text as 텠 (0xd160 a Hangul syllables).

The underlying cause is in Scan.ts which uses String.fromCharCode(), where per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode "Numbers greater than 0xFFFF are truncated".

The fix is to use String.fromCodePoint() which supports supplementary characters - BUT:
that's ES2015. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint has a polyfile, which I've adapted as a local function.