### PR TITLE
TINY-4736: Optimize Type module for tree-shaking

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -1,35 +1,43 @@
-const typeOf = function (x: any) {
-  if (x === null) {
-    return 'null';
-  }
-  const t = typeof x;
-  if (t === 'object' && (Array.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'Array')) {
-    return 'array';
-  }
-  if (t === 'object' && (String.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'String')) {
-    return 'string';
-  }
-  return t;
-};
+const typeOf = (x: any): string =>
+  x === null ? 'null' : isArray(x) ? 'array' : isString(x) ? 'string' : typeof x;
 
-const isType = function (type: string) {
-  return function (value: any) {
-    return typeOf(value) === type;
-  };
-};
+const isType = <Yolo>(type: string) => (value: any): value is Yolo =>
+  typeOf(value) === type;
 
-export const isString = <(value: any) => value is string> isType('string');
-export const isObject = isType('object');
-export const isArray = <(value: any) => value is Array<any>> isType('array');
-export const isNull = <(value: any) => value is null> isType('null');
-export const isBoolean = <(value: any) => value is boolean> isType('boolean');
-export const isUndefined = <(value: any) => value is undefined> isType('undefined');
-export const isFunction = <(value: any) => value is Function> isType('function');
-export const isNumber = <(value: any) => value is number> isType('number');
+const isSimpleType = <Yolo>(type: string) => (value: any): value is Yolo =>
+  typeof value === type;
+
+const eq = <T> (t: T) => (a: any): a is T =>
+  t === a;
+
+export const isString = (x: any): x is string =>
+  x !== null && typeof x === 'object' && (String.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'String');
+
+export const isObject: (value: any) => boolean =
+  isType('object');
+
+export const isArray = (value: any): value is Array<unknown> =>
+  Array.isArray(value);
+
+export const isNull: (a: any) => a is null =
+  eq(null);
+
+export const isBoolean: (value: any) => value is boolean =
+  isSimpleType<boolean>('boolean');
+
+export const isUndefined: (a: any) => a is undefined =
+  eq(undefined);
+
+export const isFunction: (value: any) => value is Function =
+  isSimpleType<Function>('function');
+
+export const isNumber: (value: any) => value is number =
+  isSimpleType<number>('number');
+
 export const isArrayOf = <E>(value: any, pred: (x: any) => x is E): value is Array<E> => {
   if (isArray(value)) {
     for (let i = 0, len = value.length; i < len; ++i) {
-      if (pred(value[i]) !== true) {
+      if (!(pred(value[i]))) {
         return false;
       }
     }

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -1,15 +1,14 @@
 const typeOf = (x: any): string => {
+  const t = typeof x;
   if (x === null) {
     return 'null';
-  }
-  const t = typeof x;
-  if (t === 'object' && (Array.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'Array')) {
+  } else if (t === 'object' && (Array.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'Array')) {
     return 'array';
-  }
-  if (t === 'object' && (String.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'String')) {
+  } else if (t === 'object' && (String.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'String')) {
     return 'string';
+  } else {
+    return t;
   }
-  return t;
 };
 
 const isType = <Yolo>(type: string) => (value: any): value is Yolo =>

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -1,13 +1,15 @@
 const typeOf = (x: any): string => {
   if (x === null) {
     return 'null';
-  } else if (isArray(x)) {
-    return 'array';
-  } else if (isString(x)) {
-    return 'string';
-  } else {
-    return typeof x;
   }
+  const t = typeof x;
+  if (t === 'object' && (Array.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'Array')) {
+    return 'array';
+  }
+  if (t === 'object' && (String.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'String')) {
+    return 'string';
+  }
+  return t;
 };
 
 const isType = <Yolo>(type: string) => (value: any): value is Yolo =>
@@ -19,18 +21,14 @@ const isSimpleType = <Yolo>(type: string) => (value: any): value is Yolo =>
 const eq = <T> (t: T) => (a: any): a is T =>
   t === a;
 
-function isObjectWithConstructorName(x: any, constructorName) {
-  return x !== null && isSimpleType<object>('object')(x) && x.constructor && x.constructor.name === constructorName;
-}
-
-export const isString = (x: any): x is string =>
-  isSimpleType('string')(x) || String.prototype.isPrototypeOf(x) || isObjectWithConstructorName(x, 'String');
+export const isString: (value: any) => value is string =
+  isType('string');
 
 export const isObject: (value: any) => boolean =
   isType('object');
 
-export const isArray = (x: any): x is Array<unknown> =>
-  Array.isArray(x) || isObjectWithConstructorName(x, 'Array');
+export const isArray: (value: any) => value is Array<unknown> =
+  isType('array');
 
 export const isNull: (a: any) => a is null =
   eq(null);

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -1,5 +1,14 @@
-const typeOf = (x: any): string =>
-  x === null ? 'null' : isArray(x) ? 'array' : isString(x) ? 'string' : typeof x;
+const typeOf = (x: any): string => {
+  if (x === null) {
+    return 'null';
+  } else if (isArray(x)) {
+    return 'array';
+  } else if (isString(x)) {
+    return 'string';
+  } else {
+    return typeof x;
+  }
+};
 
 const isType = <Yolo>(type: string) => (value: any): value is Yolo =>
   typeOf(value) === type;
@@ -16,8 +25,8 @@ export const isString = (x: any): x is string =>
 export const isObject: (value: any) => boolean =
   isType('object');
 
-export const isArray = (value: any): value is Array<unknown> =>
-  Array.isArray(value);
+export const isArray = (x: any): x is Array<unknown> =>
+  x !== null && typeof x === 'object' && (Array.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'Array');
 
 export const isNull: (a: any) => a is null =
   eq(null);

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -19,14 +19,18 @@ const isSimpleType = <Yolo>(type: string) => (value: any): value is Yolo =>
 const eq = <T> (t: T) => (a: any): a is T =>
   t === a;
 
+function isObjectWithConstructorName(x: any, constructorName) {
+  return x !== null && isSimpleType<object>('object')(x) && x.constructor && x.constructor.name === constructorName;
+}
+
 export const isString = (x: any): x is string =>
-  x !== null && typeof x === 'object' && (String.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'String');
+  isSimpleType('string')(x) || String.prototype.isPrototypeOf(x) || isObjectWithConstructorName(x, 'String');
 
 export const isObject: (value: any) => boolean =
   isType('object');
 
 export const isArray = (x: any): x is Array<unknown> =>
-  x !== null && typeof x === 'object' && (Array.prototype.isPrototypeOf(x) || x.constructor && x.constructor.name === 'Array');
+  Array.isArray(x) || isObjectWithConstructorName(x, 'Array');
 
 export const isNull: (a: any) => a is null =
   eq(null);

--- a/modules/tinymce/src/plugins/textpattern/main/ts/api/Pattern.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/api/Pattern.ts
@@ -34,7 +34,7 @@ const normalizePattern = (pattern: RawPattern): Result<Pattern, PatternError> =>
         if (!Arr.forall(pattern.format, Type.isString)) {
           return err(name + ' pattern has non-string items in the `format` array');
         }
-        formats = pattern.format;
+        formats = pattern.format as string[];
       } else if (Type.isString(pattern.format)) {
         formats = [pattern.format];
       } else {


### PR DESCRIPTION
In `Type`, all functions call the `typeOf` function, which is 13 lines long, and handles some strange special cases around Arrays, Strings, null and object. However, for some of the Type.isX functions, this isn't required. If a plugin only requires Type.isFunction, for instance, it's pulling in code it doesn't need to.

This change addresses this issue.

It also makes use of `Array.isArray`, which is available on all supported browsers.

This reduces the size of `dist/tinymce_5.3.0` from 656176 to 654748 bytes - a reduction of 1428 bytes.