### PR TITLE
TINY-4735: Reduce size of "help" plugin

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
@@ -43,11 +43,11 @@ const getNamesFromTabs = (tabs: TabSpecs): TabData => {
   const names = Obj.keys(tabs);
 
   // Move the versions tab to the end if it exists
-  const versionsIdx = Arr.indexOf(names, 'versions');
-  versionsIdx.each((idx) => {
+  const idx = names.indexOf('versions');
+  if (idx !== -1) {
     names.splice(idx, 1);
     names.push('versions');
-  });
+  }
 
   return {tabs, names};
 };

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -6,7 +6,7 @@
  */
 
 import { Types } from '@ephox/bridge';
-import { Arr, Fun, Obj, Strings } from '@ephox/katamari';
+import { Arr, Obj } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import * as PluginUrls from '../data/PluginUrls';
@@ -52,7 +52,8 @@ const tab = (editor: Editor): Types.Dialog.TabApi => {
       '</div>';
   };
 
-  const makeLink = Fun.curry(Strings.supplant, '<a href="${url}" target="_blank" rel="noopener">${name}</a>');
+  const makeLink = (p: {name: string, url: string}): string =>
+    `<a href="${p.url}" target="_blank" rel="noopener">${p.name}</a>`;
 
   const maybeUrlize = (editor, key: string) => {
     return Arr.find(PluginUrls.urls, function (x: PluginUrlType) {
@@ -69,7 +70,7 @@ const tab = (editor: Editor): Types.Dialog.TabApi => {
     const keys = Obj.keys(editor.plugins);
     return editor.settings.forced_plugins === undefined ?
       keys :
-      Arr.filter(keys, Fun.not(Fun.curry(Arr.contains, editor.settings.forced_plugins)));
+      Arr.filter(keys, (k) => !Arr.contains(editor.settings.forced_plugins, k));
   };
 
   const pluginLister = (editor) => {


### PR DESCRIPTION
This reduces the size of the "help" plugin, by avoiding dependencies on:
- Arr.indexOf
- Fun.curry
- Strings.supplant

This reduces the overall size of `dist/tinymce_5.3.0.zip` from 656176 bytes to 656000 - a reduction of 176 bytes.