### PR TITLE
TINY-4737: Remove usages of Struct.immutable

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
@@ -1,12 +1,29 @@
 import { window } from '@ephox/dom-globals';
-import { Fun, Struct } from '@ephox/katamari';
+import { Fun } from '@ephox/katamari';
 import { Height, Location, Width, Element, VisualViewport } from '@ephox/sugar';
 
 import { CssPositionAdt } from './CssPosition';
 import * as OuterPosition from '../frame/OuterPosition';
 
-const pointed = Struct.immutable('point', 'width', 'height') as (point: CssPositionAdt, width: number, height: number) => BoxByPoint;
-const rect = Struct.immutable('x', 'y', 'width', 'height');
+const pointed = (point: CssPositionAdt, width: number, height: number): BoxByPoint => ({
+  point: Fun.constant(point),
+  width: Fun.constant(width),
+  height: Fun.constant(height)
+});
+
+export interface Rect {
+  x: () => number;
+  y: () => number;
+  width: () => number;
+  height: () => number;
+}
+
+const rect = (x: number, y: number, width: number, height: number): Rect => ({
+  x: Fun.constant(x),
+  y: Fun.constant(y),
+  width: Fun.constant(width),
+  height: Fun.constant(height)
+});
 
 export interface Bounds {
   x: () => number;

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
@@ -12,10 +12,10 @@ const pointed = (point: CssPositionAdt, width: number, height: number): BoxByPoi
 });
 
 export interface Rect {
-  x: () => number;
-  y: () => number;
-  width: () => number;
-  height: () => number;
+  readonly x: () => number;
+  readonly y: () => number;
+  readonly width: () => number;
+  readonly height: () => number;
 }
 
 const rect = (x: number, y: number, width: number, height: number): Rect => ({
@@ -26,18 +26,18 @@ const rect = (x: number, y: number, width: number, height: number): Rect => ({
 });
 
 export interface Bounds {
-  x: () => number;
-  y: () => number;
-  width: () => number;
-  height: () => number;
-  right: () => number;
-  bottom: () => number;
+  readonly x: () => number;
+  readonly y: () => number;
+  readonly width: () => number;
+  readonly height: () => number;
+  readonly right: () => number;
+  readonly bottom: () => number;
 }
 
 export interface BoxByPoint {
-  point: () => CssPositionAdt;
-  width: () => number;
-  height: () => number;
+  readonly point: () => CssPositionAdt;
+  readonly width: () => number;
+  readonly height: () => number;
 }
 
 const bounds = (x: number, y: number, width: number, height: number): Bounds => {

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
@@ -1,18 +1,17 @@
-import { Fun } from '@ephox/katamari';
 import { Node, Text, Traverse, Element } from '@ephox/sugar';
 
-export interface ElementAndOffset {
-  readonly element: () => Element;
-  readonly offset: () => number;
+export interface ElementAndOffset<T> {
+  readonly element: Element;
+  readonly offset: number;
 }
 
-const point = (element: Element, offset: number): ElementAndOffset => ({
-  element: Fun.constant(element),
-  offset: Fun.constant(offset)
+const point = <T> (element: Element<T>, offset: number): ElementAndOffset<T> => ({
+  element,
+  offset
 });
 
 // NOTE: This only descends once.
-const descendOnce = (element: Element, offset: number): ElementAndOffset => {
+const descendOnce = <T> (element: Element, offset: number): ElementAndOffset<T> => {
   const children: Element[] = Traverse.children(element);
   if (children.length === 0) { return point(element, offset); } else if (offset < children.length) { return point(children[offset], 0); } else {
     const last = children[children.length - 1];

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
@@ -2,8 +2,8 @@ import { Fun } from '@ephox/katamari';
 import { Node, Text, Traverse, Element } from '@ephox/sugar';
 
 export interface ElementAndOffset {
-  element: () => Element;
-  offset: () => number;
+  readonly element: () => Element;
+  readonly offset: () => number;
 }
 
 const point = (element: Element, offset: number): ElementAndOffset => ({

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
@@ -1,4 +1,4 @@
-import { Struct } from '@ephox/katamari';
+import { Fun } from '@ephox/katamari';
 import { Node, Text, Traverse, Element } from '@ephox/sugar';
 
 export interface ElementAndOffset {
@@ -6,8 +6,10 @@ export interface ElementAndOffset {
   offset: () => number;
 }
 
-const point: (element: Element, offset: number) => ElementAndOffset =
-  Struct.immutable('element', 'offset');
+const point = (element: Element, offset: number): ElementAndOffset => ({
+  element: Fun.constant(element),
+  offset: Fun.constant(offset)
+});
 
 // NOTE: This only descends once.
 const descendOnce = (element: Element, offset: number): ElementAndOffset => {

--- a/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
@@ -1,4 +1,4 @@
-import { Fun, Obj, Option, Struct } from '@ephox/katamari';
+import { Fun, Obj, Option } from '@ephox/katamari';
 import { Element, TransformFind } from '@ephox/sugar';
 
 import * as Tagger from '../registry/Tagger';
@@ -9,8 +9,10 @@ export interface ElementAndHandler {
   descHandler: () => CurriedHandler;
 }
 
-const eventHandler: (element: Element, descHandler: CurriedHandler) => ElementAndHandler =
-  Struct.immutable('element', 'descHandler');
+const eventHandler = (element: Element, descHandler: CurriedHandler): ElementAndHandler => ({
+  element: Fun.constant(element),
+  descHandler: Fun.constant(descHandler)
+});
 
 export interface CurriedHandler {
   purpose: () => string;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Anchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Anchor.ts
@@ -1,4 +1,4 @@
-import { Struct } from '@ephox/katamari';
+import { Fun } from '@ephox/katamari';
 import { Element } from '@ephox/sugar';
 
 import { AnchorBox } from './LayoutTypes';
@@ -14,7 +14,10 @@ export interface Anchor {
   origin: () => Origins.OriginAdt;
 }
 
-const anchor: (anchorBox: AnchorBox, origin: Origins.OriginAdt) => Anchor = Struct.immutable('anchorBox', 'origin');
+const anchor = (anchorBox: AnchorBox, origin: Origins.OriginAdt): Anchor => ({
+  anchorBox: Fun.constant(anchorBox),
+  origin: Fun.constant(origin)
+});
 
 const element = (anchorElement: Element, origin: Origins.OriginAdt): Anchor => {
   const anchorBox = Origins.toBox(origin, anchorElement);

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Anchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Anchor.ts
@@ -10,8 +10,8 @@ import * as Origins from './Origins';
  * It is only useful for fixed origins; relative needs to do everything the old way.
  */
 export interface Anchor {
-  anchorBox: () => AnchorBox;
-  origin: () => Origins.OriginAdt;
+  readonly anchorBox: () => AnchorBox;
+  readonly origin: () => Origins.OriginAdt;
 }
 
 const anchor = (anchorBox: AnchorBox, origin: Origins.OriginAdt): Anchor => ({

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -1,6 +1,6 @@
 import { FieldSchema } from '@ephox/boulder';
 import { Window } from '@ephox/dom-globals';
-import { Fun, Option, Unicode } from '@ephox/katamari';
+import { Option, Unicode } from '@ephox/katamari';
 import { Element, Insert, Node, Remove, Selection, SimRange, Traverse, WindowSelection } from '@ephox/sugar';
 
 import * as Descend from '../../alien/Descend';
@@ -13,18 +13,19 @@ import * as ContainerOffsets from './ContainerOffsets';
 import * as ContentAnchorCommon from './ContentAnchorCommon';
 
 // TODO: This structure exists in a few places
-export interface ElementAndOffset {
-  readonly element: () => Element;
-  readonly offset: () => number;
+export interface ElementAndOffset<T> {
+  readonly element: Element<T>;
+  readonly offset: number;
 }
 
-const point = (element: Element, offset: number): ElementAndOffset => ({
-  element: Fun.constant(element),
-  offset: Fun.constant(offset)
+const point = <T> (element: Element, offset: number): ElementAndOffset<T> => ({
+  element,
+  offset
 });
 
+// TODO: remove "any"
 // A range from (a, 1) to (body, end) was giving the wrong bounds.
-const descendOnce = (element: Element, offset: number) => {
+const descendOnce = (element: Element, offset: number): ElementAndOffset<any> => {
   return Node.isText(element) ? point(element, offset) : Descend.descendOnce(element, offset);
 };
 
@@ -39,7 +40,7 @@ const getAnchorSelection = (win: Window, anchorInfo: SelectionAnchor): Option<Si
   return getSelection().map((sel) => {
     const modStart = descendOnce(sel.start(), sel.soffset());
     const modFinish = descendOnce(sel.finish(), sel.foffset());
-    return Selection.range(modStart.element(), modStart.offset(), modFinish.element(), modFinish.offset());
+    return Selection.range(modStart.element, modStart.offset, modFinish.element, modFinish.offset);
   });
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -14,8 +14,8 @@ import * as ContentAnchorCommon from './ContentAnchorCommon';
 
 // TODO: This structure exists in a few places
 export interface ElementAndOffset {
-  element: () => Element;
-  offset: () => number;
+  readonly element: () => Element;
+  readonly offset: () => number;
 }
 
 const point = (element: Element, offset: number): ElementAndOffset => ({

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -1,6 +1,6 @@
 import { FieldSchema } from '@ephox/boulder';
 import { Window } from '@ephox/dom-globals';
-import { Option, Struct, Unicode } from '@ephox/katamari';
+import { Fun, Option, Unicode } from '@ephox/katamari';
 import { Element, Insert, Node, Remove, Selection, SimRange, Traverse, WindowSelection } from '@ephox/sugar';
 
 import * as Descend from '../../alien/Descend';
@@ -12,7 +12,16 @@ import * as AnchorLayouts from './AnchorLayouts';
 import * as ContainerOffsets from './ContainerOffsets';
 import * as ContentAnchorCommon from './ContentAnchorCommon';
 
-const point: (element: Element, offset: number) => {element: () => Element; offset: () => number; } = Struct.immutable('element', 'offset');
+// TODO: This structure exists in a few places
+export interface ElementAndOffset {
+  element: () => Element;
+  offset: () => number;
+}
+
+const point = (element: Element, offset: number): ElementAndOffset => ({
+  element: Fun.constant(element),
+  offset: Fun.constant(offset)
+});
 
 // A range from (a, 1) to (body, end) was giving the wrong bounds.
 const descendOnce = (element: Element, offset: number) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/PositionCss.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/PositionCss.ts
@@ -2,11 +2,11 @@ import { Fun, Option } from '@ephox/katamari';
 import { Element, Css } from '@ephox/sugar';
 
 export interface PositionCss {
-  position: () => string;
-  left: () => Option<number>;
-  top: () => Option<number>;
-  right: () => Option<number>;
-  bottom: () => Option<number>;
+  readonly position: () => string;
+  readonly left: () => Option<number>;
+  readonly top: () => Option<number>;
+  readonly right: () => Option<number>;
+  readonly bottom: () => Option<number>;
 }
 
 const NuPositionCss = (

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/PositionCss.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/PositionCss.ts
@@ -1,4 +1,4 @@
-import { Option, Struct } from '@ephox/katamari';
+import { Fun, Option } from '@ephox/katamari';
 import { Element, Css } from '@ephox/sugar';
 
 export interface PositionCss {
@@ -9,13 +9,19 @@ export interface PositionCss {
   bottom: () => Option<number>;
 }
 
-const NuPositionCss: (
+const NuPositionCss = (
   position: string,
   left: Option<number>,
   top: Option<number>,
   right: Option<number>,
   bottom: Option<number>
-) => PositionCss = Struct.immutable('position', 'left', 'top', 'right', 'bottom');
+): PositionCss => ({
+  position: Fun.constant(position),
+  left: Fun.constant(left),
+  top: Fun.constant(top),
+  right: Fun.constant(right),
+  bottom: Fun.constant(bottom)
+});
 
 const applyPositionCss = (element: Element, position: PositionCss) => {
   const addPx = (num: number) => num + 'px';

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
@@ -2,12 +2,12 @@ import { Fun } from '@ephox/katamari';
 import { BubbleInstance } from '../layout/Bubble';
 
 export interface SpotInfo {
-  x: () => number;
-  y: () => number;
-  bubble: () => BubbleInstance;
+  readonly x: () => number;
+  readonly y: () => number;
+  readonly bubble: () => BubbleInstance;
   // TYPIFY
-  direction: () => any;
-  label: () => string;
+  readonly direction: () => any;
+  readonly label: () => string;
 }
 
 const nu = (

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
@@ -1,4 +1,4 @@
-import { Struct } from '@ephox/katamari';
+import { Fun } from '@ephox/katamari';
 import { BubbleInstance } from '../layout/Bubble';
 
 export interface SpotInfo {
@@ -10,13 +10,19 @@ export interface SpotInfo {
   label: () => string;
 }
 
-const nu: (
+const nu = (
   x: number,
   y: number,
   bubble: BubbleInstance,
   direction: any,
   label: string
-) => SpotInfo = Struct.immutable('x', 'y', 'bubble', 'direction', 'label');
+): SpotInfo => ({
+  x: Fun.constant(x),
+  y: Fun.constant(y),
+  bubble: Fun.constant(bubble),
+  direction: Fun.constant(direction),
+  label: Fun.constant(label)
+});
 
 export {
   nu

--- a/modules/alloy/src/main/ts/ephox/alloy/toolbar/Overflows.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/toolbar/Overflows.ts
@@ -3,7 +3,7 @@ import { Arr, Fun, Option } from '@ephox/katamari';
 import * as PositionArray from '../alien/PositionArray';
 
 // TODO: what types are these? I think it's AlloyComponent[], AlloyComponent, number
-const output = (within: any, extra: any, withinWidth: number) => ({
+const output = <T>(within: T[], extra: T, withinWidth: number) => ({
   within: Fun.constant(within),
   extra: Fun.constant(extra),
   withinWidth: Fun.constant(withinWidth)

--- a/modules/alloy/src/main/ts/ephox/alloy/toolbar/Overflows.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/toolbar/Overflows.ts
@@ -1,8 +1,13 @@
-import { Arr, Fun, Option, Struct } from '@ephox/katamari';
+import { Arr, Fun, Option } from '@ephox/katamari';
 
 import * as PositionArray from '../alien/PositionArray';
 
-const output = Struct.immutable('within', 'extra', 'withinWidth');
+// TODO: what types are these? I think it's AlloyComponent[], AlloyComponent, number
+const output = (within: any, extra: any, withinWidth: number) => ({
+  within: Fun.constant(within),
+  extra: Fun.constant(extra),
+  withinWidth: Fun.constant(withinWidth)
+});
 
 interface Pos {
   element: () => any;

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Response.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Response.ts
@@ -1,4 +1,4 @@
-import { Struct, Option } from '@ephox/katamari';
+import { Option, Fun } from '@ephox/katamari';
 import { Situs } from './Situs';
 
 export interface Response {
@@ -6,7 +6,10 @@ export interface Response {
   kill: () => boolean;
 }
 
-const create: (selection: Option<Situs>, kill: boolean) => Response = Struct.immutable('selection', 'kill');
+const create = (selection: Option<Situs>, kill: boolean): Response => ({
+  selection: Fun.constant(selection),
+  kill: Fun.constant(kill)
+});
 
 export const Response = {
   create

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Spot.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Spot.ts
@@ -1,20 +1,31 @@
-import { Struct } from '@ephox/katamari';
+import { Fun } from '@ephox/katamari';
 import { SpotDelta, SpotPoint, SpotPoints, SpotRange, SpotText } from './Types';
 
-type PointConstructor = <E> (element: E, offset: number) => SpotPoint<E>;
-const point: PointConstructor = Struct.immutable('element', 'offset');
+const point = <E> (element: E, offset: number): SpotPoint<E> => ({
+  element: Fun.constant(element),
+  offset: Fun.constant(offset)
+});
 
-type DeltaConstructor = <E> (element: E, deltaOffset: number) => SpotDelta<E>;
-const delta: DeltaConstructor = Struct.immutable('element', 'deltaOffset');
+const delta = <E> (element: E, deltaOffset: number): SpotDelta<E> => ({
+  element: Fun.constant(element),
+  deltaOffset: Fun.constant(deltaOffset)
+});
 
-type RangeConstructor = <E> (element: E, start: number, finish: number) => SpotRange<E>;
-const range: RangeConstructor = Struct.immutable('element', 'start', 'finish');
+const range = <E> (element: E, start: number, finish: number): SpotRange<E> => ({
+  element: Fun.constant(element),
+  start: Fun.constant(start),
+  finish: Fun.constant(finish)
+});
 
-type PointsConstructor = <E> (begin: SpotPoint<E>, end: SpotPoint<E>) => SpotPoints<E>;
-const points: PointsConstructor = Struct.immutable('begin', 'end');
+const points = <E> (begin: SpotPoint<E>, end: SpotPoint<E>): SpotPoints<E> => ({
+  begin: Fun.constant(begin),
+  end: Fun.constant(end)
+});
 
-type TextConstructor = <E> (element: E, text: any) => SpotText<E>;
-const text: TextConstructor = Struct.immutable('element', 'text');
+const text = <E> (element: E, text: any): SpotText<E> => ({
+  element: Fun.constant(element),
+  text: Fun.constant(text)
+});
 
 export {
   point,

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Types.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Types.ts
@@ -2,62 +2,62 @@ import { Universe } from '@ephox/boss';
 import { Option } from '@ephox/katamari';
 
 export interface SpotPoint<E> {
-  element(): E;
-  offset(): number;
+  readonly element: () => E;
+  readonly offset: () => number;
 }
 
 export interface SpotDelta<E> {
-  element(): E;
-  deltaOffset(): number;
+  readonly element: () => E;
+  readonly deltaOffset: () => number;
 }
 
 export interface SpotRange<E> {
-  element(): E;
-  start(): number;
-  finish(): number;
+  readonly element: () => E;
+  readonly start: () => number;
+  readonly finish: () => number;
 }
 
 export interface SpotPoints<E> {
-  begin(): SpotPoint<E>;
-  end(): SpotPoint<E>;
+  readonly begin: () => SpotPoint<E>;
+  readonly end: () => SpotPoint<E>;
 }
 
 export interface SpotText<E> {
-  element(): E;
-  text(): any; // TODO narrow type
+  readonly element: () => E;
+  readonly text: () => any; // TODO narrow type
 }
 
 export interface SearchResult<E> {
-  elements: () => E[];
-  word: () => string;
-  exact: () => string;
+  readonly elements: () => E[];
+  readonly word: () => string;
+  readonly exact: () => string;
 }
 
 export interface Direction {
-  sibling: <E, D>(universe: Universe<E, D>, item: E) => Option<E>;
-  first: <E>(children: E[]) => Option<E>;
+  readonly sibling: <E, D>(universe: Universe<E, D>, item: E) => Option<E>;
+  readonly first: <E>(children: E[]) => Option<E>;
 }
 
 export type Transition = <E, D> (universe: Universe<E, D>, item: E, direction: Direction, _transition?: Transition) => Option<Traverse<E>>;
 
 export interface Traverse<E> {
-  item(): E;
-  mode(): Transition;
+  readonly item: () => E;
+  readonly mode: () => Transition;
 }
 
 export type Successor = {
-  current: Transition,
-  next: Transition,
-  fallback: Option<Transition>
+  readonly current: Transition,
+  readonly next: Transition,
+  readonly fallback: Option<Transition>
 };
 
 export interface Wrapter<E> {
-  element: () => E;
-  wrap: (contents: E) => void;
+  readonly element: () => E;
+  readonly wrap: (contents: E) => void;
 }
 
 export interface SpanWrapRange<E> {
-  range(): SpotPoints<E>;
-  temporary(): boolean;
-  wrappers(): E[];
+  readonly range: () => SpotPoints<E>;
+  readonly temporary: () => boolean;
+  readonly wrappers: () => E[];
 }

--- a/modules/phoenix/src/main/ts/ephox/phoenix/gather/Walker.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/gather/Walker.ts
@@ -1,9 +1,11 @@
 import { Universe } from '@ephox/boss';
-import { Arr, Option, Struct } from '@ephox/katamari';
+import { Arr, Fun, Option } from '@ephox/katamari';
 import { Direction, Successor, Transition, Traverse } from '../api/data/Types';
 
-type TraverseConstructor = <E>(item: E, mode: Transition) => Traverse<E>;
-const traverse: TraverseConstructor = Struct.immutable('item', 'mode');
+const traverse = <E>(item: E, mode: Transition): Traverse<E> => ({
+  item: Fun.constant(item),
+  mode: Fun.constant(mode)
+});
 
 const backtrack: Transition = function (universe, item, _direction, transition = sidestep) {
   return universe.property().parent(item).map(function (p) {

--- a/modules/robin/src/main/ts/ephox/robin/clumps/Clumps.ts
+++ b/modules/robin/src/main/ts/ephox/robin/clumps/Clumps.ts
@@ -1,5 +1,5 @@
 import { Universe } from '@ephox/boss';
-import { Adt, Arr, Option, Struct } from '@ephox/katamari';
+import { Adt, Arr, Fun, Option } from '@ephox/katamari';
 import { Descent, Gather, Spot, Transition } from '@ephox/phoenix';
 import * as Structure from '../api/general/Structure';
 
@@ -43,7 +43,12 @@ interface ClumpRange<E> {
   finish: E;
 }
 
-const clump: <E> (start: E, soffset: number, finish: E, foffset: number) => Clump<E> = Struct.immutable('start', 'soffset', 'finish', 'foffset');
+const clump = <E> (start: E, soffset: number, finish: E, foffset: number): Clump<E> => ({
+  start: Fun.constant(start),
+  soffset: Fun.constant(soffset),
+  finish: Fun.constant(finish),
+  foffset: Fun.constant(foffset)
+});
 
 const descendBlock = function <E, D> (universe: Universe<E, D>, isRoot: (e: E) => boolean, block: E) {
   const leaf = Descent.toLeaf(universe, block, 0);

--- a/modules/robin/src/main/ts/ephox/robin/parent/Breaker.ts
+++ b/modules/robin/src/main/ts/ephox/robin/parent/Breaker.ts
@@ -1,5 +1,5 @@
 import { Universe } from '@ephox/boss';
-import { Arr, Fun, Option, Struct } from '@ephox/katamari';
+import { Arr, Fun, Option } from '@ephox/katamari';
 
 interface Bisect<E> {
   before: () => E[];
@@ -22,9 +22,16 @@ export interface BrokenPath<E> {
   splits: () => BrokenPathSplits<E>[];
 }
 
-const leftRight: <E> (left: E, right: E) => LeftRight<E> = Struct.immutable('left', 'right');
+const leftRight = <E> (left: E, right: E): LeftRight<E> => ({
+  left: Fun.constant(left),
+  right: Fun.constant(right)
+});
 
-const brokenPath: <E> (first: E, second: Option<E>, splits: BrokenPathSplits<E>[]) => BrokenPath<E> = Struct.immutable('first', 'second', 'splits');
+const brokenPath = <E> (first: E, second: Option<E>, splits: BrokenPathSplits<E>[]): BrokenPath<E> => ({
+  first: Fun.constant(first),
+  second: Fun.constant(second),
+  splits: Fun.constant(splits)
+});
 
 const bisect = function <E, D>(universe: Universe<E, D>, parent: E, child: E): Option<Bisect<E>> {
   const children = universe.property().children(parent);

--- a/modules/robin/src/main/ts/ephox/robin/textdata/TextSearch.ts
+++ b/modules/robin/src/main/ts/ephox/robin/textdata/TextSearch.ts
@@ -1,11 +1,14 @@
-import { Arr, Option, Struct, Unicode } from '@ephox/katamari';
+import { Arr, Fun, Option, Unicode } from '@ephox/katamari';
 
 export interface CharPos {
   ch: () => string;
   offset: () => number;
 }
 
-const charpos: (ch: string, offset: number) => CharPos = Struct.immutable('ch', 'offset');
+const charpos = (ch: string, offset: number): CharPos => ({
+  ch: Fun.constant(ch),
+  offset:  Fun.constant(offset)
+});
 
 const locate = function (text: string, offset: number) {
   return charpos(text.charAt(offset), offset);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Struct } from '@ephox/katamari';
+import { Arr, Fun, Obj } from '@ephox/katamari';
 import { Attr, Css, Element, Insert, Remove, Selectors } from '@ephox/sugar';
 import * as DetailsList from '../model/DetailsList';
 import { Warehouse } from '../model/Warehouse';
@@ -7,13 +7,18 @@ import { DetailExt, RowData } from './Structs';
 import { HTMLElement } from '@ephox/dom-globals';
 
 interface StatsStruct {
-  minRow: () => number;
-  minCol: () => number;
-  maxRow: () => number;
-  maxCol: () => number;
+  readonly minRow: () => number;
+  readonly minCol: () => number;
+  readonly maxRow: () => number;
+  readonly maxCol: () => number;
 }
 
-const statsStruct: (minRow: number, minCol: number, maxRow: number, maxCol: number) => StatsStruct = Struct.immutable('minRow', 'minCol', 'maxRow', 'maxCol');
+const statsStruct = (minRow: number, minCol: number, maxRow: number, maxCol: number): StatsStruct => ({
+  minRow: Fun.constant(minRow),
+  minCol: Fun.constant(minCol),
+  maxRow: Fun.constant(maxRow),
+  maxCol: Fun.constant(maxCol)
+});
 
 const findSelectedStats = function (house: Warehouse, isSelected: (detail: DetailExt) => boolean) {
   const totalColumns = house.grid().columns();

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
@@ -1,4 +1,4 @@
-import { Struct } from '@ephox/katamari';
+import { Fun } from '@ephox/katamari';
 import { Element } from '@ephox/sugar';
 
 export interface Dimension {
@@ -75,86 +75,139 @@ export interface Bounds {
   finishCol: () => number;
 }
 
-const dimension: (
-  width: ReturnType<Dimension['width']>,
-  height: ReturnType<Dimension['height']>
-) => Dimension = Struct.immutable('width', 'height');
+const dimension = (
+  width: number,
+  height: number
+): Dimension => ({
+  width: Fun.constant(width),
+  height: Fun.constant(height)
+});
 
-const dimensions: (
-  width: ReturnType<Dimensions['width']>,
-  height: ReturnType<Dimensions['height']>
-) => Dimensions = Struct.immutable('width', 'height');
+const dimensions = (
+  width: number[],
+  height: number[]
+): Dimensions => ({
+  width: Fun.constant(width),
+  height: Fun.constant(height)
+});
 
-const grid: (
-  rows: ReturnType<Grid['rows']>,
-  columns: ReturnType<Grid['columns']>
-) => Grid = Struct.immutable('rows', 'columns');
+const grid = (
+  rows: number,
+  columns: number
+): Grid => ({
+  rows: Fun.constant(rows),
+  columns: Fun.constant(columns)
+});
 
-const address: (
-  row: ReturnType<Address['row']>,
-  column: ReturnType<Address['column']>
-) => Address = Struct.immutable('row', 'column');
+const address = (
+  row: number,
+  column: number
+): Address => ({
+  row: Fun.constant(row),
+  column: Fun.constant(column)
+});
 
-const coords: (
-  x: ReturnType<Coords['x']>,
-  y: ReturnType<Coords['y']>
-) => Coords = Struct.immutable('x', 'y');
+const coords = (
+  x: number,
+  y: number
+): Coords => ({
+  x: Fun.constant(x),
+  y: Fun.constant(y)
+});
 
-const detail: (
-  element: ReturnType<Detail['element']>,
-  rowspan: ReturnType<Detail['rowspan']>,
-  colspan: ReturnType<Detail['colspan']>
-) => Detail = Struct.immutable('element', 'rowspan', 'colspan');
+const detail = (
+  element: Element,
+  rowspan: number,
+  colspan: number
+): Detail => ({
+  element: Fun.constant(element),
+  rowspan: Fun.constant(rowspan),
+  colspan: Fun.constant(colspan)
+});
 
-const detailnew: (
-  element: ReturnType<DetailNew['element']>,
-  rowspan: ReturnType<DetailNew['rowspan']>,
-  colspan: ReturnType<DetailNew['colspan']>,
-  isNew: ReturnType<DetailNew['isNew']>
-) => DetailNew = Struct.immutable('element', 'rowspan', 'colspan', 'isNew');
+const detailnew = (
+  element: Element,
+  rowspan: number,
+  colspan: number,
+  isNew: boolean
+): DetailNew => ({
+  element: Fun.constant(element),
+  rowspan: Fun.constant(rowspan),
+  colspan: Fun.constant(colspan),
+  isNew: Fun.constant(isNew)
+});
 
-const extended: (
-  element: ReturnType<DetailExt['element']>,
-  rowspan: ReturnType<DetailExt['rowspan']>,
-  colspan: ReturnType<DetailExt['colspan']>,
-  row: ReturnType<DetailExt['row']>,
-  column: ReturnType<DetailExt['column']>
-) => DetailExt = Struct.immutable('element', 'rowspan', 'colspan', 'row', 'column');
+const extended = (
+  element: Element,
+  rowspan: number,
+  colspan: number,
+  row: number,
+  column: number
+): DetailExt => ({
+  element: Fun.constant(element),
+  rowspan: Fun.constant(rowspan),
+  colspan: Fun.constant(colspan),
+  row: Fun.constant(row),
+  column: Fun.constant(column)
+});
 
-const rowdata: <T> (
-  element: ReturnType<RowData<T>['element']>,
-  cells: ReturnType<RowData<T>['cells']>,
-  section: ReturnType<RowData<T>['section']>
-) => RowData<T> = Struct.immutable('element', 'cells', 'section');
+const rowdata = <T> (
+  element: Element,
+  cells: T[],
+  section: Section
+): RowData<T> => ({
+  element: Fun.constant(element),
+  cells: Fun.constant(cells),
+  section: Fun.constant(section)
+});
 
-const elementnew: (
-  element: ReturnType<ElementNew['element']>,
-  isNew: ReturnType<ElementNew['isNew']>
-) => ElementNew = Struct.immutable('element', 'isNew');
+const elementnew = (
+  element: Element,
+  isNew: boolean
+): ElementNew => ({
+  element: Fun.constant(element),
+  isNew: Fun.constant(isNew)
+});
 
-const rowdatanew: <T> (
-  element: ReturnType<RowDataNew<T>['element']>,
-  cells: ReturnType<RowDataNew<T>['cells']>,
-  section: ReturnType<RowDataNew<T>['section']>,
-  isNew: ReturnType<RowDataNew<T>['isNew']>
-) => RowDataNew<T> = Struct.immutable('element', 'cells', 'section', 'isNew');
+const rowdatanew = <T> (
+  element: Element,
+  cells: T[],
+  section: Section,
+  isNew: boolean
+): RowDataNew<T> => ({
+  element: Fun.constant(element),
+  cells: Fun.constant(cells),
+  section: Fun.constant(section),
+  isNew: Fun.constant(isNew)
+});
 
-const rowcells: (
-  cells: ReturnType<RowCells['cells']>,
-  section: ReturnType<RowCells['section']>
-) => RowCells = Struct.immutable('cells', 'section');
+const rowcells = (
+  cells: ElementNew[],
+  section: Section
+): RowCells => ({
+  cells: Fun.constant(cells),
+  section: Fun.constant(section)
+});
 
-const rowdetails: (
-  details: ReturnType<RowDetails['details']>,
-  section: ReturnType<RowDetails['section']>
-) => RowDetails =  Struct.immutable('details', 'section');
+const rowdetails = (
+  details: DetailNew[],
+  section: Section
+): RowDetails => ({
+  details: Fun.constant(details),
+  section: Fun.constant(section)
+});
 
-const bounds: (
-  startRow: ReturnType<Bounds['startRow']>,
-  startCol: ReturnType<Bounds['startCol']>,
-  finishRow: ReturnType<Bounds['finishRow']>,
-  finishCol: ReturnType<Bounds['finishCol']>
-) => Bounds = Struct.immutable( 'startRow', 'startCol', 'finishRow', 'finishCol');
+const bounds = (
+  startRow: number,
+  startCol: number,
+  finishRow: number,
+  finishCol: number
+): Bounds => ({
+  startRow:  Fun.constant(startRow),
+  startCol: Fun.constant(startCol),
+  finishRow: Fun.constant(finishRow),
+  finishCol: Fun.constant(finishCol)
+});
 
 export {
   dimension,

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Option, Struct } from '@ephox/katamari';
+import { Arr, Fun, Option } from '@ephox/katamari';
 import { Remove, Element } from '@ephox/sugar';
 import * as DetailsList from '../model/DetailsList';
 import { run, onCell, onCells, onMergable, onUnmergable, onPaste, onPasteRows, ExtractPasteRows, ExtractPaste, ExtractMergable } from '../model/RunOperation';
@@ -28,7 +28,10 @@ const prune = function (table: Element) {
   }
 };
 
-const outcome: (grid: Structs.RowCells[], cursor: Option<Element>) => TableOperationResult = Struct.immutable('grid', 'cursor');
+const outcome = (grid: Structs.RowCells[], cursor: Option<Element>): TableOperationResult => ({
+  grid: Fun.constant(grid),
+  cursor: Fun.constant(cursor)
+});
 
 const elementFromGrid = function (grid: Structs.RowCells[], row: number, column: number) {
   return findIn(grid, row, column).orThunk(function () {

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Struct, Option } from '@ephox/katamari';
+import { Arr, Fun, Option } from '@ephox/katamari';
 import { Height, Location, Width, Element } from '@ephox/sugar';
 
 export interface RowInfo {
@@ -17,8 +17,15 @@ export interface BarPositions<T> {
   positions: (array: Option<Element>[], table: Element) => Option<T>[];
 }
 
-const rowInfo: (row: number, y: number) => RowInfo = Struct.immutable('row', 'y');
-const colInfo: (col: number, x: number) => ColInfo = Struct.immutable('col', 'x');
+const rowInfo = (row: number, y: number): RowInfo => ({
+  row: Fun.constant(row),
+  y: Fun.constant(y)
+});
+
+const colInfo = (col: number, x: number): ColInfo => ({
+  col: Fun.constant(col),
+  x: Fun.constant(x)
+});
 
 const rtlEdge = function (cell: Element) {
   const pos = Location.absolute(cell);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/ElementAddress.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/ElementAddress.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Struct } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import * as Compare from '../dom/Compare';
 import Element from '../node/Element';
 import * as PredicateFind from './PredicateFind';
@@ -21,8 +21,19 @@ export interface AddressInParent<P, C, E> {
   index: () => number;
 }
 
-const inAncestor: <A, D, E> (ancestor: Element<A>, descendants: Element<D>[], element: Element<E>, index: number) => AddressInAncestor<A, D, E> = Struct.immutable('ancestor', 'descendants', 'element', 'index');
-const inParent: <P, C, E>(parent: Element<P>, children: Element<C>[], element: Element<E>, index: number) => AddressInParent<P, C, E> = Struct.immutable('parent', 'children', 'element', 'index');
+const inAncestor = <A, D, E> (ancestor: Element<A>, descendants: Element<D>[], element: Element<E>, index: number): AddressInAncestor<A, D, E> => ({
+  ancestor: Fun.constant(ancestor),
+  descendants: Fun.constant(descendants),
+  element: Fun.constant(element),
+  index: Fun.constant(index)
+});
+
+const inParent = <P, C, E>(parent: Element<P>, children: Element<C>[], element: Element<E>, index: number): AddressInParent<P, C, E> => ({
+  parent: Fun.constant(parent),
+  children: Fun.constant(children),
+  element: Fun.constant(element),
+  index: Fun.constant(index)
+});
 
 const childOf = function (element: Element<DomNode>, ancestor: Element<DomNode>) {
   return PredicateFind.closest(element, function (elem) {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
@@ -1,5 +1,5 @@
-import { HTMLElement, Node as DomNode, Element as DomElement } from '@ephox/dom-globals';
-import { Arr, Fun, Option, Struct, Type } from '@ephox/katamari';
+import { HTMLElement, Node as DomNode } from '@ephox/dom-globals';
+import { Arr, Fun, Option, Type } from '@ephox/katamari';
 import * as Recurse from '../../alien/Recurse';
 import * as Compare from '../dom/Compare';
 import Element from '../node/Element';
@@ -110,12 +110,17 @@ const hasChildNodes = function (element: Element<DomNode>) {
   return element.dom().hasChildNodes();
 };
 
-const spot: <E>(element: Element<E>, offset: number) => {
+export interface Spot<E> {
   element: () => Element<E>;
   offset: () => number;
-} = Struct.immutable('element', 'offset');
+}
 
-const leaf = function (element: Element<DomNode>, offset: number) {
+const spot = <E>(element: Element<E>, offset: number): Spot<E> => ({
+  element: Fun.constant(element),
+  offset: Fun.constant(offset)
+});
+
+const leaf = function (element: Element<DomNode>, offset: number): Spot<DomNode> {
   const cs = children(element);
   return cs.length > 0 && offset < cs.length ? spot(cs[offset], 0) : spot(element, offset);
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
@@ -111,8 +111,8 @@ const hasChildNodes = function (element: Element<DomNode>) {
 };
 
 export interface ElementAndOffset<E> {
-  element: () => Element<E>;
-  offset: () => number;
+  readonly element: () => Element<E>;
+  readonly offset: () => number;
 }
 
 const spot = <E>(element: Element<E>, offset: number): ElementAndOffset<E> => ({

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
@@ -110,17 +110,17 @@ const hasChildNodes = function (element: Element<DomNode>) {
   return element.dom().hasChildNodes();
 };
 
-export interface Spot<E> {
+export interface ElementAndOffset<E> {
   element: () => Element<E>;
   offset: () => number;
 }
 
-const spot = <E>(element: Element<E>, offset: number): Spot<E> => ({
+const spot = <E>(element: Element<E>, offset: number): ElementAndOffset<E> => ({
   element: Fun.constant(element),
   offset: Fun.constant(offset)
 });
 
-const leaf = function (element: Element<DomNode>, offset: number): Spot<DomNode> {
+const leaf = function (element: Element<DomNode>, offset: number): ElementAndOffset<DomNode> {
   const cs = children(element);
   return cs.length > 0 && offset < cs.length ? spot(cs[offset], 0) : spot(element, offset);
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/SimRange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/SimRange.ts
@@ -1,5 +1,5 @@
 import Element from '../node/Element';
-import { Struct } from '@ephox/katamari';
+import { Fun } from '@ephox/katamari';
 import { Node as DomNode } from '@ephox/dom-globals';
 
 export interface SimRange {
@@ -9,12 +9,12 @@ export interface SimRange {
   foffset: () => number;
 }
 
-const create: (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => SimRange = Struct.immutable(
-  'start',
-  'soffset',
-  'finish',
-  'foffset'
-);
+const create = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): SimRange => ({
+  start: Fun.constant(start),
+  soffset: Fun.constant(soffset),
+  finish: Fun.constant(finish),
+  foffset: Fun.constant(foffset)
+});
 
 // tslint:disable-next-line:variable-name
 export const SimRange = {

--- a/modules/tinymce/src/core/main/ts/EditorSettings.ts
+++ b/modules/tinymce/src/core/main/ts/EditorSettings.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Merger, Obj, Option, Strings, Struct, Type } from '@ephox/katamari';
+import { Arr, Fun, Merger, Obj, Option, Strings, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
 import Editor from './api/Editor';
@@ -26,7 +26,11 @@ interface SectionResult {
   settings: () => RawEditorSettings;
 }
 
-const sectionResult = Struct.immutable('sections', 'settings');
+const sectionResult = (sections: Record<string, Partial<RawEditorSettings>>, settings: RawEditorSettings): SectionResult => ({
+  sections: Fun.constant(sections),
+  settings: Fun.constant(settings)
+});
+
 const deviceDetection = PlatformDetection.detect().deviceType;
 const isTouch = deviceDetection.isTouch();
 const isPhone = deviceDetection.isPhone();

--- a/modules/tinymce/src/core/main/ts/selection/SimpleTableModel.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SimpleTableModel.ts
@@ -5,13 +5,25 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Option, Struct } from '@ephox/katamari';
+import { Arr, Fun, Option } from '@ephox/katamari';
 import { Compare, Insert, InsertAll, Replication, Element, Attr, SelectorFilter } from '@ephox/sugar';
 import { HTMLTableCellElement } from '@ephox/dom-globals';
 
-const tableModel = Struct.immutable('element', 'width', 'rows');
-const tableRow = Struct.immutable('element', 'cells');
-const cellPosition = Struct.immutable('x', 'y');
+const tableModel = (element: Element<unknown>, width: number, rows: Element<unknown>[]) => ({
+  element: Fun.constant(element),
+  width: Fun.constant(width),
+  rows: Fun.constant(rows)
+});
+
+const tableRow = (element: Element<unknown>, cells: Element<unknown>[]) => ({
+  element: Fun.constant(element),
+  cells: Fun.constant(cells)
+});
+
+const cellPosition = (x: number, y: number) => ({
+  x: Fun.constant(x),
+  y: Fun.constant(y)
+});
 
 const getSpan = function (td, key) {
   const value = parseInt(Attr.get(td, key), 10);

--- a/modules/tinymce/src/plugins/table/main/ts/queries/TableTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/TableTargets.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun, Option, Struct } from '@ephox/katamari';
+import { Fun, Option } from '@ephox/katamari';
 import * as CellOperations from './CellOperations';
 
 const noMenu = function (cell) {
@@ -30,7 +30,12 @@ const notCell = function (element) {
   return noMenu(element);
 };
 
-const paste = Struct.immutable('element', 'clipboard', 'generators');
+// TODO: types
+const paste = (element: any, clipboard: any, generators: any) => ({
+  element: Fun.constant(element),
+  clipboard: Fun.constant(clipboard),
+  generators: Fun.constant(generators)
+});
 
 const pasteRows = function (selections, table, cell, clipboard, generators) {
   return {


### PR DESCRIPTION
`Struct.immutable` was an attempt to create objects with known fields in JavaScript and enforce some kind of run-time-typing. In TypeScript, we prefer to use interfaces and objects.  

This change removes all usages that end up in the TinyMCE output code, except for a weird one  in Porkbun. 

A lot of these could be unthunked, but that's a job for another day.

Size deltas:

```
File                                                Before   After Delta
tinymce/js/tinymce/plugins/table/plugin.min.js      117401  117574   173
tinymce/js/tinymce/themes/silver/theme.min.js       407721  407650   -71
tinymce/js/tinymce/plugins/lists/plugin.min.js       26991   26901   -90
tinymce/js/tinymce/plugins/fullscreen/plugin.min.js  15065   14973   -92
tinymce/js/tinymce/tinymce.min.js                   382678  382417  -261
tinymce/js/tinymce/themes/mobile/theme.min.js       177565  177238  -327
```