### PR TITLE
TINY-4725: Fixed the floating toolbar disconnecting from the toolbar when adding content in inline mode

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.2.1 (TBD)
     Fixed table resize handles not functioning correctly in Edge #TINY-4160
+    Fixed the floating toolbar disconnecting from the toolbar when adding content in inline mode #TINY-4725
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948
     Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
     Fixed the editor incorrectly stealing focus during initialization in IE 11 #TINY-4697

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, Attachment, Boxes, Docking, SplitFloatingToolbar } from '@ephox/alloy';
+import { AlloyComponent, Attachment, Boxes, Channels, Docking } from '@ephox/alloy';
 import { Cell, Option } from '@ephox/katamari';
 import { Body, Css, Element, Height, Width } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -22,12 +22,16 @@ import Utils from '../ui/sizing/Utils';
 import { inline as loadInlineSkin } from './../ui/skin/Loader';
 import { setToolbar } from './Toolbars';
 
-const getTargetPosition = (targetElm: Element, isToolbarTop: boolean) => {
+const getTargetPosAndHeight = (targetElm: Element, isToolbarTop: boolean) => {
   const pos = Boxes.box(targetElm);
-  return isToolbarTop ? pos.y() : pos.bottom();
+  return {
+    pos: isToolbarTop ? pos.y() : pos.bottom(),
+    height: pos.height()
+  };
 };
 
 const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
+  const { mothership, uiMothership, outerContainer } = uiComponents;
   let floatContainer;
   const DOM = DOMUtils.DOM;
   const useFixedToolbarContainer = useFixedContainer(editor);
@@ -36,11 +40,10 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
   const editorMaxWidthOpt = getMaxWidthSetting(editor).or(EditorSize.getWidth(editor));
 
   const toolbarMode = getToolbarMode(editor);
-  const isSplitFloatingToolbar = toolbarMode === ToolbarMode.floating;
-  const isSplitToolbar = toolbarMode === ToolbarMode.sliding || isSplitFloatingToolbar;
+  const isSplitToolbar = toolbarMode === ToolbarMode.sliding || toolbarMode === ToolbarMode.floating;
   const isToolbarTop = isToolbarLocationTop(editor);
 
-  const prevPos = Cell(getTargetPosition(targetElm, isToolbarTop));
+  const prevPosAndHeight = Cell(getTargetPosAndHeight(targetElm, isToolbarTop));
   const visible = Cell(false);
 
   loadInlineSkin(editor);
@@ -59,7 +62,7 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
       targetBounds.y() - Height.get(floatContainer.element()) + offset :
       targetBounds.bottom();
 
-    Css.setAll(uiComponents.outerContainer.element(), {
+    Css.setAll(outerContainer.element(), {
       position: 'absolute',
       top: Math.round(top) + 'px',
       left: Math.round(targetBounds.x()) + 'px'
@@ -74,6 +77,10 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     Css.set(floatContainer.element(), 'max-width', maxWidth + 'px');
   };
 
+  const repositionFloatingUiComponents = () => {
+    uiMothership.broadcastOn([ Channels.repositionPopups() ], { });
+  };
+
   const updateChromeUi = (resetDocking: boolean = false) => {
     // Handles positioning, docking and SplitToolbar (more drawer) behaviour. Modes:
     // 1. Basic inline: does positioning and docking
@@ -83,12 +90,12 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
 
     // Refresh split toolbar
     if (isSplitToolbar) {
-      OuterContainer.refreshToolbar(uiComponents.outerContainer);
+      OuterContainer.refreshToolbar(outerContainer);
     }
 
     // Positioning
     if (!useFixedToolbarContainer) {
-      const toolbar = OuterContainer.getToolbar(uiComponents.outerContainer);
+      const toolbar = OuterContainer.getToolbar(outerContainer);
       updateChromePosition(toolbar);
     }
 
@@ -97,28 +104,25 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
       resetDocking ? Docking.reset(floatContainer) : Docking.refresh(floatContainer);
     }
 
-    if (isSplitFloatingToolbar) {
-      OuterContainer.getToolbar(uiComponents.outerContainer).each((toolbar) => {
-        SplitFloatingToolbar.reposition(toolbar);
-      });
-    }
+    // Floating toolbar
+    repositionFloatingUiComponents();
   };
 
   const show = () => {
     visible.set(true);
-    Css.set(uiComponents.outerContainer.element(), 'display', 'flex');
+    Css.set(outerContainer.element(), 'display', 'flex');
     DOM.addClass(editor.getBody(), 'mce-edit-focus');
-    Css.remove(uiComponents.uiMothership.element(), 'display');
+    Css.remove(uiMothership.element(), 'display');
     updateChromeUi();
   };
 
   const hide = () => {
     visible.set(false);
     if (uiComponents.outerContainer) {
-      Css.set(uiComponents.outerContainer.element(), 'display', 'none');
+      Css.set(outerContainer.element(), 'display', 'none');
       DOM.removeClass(editor.getBody(), 'mce-edit-focus');
     }
-    Css.set(uiComponents.uiMothership.element(), 'display', 'none');
+    Css.set(uiMothership.element(), 'display', 'none');
   };
 
   const render = () => {
@@ -127,16 +131,16 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
       return;
     }
 
-    floatContainer = OuterContainer.getHeader(uiComponents.outerContainer).getOrDie();
+    floatContainer = OuterContainer.getHeader(outerContainer).getOrDie();
 
     const uiContainer = getUiContainer(editor);
-    Attachment.attachSystem(uiContainer, uiComponents.mothership);
-    Attachment.attachSystem(uiContainer, uiComponents.uiMothership);
+    Attachment.attachSystem(uiContainer, mothership);
+    Attachment.attachSystem(uiContainer, uiMothership);
 
     setToolbar(editor, uiComponents, rawUiConfig, backstage);
 
     OuterContainer.setMenubar(
-      uiComponents.outerContainer,
+      outerContainer,
       identifyMenus(editor, rawUiConfig)
     );
 
@@ -154,11 +158,17 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
 
     editor.on('NodeChange keydown', () => {
       Delay.requestAnimationFrame(() => {
-        const pos = getTargetPosition(targetElm, isToolbarTop);
+        const posAndHeight = getTargetPosAndHeight(targetElm, isToolbarTop);
+        const prev = prevPosAndHeight.get();
 
-        if (visible.get() && pos !== prevPos.get()) {
-          updateChromeUi(true);
-          prevPos.set(pos);
+        if (visible.get()) {
+          if (posAndHeight.pos !== prev.pos) {
+            updateChromeUi(true);
+            prevPosAndHeight.set(posAndHeight);
+          } else if (posAndHeight.height !== prev.height) {
+            repositionFloatingUiComponents();
+            prevPosAndHeight.set(posAndHeight);
+          }
         }
       });
     });
@@ -178,7 +188,7 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
   setupReadonlyModeSwitch(editor, uiComponents);
 
   return {
-    editorContainer: uiComponents.outerContainer.element().dom()
+    editorContainer: outerContainer.element().dom()
   };
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -1,0 +1,55 @@
+import { Chain, Keys, Logger, Pipeline, Step, UiFinder } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Cell } from '@ephox/katamari';
+import { Editor as McEditor, TinyActions, TinyApis, TinyUi } from '@ephox/mcagar';
+import { Body, Css, Element, Location } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
+import { sAssertFloatingToolbarPosition, sOpenFloatingToolbarAndAssertPosition } from '../../../module/ToolbarUtils';
+
+UnitTest.asynctest('Inline Editor Floating Toolbar Drawer Position test', (success, failure) => {
+  Theme();
+
+  Pipeline.async({}, [
+    Logger.t('Inline Editor Floating Toolbar Drawer Position test', Chain.asStep({}, [
+      McEditor.cFromSettings({
+        theme: 'silver',
+        inline: true,
+        menubar: false,
+        width: 400,
+        base_url: '/project/tinymce/js/tinymce',
+        toolbar: 'undo redo | styleselect | bold italic underline | strikethrough superscript subscript | alignleft aligncenter alignright aligncenter | outdent indent | cut copy paste | selectall remove',
+        toolbar_mode: 'floating'
+      }),
+      Chain.async((editor: Editor, onSuccess, onFailure) => {
+        const tinyActions = TinyActions(editor);
+        const tinyApis = TinyApis(editor);
+        const tinyUi = TinyUi(editor);
+        const uiContainer = Element.fromDom(editor.getContainer());
+        const initialContainerTop = Cell(Location.absolute(uiContainer).top() + 39);
+
+        Pipeline.async({ }, [
+          Step.sync(() => {
+            Css.set(uiContainer, 'margin-left', '100px');
+          }),
+          tinyApis.sSetContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>'),
+          tinyApis.sFocus(),
+          UiFinder.sWaitForVisible('Wait for editor to be visible', Body.body(), '.tox-editor-header button[title="More..."]'),
+          Step.sync(() => {
+            initialContainerTop.set(Location.absolute(uiContainer).top() + 39); // top of ui container + toolbar height
+          }),
+          sOpenFloatingToolbarAndAssertPosition(tinyUi, initialContainerTop.get), // top of ui container + toolbar height
+          sOpenFloatingToolbarAndAssertPosition(tinyUi, initialContainerTop.get, [
+            // Press enter a few times to change the height of the editor
+            tinyActions.sContentKeydown(Keys.enter()),
+            tinyActions.sContentKeydown(Keys.enter()),
+            tinyActions.sContentKeydown(Keys.enter()),
+            sAssertFloatingToolbarPosition(tinyUi, initialContainerTop.get, 105, 465),
+          ])
+        ], () => onSuccess(editor), onFailure);
+      }),
+      McEditor.cRemove
+    ])),
+  ], () => success(), failure);
+});

--- a/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
@@ -1,0 +1,31 @@
+import { Assertions, Chain, GeneralSteps, Step } from '@ephox/agar';
+import { TinyUi } from '@ephox/mcagar';
+import { Body, Location, Width } from '@ephox/sugar';
+
+import { ToolbarMode } from 'tinymce/themes/silver/api/Settings';
+import { sCloseMore, sOpenMore } from './MenuUtils';
+
+const sAssertFloatingToolbarPosition = (tinyUi: TinyUi, getTop: () => number, expectedLeft: number, expectedRight: number) => Chain.asStep(Body.body(), [
+  tinyUi.cWaitForUi('Wait for drawer to be visible', '.tox-toolbar__overflow'),
+  Chain.op((toolbar) => {
+    const top = getTop();
+    const diff = 10;
+    const pos = Location.absolute(toolbar);
+    const right = pos.left() + Width.get(toolbar);
+    Assertions.assertEq(`Drawer top position ${pos.top()}px should be ~${top}px`, true, Math.abs(pos.top() - top) < diff);
+    Assertions.assertEq(`Drawer left position ${pos.left()}px should be ~${expectedLeft}px`, true, Math.abs(pos.left() - expectedLeft) < diff);
+    Assertions.assertEq(`Drawer right position ${right}px should be ~${expectedRight}px`, true, Math.abs(right - expectedRight) < diff);
+  })
+]);
+
+const sOpenFloatingToolbarAndAssertPosition = (tinyUi: TinyUi, getTop: () => number, additionalSteps: Array<Step<any, any>> = []) => GeneralSteps.sequence([
+  sOpenMore(ToolbarMode.floating),
+  sAssertFloatingToolbarPosition(tinyUi, getTop, 105, 465),
+  ...additionalSteps,
+  sCloseMore(ToolbarMode.floating)
+]);
+
+export {
+  sAssertFloatingToolbarPosition,
+  sOpenFloatingToolbarAndAssertPosition
+};


### PR DESCRIPTION
The cause of this was that we only repositioned when the initial anchor point changed, however we also need to reposition anything in the sink when the height of the inline editor changes.