### PR TITLE
TINY-3862: Backport table selection not functioning correctly in Edge 44 or higher

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 Version 4.9.9 (TBD)
+    Fixed table selection not functioning correctly in Edge 44 or higher #TINY-3862
     Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
 Version 4.9.8 (2020-01-28)
     Fixed the `mobile` theme failing to load due to a bundling issue #TINY-4613

--- a/src/plugins/table/main/ts/selection/CellSelection.ts
+++ b/src/plugins/table/main/ts/selection/CellSelection.ts
@@ -6,21 +6,20 @@
  */
 
 import { InputHandlers, SelectionAnnotation, SelectionKeys } from '@ephox/darwin';
+import { Event, HTMLElement, KeyboardEvent, MouseEvent } from '@ephox/dom-globals';
 import { Fun, Option, Struct } from '@ephox/katamari';
+import { DomParent } from '@ephox/robin';
 import { TableLookup } from '@ephox/snooker';
-import {
-    Element, Selection, SelectionDirection, Class
-} from '@ephox/sugar';
+import { Class, Element, Selection, SelectionDirection } from '@ephox/sugar';
 
+import Env from 'tinymce/core/api/Env';
 import * as Util from '../alien/Util';
 import Direction from '../queries/Direction';
 import Ephemera from './Ephemera';
-import { DomParent } from '@ephox/robin';
 
 const hasInternalTarget = (e: Event) => {
   return Class.has(Element.fromDom(e.target as HTMLElement), 'ephox-snooker-resizer-bar') === false;
 };
-import { KeyboardEvent, MouseEvent, Event, HTMLElement } from '@ephox/dom-globals';
 
 export default function (editor, lazyResize) {
   const handlerStruct = Struct.immutableBag(['mousedown', 'mouseover', 'mouseup', 'keyup', 'keydown'], []);
@@ -134,6 +133,13 @@ export default function (editor, lazyResize) {
       // Only added by Chrome/Firefox in June 2015.
       // This is only to fix a 1px bug (TBIO-2836) so return true if we're on an older browser
       if (raw.buttons === undefined) {
+        return true;
+      }
+
+      // Edge 44+ broke the "buttons" property so that it now returns 0 always on mouseover
+      // so we can't detect if the left mouse button is down. The deprecated "which" property
+      // also can't be used as it returns 1 at all times, as such just return true.
+      if (Env.ie && Env.ie >= 12 && raw.buttons === 0) {
         return true;
       }
 


### PR DESCRIPTION
This just backports the PR from 5.x: https://github.com/tinymce/tinymce/pull/5437

Note: `Env.browser` and `DomEvent.fromRaw` don't exist for 4.x, so I had to use the older variants.