### PR TITLE
TINY-4726: Unthunking to reduce code size

### DIFF
--- a/modules/acid/src/main/ts/ephox/acid/api/colour/ColourTypes.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/ColourTypes.ts
@@ -1,16 +1,16 @@
 export interface Hex {
-  value: () => string;
+  readonly value: string;
 }
 
 export interface Hsv {
-  hue: () => number;
-  saturation: () => number;
-  value: () => number;
+  readonly hue: number;
+  readonly saturation: number;
+  readonly value: number;
 }
 
 export interface Rgba {
-  red: () => number;
-  green: () => number;
-  blue: () => number;
-  alpha: () => number;
+  readonly red: number;
+  readonly green: number;
+  readonly blue: number;
+  readonly alpha: number;
 }

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/HexColour.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/HexColour.ts
@@ -1,11 +1,9 @@
-import { Fun, Option } from '@ephox/katamari';
+import { Option } from '@ephox/katamari';
 import { Hex, Rgba } from './ColourTypes';
 
-const hexColour = (hexString: string): Hex => {
-  return {
-    value: Fun.constant(hexString)
-  };
-};
+const hexColour = (value: string): Hex => ({
+  value
+});
 
 const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
 const longformRegex = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i;
@@ -15,21 +13,21 @@ const isHexString = (hex: string): boolean => {
 };
 
 const fromString = (hex: string): Option<Hex> => {
-  return isHexString(hex) ? Option.some({ value: Fun.constant(hex) }) : Option.none();
+  return isHexString(hex) ? Option.some({ value: hex }) : Option.none();
 };
 
 // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
 const getLongForm = (hex: Hex): Hex => {
-  const hexString = hex.value().replace(shorthandRegex, (m, r, g, b) =>
+  const hexString = hex.value.replace(shorthandRegex, (m, r, g, b) =>
     r + r + g + g + b + b
   );
 
-  return { value: Fun.constant(hexString) };
+  return { value: hexString };
 };
 
 const extractValues = (hex: Hex): RegExpExecArray | [string, string, string, string] => {
   const longForm = getLongForm(hex);
-  const splitForm = longformRegex.exec(longForm.value());
+  const splitForm = longformRegex.exec(longForm.value);
   return splitForm === null ? [ 'FFFFFF', 'FF', 'FF', 'FF' ] : splitForm;
 };
 
@@ -39,7 +37,7 @@ const toHex = (component: number): string => {
 };
 
 const fromRgba = (rgbaColour: Rgba): Hex => {
-  const value = toHex(rgbaColour.red()) + toHex(rgbaColour.green()) + toHex(rgbaColour.blue());
+  const value = toHex(rgbaColour.red) + toHex(rgbaColour.green) + toHex(rgbaColour.blue);
   return hexColour(value);
 };
 

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/HsvColour.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/HsvColour.ts
@@ -1,19 +1,16 @@
-import { Fun } from '@ephox/katamari';
 import { Hsv, Rgba } from './ColourTypes';
 
-const hsvColour = (hue: number, saturation: number, value: number): Hsv => {
-  return {
-    hue: Fun.constant(hue),
-    saturation: Fun.constant(saturation),
-    value: Fun.constant(value)
-  };
-};
+const hsvColour = (hue: number, saturation: number, value: number): Hsv => ({
+  hue,
+  saturation,
+  value
+});
 
 const fromRgb = (rgbaColour: Rgba): Hsv => {
   let h = 0; let s = 0; let v = 0;
-  const r = rgbaColour.red() / 255;
-  const g = rgbaColour.green() / 255;
-  const b = rgbaColour.blue() / 255;
+  const r = rgbaColour.red / 255;
+  const g = rgbaColour.green / 255;
+  const b = rgbaColour.blue / 255;
 
   const minRGB = Math.min(r, Math.min(g, b));
   const maxRGB = Math.max(r, Math.max(g, b));

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
@@ -1,4 +1,4 @@
-import { Fun, Option } from '@ephox/katamari';
+import { Option } from '@ephox/katamari';
 import { Hex, Hsv, Rgba } from './ColourTypes';
 import * as HexColour from './HexColour';
 
@@ -9,14 +9,12 @@ const round = Math.round;
 const rgbRegex = /^rgb\((\d+),\s*(\d+),\s*(\d+)\)/;
 const rgbaRegex = /^rgba\((\d+),\s*(\d+),\s*(\d+),\s*(\d?(?:\.\d+)?)\)/;
 
-const rgbaColour = (red: number, green: number, blue: number, alpha: number): Rgba => {
-  return {
-    red: Fun.constant(red),
-    green: Fun.constant(green),
-    blue: Fun.constant(blue),
-    alpha: Fun.constant(alpha)
-  };
-};
+const rgbaColour = (red: number, green: number, blue: number, alpha: number): Rgba => ({
+  red,
+  green,
+  blue,
+  alpha
+});
 
 const isRgbaComponent = (value: string): boolean => {
   const num = parseInt(value, 10);
@@ -25,9 +23,9 @@ const isRgbaComponent = (value: string): boolean => {
 
 const fromHsv = (hsv: Hsv): Rgba => {
   let r; let g; let b;
-  const hue = (hsv.hue() || 0) % 360;
-  let saturation = hsv.saturation() / 100;
-  let brightness = hsv.value() / 100;
+  const hue = (hsv.hue || 0) % 360;
+  let saturation = hsv.saturation / 100;
+  let brightness = hsv.value / 100;
   saturation = max(0, min(saturation, 1));
   brightness = max(0, min(brightness, 1));
 
@@ -121,9 +119,9 @@ const fromString = (rgbaString: string): Option<Rgba> => {
   return Option.none();
 };
 
-const toString = (rgba: Rgba): string => `rgba(${rgba.red()},${rgba.green()},${rgba.blue()},${rgba.alpha()})`;
+const toString = (rgba: Rgba): string => `rgba(${rgba.red},${rgba.green},${rgba.blue},${rgba.alpha})`;
 
-const redColour = Fun.constant(rgbaColour(255, 0, 0, 1));
+const red = rgbaColour(255, 0, 0, 1);
 
 export {
   rgbaColour,
@@ -132,5 +130,5 @@ export {
   fromHex,
   fromString,
   toString,
-  redColour as red
+  red
 };

--- a/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
@@ -35,7 +35,7 @@ const makeFactory = (
     const sbPalette = SaturationBrightnessPalette.paletteFactory(translate, getClass);
 
     const state = {
-      paletteRgba: Fun.constant(Cell(RgbaColour.red()))
+      paletteRgba: Fun.constant(Cell(RgbaColour.red))
     };
 
     const memPalette = Memento.record(
@@ -71,7 +71,7 @@ const makeFactory = (
         const value = simulatedEvent.event().value();
         const oldRgb = state.paletteRgba().get();
         const hsvColour = HsvColour.fromRgb(oldRgb);
-        const newHsvColour = HsvColour.hsvColour(hsvColour.hue(), value.x(), (100 - value.y()));
+        const newHsvColour = HsvColour.hsvColour(hsvColour.hue, value.x(), (100 - value.y()));
         const rgb = RgbaColour.fromHsv(newHsvColour);
         const nuHex = HexColour.fromRgba(rgb);
         runUpdates(form, nuHex, updates);

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
@@ -134,7 +134,7 @@ const rgbFormFactory = (
       // the hex field to be the six digit version of that same three digit hex code. This is incorrect.
       if (!Focusing.isFocused(hexField)) {
         Representing.setValue(form, {
-          hex: hex.value()
+          hex: hex.value
         });
       }
     });
@@ -142,7 +142,7 @@ const rgbFormFactory = (
   };
 
   const copyRgbToForm = (form: AlloyComponent, rgb: Rgba): void => {
-    const red = rgb.red(); const green = rgb.green(); const blue = rgb.blue();
+    const red = rgb.red; const green = rgb.green; const blue = rgb.blue;
     Representing.setValue(form, { red, green, blue });
   };
 
@@ -163,7 +163,7 @@ const rgbFormFactory = (
 
   const updatePreview = (anyInSystem: AlloyComponent, hex: Hex) => {
     memPreview.getOpt(anyInSystem).each((preview: AlloyComponent) => {
-      Css.set(preview.element(), 'background-color', '#' + hex.value());
+      Css.set(preview.element(), 'background-color', '#' + hex.value);
     });
   };
 
@@ -203,7 +203,7 @@ const rgbFormFactory = (
 
     // TODO: Find way to use this for palette and slider updates
     const setValueRgb = (rgb: Rgba): void => {
-      const red = rgb.red(); const green = rgb.green(); const blue = rgb.blue();
+      const red = rgb.red; const green = rgb.green; const blue = rgb.blue;
       set('red', Option.some(red));
       set('green', Option.some(green));
       set('blue', Option.some(blue));
@@ -302,7 +302,7 @@ const rgbFormFactory = (
         apis: {
           updateHex(form: AlloyComponent, hex: Hex) {
             Representing.setValue(form, {
-              hex: hex.value()
+              hex: hex.value
             });
             copyHexToRgb(form, hex);
             updatePreview(form, hex);

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
@@ -82,7 +82,7 @@ const paletteFactory = (_translate: (key: string) => string, getClass: (key: str
 
     const onInit = (_slider: AlloyComponent, _thumb: AlloyComponent, spectrum: AlloyComponent, _value: number | SliderTypes.SliderValue) => {
       // Maybe make this initial value configurable?
-      setColour(spectrum.element().dom(), RgbaColour.toString(RgbaColour.red()));
+      setColour(spectrum.element().dom(), RgbaColour.toString(RgbaColour.red));
     };
 
     const sliderBehaviours = Behaviour.derive([

--- a/modules/acid/src/test/ts/atomic/ConversionsTest.ts
+++ b/modules/acid/src/test/ts/atomic/ConversionsTest.ts
@@ -7,8 +7,8 @@ UnitTest.test('ConversionsTest', () => {
   const rgbaWhite = RgbaColour.rgbaColour(255, 255, 255, 1);
 
   const hexBlack = HexColour.fromRgba(rgbaBlack);
-  assert.eq('000000', hexBlack.value());
+  assert.eq('000000', hexBlack.value);
 
   const hexWhite = HexColour.fromRgba(rgbaWhite);
-  assert.eq('ffffff', hexWhite.value());
+  assert.eq('ffffff', hexWhite.value);
 });

--- a/modules/darwin/src/main/ts/ephox/darwin/api/Ephemera.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/Ephemera.ts
@@ -1,13 +1,12 @@
-import { Fun } from '@ephox/katamari';
 import * as Styles from '../style/Styles';
 
 export interface Ephemera {
-  selected: () => string;
-  selectedSelector: () => string;
-  firstSelected: () => string;
-  firstSelectedSelector: () => string;
-  lastSelected: () => string;
-  lastSelectedSelector: () => string;
+  readonly selected: string;
+  readonly selectedSelector: string;
+  readonly firstSelected: string;
+  readonly firstSelectedSelector: string;
+  readonly lastSelected: string;
+  readonly lastSelectedSelector: string;
 }
 
 const selected = Styles.resolve('selected');
@@ -18,10 +17,10 @@ const lastSelected = Styles.resolve('last-selected');
 const lastSelectedSelector = '.' + lastSelected;
 
 export const Ephemera: Ephemera = {
-  selected: Fun.constant(selected),
-  selectedSelector: Fun.constant(selectedSelector),
-  firstSelected: Fun.constant(firstSelected),
-  firstSelectedSelector: Fun.constant(firstSelectedSelector),
-  lastSelected: Fun.constant(lastSelected),
-  lastSelectedSelector: Fun.constant(lastSelectedSelector)
+  selected,
+  selectedSelector,
+  firstSelected,
+  firstSelectedSelector,
+  lastSelected,
+  lastSelectedSelector
 };

--- a/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
@@ -1,10 +1,10 @@
 import { KeyboardEvent, Window } from '@ephox/dom-globals';
-import { Arr, Fun, Option, Struct } from '@ephox/katamari';
+import { Arr, Fun, Option } from '@ephox/katamari';
 import { Element, EventArgs, Situ } from '@ephox/sugar';
 import * as KeySelection from '../keyboard/KeySelection';
 import * as VerticalMovement from '../keyboard/VerticalMovement';
 import MouseSelection from '../mouse/MouseSelection';
-import { KeyDirection } from '../navigation/KeyDirection';
+import * as KeyDirection from '../navigation/KeyDirection';
 import * as CellSelection from '../selection/CellSelection';
 import { Response } from '../selection/Response';
 import { SelectionAnnotation } from './SelectionAnnotation';
@@ -12,11 +12,11 @@ import * as SelectionKeys from './SelectionKeys';
 import { WindowBridge } from './WindowBridge';
 
 interface RC {
-  rows: () => number;
-  cols: () => number;
+  readonly rows: number;
+  readonly cols: number;
 }
 
-const rc: (rows: number, cols: number) => RC = Struct.immutable('rows', 'cols');
+const rc = (rows: number, cols: number): RC => ({rows, cols});
 
 const mouse = function (win: Window, container: Element, isRoot: (e: Element) => boolean, annotations: SelectionAnnotation) {
   const bridge = WindowBridge(win);
@@ -61,7 +61,7 @@ const keyboard = function (win: Window, container: Element, isRoot: (e: Element)
       const update = function (attempts: RC[]) {
         return function () {
           const navigation = Arr.findMap(attempts, function (delta) {
-            return KeySelection.update(delta.rows(), delta.cols(), container, selected, annotations);
+            return KeySelection.update(delta.rows, delta.cols, container, selected, annotations);
           });
 
           // Shift the selected rows and update the selection.

--- a/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
@@ -43,7 +43,7 @@ const keyboard = function (win: Window, container: Element, isRoot: (e: Element)
     const keycode = realEvent.which;
     const shiftKey = realEvent.shiftKey === true;
 
-    const handler = CellSelection.retrieve(container, annotations.selectedSelector()).fold(function () {
+    const handler = CellSelection.retrieve(container, annotations.selectedSelector).fold(function () {
       // Shift down should predict the movement and set the selection.
       if (SelectionKeys.isDown(keycode) && shiftKey) {
         return Fun.curry(VerticalMovement.select, bridge, container, isRoot, KeyDirection.down, finish, start, annotations.selectRange);
@@ -68,7 +68,7 @@ const keyboard = function (win: Window, container: Element, isRoot: (e: Element)
           return navigation.fold(function () {
             // The cell selection went outside the table, so clear it and bridge from the first box to before/after
             // the table
-            return CellSelection.getEdges(container, annotations.firstSelectedSelector(), annotations.lastSelectedSelector()).map(function (edges) {
+            return CellSelection.getEdges(container, annotations.firstSelectedSelector, annotations.lastSelectedSelector).map(function (edges) {
               const relative = SelectionKeys.isDown(keycode) || direction.isForward(keycode) ? Situ.after : Situ.before;
               bridge.setRelativeSelection(Situ.on(edges.first(), 0), relative(edges.table()));
               annotations.clear(container);
@@ -99,7 +99,7 @@ const keyboard = function (win: Window, container: Element, isRoot: (e: Element)
   };
 
   const keyup = function (event: EventArgs, start: Element, soffset: number, finish: Element, foffset: number) {
-    return CellSelection.retrieve(container, annotations.selectedSelector()).fold<Option<Response>>(function () {
+    return CellSelection.retrieve(container, annotations.selectedSelector).fold<Option<Response>>(function () {
       const realEvent = event.raw() as KeyboardEvent;
       const keycode = realEvent.which;
       const shiftKey = realEvent.shiftKey === true;

--- a/modules/darwin/src/main/ts/ephox/darwin/api/SelectionAnnotation.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/SelectionAnnotation.ts
@@ -6,25 +6,25 @@ export interface SelectionAnnotation {
   clearBeforeUpdate: (container: Element) => void;
   clear: (container: Element) => void;
   selectRange: (container: Element, cells: Element[], start: Element, finish: Element) => void;
-  selectedSelector: () => string;
-  firstSelectedSelector: () => string;
-  lastSelectedSelector: () => string;
+  selectedSelector: string;
+  firstSelectedSelector: string;
+  lastSelectedSelector: string;
 }
 
 const byClass = function (ephemera: Ephemera): SelectionAnnotation {
-  const addSelectionClass = OnNode.addClass(ephemera.selected());
-  const removeSelectionClasses = OnNode.removeClasses([ ephemera.selected(), ephemera.lastSelected(), ephemera.firstSelected() ]);
+  const addSelectionClass = OnNode.addClass(ephemera.selected);
+  const removeSelectionClasses = OnNode.removeClasses([ ephemera.selected, ephemera.lastSelected, ephemera.firstSelected ]);
 
   const clear = function (container: Element) {
-    const sels = SelectorFilter.descendants(container, ephemera.selectedSelector());
+    const sels = SelectorFilter.descendants(container, ephemera.selectedSelector);
     Arr.each(sels, removeSelectionClasses);
   };
 
   const selectRange = function (container: Element, cells: Element[], start: Element, finish: Element) {
     clear(container);
     Arr.each(cells, addSelectionClass);
-    Class.add(start, ephemera.firstSelected());
-    Class.add(finish, ephemera.lastSelected());
+    Class.add(start, ephemera.firstSelected);
+    Class.add(finish, ephemera.lastSelected);
   };
 
   return {
@@ -39,13 +39,13 @@ const byClass = function (ephemera: Ephemera): SelectionAnnotation {
 
 const byAttr = function (ephemera: Ephemera, onSelection: (cells: Element[], start: Element, finish: Element) => void, onClear: () => void): SelectionAnnotation {
   const removeSelectionAttributes = function (element: Element) {
-    Attr.remove(element, ephemera.selected());
-    Attr.remove(element, ephemera.firstSelected());
-    Attr.remove(element, ephemera.lastSelected());
+    Attr.remove(element, ephemera.selected);
+    Attr.remove(element, ephemera.firstSelected);
+    Attr.remove(element, ephemera.lastSelected);
   };
 
   const addSelectionAttribute = function (element: Element) {
-    Attr.set(element, ephemera.selected(), '1');
+    Attr.set(element, ephemera.selected, '1');
   };
 
   const clear = (container: Element) => {
@@ -54,15 +54,15 @@ const byAttr = function (ephemera: Ephemera, onSelection: (cells: Element[], sta
   };
 
   const clearBeforeUpdate = (container: Element) => {
-    const sels = SelectorFilter.descendants(container, ephemera.selectedSelector());
+    const sels = SelectorFilter.descendants(container, ephemera.selectedSelector);
     Arr.each(sels, removeSelectionAttributes);
   };
 
   const selectRange = function (container: Element, cells: Element[], start: Element, finish: Element) {
     clear(container);
     Arr.each(cells, addSelectionAttribute);
-    Attr.set(start, ephemera.firstSelected(), '1');
-    Attr.set(finish, ephemera.lastSelected(), '1');
+    Attr.set(start, ephemera.firstSelected, '1');
+    Attr.set(finish, ephemera.lastSelected, '1');
     onSelection(cells, start, finish);
   };
   return {

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
@@ -46,7 +46,7 @@ const update = function (rows: number, columns: number, container: Element, sele
     return newSels.boxes();
   };
 
-  return CellSelection.shiftSelection(selected, rows, columns, annotations.firstSelectedSelector(), annotations.lastSelectedSelector()).map(updateSelection);
+  return CellSelection.shiftSelection(selected, rows, columns, annotations.firstSelectedSelector, annotations.lastSelectedSelector).map(updateSelection);
 };
 
 export {

--- a/modules/darwin/src/main/ts/ephox/darwin/navigation/KeyDirection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/navigation/KeyDirection.ts
@@ -34,7 +34,7 @@ const up: KeyDirection = {
   failure: BeforeAfter.failedUp
 };
 
-export const KeyDirection = {
+export {
   down,
   up
 };

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
@@ -42,11 +42,8 @@ function curry <OUT>(fn: (...allArgs: any[]) => OUT, ...initialArgs: any[]): (..
   };
 }
 
-const not = <T extends any[]> (f: (...args: T) => boolean) => {
-  return function (...args: T): boolean {
-    return !f.apply(null, args);
-  };
-};
+const not = <T> (f: (t: T) => boolean) => (t: T): boolean =>
+  !f(t);
 
 const die = function (msg: string) {
   return function () {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Option.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Option.ts
@@ -7,71 +7,71 @@ import * as Fun from './Fun';
  */
 export interface Option<T> {
   /** If none, run whenNone; if some(a) run whenSome(a) */
-  fold: <T2> (whenNone: () => T2, whenSome: (v: T) => T2) => T2;
+  readonly fold: <T2> (whenNone: () => T2, whenSome: (v: T) => T2) => T2;
 
   /** is this value some(t)?  */
-  is: (t: T) => boolean;
+  readonly is: (t: T) => boolean;
 
-  isSome: () => boolean;
-  isNone: () => boolean;
+  readonly isSome: () => boolean;
+  readonly isNone: () => boolean;
 
   /** If some(x) return x, otherwise return the specified default value */
-  getOr: (value: T) => T;
+  readonly getOr: (value: T) => T;
 
   /** getOr with a thunked default value */
-  getOrThunk: (makeValue: () => T) => T;
+  readonly getOrThunk: (makeValue: () => T) => T;
 
   /** get the 'some' value; throw if none */
-  getOrDie: (msg?: string) => T;
+  readonly getOrDie: (msg?: string) => T;
 
-  getOrNull: () => T | null;
-  getOrUndefined: () => T | undefined;
+  readonly getOrNull: () => T | null;
+  readonly getOrUndefined: () => T | undefined;
   /**
   - if some: return self
   - if none: return opt
   */
-  or: (opt: Option<T>) => Option<T>;
+  readonly or: (opt: Option<T>) => Option<T>;
 
   /** Same as "or", but uses a thunk instead of a value */
-  orThunk: (makeOption: () => Option<T>) => Option<T>;
+  readonly orThunk: (makeOption: () => Option<T>) => Option<T>;
 
   /** Run a function over the 'some' value.
    *  "map" operation on the Option functor.
    */
-  map: <T2> (mapper: (x: T) => T2) => Option<T2>;
+  readonly map: <T2> (mapper: (x: T) => T2) => Option<T2>;
 
   /** Run a side effect over the 'some' value */
-  each: (worker: (x: T) => void) => void;
+  readonly each: (worker: (x: T) => void) => void;
 
   /** "bind"/"flatMap" operation on the Option Bind/Monad.
    *  Equivalent to >>= in Haskell/PureScript; flatMap in Scala.
    */
-  bind: <T2> (f: (x: T) => Option<T2>) => Option<T2>;
+  readonly bind: <T2> (f: (x: T) => Option<T2>) => Option<T2>;
 
   /** Does this Option contain a value that predicate? */
-  exists: (f: (x: T) => boolean) => boolean;
+  readonly exists: (f: (x: T) => boolean) => boolean;
 
   /** Do all values contained in this option match this predicate? */
-  forall: (f: (x: T) => boolean) => boolean;
+  readonly forall: (f: (x: T) => boolean) => boolean;
 
   /** Return all values in this Option that match the predicate.
    *  The predicate may refine the constituent type using TypeScript type predicates.
    */
-  filter: {
+  readonly filter: {
     <Q extends T>(f: (x: T) => x is Q): Option<Q>;
     (f: (x: T) => boolean): Option<T>;
   };
 
   /** Compare two Options using === */
-  equals: (opt: Option<T>) => boolean;
+  readonly equals: (opt: Option<T>) => boolean;
 
   /** Compare two Options using a specified comparator. */
-  equals_: <T2> (opt: Option<T2>, equality: (a: T, b: T2) => boolean) => boolean;
+  readonly equals_: <T2> (opt: Option<T2>, equality: (a: T, b: T2) => boolean) => boolean;
 
   /** Returns all the values in this Option as an array */
-  toArray: () => T[];
+  readonly toArray: () => T[];
 
-  toString: () => string;
+  readonly toString: () => string;
 }
 
 const none = <T>() => <Option<T>> NONE;
@@ -109,9 +109,6 @@ const NONE: Option<any> = (() => {
     toArray () { return []; },
     toString: Fun.constant('none()')
   };
-  if (Object.freeze) {
-    Object.freeze(me);
-  }
   return me;
 })();
 

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
@@ -1,16 +1,7 @@
 import * as StrAppend from '../str/StrAppend';
-import * as StringParts from '../str/StringParts';
 
-const checkRange = function (str: string, substr: string, start: number) {
-  if (substr === '') {
-    return true;
-  }
-  if (str.length < substr.length) {
-    return false;
-  }
-  const x = str.substr(start, start + substr.length);
-  return x === substr;
-};
+const checkRange = (str: string, substr: string, start: number): boolean =>
+  substr === '' || str.length >= substr.length && str.substr(start, start + substr.length) === substr;
 
 /** Given a string and object, perform template-replacements on the string, as specified by the object.
  * Any template fields of the form ${name} are replaced by the string or number specified as obj["name"]
@@ -72,15 +63,15 @@ export const endsWith = function (str: string, suffix: string) {
   return checkRange(str, suffix, str.length - suffix.length);
 };
 
+const blank = (r: RegExp) => (s: string): string =>
+  s.replace(r, '');
+
 /** removes all leading and trailing spaces */
-export const trim = function (str: string) {
-  return str.replace(/^\s+|\s+$/g, '');
-};
+export const trim: (s: string) => string =
+  blank(/^\s+|\s+$/g);
 
-export const lTrim = function (str: string) {
-  return str.replace(/^\s+/g, '');
-};
+export const lTrim: (s: string) => string =
+  blank(/^\s+/g);
 
-export const rTrim = function (str: string) {
-  return str.replace(/\s+$/g, '');
-};
+export const rTrim: (s: string) => string =
+  blank(/\s+$/g);

--- a/modules/katamari/src/test/ts/atomic/api/fun/FunTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/fun/FunTest.ts
@@ -37,8 +37,8 @@ UnitTest.test('Fun: unit tests', () => {
   Assert.eq('eq', [ 'a', 'b', 'c' ], Fun.curry(c)('a', 'b', 'c'));
   Assert.eq('eq', [ 'a', 'b', 'c' ], Fun.curry(c, 'a', 'b')('c'));
 
-  Assert.eq('eq', false, Fun.not(() => true)());
-  Assert.eq('eq', true, Fun.not(() => false)());
+  Assert.eq('eq', false, Fun.not((x: number) => true)(3));
+  Assert.eq('eq', true, Fun.not((x: string) => false)('cat'));
 
   Assert.throws('should die', Fun.die('Died!'));
 

--- a/modules/robin/src/main/ts/ephox/robin/api/general/Textdata.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/Textdata.ts
@@ -1,15 +1,15 @@
 import { Universe } from '@ephox/boss';
-import { Arr, Fun, Option } from '@ephox/katamari';
+import { Arr, Option } from '@ephox/katamari';
 import { Spot, SpotRange } from '@ephox/phoenix';
 import { PositionArray } from '@ephox/polaris';
 
 interface TextdataGet<E> {
-  list: () => SpotRange<E>[];
-  text: () => string;
+  readonly list: SpotRange<E>[];
+  readonly text: string;
 }
 
 export interface Textdata<E> extends TextdataGet<E> {
-  cursor: () => Option<number>;
+  readonly cursor: Option<number>;
 }
 
 /**
@@ -27,13 +27,13 @@ const get = function <E, D> (universe: Universe<E, D>, elements: E[]) {
   }, '');
 
   return {
-    list: Fun.constant(list),
-    text: Fun.constant(allText)
+    list,
+    text: allText
   };
 };
 
 const cursor = function <E, D> (universe: Universe<E, D>, data: TextdataGet<E>, current: E, offset: number): Textdata<E> {
-  const position = PositionArray.find(data.list(), function (item) {
+  const position = PositionArray.find(data.list, function (item) {
     return universe.eq(item.element(), current);
   }).map(function (element) {
     return element.start() + offset;
@@ -42,7 +42,7 @@ const cursor = function <E, D> (universe: Universe<E, D>, data: TextdataGet<E>, 
   return {
     list: data.list,
     text: data.text,
-    cursor: Fun.constant(position)
+    cursor: position
   };
 };
 

--- a/modules/robin/src/main/ts/ephox/robin/smartselect/EndofWord.ts
+++ b/modules/robin/src/main/ts/ephox/robin/smartselect/EndofWord.ts
@@ -9,7 +9,7 @@ const toEnd = function <E> (cluster: WordDecisionItem<E>[], start: E, soffset: n
     return Option.none<WordRange<E>>();
   }
   const last = cluster[cluster.length - 1];
-  return Option.some(WordRange(start, soffset, last.item(), last.finish()));
+  return Option.some(WordRange(start, soffset, last.item, last.finish));
 };
 
 const fromStart = function <E> (cluster: WordDecisionItem<E>[], finish: E, foffset: number) {
@@ -17,7 +17,7 @@ const fromStart = function <E> (cluster: WordDecisionItem<E>[], finish: E, foffs
     return Option.none<WordRange<E>>();
   }
   const first = cluster[0];
-  return Option.some(WordRange(first.item(), first.start(), finish, foffset));
+  return Option.some(WordRange(first.item, first.start, finish, foffset));
 };
 
 const all = function <E> (cluster: WordDecisionItem<E>[]) {
@@ -26,7 +26,7 @@ const all = function <E> (cluster: WordDecisionItem<E>[]) {
   }
   const first = cluster[0];
   const last = cluster[cluster.length - 1];
-  return Option.some(WordRange(first.item(), first.start(), last.item(), last.finish()));
+  return Option.some(WordRange(first.item, first.start, last.item, last.finish));
 };
 
 const scan = function <E, D> (universe: Universe<E, D>, item: E, offset: number) {

--- a/modules/robin/src/main/ts/ephox/robin/words/ClusterSearch.ts
+++ b/modules/robin/src/main/ts/ephox/robin/words/ClusterSearch.ts
@@ -22,24 +22,24 @@ const doWords = function <E, D> (universe: Universe<E, D>, item: E, mode: Transi
   const destination = Gather.walk(universe, item, mode, direction);
   const result = destination.map(function (dest) {
     const decision = WordDecision.decide(universe, dest.item(), direction.slicer, isCustomBoundary);
-    const recursive: WordDecisionItem<E>[] = decision.abort() ? [] : doWords(universe, dest.item(), dest.mode(), direction, isCustomBoundary);
-    return decision.items().concat(recursive);
+    const recursive: WordDecisionItem<E>[] = decision.abort ? [] : doWords(universe, dest.item(), dest.mode(), direction, isCustomBoundary);
+    return decision.items.concat(recursive);
   }).getOr([]);
 
   return Arr.filter(result, function (res) {
-    return res.text().trim().length > 0;
+    return res.text.trim().length > 0;
   });
 };
 
-const creepLeft = function <E, D> (universe: Universe<E, D>, item: E, isCustomBoundary: (universe: Universe<E, D>, item: E) => boolean) {
+const creepLeft = function <E, D> (universe: Universe<E, D>, item: E, isCustomBoundary: (universe: Universe<E, D>, item: E) => boolean): WordDecisionItem<E>[] {
   return doWords(universe, item, Gather.sidestep, WordWalking.left, isCustomBoundary);
 };
 
-const creepRight = function <E, D> (universe: Universe<E, D>, item: E, isCustomBoundary: (universe: Universe<E, D>, item: E) => boolean) {
+const creepRight = function <E, D> (universe: Universe<E, D>, item: E, isCustomBoundary: (universe: Universe<E, D>, item: E) => boolean): WordDecisionItem<E>[] {
   return doWords(universe, item, Gather.sidestep, WordWalking.right, isCustomBoundary);
 };
 
-const isEmpty = function <E, D> (universe: Universe<E, D>, item: E) {
+const isEmpty = function <E, D> (universe: Universe<E, D>, item: E): boolean {
   // Empty if there are no text nodes in self or any descendants.
   return universe.property().isText(item) ? false : universe.down().predicate(item, universe.property().isText).length === 0;
 };

--- a/modules/robin/src/main/ts/ephox/robin/words/WordDecision.ts
+++ b/modules/robin/src/main/ts/ephox/robin/words/WordDecision.ts
@@ -1,20 +1,25 @@
 import { Universe } from '@ephox/boss';
-import { Option, Struct } from '@ephox/katamari';
+import { Option } from '@ephox/katamari';
 
 export interface WordDecisionItem<E> {
-  item: () => E;
-  start: () => number;
-  finish: () => number;
-  text: () => string;
+  readonly item: E;
+  readonly start: number;
+  readonly finish: number;
+  readonly text: string;
 }
 
 export interface WordDecision<E> {
-  items: () => WordDecisionItem<E>[];
-  abort: () => boolean;
+  readonly items: WordDecisionItem<E>[];
+  readonly abort: boolean;
 }
 
-const make: <E> (item: E, start: number, finish: number, text: string) => WordDecisionItem<E> = Struct.immutable('item', 'start', 'finish', 'text');
-const decision: <E> (items: WordDecisionItem<E>[], abort: boolean) => WordDecision<E> = Struct.immutable('items', 'abort');
+const make = <E> (item: E, start: number, finish: number, text: string): WordDecisionItem<E> => ({
+  item, start, finish, text
+});
+
+const decision = <E> (items: WordDecisionItem<E>[], abort: boolean): WordDecision<E> => ({
+  items, abort
+});
 
 const detail = function <E, D> (universe: Universe<E, D>, item: E) {
   const text = universe.property().getText(item);
@@ -26,11 +31,11 @@ const fromItem = function <E, D> (universe: Universe<E, D>, item: E) {
 };
 
 const onEdge = function <E, D> (universe: Universe<E, D>, item: E, slicer: (text: string) => Option<[number, number]>) {
-  return decision([] as WordDecisionItem<E>[], true);
+  return decision<E>([], true);
 };
 
 const onOther = function <E, D> (universe: Universe<E, D>, item: E, slicer: (text: string) => Option<[number, number]>) {
-  return decision([] as WordDecisionItem<E>[], false);
+  return decision<E>([], false);
 };
 
 // Returns: a 'decision' Struct with the items slot containing an empty array if None

--- a/modules/robin/src/main/ts/ephox/robin/zone/TextZone.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/TextZone.ts
@@ -28,7 +28,7 @@ const fromRange = function <E, D> (universe: Universe<E, D>, start: E, finish: E
   const isLanguageBoundary = LanguageZones.strictBounder(envLang, onlyLang);
   const edges = Clustering.getEdges(universe, start, finish, isLanguageBoundary);
   const transform = TextZones.transformEdges(edges.left(), edges.right());
-  return fromBoundedWith(universe, edges.left().item(), edges.right().item(), envLang, onlyLang, transform);
+  return fromBoundedWith(universe, edges.left().item, edges.right().item, envLang, onlyLang, transform);
 };
 
 const fromInline = function <E, D> (universe: Universe<E, D>, element: E, envLang: string, onlyLang: string) {
@@ -36,7 +36,7 @@ const fromInline = function <E, D> (universe: Universe<E, D>, element: E, envLan
   const edges = Clustering.getEdges(universe, element, element, isLanguageBoundary);
   const transform = TextZones.transformEdges(edges.left(), edges.right());
   return edges.isEmpty() ? scour(universe, element, envLang, onlyLang) :
-    fromBoundedWith(universe, edges.left().item(), edges.right().item(), envLang, onlyLang, transform);
+    fromBoundedWith(universe, edges.left().item, edges.right().item, envLang, onlyLang, transform);
 };
 
 const scour = function <E, D> (universe: Universe<E, D>, element: E, envLang: string, onlyLang: string) {

--- a/modules/robin/src/main/ts/ephox/robin/zone/TextZone.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/TextZone.ts
@@ -11,12 +11,12 @@ import { Zone } from './Zones';
 // a Text Zone enforces a language, and returns Option.some only if a single zone was identified
 // with that language.
 const filterZone = function <E> (zone: Zone<E>, onlyLang: string) {
-  return zone.lang() === onlyLang ? Option.some(zone) : Option.none<Zone<E>>();
+  return zone.lang === onlyLang ? Option.some(zone) : Option.none<Zone<E>>();
 };
 
 const fromBoundedWith = function <E, D> (universe: Universe<E, D>, left: E, right: E, envLang: string, onlyLang: string, transform: (universe: Universe<E, D>, item: E) => WordDecisionItem<E>) {
   const output = TextZones.fromBoundedWith(universe, left, right, envLang, transform, ZoneViewports.anything());
-  const zones = output.zones();
+  const zones = output.zones;
   return zones.length === 1 ? filterZone(zones[0], onlyLang) : Option.none<Zone<E>>();
 };
 

--- a/modules/robin/src/main/ts/ephox/robin/zone/TextZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/TextZones.ts
@@ -38,13 +38,13 @@ const fromBounded = function <E, D> (universe: Universe<E, D>, left: E, right: E
 const fromRange = function <E, D> (universe: Universe<E, D>, start: E, finish: E, envLang: string, viewport: ZoneViewports<E>) {
   const edges = Clustering.getEdges(universe, start, finish, Fun.constant(false));
   const transform = transformEdges(edges.left(), edges.right());
-  return fromBoundedWith(universe, edges.left().item(), edges.right().item(), envLang, transform, viewport);
+  return fromBoundedWith(universe, edges.left().item, edges.right().item, envLang, transform, viewport);
 };
 
 const transformEdges = function <E> (leftEdge: WordDecisionItem<E>, rightEdge: WordDecisionItem<E>) {
   return function <D> (universe: Universe<E, D>, element: E) {
-    return universe.eq(element, leftEdge.item()) ? leftEdge :
-      universe.eq(element, rightEdge.item()) ? rightEdge : WordDecision.detail(universe, element);
+    return universe.eq(element, leftEdge.item) ? leftEdge :
+      universe.eq(element, rightEdge.item) ? rightEdge : WordDecision.detail(universe, element);
   };
 };
 
@@ -54,7 +54,7 @@ const fromInline = function <E, D> (universe: Universe<E, D>, element: E, envLan
   // change
   const bounded = Clustering.byBoundary(universe, element);
   const transform = transformEdges(bounded.left(), bounded.right());
-  return bounded.isEmpty() ? empty<E>() : fromBoundedWith(universe, bounded.left().item(), bounded.right().item(), envLang, transform, viewport);
+  return bounded.isEmpty() ? empty<E>() : fromBoundedWith(universe, bounded.left().item, bounded.right().item, envLang, transform, viewport);
 };
 
 const empty = function <E> (): Zones<E> {

--- a/modules/robin/src/main/ts/ephox/robin/zone/TextZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/TextZones.ts
@@ -5,8 +5,10 @@ import { ZoneViewports } from '../api/general/ZoneViewports';
 import * as Clustering from '../words/Clustering';
 import { WordDecision, WordDecisionItem } from '../words/WordDecision';
 import { LanguageZones, ZoneDetails } from './LanguageZones';
-import { Zones } from './Zones';
+import * as Zones from './Zones';
 import * as ZoneWalker from './ZoneWalker';
+
+type Zones<E> = Zones.Zones<E>;
 
 const rangeOn = function <E, D> (universe: Universe<E, D>, first: E, last: E, envLang: string, transform: (universe: Universe<E, D>, item: E) => WordDecisionItem<E>, viewport: ZoneViewports<E>) {
   const ancestor = universe.eq(first, last) ? Option.some(first) : universe.property().parent(first);
@@ -57,7 +59,7 @@ const fromInline = function <E, D> (universe: Universe<E, D>, element: E, envLan
 
 const empty = function <E> (): Zones<E> {
   return {
-    zones: Fun.constant([])
+    zones: []
   };
 };
 

--- a/modules/robin/src/main/ts/ephox/robin/zone/Zones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/Zones.ts
@@ -4,12 +4,6 @@ import { WordScope } from '../data/WordScope';
 import * as Identify from '../words/Identify';
 import { ZoneDetails } from './LanguageZones';
 
-interface ZoneInput<E> {
-  readonly lang: string;
-  readonly words: WordScope[];
-  readonly elements: E[];
-}
-
 export interface Zone<E> {
   readonly elements: E[];
   readonly lang: string;
@@ -20,32 +14,22 @@ export interface Zones<E> {
   readonly zones: Zone<E>[];
 }
 
-const nu = <E> (input: ZoneInput<E>): Zone<E> => ({
-  elements: input.elements,
-  lang: input.lang,
-  words: input.words
-});
-
 export const fromWalking = function <E, D> (universe: Universe<E, D>, groups: ZoneDetails<E>[]): Zones<E> {
   const zones = Arr.map(groups, function (group: ZoneDetails<E>) {
     const details = group.details();
     const lang = group.lang();
 
-    const line = Arr.map(details, function (x) {
-      return x.text();
-    }).join('');
+    const line = Arr.map(details, (x) => x.text).join('');
 
-    const elements = Arr.map(details, function (x) {
-      return x.item();
-    });
+    const elements = Arr.map(details, (x) => x.item);
 
     const words = Identify.words(line);
 
-    return nu({
+    return {
       lang,
       words,
       elements
-    });
+    };
   });
 
   return {

--- a/modules/robin/src/main/ts/ephox/robin/zone/Zones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/Zones.ts
@@ -1,28 +1,32 @@
 import { Universe } from '@ephox/boss';
-import { Arr, Fun, Struct } from '@ephox/katamari';
+import { Arr } from '@ephox/katamari';
 import { WordScope } from '../data/WordScope';
 import * as Identify from '../words/Identify';
 import { ZoneDetails } from './LanguageZones';
 
 interface ZoneInput<E> {
-  lang: string;
-  words: WordScope[];
-  elements: E[];
+  readonly lang: string;
+  readonly words: WordScope[];
+  readonly elements: E[];
 }
 
 export interface Zone<E> {
-  elements: () => E[];
-  lang: () => string;
-  words: () => WordScope[];
+  readonly elements: E[];
+  readonly lang: string;
+  readonly words: WordScope[];
 }
 
 export interface Zones<E> {
-  zones: () => Zone<E>[];
+  readonly zones: Zone<E>[];
 }
 
-const nu: <E> (input: ZoneInput<E>) => Zone<E> = Struct.immutableBag([ 'elements', 'lang', 'words' ], [ ]);
+const nu = <E> (input: ZoneInput<E>): Zone<E> => ({
+  elements: input.elements,
+  lang: input.lang,
+  words: input.words
+});
 
-const fromWalking = function <E, D> (universe: Universe<E, D>, groups: ZoneDetails<E>[]): Zones<E> {
+export const fromWalking = function <E, D> (universe: Universe<E, D>, groups: ZoneDetails<E>[]): Zones<E> {
   const zones = Arr.map(groups, function (group: ZoneDetails<E>) {
     const details = group.details();
     const lang = group.lang();
@@ -45,10 +49,6 @@ const fromWalking = function <E, D> (universe: Universe<E, D>, groups: ZoneDetai
   });
 
   return {
-    zones: Fun.constant(zones)
+    zones
   };
-};
-
-export const Zones = {
-  fromWalking
 };

--- a/modules/robin/src/test/ts/atomic/api/TextZonesTest.ts
+++ b/modules/robin/src/test/ts/atomic/api/TextZonesTest.ts
@@ -52,7 +52,7 @@ UnitTest.test('TextZonesTest', function () {
   const checkSingle = function (info: ArbIds) {
     const item = doc1.find(doc1.get(), info.startId).getOrDie();
     const actual = TextZones.single(doc1, item, 'en', ZoneViewports.anything());
-    assertProps('Testing zones for single(' + info.startId + ')', doc1, actual.zones());
+    assertProps('Testing zones for single(' + info.startId + ')', doc1, actual.zones);
     return true;
   };
 
@@ -60,7 +60,7 @@ UnitTest.test('TextZonesTest', function () {
     const item1 = doc1.find(doc1.get(), info.startId).getOrDie();
     const item2 = doc1.find(doc1.get(), info.finishId).getOrDie();
     const actual = TextZones.range(doc1, item1, 0, item2, 0, 'en', ZoneViewports.anything());
-    assertProps('Testing zones for range(' + info.startId + '->' + info.finishId + ')', doc1, actual.zones());
+    assertProps('Testing zones for range(' + info.startId + '->' + info.finishId + ')', doc1, actual.zones);
     return true;
   };
 
@@ -79,7 +79,7 @@ UnitTest.test('TextZonesTest', function () {
           words: [
             'isolated'
           ]
-        }], raw(doc1, actual.zones()));
+        }], raw(doc1, actual.zones));
     }
   );
 
@@ -98,7 +98,7 @@ UnitTest.test('TextZonesTest', function () {
           words: [
             'isolated-text'
           ]
-        }], raw(doc1, actual.zones()));
+        }], raw(doc1, actual.zones));
     }
   );
 
@@ -124,7 +124,7 @@ UnitTest.test('TextZonesTest', function () {
     const item = doc1.find(doc1.get(), info.startId).getOrDie();
     // Consider other offsets
     const actual = TextZones.range(doc1, item, 0, item, 0, 'en', ZoneViewports.anything());
-    return Jsc.eq(0, actual.zones().length);
+    return Jsc.eq(0, actual.zones.length);
   });
 
   PropertyAssertions.check(

--- a/modules/robin/src/test/ts/atomic/words/ClusteringTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/ClusteringTest.ts
@@ -11,8 +11,8 @@ import { LanguageZones } from 'ephox/robin/zone/LanguageZones';
 UnitTest.test('ClusteringTest', function () {
   const checkWords = function (universe: TestUniverse, words: WordDecisionItem<Gene>[]) {
     return Arr.map(words, function (a) {
-      const text = universe.property().getText(a.item());
-      return text.substring(a.start(), a.finish());
+      const text = universe.property().getText(a.item);
+      return text.substring(a.start, a.finish);
     });
   };
 
@@ -177,16 +177,16 @@ UnitTest.test('ClusteringTest', function () {
   };
 
   interface ClusteringLangs {
-    all: () => WordDecisionItem<Gene>[];
-    left: () => WordDecisionItem<Gene>[];
-    middle: () => WordDecisionItem<Gene>[];
-    right: () => WordDecisionItem<Gene>[];
-    lang: () => Option<string>;
+    readonly all: () => WordDecisionItem<Gene>[];
+    readonly left: () => WordDecisionItem<Gene>[];
+    readonly middle: () => WordDecisionItem<Gene>[];
+    readonly right: () => WordDecisionItem<Gene>[];
+    readonly lang: () => Option<string>;
   }
 
   const checkProps = function (universe: TestUniverse, textIds: string[], start: Gene, actual: ClusteringLangs) {
     const checkGroup = function (label: string, group: WordDecisionItem<Gene>[]) {
-      const items = Arr.map(group, function (g) { return g.item(); });
+      const items = Arr.map(group, function (g) { return g.item; });
       Arr.each(items, function (x, i) {
         Assert.eq('Checking everything in ' + label + ' has same language', LanguageZones.calculate(universe, x).getOr('none'), actual.lang().getOr('none'));
         Assert.eq(
@@ -204,8 +204,8 @@ UnitTest.test('ClusteringTest', function () {
 
     Arr.each(actual.all(), function (x, i) {
       if (i > 0) {
-        const prev = actual.all()[i - 1].item().id;
-        const current = x.item().id;
+        const prev = actual.all()[i - 1].item.id;
+        const current = x.item.id;
         Assert.eq(
           'The text nodes should be one after the other',
           +1,
@@ -219,7 +219,7 @@ UnitTest.test('ClusteringTest', function () {
       Assert.eq(
         'All block ancestor tags should be the same as the original',
         blockParent,
-        universe.up().predicate(x.item(), universe.property().isBoundary).getOrDie('No block parent tag found')
+        universe.up().predicate(x.item, universe.property().isBoundary).getOrDie('No block parent tag found')
       );
     });
   };

--- a/modules/robin/src/test/ts/atomic/words/WordDecisionTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/WordDecisionTest.ts
@@ -26,8 +26,8 @@ UnitTest.test('WordDecisionTest', function () {
   const check = function (items: string[], abort: boolean, id: string, slicer: (text: string) => Option<[number, number]>, _currLanguage: Option<string>) {
     const isCustomBoundary = Fun.constant(false);
     const actual = WordDecision.decide(universe, universe.find(universe.get(), id).getOrDie(), slicer, isCustomBoundary);
-    assert.eq(items, Arr.map(actual.items(), function (item) { return item.item().id; }));
-    assert.eq(abort, actual.abort());
+    assert.eq(items, Arr.map(actual.items, function (item) { return item.item.id; }));
+    assert.eq(abort, actual.abort);
   };
 
   check([], true, 'p1', WordWalking.left.slicer, Option.none());

--- a/modules/robin/src/test/ts/atomic/zone/BoundedZoneTest.ts
+++ b/modules/robin/src/test/ts/atomic/zone/BoundedZoneTest.ts
@@ -10,7 +10,7 @@ UnitTest.test('BoundedZoneTest', function () {
   const check = function (universe: TestUniverse, expected: RawZone[], id: string) {
     const item = universe.find(universe.get(), id).getOrDie();
     const actual = TextZones.fromBounded(universe, item, item, 'en', ZoneViewports.anything());
-    assertZones('Starting from: ' + id, universe, expected, actual.zones());
+    assertZones('Starting from: ' + id, universe, expected, actual.zones);
   };
 
   const doc1 = TestUniverse(Gene('root', 'root', [
@@ -119,7 +119,7 @@ UnitTest.test('BoundedZoneTest', function () {
     const item1 = doc1.find(doc1.get(), info.startId).getOrDie();
     const item2 = doc1.find(doc1.get(), info.finishId).getOrDie();
     const actual = TextZones.fromBounded(doc1, item1, item2, 'en', ZoneViewports.anything());
-    assertProps('Testing zones for ' + info.startId + '->' + info.finishId, doc1, actual.zones());
+    assertProps('Testing zones for ' + info.startId + '->' + info.finishId, doc1, actual.zones);
     return true;
   });
 });

--- a/modules/robin/src/test/ts/browser/api/DomTextdataTest.ts
+++ b/modules/robin/src/test/ts/browser/api/DomTextdataTest.ts
@@ -14,9 +14,9 @@ UnitTest.test('DomTextdataTest', function () {
 
   const check = function (expected: { text: string, cursor: Option<number> }, elements: Element[], current: Element, offset: number) {
     const actual = DomTextdata.from(elements, current, offset);
-    Assert.eq('eq', expected.text, actual.text());
+    Assert.eq('eq', expected.text, actual.text);
 
-    KAssert.eqOption('eq', expected.cursor, actual.cursor());
+    KAssert.eqOption('eq', expected.cursor, actual.cursor);
   };
 
   check({

--- a/modules/robin/src/test/ts/module/ephox/robin/test/ZoneObjects.ts
+++ b/modules/robin/src/test/ts/module/ephox/robin/test/ZoneObjects.ts
@@ -13,11 +13,11 @@ export interface RawZone {
 
 const rawOne = function (universe: TestUniverse, zone: Zone<Gene>): RawZone {
   return {
-    lang: zone.lang(),
-    elements: Arr.map(zone.elements(), function (elem) {
+    lang: zone.lang,
+    elements: Arr.map(zone.elements, function (elem) {
       return elem.id;
     }),
-    words: Arr.map(zone.words(), function (w) {
+    words: Arr.map(zone.words, function (w) {
       return w.word();
     })
   };
@@ -36,7 +36,7 @@ const assertZones = function (label: string, universe: TestUniverse, expected: R
 
 const assertProps = function (label: string, universe: TestUniverse, zones: Zone<Gene>[]) {
   Arr.each(zones, function (zone) {
-    const elements = zone.elements();
+    const elements = zone.elements;
     if (elements.length === 0) {
       return;
     }
@@ -50,7 +50,7 @@ const assertProps = function (label: string, universe: TestUniverse, zones: Zone
         Arr.each(elements, function (x, i) {
           Assert.eq(
             'Checking everything in ' + label + ' has same language. Item: ' + x.id,
-            LanguageZones.calculate(universe, x).getOr('none'), zone.lang()
+            LanguageZones.calculate(universe, x).getOr('none'), zone.lang
           );
           Assert.eq(
             'Check that everything in the ' + label + ' is a text node',

--- a/modules/sand/src/main/ts/ephox/sand/core/Browser.ts
+++ b/modules/sand/src/main/ts/ephox/sand/core/Browser.ts
@@ -10,21 +10,15 @@ const firefox = 'Firefox';
 const safari = 'Safari';
 
 export interface Browser {
-  current: string | undefined;
-  version: Version;
-  isEdge: () => boolean;
-  isChrome: () => boolean;
-  isIE: () => boolean;
-  isOpera: () => boolean;
-  isFirefox: () => boolean;
-  isSafari: () => boolean;
+  readonly current: string | undefined;
+  readonly version: Version;
+  readonly isEdge: () => boolean;
+  readonly isChrome: () => boolean;
+  readonly isIE: () => boolean;
+  readonly isOpera: () => boolean;
+  readonly isFirefox: () => boolean;
+  readonly isSafari: () => boolean;
 }
-
-const isBrowser = function (name: string, current: string) {
-  return function () {
-    return current === name;
-  };
-};
 
 const unknown = function () {
   return nu({
@@ -37,17 +31,19 @@ const nu = function (info: UaString): Browser {
   const current = info.current;
   const version = info.version;
 
+  const isBrowser = (name: string) => (): boolean => current === name;
+
   return {
     current,
     version,
 
-    isEdge: isBrowser(edge, current),
-    isChrome: isBrowser(chrome, current),
+    isEdge: isBrowser(edge),
+    isChrome: isBrowser(chrome),
     // NOTE: isIe just looks too weird
-    isIE: isBrowser(ie, current),
-    isOpera: isBrowser(opera, current),
-    isFirefox: isBrowser(firefox, current),
-    isSafari: isBrowser(safari, current)
+    isIE: isBrowser(ie),
+    isOpera: isBrowser(opera),
+    isFirefox: isBrowser(firefox),
+    isSafari: isBrowser(safari)
   };
 };
 

--- a/modules/sand/src/main/ts/ephox/sand/core/OperatingSystem.ts
+++ b/modules/sand/src/main/ts/ephox/sand/core/OperatingSystem.ts
@@ -3,16 +3,16 @@ import { UaString } from '../detect/UaString';
 import { Version } from '../detect/Version';
 
 export interface OperatingSystem {
-  current: string | undefined;
-  version: Version;
-  isWindows: () => boolean;
-  isiOS: () => boolean;
-  isAndroid: () => boolean;
-  isOSX: () => boolean;
-  isLinux: () => boolean;
-  isSolaris: () => boolean;
-  isFreeBSD: () => boolean;
-  isChromeOS: () => boolean;
+  readonly current: string | undefined;
+  readonly version: Version;
+  readonly isWindows: () => boolean;
+  readonly isiOS: () => boolean;
+  readonly isAndroid: () => boolean;
+  readonly isOSX: () => boolean;
+  readonly isLinux: () => boolean;
+  readonly isSolaris: () => boolean;
+  readonly isFreeBSD: () => boolean;
+  readonly isChromeOS: () => boolean;
 }
 
 const windows = 'Windows';
@@ -26,11 +26,6 @@ const chromeos = 'ChromeOS';
 
 // Though there is a bit of dupe with this and Browser, trying to
 // reuse code makes it much harder to follow and change.
-const isOS = function (name: string, current: string) {
-  return function () {
-    return current === name;
-  };
-};
 
 const unknown = function (): OperatingSystem {
   return nu({
@@ -43,19 +38,21 @@ const nu = function (info: UaString): OperatingSystem {
   const current = info.current;
   const version = info.version;
 
+  const isOS = (name: string) => (): boolean => current === name;
+
   return {
     current,
     version,
 
-    isWindows: isOS(windows, current),
+    isWindows: isOS(windows),
     // TODO: Fix capitalisation
-    isiOS: isOS(ios, current),
-    isAndroid: isOS(android, current),
-    isOSX: isOS(osx, current),
-    isLinux: isOS(linux, current),
-    isSolaris: isOS(solaris, current),
-    isFreeBSD: isOS(freebsd, current),
-    isChromeOS: isOS(chromeos, current)
+    isiOS: isOS(ios),
+    isAndroid: isOS(android),
+    isOSX: isOS(osx),
+    isLinux: isOS(linux),
+    isSolaris: isOS(solaris),
+    isFreeBSD: isOS(freebsd),
+    isChromeOS: isOS(chromeos)
   };
 };
 

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -348,19 +348,13 @@ const Styles = function (settings?, schema?: Schema): Styles {
       };
 
       const isValid = (name: string, elementName: string): boolean => {
-        let styleMap;
-
-        styleMap = invalidStyles['*'];
+        let styleMap = invalidStyles['*'];
         if (styleMap && styleMap[name]) {
           return false;
         }
 
         styleMap = invalidStyles[elementName];
-        if (styleMap && styleMap[name]) {
-          return false;
-        }
-
-        return true;
+        return !(styleMap && styleMap[name]);
       };
 
       // Serialize styles according to schema

--- a/modules/tinymce/src/core/main/ts/delete/BlockBoundaryDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockBoundaryDelete.ts
@@ -14,7 +14,7 @@ const backspaceDelete = (editor: Editor, forward: boolean): boolean => {
   const rootNode = Element.fromDom(editor.getBody());
 
   const position = BlockMergeBoundary.read(rootNode.dom(), forward, editor.selection.getRng()).bind((blockBoundary) =>
-    MergeBlocks.mergeBlocks(rootNode, forward, blockBoundary.from().block(), blockBoundary.to().block()));
+    MergeBlocks.mergeBlocks(rootNode, forward, blockBoundary.from.block, blockBoundary.to.block));
 
   position.each(function (pos) {
     editor.selection.setRng(pos.toRange());

--- a/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun, Option, Options } from '@ephox/katamari';
+import { Option, Options } from '@ephox/katamari';
 import { Compare, Element, Traverse } from '@ephox/sugar';
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
@@ -15,23 +15,23 @@ import * as NodeType from '../dom/NodeType';
 import { Node } from '@ephox/dom-globals';
 
 interface BlockPosition {
-  block: () => Element<Node>;
-  position: () => CaretPosition;
+  readonly block: Element<Node>;
+  readonly position: CaretPosition;
 }
 
 interface BlockBoundary {
-  from: () => BlockPosition;
-  to: () => BlockPosition;
+  readonly from: BlockPosition;
+  readonly to: BlockPosition;
 }
 
 const blockPosition = (block: Element<Node>, position: CaretPosition): BlockPosition => ({
-  block: Fun.constant(block),
-  position: Fun.constant(position)
+  block,
+  position
 });
 
 const blockBoundary = (from: BlockPosition, to: BlockPosition): BlockBoundary => ({
-  from: Fun.constant(from),
-  to: Fun.constant(to)
+  from,
+  to
 });
 
 const getBlockPosition = function (rootNode: Node, pos: CaretPosition): Option<BlockPosition> {
@@ -43,25 +43,25 @@ const getBlockPosition = function (rootNode: Node, pos: CaretPosition): Option<B
 };
 
 const isDifferentBlocks = function (blockBoundary: BlockBoundary): boolean {
-  return Compare.eq(blockBoundary.from().block(), blockBoundary.to().block()) === false;
+  return Compare.eq(blockBoundary.from.block, blockBoundary.to.block) === false;
 };
 
 const hasSameParent = function (blockBoundary: BlockBoundary): boolean {
-  return Traverse.parent(blockBoundary.from().block()).bind(function (parent1) {
-    return Traverse.parent(blockBoundary.to().block()).filter(function (parent2) {
+  return Traverse.parent(blockBoundary.from.block).bind(function (parent1) {
+    return Traverse.parent(blockBoundary.to.block).filter(function (parent2) {
       return Compare.eq(parent1, parent2);
     });
   }).isSome();
 };
 
 const isEditable = function (blockBoundary: BlockBoundary): boolean {
-  return NodeType.isContentEditableFalse(blockBoundary.from().block().dom()) === false && NodeType.isContentEditableFalse(blockBoundary.to().block().dom()) === false;
+  return NodeType.isContentEditableFalse(blockBoundary.from.block.dom()) === false && NodeType.isContentEditableFalse(blockBoundary.to.block.dom()) === false;
 };
 
 const skipLastBr = function (rootNode, forward: boolean, blockPosition: BlockPosition): BlockPosition {
-  if (NodeType.isBr(blockPosition.position().getNode()) && Empty.isEmpty(blockPosition.block()) === false) {
-    return CaretFinder.positionIn(false, blockPosition.block().dom()).bind(function (lastPositionInBlock) {
-      if (lastPositionInBlock.isEqual(blockPosition.position())) {
+  if (NodeType.isBr(blockPosition.position.getNode()) && Empty.isEmpty(blockPosition.block) === false) {
+    return CaretFinder.positionIn(false, blockPosition.block.dom()).bind(function (lastPositionInBlock) {
+      if (lastPositionInBlock.isEqual(blockPosition.position)) {
         return CaretFinder.fromPosition(forward, rootNode, lastPositionInBlock).bind(function (to) {
           return getBlockPosition(rootNode, to);
         });
@@ -77,7 +77,7 @@ const skipLastBr = function (rootNode, forward: boolean, blockPosition: BlockPos
 const readFromRange = function (rootNode, forward, rng): Option<BlockBoundary> {
   const fromBlockPos = getBlockPosition(rootNode, CaretPosition.fromRangeStart(rng));
   const toBlockPos = fromBlockPos.bind(function (blockPos) {
-    return CaretFinder.fromPosition(forward, rootNode, blockPos.position()).bind(function (to) {
+    return CaretFinder.fromPosition(forward, rootNode, blockPos.position).bind(function (to) {
       return getBlockPosition(rootNode, to).map(function (blockPos) {
         return skipLastBr(rootNode, forward, blockPos);
       });

--- a/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
@@ -14,12 +14,12 @@ import * as Empty from '../dom/Empty';
 import * as NodeType from '../dom/NodeType';
 import { Node } from '@ephox/dom-globals';
 
-interface BlockPosition {
+export interface BlockPosition {
   readonly block: Element<Node>;
   readonly position: CaretPosition;
 }
 
-interface BlockBoundary {
+export interface BlockBoundary {
   readonly from: BlockPosition;
   readonly to: BlockPosition;
 }

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
@@ -36,7 +36,8 @@ const deleteAction = Adt.generate([
   { emptyCells: [ 'cells' ] }
 ]);
 
-const isRootFromElement = (root: Element<any>) => (cur: Element<any>): boolean => Compare.eq(root, cur);
+const isRootFromElement = (root: Element<any>): (cur: Element<any>) => boolean =>
+  (cur: Element<any>): boolean => Compare.eq(root, cur);
 
 const getClosestCell = (container: DomNode, isRoot: (e: Element<any>) => boolean) => {
   return SelectorFind.closest(Element.fromDom(container), 'td,th', isRoot);
@@ -57,9 +58,10 @@ const getTableFromCellRng = (cellRng: TableCellRng, isRoot: (e: Element<any>) =>
 
 const getTableCells = (table) => SelectorFilter.descendants(table, 'td,th');
 
-const getCellRangeFromStartTable = (cellRng: any, isRoot) => getClosestTable(cellRng.start(), isRoot).bind((table) => {
-  return Arr.last(getTableCells(table)).map((endCell) => tableCellRng(cellRng.start(), endCell));
-});
+const getCellRangeFromStartTable = (cellRng: TableCellRng, isRoot): Option<TableCellRng> =>
+  getClosestTable(cellRng.start, isRoot).bind((table) => {
+    return Arr.last(getTableCells(table)).map((endCell) => tableCellRng(cellRng.start, endCell));
+  });
 
 const partialSelection = (isRoot: (e: Element<any>) => boolean, rng: Range): Option<TableCellRng> => {
   const startCell = getClosestCell(rng.startContainer, isRoot);

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
@@ -111,11 +111,11 @@ const getSelectedCells = (tableSelection: TableSelection) => {
     (startIndex, endIndex) => tableSelection.cells.slice(startIndex, endIndex + 1));
 };
 
-const getAction = (tableSelection) =>
+const getAction = (tableSelection: TableSelection) =>
   getSelectedCells(tableSelection)
     .map((selected) => {
-      const cells = tableSelection.cells();
-      return selected.length === cells.length ? deleteAction.removeTable(tableSelection.table()) : deleteAction.emptyCells(selected);
+      const cells = tableSelection.cells;
+      return selected.length === cells.length ? deleteAction.removeTable(tableSelection.table) : deleteAction.emptyCells(selected);
     });
 
 export const getActionFromCells = (cells) => deleteAction.emptyCells(cells);

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
@@ -5,30 +5,30 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Adt, Arr, Fun, Option, Options } from '@ephox/katamari';
+import { Adt, Arr, Option, Options } from '@ephox/katamari';
 import { Compare, Element, SelectorFilter, SelectorFind } from '@ephox/sugar';
 import { Range, Element as DomElement, Node as DomNode } from '@ephox/dom-globals';
 
 interface TableCellRng {
-  start: () => Element<DomElement>;
-  end: () => Element<DomElement>;
+  readonly start: Element<DomElement>;
+  readonly end: Element<DomElement>;
 }
 
 const tableCellRng = (start: Element<DomElement>, end: Element<DomElement>): TableCellRng => ({
-  start: Fun.constant(start),
-  end: Fun.constant(end)
+  start,
+  end
 });
 
 interface TableSelection {
-  rng: () => TableCellRng;
-  table: () => Element<DomElement>;
-  cells: () => Element<DomElement>[];
+  readonly rng: TableCellRng;
+  readonly table: Element<DomElement>;
+  readonly cells: Element<DomElement>[];
 }
 
 const tableSelection = (rng: TableCellRng, table: Element<DomElement>, cells: Element<DomElement>[]): TableSelection => ({
-  rng: Fun.constant(rng),
-  table: Fun.constant(table),
-  cells: Fun.constant(cells)
+  rng,
+  table,
+  cells
 });
 
 const deleteAction = Adt.generate([
@@ -51,9 +51,9 @@ const isExpandedCellRng = (cellRng) => {
 };
 
 const getTableFromCellRng = (cellRng: TableCellRng, isRoot: (e: Element<any>) => boolean): Option<Element<DomElement>> =>
-  getClosestTable(cellRng.start(), isRoot)
+  getClosestTable(cellRng.start, isRoot)
     .bind((startParentTable) =>
-      getClosestTable(cellRng.end(), isRoot)
+      getClosestTable(cellRng.end, isRoot)
         .bind((endParentTable) => Options.someIf(Compare.eq(startParentTable, endParentTable), startParentTable)));
 
 const getTableCells = (table) => SelectorFilter.descendants(table, 'td,th');
@@ -107,9 +107,9 @@ const getCellIndex = <T> (cells: Element<T>[], cell: Element<T>): Option<number>
 
 const getSelectedCells = (tableSelection: TableSelection) => {
   return Options.lift2(
-    getCellIndex(tableSelection.cells(), tableSelection.rng().start()),
-    getCellIndex(tableSelection.cells(), tableSelection.rng().end()),
-    (startIndex, endIndex) => tableSelection.cells().slice(startIndex, endIndex + 1));
+    getCellIndex(tableSelection.cells, tableSelection.rng.start),
+    getCellIndex(tableSelection.cells, tableSelection.rng.end),
+    (startIndex, endIndex) => tableSelection.cells.slice(startIndex, endIndex + 1));
 };
 
 const getAction = (tableSelection) =>

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
@@ -46,9 +46,8 @@ const getClosestTable = (cell, isRoot) => {
   return SelectorFind.ancestor(cell, 'table', isRoot);
 };
 
-const isExpandedCellRng = (cellRng: TableCellRng): boolean => {
-  return Compare.eq(cellRng.start, cellRng.end) === false;
-};
+const isExpandedCellRng = (cellRng: TableCellRng): boolean =>
+  !Compare.eq(cellRng.start, cellRng.end);
 
 const getTableFromCellRng = (cellRng: TableCellRng, isRoot: (e: Element<any>) => boolean): Option<Element<DomElement>> =>
   getClosestTable(cellRng.start, isRoot)

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
@@ -46,8 +46,8 @@ const getClosestTable = (cell, isRoot) => {
   return SelectorFind.ancestor(cell, 'table', isRoot);
 };
 
-const isExpandedCellRng = (cellRng) => {
-  return Compare.eq(cellRng.start(), cellRng.end()) === false;
+const isExpandedCellRng = (cellRng: TableCellRng): boolean => {
+  return Compare.eq(cellRng.start, cellRng.end) === false;
 };
 
 const getTableFromCellRng = (cellRng: TableCellRng, isRoot: (e: Element<any>) => boolean): Option<Element<DomElement>> =>

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -6,7 +6,6 @@
  */
 
 import { Element, Node } from '@ephox/dom-globals';
-import { Fun } from '@ephox/katamari';
 import * as Bookmarks from '../bookmark/Bookmarks';
 import ElementUtils from '../api/dom/ElementUtils';
 import * as NodeType from '../dom/NodeType';
@@ -86,22 +85,17 @@ const processChildElements = function (node: Node, filter: (node: Node) => boole
   });
 };
 
-const hasStyle = function (dom: DOMUtils, name: string) {
-  return Fun.curry(function (name: string, node: Node) {
-    return !!(node && FormatUtils.getStyle(dom, node, name));
-  }, name);
-};
+const hasStyle = (dom: DOMUtils, name: string) => (node: Node): boolean =>
+  !!(node && FormatUtils.getStyle(dom, node, name));
 
-const applyStyle = function (dom: DOMUtils, name: string, value: string) {
-  return Fun.curry(function (name: string, value: string, node: Element) {
-    dom.setStyle(node, name, value);
+const applyStyle = (dom: DOMUtils, name: string, value: string) => (node: Element): void => {
+  dom.setStyle(node, name, value);
 
-    if (node.getAttribute('style') === '') {
-      node.removeAttribute('style');
-    }
+  if (node.getAttribute('style') === '') {
+    node.removeAttribute('style');
+  }
 
-    unwrapEmptySpan(dom, node);
-  }, name, value);
+  unwrapEmptySpan(dom, node);
 };
 
 const unwrapEmptySpan = function (dom: DOMUtils, node: Node) {
@@ -110,23 +104,22 @@ const unwrapEmptySpan = function (dom: DOMUtils, node: Node) {
   }
 };
 
-const processUnderlineAndColor = function (dom: DOMUtils, node: Node) {
-  let textDecoration;
-  if (node.nodeType === 1 && node.parentNode && node.parentNode.nodeType === 1) {
-    textDecoration = FormatUtils.getTextDecoration(dom, node.parentNode);
-    if (dom.getStyle(node, 'color') && textDecoration) {
-      dom.setStyle(node, 'text-decoration', textDecoration);
-    } else if (dom.getStyle(node, 'text-decoration') === textDecoration) {
-      dom.setStyle(node, 'text-decoration', null);
-    }
-  }
-};
-
 const mergeUnderlineAndColor = function (dom: DOMUtils, format, vars: FormatVars, node: Node) {
+  const processUnderlineAndColor = function (n: Node) {
+    if (n.nodeType === 1 && n.parentNode && n.parentNode.nodeType === 1) {
+      const textDecoration = FormatUtils.getTextDecoration(dom, n.parentNode);
+      if (dom.getStyle(n, 'color') && textDecoration) {
+        dom.setStyle(n, 'text-decoration', textDecoration);
+      } else if (dom.getStyle(n, 'text-decoration') === textDecoration) {
+        dom.setStyle(n, 'text-decoration', null);
+      }
+    }
+  };
+
   // Colored nodes should be underlined so that the color of the underline matches the text color.
   if (format.styles.color || format.styles.textDecoration) {
-    Tools.walk(node, Fun.curry(processUnderlineAndColor, dom), 'childNodes');
-    processUnderlineAndColor(dom, node);
+    Tools.walk(node, processUnderlineAndColor, 'childNodes');
+    processUnderlineAndColor(node);
   }
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
@@ -51,7 +51,7 @@ UnitTest.asynctest('browser.tinymce.core.delete.BlockMergeBoundary', function (s
     });
   };
 
-  const cAssertBlockBoundaryNone = Chain.op(function (blockBoundaryOption: Option<BlockBoundary>) {
+  const cAssertBlockBoundaryNone = Chain.op(function (blockBoundaryOption: Option<BlockBoundary >) {
     Assertions.assertEq('BlockBoundary should be none', true, blockBoundaryOption.isNone());
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
@@ -6,6 +6,8 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 
+type BlockBoundary = BlockMergeBoundary.BlockBoundary;
+
 UnitTest.asynctest('browser.tinymce.core.delete.BlockMergeBoundary', function (success, failure) {
   const viewBlock = ViewBlock();
 
@@ -25,31 +27,31 @@ UnitTest.asynctest('browser.tinymce.core.delete.BlockMergeBoundary', function (s
     });
   };
 
-  const cAssertBlockBoundaryPositions = function (fromPath, fromOffset, toPath, toOffset) {
-    return Chain.op(function (blockBoundaryOption: Option<any>) {
+  const cAssertBlockBoundaryPositions = function (fromPath, fromOffset, toPath, toOffset): Chain<Option<BlockBoundary>, Option<BlockBoundary>> {
+    return Chain.op(function (blockBoundaryOption: Option<BlockMergeBoundary.BlockBoundary>) {
       const fromContainer = Hierarchy.follow(Element.fromDom(viewBlock.get()), fromPath).getOrDie();
       const toContainer = Hierarchy.follow(Element.fromDom(viewBlock.get()), toPath).getOrDie();
       const blockBoundary = blockBoundaryOption.getOrDie();
 
-      Assertions.assertDomEq('Should be expected from container', fromContainer, Element.fromDom(blockBoundary.from().position().container()));
-      Assertions.assertEq('Should be expected from offset', fromOffset, blockBoundary.from().position().offset());
-      Assertions.assertDomEq('Should be expected to container', toContainer, Element.fromDom(blockBoundary.to().position().container()));
-      Assertions.assertEq('Should be expected to offset', toOffset, blockBoundary.to().position().offset());
+      Assertions.assertDomEq('Should be expected from container', fromContainer, Element.fromDom(blockBoundary.from.position.container()));
+      Assertions.assertEq('Should be expected from offset', fromOffset, blockBoundary.from.position.offset());
+      Assertions.assertDomEq('Should be expected to container', toContainer, Element.fromDom(blockBoundary.to.position.container()));
+      Assertions.assertEq('Should be expected to offset', toOffset, blockBoundary.to.position.offset());
     });
   };
 
-  const cAssertBlockBoundaryBlocks = function (fromBlockPath, toBlockPath) {
-    return Chain.op(function (blockBoundaryOption: Option<any>) {
+  const cAssertBlockBoundaryBlocks = function (fromBlockPath: number[], toBlockPath: number[]): Chain<Option<BlockBoundary>, Option<BlockBoundary>> {
+    return Chain.op(function (blockBoundaryOption: Option<BlockBoundary>) {
       const expectedFromBlock = Hierarchy.follow(Element.fromDom(viewBlock.get()), fromBlockPath).getOrDie();
       const expectedToBlock = Hierarchy.follow(Element.fromDom(viewBlock.get()), toBlockPath).getOrDie();
       const blockBoundary = blockBoundaryOption.getOrDie();
 
-      Assertions.assertDomEq('Should be expected from block', expectedFromBlock, blockBoundary.from().block());
-      Assertions.assertDomEq('Should be expected to block', expectedToBlock, blockBoundary.to().block());
+      Assertions.assertDomEq('Should be expected from block', expectedFromBlock, blockBoundary.from.block);
+      Assertions.assertDomEq('Should be expected to block', expectedToBlock, blockBoundary.to.block);
     });
   };
 
-  const cAssertBlockBoundaryNone = Chain.op(function (blockBoundaryOption: Option<any>) {
+  const cAssertBlockBoundaryNone = Chain.op(function (blockBoundaryOption: Option<BlockBoundary>) {
     Assertions.assertEq('BlockBoundary should be none', true, blockBoundaryOption.isNone());
   });
 

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Dialog.ts
@@ -66,18 +66,18 @@ const makeOpen = (editor: Editor, imageUploadTimerState) => () => {
       onCancel: () => { }, // TODO: reimplement me
       onAction: (api, details) => {
         switch (details.name) {
-          case ImageToolsEvents.saveState():
+          case ImageToolsEvents.saveState:
             if (details.value) {
               api.enable('save');
             } else {
               api.disable('save');
             }
             break;
-          case ImageToolsEvents.disable():
+          case ImageToolsEvents.disable:
             api.disable('save');
             api.disable('cancel');
             break;
-          case ImageToolsEvents.enable():
+          case ImageToolsEvents.enable:
             api.enable('cancel');
             break;
         }

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/ImageToolsEvents.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/ImageToolsEvents.ts
@@ -5,11 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun } from '@ephox/katamari';
-
-const saveState = Fun.constant('save-state');
-const disable = Fun.constant('disable');
-const enable = Fun.constant('enable');
+const saveState = 'save-state';
+const disable = 'disable';
+const enable = 'enable';
 
 // TODO: dedupe these from ImageToolsEvents.ts in silver
 

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -40,8 +40,8 @@ function Plugin(editor: Editor) {
   Buttons.addToolbars(editor);
 
   editor.on('PreInit', function () {
-    editor.serializer.addTempAttr(Ephemera.firstSelected());
-    editor.serializer.addTempAttr(Ephemera.lastSelected());
+    editor.serializer.addTempAttr(Ephemera.firstSelected);
+    editor.serializer.addTempAttr(Ephemera.lastSelected);
   });
 
   if (hasTabNavigation(editor)) {

--- a/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
@@ -20,7 +20,7 @@ import { TableActions } from './TableActions';
 const extractSelected = function (cells) {
   // Assume for now that we only have one table (also handles the case where we multi select outside a table)
   return TableLookup.table(cells[0]).map(Replication.deep).map(function (replica) {
-    return [ CopySelected.extract(replica, Ephemera.attributeSelector()) ];
+    return [ CopySelected.extract(replica, Ephemera.attributeSelector) ];
   });
 };
 

--- a/modules/tinymce/src/plugins/table/main/ts/queries/CellOperations.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/CellOperations.ts
@@ -38,7 +38,7 @@ const mergable = function (table, selections): Option<any> {
       if (cells.length === 0) {
         return Option.none();
       }
-      return TableSelection.retrieveBox(table, Ephemera.firstSelectedSelector(), Ephemera.lastSelectedSelector()).bind(function (bounds) {
+      return TableSelection.retrieveBox(table, Ephemera.firstSelectedSelector, Ephemera.lastSelectedSelector).bind(function (bounds) {
         return cells.length > 1 ? Option.some({
           bounds: Fun.constant(bounds),
           cells: Fun.constant(cells)

--- a/modules/tinymce/src/plugins/table/main/ts/selection/Ephemera.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/Ephemera.ts
@@ -5,8 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun } from '@ephox/katamari';
-
 const strSelected = 'data-mce-selected';
 const strSelectedSelector = 'td[' + strSelected + '],th[' + strSelected + ']';
 // used with not selectors
@@ -16,10 +14,10 @@ const strFirstSelectedSelector = 'td[' + strFirstSelected + '],th[' + strFirstSe
 const strLastSelected = 'data-mce-last-selected';
 const strLastSelectedSelector = 'td[' + strLastSelected + '],th[' + strLastSelected + ']';
 
-export const selected = Fun.constant(strSelected);
-export const selectedSelector = Fun.constant(strSelectedSelector);
-export const attributeSelector = Fun.constant(strAttributeSelector);
-export const firstSelected = Fun.constant(strFirstSelected);
-export const firstSelectedSelector = Fun.constant(strFirstSelectedSelector);
-export const lastSelected = Fun.constant(strLastSelected);
-export const lastSelectedSelector = Fun.constant(strLastSelectedSelector);
+export const selected = strSelected;
+export const selectedSelector = strSelectedSelector;
+export const attributeSelector = strAttributeSelector;
+export const firstSelected = strFirstSelected;
+export const firstSelectedSelector = strFirstSelectedSelector;
+export const lastSelected = strLastSelected;
+export const lastSelectedSelector = strLastSelectedSelector;

--- a/modules/tinymce/src/plugins/table/main/ts/selection/Selections.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/Selections.ts
@@ -19,7 +19,7 @@ export const Selections = function (editor: Editor) {
   const get = function () {
     const body = Util.getBody(editor);
 
-    return TableSelection.retrieve(body, Ephemera.selectedSelector()).fold(function () {
+    return TableSelection.retrieve(body, Ephemera.selectedSelector).fold(function () {
       if (editor.selection.getStart() === undefined) {
         return SelectionTypes.none();
       } else {

--- a/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
@@ -61,7 +61,7 @@ const renderMobileTheme = function (editor: Editor) {
     const orientation = Orientation.onChange(outerWindow, {
       onChange () {
         const alloy = realm.system();
-        alloy.broadcastOn([ TinyChannels.orientationChanged() ], { width: Orientation.getActualWidth(outerWindow) });
+        alloy.broadcastOn([ TinyChannels.orientationChanged ], { width: Orientation.getActualWidth(outerWindow) });
       },
       onReady: Fun.noop
     });
@@ -188,7 +188,7 @@ const renderMobileTheme = function (editor: Editor) {
 
       const hideDropup = function () {
         realm.dropup().disappear(function () {
-          realm.system().broadcastOn([ TinyChannels.dropupDismissed() ], { });
+          realm.system().broadcastOn([ TinyChannels.dropupDismissed ], { });
         });
       };
 

--- a/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
@@ -29,8 +29,8 @@ import * as SkinLoaded from './util/SkinLoaded';
 import { NotificationSpec } from 'tinymce/core/api/NotificationManager';
 
 /// not to be confused with editor mode
-const READING = Fun.constant('toReading'); /// 'hide the keyboard'
-const EDITING = Fun.constant('toEditing'); /// 'show the keyboard'
+const READING = 'toReading'; /// 'hide the keyboard'
+const EDITING = 'toEditing'; /// 'show the keyboard'
 
 const renderMobileTheme = function (editor: Editor) {
   const renderUI = function () {
@@ -74,7 +74,7 @@ const renderMobileTheme = function (editor: Editor) {
       realm.setToolbarGroups(ro === true ? toolbars.readOnly : toolbars.main);
 
       editor.setMode(ro === true ? 'readonly' : 'design');
-      editor.fire(ro === true ? READING() : EDITING());
+      editor.fire(ro === true ? READING : EDITING);
       realm.updateMode(ro);
     };
 
@@ -93,7 +93,7 @@ const renderMobileTheme = function (editor: Editor) {
       return toolbars;
     };
 
-    const bindHandler = function (label, handler) {
+    const bindHandler = function (label: string, handler) {
       editor.on(label, handler);
       return {
         unbind () {
@@ -116,11 +116,11 @@ const renderMobileTheme = function (editor: Editor) {
           },
 
           onToReading (handler) {
-            return bindHandler(READING(), handler);
+            return bindHandler(READING, handler);
           },
 
           onToEditing (handler) {
-            return bindHandler(EDITING(), handler);
+            return bindHandler(EDITING, handler);
           },
 
           onScrollToCursor (handler) {

--- a/modules/tinymce/src/themes/mobile/main/ts/channels/Receivers.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/channels/Receivers.ts
@@ -12,7 +12,7 @@ import * as TinyChannels from './TinyChannels';
 const format = function (command, update) {
   return Receiving.config({
     channels: Objects.wrap(
-      TinyChannels.formatChanged(),
+      TinyChannels.formatChanged,
       {
         onReceive (button, data) {
           if (data.command === command) {
@@ -27,7 +27,7 @@ const format = function (command, update) {
 const orientation = function (onReceive) {
   return Receiving.config({
     channels: Objects.wrap(
-      TinyChannels.orientationChanged(),
+      TinyChannels.orientationChanged,
       {
         onReceive
       }
@@ -35,7 +35,7 @@ const orientation = function (onReceive) {
   });
 };
 
-const receive = function (channel, onReceive) {
+const receive = function (channel: string, onReceive) {
   return {
     key: channel,
     value: {

--- a/modules/tinymce/src/themes/mobile/main/ts/channels/TinyChannels.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/channels/TinyChannels.ts
@@ -5,10 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun } from '@ephox/katamari';
+export const formatChanged = 'formatChanged';
 
-export const formatChanged = Fun.constant('formatChanged');
+export const orientationChanged = 'orientationChanged';
 
-export const orientationChanged = Fun.constant('orientationChanged');
-
-export const dropupDismissed = Fun.constant('dropupDismissed');
+export const dropupDismissed = 'dropupDismissed';

--- a/modules/tinymce/src/themes/mobile/main/ts/features/Features.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/features/Features.ts
@@ -116,8 +116,8 @@ const setup = function (realm, editor: Editor) {
       }),
       Receiving.config({
         channels: Objects.wrapAll([
-          Receivers.receive(TinyChannels.orientationChanged(), Toggling.off),
-          Receivers.receive(TinyChannels.dropupDismissed(), Toggling.off)
+          Receivers.receive(TinyChannels.orientationChanged, Toggling.off),
+          Receivers.receive(TinyChannels.dropupDismissed, Toggling.off)
         ])
       })
     ]), editor);

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosMode.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosMode.ts
@@ -46,7 +46,7 @@ const create = function (platform, mask) {
       scrollEvents.set({
         // Allow only things that have scrollable class to be scrollable. Without this,
         // the toolbar scrolling gets prevented
-        exclusives: Scrollables.exclusive(doc, '.' + Scrollable.scrollable())
+        exclusives: Scrollables.exclusive(doc, '.' + Scrollable.scrollable)
       });
 
       Class.add(platform.container, Styles.resolve('fullscreen-maximized'));

--- a/modules/tinymce/src/themes/mobile/main/ts/style/Styles.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/style/Styles.ts
@@ -5,15 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun } from '@ephox/katamari';
+const prefix = 'tinymce-mobile';
 
-const strPrefix = 'tinymce-mobile';
-
-const resolve = function (p) {
-  return strPrefix + '-' + p;
-};
-
-const prefix = Fun.constant(strPrefix);
+const resolve = (p) =>
+  prefix + '-' + p;
 
 export {
   resolve,

--- a/modules/tinymce/src/themes/mobile/main/ts/touch/scroll/Scrollable.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/touch/scroll/Scrollable.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun } from '@ephox/katamari';
 import { Class } from '@ephox/sugar';
 import * as Styles from '../../style/Styles';
 
@@ -24,7 +23,7 @@ const deregister = function (element) {
   Class.remove(element, scrollableStyle);
 };
 
-const scrollable = Fun.constant(scrollableStyle);
+const scrollable = scrollableStyle;
 
 export {
   register,

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/OuterContainer.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/OuterContainer.ts
@@ -6,12 +6,11 @@
  */
 
 import { Behaviour, Container, Gui, GuiFactory, Swapping } from '@ephox/alloy';
-import { Fun } from '@ephox/katamari';
 
 import * as Styles from '../style/Styles';
 
-const READ_ONLY_MODE_CLASS = Fun.constant(Styles.resolve('readonly-mode'));
-const EDIT_MODE_CLASS = Fun.constant(Styles.resolve('edit-mode'));
+const READ_ONLY_MODE_CLASS = Styles.resolve('readonly-mode');
+const EDIT_MODE_CLASS = Styles.resolve('edit-mode');
 
 export default function (spec) {
   const root = GuiFactory.build(
@@ -22,8 +21,8 @@ export default function (spec) {
 
       containerBehaviours: Behaviour.derive([
         Swapping.config({
-          alpha: READ_ONLY_MODE_CLASS(),
-          omega: EDIT_MODE_CLASS()
+          alpha: READ_ONLY_MODE_CLASS,
+          omega: EDIT_MODE_CLASS
         })
       ])
     })

--- a/modules/tinymce/src/themes/mobile/main/ts/util/FormatChangers.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/FormatChangers.ts
@@ -13,7 +13,7 @@ import * as TinyChannels from '../channels/TinyChannels';
 const fontSizesArray = [ 'x-small', 'small', 'medium', 'large', 'x-large' ];
 
 const fireChange = function (realm, command, state) {
-  realm.system().broadcastOn([ TinyChannels.formatChanged() ], {
+  realm.system().broadcastOn([ TinyChannels.formatChanged ], {
     command,
     state
   });

--- a/modules/tinymce/src/themes/mobile/main/ts/util/UiDomFactory.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/UiDomFactory.ts
@@ -11,7 +11,7 @@ import * as Styles from '../style/Styles';
 
 const dom = function (rawHtml): RawDomSchema {
   const html = Strings.supplant(rawHtml, {
-    prefix: Styles.prefix()
+    prefix: Styles.prefix
   });
   return DomFactory.fromHtml(html);
 };

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/ui/ButtonsTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/ui/ButtonsTest.ts
@@ -113,7 +113,7 @@ UnitTest.asynctest('Browser Test: ui.ButtonsTest', function (success, failure) {
     tEditor.sClear,
     sCheckComponent('Initially, beta should be unselected', false)(memBeta),
     // Fire a format change
-    TestUi.sBroadcastState(realm, [ TinyChannels.formatChanged() ], 'beta', true),
+    TestUi.sBroadcastState(realm, [ TinyChannels.formatChanged ], 'beta', true),
     sCheckComponent('After broadcast, beta should be selected', true)(memBeta),
     tEditor.sClear
   ]);
@@ -130,7 +130,7 @@ UnitTest.asynctest('Browser Test: ui.ButtonsTest', function (success, failure) {
     tEditor.sClear,
     sCheckComponent('Initially, gamma should be unselected', false)(memGamma),
     // Fire a format change
-    TestUi.sBroadcastState(realm, [ TinyChannels.formatChanged() ], 'gamma-query', true),
+    TestUi.sBroadcastState(realm, [ TinyChannels.formatChanged ], 'gamma-query', true),
     sCheckComponent('After broadcast, gamma should be selected', true)(memGamma)
   ]);
 

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestUi.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestUi.ts
@@ -61,7 +61,7 @@ const sWaitForToggledState = function (label, state, realm, memento) {
   );
 };
 
-const sBroadcastState = function (realm, channels, command, state) {
+const sBroadcastState = function (realm, channels: string[], command, state) {
   return Step.sync(function () {
     realm.system().broadcastOn(channels, {
       command,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -132,7 +132,7 @@ const registerTextColorButton = (editor: Editor, name: string, format: string, t
       const optCurrentRgb = Option.from(getCurrentColor(editor, format));
       return optCurrentRgb.bind((currentRgb) => {
         return RgbaColour.fromString(currentRgb).map((rgba) => {
-          const currentHex = HexColour.fromRgba(rgba).value();
+          const currentHex = HexColour.fromRgba(rgba).value;
           // note: value = '#FFFFFF', currentHex = 'ffffff'
           return Strings.contains(value.toLowerCase(), currentHex);
         });


### PR DESCRIPTION
In the past (the time of JavaScript), we thunked variables in order to change behavior when dereferencing unknown fields - instead of evaluating to `undefined`, you'd get an exception, which was easier to debug. Now, in the time of TypeScript, the type checker can check this statically, so we don't need the thunks. This change removes several thunks, in order to reduce TinyMCE's output size.

This change also removes the `Object.freeze` call in `Option.none`. This object was frozen because it is a singleton - mutating it could lead to bugs. Again, the typechecker can help prevent this, so `Option`'s fields have been marked `readonly`.

I've also marked other interface fields as `readonly` because they're not required to be mutable.

Some other changes have been made to reduce code size.

These changes reduce the size of `dist/tinymce_5.3.0.zip` from 657198 to 655786 bytes, a reduction of 1412 bytes.