### PR TITLE
TINY-4578: Add parser filter for styling elements

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.3.0 (TBD)
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
+    Changed the style attribute on inline style elements (strong, em, i, etc.) to always apply to an inner span rather than directly on the element #TINY-4578
     Changed the default icons to be lazy loaded during initialization #TINY-4729
     Fixed the `quickimage` button not restricting the file types to images #TINY-4715
     Fixed table picker breaking in Firefox on low zoom levels #TINY-4728

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -65,7 +65,7 @@ const createParser = function (editor: Editor): DomParser {
       internalName = 'data-mce-' + name;
 
       // Add internal attribute if we need to we don't on a refresh of the document
-      if (!node.attr(internalName)) {
+      if (value && !node.attr(internalName)) {
         // Don't duplicate these since they won't get modified by any browser
         if (value.indexOf('data:') === 0 || value.indexOf('blob:') === 0) {
           continue;

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -225,7 +225,7 @@ UnitTest.asynctest('browser.tinymce.core.FormatterApplyTest', function (success,
     rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
-    LegacyUnit.equal(getContent(editor), '<p><b style=\"color: #ff0000; font-size: 10px;\">1234</b></p>', 'Inline element with styles');
+    LegacyUnit.equal(getContent(editor), '<p><b><span style="color: #ff0000; font-size: 10px;">1234</span></b></p>', 'Inline element with styles');
   });
 
   suite.test('Inline element with attributes and styles', function (editor) {
@@ -248,7 +248,7 @@ UnitTest.asynctest('browser.tinymce.core.FormatterApplyTest', function (success,
     editor.formatter.apply('format');
     LegacyUnit.equal(
       getContent(editor),
-      '<p><b id="value2" style="color: #ff0000; font-size: 10px;" title="value1">1234</b></p>',
+      '<p><b id="value2" title="value1"><span style="color: #ff0000; font-size: 10px;">1234</span></b></p>',
       'Inline element with attributes and styles'
     );
   });
@@ -721,7 +721,7 @@ UnitTest.asynctest('browser.tinymce.core.FormatterApplyTest', function (success,
       color: '#ff0000',
       title: 'title'
     });
-    LegacyUnit.equal(getContent(editor), '<p><b style="color: #ff0000;" title="title">1234</b></p>', 'Inline element on selected text');
+    LegacyUnit.equal(getContent(editor), '<p><b title="title"><span style="color: #ff0000;">1234</span></b></p>', 'Inline element on selected text');
   });
 
   suite.test('Remove redundant children', function (editor) {
@@ -765,7 +765,7 @@ UnitTest.asynctest('browser.tinymce.core.FormatterApplyTest', function (success,
       color: '#ff',
       title: 'title'
     });
-    LegacyUnit.equal(getContent(editor), '<p><b style="color: #ff00ff;" title="title2">1234</b></p>', 'Inline element on selected text with function values');
+    LegacyUnit.equal(getContent(editor), '<p><b title="title2"><span style="color: #ff00ff;">1234</span></b></p>', 'Inline element on selected text with function values');
   });
 
   suite.test('Block element on selected text', function (editor) {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -719,6 +719,24 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
     Assertions.assertEq('Should be extected filter', {name: 'node', callbacks: [cb2] }, nodeFilters[nodeFilters.length - 1]);
   });
 
+  suite.test('Convert style in inline tag to span', () => {
+    let parser, root;
+    const schema = Schema();
+
+    parser = DomParser({}, schema);
+    root = parser.parse('<p><strong class="abc" style="color: red; font-size: 10px;">a</strong></p>');
+    LegacyUnit.equal(
+      serializer.serialize(root),
+      '<p><strong class="abc"><span style="color: red; font-size: 10px;">a</span></strong></p>'
+    );
+
+    root = parser.parse('<p><strong class="abc" style="color: red;"><em class="def" style="font-family: monospace;">def</em></strong></p>');
+    LegacyUnit.equal(
+      serializer.serialize(root),
+      '<p><strong class="abc"><span style="color: red;"><em class="def"><span style="font-family: monospace;">def</span></em></span></strong></p>'
+    );
+  });
+
   Pipeline.async({}, suite.toSteps({}), function () {
     success();
   }, failure);


### PR DESCRIPTION
A node filter has been added for styling elements (strong, em, i, b, u, strike) so that if a style attribute is present on the element it is removed and applied to an inner span instead.