### PR TITLE
TINY-4729: Changed the default icons to be lazy loaded

### DIFF
--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -149,6 +149,7 @@ module.exports = function (grunt) {
         core: {
           files: [
             { src: 'js/tinymce/tinymce.js', dest: 'js/tinymce/tinymce.min.js' },
+            { src: 'js/tinymce/icons/default/icons.js', dest: 'js/tinymce/icons/default/icons.min.js' },
             { src: 'src/core/main/js/JqueryIntegration.js', dest: 'js/tinymce/jquery.tinymce.min.js' }
           ]
         },
@@ -279,6 +280,16 @@ module.exports = function (grunt) {
           }
         ]
       },
+      'default-icons': {
+        files: [
+          {
+            expand: true,
+            cwd: '../oxide-icons-default/dist/icons/default',
+            src: '**',
+            dest: 'js/tinymce/icons/default'
+          }
+        ]
+      },
       'ui-skins': {
         files: gruntUtils.flatMap(oxideUiSkinMap, function (name, mappedName) {
           return [
@@ -315,6 +326,7 @@ module.exports = function (grunt) {
           excludes: [
             'js/**/plugin.js',
             'js/**/theme.js',
+            'js/**/icons.js',
             'js/**/*.map',
             'js/tinymce/tinymce.full.min.js',
             'js/tinymce/plugins/moxiemanager',
@@ -337,6 +349,7 @@ module.exports = function (grunt) {
           'js/tinymce/plugins',
           'js/tinymce/skins/**/*.min.css',
           'js/tinymce/skins/**/*.woff',
+          'js/tinymce/icons',
           'js/tinymce/themes',
           'js/tinymce/tinymce.min.js',
           'js/tinymce/jquery.tinymce.min.js',
@@ -456,6 +469,7 @@ module.exports = function (grunt) {
           'js/tinymce/langs',
           'js/tinymce/plugins',
           'js/tinymce/skins',
+          'js/tinymce/icons',
           'js/tinymce/themes',
           'js/tinymce/license.txt'
         ]
@@ -529,13 +543,15 @@ module.exports = function (grunt) {
                   'scripts': [
                     'tinymce.js',
                     'plugins/*/plugin.js',
-                    'themes/*/theme.js'
+                    'themes/*/theme.js',
+                    'themes/*/icons.js',
                   ],
                   'files': [
                     'tinymce.min.js',
                     'plugins/*/plugin.min.js',
                     'themes/*/theme.min.js',
-                    'skins/**'
+                    'skins/**',
+                    'icons/*/icons.min.js'
                   ]
                 }
               },
@@ -561,11 +577,17 @@ module.exports = function (grunt) {
               getDirs('js/tinymce/themes'),
               zipUtils.generateIndex('themes', 'theme')
             );
+            zipUtils.addIndexFiles(
+              zip,
+              getDirs('js/tinymce/icons'),
+              zipUtils.generateIndex('icons', 'icons')
+            );
           },
           to: 'dist/tinymce_<%= pkg.version %>_component.zip'
         },
         src: [
           'js/tinymce/skins',
+          'js/tinymce/icons',
           'js/tinymce/plugins',
           'js/tinymce/themes',
           'js/tinymce/tinymce.js',
@@ -617,6 +639,7 @@ module.exports = function (grunt) {
           { src: 'js/tinymce/plugins', dest: '/content/scripts/tinymce/plugins' },
           { src: 'js/tinymce/themes', dest: '/content/scripts/tinymce/themes' },
           { src: 'js/tinymce/skins', dest: '/content/scripts/tinymce/skins' },
+          { src: 'js/tinymce/icons', dest: '/content/scripts/tinymce/icons' },
           { src: 'js/tinymce/tinymce.js', dest: '/content/scripts/tinymce/tinymce.js' },
           { src: 'js/tinymce/tinymce.min.js', dest: '/content/scripts/tinymce/tinymce.min.js' },
           { src: 'js/tinymce/jquery.tinymce.min.js', dest: '/content/scripts/tinymce/jquery.tinymce.min.js' },
@@ -660,6 +683,7 @@ module.exports = function (grunt) {
           { src: 'js/tinymce/plugins', dest: '/content/scripts/tinymce/plugins' },
           { src: 'js/tinymce/themes', dest: '/content/scripts/tinymce/themes' },
           { src: 'js/tinymce/skins', dest: '/content/scripts/tinymce/skins' },
+          { src: 'js/tinymce/icons', dest: '/content/scripts/tinymce/icons' },
           { src: 'js/tinymce/tinymce.js', dest: '/content/scripts/tinymce/tinymce.js' },
           { src: 'js/tinymce/tinymce.min.js', dest: '/content/scripts/tinymce/tinymce.min.js' },
           { src: 'js/tinymce/jquery.tinymce.min.js', dest: '/content/scripts/tinymce/jquery.tinymce.min.js' },
@@ -673,8 +697,10 @@ module.exports = function (grunt) {
         options: {
           themesDir: 'js/tinymce/themes',
           pluginsDir: 'js/tinymce/plugins',
+          iconsDir: 'js/tinymce/icons',
           pluginFileName: 'plugin.min.js',
           themeFileName: 'theme.min.js',
+          iconsFileName: 'icons.min.js',
           outputPath: 'js/tinymce/tinymce.full.min.js'
         },
 
@@ -687,8 +713,10 @@ module.exports = function (grunt) {
         options: {
           themesDir: 'js/tinymce/themes',
           pluginsDir: 'js/tinymce/plugins',
+          iconsDir: 'js/tinymce/icons',
           pluginFileName: 'plugin.js',
           themeFileName: 'theme.js',
+          iconsFileName: 'icons.js',
           outputPath: 'js/tinymce/tinymce.full.js'
         },
 
@@ -807,8 +835,8 @@ module.exports = function (grunt) {
     'rollup',
     'unicode',
     'concat',
-    'uglify',
-    'copy'
+    'copy',
+    'uglify'
   ]);
 
   grunt.registerTask('prod', [
@@ -827,7 +855,8 @@ module.exports = function (grunt) {
     // as well as making development easier, then we can update 'yarn dev' to run 'oxide-build' in parallel with 'tinymce-grunt dev'
     // that will save 2-3 seconds on incremental builds
     'copy:ui-skins',
-    'copy:content-skins'
+    'copy:content-skins',
+    'copy:default-icons'
   ]);
 
   grunt.registerTask('unicode', ['uglify:emoticons-raw']);

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.3.0 (TBD)
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
+    Changed the default icons to be lazy loaded during initialization #TINY-4729
     Fixed the `quickimage` button not restricting the file types to images #TINY-4715
 Version 5.2.1 (TBD)
     Fixed table resize handles not functioning correctly in Edge #TINY-4160

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -7,11 +7,11 @@
 
 import { Element, HTMLElement } from '@ephox/dom-globals';
 import { Obj, Type } from '@ephox/katamari';
-import { getAll as getAllOxide } from '@tinymce/oxide-icons-default';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import IconManager from '../api/IconManager';
 import PluginManager from '../api/PluginManager';
+import * as Settings from '../api/Settings';
 import { ThemeInitFunc } from '../api/SettingsTypes';
 import ThemeManager from '../api/ThemeManager';
 import Tools from '../api/util/Tools';
@@ -65,12 +65,11 @@ const initPlugins = function (editor: Editor) {
 };
 
 const initIcons = (editor: Editor) => {
-  const iconPackName: string = Tools.trim(editor.settings.icons);
+  const iconPackName: string = Tools.trim(Settings.getIconPackName(editor));
   const currentIcons = editor.ui.registry.getAll().icons;
 
-  const defaultIcons = getAllOxide();
   const loadIcons = {
-    ...defaultIcons,
+    ...IconManager.get('default').icons,
     ...IconManager.get(iconPackName).icons
   };
 

--- a/modules/tinymce/tools/tasks/bundle.js
+++ b/modules/tinymce/tools/tasks/bundle.js
@@ -3,7 +3,7 @@ var path = require("path");
 
 module.exports = function (grunt) {
   grunt.registerMultiTask("bundle", "Bundles code, themes and bundles to a single file.", function () {
-    var options, contents, themes, plugins;
+    var options, contents, themes, plugins, icons;
 
     function appendFile(src) {
       src = src.replace(/\\/g, '/');
@@ -29,13 +29,16 @@ module.exports = function (grunt) {
     options.themeFileName = options.themeFileName || "theme.min.js";
     options.pluginsDir = options.pluginsDir || "plugins";
     options.pluginFileName = options.pluginFileName || "plugin.min.js";
+    options.iconsDir = options.iconsDir || "icons";
+    options.iconsFileName = options.iconsFileName || "icons.min.js";
     options.outputPath = options.outputPath || "full.min.js";
 
     themes = grunt.option("themes");
     plugins = grunt.option("plugins");
+    icons = grunt.option("icons") || 'default';
 
-    if (!themes && !plugins) {
-      grunt.log.writeln("Use: grunt bundle --themes <comma separated list of themes> --plugins <comma separated list of plugins>");
+    if (!themes && !plugins && !icons) {
+      grunt.log.writeln("Use: grunt bundle --themes <comma separated list of themes> --plugins <comma separated list of plugins> --icons <comma separated list of icons>");
       process.exit(-1);
       return;
     }
@@ -49,6 +52,7 @@ module.exports = function (grunt) {
 
     append(options.themesDir, options.themeFileName, themes);
     append(options.pluginsDir, options.pluginFileName, plugins);
+    append(options.iconsDir, options.iconsFileName, icons);
 
     if (contents.length > 0) {
       grunt.file.write(options.outputPath, contents);

--- a/modules/tinymce/tools/tasks/bundle.js
+++ b/modules/tinymce/tools/tasks/bundle.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
     plugins = grunt.option("plugins");
     icons = grunt.option("icons") || 'default';
 
-    if (!themes && !plugins && !icons) {
+    if (!themes && !plugins) {
       grunt.log.writeln("Use: grunt bundle --themes <comma separated list of themes> --plugins <comma separated list of plugins> --icons <comma separated list of icons>");
       process.exit(-1);
       return;


### PR DESCRIPTION
This is something we've been discussing for a while now, so I decided to do it while in transit. This will reduce the initial `tinymce.js` load time and allow the icons to be loaded in parallel with everything else which should provide very marginal editor load time improvements.