### PR TITLE
TINY-4727: Inserting large base64 encoded images in Safari creates an empty `<img>` tag

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,8 +1,10 @@
 Version 5.3.0 (TBD)
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
     Changed the default icons to be lazy loaded during initialization #TINY-4729
+    Changed so base64 encoded urls are converted to blob urls when content is parsed #TINY-4727
     Fixed the `quickimage` button not restricting the file types to images #TINY-4715
     Fixed table picker breaking in Firefox on low zoom levels #TINY-4728
+    Fixed issue with loading or pasting contents with large base64 encoded images on Safari #TINY-4715
 Version 5.2.1 (TBD)
     Fixed table selection not functioning correctly in Microsoft Edge 44 or higher #TINY-3862
     Fixed table resize handles not functioning correctly in Microsoft Edge #TINY-4160

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -66,7 +66,7 @@ export interface DomParserSettings {
   root_name?: string;
   validate?: boolean;
   inline_styles?: boolean;
-  blobCache?: BlobCache;
+  blob_cache?: BlobCache;
 }
 
 interface DomParser {
@@ -685,7 +685,7 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
       },
 
       dataUri (match) {
-        const { blobCache } = settings;
+        const { blob_cache: blobCache } = settings;
 
         if (blobCache) {
           return Conversions.buildBlob(match.mime, match.base64).fold(

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -13,9 +13,6 @@ import Node from './Node';
 import SaxParser from './SaxParser';
 import Schema from './Schema';
 import { BlobCache } from '../file/BlobCache';
-import { uniqueId } from '../../file/ImageScanner';
-import * as Conversions from '../../file/Conversions';
-import { buildBase64DataUri } from 'tinymce/core/html/Base64Uris';
 
 /**
  * This class parses HTML code into a DOM like structure of nodes it will remove redundant whitespace and make
@@ -681,23 +678,6 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
           }
 
           node = node.parent;
-        }
-      },
-
-      dataUri (match) {
-        const { blob_cache: blobCache } = settings;
-
-        if (blobCache) {
-          return Conversions.buildBlob(match.mime, match.base64).fold(
-            () => buildBase64DataUri(match),
-            (blob) => {
-              const blobInfo = blobCache.create(uniqueId(), blob, match.base64);
-              blobCache.add(blobInfo);
-              return blobInfo.blobUri();
-            }
-          );
-        } else {
-          return buildBase64DataUri(match);
         }
       }
     }, schema);

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -61,6 +61,7 @@ export interface DomParserSettings {
   remove_trailing_brs?: boolean;
   root_name?: string;
   validate?: boolean;
+  inline_styles?: boolean;
 }
 
 interface DomParser {

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializer.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializer.ts
@@ -21,13 +21,13 @@ import * as Zwsp from '../text/Zwsp';
 import * as DomSerializerFilters from './DomSerializerFilters';
 import * as DomSerializerPreProcess from './DomSerializerPreProcess';
 import { isWsPreserveElement } from './ElementType';
+import { WriterSettings } from '../api/html/Writer';
 
 export interface SerializerArgs extends ParserArgs {
   format?: string;
 }
 
-interface DomSerializerSettings extends DomParserSettings, SchemaSettings, SerializerSettings {
-  entity_encoding?: string;
+interface DomSerializerSettings extends DomParserSettings, WriterSettings, SchemaSettings, SerializerSettings {
   url_converter?: URLConverter;
   url_converter_scope?: {};
 }

--- a/modules/tinymce/src/core/main/ts/file/ImageScanner.ts
+++ b/modules/tinymce/src/core/main/ts/file/ImageScanner.ts
@@ -30,7 +30,7 @@ export interface ImageScanner {
 
 let count = 0;
 
-const uniqueId = function (prefix?: string): string {
+export const uniqueId = function (prefix?: string): string {
   return (prefix || 'blobid') + (count++);
 };
 

--- a/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
+++ b/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Id, Obj } from '@ephox/katamari';
+
+export interface Base64UriMatch {
+  mime: string;
+  base64: string;
+}
+
+export interface Base64Extract {
+  prefix: string;
+  uris: Record<string, Base64UriMatch>;
+  html: string;
+}
+
+export const extractBase64DataUris = (html: string): Base64Extract => {
+  const dataImageUri = /data:(image\/[a-z]+);base64,([a-z0-9\+\/=]+)/gi;
+  const chunks = [];
+  const uris = {};
+  const prefix = Id.generate('img');
+  let matches: RegExpExecArray;
+  let index = 0;
+  let count = 0;
+
+  while ((matches = dataImageUri.exec(html))) {
+    const [matchText, mime, base64] = matches;
+    const imageId = prefix + '_' + count++;
+
+    uris[imageId] = { mime, base64 };
+
+    if (index < matches.index) {
+      chunks.push(html.substr(index, matches.index - index));
+    }
+
+    chunks.push(imageId);
+    index = matches.index + matchText.length;
+  }
+
+  if (index === 0) {
+    return { prefix, uris, html };
+  } else {
+    if (index < html.length) {
+      chunks.push(html.substr(index));
+    }
+
+    return { prefix, uris, html: chunks.join('') };
+  }
+};
+
+export const buildBase64DataUri = (match: Base64UriMatch) => {
+  return `data:${match.mime};base64,${match.base64}`;
+};
+
+export const restoreDataUris = (html: string, result: Base64Extract) => {
+  return html.replace(new RegExp(`${result.prefix}_[0-9]+`, 'g'), (imageId) => {
+    return Obj.get(result.uris, imageId).map(buildBase64DataUri).getOr(imageId);
+  });
+};

--- a/modules/tinymce/src/core/main/ts/html/LegacyFilter.ts
+++ b/modules/tinymce/src/core/main/ts/html/LegacyFilter.ts
@@ -8,16 +8,18 @@
 import { Arr } from '@ephox/katamari';
 import Styles from '../api/html/Styles';
 import Tools from '../api/util/Tools';
+import DomParser, { DomParserSettings } from '../api/html/DomParser';
+import Node from '../api/html/Node';
 
-const removeAttrs = function (node, names) {
-  Arr.each(names, function (name) {
+const removeAttrs = (node: Node, names: string[]) => {
+  Arr.each(names, (name) => {
     node.attr(name, null);
   });
 };
 
-const addFontToSpansFilter = function (domParser, styles, fontSizes) {
-  domParser.addNodeFilter('font', function (nodes) {
-    Arr.each(nodes, function (node) {
+const addFontToSpansFilter = (domParser: DomParser, styles: Styles, fontSizes: string[]) => {
+  domParser.addNodeFilter('font', (nodes) => {
+    Arr.each(nodes, (node) => {
       const props = styles.parse(node.attr('style'));
       const color = node.attr('color');
       const face = node.attr('face');
@@ -42,9 +44,9 @@ const addFontToSpansFilter = function (domParser, styles, fontSizes) {
   });
 };
 
-const addStrikeToSpanFilter = function (domParser, styles) {
-  domParser.addNodeFilter('strike', function (nodes) {
-    Arr.each(nodes, function (node) {
+const addStrikeToSpanFilter = (domParser: DomParser, styles: Styles) => {
+  domParser.addNodeFilter('strike', (nodes) => {
+    Arr.each(nodes, (node) => {
       const props = styles.parse(node.attr('style'));
 
       props['text-decoration'] = 'line-through';
@@ -55,7 +57,7 @@ const addStrikeToSpanFilter = function (domParser, styles) {
   });
 };
 
-const addFilters = function (domParser, settings) {
+const addFilters = (domParser: DomParser, settings: DomParserSettings) => {
   const styles = Styles();
 
   if (settings.convert_fonts_to_spans) {
@@ -65,7 +67,7 @@ const addFilters = function (domParser, settings) {
   addStrikeToSpanFilter(domParser, styles);
 };
 
-const register = function (domParser, settings) {
+const register = (domParser: DomParser, settings: DomParserSettings) => {
   if (settings.inline_styles) {
     addFilters(domParser, settings);
   }

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -9,8 +9,9 @@ import Tools from '../api/util/Tools';
 import { isEmpty, paddEmptyNode } from './ParserUtils';
 import Node from '../api/html/Node';
 import { Unicode } from '@ephox/katamari';
+import DomParser, { DomParserSettings } from '../api/html/DomParser';
 
-const register = (parser, settings: any): void => {
+const register = (parser: DomParser, settings: DomParserSettings): void => {
   const schema = parser.schema;
 
   // Remove <br> at end of block elements Gecko and WebKit injects BR elements to
@@ -100,17 +101,17 @@ const register = (parser, settings: any): void => {
     });
   }
 
-  parser.addAttributeFilter('href', function (nodes) {
-    let i = nodes.length, node;
+  parser.addAttributeFilter('href', (nodes) => {
+    let i = nodes.length;
 
-    const appendRel = function (rel) {
-      const parts = rel.split(' ').filter(function (p) {
+    const appendRel = (rel: string) => {
+      const parts = rel.split(' ').filter((p) => {
         return p.length > 0;
       });
       return parts.concat(['noopener']).sort().join(' ');
     };
 
-    const addNoOpener = function (rel) {
+    const addNoOpener = (rel: string) => {
       const newRel = rel ? Tools.trim(rel) : '';
       if (!/\b(noopener)\b/g.test(newRel)) {
         return appendRel(newRel);
@@ -121,7 +122,7 @@ const register = (parser, settings: any): void => {
 
     if (!settings.allow_unsafe_link_target) {
       while (i--) {
-        node = nodes[i];
+        const node = nodes[i];
         if (node.name === 'a' && node.attr('target') === '_blank') {
           node.attr('rel', addNoOpener(node.attr('rel')));
         }
@@ -131,7 +132,7 @@ const register = (parser, settings: any): void => {
 
   // Force anchor names closed, unless the setting "allow_html_in_named_anchor" is explicitly included.
   if (!settings.allow_html_in_named_anchor) {
-    parser.addAttributeFilter('id,name', function (nodes) {
+    parser.addAttributeFilter('id,name', (nodes) => {
       let i = nodes.length, sibling, prevSibling, parent, node;
 
       while (i--) {
@@ -152,7 +153,7 @@ const register = (parser, settings: any): void => {
   }
 
   if (settings.fix_list_elements) {
-    parser.addNodeFilter('ul,ol', function (nodes) {
+    parser.addNodeFilter('ul,ol', (nodes) => {
       let i = nodes.length, node, parentNode;
 
       while (i--) {
@@ -173,7 +174,7 @@ const register = (parser, settings: any): void => {
   }
 
   if (settings.validate && schema.getValidClasses()) {
-    parser.addAttributeFilter('class', function (nodes) {
+    parser.addAttributeFilter('class', (nodes) => {
       let i = nodes.length, node, classList, ci, className, classValue;
       const validClasses = schema.getValidClasses();
       let validClassesMap, valid;

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -13,11 +13,18 @@ import DomParser, { DomParserSettings } from '../api/html/DomParser';
 import { uniqueId } from '../file/ImageScanner';
 import * as Conversions from '../file/Conversions';
 import { parseDataUri } from './Base64Uris';
+import Env from '../api/Env';
+
+const isInternalImageSource = (src: string) => src === Env.transparentSrc;
 
 const registerBase64ImageFilter = (parser: DomParser, settings: DomParserSettings) => {
   const { blob_cache: blobCache } = settings;
   const processImage = (img: Node): void => {
     const inputSrc = img.attr('src');
+
+    if (isInternalImageSource(inputSrc)) {
+      return;
+    }
 
     parseDataUri(inputSrc).map(({ type, data }) => Conversions.buildBlob(type, data).each(
       (blob) => {

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -7,8 +7,10 @@
 
 import Node from '../api/html/Node';
 import { Unicode } from '@ephox/katamari';
+import { DomParserSettings, ParserArgs } from '../api/html/DomParser';
+import Schema, { SchemaMap } from '../api/html/Schema';
 
-const paddEmptyNode = function (settings, args, blockElements, node) {
+const paddEmptyNode = (settings: DomParserSettings, args: ParserArgs, blockElements: SchemaMap, node: Node) => {
   const brPreferred = settings.padd_empty_with_br || args.insert;
 
   if (brPreferred && blockElements[node.name]) {
@@ -18,26 +20,26 @@ const paddEmptyNode = function (settings, args, blockElements, node) {
   }
 };
 
-const isPaddedWithNbsp = function (node) {
+const isPaddedWithNbsp = (node: Node) => {
   return hasOnlyChild(node, '#text') && node.firstChild.value === Unicode.nbsp;
 };
 
-const hasOnlyChild = function (node, name) {
+const hasOnlyChild = (node: Node, name: string) => {
   return node && node.firstChild && node.firstChild === node.lastChild && node.firstChild.name === name;
 };
 
-const isPadded = function (schema, node) {
+const isPadded = (schema: Schema, node: Node) => {
   const rule = schema.getElementRule(node.name);
   return rule && rule.paddEmpty;
 };
 
-const isEmpty = function (schema, nonEmptyElements, whitespaceElements, node) {
-  return node.isEmpty(nonEmptyElements, whitespaceElements, function (node) {
+const isEmpty = (schema: Schema, nonEmptyElements: SchemaMap, whitespaceElements: SchemaMap, node: Node) => {
+  return node.isEmpty(nonEmptyElements, whitespaceElements, (node) => {
     return isPadded(schema, node);
   });
 };
 
-const isLineBreakNode = (node, blockElements) => node && (blockElements[node.name] || node.name === 'br');
+const isLineBreakNode = (node: Node, blockElements: SchemaMap) => node && (blockElements[node.name] || node.name === 'br');
 
 export {
   paddEmptyNode,

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -53,15 +53,15 @@ const appendStyle = function (editor: Editor, text: string) {
 
 const getRootName = (editor: Editor): string => editor.inline ? editor.getElement().nodeName.toLowerCase() : undefined;
 
-const removeUndefined = <T>(obj: Record<string, T>) => {
-  return Obj.filter(obj, (v) => Type.isUndefined(v) === false);
+const removeUndefined = <T>(obj: T): T => {
+  return Obj.filter(obj as Record<string, unknown>, (v) => Type.isUndefined(v) === false) as T;
 };
 
 const mkParserSettings = (editor: Editor): DomParserSettings => {
   const settings = editor.settings;
   const blobCache = editor.editorUpload.blobCache;
 
-  return removeUndefined({
+  return removeUndefined<DomParserSettings>({
     allow_conditional_comments: settings.allow_conditional_comments,
     allow_html_in_named_anchor: settings.allow_html_in_named_anchor,
     allow_script_urls: settings.allow_script_urls,
@@ -84,7 +84,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
 const mkSerializerSettings = (editor: Editor): SerializerSettings => {
   const settings = editor.settings;
 
-  return removeUndefined({
+  return removeUndefined<SerializerSettings>({
     // DomParser settings
     allow_conditional_comments: settings.allow_conditional_comments,
     allow_html_in_named_anchor: settings.allow_html_in_named_anchor,

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -10,13 +10,13 @@ import { Attr, Element, Insert } from '@ephox/sugar';
 import Annotator from '../api/Annotator';
 import DOMUtils from '../api/dom/DOMUtils';
 import Selection from '../api/dom/Selection';
-import DomSerializer from '../api/dom/Serializer';
+import DomSerializer, { SerializerSettings } from '../api/dom/Serializer';
 import Editor from '../api/Editor';
 import EditorUpload from '../api/EditorUpload';
 import Env from '../api/Env';
 import * as Events from '../api/Events';
 import Formatter from '../api/Formatter';
-import DomParser from '../api/html/DomParser';
+import DomParser, { DomParserSettings } from '../api/html/DomParser';
 import Node from '../api/html/Node';
 import Schema from '../api/html/Schema';
 import * as Settings from '../api/Settings';
@@ -37,6 +37,7 @@ import * as SelectionBookmark from '../selection/SelectionBookmark';
 import { hasAnyRanges } from '../selection/SelectionUtils';
 import SelectionOverrides from '../SelectionOverrides';
 import Quirks from '../util/Quirks';
+import { EditorSettings } from '../api/SettingsTypes';
 
 declare const escape: any;
 
@@ -50,8 +51,48 @@ const appendStyle = function (editor: Editor, text: string) {
   Insert.append(head, tag);
 };
 
+const mkParserSettings = (settings: EditorSettings): DomParserSettings => {
+  return {
+    allow_conditional_comments: settings.allow_conditional_comments,
+    allow_html_in_named_anchor: settings.allow_html_in_named_anchor,
+    allow_script_urls: settings.allow_script_urls,
+    allow_unsafe_link_target: settings.allow_unsafe_link_target,
+    convert_fonts_to_spans: settings.convert_fonts_to_spans,
+    fix_list_elements: settings.fix_list_elements,
+    font_size_legacy_values: settings.font_size_legacy_values,
+    forced_root_block: settings.forced_root_block,
+    forced_root_block_attrs: settings.forced_root_block_attrs,
+    padd_empty_with_br: settings.padd_empty_with_br,
+    preserve_cdata: settings.preserve_cdata,
+    remove_trailing_brs: settings.remove_trailing_brs,
+    inline_styles: settings.inline_styles,
+    root_name: settings.root_name,
+    validate: true
+  };
+};
+
+const mkSerializerSettings = (settings: EditorSettings): SerializerSettings => {
+  return {
+    allow_conditional_comments: settings.allow_conditional_comments,
+    allow_html_in_named_anchor: settings.allow_html_in_named_anchor,
+    allow_script_urls: settings.allow_script_urls,
+    allow_unsafe_link_target: settings.allow_unsafe_link_target,
+    convert_fonts_to_spans: settings.convert_fonts_to_spans,
+    fix_list_elements: settings.fix_list_elements,
+    font_size_legacy_values: settings.font_size_legacy_values,
+    forced_root_block: settings.forced_root_block,
+    forced_root_block_attrs: settings.forced_root_block_attrs,
+    padd_empty_with_br: settings.padd_empty_with_br,
+    preserve_cdata: settings.preserve_cdata,
+    remove_trailing_brs: settings.remove_trailing_brs,
+    inline_styles: settings.inline_styles,
+    root_name: settings.root_name,
+    validate: true
+  };
+};
+
 const createParser = function (editor: Editor): DomParser {
-  const parser = DomParser(editor.settings, editor.schema);
+  const parser = DomParser(mkParserSettings(editor.settings), editor.schema);
 
   // Convert src and href into data-mce-src, data-mce-href and data-mce-style
   parser.addAttributeFilter('src,href,style,tabindex', function (nodes, name) {
@@ -256,7 +297,7 @@ const initContentBody = function (editor: Editor, skipWrite?: boolean) {
   });
 
   editor.parser = createParser(editor);
-  editor.serializer = DomSerializer(settings, editor);
+  editor.serializer = DomSerializer(mkSerializerSettings(settings), editor);
   editor.selection = Selection(editor.dom, editor.getWin(), editor.serializer, editor);
   editor.annotator = Annotator(editor);
   editor.formatter = Formatter(editor);

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -77,7 +77,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     inline_styles: settings.inline_styles,
     root_name: getRootName(editor),
     validate: true,
-    blobCache
+    blob_cache: blobCache
   });
 };
 

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -84,58 +84,44 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
 const mkSerializerSettings = (editor: Editor): SerializerSettings => {
   const settings = editor.settings;
 
-  return removeUndefined<SerializerSettings>({
-    // DomParser settings
-    allow_conditional_comments: settings.allow_conditional_comments,
-    allow_html_in_named_anchor: settings.allow_html_in_named_anchor,
-    allow_script_urls: settings.allow_script_urls,
-    allow_unsafe_link_target: settings.allow_unsafe_link_target,
-    convert_fonts_to_spans: settings.convert_fonts_to_spans,
-    fix_list_elements: settings.fix_list_elements,
-    font_size_legacy_values: settings.font_size_legacy_values,
-    forced_root_block: settings.forced_root_block,
-    forced_root_block_attrs: settings.forced_root_block_attrs,
-    padd_empty_with_br: settings.padd_empty_with_br,
-    preserve_cdata: settings.preserve_cdata,
-    remove_trailing_brs: settings.remove_trailing_brs,
-    inline_styles: settings.inline_styles,
-    root_name: getRootName(editor),
-    validate: true,
+  return {
+    ...mkParserSettings(editor),
+    ...removeUndefined<SerializerSettings>({
+      // SerializerSettings
+      url_converter: settings.url_converter,
+      url_converter_scope: settings.url_converter_scope,
 
-    // SerializerSettings
-    url_converter: settings.url_converter,
-    url_converter_scope: settings.url_converter_scope,
+      // Writer settings
+      element_format: settings.element_format,
+      entities: settings.entities,
+      entity_encoding: settings.entity_encoding,
+      indent: settings.indent,
+      indent_after: settings.indent_after,
+      indent_before: settings.indent_before,
 
-    // Writer settings
-    element_format: settings.element_format,
-    entities: settings.entities,
-    entity_encoding: settings.entity_encoding,
-    indent: settings.indent,
-    indent_after: settings.indent_after,
-    indent_before: settings.indent_before,
-
-    // Schema settings
-    block_elements: settings.block_elements,
-    boolean_attributes: settings.boolean_attributes,
-    custom_elements: settings.custom_elements,
-    extended_valid_elements: settings.extended_valid_elements,
-    invalid_elements: settings.invalid_elements,
-    invalid_styles: settings.invalid_styles,
-    move_caret_before_on_enter_elements: settings.move_caret_before_on_enter_elements,
-    non_empty_elements: settings.non_empty_elements,
-    schema: settings.schema,
-    self_closing_elements: settings.self_closing_elements,
-    short_ended_elements: settings.short_ended_elements,
-    special: settings.special,
-    text_block_elements: settings.text_block_elements,
-    text_inline_elements: settings.text_inline_elements,
-    valid_children: settings.valid_children,
-    valid_classes: settings.valid_classes,
-    valid_elements: settings.valid_elements,
-    valid_styles: settings.valid_styles,
-    verify_html: settings.verify_html,
-    whitespace_elements: settings.whitespace_elements,
-  });
+      // Schema settings
+      block_elements: settings.block_elements,
+      boolean_attributes: settings.boolean_attributes,
+      custom_elements: settings.custom_elements,
+      extended_valid_elements: settings.extended_valid_elements,
+      invalid_elements: settings.invalid_elements,
+      invalid_styles: settings.invalid_styles,
+      move_caret_before_on_enter_elements: settings.move_caret_before_on_enter_elements,
+      non_empty_elements: settings.non_empty_elements,
+      schema: settings.schema,
+      self_closing_elements: settings.self_closing_elements,
+      short_ended_elements: settings.short_ended_elements,
+      special: settings.special,
+      text_block_elements: settings.text_block_elements,
+      text_inline_elements: settings.text_inline_elements,
+      valid_children: settings.valid_children,
+      valid_classes: settings.valid_classes,
+      valid_elements: settings.valid_elements,
+      valid_styles: settings.valid_styles,
+      verify_html: settings.verify_html,
+      whitespace_elements: settings.whitespace_elements,
+    })
+  };
 };
 
 const createParser = function (editor: Editor): DomParser {

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -38,6 +38,7 @@ import { hasAnyRanges } from '../selection/SelectionUtils';
 import SelectionOverrides from '../SelectionOverrides';
 import Quirks from '../util/Quirks';
 import { EditorSettings } from '../api/SettingsTypes';
+import { BlobCache } from '../api/file/BlobCache';
 
 declare const escape: any;
 
@@ -51,7 +52,7 @@ const appendStyle = function (editor: Editor, text: string) {
   Insert.append(head, tag);
 };
 
-const mkParserSettings = (settings: EditorSettings): DomParserSettings => {
+const mkParserSettings = (settings: EditorSettings, blobCache: BlobCache): DomParserSettings => {
   return {
     allow_conditional_comments: settings.allow_conditional_comments,
     allow_html_in_named_anchor: settings.allow_html_in_named_anchor,
@@ -67,7 +68,8 @@ const mkParserSettings = (settings: EditorSettings): DomParserSettings => {
     remove_trailing_brs: settings.remove_trailing_brs,
     inline_styles: settings.inline_styles,
     root_name: settings.root_name,
-    validate: true
+    validate: true,
+    blobCache
   };
 };
 
@@ -92,7 +94,7 @@ const mkSerializerSettings = (settings: EditorSettings): SerializerSettings => {
 };
 
 const createParser = function (editor: Editor): DomParser {
-  const parser = DomParser(mkParserSettings(editor.settings), editor.schema);
+  const parser = DomParser(mkParserSettings(editor.settings, editor.editorUpload.blobCache), editor.schema);
 
   // Convert src and href into data-mce-src, data-mce-href and data-mce-style
   parser.addAttributeFilter('src,href,style,tabindex', function (nodes, name) {

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -1,0 +1,134 @@
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { extractBase64DataUris, Base64Extract, buildBase64DataUri, restoreDataUris, Base64UriMatch } from 'tinymce/core/html/Base64Uris';
+import { Obj } from '@ephox/katamari';
+import { Logger } from '@ephox/agar';
+
+UnitTest.test('Base64Uris Test', () => {
+  const replacePrefix = (value: string, prefix: string) => value.replace(/\$prefix/g, prefix);
+  const replaceUrisPrefix = (uris: Record<string, Base64UriMatch>, prefix: string): Record<string, Base64UriMatch> => {
+    return Obj.tupleMap(uris, (value, key) => ({k: replacePrefix(key, prefix), v: value}));
+  };
+
+  const testExtract = (label: string, html: string, expectedExtract: Partial<Base64Extract>) => {
+    Logger.sync(label, () => {
+      const actualExtract = extractBase64DataUris(html);
+      const expectedHtml = replacePrefix(expectedExtract.html, actualExtract.prefix);
+      const expectedUris = replaceUrisPrefix(expectedExtract.uris, actualExtract.prefix);
+
+      Assert.eq('Should be expected html', expectedHtml, actualExtract.html);
+      Assert.eq('Should have expected uris', expectedUris, actualExtract.uris);
+    });
+  };
+
+  Logger.sync('extractBase64DataUris', () => {
+    testExtract(
+      'Should not touch images that is not base64 data uris',
+      '<img src="my.gif"><img src="blob:https://localhost">',
+      {
+        html: '<img src="my.gif"><img src="blob:https://localhost">',
+        uris: {}
+      }
+    );
+
+    testExtract(
+      'Should extract one base64 encoded image from html with just a image',
+      '<img src="data:image/gif;base64,R0/yw==">',
+      {
+        html: '<img src="$prefix_0">',
+        uris: {
+          $prefix_0: {
+            mime: 'image/gif',
+            base64: 'R0/yw=='
+          }
+        }
+      }
+    );
+
+    testExtract(
+      'Should extract one base64 encoded image from html with text before/after the image',
+      'a<img src="data:image/gif;base64,R0/yw==">b',
+      {
+        html: 'a<img src="$prefix_0">b',
+        uris: {
+          $prefix_0: {
+            mime: 'image/gif',
+            base64: 'R0/yw=='
+          }
+        }
+      }
+    );
+
+    testExtract(
+      'Should extract three base64 encoded images with different mimes from html',
+      '<img src="data:image/gif;base64,R0/yw=="><img src="data:image/png;base64,R1/yw=="><img src="data:image/jpeg;base64,R2/yw==">',
+      {
+        html: '<img src="$prefix_0"><img src="$prefix_1"><img src="$prefix_2">',
+        uris: {
+          $prefix_0: {
+            mime: 'image/gif',
+            base64: 'R0/yw=='
+          },
+          $prefix_1: {
+            mime: 'image/png',
+            base64: 'R1/yw=='
+          },
+          $prefix_2: {
+            mime: 'image/jpeg',
+            base64: 'R2/yw=='
+          }
+        }
+      }
+    );
+  });
+
+  Logger.sync('buildBase64DataUri', () => {
+    Assert.eq('Should be a gif base64 image', 'data:image/gif;base64,R0/yw==', buildBase64DataUri({
+      mime: 'image/gif',
+      base64: 'R0/yw=='
+    }));
+
+    Assert.eq('Should be a png base64 image', 'data:image/png;base64,R1/yw==', buildBase64DataUri({
+      mime: 'image/png',
+      base64: 'R1/yw=='
+    }));
+
+    Assert.eq('Should be a jpeg base64 image', 'data:image/jpeg;base64,R2/yw==', buildBase64DataUri({
+      mime: 'image/jpeg',
+      base64: 'R2/yw=='
+    }));
+  });
+
+  const testRestoreDataUris = (label, inputResult, inputHtml, expectedHtml) => {
+    Logger.sync(label, () => {
+      const actualHtml = restoreDataUris(inputHtml, inputResult);
+
+      Assert.eq('Should be the extected html', expectedHtml, actualHtml);
+    });
+  };
+
+  Logger.sync('restoreDataUris', () => {
+    testRestoreDataUris(
+      'Should restore image uris to base64 uris',
+      {
+        prefix: 'img_123',
+        html: '<img src="img_123_0"><img src="img_123_1"><img src="img_123_2">',
+        uris: {
+          img_123_0: {
+            mime: 'image/gif',
+            base64: 'R0/yw=='
+          },
+          img_123_1: {
+            mime: 'image/png',
+            base64: 'R1/yw=='
+          },
+          img_123_2: {
+            mime: 'image/jpeg',
+            base64: 'R2/yw=='
+          }
+        }
+      },
+      '<img src="img_123_0"><img src="img_123_1"><img src="img_123_2">',
+      '<img src="data:image/gif;base64,R0/yw=="><img src="data:image/png;base64,R1/yw=="><img src="data:image/jpeg;base64,R2/yw==">'
+    );
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/EditorPaddEmptyWithBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorPaddEmptyWithBrTest.ts
@@ -1,0 +1,39 @@
+import { Pipeline } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.core.EditorPaddEmptyWithBrTest', (success, failure) => {
+  const suite = LegacyUnit.createSuite<Editor>();
+
+  Theme();
+
+  suite.test('Padd empty elements with br', (editor) => {
+    editor.setContent('<p>a</p><p></p>');
+    LegacyUnit.equal(editor.getContent(), '<p>a</p><p><br /></p>');
+  });
+
+  suite.test('Padd empty elements with br on insert at caret', (editor) => {
+    editor.setContent('<p>a</p>');
+    LegacyUnit.setSelection(editor, 'p', 1);
+    editor.insertContent('<p>b</p><p></p>');
+    LegacyUnit.equal(editor.getContent(), '<p>a</p><p>b</p><p><br /></p>');
+  });
+
+  TinyLoader.setup((editor, onSuccess, onFailure) => {
+    Pipeline.async({}, suite.toSteps(editor), () => {
+      onSuccess();
+    }, onFailure);
+  }, {
+    selector: 'textarea',
+    add_unload_trigger: false,
+    disable_nodechange: true,
+    custom_elements: 'custom1,~custom2',
+    extended_valid_elements: 'custom1,custom2,script[*]',
+    entities: 'raw',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    padd_empty_with_br: true
+  }, success, failure);
+});

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -409,22 +409,6 @@ UnitTest.asynctest('browser.tinymce.core.EditorTest', function (success, failure
     LegacyUnit.equal(editor.getContent(), '<p>!\u200b!\u200b!</p>');
   });
 
-  suite.test('Padd empty elements with br', function (editor) {
-    editor.settings.padd_empty_with_br = true;
-    editor.setContent('<p>a</p><p></p>');
-    LegacyUnit.equal(editor.getContent(), '<p>a</p><p><br /></p>');
-    delete editor.settings.padd_empty_with_br;
-  });
-
-  suite.test('Padd empty elements with br on insert at caret', function (editor) {
-    editor.settings.padd_empty_with_br = true;
-    editor.setContent('<p>a</p>');
-    LegacyUnit.setSelection(editor, 'p', 1);
-    editor.insertContent('<p>b</p><p></p>');
-    LegacyUnit.equal(editor.getContent(), '<p>a</p><p>b</p><p><br /></p>');
-    delete editor.settings.padd_empty_with_br;
-  });
-
   suite.test('Preserve whitespace pre elements', function (editor) {
     editor.setContent('<pre> </pre>');
     LegacyUnit.equal(editor.getContent(), '<pre> </pre>');

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
@@ -1,0 +1,37 @@
+import { Pipeline } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.core.FormatterRemoveForcedRootBlockFalseTest', (success, failure) => {
+  const suite = LegacyUnit.createSuite<Editor>();
+
+  Theme();
+
+  const getContent = (editor: Editor) {
+    return editor.getContent().toLowerCase().replace(/[\r]+/g, '');
+  };
+
+  suite.test('Remove block format from first block with forced_root_block: false', (editor) => {
+    editor.formatter.register('format', { block: 'h1' });
+    editor.getBody().innerHTML = '<h1>a</h1>b';
+    LegacyUnit.setSelection(editor, 'h1', 0, 'h1', 1);
+    editor.formatter.remove('format');
+    LegacyUnit.equal(getContent(editor), 'a<br />b', 'Lines should be separated with br');
+  });
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
+  }, {
+    indent: false,
+    extended_valid_elements: 'b,i,span[style|contenteditable|class]',
+    entities: 'raw',
+    valid_styles: {
+      '*': 'color,font-size,font-family,background-color,font-weight,font-style,text-decoration,float,' +
+      'margin,margin-top,margin-right,margin-bottom,margin-left,display,text-align'
+    },
+    base_url: '/project/tinymce/js/tinymce',
+    forced_root_block: false
+  }, success, failure);
+});

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
@@ -9,7 +9,7 @@ UnitTest.asynctest('browser.tinymce.core.FormatterRemoveForcedRootBlockFalseTest
 
   Theme();
 
-  const getContent = (editor: Editor) {
+  const getContent = (editor: Editor) => {
     return editor.getContent().toLowerCase().replace(/[\r]+/g, '');
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -480,23 +480,12 @@ UnitTest.asynctest('browser.tinymce.core.FormatterRemoveTest', function (success
     );
   });
 
-  suite.test('Remove block format from first block with forced_root_block: false', function (editor) {
-    editor.settings.forced_root_block = false;
-    editor.formatter.register('format', { block: 'h1' });
-    editor.getBody().innerHTML = '<h1>a</h1>b';
-    LegacyUnit.setSelection(editor, 'h1', 0, 'h1', 1);
-    editor.formatter.remove('format');
-    LegacyUnit.equal(getContent(editor), 'a<br />b', 'Lines should be separated with br');
-    editor.settings.forced_root_block = 'p';
-  });
-
   suite.test('Remove format from first position in table cell', function (editor) {
     editor.formatter.register('format', { inline: 'b' });
     editor.getBody().innerHTML = '<table><tbody><tr><td><b>ab</b> cd</td></tr></tbody></table>';
     LegacyUnit.setSelection(editor, 'b', 0, 'b', 2);
     editor.formatter.remove('format');
     LegacyUnit.equal(getContent(editor), '<table><tbody><tr><td>ab cd</td></tr></tbody></table>', 'Should have removed format.');
-    editor.settings.forced_root_block = 'p';
   });
 
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentForcedRootBlockTest.ts
@@ -1,0 +1,25 @@
+import { GeneralSteps, Logger, Pipeline } from '@ephox/agar';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import Theme from 'tinymce/themes/silver/Theme';
+import { UnitTest } from '@ephox/bedrock-client';
+
+UnitTest.asynctest('browser.tinymce.core.content.EditorContentForcedRootBlockTest', (success, failure) => {
+  Theme();
+
+  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+    const tinyApis = TinyApis(editor);
+
+    Pipeline.async({}, [
+      Logger.t('getContent empty editor depending on forced_root_block setting', GeneralSteps.sequence([
+        tinyApis.sSetRawContent('<p><br></p>'),
+        tinyApis.sAssertContent('<p>&nbsp;</p>'),
+        tinyApis.sSetRawContent('<div><br></div>'),
+        tinyApis.sAssertContent('')
+      ]))
+    ], onSuccess, onFailure);
+  }, {
+    base_url: '/project/tinymce/js/tinymce',
+    inline: true,
+    forced_root_block: 'div'
+  }, success, failure);
+});

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -92,14 +92,6 @@ UnitTest.asynctest('browser.tinymce.core.content.EditorContentTest', (success, f
           editor.setContent(getFontTree());
           Assertions.assertHtml('Should be expected filtered html', '<span style="font-size: 300%;">x</span>', <string> EditorContent.getContent(editor));
         })
-      ])),
-      Logger.t('getContent empty editor depending on forced_root_block setting', GeneralSteps.sequence([
-        tinyApis.sSetSetting('forced_root_block', 'div'),
-        tinyApis.sSetRawContent('<p><br></p>'),
-        tinyApis.sAssertContent('<p>&nbsp;</p>'),
-        tinyApis.sSetRawContent('<div><br></div>'),
-        tinyApis.sAssertContent(''),
-        tinyApis.sSetSetting('forced_root_block', 'p')
       ]))
     ], onSuccess, onFailure);
   }, {

--- a/modules/tinymce/src/core/test/ts/browser/delete/OutdentForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/OutdentForcedRootBlockFalseTest.ts
@@ -4,11 +4,11 @@ import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.core.delete.DeindentTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.core.delete.OutdentForcedRootBlockFalseTest', (success, failure) => {
   Theme();
 
-  const sTestDeleteOrBackspaceKey = function (editor: Editor, tinyApis: TinyApis, tinyActions: TinyActions, key: number) {
-    return function (setupHtml: string, setupPath: number[], setupOffset: number, expectedHtml: string, expectedPath: number[], expectedOffset: number) {
+  const sTestDeleteOrBackspaceKey = (editor: Editor, tinyApis: TinyApis, tinyActions: TinyActions, key: number) => {
+    return (setupHtml: string, setupPath: number[], setupOffset: number, expectedHtml: string, expectedPath: number[], expectedOffset: number) => {
       return GeneralSteps.sequence([
         tinyApis.sSetContent(setupHtml),
         tinyApis.sSetCursor(setupPath, setupOffset),
@@ -22,27 +22,28 @@ UnitTest.asynctest('browser.tinymce.core.delete.DeindentTest', function (success
     };
   };
 
-  const sNormalizeBody = function (editor: Editor) {
-    return Step.sync(function () {
+  const sNormalizeBody = (editor: Editor) => {
+    return Step.sync(() => {
       editor.getBody().normalize();
     });
   };
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
     const tinyActions = TinyActions(editor);
     const sTestBackspace = sTestDeleteOrBackspaceKey(editor, tinyApis, tinyActions, Keys.backspace());
 
     Pipeline.async({}, [
       tinyApis.sFocus(),
-      Logger.t('Backspace key on text', GeneralSteps.sequence([
-        sTestBackspace('<p>a</p>', [0, 0], 0, '<p>a</p>', [0, 0], 0), // outdent
-        sTestBackspace('<p>aa</p>', [0, 0], 1, '<p style="padding-left: 40px;">aa</p>', [0, 0], 1), // no outdent
-        sTestBackspace('<p>a</p><p>b</p>', [1, 0], 0, '<p>a</p>\n<p>b</p>', [1, 0], 0), // outdent
-        sTestBackspace('<p>a</p><p>bb</p>', [1, 0], 1, '<p>a</p>\n<p style="padding-left: 40px;">bb</p>', [1, 0], 1), // no outdent
+      Logger.t('Backspace key on text with forced_root_block: false', GeneralSteps.sequence([
+        sTestBackspace('a', [0], 0, '<div>a</div>', [0, 0], 0), // outdent
+        sTestBackspace('aa', [0], 1, '<div style="padding-left: 40px;">aa</div>', [0, 0], 1), // no outdent
+        sTestBackspace('a <br>b', [2], 0, 'a\n<div>b</div>', [1, 0], 0), // outdent
+        sTestBackspace('aa<br>bb', [2], 1, 'aa\n<div style="padding-left: 40px;">bb</div>', [1, 0], 1), // no outdent
       ]))
     ], onSuccess, onFailure);
   }, {
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    forced_root_block: false
   }, success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -5,6 +5,7 @@ import { LegacyUnit } from '@ephox/mcagar';
 import DomParser from 'tinymce/core/api/html/DomParser';
 import Schema from 'tinymce/core/api/html/Schema';
 import Serializer from 'tinymce/core/api/html/Serializer';
+import { BlobCache } from 'tinymce/core/api/file/BlobCache';
 
 UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success, failure) {
   const suite = LegacyUnit.createSuite();
@@ -717,6 +718,34 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
 
     Assertions.assertEq('Should be expected filter', {name: 'attr', callbacks: [cb1] }, attrFilters[attrFilters.length - 1]);
     Assertions.assertEq('Should be extected filter', {name: 'node', callbacks: [cb2] }, nodeFilters[nodeFilters.length - 1]);
+  });
+
+  suite.test('extract base64 uris to blobcache if blob cache is provided', () => {
+    const blobCache = BlobCache();
+    const parser = DomParser({ blobCache });
+    const base64 = 'R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==';
+    const base64Uri = `data:image/gif;base64,${base64}`;
+    const serializedHtml = serializer.serialize(parser.parse(`<p><img src="${base64Uri}" /></p>`));
+    const blobInfo = blobCache.findFirst((bi) => bi.base64() === base64);
+    const blobUri = blobInfo.blobUri();
+
+    Assertions.assertEq(
+      'Should be html with blob uri',
+      `<p><img src="${blobUri}" /></p>`,
+      serializedHtml
+    );
+  });
+
+  suite.test('do not extract base64 uris if blob cache is not provided', () => {
+    const parser = DomParser();
+    const html = '<p><img src="data:image/gif;base64,R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==" /></p>';
+    const serializedHtml = serializer.serialize(parser.parse(html));
+
+    Assertions.assertEq(
+      'Should be html with base64 uri retained',
+      html,
+      serializedHtml
+    );
   });
 
   Pipeline.async({}, suite.toSteps({}), function () {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -722,7 +722,7 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
 
   suite.test('extract base64 uris to blobcache if blob cache is provided', () => {
     const blobCache = BlobCache();
-    const parser = DomParser({ blobCache });
+    const parser = DomParser({ blob_cache: blobCache });
     const base64 = 'R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==';
     const base64Uri = `data:image/gif;base64,${base64}`;
     const serializedHtml = serializer.serialize(parser.parse(`<p><img src="${base64Uri}" /></p>`));

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -734,6 +734,8 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
       `<p><img src="${blobUri}" /></p>`,
       serializedHtml
     );
+
+    blobCache.destroy();
   });
 
   suite.test('do not extract base64 uris if blob cache is not provided', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -6,6 +6,7 @@ import DomParser from 'tinymce/core/api/html/DomParser';
 import Schema from 'tinymce/core/api/html/Schema';
 import Serializer from 'tinymce/core/api/html/Serializer';
 import { BlobCache } from 'tinymce/core/api/file/BlobCache';
+import Env from 'tinymce/core/api/Env';
 
 UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success, failure) {
   const suite = LegacyUnit.createSuite();
@@ -733,6 +734,21 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
       'Should be html with blob uri',
       `<p><img src="${blobUri}" /></p>`,
       serializedHtml
+    );
+
+    blobCache.destroy();
+  });
+
+  suite.test('do not extract base64 uris for transparent images used by for example the page break plugin', () => {
+    const blobCache = BlobCache();
+    const parser = DomParser({ blob_cache: blobCache });
+    const html = `<p><img src="${Env.transparentSrc}" /></p>`;
+    const root = parser.parse(html);
+
+    Assertions.assertEq(
+      'Should be the unchanged transparent image source',
+      Env.transparentSrc,
+      root.getAll('img')[0].attr('src')
     );
 
     blobCache.destroy();

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -993,6 +993,55 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', function (success,
     );
   });
 
+  suite.test('Retain base64 images', function () {
+    const counter = createCounter(writer);
+    const parser = SaxParser(counter, schema);
+
+    writer.reset();
+    parser.parse('a<img src="data:image/gif;base64,R0/yw==" /><img src="data:image/jpeg;base64,R1/yw==" /><!-- <img src="data:image/jpeg;base64,R1/yw==" /> -->b');
+    LegacyUnit.equal(writer.getContent(), 'a<img src="data:image/gif;base64,R0/yw==" /><img src="data:image/jpeg;base64,R1/yw==" /><!-- <img src="data:image/jpeg;base64,R1/yw==" /> -->b');
+  });
+
+  suite.test('Replace base64 images with custom string', function () {
+    const parser = SaxParser({
+      comment (text) {
+        writer.comment(text);
+      },
+
+      cdata (text) {
+        writer.cdata(text);
+      },
+
+      text (text, raw) {
+        writer.text(text, raw);
+      },
+
+      start (name, attrs, empty) {
+        writer.start(name, attrs, empty);
+      },
+
+      end (name) {
+        writer.end(name);
+      },
+
+      pi (name, text) {
+        writer.pi(name, text);
+      },
+
+      doctype (text) {
+        writer.doctype(text);
+      },
+
+      dataUri (match) {
+        return `custom:${match.mime},${match.base64}`;
+      }
+    }, schema);
+
+    writer.reset();
+    parser.parse('a<img src="data:image/gif;base64,R0/yw==" /><img src="data:image/jpeg;base64,R1/yw==" />b');
+    LegacyUnit.equal(writer.getContent(), 'a<img src=\"custom:image/gif,R0/yw==\" /><img src=\"custom:image/jpeg,R1/yw==\" />b');
+  });
+
   Pipeline.async({}, suite.toSteps({}), function () {
     success();
   }, failure);

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -1002,46 +1002,6 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', function (success,
     LegacyUnit.equal(writer.getContent(), 'a<img src="data:image/gif;base64,R0/yw==" /><img src="data:image/jpeg;base64,R1/yw==" /><!-- <img src="data:image/jpeg;base64,R1/yw==" /> -->b');
   });
 
-  suite.test('Replace base64 images with custom string', function () {
-    const parser = SaxParser({
-      comment (text) {
-        writer.comment(text);
-      },
-
-      cdata (text) {
-        writer.cdata(text);
-      },
-
-      text (text, raw) {
-        writer.text(text, raw);
-      },
-
-      start (name, attrs, empty) {
-        writer.start(name, attrs, empty);
-      },
-
-      end (name) {
-        writer.end(name);
-      },
-
-      pi (name, text) {
-        writer.pi(name, text);
-      },
-
-      doctype (text) {
-        writer.doctype(text);
-      },
-
-      dataUri (match) {
-        return `custom:${match.mime},${match.base64}`;
-      }
-    }, schema);
-
-    writer.reset();
-    parser.parse('a<img src="data:image/gif;base64,R0/yw==" /><img src="data:image/jpeg;base64,R1/yw==" />b');
-    LegacyUnit.equal(writer.getContent(), 'a<img src=\"custom:image/gif,R0/yw==\" /><img src=\"custom:image/jpeg,R1/yw==\" />b');
-  });
-
   Pipeline.async({}, suite.toSteps({}), function () {
     success();
   }, failure);

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockAttrsTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockAttrsTest.ts
@@ -1,0 +1,54 @@
+import { Pipeline, Log } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('tinymce.lists.browser.RemoveForcedRootBlockAttrsTest', (success, failure) => {
+  const suite = LegacyUnit.createSuite<Editor>();
+
+  Plugin();
+  Theme();
+
+  suite.test('TestCase-TBA: Lists: Remove UL with forced_root_block_attrs', (editor) => {
+    editor.getBody().innerHTML = LegacyUnit.trimBrs(
+      '<ul>' +
+      '<li data-editor="1">a</li>' +
+      '</ul>'
+    );
+
+    editor.focus();
+    LegacyUnit.setSelection(editor, 'li', 0);
+    LegacyUnit.execCommand(editor, 'InsertUnorderedList');
+
+    LegacyUnit.equal(editor.getContent(),
+      '<p data-editor="1">a</p>'
+    );
+    LegacyUnit.equal(editor.selection.getStart().nodeName, 'P');
+  });
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    Pipeline.async({}, Log.steps('TBA', 'Link: Remove tests', suite.toSteps(editor)), onSuccess, onFailure);
+  }, {
+    plugins: 'lists',
+    add_unload_trigger: false,
+    disable_nodechange: true,
+    indent: false,
+    entities: 'raw',
+    valid_elements:
+      'li[style|class|data-custom],ol[style|class|data-custom],' +
+      'ul[style|class|data-custom],dl,dt,dd,em,strong,span,#p,div,br',
+    valid_styles: {
+      '*': 'color,font-size,font-family,background-color,font-weight,' +
+        'font-style,text-decoration,float,margin,margin-top,margin-right,' +
+        'margin-bottom,margin-left,display,position,top,left,list-style-type'
+    },
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+    forced_root_block_attrs: {
+      'data-editor': '1'
+    }
+  }, success, failure);
+});

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
@@ -1,0 +1,92 @@
+import { Pipeline, Log } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('tinymce.lists.browser.RemoveForcedRootBlockFalseTest', (success, failure) => {
+  const suite = LegacyUnit.createSuite<Editor>();
+
+  Plugin();
+  Theme();
+
+  suite.test('TestCase-TBA: Lists: Remove UL with single LI in BR mode', function (editor) {
+    editor.getBody().innerHTML = LegacyUnit.trimBrs(
+      '<ul>' +
+      '<li>a</li>' +
+      '</ul>'
+    );
+
+    editor.focus();
+    LegacyUnit.setSelection(editor, 'li', 1);
+    LegacyUnit.execCommand(editor, 'InsertUnorderedList');
+
+    LegacyUnit.equal(editor.getContent(),
+      'a'
+    );
+    LegacyUnit.equal(editor.selection.getStart().nodeName, 'BODY');
+  });
+
+  suite.test('TestCase-TBA: Lists: Remove UL with multiple LI in BR mode', function (editor) {
+    editor.getBody().innerHTML = LegacyUnit.trimBrs(
+      '<ul>' +
+      '<li>a</li>' +
+      '<li>b</li>' +
+      '</ul>'
+    );
+
+    editor.focus();
+    LegacyUnit.setSelection(editor, 'li:first', 1, 'li:last', 1);
+    LegacyUnit.execCommand(editor, 'InsertUnorderedList');
+
+    LegacyUnit.equal(editor.getContent(),
+      'a<br />' +
+      'b'
+    );
+    LegacyUnit.equal(editor.selection.getStart().nodeName, 'BODY');
+  });
+
+  suite.test('TestCase-TBA: Lists: Remove empty UL between two textblocks in BR mode', function (editor) {
+    editor.getBody().innerHTML = LegacyUnit.trimBrs(
+      '<div>a</div>' +
+      '<ul>' +
+      '<li></li>' +
+      '</ul>' +
+      '<div>b</div>'
+    );
+
+    editor.focus();
+    LegacyUnit.setSelection(editor, 'li:first', 0);
+    LegacyUnit.execCommand(editor, 'InsertUnorderedList');
+
+    LegacyUnit.equal(editor.getContent(),
+      '<div>a</div>' +
+      '<br />' +
+      '<div>b</div>'
+    );
+    LegacyUnit.equal(editor.selection.getStart().nodeName, 'BR');
+  });
+
+  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+    Pipeline.async({}, Log.steps('TBA', 'Link: Remove tests', suite.toSteps(editor)), onSuccess, onFailure);
+  }, {
+    plugins: 'lists',
+    add_unload_trigger: false,
+    disable_nodechange: true,
+    indent: false,
+    entities: 'raw',
+    valid_elements:
+      'li[style|class|data-custom],ol[style|class|data-custom],' +
+      'ul[style|class|data-custom],dl,dt,dd,em,strong,span,#p,div,br',
+    valid_styles: {
+      '*': 'color,font-size,font-family,background-color,font-weight,' +
+        'font-style,text-decoration,float,margin,margin-top,margin-right,' +
+        'margin-bottom,margin-left,display,position,top,left,list-style-type'
+    },
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+    forced_root_block: false
+  }, success, failure);
+});

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
@@ -307,50 +307,6 @@ UnitTest.asynctest('tinymce.lists.browser.RemoveTest', (success, failure) => {
     LegacyUnit.equal(editor.selection.getStart().nodeName, 'P');
   });
 
-  suite.test('TestCase-TBA: Lists: Remove UL with single LI in BR mode', function (editor) {
-    editor.settings.forced_root_block = false;
-
-    editor.getBody().innerHTML = LegacyUnit.trimBrs(
-      '<ul>' +
-      '<li>a</li>' +
-      '</ul>'
-    );
-
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li', 1);
-    LegacyUnit.execCommand(editor, 'InsertUnorderedList');
-
-    LegacyUnit.equal(editor.getContent(),
-      'a'
-    );
-    LegacyUnit.equal(editor.selection.getStart().nodeName, 'BODY');
-
-    editor.settings.forced_root_block = 'p';
-  });
-
-  suite.test('TestCase-TBA: Lists: Remove UL with multiple LI in BR mode', function (editor) {
-    editor.settings.forced_root_block = false;
-
-    editor.getBody().innerHTML = LegacyUnit.trimBrs(
-      '<ul>' +
-      '<li>a</li>' +
-      '<li>b</li>' +
-      '</ul>'
-    );
-
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li:first', 1, 'li:last', 1);
-    LegacyUnit.execCommand(editor, 'InsertUnorderedList');
-
-    LegacyUnit.equal(editor.getContent(),
-      'a<br />' +
-      'b'
-    );
-    LegacyUnit.equal(editor.selection.getStart().nodeName, 'BODY');
-
-    editor.settings.forced_root_block = 'p';
-  });
-
   suite.test('TestCase-TBA: Lists: Remove empty UL between two textblocks', function (editor) {
     editor.getBody().innerHTML = LegacyUnit.trimBrs(
       '<div>a</div>' +
@@ -453,56 +409,6 @@ UnitTest.asynctest('tinymce.lists.browser.RemoveTest', (success, failure) => {
         '<li>c</li>' +
       '</ul>'
     );
-  });
-
-  suite.test('TestCase-TBA: Lists: Remove empty UL between two textblocks in BR mode', function (editor) {
-    editor.settings.forced_root_block = false;
-
-    editor.getBody().innerHTML = LegacyUnit.trimBrs(
-      '<div>a</div>' +
-      '<ul>' +
-      '<li></li>' +
-      '</ul>' +
-      '<div>b</div>'
-    );
-
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li:first', 0);
-    LegacyUnit.execCommand(editor, 'InsertUnorderedList');
-
-    LegacyUnit.equal(editor.getContent(),
-      '<div>a</div>' +
-      '<br />' +
-      '<div>b</div>'
-    );
-    LegacyUnit.equal(editor.selection.getStart().nodeName, 'BR');
-
-    editor.settings.forced_root_block = 'p';
-  });
-
-  suite.test('TestCase-TBA: Lists: Remove UL with forced_root_block_attrs', function (editor) {
-    editor.settings.forced_root_block = 'p';
-    editor.settings.forced_root_block_attrs = {
-      'data-editor': '1'
-    };
-
-    editor.getBody().innerHTML = LegacyUnit.trimBrs(
-      '<ul>' +
-      '<li data-editor="1">a</li>' +
-      '</ul>'
-    );
-
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li', 0);
-    LegacyUnit.execCommand(editor, 'InsertUnorderedList');
-
-    LegacyUnit.equal(editor.getContent(),
-      '<p data-editor="1">a</p>'
-    );
-    LegacyUnit.equal(editor.selection.getStart().nodeName, 'P');
-
-    editor.settings.forced_root_block = 'p';
-    delete editor.settings.forced_root_block_attrs;
   });
 
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -458,8 +458,8 @@ const registerEventsAndFilters = (editor: Editor, pasteBin: PasteBin, pasteForma
       return src.indexOf('webkit-fake-url') === 0;
     };
 
-    const isBlobUri = (src: string) => {
-      return src.indexOf('blob:') === 0;
+    const isDataUri = (src: string) => {
+      return src.indexOf('data:') === 0;
     };
 
     if (!editor.settings.paste_data_images && isPasteInsert(args)) {
@@ -475,7 +475,7 @@ const registerEventsAndFilters = (editor: Editor, pasteBin: PasteBin, pasteForma
         // Safari on Mac produces webkit-fake-url see: https://bugs.webkit.org/show_bug.cgi?id=49141
         if (isWebKitFakeUrl(src)) {
           remove(nodes[i]);
-        } else if (!editor.settings.allow_html_data_urls && isBlobUri(src)) {
+        } else if (!editor.settings.allow_html_data_urls && isDataUri(src)) {
           remove(nodes[i]);
         }
       }

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -458,8 +458,8 @@ const registerEventsAndFilters = (editor: Editor, pasteBin: PasteBin, pasteForma
       return src.indexOf('webkit-fake-url') === 0;
     };
 
-    const isDataUri = (src) => {
-      return src.indexOf('data:') === 0;
+    const isBlobUri = (src: string) => {
+      return src.indexOf('blob:') === 0;
     };
 
     if (!editor.settings.paste_data_images && isPasteInsert(args)) {
@@ -475,7 +475,7 @@ const registerEventsAndFilters = (editor: Editor, pasteBin: PasteBin, pasteForma
         // Safari on Mac produces webkit-fake-url see: https://bugs.webkit.org/show_bug.cgi?id=49141
         if (isWebKitFakeUrl(src)) {
           remove(nodes[i]);
-        } else if (!editor.settings.allow_html_data_urls && isDataUri(src)) {
+        } else if (!editor.settings.allow_html_data_urls && isBlobUri(src)) {
           remove(nodes[i]);
         }
       }

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
@@ -189,7 +189,7 @@ UnitTest.asynctest('tinymce.plugins.paste.browser.ImagePasteTest', (success, fai
 
     waitForSelector(editor, 'img').then(function () {
       LegacyUnit.equal(editor.getContent(), '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '" />a</p>');
-      LegacyUnit.strictEqual(editor.dom.select('img')[0].src.indexOf('data:'), 0);
+      LegacyUnit.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
 
       done();
     }).catch(die);
@@ -213,7 +213,7 @@ UnitTest.asynctest('tinymce.plugins.paste.browser.ImagePasteTest', (success, fai
 
     waitForSelector(editor, 'img').then(function () {
       LegacyUnit.equal(editor.getContent(), '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '" />a</p>');
-      LegacyUnit.strictEqual(editor.dom.select('img')[0].src.indexOf('data:'), 0);
+      LegacyUnit.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
 
       done();
     }).catch(die);

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginForcedRootBlockFalseTest.ts
@@ -1,0 +1,35 @@
+import {GeneralSteps, Pipeline, Step } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
+
+import TextpatternPlugin from 'tinymce/plugins/textpattern/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+import * as Utils from '../module/test/Utils';
+
+UnitTest.asynctest('browser.tinymce.plugins.textpattern.TextPatternPluginForcedRootBlockFalseTest', (success, failure) => {
+  TextpatternPlugin();
+  Theme();
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+    const tinyActions = TinyActions(editor);
+
+    const steps = Utils.withTeardown([
+      Step.label('inline format with forced_root_block: false', GeneralSteps.sequence([
+        Utils.sSetContentAndPressEnter(tinyApis, tinyActions, '**a**', 5, [0], false),
+        Step.label('Check bold format was applied', tinyApis.sAssertContentStructure(Utils.forcedRootBlockInlineStructHelper('strong', 'a')))
+      ])),
+      Step.label('block format with forced_root_block: false', GeneralSteps.sequence([
+        Utils.sSetContentAndPressEnter(tinyApis, tinyActions, '# heading 1', 11, [0], false),
+        Step.label('Check heading format was applied', tinyApis.sAssertContentStructure(Utils.forcedRootBlockStructHelper('h1', ' heading 1'))),
+      ]))
+    ], tinyApis.sSetContent(''));
+
+    Pipeline.async({}, steps, onSuccess, onFailure);
+  }, {
+    plugins: 'textpattern lists',
+    base_url: '/project/tinymce/js/tinymce',
+    forced_root_block: false
+  }, success, failure);
+});

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginForcedRootBlockFalseTest.ts
@@ -1,4 +1,4 @@
-import {GeneralSteps, Pipeline, Step } from '@ephox/agar';
+import { GeneralSteps, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
 

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginTest.ts
@@ -167,18 +167,6 @@ UnitTest.asynctest('browser.tinymce.plugins.textpattern.TextPatternPluginTest', 
         Utils.sSetContentAndPressEnter(tinyApis, tinyActions, '<span data-mce-spellcheck="invalid">1</span>. a', 3, [0, 1]),
         tinyApis.sAssertContentPresence({ ol: 1, li: 2 })
       ])),
-      Step.label('inline format with forced_root_block: false', GeneralSteps.sequence([
-        tinyApis.sSetSetting('forced_root_block', false),
-        Utils.sSetContentAndPressEnter(tinyApis, tinyActions, '**a**', 5, [0], false),
-        Step.label('Check bold format was applied', tinyApis.sAssertContentStructure(Utils.forcedRootBlockInlineStructHelper('strong', 'a'))),
-        tinyApis.sDeleteSetting('forced_root_block')
-      ])),
-      Step.label('block format with forced_root_block: false', GeneralSteps.sequence([
-        tinyApis.sSetSetting('forced_root_block', false),
-        Utils.sSetContentAndPressEnter(tinyApis, tinyActions, '# heading 1', 11, [0], false),
-        Step.label('Check heading format was applied', tinyApis.sAssertContentStructure(Utils.forcedRootBlockStructHelper('h1', ' heading 1'))),
-        tinyApis.sDeleteSetting('forced_root_block')
-      ])),
       Step.label('getPatterns/setPatterns', Step.sync(function () {
         // Store the original patterns
         const origPatterns = editor.plugins.textpattern.getPatterns();


### PR DESCRIPTION
This fixes a github community bug but it's also something we need for RTC basically we want to avoid having base64 encoded attributes in the editor and let the scanner convert them to blobs. Instead this will convert everything upfront to blobs when content is inserted into the editor.

I also changed the DomParser and DomSerializer setups so they don't get the editor settings but instead a copy of the settings specific to those things this is something I have wanted to change for a long time but I had to separate out a bunch of mutating tests since mutating editor.settings will now no longer mutate DomParser or DomSerializer settings they are immutable copies.

Fixes #5425