### PR TITLE
TINY-4732: Fixed resize handlers displaying in the wrong location sometimes for remote images

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,6 +2,7 @@ Version 5.3.0 (TBD)
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
     Changed the default icons to be lazy loaded during initialization #TINY-4729
     Fixed the `quickimage` button not restricting the file types to images #TINY-4715
+    Fixed resize handlers displaying in the wrong location sometimes for remote images #TINY-4732
     Fixed table picker breaking in Firefox on low zoom levels #TINY-4728
 Version 5.2.1 (TBD)
     Fixed table selection not functioning correctly in Microsoft Edge 44 or higher #TINY-3862

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -485,7 +485,7 @@ const ControlSelection = (selection: Selection, editor: Editor): ControlSelectio
       }
     });
 
-    editor.on('nodechange ResizeEditor ResizeWindow drop FullscreenStateChanged', throttledUpdateResizeRect);
+    editor.on('nodechange ResizeEditor ResizeWindow ResizeContent drop FullscreenStateChanged', throttledUpdateResizeRect);
 
     // Update resize rect while typing in a table
     editor.on('keyup compositionend', function (e) {

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -5,133 +5,91 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, Attachment, Boxes, Channels, Docking } from '@ephox/alloy';
-import { Cell, Option } from '@ephox/katamari';
-import { Body, Css, Element, Height, Width } from '@ephox/sugar';
-import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import { AlloyComponent, Attachment, Boxes } from '@ephox/alloy';
+import { Cell, Singleton } from '@ephox/katamari';
+import { DomEvent, Element } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
-import { getMaxWidthSetting, getToolbarMode, getUiContainer, isStickyToolbar, isToolbarLocationTop, useFixedContainer, ToolbarMode } from '../api/Settings';
+import * as Events from '../api/Events';
+import { getUiContainer, isToolbarLocationTop } from '../api/Settings';
 import { UiFactoryBackstage } from '../backstage/Backstage';
 import { setupReadonlyModeSwitch } from '../ReadOnly';
 import { ModeRenderInfo, RenderArgs, RenderUiComponents, RenderUiConfig } from '../Render';
 import OuterContainer from '../ui/general/OuterContainer';
+import { InlineHeader } from '../ui/header/InlineHeader';
 import { identifyMenus } from '../ui/menus/menubar/Integration';
-import * as EditorSize from '../ui/sizing/EditorSize';
-import * as Utils from '../ui/sizing/Utils';
 import { inline as loadInlineSkin } from './../ui/skin/Loader';
 import { setToolbar } from './Toolbars';
 
-const getTargetPosAndHeight = (targetElm: Element, isToolbarTop: boolean) => {
-  const pos = Boxes.box(targetElm);
+const getTargetPosAndBounds = (targetElm: Element, isToolbarTop: boolean) => {
+  const bounds = Boxes.box(targetElm);
   return {
-    pos: isToolbarTop ? pos.y() : pos.bottom(),
-    height: pos.height()
+    pos: isToolbarTop ? bounds.y() : bounds.bottom(),
+    bounds
   };
+};
+
+const setupEvents = (editor: Editor, targetElm: Element, ui: InlineHeader) => {
+  const isToolbarTop = isToolbarLocationTop(editor);
+  const prevPosAndBounds = Cell(getTargetPosAndBounds(targetElm, isToolbarTop));
+
+  const resizeContent = (e) => {
+    const { pos, bounds } = getTargetPosAndBounds(targetElm, isToolbarTop);
+    const { pos: prevPos, bounds: prevBounds} = prevPosAndBounds.get();
+
+    const hasResized = bounds.height() !== prevBounds.height() || bounds.width() !== prevBounds.width();
+    prevPosAndBounds.set({ pos, bounds });
+
+    if (hasResized) {
+      Events.fireResizeContent(editor, e);
+    }
+
+    if (ui.isVisible()) {
+      if (prevPos !== pos) {
+        ui.update(true);
+      } else if (hasResized) {
+        ui.repositionPopups();
+      }
+    }
+  };
+
+  editor.on('activate', ui.show);
+  editor.on('deactivate', ui.hide);
+
+  editor.on('SkinLoaded ResizeWindow', () => {
+    if (ui.isVisible()) {
+      ui.update(true);
+    }
+  });
+
+  editor.on('NodeChange keydown', (e) => {
+    Delay.requestAnimationFrame(() => resizeContent(e));
+  });
+
+  // Bind to async load events and trigger a content resize event if the size has changed
+  const elementLoad = Singleton.unbindable();
+  elementLoad.set(DomEvent.capture(Element.fromDom(editor.getBody()), 'load', resizeContent));
+
+  editor.on('remove', () => {
+    elementLoad.clear();
+  });
 };
 
 const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
   const { mothership, uiMothership, outerContainer } = uiComponents;
-  let floatContainer;
-  const DOM = DOMUtils.DOM;
-  const useFixedToolbarContainer = useFixedContainer(editor);
-  const isSticky = isStickyToolbar(editor);
+  const floatContainer = Cell<AlloyComponent>(null);
   const targetElm = Element.fromDom(args.targetNode);
-  const editorMaxWidthOpt = getMaxWidthSetting(editor).or(EditorSize.getWidth(editor));
-
-  const toolbarMode = getToolbarMode(editor);
-  const isSplitToolbar = toolbarMode === ToolbarMode.sliding || toolbarMode === ToolbarMode.floating;
-  const isToolbarTop = isToolbarLocationTop(editor);
-
-  const prevPosAndHeight = Cell(getTargetPosAndHeight(targetElm, isToolbarTop));
-  const visible = Cell(false);
+  const ui = InlineHeader(editor, targetElm, uiComponents, floatContainer);
 
   loadInlineSkin(editor);
 
-  const updateChromePosition = (toolbar: Option<AlloyComponent>) => {
-    // Calculate the toolbar offset when using a split toolbar drawer
-    const offset = isSplitToolbar ? toolbar.fold(() => 0, (tbar) => {
-      // If we have an overflow toolbar, we need to offset the positioning by the height of the overflow toolbar
-      return tbar.components().length > 1 ? Height.get(tbar.components()[1].element()) : 0;
-    }) : 0;
-
-    // The float container/editor may not have been rendered yet, which will cause it to have a non integer based positions
-    // so we need to round this to account for that.
-    const targetBounds = Boxes.box(targetElm);
-    const top = isToolbarTop ?
-      targetBounds.y() - Height.get(floatContainer.element()) + offset :
-      targetBounds.bottom();
-
-    Css.setAll(outerContainer.element(), {
-      position: 'absolute',
-      top: Math.round(top) + 'px',
-      left: Math.round(targetBounds.x()) + 'px'
-    });
-
-    // Update the max width of the inline toolbar
-    const maxWidth = editorMaxWidthOpt.getOrThunk(() => {
-      // No max width, so use the body width, minus the left pos as the maximum
-      const bodyMargin = Utils.parseToInt(Css.get(Body.body(), 'margin-left')).getOr(0);
-      return Width.get(Body.body()) - targetBounds.x() + bodyMargin;
-    });
-    Css.set(floatContainer.element(), 'max-width', maxWidth + 'px');
-  };
-
-  const repositionFloatingUiComponents = () => {
-    uiMothership.broadcastOn([ Channels.repositionPopups() ], { });
-  };
-
-  const updateChromeUi = (resetDocking: boolean = false) => {
-    // Handles positioning, docking and SplitToolbar (more drawer) behaviour. Modes:
-    // 1. Basic inline: does positioning and docking
-    // 2. Inline + more drawer: does positioning, docking and SplitToolbar
-    // 3. Inline + fixed_toolbar_container: does nothing
-    // 4. Inline + fixed_toolbar_container + more drawer: does SplitToolbar
-
-    // Refresh split toolbar
-    if (isSplitToolbar) {
-      OuterContainer.refreshToolbar(outerContainer);
-    }
-
-    // Positioning
-    if (!useFixedToolbarContainer) {
-      const toolbar = OuterContainer.getToolbar(outerContainer);
-      updateChromePosition(toolbar);
-    }
-
-    // Docking
-    if (isSticky) {
-      resetDocking ? Docking.reset(floatContainer) : Docking.refresh(floatContainer);
-    }
-
-    // Floating toolbar
-    repositionFloatingUiComponents();
-  };
-
-  const show = () => {
-    visible.set(true);
-    Css.set(outerContainer.element(), 'display', 'flex');
-    DOM.addClass(editor.getBody(), 'mce-edit-focus');
-    Css.remove(uiMothership.element(), 'display');
-    updateChromeUi();
-  };
-
-  const hide = () => {
-    visible.set(false);
-    if (uiComponents.outerContainer) {
-      Css.set(outerContainer.element(), 'display', 'none');
-      DOM.removeClass(editor.getBody(), 'mce-edit-focus');
-    }
-    Css.set(uiMothership.element(), 'display', 'none');
-  };
-
   const render = () => {
-    if (floatContainer) {
-      show();
+    if (floatContainer.get()) {
+      ui.show();
       return;
     }
 
-    floatContainer = OuterContainer.getHeader(outerContainer).getOrDie();
+    floatContainer.set(OuterContainer.getHeader(outerContainer).getOrDie());
 
     const uiContainer = getUiContainer(editor);
     Attachment.attachSystem(uiContainer, mothership);
@@ -145,39 +103,15 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     );
 
     // Initialise the toolbar - set initial positioning then show
-    show();
+    ui.show();
 
-    editor.on('activate', show);
-    editor.on('deactivate', hide);
-
-    editor.on('SkinLoaded ResizeWindow', () => {
-      if (visible.get()) {
-        updateChromeUi(true);
-      }
-    });
-
-    editor.on('NodeChange keydown', () => {
-      Delay.requestAnimationFrame(() => {
-        const posAndHeight = getTargetPosAndHeight(targetElm, isToolbarTop);
-        const prev = prevPosAndHeight.get();
-
-        if (visible.get()) {
-          if (posAndHeight.pos !== prev.pos) {
-            updateChromeUi(true);
-            prevPosAndHeight.set(posAndHeight);
-          } else if (posAndHeight.height !== prev.height) {
-            repositionFloatingUiComponents();
-            prevPosAndHeight.set(posAndHeight);
-          }
-        }
-      });
-    });
+    setupEvents(editor, targetElm, ui);
 
     editor.nodeChanged();
   };
 
   editor.on('focus', render);
-  editor.on('blur hide', hide);
+  editor.on('blur hide', ui.hide);
 
   editor.on('init', () => {
     if (editor.hasFocus()) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { AlloyComponent, Boxes, Channels, Docking } from '@ephox/alloy';
+import { Cell, Option } from '@ephox/katamari';
+import { Body, Css, Element, Height, Location, Width } from '@ephox/sugar';
+
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import Editor from 'tinymce/core/api/Editor';
+import { getMaxWidthSetting, getToolbarMode, isStickyToolbar, isToolbarLocationTop, ToolbarMode, useFixedContainer } from '../../api/Settings';
+import { RenderUiComponents } from '../../Render';
+import OuterContainer from '../general/OuterContainer';
+import * as EditorSize from '../sizing/EditorSize';
+import * as Utils from '../sizing/Utils';
+
+export interface InlineHeader {
+  isVisible: () => boolean;
+  show: () => void;
+  hide: () => void;
+  update: (resetDocking?: boolean) => void;
+  repositionPopups: () => void;
+}
+
+export const InlineHeader = (editor: Editor, targetElm: Element, uiComponents: RenderUiComponents, floatContainer: Cell<AlloyComponent>): InlineHeader => {
+  const { uiMothership, outerContainer } = uiComponents;
+  const DOM = DOMUtils.DOM;
+  const useFixedToolbarContainer = useFixedContainer(editor);
+  const isSticky = isStickyToolbar(editor);
+  const editorMaxWidthOpt = getMaxWidthSetting(editor).or(EditorSize.getWidth(editor));
+
+  const toolbarMode = getToolbarMode(editor);
+  const isSplitToolbar = toolbarMode === ToolbarMode.sliding || toolbarMode === ToolbarMode.floating;
+  const isToolbarTop = isToolbarLocationTop(editor);
+
+  const visible = Cell(false);
+
+  const updateChromeWidth = () => {
+    // Update the max width of the inline toolbar
+    const maxWidth = editorMaxWidthOpt.getOrThunk(() => {
+      // No max width, so use the body width, minus the left pos as the maximum
+      const bodyMargin = Utils.parseToInt(Css.get(Body.body(), 'margin-left')).getOr(0);
+      return Width.get(Body.body()) - Location.absolute(targetElm).left() + bodyMargin;
+    });
+    Css.set(floatContainer.get().element(), 'max-width', maxWidth + 'px');
+  };
+
+  const updateChromePosition = (toolbar: Option<AlloyComponent>) => {
+    // Calculate the toolbar offset when using a split toolbar drawer
+    const offset = isSplitToolbar ? toolbar.fold(() => 0, (tbar) => {
+      // If we have an overflow toolbar, we need to offset the positioning by the height of the overflow toolbar
+      return tbar.components().length > 1 ? Height.get(tbar.components()[1].element()) : 0;
+    }) : 0;
+
+    // The float container/editor may not have been rendered yet, which will cause it to have a non integer based positions
+    // so we need to round this to account for that.
+    const targetBounds = Boxes.box(targetElm);
+    const top = isToolbarTop ?
+      targetBounds.y() - Height.get(floatContainer.get().element()) + offset :
+      targetBounds.bottom();
+
+    Css.setAll(outerContainer.element(), {
+      position: 'absolute',
+      top: Math.round(top) + 'px',
+      left: Math.round(targetBounds.x()) + 'px'
+    });
+  };
+
+  const repositionPopups = () => {
+    uiMothership.broadcastOn([ Channels.repositionPopups() ], { });
+  };
+
+  const updateChromeUi = (resetDocking: boolean = false) => {
+    // Handles positioning, docking and SplitToolbar (more drawer) behaviour. Modes:
+    // 1. Basic inline: does positioning and docking
+    // 2. Inline + more drawer: does positioning, docking and SplitToolbar
+    // 3. Inline + fixed_toolbar_container: does nothing
+    // 4. Inline + fixed_toolbar_container + more drawer: does SplitToolbar
+
+    // Update the max width, as the body width may have changed
+    updateChromeWidth();
+
+    // Refresh split toolbar
+    if (isSplitToolbar) {
+      OuterContainer.refreshToolbar(outerContainer);
+    }
+
+    // Positioning
+    if (!useFixedToolbarContainer) {
+      const toolbar = OuterContainer.getToolbar(outerContainer);
+      updateChromePosition(toolbar);
+    }
+
+    // Docking
+    if (isSticky) {
+      const floatContainerComp = floatContainer.get();
+      resetDocking ? Docking.reset(floatContainerComp) : Docking.refresh(floatContainerComp);
+    }
+
+    // Floating toolbar
+    repositionPopups();
+  };
+
+  const show = () => {
+    visible.set(true);
+    Css.set(outerContainer.element(), 'display', 'flex');
+    DOM.addClass(editor.getBody(), 'mce-edit-focus');
+    Css.remove(uiMothership.element(), 'display');
+    updateChromeUi();
+  };
+
+  const hide = () => {
+    visible.set(false);
+    if (uiComponents.outerContainer) {
+      Css.set(outerContainer.element(), 'display', 'none');
+      DOM.removeClass(editor.getBody(), 'mce-edit-focus');
+    }
+    Css.set(uiMothership.element(), 'display', 'none');
+  };
+
+  return {
+    isVisible: () => visible.get() && !editor.removed,
+    show,
+    hide,
+    update: updateChromeUi,
+    repositionPopups
+  };
+};


### PR DESCRIPTION
This is just something I'd noticed a while back that had been bugging me. Basically the cause is that we don't listen to the load event, which means only the initial size is used but that can change after the image has loaded. So this makes `ControlSelection` also listen to the `ResizeContent` event, which is currently only fired in iframe mode so I've also hooked that up in a similar way for inline mode.

I've also taken the chance to move out the inline positioning, etc... logic to a separate module as it was getting a bit cluttered (see `InlineHeader.ts`).

Note: No tests, as loading a remote image and getting the load timing right is quite fickle and likely to lead to tests that either do nothing or flake.