### PR TITLE
TINY-4748: Reduce size of autosave plugin

### DIFF
--- a/modules/tinymce/src/plugins/autosave/demo/html/demo.html
+++ b/modules/tinymce/src/plugins/autosave/demo/html/demo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+  <!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Plugin: autosave Demo Page</title>
@@ -10,6 +10,6 @@
       <textarea name="" id="" cols="30" rows="10" class="tinymce"></textarea>
     </div>
     <script src="../../../../../js/tinymce/tinymce.js"></script>
-    <script src="../../../../../scratch/demos/plugins/autosave/demo.js"></script>
+    <script src="../../../../../lib/plugins/autosave/demo/ts/demo/Demo.js"></script>
   </body>
 </html>

--- a/modules/tinymce/src/plugins/autosave/demo/html/demo.html
+++ b/modules/tinymce/src/plugins/autosave/demo/html/demo.html
@@ -1,4 +1,4 @@
-  <!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Plugin: autosave Demo Page</title>
@@ -10,6 +10,6 @@
       <textarea name="" id="" cols="30" rows="10" class="tinymce"></textarea>
     </div>
     <script src="../../../../../js/tinymce/tinymce.js"></script>
-    <script src="../../../../../lib/plugins/autosave/demo/ts/demo/Demo.js"></script>
+    <script src="../../../../../scratch/demos/plugins/autosave/demo.js"></script>
   </body>
 </html>

--- a/modules/tinymce/src/plugins/autosave/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/Plugin.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell } from '@ephox/katamari';
 import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Api from './api/Api';
 import * as BeforeUnload from './core/BeforeUnload';
@@ -22,10 +21,8 @@ import * as Settings from './api/Settings';
 
 export default function () {
   PluginManager.add('autosave', function (editor) {
-    const started = Cell(false);
-
     BeforeUnload.setup(editor);
-    Buttons.register(editor, started);
+    Buttons.register(editor);
 
     editor.on('init', function () {
       if (Settings.shouldRestoreWhenEmpty(editor) && editor.dom.isEmpty(editor.getBody())) {

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
@@ -6,17 +6,14 @@
  */
 
 import * as Storage from '../core/Storage';
-import { Fun } from '@ephox/katamari';
 
-const get = function (editor) {
-  return {
-    hasDraft: Fun.curry(Storage.hasDraft, editor),
-    storeDraft: Fun.curry(Storage.storeDraft, editor),
-    restoreDraft: Fun.curry(Storage.restoreDraft, editor),
-    removeDraft: Fun.curry(Storage.removeDraft, editor),
-    isEmpty: Fun.curry(Storage.isEmpty, editor)
-  };
-};
+const get = (editor) => ({
+  hasDraft: () => Storage.hasDraft(editor),
+  storeDraft: () => Storage.storeDraft(editor),
+  restoreDraft: () => Storage.restoreDraft(editor),
+  removeDraft: (fire?: boolean) => Storage.removeDraft(editor, fire),
+  isEmpty: (html?: string) => Storage.isEmpty(editor, html)
+});
 
 export {
   get

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Settings.ts
@@ -13,14 +13,13 @@ const shouldAskBeforeUnload = (editor) => {
 };
 
 const getAutoSavePrefix = (editor) => {
-  let prefix = editor.getParam('autosave_prefix', 'tinymce-autosave-{path}{query}{hash}-{id}-');
+  const l = document.location;
 
-  prefix = prefix.replace(/\{path\}/g, document.location.pathname);
-  prefix = prefix.replace(/\{query\}/g, document.location.search);
-  prefix = prefix.replace(/\{hash\}/g, document.location.hash);
-  prefix = prefix.replace(/\{id\}/g, editor.id);
-
-  return prefix;
+  return editor.getParam('autosave_prefix', 'tinymce-autosave-{path}{query}{hash}-{id}-')
+  .replace(/{path}/g, l.pathname)
+  .replace(/{query}/g, l.search)
+  .replace(/{hash}/g, l.hash)
+  .replace(/{id}/g, editor.id);
 };
 
 const shouldRestoreWhenEmpty = (editor) => {

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Settings.ts
@@ -13,12 +13,12 @@ const shouldAskBeforeUnload = (editor) => {
 };
 
 const getAutoSavePrefix = (editor) => {
-  const l = document.location;
+  const location = document.location;
 
   return editor.getParam('autosave_prefix', 'tinymce-autosave-{path}{query}{hash}-{id}-')
-  .replace(/{path}/g, l.pathname)
-  .replace(/{query}/g, l.search)
-  .replace(/{hash}/g, l.hash)
+  .replace(/{path}/g, location.pathname)
+  .replace(/{query}/g, location.search)
+  .replace(/{hash}/g, location.hash)
   .replace(/{id}/g, editor.id);
 };
 

--- a/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
@@ -64,18 +63,13 @@ const restoreDraft = (editor: Editor) => {
   }
 };
 
-const startStoreDraft = (editor: Editor, started: Cell<boolean>) => {
+const startStoreDraft = (editor: Editor) => {
   const interval = Settings.getAutoSaveInterval(editor);
-
-  if (!started.get()) {
-    Delay.setInterval(() => {
-      if (!editor.removed) {
-        storeDraft(editor);
-      }
-    }, interval);
-
-    started.set(true);
-  }
+  Delay.setInterval(() => {
+    if (!editor.removed) {
+      storeDraft(editor);
+    }
+  }, interval);
 };
 
 const restoreLastDraft = (editor: Editor) => {

--- a/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
@@ -7,19 +7,18 @@
 
 import * as Storage from '../core/Storage';
 import Editor from 'tinymce/core/api/Editor';
-import { Cell } from '@ephox/katamari';
 
-const makeSetupHandler = (editor: Editor, started: Cell<boolean>) => (api) => {
+const makeSetupHandler = (editor: Editor) => (api) => {
   api.setDisabled(!Storage.hasDraft(editor));
   const editorEventCallback = () => api.setDisabled(!Storage.hasDraft(editor));
   editor.on('StoreDraft RestoreDraft RemoveDraft', editorEventCallback);
   return () => editor.off('StoreDraft RestoreDraft RemoveDraft', editorEventCallback);
 };
 
-const register = (editor: Editor, started: Cell<boolean>) => {
+const register = (editor: Editor) => {
   // TODO: This was moved from makeSetupHandler as it would only be called when the menu item was rendered?
   //       Is it safe to start this process when the plugin is registered?
-  Storage.startStoreDraft(editor, started);
+  Storage.startStoreDraft(editor);
 
   editor.ui.registry.addButton('restoredraft', {
     tooltip: 'Restore last draft',
@@ -27,7 +26,7 @@ const register = (editor: Editor, started: Cell<boolean>) => {
     onAction: () => {
       Storage.restoreLastDraft(editor);
     },
-    onSetup: makeSetupHandler(editor, started)
+    onSetup: makeSetupHandler(editor)
   });
 
   editor.ui.registry.addMenuItem('restoredraft', {
@@ -36,7 +35,7 @@ const register = (editor: Editor, started: Cell<boolean>) => {
     onAction: () => {
       Storage.restoreLastDraft(editor);
     },
-    onSetup: makeSetupHandler(editor, started),
+    onSetup: makeSetupHandler(editor),
   });
 };
 


### PR DESCRIPTION
In the TypeScript conversion, `Fun.curry` had its type and implementation improved. However, this increased its output size. For small plugins, it's more overhead than the benefit it brings. This PR removes the `Fun.curry` calls, allowing it to be tree-shaken out. 

As well as reducing size, removing the curry also makes the `Api` method types a bit more correct. The optional nature of the parameters on `removeDraft` and `isEmpty` were not surviving the currying. 

This change also removes the `Cell` value passed through. This `Cell` was created, passed through, mutated, then out-of-scope. This didn't have any net effect.

Paths in the demo page were corrected.

Size reductions when running `yarn build`:

- `dist/tinymce-5.3.0.zip`: 653363 - 653218 = 145 bytes
- `js/tinymce/plugins/autosave/plugin.min.js`: 3485 - 3167 = 318 bytes



