### PR TITLE
TINY-4742: Fixed possible uncaught exception when creating a parser

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.2.1 (TBD)
     Fixed "is decorative" checkbox in the image dialog not staying checked on certain actions #FOAM-11
+    Fixed possible uncaught exception when creating a parser #TINY-4742
     Fixed table selection not functioning correctly in Microsoft Edge 44 or higher #TINY-3862
     Fixed table resize handles not functioning correctly in Microsoft Edge #TINY-4160
     Fixed the floating toolbar disconnecting from the toolbar when adding content in inline mode #TINY-4725

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,6 @@
 Version 5.2.1 (TBD)
     Fixed "is decorative" checkbox in the image dialog not staying checked on certain actions #FOAM-11
-    Fixed possible uncaught exception when creating a parser #TINY-4742
+    Fixed possible uncaught exception when a style attribute is removed using a parser filter #TINY-4742
     Fixed table selection not functioning correctly in Microsoft Edge 44 or higher #TINY-3862
     Fixed table resize handles not functioning correctly in Microsoft Edge #TINY-4160
     Fixed the floating toolbar disconnecting from the toolbar when adding content in inline mode #TINY-4725

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -55,13 +55,13 @@ const createParser = function (editor: Editor): DomParser {
 
   // Convert src and href into data-mce-src, data-mce-href and data-mce-style
   parser.addAttributeFilter('src,href,style,tabindex', function (nodes, name) {
-    let i = nodes.length, node;
+    let i = nodes.length, node: Node;
     const dom = editor.dom;
-    let value, internalName;
+    let value: string, internalName: string;
 
     while (i--) {
       node = nodes[i];
-      value = node.attr(name);
+      value = node.attr(name) || '';
       internalName = 'data-mce-' + name;
 
       // Add internal attribute if we need to we don't on a refresh of the document

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -55,14 +55,13 @@ const createParser = function (editor: Editor): DomParser {
 
   // Convert src and href into data-mce-src, data-mce-href and data-mce-style
   parser.addAttributeFilter('src,href,style,tabindex', function (nodes, name) {
-    let i = nodes.length, node: Node;
+    let i = nodes.length, node: Node, value: string;
     const dom = editor.dom;
-    let value: string, internalName: string;
+    const internalName = 'data-mce-' + name;
 
     while (i--) {
       node = nodes[i];
       value = node.attr(name) || '';
-      internalName = 'data-mce-' + name;
 
       // Add internal attribute if we need to we don't on a refresh of the document
       if (!node.attr(internalName)) {

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -61,10 +61,10 @@ const createParser = function (editor: Editor): DomParser {
 
     while (i--) {
       node = nodes[i];
-      value = node.attr(name) || '';
+      value = node.attr(name);
 
       // Add internal attribute if we need to we don't on a refresh of the document
-      if (!node.attr(internalName)) {
+      if (value && !node.attr(internalName)) {
         // Don't duplicate these since they won't get modified by any browser
         if (value.indexOf('data:') === 0 || value.indexOf('blob:') === 0) {
           continue;

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyFiltersTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyFiltersTest.ts
@@ -3,8 +3,9 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
+import { Arr } from '@ephox/katamari';
 
-UnitTest.asynctest('browser.tinymce.core.init.InitContentParserSelectionTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.core.init.InitContentBodyFiltersTest', (success, failure) => {
   Theme();
 
   TinyLoader.setupLight((editor, onSuccess, onFailure) => {
@@ -22,15 +23,15 @@ UnitTest.asynctest('browser.tinymce.core.init.InitContentParserSelectionTest', (
     theme: 'silver',
     base_url: '/project/tinymce/js/tinymce',
     setup: (ed: Editor) => {
-      ed.on('Init', () => {
+      ed.on('init', () => {
         ed.parser.addNodeFilter('p', (nodes) => {
-          nodes.forEach((node) => {
+          Arr.each(nodes, (node) => {
             // Remove style attributes from node
             node.attr('style', null);
             node.attr('data-mce-style', null);
           });
         });
-      }, true);
+      });
     },
   }, success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyParserTest.ts
@@ -1,0 +1,36 @@
+import { Log, Pipeline } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.core.init.InitContentParserSelectionTest', (success, failure) => {
+  Theme();
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+
+    Pipeline.async({}, [
+      Log.stepsAsStep('TINY-4742', 'Insert content to activate node filters, check content is in editor', [
+        tinyApis.sFocus(),
+        tinyApis.sSetContent('<p style="color: rgb(255, 0, 0);">abc</p>'),
+        // If an exception occurs, then no content will be inserted into the editor
+        tinyApis.sAssertContent('<p>abc</p>'),
+      ]),
+    ], onSuccess, onFailure);
+  }, {
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed: Editor) => {
+      ed.on('Init', () => {
+        ed.parser.addNodeFilter('p', (nodes) => {
+          nodes.forEach((node) => {
+            // Remove style attributes from node
+            node.attr('style', null);
+            node.attr('data-mce-style', null);
+          });
+        });
+      }, true);
+    },
+  }, success, failure);
+});


### PR DESCRIPTION
It is possible that the result from `node.attr` may be undefined which will cause an exception when calling `value.indexOf`. The fix ensures that the `value` variable is a string of some kind. 