### PR TITLE
TINY-4586: Fixed bottom/right bounds not being constrained

### DIFF
--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed `Bounder` incorrectly calculating the bottom/right limits, due to not taking into account the element size.
+- Fixed `LayoutInside` incorrectly placing items in the opposite direction.
 
 # [6.0.0] - 2020-02-13
 

--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+# [6.0.1] - 2020-03-02
+
+### Fixed
+
+- Fixed `Bounder` incorrectly calculating the bottom/right limits, due to not taking into account the element size.
+
 # [6.0.0] - 2020-02-13
 
 ### Removed

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
@@ -1,12 +1,8 @@
-import { Fun } from '@ephox/katamari';
-import { Bounds } from '../../alien/Boxes';
 import { nu as NuSpotInfo } from '../view/SpotInfo';
 import { Bubble } from './Bubble';
 import * as Direction from './Direction';
-import { adjustBounds, anchorBottom, anchorLeft, anchorRight, anchorTop } from './LayoutBounds';
+import { boundsRestriction, AnchorBoxBounds } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
-
-const identity = Fun.identity;
 
 /*
   Layout for menus and inline context dialogs;
@@ -14,7 +10,7 @@ const identity = Fun.identity;
   Aligned to the left or right of the anchor as appropriate.
  */
 
- // display element to the right, left edge against the anchor
+// display element to the right, left edge against the anchor
 const eastX = (anchor: AnchorBox): number => {
   return anchor.x();
 };
@@ -52,89 +48,89 @@ const westEdgeX = (anchor: AnchorBox, element: AnchorElement): number => {
   return anchor.x() - element.width();
 };
 
-const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     eastX(anchor),
     southY(anchor),
     bubbles.southeast(),
     Direction.southeast(),
-    adjustBounds(bounds, anchor, bubbles.southeast(), anchorLeft, anchorBottom, identity, identity),
+    boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.BottomEdge }),
     'layout-se');
 };
 
-const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     westX(anchor, element),
     southY(anchor),
     bubbles.southwest(),
     Direction.southwest(),
-    adjustBounds(bounds, anchor, bubbles.southwest(), identity, anchorBottom, anchorRight, identity),
+    boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.BottomEdge }),
     'layout-sw'
   );
 };
 
-const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     eastX(anchor),
     northY(anchor, element),
     bubbles.northeast(),
     Direction.northeast(),
-    adjustBounds(bounds, anchor, bubbles.northeast(), anchorLeft, identity, identity, anchorTop),
+    boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.TopEdge }),
     'layout-ne'
   );
 };
 
-const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     westX(anchor, element),
     northY(anchor, element),
     bubbles.northwest(),
     Direction.northwest(),
-    adjustBounds(bounds, anchor, bubbles.northwest(), identity, identity, anchorRight, anchorTop),
+    boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.TopEdge }),
     'layout-nw'
   );
 };
 
-const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     middleX(anchor, element),
     northY(anchor, element),
     bubbles.north(),
     Direction.north(),
-    adjustBounds(bounds, anchor, bubbles.north(), identity, identity, identity, anchorTop),
+    boundsRestriction(anchor, { bottom: AnchorBoxBounds.TopEdge }),
     'layout-n'
   );
 };
 
-const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     middleX(anchor, element),
     southY(anchor),
     bubbles.south(),
     Direction.south(),
-    adjustBounds(bounds, anchor, bubbles.south(), identity, anchorBottom, identity, identity),
+    boundsRestriction(anchor, { top: AnchorBoxBounds.BottomEdge }),
     'layout-s'
   );
 };
 
-const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     eastEdgeX(anchor),
     centreY(anchor, element),
     bubbles.east(),
     Direction.east(),
-    adjustBounds(bounds, anchor, bubbles.east(), anchorRight, identity, identity, identity),
+    boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge }),
     'layout-e'
   );
 };
 
-const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     westEdgeX(anchor, element),
     centreY(anchor, element),
     bubbles.west(),
     Direction.west(),
-    adjustBounds(bounds, anchor, bubbles.west(), identity, identity, anchorLeft, identity),
+    boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge }),
     'layout-w'
   );
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
@@ -1,7 +1,12 @@
+import { Fun } from '@ephox/katamari';
+import { Bounds } from '../../alien/Boxes';
 import { nu as NuSpotInfo } from '../view/SpotInfo';
 import { Bubble } from './Bubble';
 import * as Direction from './Direction';
+import { adjustBounds, anchorBottom, anchorLeft, anchorRight, anchorTop } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
+
+const identity = Fun.identity;
 
 /*
   Layout for menus and inline context dialogs;
@@ -47,36 +52,91 @@ const westEdgeX = (anchor: AnchorBox, element: AnchorElement): number => {
   return anchor.x() - element.width();
 };
 
-const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(eastX(anchor), southY(anchor), bubbles.southeast(), Direction.southeast(), 'layout-se');
+const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    eastX(anchor),
+    southY(anchor),
+    bubbles.southeast(),
+    Direction.southeast(),
+    adjustBounds(bounds, anchor, bubbles.southeast(), anchorLeft, anchorBottom, identity, identity),
+    'layout-se');
 };
 
-const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(westX(anchor, element), southY(anchor), bubbles.southwest(), Direction.southwest(), 'layout-sw');
+const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    westX(anchor, element),
+    southY(anchor),
+    bubbles.southwest(),
+    Direction.southwest(),
+    adjustBounds(bounds, anchor, bubbles.southwest(), identity, anchorBottom, anchorRight, identity),
+    'layout-sw'
+  );
 };
 
-const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(eastX(anchor), northY(anchor, element), bubbles.northeast(), Direction.northeast(), 'layout-ne');
+const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    eastX(anchor),
+    northY(anchor, element),
+    bubbles.northeast(),
+    Direction.northeast(),
+    adjustBounds(bounds, anchor, bubbles.northeast(), anchorLeft, identity, identity, anchorTop),
+    'layout-ne'
+  );
 };
 
-const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(westX(anchor, element), northY(anchor, element), bubbles.northwest(), Direction.northwest(), 'layout-nw');
+const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    westX(anchor, element),
+    northY(anchor, element),
+    bubbles.northwest(),
+    Direction.northwest(),
+    adjustBounds(bounds, anchor, bubbles.northwest(), identity, identity, anchorRight, anchorTop),
+    'layout-nw'
+  );
 };
 
-const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(middleX(anchor, element), northY(anchor, element), bubbles.north(), Direction.north(), 'layout-n');
+const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    middleX(anchor, element),
+    northY(anchor, element),
+    bubbles.north(),
+    Direction.north(),
+    adjustBounds(bounds, anchor, bubbles.north(), identity, identity, identity, anchorTop),
+    'layout-n'
+  );
 };
 
-const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(middleX(anchor, element), southY(anchor), bubbles.south(), Direction.south(), 'layout-s');
+const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    middleX(anchor, element),
+    southY(anchor),
+    bubbles.south(),
+    Direction.south(),
+    adjustBounds(bounds, anchor, bubbles.south(), identity, anchorBottom, identity, identity),
+    'layout-s'
+  );
 };
 
-const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(eastEdgeX(anchor), centreY(anchor, element), bubbles.east(), Direction.east(), 'layout-e');
+const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    eastEdgeX(anchor),
+    centreY(anchor, element),
+    bubbles.east(),
+    Direction.east(),
+    adjustBounds(bounds, anchor, bubbles.east(), anchorRight, identity, identity, identity),
+    'layout-e'
+  );
 };
 
-const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(westEdgeX(anchor, element), centreY(anchor, element), bubbles.west(), Direction.west(), 'layout-w');
+const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    westEdgeX(anchor, element),
+    centreY(anchor, element),
+    bubbles.west(),
+    Direction.west(),
+    adjustBounds(bounds, anchor, bubbles.west(), identity, identity, anchorLeft, identity),
+    'layout-w'
+  );
 };
 
 const all = (): AnchorLayout[] => [ southeast, southwest, northeast, northwest, south, north, east, west ];

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutBounds.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutBounds.ts
@@ -1,22 +1,54 @@
+import { Arr, Obj, Option } from '@ephox/katamari';
+import { Position } from '@ephox/sugar';
 import * as Boxes from '../../alien/Boxes';
-import { BubbleInstance } from './Bubble';
 import { AnchorBox } from './LayoutTypes';
 
-type BoundFunc = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => number;
+export interface BoundsRestriction {
+  left: Option<number>;
+  right: Option<number>;
+  top: Option<number>;
+  bottom: Option<number>;
+}
 
-export const anchorLeft = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => anchor.x() + bubbleOffset;
-export const anchorRight = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => anchor.x() + anchor.width() + bubbleOffset;
-export const anchorTop = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => anchor.y() + bubbleOffset;
-export const anchorBottom = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => anchor.y() + anchor.height() + bubbleOffset;
+export const enum AnchorBoxBounds {
+  RightEdge,
+  LeftEdge,
+  TopEdge,
+  BottomEdge
+}
 
-export const adjustBounds = (bounds: Boxes.Bounds, anchor: AnchorBox, bubble: BubbleInstance, left: BoundFunc, top: BoundFunc, right: BoundFunc, bottom: BoundFunc) => {
-  const bubbleLeft = bubble.offset().left();
-  const bubbleTop = bubble.offset().top();
+type BoundsRestrictionKeys = keyof BoundsRestriction;
+type Restriction = AnchorBoxBounds;
 
-  const adjustedLeft = left(bounds.x(), anchor, bubbleLeft);
-  const adjustedTop = top(bounds.y(), anchor, bubbleTop);
-  const adjustedRight = right(bounds.right(), anchor, bubbleLeft);
-  const adjustedBottom = bottom(bounds.bottom(), anchor, bubbleTop);
+const getRestriction = (anchor: AnchorBox, restriction: Restriction) => {
+  switch (restriction) {
+    case AnchorBoxBounds.LeftEdge:
+      return anchor.x();
+    case AnchorBoxBounds.RightEdge:
+      return anchor.x() + anchor.width();
+    case AnchorBoxBounds.TopEdge:
+      return anchor.y();
+    case AnchorBoxBounds.BottomEdge:
+      return anchor.y() + anchor.height();
+  }
+};
+
+export const boundsRestriction = (anchor: AnchorBox, restrictions: Partial<Record<BoundsRestrictionKeys, Restriction>>): BoundsRestriction => {
+  return Arr.mapToObject([ 'left', 'right', 'top', 'bottom' ], (dir) => {
+    return Obj.get(restrictions, dir).map((restriction) => getRestriction(anchor, restriction));
+  });
+};
+
+export const adjustBounds = (bounds: Boxes.Bounds, boundsRestrictions: BoundsRestriction, bubbleOffsets: Position) => {
+  const applyRestriction = (dir: BoundsRestrictionKeys) => {
+    const bubbleOffset = dir === 'top' || dir === 'bottom' ? bubbleOffsets.top() : bubbleOffsets.left();
+    return Obj.get(boundsRestrictions, dir).bind((v) => v).map((v) => v + bubbleOffset);
+  };
+
+  const adjustedLeft = applyRestriction('left').getOr(bounds.x());
+  const adjustedTop = applyRestriction('top').getOr(bounds.y());
+  const adjustedRight = applyRestriction('right').getOr(bounds.right());
+  const adjustedBottom = applyRestriction('bottom').getOr(bounds.bottom());
 
   return Boxes.bounds(adjustedLeft, adjustedTop, adjustedRight - adjustedLeft, adjustedBottom - adjustedTop);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutBounds.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutBounds.ts
@@ -1,0 +1,22 @@
+import * as Boxes from '../../alien/Boxes';
+import { BubbleInstance } from './Bubble';
+import { AnchorBox } from './LayoutTypes';
+
+type BoundFunc = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => number;
+
+export const anchorLeft = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => anchor.x() + bubbleOffset;
+export const anchorRight = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => anchor.x() + anchor.width() + bubbleOffset;
+export const anchorTop = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => anchor.y() + bubbleOffset;
+export const anchorBottom = (bounds: number, anchor: AnchorBox, bubbleOffset: number) => anchor.y() + anchor.height() + bubbleOffset;
+
+export const adjustBounds = (bounds: Boxes.Bounds, anchor: AnchorBox, bubble: BubbleInstance, left: BoundFunc, top: BoundFunc, right: BoundFunc, bottom: BoundFunc) => {
+  const bubbleLeft = bubble.offset().left();
+  const bubbleTop = bubble.offset().top();
+
+  const adjustedLeft = left(bounds.x(), anchor, bubbleLeft);
+  const adjustedTop = top(bounds.y(), anchor, bubbleTop);
+  const adjustedRight = right(bounds.right(), anchor, bubbleLeft);
+  const adjustedBottom = bottom(bounds.bottom(), anchor, bubbleTop);
+
+  return Boxes.bounds(adjustedLeft, adjustedTop, adjustedRight - adjustedLeft, adjustedBottom - adjustedTop);
+};

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
@@ -1,12 +1,8 @@
-import { Fun } from '@ephox/katamari';
-import { Bounds } from '../../alien/Boxes';
 import { nu as NuSpotInfo } from '../view/SpotInfo';
 import { Bubble } from './Bubble';
 import * as Direction from './Direction';
-import { adjustBounds, anchorBottom, anchorLeft, anchorRight, anchorTop } from './LayoutBounds';
+import { AnchorBoxBounds, boundsRestriction } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
-
-const identity = Fun.identity;
 
 /*
   Layouts for things that go inside the editable area.
@@ -45,95 +41,95 @@ const centreY = (anchor: AnchorBox, element: AnchorElement): number => {
 };
 
 // positions element in bottom right of the anchor
-const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     eastEdgeX(anchor, element),
     southY(anchor, element),
     bubbles.innerSoutheast(),
     Direction.northwest(),
-    adjustBounds(bounds, anchor, bubbles.innerSoutheast(), identity, identity, anchorRight, anchorBottom),
+    boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.BottomEdge }),
     'layout-inner-se'
   );
 };
 
 // positions element in the bottom left of the anchor
-const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     westEdgeX(anchor),
     southY(anchor, element),
     bubbles.innerSouthwest(),
     Direction.northeast(),
-    adjustBounds(bounds, anchor, bubbles.innerSouthwest(), anchorLeft, identity, identity, anchorBottom),
+    boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.BottomEdge }),
     'layout-inner-sw'
   );
 };
 
 // positions element in the top right of the anchor
-const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     eastEdgeX(anchor, element),
     northY(anchor),
     bubbles.innerNortheast(),
     Direction.southwest(),
-    adjustBounds(bounds, anchor, bubbles.innerNortheast(), identity, anchorTop, anchorRight, identity),
+    boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.TopEdge }),
     'layout-inner-ne'
   );
 };
 
 // positions element in the top left of the anchor
-const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     westEdgeX(anchor),
     northY(anchor),
     bubbles.innerNorthwest(),
     Direction.southeast(),
-    adjustBounds(bounds, anchor, bubbles.innerNorthwest(), anchorLeft, anchorTop, identity, identity),
+    boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.TopEdge }),
     'layout-inner-nw'
   );
 };
 
 // positions element at the top of the anchor, horizontally centered
-const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     middleX(anchor, element),
     northY(anchor),
     bubbles.innerNorth(),
     Direction.south(),
-    adjustBounds(bounds, anchor, bubbles.innerNorth(), identity, anchorTop, identity, identity),
+    boundsRestriction(anchor, { top: AnchorBoxBounds.TopEdge }),
     'layout-inner-n');
 };
 
 // positions element at the bottom of the anchor, horizontally centered
-const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     middleX(anchor, element),
     southY(anchor, element),
     bubbles.innerSouth(),
     Direction.north(),
-    adjustBounds(bounds, anchor, bubbles.innerSouth(), identity, identity, identity, anchorBottom),
+    boundsRestriction(anchor, { bottom: AnchorBoxBounds.BottomEdge }),
     'layout-inner-s'
   );
 };
 
 // positions element with right edge against the anchor, vertically centered
-const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     eastEdgeX(anchor, element),
     centreY(anchor, element),
     bubbles.innerEast(),
     Direction.west(),
-    adjustBounds(bounds, anchor, bubbles.innerEast(), identity, identity, anchorRight, identity),
+    boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge }),
     'layout-inner-e');
 };
 
 // positions element with left each against the anchor, vertically centered
-const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
   return NuSpotInfo(
     westEdgeX(anchor),
     centreY(anchor, element),
     bubbles.innerWest(),
     Direction.east(),
-    adjustBounds(bounds, anchor, bubbles.innerWest(), anchorLeft, identity, identity, identity),
+    boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge }),
     'layout-inner-w'
   );
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
@@ -1,7 +1,12 @@
+import { Fun } from '@ephox/katamari';
+import { Bounds } from '../../alien/Boxes';
 import { nu as NuSpotInfo } from '../view/SpotInfo';
 import { Bubble } from './Bubble';
 import * as Direction from './Direction';
+import { adjustBounds, anchorBottom, anchorLeft, anchorRight, anchorTop } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
+
+const identity = Fun.identity;
 
 /*
   Layouts for things that go inside the editable area.
@@ -40,43 +45,97 @@ const centreY = (anchor: AnchorBox, element: AnchorElement): number => {
 };
 
 // positions element in bottom right of the anchor
-const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(eastEdgeX(anchor, element), southY(anchor, element), bubbles.innerSoutheast(), Direction.northwest(), 'layout-inner-se');
+const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    eastEdgeX(anchor, element),
+    southY(anchor, element),
+    bubbles.innerSoutheast(),
+    Direction.northwest(),
+    adjustBounds(bounds, anchor, bubbles.innerSoutheast(), identity, identity, anchorRight, anchorBottom),
+    'layout-inner-se'
+  );
 };
 
 // positions element in the bottom left of the anchor
-const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(westEdgeX(anchor), southY(anchor, element), bubbles.innerSouthwest(), Direction.northeast(), 'layout-inner-sw');
+const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    westEdgeX(anchor),
+    southY(anchor, element),
+    bubbles.innerSouthwest(),
+    Direction.northeast(),
+    adjustBounds(bounds, anchor, bubbles.innerSouthwest(), anchorLeft, identity, identity, anchorBottom),
+    'layout-inner-sw'
+  );
 };
 
 // positions element in the top right of the anchor
-const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(eastEdgeX(anchor, element), northY(anchor), bubbles.innerNortheast(), Direction.southwest(), 'layout-inner-ne');
+const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    eastEdgeX(anchor, element),
+    northY(anchor),
+    bubbles.innerNortheast(),
+    Direction.southwest(),
+    adjustBounds(bounds, anchor, bubbles.innerNortheast(), identity, anchorTop, anchorRight, identity),
+    'layout-inner-ne'
+  );
 };
 
 // positions element in the top left of the anchor
-const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(westEdgeX(anchor), northY(anchor), bubbles.innerNorthwest(), Direction.southeast(), 'layout-inner-nw');
+const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    westEdgeX(anchor),
+    northY(anchor),
+    bubbles.innerNorthwest(),
+    Direction.southeast(),
+    adjustBounds(bounds, anchor, bubbles.innerNorthwest(), anchorLeft, anchorTop, identity, identity),
+    'layout-inner-nw'
+  );
 };
 
 // positions element at the top of the anchor, horizontally centered
-const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(middleX(anchor, element), northY(anchor), bubbles.innerNorth(), Direction.south(), 'layout-inner-n');
+const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    middleX(anchor, element),
+    northY(anchor),
+    bubbles.innerNorth(),
+    Direction.south(),
+    adjustBounds(bounds, anchor, bubbles.innerNorth(), identity, anchorTop, identity, identity),
+    'layout-inner-n');
 };
 
 // positions element at the bottom of the anchor, horizontally centered
-const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(middleX(anchor, element), southY(anchor, element), bubbles.innerSouth(), Direction.north(), 'layout-inner-s');
+const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    middleX(anchor, element),
+    southY(anchor, element),
+    bubbles.innerSouth(),
+    Direction.north(),
+    adjustBounds(bounds, anchor, bubbles.innerSouth(), identity, identity, identity, anchorBottom),
+    'layout-inner-s'
+  );
 };
 
 // positions element with right edge against the anchor, vertically centered
-const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(eastEdgeX(anchor, element), centreY(anchor, element), bubbles.innerEast(), Direction.west(), 'layout-inner-e');
+const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    eastEdgeX(anchor, element),
+    centreY(anchor, element),
+    bubbles.innerEast(),
+    Direction.west(),
+    adjustBounds(bounds, anchor, bubbles.innerEast(), identity, identity, anchorRight, identity),
+    'layout-inner-e');
 };
 
 // positions element with left each against the anchor, vertically centered
-const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(westEdgeX(anchor), centreY(anchor, element), bubbles.innerWest(), Direction.east(), 'layout-inner-w');
+const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
+  return NuSpotInfo(
+    westEdgeX(anchor),
+    centreY(anchor, element),
+    bubbles.innerWest(),
+    Direction.east(),
+    adjustBounds(bounds, anchor, bubbles.innerWest(), anchorLeft, identity, identity, identity),
+    'layout-inner-w'
+  );
 };
 
 const all = (): AnchorLayout[] => {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
@@ -41,42 +41,42 @@ const centreY = (anchor: AnchorBox, element: AnchorElement): number => {
 
 // positions element in bottom right of the anchor
 const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(westEdgeX(anchor), southY(anchor, element), bubbles.innerSoutheast(), Direction.southeast(), 'layout-se');
+  return NuSpotInfo(eastEdgeX(anchor, element), southY(anchor, element), bubbles.innerSoutheast(), Direction.northwest(), 'layout-inner-se');
 };
 
 // positions element in the bottom left of the anchor
 const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(eastEdgeX(anchor, element), southY(anchor, element), bubbles.innerSouthwest(), Direction.southwest(), 'layout-sw');
+  return NuSpotInfo(westEdgeX(anchor), southY(anchor, element), bubbles.innerSouthwest(), Direction.northeast(), 'layout-inner-sw');
 };
 
 // positions element in the top right of the anchor
 const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(westEdgeX(anchor), northY(anchor), bubbles.innerNortheast(), Direction.northeast(), 'layout-ne');
+  return NuSpotInfo(eastEdgeX(anchor, element), northY(anchor), bubbles.innerNortheast(), Direction.southwest(), 'layout-inner-ne');
 };
 
 // positions element in the top left of the anchor
 const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(eastEdgeX(anchor, element), northY(anchor), bubbles.innerNorthwest(), Direction.northwest(), 'layout-nw');
+  return NuSpotInfo(westEdgeX(anchor), northY(anchor), bubbles.innerNorthwest(), Direction.southeast(), 'layout-inner-nw');
 };
 
 // positions element at the top of the anchor, horizontally centered
 const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(middleX(anchor, element), northY(anchor), bubbles.innerNorth(), Direction.north(), 'layout-n');
+  return NuSpotInfo(middleX(anchor, element), northY(anchor), bubbles.innerNorth(), Direction.south(), 'layout-inner-n');
 };
 
 // positions element at the bottom of the anchor, horizontally centered
 const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(middleX(anchor, element), southY(anchor, element), bubbles.innerSouth(), Direction.south(), 'layout-s');
+  return NuSpotInfo(middleX(anchor, element), southY(anchor, element), bubbles.innerSouth(), Direction.north(), 'layout-inner-s');
 };
 
 // positions element with right edge against the anchor, vertically centered
 const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(eastEdgeX(anchor, element), centreY(anchor, element), bubbles.innerEast(), Direction.east(), 'layout-e');
+  return NuSpotInfo(eastEdgeX(anchor, element), centreY(anchor, element), bubbles.innerEast(), Direction.west(), 'layout-inner-e');
 };
 
 // positions element with left each against the anchor, vertically centered
 const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => {
-  return NuSpotInfo(westEdgeX(anchor), centreY(anchor, element), bubbles.innerWest(), Direction.west(), 'layout-w');
+  return NuSpotInfo(westEdgeX(anchor), centreY(anchor, element), bubbles.innerWest(), Direction.east(), 'layout-inner-w');
 };
 
 const all = (): AnchorLayout[] => {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutTypes.ts
@@ -1,4 +1,3 @@
-import { Bounds } from '../../alien/Boxes';
 import { SpotInfo } from '../view/SpotInfo';
 import { Bubble } from './Bubble';
 
@@ -17,6 +16,5 @@ export interface AnchorElement {
 export type AnchorLayout = (
   anchor: AnchorBox,
   element: AnchorElement,
-  bubbles: Bubble,
-  bounds: Bounds
+  bubbles: Bubble
 ) => SpotInfo;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutTypes.ts
@@ -1,5 +1,6 @@
-import { Bubble } from './Bubble';
+import { Bounds } from '../../alien/Boxes';
 import { SpotInfo } from '../view/SpotInfo';
+import { Bubble } from './Bubble';
 
 export interface AnchorBox {
   x: () => number;
@@ -16,5 +17,6 @@ export interface AnchorElement {
 export type AnchorLayout = (
   anchor: AnchorBox,
   element: AnchorElement,
-  bubbles: Bubble
+  bubbles: Bubble,
+  bounds: Bounds
 ) => SpotInfo;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
@@ -1,10 +1,7 @@
-import { Fun } from '@ephox/katamari';
 import { nu as NuSpotInfo } from '../view/SpotInfo';
 import * as Direction from './Direction';
-import { adjustBounds, anchorBottom, anchorLeft, anchorRight, anchorTop } from './LayoutBounds';
+import { AnchorBoxBounds, boundsRestriction } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
-
-const identity = Fun.identity;
 
 /*
   Layout for submenus;
@@ -32,45 +29,45 @@ const southY = (anchor: AnchorBox): number => {
   return anchor.y();
 };
 
-const southeast: AnchorLayout = (anchor, element, bubbles, bounds) => {
+const southeast: AnchorLayout = (anchor, element, bubbles) => {
   return NuSpotInfo(
     eastX(anchor),
     southY(anchor),
     bubbles.southeast(),
     Direction.southeast(),
-    adjustBounds(bounds, anchor, bubbles.southeast(), anchorRight, anchorTop, identity, identity),
+    boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.TopEdge }),
     'link-layout-se');
 };
 
-const southwest: AnchorLayout = (anchor, element, bubbles, bounds) => {
+const southwest: AnchorLayout = (anchor, element, bubbles) => {
   return NuSpotInfo(
     westX(anchor, element),
     southY(anchor),
     bubbles.southwest(),
     Direction.southwest(),
-    adjustBounds(bounds, anchor, bubbles.southwest(), identity, anchorTop, anchorLeft, identity),
+    boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.TopEdge }),
     'link-layout-sw'
   );
 };
 
-const northeast: AnchorLayout = (anchor, element, bubbles, bounds) => {
+const northeast: AnchorLayout = (anchor, element, bubbles) => {
   return NuSpotInfo(
     eastX(anchor),
     northY(anchor, element),
     bubbles.northeast(),
     Direction.northeast(),
-    adjustBounds(bounds, anchor, bubbles.northeast(), anchorRight, identity, identity, anchorBottom),
+    boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.BottomEdge }),
     'link-layout-ne'
   );
 };
 
-const northwest: AnchorLayout = (anchor, element, bubbles, bounds) => {
+const northwest: AnchorLayout = (anchor, element, bubbles) => {
   return NuSpotInfo(
     westX(anchor, element),
     northY(anchor, element),
     bubbles.northwest(),
     Direction.northwest(),
-    adjustBounds(bounds, anchor, bubbles.northwest(), identity, identity, anchorLeft, anchorBottom),
+    boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.BottomEdge }),
     'link-layout-nw'
   );
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
@@ -1,6 +1,11 @@
+import { Fun } from '@ephox/katamari';
 import { nu as NuSpotInfo } from '../view/SpotInfo';
 import * as Direction from './Direction';
+import { adjustBounds, anchorBottom, anchorLeft, anchorRight, anchorTop } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
+
+const identity = Fun.identity;
+
 /*
   Layout for submenus;
   Either left or right of the anchor menu item. Never above or below.
@@ -27,20 +32,47 @@ const southY = (anchor: AnchorBox): number => {
   return anchor.y();
 };
 
-const southeast: AnchorLayout = (anchor, element, bubbles) => {
-  return NuSpotInfo(eastX(anchor), southY(anchor), bubbles.southeast(), Direction.southeast(), 'link-layout-se');
+const southeast: AnchorLayout = (anchor, element, bubbles, bounds) => {
+  return NuSpotInfo(
+    eastX(anchor),
+    southY(anchor),
+    bubbles.southeast(),
+    Direction.southeast(),
+    adjustBounds(bounds, anchor, bubbles.southeast(), anchorRight, anchorTop, identity, identity),
+    'link-layout-se');
 };
 
-const southwest: AnchorLayout = (anchor, element, bubbles) => {
-  return NuSpotInfo(westX(anchor, element), southY(anchor), bubbles.southwest(), Direction.southwest(), 'link-layout-sw');
+const southwest: AnchorLayout = (anchor, element, bubbles, bounds) => {
+  return NuSpotInfo(
+    westX(anchor, element),
+    southY(anchor),
+    bubbles.southwest(),
+    Direction.southwest(),
+    adjustBounds(bounds, anchor, bubbles.southwest(), identity, anchorTop, anchorLeft, identity),
+    'link-layout-sw'
+  );
 };
 
-const northeast: AnchorLayout = (anchor, element, bubbles) => {
-  return NuSpotInfo(eastX(anchor), northY(anchor, element), bubbles.northeast(), Direction.northeast(), 'link-layout-ne');
+const northeast: AnchorLayout = (anchor, element, bubbles, bounds) => {
+  return NuSpotInfo(
+    eastX(anchor),
+    northY(anchor, element),
+    bubbles.northeast(),
+    Direction.northeast(),
+    adjustBounds(bounds, anchor, bubbles.northeast(), anchorRight, identity, identity, anchorBottom),
+    'link-layout-ne'
+  );
 };
 
-const northwest: AnchorLayout = (anchor, element, bubbles) => {
-  return NuSpotInfo(westX(anchor, element), northY(anchor, element), bubbles.northwest(), Direction.northwest(), 'link-layout-nw');
+const northwest: AnchorLayout = (anchor, element, bubbles, bounds) => {
+  return NuSpotInfo(
+    westX(anchor, element),
+    northY(anchor, element),
+    bubbles.northwest(),
+    Direction.northwest(),
+    adjustBounds(bounds, anchor, bubbles.northwest(), identity, identity, anchorLeft, anchorBottom),
+    'link-layout-nw'
+  );
 };
 
 const all = (): AnchorLayout[] => {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
@@ -49,9 +49,9 @@ const calcReposition = (newX: number, newY: number, width: number, height: numbe
   // TBIO-3366 + TBIO-4236:
   // Futz with the X position to ensure that x is positive, but not off the right side of the screen.
   // NOTE: bounds.x() is 0 in repartee here.
-  const limitX = Num.clamp(newX, bounds.x(), bounds.right());
+  const limitX = Num.clamp(newX, bounds.x(), bounds.right() - width);
   // Futz with the Y value to ensure that we're not off the top of the screen
-  const limitY = Num.clamp(newY, bounds.y(), bounds.bottom());
+  const limitY = Num.clamp(newY, bounds.y(), bounds.bottom() - height);
 
   return {
     originInBounds,

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
@@ -1,25 +1,25 @@
 import { Struct } from '@ephox/katamari';
-import { Bounds } from '../../alien/Boxes';
 import { BubbleInstance } from '../layout/Bubble';
+import { DirectionAdt } from '../layout/Direction';
+import { BoundsRestriction } from '../layout/LayoutBounds';
 
 export interface SpotInfo {
   x: () => number;
   y: () => number;
   bubble: () => BubbleInstance;
-  // TYPIFY
-  direction: () => any;
+  direction: () => DirectionAdt;
   label: () => string;
-  bounds: () => Bounds;
+  boundsRestriction: () => BoundsRestriction;
 }
 
 const nu: (
   x: number,
   y: number,
   bubble: BubbleInstance,
-  direction: any,
-  bounds: Bounds,
+  direction: DirectionAdt,
+  boundsRestriction: BoundsRestriction,
   label: string
-) => SpotInfo = Struct.immutable('x', 'y', 'bubble', 'direction', 'bounds', 'label');
+) => SpotInfo = Struct.immutable('x', 'y', 'bubble', 'direction', 'boundsRestriction', 'label');
 
 export {
   nu

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
@@ -1,4 +1,5 @@
 import { Struct } from '@ephox/katamari';
+import { Bounds } from '../../alien/Boxes';
 import { BubbleInstance } from '../layout/Bubble';
 
 export interface SpotInfo {
@@ -8,6 +9,7 @@ export interface SpotInfo {
   // TYPIFY
   direction: () => any;
   label: () => string;
+  bounds: () => Bounds;
 }
 
 const nu: (
@@ -15,8 +17,9 @@ const nu: (
   y: number,
   bubble: BubbleInstance,
   direction: any,
+  bounds: Bounds,
   label: string
-) => SpotInfo = Struct.immutable('x', 'y', 'bubble', 'direction', 'label');
+) => SpotInfo = Struct.immutable('x', 'y', 'bubble', 'direction', 'bounds', 'label');
 
 export {
   nu

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderCalcRepositionTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderCalcRepositionTest.ts
@@ -6,18 +6,19 @@ import * as Bounder from 'ephox/alloy/positioning/view/Bounder';
 
 UnitTest.test('BounderCalcRepositionTest', () => {
 
-  const nonZeroArb = Jsc.integer(10, 1000);
-  const zeroableArb = Jsc.integer(0, 1000);
+  const maxBounds = 2000;
+  const minBounds  = 0;
+  const zeroableArb = Jsc.integer(minBounds, maxBounds);
 
   const arbTestCase = Jsc.bless({
-    generator: zeroableArb.generator.flatMap((newX: number) => {
-      return zeroableArb.generator.flatMap((newY: number) => {
-        return nonZeroArb.generator.flatMap((width: number) => {
-          return nonZeroArb.generator.flatMap((height: number) => {
-            return zeroableArb.generator.flatMap((boundsX: number) => {
-              return zeroableArb.generator.flatMap((boundsY: number) => {
-                return zeroableArb.generator.flatMap((boundsW: number) => {
-                  return zeroableArb.generator.map((boundsH: number) => {
+    generator: zeroableArb.generator.flatMap((boundsX: number) => {
+      return zeroableArb.generator.flatMap((boundsY: number) => {
+        return Jsc.integer(boundsX, maxBounds).generator.flatMap((newX: number) => {
+          return Jsc.integer(boundsY, maxBounds).generator.flatMap((newY: number) => {
+            return zeroableArb.generator.flatMap((width: number) => {
+              return zeroableArb.generator.flatMap((height: number) => {
+                return Jsc.integer(newX + width, maxBounds).generator.flatMap((boundsW: number) => {
+                  return Jsc.integer(newY + height, maxBounds).generator.map((boundsH: number) => {
                     return {
                       newX,
                       newY,
@@ -45,8 +46,8 @@ UnitTest.test('BounderCalcRepositionTest', () => {
       const bounds = makeBounds(input.boundsX, input.boundsY, input.boundsW, input.boundsH);
       const output = Bounder.calcReposition(input.newX, input.newY, input.width, input.height, bounds);
 
-      const xIsVisible = output.limitX <= bounds.right() && output.limitX >= bounds.x();
-      const yIsVisible = output.limitY <= bounds.bottom() && output.limitY >= bounds.y();
+      const xIsVisible = output.limitX <= (bounds.right() - input.width) && output.limitX >= bounds.x();
+      const yIsVisible = output.limitY <= (bounds.bottom() - input.height) && output.limitY >= bounds.y();
       if (!xIsVisible) {
         return 'X is not inside bounds. Returned: ' + JSON.stringify(output);
       } else if (!yIsVisible) {

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderCursorTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderCursorTest.ts
@@ -1,4 +1,4 @@
-import { UnitTest, assert } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { Bounds, bounds } from 'ephox/alloy/alien/Boxes';
 import * as Bubble from 'ephox/alloy/positioning/layout/Bubble';
@@ -17,14 +17,15 @@ UnitTest.test('BounderCursorTest', () => {
   /* global assert */
   const check = (expected: TestDecisionSpec, preference: AnchorLayout[], anchor: AnchorBox, panel: AnchorElement, bubbles: Bubble.Bubble, bounds: Bounds) => {
     const actual = Bounder.attempts(preference, anchor, panel, bubbles, bounds);
-    assert.eq(expected.label, actual.label());
-    assert.eq(expected.x, actual.x());
-    assert.eq(expected.y, actual.y());
-    if (expected.candidateYforTest !== undefined) { assert.eq(expected.candidateYforTest, actual.candidateYforTest()); }
+    Assert.eq('label', expected.label, actual.label());
+    Assert.eq('X', expected.x, actual.x());
+    Assert.eq('Y', expected.y, actual.y());
+    if (expected.candidateYforTest !== undefined) { Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest()); }
   };
 
   // Layout is for boxes with a bubble pointing to a cursor position (vertically aligned to nearest side)
   const four = [ Layout.southeast, Layout.southwest, Layout.northeast, Layout.northwest ];
+  const two = [ Layout.east, Layout.west ];
 
   // empty input array is now invalid, just returns anchor coordinates
   check({
@@ -165,4 +166,46 @@ UnitTest.test('BounderCursorTest', () => {
     x: 350 + 50 - 99 - 100 + 2,
     y: 220 + 50 - 2 - 74 - 75
   }, four, bounds(350 + 50 - 99, 220 + 50 - 2 - 74, 2, 2), panelBox, bubb, view);
+
+  // East
+  check({
+    label: 'layout-e',
+    x: 55 + 10 ,
+    y: 150 - (75 / 2) + (10 / 2)
+  }, two, bounds(55, 150, 10, 10), panelBox, bubb, view);
+
+  // None near bottom left -> best fit is east (limited to bottom bounds)
+  check({
+    label: 'layout-e',
+    x: 55 + 10,
+    y: 270 - 75
+  }, two, bounds(55, 240, 10, 10), panelBox, bubb, view);
+
+  // None near top left -> best fit is east (limited to top bounds)
+  check({
+    label: 'layout-e',
+    x: 55 + 10,
+    y: 50
+  }, two, bounds(55, 80, 10, 10), panelBox, bubb, view);
+
+  // West
+  check({
+    label: 'layout-w',
+    x: 350 - 100,
+    y: 150 - (75 / 2) + (10 / 2)
+  }, two, bounds(350, 150, 10, 10), panelBox, bubb, view);
+
+  // None near bottom right -> best fit is west (limited to bottom bounds)
+  check({
+    label: 'layout-w',
+    x: 350 - 100,
+    y: 270 - 75
+  }, two, bounds(350, 240, 10, 10), panelBox, bubb, view);
+
+  // None near top right -> best fit is west (limited to top bounds)
+  check({
+    label: 'layout-w',
+    x: 350 - 100,
+    y: 50
+  }, two, bounds(350, 80, 10, 10), panelBox, bubb, view);
 });

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderToolbuttonTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderToolbuttonTest.ts
@@ -1,4 +1,4 @@
-import { UnitTest, assert } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Position } from '@ephox/sugar';
 
 import { Bounds, bounds } from 'ephox/alloy/alien/Boxes';
@@ -18,10 +18,10 @@ UnitTest.test('BounderToolbuttonTest', () => {
   /* global assert */
   const check = (expected: TestDecisionSpec, preference: AnchorLayout[], anchor: AnchorBox, panel: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
     const actual = Bounder.attempts(preference, anchor, panel, bubbles, bounds);
-    assert.eq(expected.label, actual.label());
-    assert.eq(expected.x, actual.x());
-    assert.eq(expected.y, actual.y());
-    if (expected.candidateYforTest !== undefined) { assert.eq(expected.candidateYforTest, actual.candidateYforTest()); }
+    Assert.eq('label', expected.label, actual.label());
+    Assert.eq('X', expected.x, actual.x());
+    Assert.eq('Y', expected.y, actual.y());
+    if (expected.candidateYforTest !== undefined) { Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest()); }
   };
 
   // Layout is for boxes with a bubble pointing to a cursor position (vertically aligned to nearest side)
@@ -113,6 +113,7 @@ UnitTest.test('BounderToolbuttonTest', () => {
   };
 
   const four = [ Layout.southeast, Layout.southwest, Layout.northeast, Layout.northwest ];
+  const two = [ Layout.east, Layout.west ];
 
   // empty input array is now invalid, just returns anchor coordinates
   check({
@@ -235,4 +236,46 @@ UnitTest.test('BounderToolbuttonTest', () => {
     x: 350 + 50 + 1 - 99 - 100 + 32 + 10 - 1,
     y: 220 + 50 + 2 - 10 - 74 - 75 + 1
   }, four, bounds(350 + 50 + 1 - 99, 220 + 50 + 2 - 10 - 74, 10, 10), panelBox, bubb, view);
+
+  // East
+  check({
+    label: 'layout-e',
+    x: 55 + 10 - 1,
+    y: 150 + 1 - (75 / 2) + (10 / 2)
+  }, two, bounds(55, 150, 10, 10), panelBox, bubb, view);
+
+  // None near bottom left -> best fit is east (limited to bottom bounds)
+  check({
+    label: 'layout-e',
+    x: 55 + 10 - 1,
+    y: 270 - 75
+  }, two, bounds(55, 240, 10, 10), panelBox, bubb, view);
+
+  // None near top left -> best fit is east (limited to top bounds)
+  check({
+    label: 'layout-e',
+    x: 55 + 10 - 1,
+    y: 50
+  }, two, bounds(55, 80, 10, 10), panelBox, bubb, view);
+
+  // West
+  check({
+    label: 'layout-w',
+    x: 350 - 1 - 100,
+    y: 150 + 1 - (75 / 2) + (10 / 2)
+  }, two, bounds(350, 150, 10, 10), panelBox, bubb, view);
+
+  // None near bottom right -> best fit is west (limited to bottom bounds)
+  check({
+    label: 'layout-w',
+    x: 350 - 1 - 100,
+    y: 270 - 75
+  }, two, bounds(350, 240, 10, 10), panelBox, bubb, view);
+
+  // None near top right -> best fit is west (limited to top bounds)
+  check({
+    label: 'layout-w',
+    x: 350 - 1 - 100,
+    y: 50
+  }, two, bounds(350, 80, 10, 10), panelBox, bubb, view);
 });

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -225,8 +225,8 @@ export const difference = <T>(a1: ArrayLike<T>, a2: ArrayLike<T>): T[] => {
   return filter(a1, (x) => !contains(a2, x));
 };
 
-export const mapToObject = <T, U>(xs: ArrayLike<T>, f: (x: T, i: number) => U): Record<string, U> => {
-  const r: Record<string, U> = {};
+export const mapToObject = <T extends keyof any, U>(xs: ArrayLike<T>, f: (x: T, i: number) => U): Record<T, U> => {
+  const r = {} as Record<T, U>;
   for (let i = 0, len = xs.length; i < len; i++) {
     const x = xs[i];
     r[String(x)] = f(x, i);

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -5,6 +5,8 @@ Version 5.2.1 (TBD)
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948
     Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
     Fixed the editor incorrectly stealing focus during initialization in Microsoft IE #TINY-4697
+    Fixed the context toolbar overlapping with the menu bar and toolbar #TINY-4586
+    Fixed notification and inline dialog positioning issues when using the bottom toolbar #TINY-4586
     Fixed the `colorinput` popup appearing offscreen on mobile devices #TINY-4711
 Version 5.2.0 (2020-02-13)
     Added the ability to apply formats to spaces #TINY-4200

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NoticationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NoticationManagerImplTest.ts
@@ -1,8 +1,8 @@
-import { ApproxStructure, Assertions, Chain, Guard, NamedChain, Pipeline, UiFinder, Mouse } from '@ephox/agar';
+import { ApproxStructure, Assertions, Chain, Guard, Mouse, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { HTMLElement } from '@ephox/dom-globals';
 import { Editor as McEditor } from '@ephox/mcagar';
-import { Element, Traverse, Body } from '@ephox/sugar';
+import { Body, Element, Traverse } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { NotificationApi } from 'tinymce/core/api/NotificationManager';
@@ -196,8 +196,8 @@ UnitTest.asynctest('NotificationManagerImpl test', (success, failure) => {
             NamedChain.write('nWarn', cOpenNotification(editor, 'warning', 'Message 2')),
 
             // Check items are positioned so that they are stacked
-            NamedChain.direct('nError', cAssertPosition('Error notification', 220, -383), '_'),
-            NamedChain.direct('nWarn', cAssertPosition('Warning notification', 220, -335), '_'),
+            NamedChain.direct('nError', cAssertPosition('Error notification', 220, -399), '_'),
+            NamedChain.direct('nWarn', cAssertPosition('Warning notification', 220, -351), '_'),
 
             // Shrink the editor to 300px
             NamedChain.direct('body', UiFinder.cFindIn('.tox-statusbar__resize-handle'), 'resizeHandle'),
@@ -205,8 +205,8 @@ UnitTest.asynctest('NotificationManagerImpl test', (success, failure) => {
             NamedChain.direct('body', cResizeToPos(600, 400, 600, 300), '_'),
 
             // Check items are positioned so that they are stacked
-            NamedChain.direct('nError', cAssertPosition('Error notification', 220, -283), '_'),
-            NamedChain.direct('nWarn', cAssertPosition('Warning notification', 220, -235), '_'),
+            NamedChain.direct('nError', cAssertPosition('Error notification', 220, -299), '_'),
+            NamedChain.direct('nWarn', cAssertPosition('Warning notification', 220, -251), '_'),
 
             NamedChain.direct('nError', cCloseNotification, '_'),
             NamedChain.direct('nWarn', cCloseNotification, '_')

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -1,12 +1,12 @@
-import { Assertions, Chain, Guard, NamedChain, Mouse, Pipeline, UiFinder } from '@ephox/agar';
+import { Assertions, Chain, Guard, Mouse, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Types } from '@ephox/bridge';
 import { HTMLElement } from '@ephox/dom-globals';
 import { Editor as McEditor } from '@ephox/mcagar';
 import { Body, Css, Element, Height, Scroll, Traverse } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
 
 import Theme from 'tinymce/themes/silver/Theme';
-import Editor from 'tinymce/core/api/Editor';
 import * as DialogUtils from '../../module/DialogUtils';
 import { cResizeToPos, cScrollRelativeEditor } from '../../module/UiChainUtils';
 import { setupPageScroll } from '../../module/Utils';
@@ -167,15 +167,15 @@ UnitTest.asynctest('WindowManager:inline-dialog Position Test', (success, failur
             // Scroll so that the editor is fully in view
             cScrollRelativeEditor(editor, 'top', -100),
             NamedChain.direct('body', cTestOpen, 'dialog'),
-            NamedChain.direct('dialog', cAssertPos('absolute', 113, -1395), '_'),
+            NamedChain.direct('dialog', cAssertPos('absolute', 105, -1387), '_'),
 
             // Scroll so that bottom of window overlaps bottom of editor
             cScrollRelativeEditor(editor, 'bottom', -200),
-            NamedChain.direct('dialog', cAssertPos('absolute', 113, -1395), '_'),
+            NamedChain.direct('dialog', cAssertPos('absolute', 105, -1387), '_'),
 
             // Scroll so that top of window overlaps top of editor
             cScrollRelativeEditor(editor, 'top', 200),
-            NamedChain.direct('dialog', cAssertPos('fixed', 113, 0), '_'),
+            NamedChain.direct('dialog', cAssertPos('fixed', 105, 0), '_'),
 
             NamedChain.direct('body', DialogUtils.cClose, '_'),
             NamedChain.outputInput
@@ -187,12 +187,12 @@ UnitTest.asynctest('WindowManager:inline-dialog Position Test', (success, failur
 
             cScrollRelativeEditor(editor, 'top', -100),
             NamedChain.direct('body', cTestOpen, 'dialog'),
-            NamedChain.direct('dialog', cAssertPos('absolute', 113, -1395), '_'),
+            NamedChain.direct('dialog', cAssertPos('absolute', 105, -1387), '_'),
 
             // Shrink the editor to 300px
             NamedChain.direct('resizeHandle', Mouse.cMouseDown, '_'),
             NamedChain.direct('body', cResizeToPos(600, 400, 600, 300), '_'),
-            NamedChain.direct('dialog', cAssertPos('absolute', 113, -1295), '_'),
+            NamedChain.direct('dialog', cAssertPos('absolute', 105, -1287), '_'),
 
             NamedChain.direct('body', DialogUtils.cClose, '_'),
             NamedChain.outputInput
@@ -227,15 +227,15 @@ UnitTest.asynctest('WindowManager:inline-dialog Position Test', (success, failur
             Chain.op(() => editor.focus()),
             NamedChain.read('body', UiFinder.cWaitForVisible('Wait for editor', '.tox-tinymce-inline')),
             NamedChain.direct('body', cTestOpen, 'dialog'),
-            NamedChain.direct('dialog', cAssertPos('absolute', 130, -1412), '_'),
+            NamedChain.direct('dialog', cAssertPos('absolute', 106, -1388), '_'),
 
             // Scroll so that bottom of window overlaps bottom of editor
             cScrollRelativeEditor(editor, 'bottom', -200),
-            NamedChain.direct('dialog', cAssertPos('absolute', 130, -1412), '_'),
+            NamedChain.direct('dialog', cAssertPos('absolute', 106, -1388), '_'),
 
             // Scroll so that top of window overlaps top of editor
             cScrollRelativeEditor(editor, 'top', 200),
-            NamedChain.direct('dialog', cAssertPos('fixed', 130, 0), '_'),
+            NamedChain.direct('dialog', cAssertPos('fixed', 106, 0), '_'),
 
             NamedChain.direct('body', DialogUtils.cClose, '_'),
             NamedChain.outputInput


### PR DESCRIPTION
This fixes the context toolbar overlapping with the header when using toolbar bottom, as our `Bounder` logic wasn't taking into account the width/height.

Fixing the bottom/right bounds constraints however highlighted another issue, in that we also allowed the component to overlap with the anchor if the X/Y was limited by the bounds. As such I've also added logic to adjust the bounds based on the anchor layout, so that the new bounds will be the anchor point out to the specified bounds.

Lastly, this also fixes an issue I found whereby the inline dialog anchor was incorrect for iframe mode (the logic was only originally setup for fixed toolbar, which is inline only). That also then highlighted that there was a bug in the `LayoutInside` logic for anything where the point was in the corners, as it had the east/west logic backwards and also all the directions were backwards (eg a north inside anchor layout actually displays the component south of the anchor).