### PR TITLE
TINY-4728: Fix table picker breaking in Firefox on low zoom levels

### DIFF
--- a/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
+++ b/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
@@ -20,6 +20,11 @@
     flex-wrap: wrap;
     width: @insert-table-picker-cell-size * 10 + 9px;
 
+    @supports (display: grid) {
+      display: grid;
+      grid-template-columns: repeat(10, minmax(@insert-table-picker-cell-size, auto));
+    }
+
     // Cell styles
     > div {
       border-color: @insert-table-picker-border-color;
@@ -52,7 +57,9 @@
     color: @insert-table-picker-label-color;
     display: block;
     font-size: @font-size-sm;
-    padding: @pad-xs;
+    grid-column-end: -1;
+    grid-column-start: 1;
+    padding: @pad-xs 0;
     text-align: center;
     width: 100%;
   }

--- a/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
+++ b/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
@@ -9,7 +9,7 @@
 // Insert table picker
 //
 
-@insert-table-picker-cell-size: @base-value;
+@insert-table-picker-cell-size: @base-value + 1; // Add 1 to account for the border size
 @insert-table-picker-selected-background-color: fade(@color-tint, 50%);
 @insert-table-picker-border-color: @border-color;
 @insert-table-picker-label-color: contrast(@menu-background-color, @text-color-muted, @color-white);
@@ -18,19 +18,14 @@
   .tox-insert-table-picker {
     display: flex;
     flex-wrap: wrap;
-    width: @insert-table-picker-cell-size * 10 + 9px;
-
-    @supports (display: grid) {
-      display: grid;
-      grid-template-columns: repeat(10, minmax(@insert-table-picker-cell-size, auto));
-    }
+    width: @insert-table-picker-cell-size * 10;
 
     // Cell styles
     > div {
       border-color: @insert-table-picker-border-color;
       border-style: solid;
       border-width: 0 1px 1px 0;
-      box-sizing: content-box;
+      box-sizing: border-box;
       height: @insert-table-picker-cell-size;
       width: @insert-table-picker-cell-size;
 
@@ -57,9 +52,7 @@
     color: @insert-table-picker-label-color;
     display: block;
     font-size: @font-size-sm;
-    grid-column-end: -1;
-    grid-column-start: 1;
-    padding: @pad-xs 0;
+    padding: @pad-xs;
     text-align: center;
     width: 100%;
   }

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.3.0 (TBD)
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
     Fixed the `quickimage` button not restricting the file types to images #TINY-4715
+    Fixed table picker breaking in Firefox on low zoom levels
 Version 5.2.1 (TBD)
     Fixed table resize handles not functioning correctly in Edge #TINY-4160
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,7 +1,7 @@
 Version 5.3.0 (TBD)
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
     Fixed the `quickimage` button not restricting the file types to images #TINY-4715
-    Fixed table picker breaking in Firefox on low zoom levels
+    Fixed table picker breaking in Firefox on low zoom levels #TINY-4728
 Version 5.2.1 (TBD)
     Fixed table resize handles not functioning correctly in Edge #TINY-4160
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948


### PR DESCRIPTION
Quick fix, this makes the table picker use grid layout whenever possible.
Fixes #5430 