### PR TITLE
TINY-4759: Remove usages of immutableBag

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/Cursors.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Cursors.ts
@@ -1,13 +1,13 @@
-import { Result, Struct } from '@ephox/katamari';
+import { Fun, Result } from '@ephox/katamari';
 import { Element, Hierarchy } from '@ephox/sugar';
 
 import { Chain } from './Chain';
 
 export interface CursorRange {
-  start: () => Element<any>;
-  soffset: () => number;
-  finish: () => Element<any>;
-  foffset: () => number;
+  readonly start: () => Element<any>;
+  readonly soffset: () => number;
+  readonly finish: () => Element<any>;
+  readonly foffset: () => number;
 }
 
 export interface CursorPath {
@@ -17,17 +17,23 @@ export interface CursorPath {
   foffset: () => number;
 }
 
-type RangeConstructor = (obj: { start: Element<any>; soffset: number; finish: Element<any>; foffset: number; }) => CursorRange;
+const range = (obj: { start: Element<any>; soffset: number; finish: Element<any>; foffset: number; }): CursorRange => ({
+  start: Fun.constant(obj.start),
+  soffset: Fun.constant(obj.soffset),
+  finish: Fun.constant(obj.finish),
+  foffset: Fun.constant(obj.foffset)
+});
 
-const range: RangeConstructor = Struct.immutableBag(['start', 'soffset', 'finish', 'foffset'], []);
-
-type PathConstructor = (obj: { startPath: number[]; soffset: number; finishPath: number[]; foffset: number; }) => CursorPath;
-
-const path: PathConstructor = Struct.immutableBag(['startPath', 'soffset', 'finishPath', 'foffset'], []);
+const path = (obj: { startPath: number[]; soffset: number; finishPath: number[]; foffset: number; }): CursorPath => ({
+  startPath: Fun.constant(obj.startPath),
+  soffset: Fun.constant(obj.soffset),
+  finishPath: Fun.constant(obj.finishPath),
+  foffset: Fun.constant(obj.foffset)
+});
 
 export interface CursorSpec {
-  element: number[];
-  offset: number;
+  readonly element: number[];
+  readonly offset: number;
 }
 
 const pathFromCollapsed = (spec: CursorSpec): CursorPath =>
@@ -39,8 +45,8 @@ const pathFromCollapsed = (spec: CursorSpec): CursorPath =>
   });
 
 export interface RangeSpec {
-  start: CursorSpec;
-  finish?: CursorSpec;
+  readonly start: CursorSpec;
+  readonly finish?: CursorSpec;
 }
 
 const pathFromRange = (spec: RangeSpec): CursorPath => {

--- a/modules/agar/src/main/ts/ephox/agar/api/RealKeys.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RealKeys.ts
@@ -1,6 +1,6 @@
-import { Adt, Arr, Option, Struct } from '@ephox/katamari';
+import { Adt, Arr, Fun, Option } from '@ephox/katamari';
 
-import { MixedKeyModifiers, newModifiers } from '../keyboard/FakeKeys';
+import { KeyModifiers, MixedKeyModifiers, newModifiers } from '../keyboard/FakeKeys';
 import * as SeleniumAction from '../server/SeleniumAction';
 import { Step } from './Step';
 
@@ -31,12 +31,12 @@ interface Modifiers {
   altKey: () => Option<boolean>;
 }
 
-const modifierList = Struct.immutableBag<Modifiers>([], [
-  'ctrlKey',
-  'metaKey',
-  'shiftKey',
-  'altKey'
-]);
+const modifierList = (obj: KeyModifiers): Modifiers => ({
+  ctrlKey: Fun.constant(Option.from(obj.ctrlKey)),
+  metaKey: Fun.constant(Option.from(obj.metaKey)),
+  shiftKey: Fun.constant(Option.from(obj.shiftKey)),
+  altKey: Fun.constant(Option.from(obj.altKey))
+});
 
 const toSimpleFormat = (keys: KeyPressAdt[]) =>
   Arr.map(keys, (key: KeyPressAdt) => key.fold<any>((modifiers: Modifiers, letter: string) => ({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Dragging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Dragging.ts
@@ -1,4 +1,4 @@
-import { Struct } from '@ephox/katamari';
+import { Fun, Option } from '@ephox/katamari';
 import { BehaviourStateInitialiser } from '../../behaviour/common/BehaviourState';
 
 import * as DraggingApis from '../../behaviour/dragging/DraggingApis';
@@ -19,7 +19,12 @@ const Dragging: DraggingBehaviour<any> = Behaviour.createModes({
   },
   extra: {
     // Extra. Does not need component as input.
-    snap: Struct.immutableBag([ 'sensor', 'range', 'output' ], [ 'extra' ]) as (sConfig: SnapConfigSpec<any>) => SnapConfig<any>
+    snap: (sConfig: SnapConfigSpec<any>): SnapConfig<any> => ({
+      sensor: Fun.constant(sConfig.sensor),
+      range: Fun.constant(sConfig.range),
+      output: Fun.constant(sConfig.output),
+      extra: Fun.constant(Option.from(sConfig.extra))
+    })
   },
   state: DragState as BehaviourStateInitialiser<DraggingConfig<any>, DraggingState>,
   apis: DraggingApis

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/snap/Snappables.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/snap/Snappables.ts
@@ -78,7 +78,6 @@ const stopDrag = <E>(component: AlloyComponent, snapInfo: SnapsConfig<E>): void 
 
 const findMatchingSnap = <E>(snaps: Array<SnapConfig<E>>, newCoord: DragCoord.CoordAdt, scroll: Position, origin: Position): Option<SnapOutput<E>> => {
   return Arr.findMap(snaps, (snap) => {
-    // NOTE: These are structs because of the immutableBag in Dragging.ts
     const sensor = snap.sensor();
     const inRange = DragCoord.withinRange(newCoord, sensor, snap.range().left(), snap.range().top(), scroll, origin);
     return inRange ? Option.some(
@@ -102,7 +101,6 @@ const findClosestSnap = <E>(component: AlloyComponent, snapInfo: SnapsConfig<E>,
   const matchSnap = findMatchingSnap(snaps, newCoord, scroll, origin);
   return matchSnap.orThunk((): Option<SnapOutput<E>> => {
     const bestSnap = Arr.foldl(snaps, (acc: SnapCandidate<E>, snap: SnapConfig<E>): SnapCandidate<E> => {
-      // NOTE: These are structs because of the immutableBag in Dragging.ts
       const sensor = snap.sensor();
       const deltas = DragCoord.getDeltas(newCoord, sensor, snap.range().left(), snap.range().top(), scroll, origin);
       return acc.deltas.fold(() => {

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/MatrixType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/MatrixType.ts
@@ -60,9 +60,7 @@ const doMove = (ifCycle: MatrixNavigation.MatrixNavigationFunc<Element>, ifMove:
         return DomPinpoint.findIndex(allRows, inRow).bind((rowIndex) => {
           // Now, make the matrix.
           const matrix = toMatrix(allRows, matrixConfig);
-          return move(matrix, rowIndex, colIndex).map((next) => {
-            return next.cell();
-          });
+          return move(matrix, rowIndex, colIndex).map((next) => next.cell);
         });
       });
     });

--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/MatrixNavigation.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/MatrixNavigation.ts
@@ -1,9 +1,9 @@
 import { Num, Option } from '@ephox/katamari';
 
 export type MatrixNavigationOutcome<A> = {
-  rowIndex: number,
-  columnIndex: number,
-  cell: A
+  readonly rowIndex: number,
+  readonly columnIndex: number,
+  readonly cell: A
 };
 
 export type MatrixNavigationFunc<A> = (matrix: A[][], startRow: number, startCol: number) => Option<MatrixNavigationOutcome<A>>;

--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/MatrixNavigation.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/MatrixNavigation.ts
@@ -1,23 +1,21 @@
-import { Num, Option, Struct } from '@ephox/katamari';
+import { Num, Option } from '@ephox/katamari';
 
 export type MatrixNavigationOutcome<A> = {
-  rowIndex: () => number,
-  columnIndex: () => number,
-  cell: () => A
+  rowIndex: number,
+  columnIndex: number,
+  cell: A
 };
 
 export type MatrixNavigationFunc<A> = (matrix: A[][], startRow: number, startCol: number) => Option<MatrixNavigationOutcome<A>>;
 
-const outcome: <A>(outcome: { rowIndex: number, columnIndex: number, cell: A }) => MatrixNavigationOutcome<A> = Struct.immutableBag([ 'rowIndex', 'columnIndex', 'cell' ], [ ]);
-
 const toCell = <A>(matrix: A[][], rowIndex: number, columnIndex: number): Option<MatrixNavigationOutcome<NonNullable<A>>> => {
   return Option.from(matrix[rowIndex]).bind((row) => {
     return Option.from(row[columnIndex]).map((cell) => {
-      return outcome({
+      return {
         rowIndex,
         columnIndex,
         cell
-      });
+      };
     });
   });
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/MatrixNavigation.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/MatrixNavigation.ts
@@ -8,7 +8,7 @@ export type MatrixNavigationOutcome<A> = {
 
 export type MatrixNavigationFunc<A> = (matrix: A[][], startRow: number, startCol: number) => Option<MatrixNavigationOutcome<A>>;
 
-const toCell = <A>(matrix: A[][], rowIndex: number, columnIndex: number): Option<MatrixNavigationOutcome<NonNullable<A>>> => {
+const toCell = <A>(matrix: A[][], rowIndex: number, columnIndex: number): Option<MatrixNavigationOutcome<A>> => {
   return Option.from(matrix[rowIndex]).bind((row) => {
     return Option.from(row[columnIndex]).map((cell) => {
       return {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Origins.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Origins.ts
@@ -36,10 +36,10 @@ const adt: {
 ]);
 
 const positionWithDirection = (posName: string, decision: RepositionDecision, x: number, y: number, width: number, height: number) => {
-  const decisionX = decision.x() - x;
-  const decisionY = decision.y() - y;
-  const decisionWidth = decision.width();
-  const decisionHeight = decision.height();
+  const decisionX = decision.x - x;
+  const decisionY = decision.y - y;
+  const decisionWidth = decision.width;
+  const decisionHeight = decision.height;
   const decisionRight = width - (decisionX + decisionWidth);
   const decisionBottom = height - (decisionY + decisionHeight);
 
@@ -49,7 +49,7 @@ const positionWithDirection = (posName: string, decision: RepositionDecision, x:
   const bottom = Option.some(decisionBottom);
   const none = Option.none<number>();
 
-  return Direction.cata(decision.direction(),
+  return Direction.cata(decision.direction,
     () => {
       // southeast
       return NuPositionCss(posName, left, top, none, none);
@@ -87,7 +87,7 @@ const positionWithDirection = (posName: string, decision: RepositionDecision, x:
 
 const reposition = (origin: OriginAdt, decision: RepositionDecision): PositionCss => {
   return origin.fold(function () {
-    return NuPositionCss('absolute', Option.some(decision.x()), Option.some(decision.y()), Option.none(), Option.none());
+    return NuPositionCss('absolute', Option.some(decision.x), Option.some(decision.y), Option.none(), Option.none());
   }, function (x, y, width, height) {
     return positionWithDirection('absolute', decision, x, y, width, height);
   }, function (x, y, width, height) {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
@@ -1,4 +1,4 @@
-import { Fun, Option, Struct } from '@ephox/katamari';
+import { Fun, Option } from '@ephox/katamari';
 import { Element } from '@ephox/sugar';
 import { Bounds } from '../../alien/Boxes';
 import { AnchorOverrides, MaxHeightFunction, MaxWidthFunction } from '../mode/Anchoring';
@@ -9,23 +9,14 @@ import * as LayoutTypes from './LayoutTypes';
 import * as MaxHeight from './MaxHeight';
 import * as Origins from './Origins';
 
-export interface ReparteeOptionsSpec {
-  bounds: Bounds;
-  origin: Origins.OriginAdt;
-  preference: LayoutTypes.AnchorLayout[];
-  maxHeightFunction: MaxHeightFunction;
-  maxWidthFunction: MaxWidthFunction;
-}
-
 export interface ReparteeOptions {
-  bounds: () => Bounds;
-  origin: () => Origins.OriginAdt;
-  preference: () => LayoutTypes.AnchorLayout[];
-  maxHeightFunction: () => MaxHeightFunction;
-  maxWidthFunction: () => MaxWidthFunction;
+  readonly bounds: Bounds;
+  readonly origin: Origins.OriginAdt;
+  readonly preference: LayoutTypes.AnchorLayout[];
+  readonly maxHeightFunction: MaxHeightFunction;
+  readonly maxWidthFunction: MaxWidthFunction;
 }
 
-const reparteeOptions: (obj: ReparteeOptionsSpec) => ReparteeOptions = Struct.immutableBag(['bounds', 'origin', 'preference', 'maxHeightFunction', 'maxWidthFunction'], []);
 const defaultOr = <K extends keyof AnchorOverrides>(options: AnchorOverrides, key: K, dephault: NonNullable<AnchorOverrides[K]>): NonNullable<AnchorOverrides[K]> => {
   return options[key] === undefined ? dephault : options[key] as NonNullable<AnchorOverrides[K]>;
 };
@@ -39,19 +30,19 @@ const simple = (anchor: Anchor, element: Element, bubble: Bubble, layouts: Layou
   const anchorBox = anchor.anchorBox();
   const origin = anchor.origin();
 
-  const options = reparteeOptions({
+  const options: ReparteeOptions = {
     bounds: Origins.viewport(origin, getBounds),
     origin,
     preference: layouts,
     maxHeightFunction,
     maxWidthFunction
-  });
+  };
 
   go(anchorBox, element, bubble, options);
 };
 
 // This is the old public API. If we ever need full customisability again, this is how to expose it
-const go = (anchorBox: LayoutTypes.AnchorBox, element: Element, bubble: Bubble, options: ReparteeOptions) => {
+const go = (anchorBox: LayoutTypes.AnchorBox, element: Element, bubble: Bubble, options: ReparteeOptions): void => {
   const decision = Callouts.layout(anchorBox, element, bubble, options);
 
   Callouts.position(element, decision, options);

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
@@ -31,7 +31,7 @@ const layout = (anchorBox: AnchorBox, element: Element, bubbles: Bubble, options
 };
 
 const setClasses = (element: Element, decision: RepositionDecision) => {
-  const classInfo = decision.classes();
+  const classInfo = decision.classes;
   Classes.remove(element, classInfo.off);
   Classes.add(element, classInfo.on);
 };
@@ -46,12 +46,12 @@ const setHeight = (element: Element, decision: RepositionDecision, options: Repa
   // The old API enforced MaxHeight.anchored() for fixed position. That no longer seems necessary.
   const maxHeightFunction = options.maxHeightFunction();
 
-  maxHeightFunction(element, decision.maxHeight());
+  maxHeightFunction(element, decision.maxHeight);
 };
 
 const setWidth = (element: Element, decision: RepositionDecision, options: ReparteeOptions) => {
   const maxWidthFunction = options.maxWidthFunction();
-  maxWidthFunction(element, decision.maxWidth());
+  maxWidthFunction(element, decision.maxWidth);
 };
 
 const position = (element: Element, decision: RepositionDecision, options: ReparteeOptions) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
@@ -21,13 +21,13 @@ const elementSize = (p: Element): AnchorElement => {
   };
 };
 
-const layout = (anchorBox: AnchorBox, element: Element, bubbles: Bubble, options: ReparteeOptions) => {
+const layout = (anchorBox: AnchorBox, element: Element, bubbles: Bubble, options: ReparteeOptions): RepositionDecision => {
   // clear the potentially limiting factors before measuring
   Css.remove(element, 'max-height');
   Css.remove(element, 'max-width');
 
   const elementBox = elementSize(element);
-  return Bounder.attempts(options.preference(), anchorBox, elementBox, bubbles, options.bounds());
+  return Bounder.attempts(options.preference, anchorBox, elementBox, bubbles, options.bounds);
 };
 
 const setClasses = (element: Element, decision: RepositionDecision) => {
@@ -44,20 +44,20 @@ const setClasses = (element: Element, decision: RepositionDecision) => {
  */
 const setHeight = (element: Element, decision: RepositionDecision, options: ReparteeOptions) => {
   // The old API enforced MaxHeight.anchored() for fixed position. That no longer seems necessary.
-  const maxHeightFunction = options.maxHeightFunction();
+  const maxHeightFunction = options.maxHeightFunction;
 
   maxHeightFunction(element, decision.maxHeight);
 };
 
 const setWidth = (element: Element, decision: RepositionDecision, options: ReparteeOptions) => {
-  const maxWidthFunction = options.maxWidthFunction();
+  const maxWidthFunction = options.maxWidthFunction;
   maxWidthFunction(element, decision.maxWidth);
 };
 
 const position = (element: Element, decision: RepositionDecision, options: ReparteeOptions) => {
   // This is a point of difference between Alloy and Repartee. Repartee appears to use Measure to calculate the available space for fixed origin
   // That is not ported yet.
-  applyPositionCss(element, Origins.reposition(options.origin(), decision));
+  applyPositionCss(element, Origins.reposition(options.origin, decision));
 };
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
@@ -1,4 +1,5 @@
 import { Struct } from '@ephox/katamari';
+import { DirectionAdt } from '../layout/Direction';
 
 export interface RepositionDecisionSpec {
   x: number;
@@ -23,7 +24,7 @@ export interface RepositionDecision {
   height: () => number;
   maxHeight: () => number;
   maxWidth: () => number;
-  direction: () => any;
+  direction: () => DirectionAdt;
   classes: () => {
     off: string[];
     on: string[]

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
@@ -1,7 +1,6 @@
-import { Struct } from '@ephox/katamari';
 import { DirectionAdt } from '../layout/Direction';
 
-export interface RepositionDecisionSpec {
+export interface RepositionDecision {
   readonly x: number;
   readonly y: number;
   readonly width: number;
@@ -16,25 +15,3 @@ export interface RepositionDecisionSpec {
   readonly label: string;
   readonly candidateYforTest: number;
 }
-
-export interface RepositionDecision {
-  readonly x: () => number;
-  readonly y: () => number;
-  readonly width: () => number;
-  readonly height: () => number;
-  readonly maxHeight: () => number;
-  readonly maxWidth: () => number;
-  readonly direction: () => DirectionAdt;
-  readonly classes: () => {
-    off: string[];
-    on: string[]
-  };
-  readonly label: () => string;
-  readonly candidateYforTest: () => number;
-}
-
-const decision: (obj: RepositionDecisionSpec) => RepositionDecision = Struct.immutableBag(['x', 'y', 'width', 'height', 'maxHeight', 'maxWidth', 'direction', 'classes', 'label', 'candidateYforTest'], []);
-
-export {
-  decision
-};

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
@@ -2,35 +2,35 @@ import { Struct } from '@ephox/katamari';
 import { DirectionAdt } from '../layout/Direction';
 
 export interface RepositionDecisionSpec {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  maxHeight: number;
-  maxWidth: number;
-  direction: any;
-  classes: {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly maxHeight: number;
+  readonly maxWidth: number;
+  readonly direction: DirectionAdt;
+  readonly classes: {
     off: string[];
     on: string[]
   };
-  label: string;
-  candidateYforTest: number;
+  readonly label: string;
+  readonly candidateYforTest: number;
 }
 
 export interface RepositionDecision {
-  x: () => number;
-  y: () => number;
-  width: () => number;
-  height: () => number;
-  maxHeight: () => number;
-  maxWidth: () => number;
-  direction: () => DirectionAdt;
-  classes: () => {
+  readonly x: () => number;
+  readonly y: () => number;
+  readonly width: () => number;
+  readonly height: () => number;
+  readonly maxHeight: () => number;
+  readonly maxWidth: () => number;
+  readonly direction: () => DirectionAdt;
+  readonly classes: () => {
     off: string[];
     on: string[]
   };
-  label: () => string;
-  candidateYforTest: () => number;
+  readonly label: () => string;
+  readonly candidateYforTest: () => number;
 }
 
 const decision: (obj: RepositionDecisionSpec) => RepositionDecision = Struct.immutableBag(['x', 'y', 'width', 'height', 'maxHeight', 'maxWidth', 'direction', 'classes', 'label', 'candidateYforTest'], []);

--- a/modules/alloy/src/test/ts/atomic/navigation/MatrixNavigationTest.ts
+++ b/modules/alloy/src/test/ts/atomic/navigation/MatrixNavigationTest.ts
@@ -45,10 +45,10 @@ UnitTest.test('MatrixNavigationTest', () => {
       const postUp = MatrixNavigation.cycleUp(arb.matrix, arb.row, arb.col).getOrDie(
         'Should be able to cycleUp!'
       );
-      const postDown = MatrixNavigation.cycleDown(arb.matrix, postUp.rowIndex(), postUp.columnIndex()).getOrDie(
+      const postDown = MatrixNavigation.cycleDown(arb.matrix, postUp.rowIndex, postUp.columnIndex).getOrDie(
         'Should be able to cycleDown!'
       );
-      return Jsc.eq(postDown.rowIndex(), arb.row) && Jsc.eq(postDown.columnIndex(), arb.col);
+      return Jsc.eq(postDown.rowIndex, arb.row) && Jsc.eq(postDown.columnIndex, arb.col);
     }
   );
 
@@ -59,10 +59,10 @@ UnitTest.test('MatrixNavigationTest', () => {
       const postLeft = MatrixNavigation.cycleLeft(arb.matrix, arb.row, arb.col).getOrDie(
         'Should be able to cycleLeft'
       );
-      const postRight = MatrixNavigation.cycleRight(arb.matrix, postLeft.rowIndex(), postLeft.columnIndex()).getOrDie(
+      const postRight = MatrixNavigation.cycleRight(arb.matrix, postLeft.rowIndex, postLeft.columnIndex).getOrDie(
         'Should be able to cycleRight'
       );
-      return Jsc.eq(postRight.rowIndex(), arb.row) && Jsc.eq(postRight.columnIndex(), arb.col);
+      return Jsc.eq(postRight.rowIndex, arb.row) && Jsc.eq(postRight.columnIndex, arb.col);
     }
   );
 

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderCursorTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderCursorTest.ts
@@ -17,10 +17,10 @@ UnitTest.test('BounderCursorTest', () => {
   /* global assert */
   const check = (expected: TestDecisionSpec, preference: AnchorLayout[], anchor: AnchorBox, panel: AnchorElement, bubbles: Bubble.Bubble, bounds: Bounds) => {
     const actual = Bounder.attempts(preference, anchor, panel, bubbles, bounds);
-    Assert.eq('label', expected.label, actual.label());
-    Assert.eq('X', expected.x, actual.x());
-    Assert.eq('Y', expected.y, actual.y());
-    if (expected.candidateYforTest !== undefined) { Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest()); }
+    Assert.eq('label', expected.label, actual.label);
+    Assert.eq('X', expected.x, actual.x);
+    Assert.eq('Y', expected.y, actual.y);
+    if (expected.candidateYforTest !== undefined) { Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest); }
   };
 
   // Layout is for boxes with a bubble pointing to a cursor position (vertically aligned to nearest side)

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderMenuTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderMenuTest.ts
@@ -17,10 +17,10 @@ UnitTest.test('BounderMenuTest', () => {
   /* global assert */
   const check = (expected: TestDecisionSpec, preference: AnchorLayout[], anchor: AnchorBox, panel: AnchorElement, bubbles: Bubble.Bubble, bounds: Bounds) => {
     const actual = Bounder.attempts(preference, anchor, panel, bubbles, bounds);
-    assert.eq(expected.label, actual.label());
-    assert.eq(expected.x, actual.x());
-    assert.eq(expected.y, actual.y());
-    if (expected.candidateYforTest !== undefined) { assert.eq(expected.candidateYforTest, actual.candidateYforTest()); }
+    assert.eq(expected.label, actual.label);
+    assert.eq(expected.x, actual.x);
+    assert.eq(expected.y, actual.y);
+    if (expected.candidateYforTest !== undefined) { assert.eq(expected.candidateYforTest, actual.candidateYforTest); }
   };
 
   // LinkedLayout is for submenus (vertically aligned to opposite side of menu)

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderToolbuttonTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderToolbuttonTest.ts
@@ -18,10 +18,10 @@ UnitTest.test('BounderToolbuttonTest', () => {
   /* global assert */
   const check = (expected: TestDecisionSpec, preference: AnchorLayout[], anchor: AnchorBox, panel: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
     const actual = Bounder.attempts(preference, anchor, panel, bubbles, bounds);
-    Assert.eq('label', expected.label, actual.label());
-    Assert.eq('X', expected.x, actual.x());
-    Assert.eq('Y', expected.y, actual.y());
-    if (expected.candidateYforTest !== undefined) { Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest()); }
+    Assert.eq('label', expected.label, actual.label);
+    Assert.eq('X', expected.x, actual.x);
+    Assert.eq('Y', expected.y, actual.y);
+    if (expected.candidateYforTest !== undefined) { Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest); }
   };
 
   // Layout is for boxes with a bubble pointing to a cursor position (vertically aligned to nearest side)

--- a/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
@@ -126,8 +126,8 @@ const external = (win: Window, container: Element, isRoot: (e: Element) => boole
   return (start: Element, finish: Element) => {
     annotations.clearBeforeUpdate(container);
     CellSelection.identify(start, finish, isRoot).each(function (cellSel) {
-      const boxes = cellSel.boxes().getOr([]);
-      annotations.selectRange(container, boxes, cellSel.start(), cellSel.finish());
+      const boxes = cellSel.boxes.getOr([]);
+      annotations.selectRange(container, boxes, cellSel.start, cellSel.finish);
 
       // stop the browser from creating a big text selection, place the selection at the end of the cell where the cursor is
       bridge.selectContents(finish);

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Carets.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Carets.ts
@@ -1,82 +1,70 @@
-import { Struct } from '@ephox/katamari';
-
 export interface Carets {
-  left: () => number;
-  top: () => number;
-  right: () => number;
-  bottom: () => number;
+  readonly left: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
 }
 
-interface CaretsIn {
-  left: number;
-  top: number;
-  right: number;
-  bottom: number;
-}
-
-const nu: (data: CaretsIn) => Carets = Struct.immutableBag(['left', 'top', 'right', 'bottom'], []);
-
-const moveDown = function (caret: Carets, amount: number) {
-  return nu({
-    left: caret.left(),
-    top: caret.top() + amount,
-    right: caret.right(),
-    bottom: caret.bottom() + amount
-  });
+const moveDown = function (caret: Carets, amount: number): Carets {
+  return {
+    left: caret.left,
+    top: caret.top + amount,
+    right: caret.right,
+    bottom: caret.bottom + amount
+  };
 };
 
-const moveUp = function (caret: Carets, amount: number) {
-  return nu({
-    left: caret.left(),
-    top: caret.top() - amount,
-    right: caret.right(),
-    bottom: caret.bottom() - amount
-  });
+const moveUp = function (caret: Carets, amount: number): Carets {
+  return {
+    left: caret.left,
+    top: caret.top - amount,
+    right: caret.right,
+    bottom: caret.bottom - amount
+  };
 };
 
-const moveBottomTo = function (caret: Carets, bottom: number) {
-  const height = caret.bottom() - caret.top();
-  return nu({
-    left: caret.left(),
+const moveBottomTo = function (caret: Carets, bottom: number): Carets {
+  const height = caret.bottom - caret.top;
+  return {
+    left: caret.left,
     top: bottom - height,
-    right: caret.right(),
+    right: caret.right,
     bottom
-  });
+  };
 };
 
-const moveTopTo = function (caret: Carets, top: number) {
-  const height = caret.bottom() - caret.top();
-  return nu({
-    left: caret.left(),
+const moveTopTo = function (caret: Carets, top: number): Carets {
+  const height = caret.bottom - caret.top;
+  return ({
+    left: caret.left,
     top,
-    right: caret.right(),
+    right: caret.right,
     bottom: top + height
   });
 };
 
-const translate = function (caret: Carets, xDelta: number, yDelta: number) {
-  return nu({
-    left: caret.left() + xDelta,
-    top: caret.top() + yDelta,
-    right: caret.right() + xDelta,
-    bottom: caret.bottom() + yDelta
-  });
+const translate = function (caret: Carets, xDelta: number, yDelta: number): Carets {
+  return {
+    left: caret.left + xDelta,
+    top: caret.top + yDelta,
+    right: caret.right + xDelta,
+    bottom: caret.bottom + yDelta
+  };
 };
 
-const getTop = function (caret: Carets) {
-  return caret.top();
+const getTop = function (caret: Carets): number {
+  return caret.top;
 };
 
-const getBottom = function (caret: Carets) {
-  return caret.bottom();
+const getBottom = function (caret: Carets): number {
+  return caret.bottom;
 };
 
 const toString = function (caret: Carets) {
-  return '(' + caret.left() + ', ' + caret.top() + ') -> (' + caret.right() + ', ' + caret.bottom() + ')';
+  return '(' + caret.left + ', ' + caret.top + ') -> (' + caret.right + ', ' + caret.bottom + ')';
 };
 
-export const Carets = {
-  nu,
+export {
   moveUp,
   moveDown,
   moveBottomTo,

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
@@ -23,9 +23,9 @@ const sync = function (container: Element, isRoot: (element: Element) => boolean
 const detect = function (container: Element, isRoot: (element: Element) => boolean, start: Element, finish: Element, selectRange: (container: Element, boxes: Element[], start: Element, finish: Element) => void) {
   if (!Compare.eq(start, finish)) {
     return CellSelection.identify(start, finish, isRoot).bind(function (cellSel) {
-      const boxes = cellSel.boxes().getOr([]);
+      const boxes = cellSel.boxes.getOr([]);
       if (boxes.length > 0) {
-        selectRange(container, boxes, cellSel.start(), cellSel.finish());
+        selectRange(container, boxes, cellSel.start, cellSel.finish);
         return Option.some(Response.create(
           Option.some(Util.makeSitus(start, 0, start, Awareness.getEnd(start))),
           true
@@ -42,8 +42,8 @@ const detect = function (container: Element, isRoot: (element: Element) => boole
 const update = function (rows: number, columns: number, container: Element, selected: Element[], annotations: SelectionAnnotation) {
   const updateSelection = function (newSels: IdentifiedExt) {
     annotations.clearBeforeUpdate(container);
-    annotations.selectRange(container, newSels.boxes(), newSels.start(), newSels.finish());
-    return newSels.boxes();
+    annotations.selectRange(container, newSels.boxes, newSels.start, newSels.finish);
+    return newSels.boxes;
   };
 
   return CellSelection.shiftSelection(selected, rows, columns, annotations.firstSelectedSelector, annotations.lastSelectedSelector).map(updateSelection);

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Rectangles.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Rectangles.ts
@@ -1,7 +1,9 @@
 import { Option } from '@ephox/katamari';
 import { Awareness, Node, Element, RawRect } from '@ephox/sugar';
-import { Carets } from './Carets';
+import * as Carets from './Carets';
 import { WindowBridge } from '../api/WindowBridge';
+
+type Carets = Carets.Carets;
 
 const getPartialBox = function (bridge: WindowBridge, element: Element, offset: number) {
   if (offset >= 0 && offset < Awareness.getEnd(element)) {
@@ -12,20 +14,18 @@ const getPartialBox = function (bridge: WindowBridge, element: Element, offset: 
   return Option.none<RawRect>();
 };
 
-const toCaret = function (rect: RawRect) {
-  return Carets.nu({
-    left: rect.left,
-    top: rect.top,
-    right: rect.right,
-    bottom: rect.bottom
-  });
-};
+const toCaret = (rect: RawRect): Carets => ({
+  left: rect.left,
+  top: rect.top,
+  right: rect.right,
+  bottom: rect.bottom
+});
 
 const getElemBox = function (bridge: WindowBridge, element: Element) {
   return Option.some(bridge.getRect(element));
 };
 
-const getBoxAt = function (bridge: WindowBridge, element: Element, offset: number) {
+const getBoxAt = function (bridge: WindowBridge, element: Element, offset: number): Option<Carets> {
   // Note, we might need to consider this offset and descend.
   if (Node.isElement(element)) {
     return getElemBox(bridge, element).map(toCaret);
@@ -36,7 +36,7 @@ const getBoxAt = function (bridge: WindowBridge, element: Element, offset: numbe
   }
 };
 
-const getEntireBox = function (bridge: WindowBridge, element: Element) {
+const getEntireBox = function (bridge: WindowBridge, element: Element): Option<Carets> {
   if (Node.isElement(element)) {
     return getElemBox(bridge, element).map(toCaret);
   } else if (Node.isText(element)) {

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
@@ -2,9 +2,12 @@ import { Adt, Fun, Option } from '@ephox/katamari';
 import { DomGather } from '@ephox/phoenix';
 import { DomStructure } from '@ephox/robin';
 import { Node, PredicateFind, Element } from '@ephox/sugar';
-import { Carets } from './Carets';
+import * as Carets from './Carets';
 import * as Rectangles from './Rectangles';
 import { WindowBridge } from '../api/WindowBridge';
+import { Situs } from '../selection/Situs';
+
+type Carets = Carets.Carets;
 
 type NoneHandler<T> = () => T;
 type RetryHandler<T> = (caret: Carets) => T;
@@ -39,8 +42,8 @@ const adt: {
   { retry: ['caret'] }
 ]);
 
-const isOutside = function (caret: Carets, box: Carets) {
-  return caret.left() < box.left() || Math.abs(box.right() - caret.left()) < 1 || caret.left() > box.right();
+const isOutside = function (caret: Carets, box: Carets): boolean {
+  return caret.left < box.left || Math.abs(box.right - caret.left) < 1 || caret.left > box.right;
 };
 
 // Find the block and determine whether or not that block is outside. If it is outside, move up/down and right.
@@ -72,26 +75,26 @@ const inOutsideBlock = function (bridge: WindowBridge, element: Element, caret: 
  *    because the guess is GOOD.
  */
 
-const adjustDown = function (bridge: WindowBridge, element: Element, guessBox: Carets, original: Carets, caret: Carets) {
+const adjustDown = function (bridge: WindowBridge, element: Element, guessBox: Carets, original: Carets, caret: Carets): Retries {
   const lowerCaret = Carets.moveDown(caret, JUMP_SIZE);
-  if (Math.abs(guessBox.bottom() - original.bottom()) < 1) {
+  if (Math.abs(guessBox.bottom - original.bottom) < 1) {
     return adt.retry(lowerCaret);
-  } else if (guessBox.top() > caret.bottom()) {
+  } else if (guessBox.top > caret.bottom) {
     return adt.retry(lowerCaret);
-  } else if (guessBox.top() === caret.bottom()) {
+  } else if (guessBox.top === caret.bottom) {
     return adt.retry(Carets.moveDown(caret, 1));
   } else {
     return inOutsideBlock(bridge, element, caret) ? adt.retry(Carets.translate(lowerCaret, JUMP_SIZE, 0)) : adt.none();
   }
 };
 
-const adjustUp = function (bridge: WindowBridge, element: Element, guessBox: Carets, original: Carets, caret: Carets) {
+const adjustUp = function (bridge: WindowBridge, element: Element, guessBox: Carets, original: Carets, caret: Carets): Retries {
   const higherCaret = Carets.moveUp(caret, JUMP_SIZE);
-  if (Math.abs(guessBox.top() - original.top()) < 1) {
+  if (Math.abs(guessBox.top - original.top) < 1) {
     return adt.retry(higherCaret);
-  } else if (guessBox.bottom() < caret.top()) {
+  } else if (guessBox.bottom < caret.top) {
     return adt.retry(higherCaret);
-  } else if (guessBox.bottom() === caret.top()) {
+  } else if (guessBox.bottom === caret.top) {
     return adt.retry(Carets.moveUp(caret, 1));
   } else {
     return inOutsideBlock(bridge, element, caret) ? adt.retry(Carets.translate(higherCaret, JUMP_SIZE, 0)) : adt.none();
@@ -112,7 +115,7 @@ const downMovement: CaretMovement = {
   gather: DomGather.after
 };
 
-const isAtTable = function (bridge: WindowBridge, x: number, y: number) {
+const isAtTable = function (bridge: WindowBridge, x: number, y: number): boolean {
   return bridge.elementFromPoint(x, y).filter(function (elm) {
     return Node.name(elm) === 'table';
   }).isSome();
@@ -126,11 +129,11 @@ const adjustTil = function (bridge: WindowBridge, movement: CaretMovement, origi
   if (numRetries === 0) {
     return Option.some(caret);
   }
-  if (isAtTable(bridge, caret.left(), movement.point(caret))) {
+  if (isAtTable(bridge, caret.left, movement.point(caret))) {
     return adjustForTable(bridge, movement, original, caret, numRetries - 1);
   }
 
-  return bridge.situsFromPoint(caret.left(), movement.point(caret)).bind(function (guess) {
+  return bridge.situsFromPoint(caret.left, movement.point(caret)).bind(function (guess) {
     return guess.start().fold<Option<Carets>>(Option.none, function (element) {
       return Rectangles.getEntireBox(bridge, element).bind(function (guessBox) {
         return movement.adjuster(bridge, element, guessBox, original, caret).fold<Option<Carets>>(
@@ -146,15 +149,15 @@ const adjustTil = function (bridge: WindowBridge, movement: CaretMovement, origi
   });
 };
 
-const ieTryDown = function (bridge: WindowBridge, caret: Carets) {
-  return bridge.situsFromPoint(caret.left(), caret.bottom() + JUMP_SIZE);
+const ieTryDown = function (bridge: WindowBridge, caret: Carets): Option<Situs> {
+  return bridge.situsFromPoint(caret.left, caret.bottom + JUMP_SIZE);
 };
 
-const ieTryUp = function (bridge: WindowBridge, caret: Carets) {
-  return bridge.situsFromPoint(caret.left(), caret.top() - JUMP_SIZE);
+const ieTryUp = function (bridge: WindowBridge, caret: Carets): Option<Situs> {
+  return bridge.situsFromPoint(caret.left, caret.top - JUMP_SIZE);
 };
 
-const checkScroll = function (movement: CaretMovement, adjusted: Carets, bridge: WindowBridge) {
+const checkScroll = function (movement: CaretMovement, adjusted: Carets, bridge: WindowBridge): Option<number> {
   // I'm not convinced that this is right. Let's re-examine it later.
   if (movement.point(adjusted) > bridge.getInnerHeight()) {
     return Option.some(movement.point(adjusted) - bridge.getInnerHeight());
@@ -165,14 +168,14 @@ const checkScroll = function (movement: CaretMovement, adjusted: Carets, bridge:
   }
 };
 
-const retry = function (movement: CaretMovement, bridge: WindowBridge, caret: Carets) {
+const retry = function (movement: CaretMovement, bridge: WindowBridge, caret: Carets): Option<Situs> {
   const moved = movement.move(caret, JUMP_SIZE);
   const adjusted = adjustTil(bridge, movement, caret, moved, NUM_RETRIES).getOr(moved);
   return checkScroll(movement, adjusted, bridge).fold(function () {
-    return bridge.situsFromPoint(adjusted.left(), movement.point(adjusted));
+    return bridge.situsFromPoint(adjusted.left, movement.point(adjusted));
   }, function (delta) {
     bridge.scrollBy(0, delta);
-    return bridge.situsFromPoint(adjusted.left(), movement.point(adjusted) - delta);
+    return bridge.situsFromPoint(adjusted.left, movement.point(adjusted) - delta);
   });
 };
 

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
@@ -4,12 +4,14 @@ import { PlatformDetection } from '@ephox/sand';
 import { Awareness, Compare, Element } from '@ephox/sugar';
 import { BeforeAfter } from '../navigation/BeforeAfter';
 import * as BrTags from '../navigation/BrTags';
-import { Carets } from './Carets';
+import * as Carets from './Carets';
 import * as Rectangles from './Rectangles';
 import { Retries } from './Retries';
 import { WindowBridge } from '../api/WindowBridge';
 import { KeyDirection } from '../navigation/KeyDirection';
 import { Situs } from '../selection/Situs';
+
+type Carets = Carets.Carets;
 
 const MAX_RETRIES = 20;
 

--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -26,12 +26,12 @@ export default function (bridge: WindowBridge, container: Element, isRoot: (e: E
       annotations.clearBeforeUpdate(container);
       findCell(event.target(), isRoot).each(function (finish) {
         CellSelection.identify(start, finish, isRoot).each(function (cellSel) {
-          const boxes = cellSel.boxes().getOr([]);
+          const boxes = cellSel.boxes.getOr([]);
           // Wait until we have more than one, otherwise you can't do text selection inside a cell.
           // Alternatively, if the one cell selection starts in one cell and ends in a different cell,
           // we can assume that the user is trying to make a one cell selection in two different tables which should be possible.
           if (boxes.length > 1 || (boxes.length === 1 && !Compare.eq(start, finish))) {
-            annotations.selectRange(container, boxes, cellSel.start(), cellSel.finish());
+            annotations.selectRange(container, boxes, cellSel.start, cellSel.finish);
 
             // stop the browser from creating a big text selection, select the cell where the cursor is
             bridge.selectContents(finish);

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/CellSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/CellSelection.ts
@@ -18,36 +18,36 @@ const identify = function (start: Element, finish: Element, isRoot?: (element: E
 
   // Optimisation: If the cells are equal, it's a single cell array
   if (Compare.eq(start, finish)) {
-    return Option.some(Identified.create({
-      boxes: Option.some([start]),
+    return Option.some({
+      boxes: Option.some([ start ]),
       start,
       finish
-    }));
+    });
   } else {
     return lookupTable(start).bind(function (startTable) {
       return lookupTable(finish).bind(function (finishTable) {
         if (Compare.eq(startTable, finishTable)) { // Selecting from within the same table.
-          return Option.some(Identified.create({
+          return Option.some({
             boxes: TablePositions.intercepts(startTable, start, finish),
             start,
             finish
-          }));
+          });
         } else if (Compare.contains(startTable, finishTable)) { // Selecting from the parent table to the nested table.
           const ancestorCells = SelectorFilter.ancestors(finish, 'td,th', getIsRoot(startTable));
           const finishCell = ancestorCells.length > 0 ? ancestorCells[ancestorCells.length - 1] : finish;
-          return Option.some(Identified.create({
+          return Option.some({
             boxes: TablePositions.nestedIntercepts(startTable, start, startTable, finish, finishTable),
             start,
             finish: finishCell
-          }));
+          });
         } else if (Compare.contains(finishTable, startTable)) { // Selecting from the nested table to the parent table.
           const ancestorCells = SelectorFilter.ancestors(start, 'td,th', getIsRoot(finishTable));
           const startCell = ancestorCells.length > 0 ? ancestorCells[ancestorCells.length - 1] : start;
-          return Option.some(Identified.create({
+          return Option.some({
             boxes: TablePositions.nestedIntercepts(finishTable, start, startTable, finish, finishTable),
             start,
             finish: startCell
-          }));
+          });
         } else { // Selecting from a nested table to a different nested table.
           return DomParent.ancestors(start, finish).shared().bind(function (lca) {
             return SelectorFind.closest(lca, 'table', isRoot).bind(function (lcaTable) {
@@ -55,11 +55,11 @@ const identify = function (start: Element, finish: Element, isRoot?: (element: E
               const finishCell = finishAncestorCells.length > 0 ? finishAncestorCells[finishAncestorCells.length - 1] : finish;
               const startAncestorCells = SelectorFilter.ancestors(start, 'td,th', getIsRoot(lcaTable));
               const startCell = startAncestorCells.length > 0 ? startAncestorCells[startAncestorCells.length - 1] : start;
-              return Option.some(Identified.create({
+              return Option.some({
                 boxes: TablePositions.nestedIntercepts(lcaTable, start, startTable, finish, finishTable),
                 start: startCell,
                 finish: finishCell
-              }));
+              });
             });
           });
         }
@@ -93,15 +93,15 @@ const getEdges = function (container: Element, firstSelectedSelector: string, la
   });
 };
 
-const expandTo = function (finish: Element, firstSelectedSelector: string) {
+const expandTo = function (finish: Element, firstSelectedSelector: string): Option<IdentifiedExt> {
   return SelectorFind.ancestor(finish, 'table').bind(function (table) {
     return SelectorFind.descendant(table, firstSelectedSelector).bind(function (start) {
       return identify(start, finish).bind(function (identified) {
-        return identified.boxes().map<IdentifiedExt>(function (boxes) {
+        return identified.boxes.map<IdentifiedExt>(function (boxes) {
           return {
-            boxes: Fun.constant(boxes),
-            start: Fun.constant(identified.start()),
-            finish: Fun.constant(identified.finish())
+            boxes,
+            start: identified.start,
+            finish: identified.finish
           };
         });
       });

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Identified.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Identified.ts
@@ -1,26 +1,14 @@
-import { Option, Struct } from '@ephox/katamari';
+import { Option } from '@ephox/katamari';
 import { Element } from '@ephox/sugar';
 
-interface IdentifiedInput {
+export interface Identified {
   boxes: Option<Element[]>;
   start: Element;
   finish: Element;
 }
 
-export interface Identified {
-  boxes: () => Option<Element[]>;
-  start: () => Element;
-  finish: () => Element;
-}
-
 export interface IdentifiedExt {
-  boxes: () => Element[];
-  start: () => Element;
-  finish: () => Element;
+  boxes: Element[];
+  start: Element;
+  finish: Element;
 }
-
-const create: (obj: IdentifiedInput) => Identified = Struct.immutableBag(['boxes', 'start', 'finish'], []);
-
-export const Identified = {
-  create
-};

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Option.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Option.ts
@@ -160,7 +160,7 @@ const some = <T>(a: T): Option<T> => {
   return me;
 };
 
-const from = <T>(value: T | undefined | null): Option<NonNullable<T>> => value === null || value === undefined ? NONE : some(value as NonNullable<T>);
+const from = <T>(value: T | undefined | null): Option<T> => value === null || value === undefined ? NONE : some(value);
 
 export const Option = {
   some,

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyDom.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyDom.ts
@@ -1,5 +1,4 @@
 import { Node as DomNode, Range } from '@ephox/dom-globals';
-import { Struct } from '@ephox/katamari';
 import { Element, SimRange } from '@ephox/sugar';
 
 export interface TinyDom {
@@ -7,20 +6,15 @@ export interface TinyDom {
   fromRange: (rng: Range) => SimRange;
 }
 
-const range: (range: { start: DomNode; soffset: number; finish: DomNode; foffset: number; }) => SimRange = Struct.immutableBag([ 'start', 'soffset', 'finish', 'foffset' ], [ ]);
+const fromDom = (elm: DomNode): Element<DomNode> =>
+  Element.fromDom(elm);
 
-const fromDom = function (elm: DomNode) {
-  return Element.fromDom(elm);
-};
-
-const fromRange = function (rng: Range) {
-  return range({
-    start: rng.startContainer,
-    soffset: rng.startOffset,
-    finish: rng.endContainer,
-    foffset: rng.endOffset
-  });
-};
+const fromRange = (rng: Range): SimRange =>
+  SimRange.create(
+    Element.fromDom(rng.startContainer),
+    rng.startOffset,
+    Element.fromDom(rng.endContainer), rng.endOffset
+  );
 
 export const TinyDom: TinyDom = {
   fromDom,

--- a/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
@@ -7,7 +7,7 @@
 
 import { InputHandlers, SelectionAnnotation, SelectionKeys } from '@ephox/darwin';
 import { Event, HTMLElement, KeyboardEvent, MouseEvent, Node as HtmlNode, TouchEvent } from '@ephox/dom-globals';
-import { Cell, Fun, Option, Struct } from '@ephox/katamari';
+import { Cell, Fun, Option } from '@ephox/katamari';
 import { DomParent } from '@ephox/robin';
 import { OtherCells, TableFill, TableLookup, TableResize } from '@ephox/snooker';
 import { Class, Compare, DomEvent, Element, Node, Selection, SelectionDirection } from '@ephox/sugar';
@@ -25,9 +25,16 @@ const hasInternalTarget = (e: Event) => {
   return Class.has(Element.fromDom(e.target as HTMLElement), 'ephox-snooker-resizer-bar') === false;
 };
 
+interface HandlerStruct {
+  readonly mousedown: (e: MouseEvent) => void;
+  readonly mouseover: (e: MouseEvent) => void;
+  readonly mouseup: (e: MouseEvent) => void;
+  readonly keyup: (e: KeyboardEvent) => void;
+  readonly keydown: (e: KeyboardEvent) => void;
+}
+
 export default function (editor: Editor, lazyResize: () => Option<TableResize>, selectionTargets: SelectionTargets) {
-  const handlerStruct = Struct.immutableBag(['mousedown', 'mouseover', 'mouseup', 'keyup', 'keydown'], []);
-  let handlers = Option.none();
+  let handlers: Option<HandlerStruct> = Option.none();
 
   const cloneFormats = getCloneElements(editor);
 
@@ -194,13 +201,13 @@ export default function (editor: Editor, lazyResize: () => Option<TableResize>, 
     editor.on('keydown', keydown);
     editor.on('NodeChange', syncSelection);
 
-    handlers = Option.some(handlerStruct({
+    handlers = Option.some({
       mousedown: mouseDown,
       mouseover: mouseOver,
       mouseup: mouseUp,
       keyup,
       keydown
-    }));
+    });
   });
 
   const destroy = function () {


### PR DESCRIPTION
`immutableBag` is a remnant of an old coding style. It was an attempt to make a "constructor" which validated arguments and provided getters. 

This change removes all references except for a tricky one in `IosMode` - we need more types in there to make it safe to change.