### PR TITLE
Feature/tiny 4734

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
@@ -48,6 +48,24 @@ function curry <OUT>(fn: (...allArgs: any[]) => OUT, ...initialArgs: any[]): (..
 const curry1_1 = <A, B> (f: (a: A) => B, a: A) => (): B =>
   f(a);
 
+/** Partially apply 1 argument of a 2-ary function.
+ *  Special case of "curry" which avoids Function.prototype.apply and has smaller code size footprint.
+ */
+const curry1_2 = <A, B, C> (f: (a: A, b: B) => C, a: A) => (b: B): C =>
+  f(a, b);
+
+/** Partially apply 1 argument of a 3-ary function.
+ *  Special case of "curry" which avoids Function.prototype.apply and has smaller code size footprint.
+ */
+const curry1_3 = <A, B, C, D> (f: (a: A, b: B, c: C) => D, a: A) => (b: B, c: C): D =>
+  f(a, b, c);
+
+/** Partially apply 1 argument of a 4-ary function.
+ *  Special case of "curry" which avoids Function.prototype.apply and has smaller code size footprint.
+ */
+const curry1_4 = <A, B, C, D, E> (f: (a: A, b: B, c: C, d: D) => E, a: A) => (b: B, c: C, d: D): E =>
+  f(a, b, c, d);
+
 const not = <T> (f: (t: T) => boolean) => (t: T): boolean =>
   !f(t);
 
@@ -77,6 +95,9 @@ export {
   tripleEquals,
   curry,
   curry1_1,
+  curry1_2,
+  curry1_3,
+  curry1_4,
   not,
   die,
   apply,

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
@@ -42,6 +42,12 @@ function curry <OUT>(fn: (...allArgs: any[]) => OUT, ...initialArgs: any[]): (..
   };
 }
 
+/** Partially apply 1 argument of a 1-ary function.
+ * Special case of "curry" which avoids Function.prototype.apply and has smaller code size footprint.
+ */
+const curry1_1 = <A, B> (f: (a: A) => B, a: A) => (): B =>
+  f(a);
+
 const not = <T> (f: (t: T) => boolean) => (t: T): boolean =>
   !f(t);
 
@@ -70,6 +76,7 @@ export {
   identity,
   tripleEquals,
   curry,
+  curry1_1,
   not,
   die,
   apply,

--- a/modules/katamari/src/test/ts/atomic/api/fun/FunTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/fun/FunTest.ts
@@ -95,6 +95,34 @@ UnitTest.test('Check curry', () => {
   }));
 });
 
+UnitTest.test('Check curry1_1', () => {
+  fc.assert(fc.property(fc.integer(), (a) => {
+    const f = (a) => [ a ];
+    Assert.eq('curry 1_1', Fun.curry1_1(f, a)(), [ a ]);
+  }));
+});
+
+UnitTest.test('Check curry1_2', () => {
+  fc.assert(fc.property(fc.integer(), fc.integer(), (a, b) => {
+    const f = (a, b) => [ a, b ];
+    Assert.eq('curry 1_2', Fun.curry1_2(f, a)(b), [ a, b ]);
+  }));
+});
+
+UnitTest.test('Check curry1_3', () => {
+  fc.assert(fc.property(fc.integer(), fc.integer(), fc.string(), (a, b, c) => {
+    const f = (a, b, c) => [ a, b, c ];
+    Assert.eq('curry 1_2', Fun.curry1_3(f, a)(b, c), [ a, b, c ]);
+  }));
+});
+
+UnitTest.test('Check curry1_4', () => {
+  fc.assert(fc.property(fc.integer(), fc.integer(), fc.string(), fc.integer(), (a, b, c, d) => {
+    const f = (a, b, c, d) => [ a, b, c, d ];
+    Assert.eq('curry 1_2', Fun.curry1_4(f, a)(b, c, d), [ a, b, c, d ]);
+  }));
+});
+
 UnitTest.test('Check not :: not(f(x)) === !f(x)', () => {
   fc.assert(fc.property(fc.json(), fc.func(fc.boolean()), (x, f) => {
     const g = Fun.not(f);

--- a/modules/tinymce/src/plugins/autosave/demo/html/demo.html
+++ b/modules/tinymce/src/plugins/autosave/demo/html/demo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+  <!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Plugin: autosave Demo Page</title>
@@ -10,6 +10,6 @@
       <textarea name="" id="" cols="30" rows="10" class="tinymce"></textarea>
     </div>
     <script src="../../../../../js/tinymce/tinymce.js"></script>
-    <script src="../../../../../scratch/demos/plugins/autosave/demo.js"></script>
+    <script src="../../../../../lib/plugins/autosave/demo/ts/demo/Demo.js"></script>
   </body>
 </html>

--- a/modules/tinymce/src/plugins/autosave/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/Plugin.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell } from '@ephox/katamari';
 import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Api from './api/Api';
 import * as BeforeUnload from './core/BeforeUnload';
@@ -22,10 +21,8 @@ import * as Settings from './api/Settings';
 
 export default function () {
   PluginManager.add('autosave', function (editor) {
-    const started = Cell(false);
-
     BeforeUnload.setup(editor);
-    Buttons.register(editor, started);
+    Buttons.register(editor);
 
     editor.on('init', function () {
       if (Settings.shouldRestoreWhenEmpty(editor) && editor.dom.isEmpty(editor.getBody())) {

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
@@ -6,14 +6,13 @@
  */
 
 import * as Storage from '../core/Storage';
-import { Fun } from '@ephox/katamari';
 
 const get = (editor) => ({
-  hasDraft: Fun.curry1_1(Storage.hasDraft, editor),
-  storeDraft: Fun.curry1_1(Storage.storeDraft, editor),
-  restoreDraft: Fun.curry1_1(Storage.restoreDraft, editor),
-  removeDraft: Fun.curry1_2(Storage.removeDraft, editor),
-  isEmpty: Fun.curry1_2(Storage.isEmpty, editor)
+  hasDraft: () => Storage.hasDraft(editor),
+  storeDraft: () => Storage.storeDraft(editor),
+  restoreDraft: () => Storage.restoreDraft(editor),
+  removeDraft: (fire?: boolean) => Storage.removeDraft(editor, fire),
+  isEmpty: (html?: string) => Storage.isEmpty(editor, html)
 });
 
 export {

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
@@ -12,8 +12,8 @@ const get = (editor) => ({
   hasDraft: Fun.curry1_1(Storage.hasDraft, editor),
   storeDraft: Fun.curry1_1(Storage.storeDraft, editor),
   restoreDraft: Fun.curry1_1(Storage.restoreDraft, editor),
-  removeDraft: Fun.curry1_1(Storage.removeDraft, editor),
-  isEmpty: Fun.curry1_1(Storage.isEmpty, editor)
+  removeDraft: Fun.curry1_2(Storage.removeDraft, editor),
+  isEmpty: Fun.curry1_2(Storage.isEmpty, editor)
 });
 
 export {

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
@@ -8,15 +8,13 @@
 import * as Storage from '../core/Storage';
 import { Fun } from '@ephox/katamari';
 
-const get = function (editor) {
-  return {
-    hasDraft: Fun.curry(Storage.hasDraft, editor),
-    storeDraft: Fun.curry(Storage.storeDraft, editor),
-    restoreDraft: Fun.curry(Storage.restoreDraft, editor),
-    removeDraft: Fun.curry(Storage.removeDraft, editor),
-    isEmpty: Fun.curry(Storage.isEmpty, editor)
-  };
-};
+const get = (editor) => ({
+  hasDraft: Fun.curry1_1(Storage.hasDraft, editor),
+  storeDraft: Fun.curry1_1(Storage.storeDraft, editor),
+  restoreDraft: Fun.curry1_1(Storage.restoreDraft, editor),
+  removeDraft: Fun.curry1_1(Storage.removeDraft, editor),
+  isEmpty: Fun.curry1_1(Storage.isEmpty, editor)
+});
 
 export {
   get

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Settings.ts
@@ -13,14 +13,13 @@ const shouldAskBeforeUnload = (editor) => {
 };
 
 const getAutoSavePrefix = (editor) => {
-  let prefix = editor.getParam('autosave_prefix', 'tinymce-autosave-{path}{query}{hash}-{id}-');
+  const l = document.location;
 
-  prefix = prefix.replace(/\{path\}/g, document.location.pathname);
-  prefix = prefix.replace(/\{query\}/g, document.location.search);
-  prefix = prefix.replace(/\{hash\}/g, document.location.hash);
-  prefix = prefix.replace(/\{id\}/g, editor.id);
-
-  return prefix;
+  return editor.getParam('autosave_prefix', 'tinymce-autosave-{path}{query}{hash}-{id}-')
+  .replace(/{path}/g, l.pathname)
+  .replace(/{query}/g, l.search)
+  .replace(/{hash}/g, l.hash)
+  .replace(/{id}/g, editor.id);
 };
 
 const shouldRestoreWhenEmpty = (editor) => {

--- a/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
@@ -64,18 +63,13 @@ const restoreDraft = (editor: Editor) => {
   }
 };
 
-const startStoreDraft = (editor: Editor, started: Cell<boolean>) => {
+const startStoreDraft = (editor: Editor) => {
   const interval = Settings.getAutoSaveInterval(editor);
-
-  if (!started.get()) {
-    Delay.setInterval(() => {
-      if (!editor.removed) {
-        storeDraft(editor);
-      }
-    }, interval);
-
-    started.set(true);
-  }
+  Delay.setInterval(() => {
+    if (!editor.removed) {
+      storeDraft(editor);
+    }
+  }, interval);
 };
 
 const restoreLastDraft = (editor: Editor) => {

--- a/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
@@ -7,19 +7,18 @@
 
 import * as Storage from '../core/Storage';
 import Editor from 'tinymce/core/api/Editor';
-import { Cell } from '@ephox/katamari';
 
-const makeSetupHandler = (editor: Editor, started: Cell<boolean>) => (api) => {
+const makeSetupHandler = (editor: Editor) => (api) => {
   api.setDisabled(!Storage.hasDraft(editor));
   const editorEventCallback = () => api.setDisabled(!Storage.hasDraft(editor));
   editor.on('StoreDraft RestoreDraft RemoveDraft', editorEventCallback);
   return () => editor.off('StoreDraft RestoreDraft RemoveDraft', editorEventCallback);
 };
 
-const register = (editor: Editor, started: Cell<boolean>) => {
+const register = (editor: Editor) => {
   // TODO: This was moved from makeSetupHandler as it would only be called when the menu item was rendered?
   //       Is it safe to start this process when the plugin is registered?
-  Storage.startStoreDraft(editor, started);
+  Storage.startStoreDraft(editor);
 
   editor.ui.registry.addButton('restoredraft', {
     tooltip: 'Restore last draft',
@@ -27,7 +26,7 @@ const register = (editor: Editor, started: Cell<boolean>) => {
     onAction: () => {
       Storage.restoreLastDraft(editor);
     },
-    onSetup: makeSetupHandler(editor, started)
+    onSetup: makeSetupHandler(editor)
   });
 
   editor.ui.registry.addMenuItem('restoredraft', {
@@ -36,7 +35,7 @@ const register = (editor: Editor, started: Cell<boolean>) => {
     onAction: () => {
       Storage.restoreLastDraft(editor);
     },
-    onSetup: makeSetupHandler(editor, started),
+    onSetup: makeSetupHandler(editor),
   });
 };
 

--- a/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
@@ -9,7 +9,7 @@ import { Fun } from '@ephox/katamari';
 import * as Templates from '../core/Templates';
 
 const register = function (editor) {
-  editor.addCommand('mceInsertTemplate', Fun.curry(Templates.insertTemplate, editor));
+  editor.addCommand('mceInsertTemplate', Fun.curry1_3(Templates.insertTemplate, editor));
 };
 
 export {


### PR DESCRIPTION
The general-purpose curry partially applies n arguments of n values. When this was ported to TypeScript and given better types, its output code grew, as TypeScript added some `for` loops to change how arguments were used.

Also, the general-purpose curry uses Function.prototype.apply. This impacts debugging, and I wouldn't be surprised if it impacts the JS runtime and JIT. IMHO, it's a JS language feature we probably should be avoiding.

This change introduces some special-case variants of curry and uses them to remove the n*n curry from two community plugins. 

This change also removes an unnecessary use of `Cell` from the autosave plugin, allowing it to be shaken out.

The change also corrects a path in the autosave demo page, allowing it to be run correctly from a local static web server.

- The `dist/tinymce_5.3.0.zip` size goes from 653363 to 653159 bytes - a reduction of 194 bytes. 
- The autosave plugin.min.js size goes from 3485 to 3173 bytes - a reduction of 312 bytes
- The template plugin.min.js size goes from 7878 to 7734 bytes  - a reduction of 144 bytes
