### PR TITLE
TINY-3862: Fixed table selection not functioning correctly in Edge 44 or higher

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.2.1 (TBD)
+    Fixed table selection not functioning correctly in Edge 44 or higher #TINY-3862
     Fixed table resize handles not functioning correctly in Edge #TINY-4160
     Fixed the floating toolbar disconnecting from the toolbar when adding content in inline mode #TINY-4725
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,10 +1,10 @@
 Version 5.2.1 (TBD)
-    Fixed table selection not functioning correctly in Edge 44 or higher #TINY-3862
-    Fixed table resize handles not functioning correctly in Edge #TINY-4160
+    Fixed table selection not functioning correctly in Microsoft Edge 44 or higher #TINY-3862
+    Fixed table resize handles not functioning correctly in Microsoft Edge #TINY-4160
     Fixed the floating toolbar disconnecting from the toolbar when adding content in inline mode #TINY-4725
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948
     Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
-    Fixed the editor incorrectly stealing focus during initialization in IE 11 #TINY-4697
+    Fixed the editor incorrectly stealing focus during initialization in Microsoft IE #TINY-4697
     Fixed the `colorinput` popup appearing offscreen on mobile devices #TINY-4711
 Version 5.2.0 (2020-02-13)
     Added the ability to apply formats to spaces #TINY-4200


### PR DESCRIPTION
Edge apparently has a bug they introduced in version 44+ whereby the `buttons` property on `mouseover` events is incorrect and always returns `0`. As such there's no reliable way for us to determine if the left mouse key is pressed down anymore on Edge, so we just assume it is for most cases.

Fixes #5056 

Note: I also cleaned up some duplicate code, as the `wrapEvent` code was the same as `DomEvents.fromRawEvent`