### PR TITLE
TINY-4195: Fixed an issue where dragging images could cause them to be duplicated

### DIFF
--- a/modules/oxide/src/less/theme/content/contenteditable/contenteditable.less
+++ b/modules/oxide/src/less/theme/content/contenteditable/contenteditable.less
@@ -33,7 +33,7 @@
   }
 
   .mce-offscreen-selection {
-    left: -9999999999px;
+    left: -2000000px;
     max-width: 1000000px;
     position: absolute;
   }

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,6 +7,7 @@ Version 5.2.1 (TBD)
     Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
     Fixed the editor incorrectly stealing focus during initialization in Microsoft IE #TINY-4697
     Fixed the `colorinput` popup appearing offscreen on mobile devices #TINY-4711
+    Fixed an issue where dragging images could cause them to be duplicated #TINY-4195
 Version 5.2.0 (2020-02-13)
     Added the ability to apply formats to spaces #TINY-4200
     Added new `toolbar_location` setting to allow for positioning the menu and toolbar at the bottom of the editor #TINY-4210


### PR DESCRIPTION
This one was very strange... but ultimately it seems to be a bit of a browser quirk due to the massive negative left value that was being used.

Other solutions I found for this were:
 - adding the offscreen selection to the body instead
- using fixed positioning instead of absolute for the offscreen selection
- using the HTML 5 drag/drop APIs instead of mouse events (browser behaviour was pretty different so it would have required a mixed approach of both mouse and drag events)

however using a lower negative left value seemed like the simplest and safest solution.

@metricjs also found the following, which asserts that our negative left value was likely far too high anyways for most browsers.
> There is no official range of valid values. Opera supports values up to 2^15-1, IE up to 2^20-1 and other browsers even higher. During the CSS3 Values cycle there were a lot of discussion about setting a minimal limit to support: the latest decision, in April 2012 during the LC phase, was [-2^27-1; 2^27-1] # but other values like 2^24-1 and 2^30-1 were also proposed # #. The latest Editor's draft doesn't list a limit anymore.