### PR TITLE
TINY-4754: Fixed context toolbars activating without the editor having focus

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -10,6 +10,7 @@ Version 5.2.1 (TBD)
     Fixed notification and inline dialog positioning issues when using the bottom toolbar #TINY-4586
     Fixed the `colorinput` popup appearing offscreen on mobile devices #TINY-4711
     Fixed an issue where dragging images could cause them to be duplicated #TINY-4195
+    Fixed context toolbars activating without the editor having focus #TINY-4754
 Version 5.2.0 (2020-02-13)
     Added the ability to apply formats to spaces #TINY-4200
     Added new `toolbar_location` setting to allow for positioning the menu and toolbar at the bottom of the editor #TINY-4210

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -200,6 +200,7 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
         sAssertResizeBars(true)
       ]),
       Log.stepsAsStep('TBA', 'Context toolbar should hide in readonly mode', [
+        tinyApis.sFocus(),
         sSetMode('design'),
         tinyApis.sSetContent('<table><tbody><tr><td>a</td></tr></tbody></table>'),
         tinyApis.sSetCursor([0, 0, 0, 0, 0], 0),

--- a/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
@@ -244,6 +244,11 @@ const register = (editor: Editor, registryContextToolbars, sink, extras) => {
   };
 
   const launchContextToolbar = () => {
+    // Don't launch if the editor doesn't have focus
+    if (!editor.hasFocus()) {
+      return;
+    }
+
     const scopes = getScopes();
     ToolbarLookup.lookup(scopes, editor).fold(
       () => {
@@ -275,7 +280,7 @@ const register = (editor: Editor, registryContextToolbars, sink, extras) => {
     editor.on('ScrollContent ScrollWindow longpress', hideOrRepositionIfNecessary);
 
     // FIX: Make it go away when the action makes it go away. E.g. deleting a column deletes the table.
-    editor.on('click keyup SetContent ObjectResized ResizeEditor', (e) => {
+    editor.on('click keyup focus SetContent ObjectResized ResizeEditor', () => {
       // Fixing issue with chrome focus on img.
       resetTimer(
         Delay.setEditorTimeout(editor, launchContextToolbar, 0)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarLookup.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarLookup.ts
@@ -7,7 +7,7 @@
 
 import { Toolbar } from '@ephox/bridge';
 import { Node as DomNode } from '@ephox/dom-globals';
-import { Option, Arr } from '@ephox/katamari';
+import { Arr, Option } from '@ephox/katamari';
 import { Compare, Element, TransformFind } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
@@ -33,10 +33,15 @@ const lookup = (scopes: ScopedToolbars, editor: Editor): Option<LookupResult> =>
 
   return matchTargetWith(startNode, scopes.inNodeScope).orThunk(() => {
     return matchTargetWith(startNode, scopes.inEditorScope).orThunk(() => {
-      return TransformFind.ancestor(startNode, (elem) => {
-        // TransformFind will try to transform before doing the isRoot check, so we need to check here as well
-        return isRoot(elem) ? Option.none() : matchTargetWith(elem, scopes.inNodeScope);
-      }, isRoot);
+      // Don't continue to traverse if the start node is the root node
+      if (isRoot(startNode)) {
+        return Option.none();
+      } else {
+        return TransformFind.ancestor(startNode, (elem) => {
+          // TransformFind will try to transform before doing the isRoot check, so we need to check here as well
+          return isRoot(elem) ? Option.none() : matchTargetWith(elem, scopes.inNodeScope);
+        }, isRoot);
+      }
     });
   });
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -1,4 +1,4 @@
-import { Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
+import { Log, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
@@ -17,9 +17,13 @@ UnitTest.asynctest('Editor ContextToolbar test', (success, failure) => {
 
       Pipeline.async({ }, [
         Log.stepsAsStep('TBA', 'Moving selection away from the context toolbar predicate should make it disappear', [
-          tinyApis.sFocus(),
           tinyApis.sSetContent('<p>One <a href="http://tiny.cloud">link</a> Two</p>'),
+          // Need to wait a little before checking the context toolbar isn't shown,
+          // since we don't have anything we can wait for a change in
+          Step.wait(100),
+          UiFinder.sNotExists(Body.body(), '.tox-pop'),
           tinyApis.sSetCursor([ 0, 1, 0 ], 'L'.length),
+          tinyApis.sFocus(),
           UiFinder.sWaitForVisible('Waiting for toolbar', Body.body(), '.tox-pop'),
           // NOTE: This internally fires a nodeChange
           tinyApis.sSetCursor([ 0, 0 ], 'O'.length),


### PR DESCRIPTION
This fixes a regression (sort of) introduced in 5.2.0 whereby the context toolbars will show without the editor having focus. The cause of this, is that we now set the selection to an initial position on init, which meant a predicate matched.

Fixes #5456