### PR TITLE
TINY-4160: Backport table resize handles not functioning correctly in Edge

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 4.9.9 (TBD)
     Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
+    Fixed table resize handles not functioning correctly in Microsoft Edge #TINY-4160
 Version 4.9.8 (2020-01-28)
     Fixed the `mobile` theme failing to load due to a bundling issue #TINY-4613
     Fixed security issue related to parsing HTML comments and CDATA #TINY-4544

--- a/src/skins/lightgray/main/less/desktop/Content.Objects.less
+++ b/src/skins/lightgray/main/less/desktop/Content.Objects.less
@@ -200,6 +200,10 @@ td[data-mce-selected], th[data-mce-selected] {
 .ephox-snooker-resizer-bar {
   background-color: @content-selection-bg;
   opacity: 0.0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .ephox-snooker-resizer-cols {


### PR DESCRIPTION
This just backports @jhaines fix for the table resize handler issue on Edge: https://github.com/tinymce/tinymce/pull/5422 and https://github.com/tinymce/tinymce/pull/5432