### PR TITLE
TINY-4760: Add quick-win type information to mobile theme

### DIFF
--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Rect.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Rect.ts
@@ -1,4 +1,6 @@
-/** @deprecated Use RawRect instead */
+/**
+ * @deprecated Use RawRect instead
+ */
 export interface StructRect {
   left: () => number;
   top: () => number;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Rect.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Rect.ts
@@ -1,3 +1,4 @@
+/** @deprecated Use RawRect instead */
 export interface StructRect {
   left: () => number;
   top: () => number;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/WindowSelection.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/WindowSelection.ts
@@ -13,29 +13,28 @@ import { Selection } from './Selection';
 import { SimRange } from './SimRange';
 import { Situ } from './Situ';
 
-const doSetNativeRange = function (win: Window, rng: Range) {
-  Option.from(win.getSelection()).each(function (selection) {
+const doSetNativeRange = (win: Window, rng: Range): void => {
+  Option.from(win.getSelection()).each((selection) => {
     selection.removeAllRanges();
     selection.addRange(rng);
   });
 };
 
-const doSetRange = function (win: Window, start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) {
+const doSetRange = (win: Window, start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): void => {
   const rng = NativeRange.exactToNative(win, start, soffset, finish, foffset);
   doSetNativeRange(win, rng);
 };
 
-const findWithin = function (win: Window, selection: Selection, selector: string): Element<DomElement>[] {
-  return Within.find(win, selection, selector);
-};
+const findWithin = (win: Window, selection: Selection, selector: string): Element<DomElement>[] =>
+  Within.find(win, selection, selector);
 
-const setLegacyRtlRange = function (win: Window, selection: DomSelection, start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) {
+const setLegacyRtlRange = (win: Window, selection: DomSelection, start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): void => {
   selection.collapse(start.dom(), soffset);
   selection.extend(finish.dom(), foffset);
 };
 
-const setRangeFromRelative = function (win: Window, relative: Selection) {
-  return SelectionDirection.diagnose(win, relative).match({
+const setRangeFromRelative = (win: Window, relative: Selection): void =>
+  SelectionDirection.diagnose(win, relative).match({
     ltr(start, soffset, finish, foffset) {
       doSetRange(win, start, soffset, finish, foffset);
     },
@@ -57,25 +56,22 @@ const setRangeFromRelative = function (win: Window, relative: Selection) {
       }
     }
   });
-};
 
-const setExact = function (win: Window, start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) {
+const setExact = (win: Window, start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): void => {
   const relative = Prefilter.preprocessExact(start, soffset, finish, foffset);
 
   setRangeFromRelative(win, relative);
 };
 
-const setRelative = function (win: Window, startSitu: Situ, finishSitu: Situ) {
+const setRelative = (win: Window, startSitu: Situ, finishSitu: Situ): void => {
   const relative = Prefilter.preprocessRelative(startSitu, finishSitu);
 
   setRangeFromRelative(win, relative);
 };
 
-const toNative = function (selection: Selection) {
+const toNative = (selection: Selection): Range => {
   const win: Window = Selection.getWin(selection).dom();
-  const getDomRange = function (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) {
-    return NativeRange.exactToNative(win, start, soffset, finish, foffset);
-  };
+  const getDomRange = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => NativeRange.exactToNative(win, start, soffset, finish, foffset);
   const filtered = Prefilter.preprocess(selection);
   return SelectionDirection.diagnose(win, filtered).match({
     ltr: getDomRange,
@@ -86,7 +82,7 @@ const toNative = function (selection: Selection) {
 // NOTE: We are still reading the range because it gives subtly different behaviour
 // than using the anchorNode and focusNode. I'm not sure if this behaviour is any
 // better or worse; it's just different.
-const readRange = function (selection: DomSelection) {
+const readRange = (selection: DomSelection) => {
   if (selection.rangeCount > 0) {
     const firstRng = selection.getRangeAt(0);
     const lastRng = selection.getRangeAt(selection.rangeCount - 1);
@@ -102,7 +98,7 @@ const readRange = function (selection: DomSelection) {
   }
 };
 
-const doGetExact = function (selection: DomSelection) {
+const doGetExact = (selection: DomSelection) => {
   const anchor = Element.fromDom(selection.anchorNode);
   const focus = Element.fromDom(selection.focusNode);
 
@@ -117,12 +113,12 @@ const doGetExact = function (selection: DomSelection) {
   ) : readRange(selection);
 };
 
-const setToElement = function (win: Window, element: Element<DomNode>) {
+const setToElement = (win: Window, element: Element<DomNode>) => {
   const rng = NativeRange.selectNodeContents(win, element);
   doSetNativeRange(win, rng);
 };
 
-const forElement = function (win: Window, element: Element<DomNode>) {
+const forElement = (win: Window, element: Element<DomNode>) => {
   const rng = NativeRange.selectNodeContents(win, element);
   return SimRange.create(
     Element.fromDom(rng.startContainer), rng.startOffset,
@@ -130,7 +126,7 @@ const forElement = function (win: Window, element: Element<DomNode>) {
   );
 };
 
-const getExact = function (win: Window) {
+const getExact = (win: Window) => {
   // We want to retrieve the selection as it is.
   return Option.from(win.getSelection())
     .filter((sel) => sel.rangeCount > 0)
@@ -138,54 +134,65 @@ const getExact = function (win: Window) {
 };
 
 // TODO: Test this.
-const get = function (win: Window) {
-  return getExact(win).map(function (range) {
-    return Selection.exact(range.start(), range.soffset(), range.finish(), range.foffset());
-  });
-};
+const get = (win: Window) =>
+  getExact(win).map((range) => Selection.exact(range.start(), range.soffset(), range.finish(), range.foffset()));
 
-const getFirstRect = function (win: Window, selection: Selection) {
+const getFirstRect = (win: Window, selection: Selection) => {
   const rng = SelectionDirection.asLtrRange(win, selection);
   return NativeRange.getFirstRect(rng);
 };
 
-const getBounds = function (win: Window, selection: Selection) {
+const getBounds = (win: Window, selection: Selection) => {
   const rng = SelectionDirection.asLtrRange(win, selection);
   return NativeRange.getBounds(rng);
 };
 
-const getAtPoint = function (win: Window, x: number, y: number) {
-  return CaretRange.fromPoint(win, x, y);
-};
+const getAtPoint = (win: Window, x: number, y: number) => CaretRange.fromPoint(win, x, y);
 
-const getAsString = function (win: Window, selection: Selection) {
+const getAsString = (win: Window, selection: Selection) => {
   const rng = SelectionDirection.asLtrRange(win, selection);
   return NativeRange.toString(rng);
 };
 
-const clear = function (win: Window) {
+const clear = (win: Window) => {
   const selection = win.getSelection();
   selection.removeAllRanges();
 };
 
-const clone = function (win: Window, selection: Selection) {
+const clone = (win: Window, selection: Selection) => {
   const rng = SelectionDirection.asLtrRange(win, selection);
   return NativeRange.cloneFragment(rng);
 };
 
-const replace = function (win: Window, selection: Selection, elements: Element<DomNode>[]) {
+const replace = (win: Window, selection: Selection, elements: Element<DomNode>[]) => {
   const rng = SelectionDirection.asLtrRange(win, selection);
   const fragment = Fragment.fromElements(elements, win.document);
   NativeRange.replaceWith(rng, fragment);
 };
 
-const deleteAt = function (win: Window, selection: Selection) {
+const deleteAt = (win: Window, selection: Selection) => {
   const rng = SelectionDirection.asLtrRange(win, selection);
   NativeRange.deleteContents(rng);
 };
 
-const isCollapsed = function (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) {
-  return Compare.eq(start, finish) && soffset === foffset;
-};
+const isCollapsed = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => Compare.eq(start, finish) && soffset === foffset;
 
-export { setExact, getExact, get, setRelative, toNative, setToElement, clear, clone, replace, deleteAt, forElement, getFirstRect, getBounds, getAtPoint, findWithin, getAsString, isCollapsed, };
+export {
+  setExact,
+  getExact,
+  get,
+  setRelative,
+  toNative,
+  setToElement,
+  clear,
+  clone,
+  replace,
+  deleteAt,
+  forElement,
+  getFirstRect,
+  getBounds,
+  getAtPoint,
+  findWithin,
+  getAsString,
+  isCollapsed,
+};

--- a/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
@@ -32,8 +32,8 @@ import { NotificationSpec } from 'tinymce/core/api/NotificationManager';
 const READING = 'toReading'; /// 'hide the keyboard'
 const EDITING = 'toEditing'; /// 'show the keyboard'
 
-const renderMobileTheme = function (editor: Editor) {
-  const renderUI = function () {
+const renderMobileTheme = (editor: Editor) => {
+  const renderUI = () => {
     const targetNode = editor.getElement();
     const cssUrls = CssUrls.derive(editor);
 
@@ -44,7 +44,7 @@ const renderMobileTheme = function (editor: Editor) {
       SkinLoaded.fireSkinLoaded(editor)();
     }
 
-    const doScrollIntoView = function () {
+    const doScrollIntoView = () => {
       editor.fire('ScrollIntoView');
     };
 
@@ -52,11 +52,11 @@ const renderMobileTheme = function (editor: Editor) {
     const original = Element.fromDom(targetNode);
     Attachment.attachSystemAfter(original, realm.system());
 
-    const findFocusIn = function (elem) {
-      return Focus.search(elem).bind(function (focused) {
-        return realm.system().getByDom(focused).toOption();
-      });
+    const findFocusIn = (elem) => {
+      return Focus.search(elem).bind((focused) =>
+        realm.system().getByDom(focused).toOption());
     };
+
     const outerWindow = targetNode.ownerDocument.defaultView;
     const orientation = Orientation.onChange(outerWindow, {
       onChange () {
@@ -66,7 +66,7 @@ const renderMobileTheme = function (editor: Editor) {
       onReady: Fun.noop
     });
 
-    const setReadOnly = function (dynamicGroup, readOnlyGroups, mainGroups, ro) {
+    const setReadOnly = (dynamicGroup, readOnlyGroups, mainGroups, ro) => {
       if (ro === false) {
         editor.selection.collapse();
       }
@@ -78,7 +78,7 @@ const renderMobileTheme = function (editor: Editor) {
       realm.updateMode(ro);
     };
 
-    const configureToolbar = function (dynamicGroup, readOnlyGroups, mainGroups) {
+    const configureToolbar = (dynamicGroup, readOnlyGroups, mainGroups) => {
       const dynamic = dynamicGroup.get();
       const toolbars = {
         readOnly: dynamic.backToMask.concat(readOnlyGroups.get()),
@@ -93,7 +93,7 @@ const renderMobileTheme = function (editor: Editor) {
       return toolbars;
     };
 
-    const bindHandler = function (label: string, handler) {
+    const bindHandler = (label: string, handler) => {
       editor.on(label, handler);
       return {
         unbind () {
@@ -102,7 +102,7 @@ const renderMobileTheme = function (editor: Editor) {
       };
     };
 
-    editor.on('init', function () {
+    editor.on('init', () => {
       realm.init({
         editor: {
           getFrame () {
@@ -124,11 +124,11 @@ const renderMobileTheme = function (editor: Editor) {
           },
 
           onScrollToCursor (handler) {
-            editor.on('ScrollIntoView', function (tinyEvent) {
+            editor.on('ScrollIntoView', (tinyEvent) => {
               handler(tinyEvent);
             });
 
-            const unbind = function () {
+            const unbind = () => {
               editor.off('ScrollIntoView');
               orientation.destroy();
             };
@@ -160,7 +160,7 @@ const renderMobileTheme = function (editor: Editor) {
               evt.kill();
             } else if (Node.name(target) === 'a') {
               const component = realm.system().getByDom(Element.fromDom(editor.editorContainer));
-              component.each(function (container) {
+              component.each((container) => {
                 /// view mode
                 if (Swapping.isAlpha(container)) {
                   TinyCodeDupe.openLink(target.dom());
@@ -186,8 +186,8 @@ const renderMobileTheme = function (editor: Editor) {
         }
       });
 
-      const hideDropup = function () {
-        realm.dropup().disappear(function () {
+      const hideDropup = () => {
+        realm.dropup().disappear(() => {
           realm.system().broadcastOn([ TinyChannels.dropupDismissed ], { });
         });
       };
@@ -196,7 +196,7 @@ const renderMobileTheme = function (editor: Editor) {
         label: 'The first group',
         scrollable: false,
         items: [
-          Buttons.forToolbar('back', function (/* btn */) {
+          Buttons.forToolbar('back', (/* btn */) => {
             editor.selection.collapse();
             realm.exit();
           }, { }, editor)
@@ -207,7 +207,7 @@ const renderMobileTheme = function (editor: Editor) {
         label: 'Back to read only',
         scrollable: false,
         items: [
-          Buttons.forToolbar('readonly-back', function (/* btn */) {
+          Buttons.forToolbar('readonly-back', (/* btn */) => {
             setReadOnly(dynamicGroup, readOnlyGroups, mainGroups, true);
           }, {}, editor)
         ]
@@ -282,6 +282,6 @@ const renderMobileTheme = function (editor: Editor) {
   };
 };
 
-export default function () {
+export default () => {
   ThemeManager.add('mobile', renderMobileTheme);
-}
+};

--- a/modules/tinymce/src/themes/mobile/main/ts/features/Features.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/features/Features.ts
@@ -20,7 +20,7 @@ import * as FontSizeSlider from '../ui/FontSizeSlider';
 import * as ImagePicker from '../ui/ImagePicker';
 import * as LinkButton from '../ui/LinkButton';
 import * as StyleFormats from '../util/StyleFormats';
-import { MobileRealm } from 'tinymce/themes/mobile/ui/IosRealm';
+import { MobileRealm } from '../ui/IosRealm';
 
 const defaults = [ 'undo', 'bold', 'italic', 'link', 'image', 'bullist', 'styleselect' ];
 

--- a/modules/tinymce/src/themes/mobile/main/ts/features/Features.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/features/Features.ts
@@ -20,6 +20,7 @@ import * as FontSizeSlider from '../ui/FontSizeSlider';
 import * as ImagePicker from '../ui/ImagePicker';
 import * as LinkButton from '../ui/LinkButton';
 import * as StyleFormats from '../util/StyleFormats';
+import { MobileRealm } from 'tinymce/themes/mobile/ui/IosRealm';
 
 const defaults = [ 'undo', 'bold', 'italic', 'link', 'image', 'bullist', 'styleselect' ];
 
@@ -41,7 +42,7 @@ const identify = function (settings) {
   return Type.isArray(toolbar) ? identifyFromArray(toolbar) : extract(toolbar);
 };
 
-const setup = function (realm, editor: Editor) {
+const setup = function (realm: MobileRealm, editor: Editor) {
   const commandSketch = function (name) {
     return function () {
       return Buttons.forToolbarCommand(editor, name);

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosEvents.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosEvents.ts
@@ -10,62 +10,62 @@ import { Compare, DomEvent, Height } from '@ephox/sugar';
 
 import * as TappingEvent from '../../util/TappingEvent';
 
-const initEvents = function (editorApi, iosApi, toolstrip, socket, dropup) {
-  const saveSelectionFirst = function () {
-    iosApi.run(function (api) {
+const initEvents = (editorApi, iosApi, toolstrip, socket, dropup): { destroy: () => void } => {
+  const saveSelectionFirst = () => {
+    iosApi.run((api) => {
       api.highlightSelection();
     });
   };
 
-  const refreshIosSelection = function () {
-    iosApi.run(function (api) {
+  const refreshIosSelection = () => {
+    iosApi.run((api) => {
       api.refreshSelection();
     });
   };
 
-  const scrollToY = function (yTop, height) {
+  const scrollToY = (yTop: number, height: number): void => {
     // Because the iframe has no scroll, and the socket is the part that scrolls,
     // anything visible inside the iframe actually has a top value (for bounding
     // rectangle) > socket.scrollTop. The rectangle is with respect to the top of
     // the iframe, which has scrolled up above the socket viewport.
     const y = yTop - socket.dom().scrollTop;
-    iosApi.run(function (api) {
+    iosApi.run((api) => {
       api.scrollIntoView(y, y + height);
     });
   };
 
-  const scrollToElement = function (target) {
+  const scrollToElement = (target): void => {
     scrollToY(iosApi, socket);
   };
 
-  const scrollToCursor = function () {
-    editorApi.getCursorBox().each(function (box) {
+  const scrollToCursor = (): void => {
+    editorApi.getCursorBox().each((box) => {
       scrollToY(box.top(), box.height());
     });
   };
 
-  const clearSelection = function () {
+  const clearSelection = (): void => {
     // Clear any fake selections visible.
-    iosApi.run(function (api) {
+    iosApi.run((api) => {
       api.clearSelection();
     });
   };
 
-  const clearAndRefresh = function () {
+  const clearAndRefresh = (): void => {
     clearSelection();
     refreshThrottle.throttle();
   };
 
-  const refreshView = function () {
+  const refreshView = (): void => {
     scrollToCursor();
-    iosApi.run(function (api) {
+    iosApi.run((api) => {
       api.syncHeight();
     });
   };
 
-  const reposition = function () {
+  const reposition = (): void => {
     const toolbarHeight = Height.get(toolstrip);
-    iosApi.run(function (api) {
+    iosApi.run((api) => {
       api.setViewportOffset(toolbarHeight);
     });
 
@@ -73,20 +73,20 @@ const initEvents = function (editorApi, iosApi, toolstrip, socket, dropup) {
     refreshView();
   };
 
-  const toEditing = function () {
-    iosApi.run(function (api) {
+  const toEditing = (): void => {
+    iosApi.run((api) => {
       api.toEditing();
     });
   };
 
-  const toReading = function () {
-    iosApi.run(function (api) {
+  const toReading = (): void => {
+    iosApi.run((api) => {
       api.toReading();
     });
   };
 
-  const onToolbarTouch = function (event) {
-    iosApi.run(function (api) {
+  const onToolbarTouch = (event): void => {
+    iosApi.run((api) => {
       api.onToolbarTouch(event);
     });
   };
@@ -106,13 +106,13 @@ const initEvents = function (editorApi, iosApi, toolstrip, socket, dropup) {
     editorApi.onDomChanged(refreshIosSelection),
 
     // Scroll to cursor and update the iframe height
-    editorApi.onScrollToCursor(function (tinyEvent) {
+    editorApi.onScrollToCursor((tinyEvent) => {
       tinyEvent.preventDefault();
       refreshThrottle.throttle();
     }),
 
     // Scroll to element
-    editorApi.onScrollToElement(function (event) {
+    editorApi.onScrollToElement((event) => {
       scrollToElement(event.element());
     }),
 
@@ -124,14 +124,14 @@ const initEvents = function (editorApi, iosApi, toolstrip, socket, dropup) {
 
     // If the user is touching outside the content, but on the body(?) or html elements, find the nearest selection
     // and focus that.
-    DomEvent.bind(editorApi.doc(), 'touchend', function (touchEvent) {
+    DomEvent.bind(editorApi.doc(), 'touchend', (touchEvent) => {
       if (Compare.eq(editorApi.html(), touchEvent.target()) || Compare.eq(editorApi.body(), touchEvent.target())) {
         // IosHacks.setSelectionAtTouch(editorApi, touchEvent);
       }
     }),
 
     // Listen to the toolstrip growing animation so that we can update the position of the socket once it is done.
-    DomEvent.bind(toolstrip, 'transitionend', function (transitionEvent) {
+    DomEvent.bind(toolstrip, 'transitionend', (transitionEvent) => {
       if (transitionEvent.raw().propertyName === 'height') {
         reposition();
       }
@@ -139,7 +139,7 @@ const initEvents = function (editorApi, iosApi, toolstrip, socket, dropup) {
 
     // Capture the start of interacting with a toolstrip. It is most likely going to lose the selection, so we save it
     // before that happens
-    DomEvent.capture(toolstrip, 'touchstart', function (touchEvent) {
+    DomEvent.capture(toolstrip, 'touchstart', (touchEvent) => {
       // When touching the toolbar, the first thing that we need to do is 'represent' the selection. We do this with
       // a fake selection. As soon as the focus switches away from the content, the real selection will disappear, so
       // this lets the user still see their selection.
@@ -154,7 +154,7 @@ const initEvents = function (editorApi, iosApi, toolstrip, socket, dropup) {
     }),
 
     // When the user clicks back into the content, clear any fake selections
-    DomEvent.bind(editorApi.body(), 'touchstart', function (evt) {
+    DomEvent.bind(editorApi.body(), 'touchstart', (evt) => {
       clearSelection();
       editorApi.onTouchContent();
       tapping.fireTouchstart(evt);
@@ -164,18 +164,18 @@ const initEvents = function (editorApi, iosApi, toolstrip, socket, dropup) {
     tapping.onTouchend(),
 
     // Stop any "clicks" being processed in the body at alls
-    DomEvent.bind(editorApi.body(), 'click', function (event) {
+    DomEvent.bind(editorApi.body(), 'click', (event) => {
       event.kill();
     }),
 
     // Close any menus when scrolling the toolstrip
-    DomEvent.bind(toolstrip, 'touchmove', function (/* event */) {
+    DomEvent.bind(toolstrip, 'touchmove', (/* event */) => {
       editorApi.onToolbarScrollStart();
     })
   ];
 
-  const destroy = function () {
-    Arr.each(listeners, function (l) {
+  const destroy = () => {
+    Arr.each(listeners, (l) => {
       l.unbind();
     });
   };

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/core/PlatformEditor.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/core/PlatformEditor.ts
@@ -6,7 +6,7 @@
  */
 
 import { Fun, Option } from '@ephox/katamari';
-import { Compare, DomEvent, Element, WindowSelection, StructRect } from '@ephox/sugar';
+import { Compare, DomEvent, Element, WindowSelection, StructRect, RawRect } from '@ephox/sugar';
 
 const getBodyFromFrame = function (frame) {
   return Option.some(Element.fromDom(frame.dom().contentWindow.document.body));
@@ -42,7 +42,7 @@ const getOrDerive = function (name, f) {
   };
 };
 
-const getOrListen = function (editor, doc, name, type) {
+const getOrListen = function (editor, doc, name, type: string) {
   return editor[name].getOrThunk(function () {
     return function (handler) {
       return DomEvent.bind(doc, type, handler);
@@ -50,7 +50,8 @@ const getOrListen = function (editor, doc, name, type) {
   });
 };
 
-const toRect = function (rect) {
+// TODO: This function belongs in modules/sugar/src/main/ts/ephox/sugar/api/selection/Rect.ts
+const toRect = function (rect: RawRect): StructRect {
   return {
     left: Fun.constant(rect.left),
     top: Fun.constant(rect.top),

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/view/DeviceZones.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/view/DeviceZones.ts
@@ -5,10 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Css, Height, Traverse } from '@ephox/sugar';
+import { Css, Element, Height, Traverse } from '@ephox/sugar';
+import { HTMLElement, Node as DomNode, Window } from '@ephox/dom-globals';
 
 import * as Orientation from '../../touch/view/Orientation';
 import * as Devices from './Devices';
+
+type Keyboard = Devices.Keyboard;
 
 // Green zone is the area below the toolbar and above the keyboard, its considered the viewable
 // region that is not obstructed by the keyboard. If the keyboard is down, then the Green Zone is larger.
@@ -27,11 +30,10 @@ import * as Devices from './Devices';
 
 */
 
-const softKeyboardLimits = function (outerWindow) {
-  return Devices.findDevice(outerWindow.screen.width, outerWindow.screen.height);
-};
+const softKeyboardLimits = (outerWindow): Keyboard =>
+  Devices.findDevice(outerWindow.screen.width, outerWindow.screen.height);
 
-const accountableKeyboardHeight = function (outerWindow) {
+const accountableKeyboardHeight = (outerWindow: Window): number => {
   const portrait = Orientation.get(outerWindow).isPortrait();
   const limits = softKeyboardLimits(outerWindow);
 
@@ -45,7 +47,7 @@ const accountableKeyboardHeight = function (outerWindow) {
   return (visualScreenHeight - outerWindow.innerHeight) > keyboard ? 0 : keyboard;
 };
 
-const getGreenzone = function (socket, dropup) {
+const getGreenzone = (socket: Element<HTMLElement>, dropup: Element<HTMLElement>): number => {
   const outerWindow = Traverse.owner(socket).dom().defaultView;
   // Include the dropup for this calculation because it represents the total viewable height.
   const viewportHeight = Height.get(socket) + Height.get(dropup);
@@ -53,7 +55,7 @@ const getGreenzone = function (socket, dropup) {
   return viewportHeight - acc;
 };
 
-const updatePadding = function (contentBody, socket, dropup) {
+const updatePadding = (contentBody: Element<DomNode>, socket: Element<HTMLElement>, dropup: Element<HTMLElement>): void => {
   const greenzoneHeight = getGreenzone(socket, dropup);
   const deltaHeight = (Height.get(socket) + Height.get(dropup)) - greenzoneHeight;
   // TBIO-3878 Changed the element that was receiving the padding from the iframe to the body of the

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosViewport.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosViewport.ts
@@ -7,7 +7,7 @@
 
 import { Adt, Arr, Fun } from '@ephox/katamari';
 import { Attr, Css, Element, Height, SelectorFilter, Traverse } from '@ephox/sugar';
-import { Element as DomElement } from '@ephox/dom-globals';
+import { Element as DomElement, Node as DomNode, HTMLElement } from '@ephox/dom-globals';
 
 import * as Styles from '../../style/Styles';
 import * as Scrollable from '../../touch/scroll/Scrollable';
@@ -31,7 +31,7 @@ const getYFixedData = (element: Element<DomElement>): number =>
 const getYFixedProperty = (element: Element<DomElement>): string =>
   Attr.get(element, yFixedProperty);
 
-const getLastWindowSize = (element): number =>
+const getLastWindowSize = (element: Element<DomElement>): number =>
   DataAttributes.safeParse(element, windowSizeData);
 
 const classifyFixed = (element: Element<DomElement>, offsetY: number) => {
@@ -103,7 +103,7 @@ const takeoverViewport = (toolbarHeight: number, height: number, viewport: Eleme
   };
 };
 
-const takeoverDropup = (dropup: Element<DomElement>, toolbarHeight, viewportHeight): { restore: () => void } => {
+const takeoverDropup = (dropup: Element<DomElement>): { restore: () => void } => {
   const oldDropupStyle = Attr.get(dropup, 'style');
   Css.setAll(dropup, {
     position: 'absolute',
@@ -124,7 +124,7 @@ const takeoverDropup = (dropup: Element<DomElement>, toolbarHeight, viewportHeig
   };
 };
 
-const deriveViewportHeight = (viewport, toolbarHeight: number, dropupHeight: number) => {
+const deriveViewportHeight = (viewport: Element<DomElement>, toolbarHeight: number, dropupHeight: number) => {
   // Note, Mike thinks this value changes when the URL address bar grows and shrinks. If this value is too high
   // the main problem is that scrolling into the greenzone may not scroll into an area that is viewable. Investigate.
   const outerWindow = Traverse.owner(viewport).dom().defaultView;
@@ -133,7 +133,7 @@ const deriveViewportHeight = (viewport, toolbarHeight: number, dropupHeight: num
   return winH - toolbarHeight - dropupHeight;
 };
 
-const takeover = (viewport, contentBody, toolbar, dropup) => {
+const takeover = (viewport: Element<HTMLElement>, contentBody: Element<DomNode>, toolbar: Element<HTMLElement>, dropup: Element<HTMLElement>) => {
   const outerWindow = Traverse.owner(viewport).dom().defaultView;
   const toolbarSetup = takeoverToolbar(toolbar);
   const toolbarHeight = Height.get(toolbar);
@@ -142,7 +142,7 @@ const takeover = (viewport, contentBody, toolbar, dropup) => {
 
   const viewportSetup = takeoverViewport(toolbarHeight, viewportHeight, viewport);
 
-  const dropupSetup = takeoverDropup(dropup, toolbarHeight, viewportHeight);
+  const dropupSetup = takeoverDropup(dropup);
 
   let isActive = true;
 

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosViewport.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosViewport.ts
@@ -6,7 +6,8 @@
  */
 
 import { Adt, Arr, Fun } from '@ephox/katamari';
-import { Attr, Css, Height, SelectorFilter, Traverse } from '@ephox/sugar';
+import { Attr, Css, Element, Height, SelectorFilter, Traverse } from '@ephox/sugar';
+import { Element as DomElement } from '@ephox/dom-globals';
 
 import * as Styles from '../../style/Styles';
 import * as Scrollable from '../../touch/scroll/Scrollable';
@@ -24,39 +25,35 @@ const yFixedProperty = 'data-' + Styles.resolve('y-property');
 const yScrollingData = 'data-' + Styles.resolve('scrolling');
 const windowSizeData = 'data-' + Styles.resolve('last-window-height');
 
-const getYFixedData = function (element) {
-  return DataAttributes.safeParse(element, yFixedData);
-};
+const getYFixedData = (element: Element<DomElement>): number =>
+  DataAttributes.safeParse(element, yFixedData);
 
-const getYFixedProperty = function (element) {
-  return Attr.get(element, yFixedProperty);
-};
+const getYFixedProperty = (element: Element<DomElement>): string =>
+  Attr.get(element, yFixedProperty);
 
-const getLastWindowSize = function (element) {
-  return DataAttributes.safeParse(element, windowSizeData);
-};
+const getLastWindowSize = (element): number =>
+  DataAttributes.safeParse(element, windowSizeData);
 
-const classifyFixed = function (element, offsetY) {
+const classifyFixed = (element: Element<DomElement>, offsetY: number) => {
   const prop = getYFixedProperty(element);
   return fixture.fixed(element, prop, offsetY);
 };
 
-const classifyScrolling = function (element, offsetY) {
-  return fixture.scroller(element, offsetY);
-};
+const classifyScrolling = (element: Element<DomElement>, offsetY: number) =>
+  fixture.scroller(element, offsetY);
 
-const classify = function (element) {
+const classify = (element: Element<DomElement>) => {
   const offsetY = getYFixedData(element);
   const classifier = Attr.get(element, yScrollingData) === 'true' ? classifyScrolling : classifyFixed;
   return classifier(element, offsetY);
 };
 
-const findFixtures = function (container) {
+const findFixtures = (container: Element<DomElement>) => {
   const candidates = SelectorFilter.descendants(container, '[' + yFixedData + ']');
   return Arr.map(candidates, classify);
 };
 
-const takeoverToolbar = function (toolbar) {
+const takeoverToolbar = (toolbar: Element<DomElement>): { restore: () => void } => {
   const oldToolbarStyle = Attr.get(toolbar, 'style');
   Css.setAll(toolbar, {
     position: 'absolute',
@@ -66,7 +63,7 @@ const takeoverToolbar = function (toolbar) {
   Attr.set(toolbar, yFixedData, '0px');
   Attr.set(toolbar, yFixedProperty, 'top');
 
-  const restore = function () {
+  const restore = () => {
     Attr.set(toolbar, 'style', oldToolbarStyle || '');
     Attr.remove(toolbar, yFixedData);
     Attr.remove(toolbar, yFixedProperty);
@@ -77,7 +74,7 @@ const takeoverToolbar = function (toolbar) {
   };
 };
 
-const takeoverViewport = function (toolbarHeight, height, viewport) {
+const takeoverViewport = (toolbarHeight: number, height: number, viewport: Element<DomElement>): { restore: () => void } => {
   const oldViewportStyle = Attr.get(viewport, 'style');
 
   Scrollable.register(viewport);
@@ -93,7 +90,7 @@ const takeoverViewport = function (toolbarHeight, height, viewport) {
   Attr.set(viewport, yScrollingData, 'true');
   Attr.set(viewport, yFixedProperty, 'top');
 
-  const restore = function () {
+  const restore = () => {
     Scrollable.deregister(viewport);
     Attr.set(viewport, 'style', oldViewportStyle || '');
     Attr.remove(viewport, yFixedData);
@@ -106,7 +103,7 @@ const takeoverViewport = function (toolbarHeight, height, viewport) {
   };
 };
 
-const takeoverDropup = function (dropup, toolbarHeight, viewportHeight) {
+const takeoverDropup = (dropup: Element<DomElement>, toolbarHeight, viewportHeight): { restore: () => void } => {
   const oldDropupStyle = Attr.get(dropup, 'style');
   Css.setAll(dropup, {
     position: 'absolute',
@@ -116,7 +113,7 @@ const takeoverDropup = function (dropup, toolbarHeight, viewportHeight) {
   Attr.set(dropup, yFixedData, '0px');
   Attr.set(dropup, yFixedProperty, 'bottom');
 
-  const restore = function () {
+  const restore = () => {
     Attr.set(dropup, 'style', oldDropupStyle || '');
     Attr.remove(dropup, yFixedData);
     Attr.remove(dropup, yFixedProperty);
@@ -127,7 +124,7 @@ const takeoverDropup = function (dropup, toolbarHeight, viewportHeight) {
   };
 };
 
-const deriveViewportHeight = function (viewport, toolbarHeight, dropupHeight) {
+const deriveViewportHeight = (viewport, toolbarHeight: number, dropupHeight: number) => {
   // Note, Mike thinks this value changes when the URL address bar grows and shrinks. If this value is too high
   // the main problem is that scrolling into the greenzone may not scroll into an area that is viewable. Investigate.
   const outerWindow = Traverse.owner(viewport).dom().defaultView;
@@ -136,7 +133,7 @@ const deriveViewportHeight = function (viewport, toolbarHeight, dropupHeight) {
   return winH - toolbarHeight - dropupHeight;
 };
 
-const takeover = function (viewport, contentBody, toolbar, dropup) {
+const takeover = (viewport, contentBody, toolbar, dropup) => {
   const outerWindow = Traverse.owner(viewport).dom().defaultView;
   const toolbarSetup = takeoverToolbar(toolbar);
   const toolbarHeight = Height.get(toolbar);
@@ -149,20 +146,20 @@ const takeover = function (viewport, contentBody, toolbar, dropup) {
 
   let isActive = true;
 
-  const restore = function () {
+  const restore = (): void => {
     isActive = false;
     toolbarSetup.restore();
     viewportSetup.restore();
     dropupSetup.restore();
   };
 
-  const isExpanding = function () {
+  const isExpanding = (): boolean => {
     const currentWinHeight = outerWindow.innerHeight;
     const lastWinHeight = getLastWindowSize(viewport);
     return currentWinHeight > lastWinHeight;
   };
 
-  const refresh = function () {
+  const refresh = (): void => {
     if (isActive) {
       const newToolbarHeight = Height.get(toolbar);
       const dropupHeight = Height.get(dropup);
@@ -174,7 +171,7 @@ const takeover = function (viewport, contentBody, toolbar, dropup) {
     }
   };
 
-  const setViewportOffset = function (newYOffset) {
+  const setViewportOffset = (newYOffset: number): void => {
     const offsetPx = newYOffset + 'px';
     Attr.set(viewport, yFixedData, offsetPx);
     // The toolbar height has probably changed, so recalculate the viewport height.

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/AndroidRealm.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/AndroidRealm.ts
@@ -17,7 +17,7 @@ import OuterContainer from './OuterContainer';
 import { MobileRealm } from 'tinymce/themes/mobile/ui/IosRealm';
 import { MobileWebApp } from 'tinymce/themes/mobile/api/IosWebapp';
 
-export default function (scrollIntoView: () => void) {
+export default (scrollIntoView: () => void): MobileRealm => {
   const alloy = OuterContainer({
     classes: [ Styles.resolve('android-container') ]
   }) as Gui.GuiSystem;
@@ -36,39 +36,39 @@ export default function (scrollIntoView: () => void) {
   alloy.add(socket);
   alloy.add(dropup.component());
 
-  const setToolbarGroups = function (rawGroups) {
+  const setToolbarGroups = (rawGroups) => {
     const groups = toolbar.createGroups(rawGroups);
     toolbar.setGroups(groups);
   };
 
-  const setContextToolbar = function (rawGroups) {
+  const setContextToolbar = (rawGroups) => {
     const groups = toolbar.createGroups(rawGroups);
     toolbar.setContextToolbar(groups);
   };
 
   // You do not always want to do this.
-  const focusToolbar = function () {
+  const focusToolbar = () => {
     toolbar.focus();
   };
 
-  const restoreToolbar = function () {
+  const restoreToolbar = () => {
     toolbar.restoreToolbar();
   };
 
-  const init = function (spec) {
+  const init = (spec) => {
     webapp.set(
       AndroidWebapp.produce(spec)
     );
   };
 
-  const exit = function () {
-    webapp.run(function (w) {
+  const exit = () => {
+    webapp.run((w) => {
       w.exit();
       Replacing.remove(socket, switchToEdit);
     });
   };
 
-  const updateMode = function (readOnly) {
+  const updateMode = (readOnly) => {
     CommonRealm.updateMode(socket, switchToEdit, readOnly, alloy.root());
   };
 
@@ -84,5 +84,5 @@ export default function (scrollIntoView: () => void) {
     updateMode,
     socket: Fun.constant(socket),
     dropup: Fun.constant(dropup)
-  } as MobileRealm;
-}
+  };
+};

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/Buttons.ts
@@ -5,20 +5,21 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Behaviour, Button, Toggling, Unselecting, SketchSpec } from '@ephox/alloy';
+import { Behaviour, Button, Toggling, Unselecting, SketchSpec, RawDomSchema, AlloyComponent } from '@ephox/alloy';
 import { Merger, Option } from '@ephox/katamari';
 
 import * as Receivers from '../channels/Receivers';
 import * as Styles from '../style/Styles';
 import * as UiDomFactory from '../util/UiDomFactory';
+import Editor from 'tinymce/core/api/Editor';
 
-const forToolbarCommand = function (editor, command) {
-  return forToolbar(command, function () {
+const forToolbarCommand = (editor, command): SketchSpec => {
+  return forToolbar(command, () => {
     editor.execCommand(command);
-  }, { }, editor);
+  }, {}, editor);
 };
 
-const getToggleBehaviours = function (command) {
+const getToggleBehaviours = (command: string) => {
   return Behaviour.derive([
     Toggling.config({
       toggleClass: Styles.resolve('toolbar-button-selected'),
@@ -27,28 +28,28 @@ const getToggleBehaviours = function (command) {
         mode: 'pressed'
       }
     }),
-    Receivers.format(command, function (button, status) {
+    Receivers.format(command, (button, status) => {
       const toggle = status ? Toggling.on : Toggling.off;
       toggle(button);
     })
   ]);
 };
 
-const forToolbarStateCommand = function (editor, command) {
+const forToolbarStateCommand = (editor, command: string): SketchSpec => {
   const extraBehaviours = getToggleBehaviours(command);
 
-  return forToolbar(command, function () {
+  return forToolbar(command, () => {
     editor.execCommand(command);
   }, extraBehaviours, editor);
 };
 
 // The action is not just executing the same command
-const forToolbarStateAction = function (editor, clazz, command, action) {
+const forToolbarStateAction = (editor, clazz: string, command, action): SketchSpec => {
   const extraBehaviours = getToggleBehaviours(command);
   return forToolbar(clazz, action, extraBehaviours, editor);
 };
 
-const getToolbarIconButton = (clazz, editor) => {
+const getToolbarIconButton = (clazz: string, editor: Editor): RawDomSchema => {
   const icons = editor.ui.registry.getAll().icons;
   const optOxideIcon = Option.from(icons[clazz]);
 
@@ -58,19 +59,18 @@ const getToolbarIconButton = (clazz, editor) => {
   );
 };
 
-const forToolbar = function (clazz, action, extraBehaviours, editor): SketchSpec {
-  return Button.sketch({
+const forToolbar = (clazz: string, action: (c: AlloyComponent) => void, extraBehaviours, editor: Editor): SketchSpec =>
+  Button.sketch({
     dom: getToolbarIconButton(clazz, editor),
     action,
 
     buttonBehaviours: Merger.deepMerge(
       Behaviour.derive([
-        Unselecting.config({ })
+        Unselecting.config({})
       ]),
       extraBehaviours
     )
   });
-};
 
 export {
   forToolbar,

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/ColorSlider.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/ColorSlider.ts
@@ -12,11 +12,13 @@ import * as Receivers from '../channels/Receivers';
 import * as Styles from '../style/Styles';
 import * as UiDomFactory from '../util/UiDomFactory';
 import * as ToolbarWidgets from './ToolbarWidgets';
+import Editor from 'tinymce/core/api/Editor';
+import { MobileRealm } from '../ui/IosRealm';
 
 const BLACK = -1;
 
-const makeSlider = function (spec) {
-  const getColor = function (hue) {
+const makeSlider = (spec): SketchSpec => {
+  const getColor = (hue: number): string => {
     // Handle edges.
     if (hue < 0) {
       return 'black';
@@ -28,12 +30,12 @@ const makeSlider = function (spec) {
   };
 
   // Does not fire change intentionally.
-  const onInit = function (slider, thumb, spectrum, value) {
+  const onInit = (slider, thumb, spectrum, value): void => {
     const color = getColor(value.x());
     Css.set(thumb.element(), 'background-color', color);
   };
 
-  const onChange = function (slider, thumb, value) {
+  const onChange = (slider, thumb, value): void => {
     const color = getColor(value.x());
     Css.set(thumb.element(), 'background-color', color);
     spec.onChange(slider, thumb, color);
@@ -66,10 +68,10 @@ const makeSlider = function (spec) {
     ],
 
     onChange,
-    onDragStart (slider, thumb) {
+    onDragStart(slider, thumb) {
       Toggling.on(thumb);
     },
-    onDragEnd (slider, thumb) {
+    onDragEnd(slider, thumb) {
       Toggling.off(thumb);
     },
     onInit,
@@ -91,29 +93,27 @@ const makeSlider = function (spec) {
   });
 };
 
-const makeItems = function (spec): SketchSpec[] {
+const makeItems = (spec): SketchSpec[] => {
   return [
     makeSlider(spec)
   ];
 };
 
-const sketch = function (realm, editor) {
+const sketch = (realm: MobileRealm, editor: Editor) => {
   const spec = {
-    onChange (slider, thumb, color) {
-      editor.undoManager.transact(function () {
+    onChange(slider, thumb, color) {
+      editor.undoManager.transact(() => {
         editor.formatter.apply('forecolor', { value: color });
         editor.nodeChanged();
       });
     },
-    getInitialValue (/* slider */) {
+    getInitialValue(/* slider */) {
       // Return black
       return BLACK;
     }
   };
 
-  return ToolbarWidgets.button(realm, 'color-levels', function () {
-    return makeItems(spec);
-  }, editor);
+  return ToolbarWidgets.button(realm, 'color-levels', () => makeItems(spec), editor);
 };
 
 export {

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/CommonRealm.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/CommonRealm.ts
@@ -14,7 +14,7 @@ const makeEditSwitch = (webapp): AlloyComponent => {
     Button.sketch({
       dom: UiDomFactory.dom('<div class="${prefix}-mask-edit-icon ${prefix}-icon"></div>'),
       action() {
-        webapp.run(w => {
+        webapp.run((w) => {
           w.setReadOnly(false);
         });
       }

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/CommonRealm.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/CommonRealm.ts
@@ -9,12 +9,12 @@ import { Behaviour, Button, Container, GuiFactory, Replacing, Swapping, AlloyCom
 
 import * as UiDomFactory from '../util/UiDomFactory';
 
-const makeEditSwitch = function (webapp): AlloyComponent {
+const makeEditSwitch = (webapp): AlloyComponent => {
   return GuiFactory.build(
     Button.sketch({
       dom: UiDomFactory.dom('<div class="${prefix}-mask-edit-icon ${prefix}-icon"></div>'),
-      action () {
-        webapp.run(function (w) {
+      action() {
+        webapp.run(w => {
           w.setReadOnly(false);
         });
       }
@@ -22,27 +22,27 @@ const makeEditSwitch = function (webapp): AlloyComponent {
   );
 };
 
-const makeSocket = function () {
+const makeSocket = (): AlloyComponent => {
   return GuiFactory.build(
     Container.sketch({
       dom: UiDomFactory.dom('<div class="${prefix}-editor-socket"></div>'),
-      components: [ ],
+      components: [],
       containerBehaviours: Behaviour.derive([
-        Replacing.config({ })
+        Replacing.config({})
       ])
     })
   );
 };
 
-const showEdit = function (socket, switchToEdit) {
+const showEdit = (socket: AlloyComponent, switchToEdit: AlloyComponent): void => {
   Replacing.append(socket, GuiFactory.premade(switchToEdit));
 };
 
-const hideEdit = function (socket, switchToEdit) {
+const hideEdit = (socket: AlloyComponent, switchToEdit: AlloyComponent): void => {
   Replacing.remove(socket, switchToEdit);
 };
 
-const updateMode = function (socket, switchToEdit, readOnly, root) {
+const updateMode = (socket: AlloyComponent, switchToEdit: AlloyComponent, readOnly: boolean, root: AlloyComponent): void => {
   const swap = (readOnly === true) ? Swapping.toAlpha : Swapping.toOmega;
   swap(root);
 

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/Dropup.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/Dropup.ts
@@ -20,7 +20,7 @@ export interface DropUp {
   element: () => SugarElement;
 }
 
-const build = function (refresh, scrollIntoView): DropUp {
+const build = (refresh, scrollIntoView): DropUp => {
   const dropup = GuiFactory.build(
     Container.sketch({
       dom: {
@@ -51,16 +51,16 @@ const build = function (refresh, scrollIntoView): DropUp {
             scrollIntoView();
           }
         }),
-        Receivers.orientation(function (component, data) {
+        Receivers.orientation((component, data) => {
           disappear(Fun.noop);
         })
       ])
     })
   ) as AlloyComponent;
 
-  const appear = function (menu, update, component) {
+  const appear = (menu, update, component) => {
     if (Sliding.hasShrunk(dropup) === true && Sliding.isTransitioning(dropup) === false) {
-      window.requestAnimationFrame(function () {
+      window.requestAnimationFrame(() => {
         update(component);
         Replacing.set(dropup, [ menu() ]);
         Sliding.grow(dropup);
@@ -68,8 +68,8 @@ const build = function (refresh, scrollIntoView): DropUp {
     }
   };
 
-  const disappear = function (onReadyToShrink) {
-    window.requestAnimationFrame(function () {
+  const disappear = (onReadyToShrink) => {
+    window.requestAnimationFrame(() => {
       onReadyToShrink();
       Sliding.shrink(dropup);
     });

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/FontSizeSlider.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/FontSizeSlider.ts
@@ -10,10 +10,11 @@ import * as ToolbarWidgets from './ToolbarWidgets';
 import * as FontSizes from '../util/FontSizes';
 import * as UiDomFactory from '../util/UiDomFactory';
 import { SketchSpec } from '@ephox/alloy';
+import { MobileRealm } from '../ui/IosRealm';
 
 const sizes = FontSizes.candidates();
 
-const makeSlider = function (spec) {
+const makeSlider = (spec): SketchSpec => {
   return SizeSlider.sketch({
     onChange: spec.onChange,
     sizes,
@@ -22,7 +23,7 @@ const makeSlider = function (spec) {
   });
 };
 
-const makeItems = function (spec) {
+const makeItems = (spec) => {
   return [
     UiDomFactory.spec('<span class="${prefix}-toolbar-button ${prefix}-icon-small-font ${prefix}-icon"></span>'),
     makeSlider(spec),
@@ -30,7 +31,7 @@ const makeItems = function (spec) {
   ];
 };
 
-const sketch = function (realm, editor): SketchSpec {
+const sketch = (realm: MobileRealm, editor): SketchSpec => {
   const spec = {
     onChange (value) {
       FontSizes.apply(editor, value);
@@ -40,9 +41,7 @@ const sketch = function (realm, editor): SketchSpec {
     }
   };
 
-  return ToolbarWidgets.button(realm, 'font-size', function () {
-    return makeItems(spec);
-  }, editor);
+  return ToolbarWidgets.button(realm, 'font-size', () => makeItems(spec), editor);
 };
 
 export {

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/HeadingSlider.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/HeadingSlider.ts
@@ -12,10 +12,11 @@ import * as Buttons from '../ui/Buttons';
 import * as SizeSlider from './SizeSlider';
 import * as ToolbarWidgets from './ToolbarWidgets';
 import { SketchSpec } from '@ephox/alloy';
+import { MobileRealm } from '../ui/IosRealm';
 
 const headings = [ 'p', 'h3', 'h2', 'h1' ];
 
-const makeSlider = function (spec) {
+const makeSlider = (spec): SketchSpec => {
   return SizeSlider.sketch({
     category: 'heading',
     sizes: headings,
@@ -24,32 +25,28 @@ const makeSlider = function (spec) {
   });
 };
 
-const sketch = function (realm, editor): SketchSpec {
+const sketch = (realm: MobileRealm, editor): SketchSpec => {
   const spec = {
-    onChange (value) {
+    onChange(value) {
       editor.execCommand('FormatBlock', null, headings[value].toLowerCase());
     },
-    getInitialValue () {
+    getInitialValue() {
       const node = editor.selection.getStart();
       const elem = Element.fromDom(node);
       const heading = PredicateFind.closest(elem, (e) => {
         const nodeName = Node.name(e);
         return Arr.contains(headings, nodeName);
-      }, function (e) {
-        return Compare.eq(e, Element.fromDom(editor.getBody()));
-      });
+      }, (e) => Compare.eq(e, Element.fromDom(editor.getBody())));
 
       return heading.bind((elm) => Arr.indexOf(headings, Node.name(elm))).getOr(0);
     }
   };
 
-  return ToolbarWidgets.button(realm, 'heading', function () {
-    return [
-      Buttons.getToolbarIconButton('small-heading', editor),
-      makeSlider(spec),
-      Buttons.getToolbarIconButton('large-heading', editor)
-    ];
-  }, editor);
+  return ToolbarWidgets.button(realm, 'heading', () => [
+    Buttons.getToolbarIconButton('small-heading', editor),
+    makeSlider(spec),
+    Buttons.getToolbarIconButton('large-heading', editor)
+  ], editor);
 };
 
 export {

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/ImagePicker.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/ImagePicker.ts
@@ -10,10 +10,12 @@ import { BlobConversions } from '@ephox/imagetools';
 import { Id, Option } from '@ephox/katamari';
 
 import * as Buttons from '../ui/Buttons';
+import Editor from 'tinymce/core/api/Editor';
+import { Blob } from '@ephox/dom-globals';
 
-const addImage = function (editor, blob) {
-  BlobConversions.blobToBase64(blob).then(function (base64) {
-    editor.undoManager.transact(function () {
+const addImage = (editor: Editor, blob: Blob) => {
+  BlobConversions.blobToBase64(blob).then((base64) => {
+    editor.undoManager.transact(() => {
       const cache = editor.editorUpload.blobCache;
       const info = cache.create(
         Id.generate('mceu'), blob, base64
@@ -27,13 +29,13 @@ const addImage = function (editor, blob) {
   });
 };
 
-const extractBlob = function (simulatedEvent) {
+const extractBlob = (simulatedEvent): Option<Blob> => {
   const event = simulatedEvent.event();
   const files = event.raw().target.files || event.raw().dataTransfer.files;
   return Option.from(files[0]);
 };
 
-const sketch = function (editor): SketchSpec {
+const sketch = (editor): SketchSpec => {
   const pickerDom = {
     tag: 'input',
     attributes: { accept: 'image/*', type: 'file', title: '' },
@@ -48,8 +50,8 @@ const sketch = function (editor): SketchSpec {
       // Stop the event firing again at the button level
       AlloyEvents.cutter(NativeEvents.click()),
 
-      AlloyEvents.run(NativeEvents.change(), function (picker, simulatedEvent) {
-        extractBlob(simulatedEvent).each(function (blob) {
+      AlloyEvents.run(NativeEvents.change(), (picker, simulatedEvent) => {
+        extractBlob(simulatedEvent).each((blob) => {
           addImage(editor, blob);
         });
       })

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/Inputs.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/Inputs.ts
@@ -93,22 +93,20 @@ const field = function (name, placeholder) {
   };
 };
 
-const hidden = function (name) {
-  return {
-    name,
-    spec: DataField.sketch({
-      dom: {
-        tag: 'span',
-        styles: {
-          display: 'none'
-        }
-      },
-      getInitialValue () {
-        return Option.none();
+const hidden = (name) => ({
+  name,
+  spec: DataField.sketch({
+    dom: {
+      tag: 'span',
+      styles: {
+        display: 'none'
       }
-    }) as SketchSpec
-  };
-};
+    },
+    getInitialValue() {
+      return Option.none();
+    }
+  }) as SketchSpec
+});
 
 export {
   field,

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/IosRealm.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/IosRealm.ts
@@ -32,7 +32,7 @@ export interface MobileRealm {
   dropup(): Dropup.DropUp;
 }
 
-export default function (scrollIntoView: () => void) {
+export default (scrollIntoView: () => void): MobileRealm => {
   const alloy = OuterContainer({
     classes: [ Styles.resolve('ios-container') ]
   }) as Gui.GuiSystem;
@@ -102,5 +102,5 @@ export default function (scrollIntoView: () => void) {
     updateMode,
     socket: Fun.constant(socket),
     dropup: Fun.constant(dropup)
-  } as MobileRealm;
-}
+  };
+};

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/ToolbarWidgets.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/ToolbarWidgets.ts
@@ -7,9 +7,10 @@
 
 import * as Buttons from './Buttons';
 import { SketchSpec } from '@ephox/alloy';
+import { MobileRealm } from './IosRealm';
 
-const button = function (realm, clazz, makeItems, editor): SketchSpec {
-  return Buttons.forToolbar(clazz, function () {
+const button = (realm: MobileRealm, clazz: string, makeItems, editor): SketchSpec => {
+  return Buttons.forToolbar(clazz, () => {
     const items = makeItems();
     realm.setContextToolbar([
       {
@@ -18,7 +19,7 @@ const button = function (realm, clazz, makeItems, editor): SketchSpec {
         items
       }
     ]);
-  }, { }, editor);
+  }, {}, editor);
 };
 
 export {

--- a/modules/tinymce/src/themes/mobile/main/ts/util/CaptureBin.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/CaptureBin.ts
@@ -6,10 +6,11 @@
  */
 
 import { Css, Element, Focus, Insert, Remove } from '@ephox/sugar';
+import { HTMLInputElement, Node as DomNode } from '@ephox/dom-globals';
 
-const input = function (parent, operation) {
+const input = (parent: Element<DomNode>, operation: (e: Element<HTMLInputElement>) => void): void => {
   // to capture focus allowing the keyboard to remain open with no 'real' selection
-  const input = Element.fromTag('input');
+  const input: Element<HTMLInputElement> = Element.fromTag('input');
   Css.setAll(input, {
     opacity: '0',
     position: 'absolute',

--- a/modules/tinymce/src/themes/mobile/main/ts/util/CssUrls.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/CssUrls.ts
@@ -9,12 +9,16 @@ import EditorManager from 'tinymce/core/api/EditorManager';
 import Editor from 'tinymce/core/api/Editor';
 import { Obj } from '@ephox/katamari';
 
-const derive = function (editor: Editor) {
-  const base = Obj.get(editor.settings, 'skin_url').fold(function () {
-    return EditorManager.baseURL + '/skins/ui/oxide';
-  }, function (url) {
-    return url;
-  });
+export interface CssUrls {
+  readonly content: string;
+  readonly ui: string;
+}
+
+const derive = (editor: Editor): CssUrls => {
+  const base = Obj.get(editor.settings, 'skin_url').fold(
+    () => EditorManager.baseURL + '/skins/ui/oxide',
+    (url) => url
+  );
 
   return {
     content: base + '/content.mobile.min.css',

--- a/modules/tinymce/src/themes/mobile/main/ts/util/DataAttributes.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/DataAttributes.ts
@@ -5,9 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Attr } from '@ephox/sugar';
+import { Attr, Element } from '@ephox/sugar';
+import { Element as DomElement } from '@ephox/dom-globals';
 
-const safeParse = function (element, attribute) {
+const safeParse = (element: Element<DomElement>, attribute: string): number => {
   const parsed = parseInt(Attr.get(element, attribute), 10);
   return isNaN(parsed) ? 0 : parsed;
 };

--- a/modules/tinymce/src/themes/mobile/main/ts/util/FormatChangers.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/FormatChangers.ts
@@ -9,26 +9,27 @@ import { Arr, Fun, Obj } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 import * as TinyChannels from '../channels/TinyChannels';
+import { MobileRealm } from '../ui/IosRealm';
 
-const fontSizesArray = [ 'x-small', 'small', 'medium', 'large', 'x-large' ];
+const fontSizesArray: readonly string[] = [ 'x-small', 'small', 'medium', 'large', 'x-large' ];
 
-const fireChange = function (realm, command, state) {
+const fireChange = (realm: MobileRealm, command: string, state: boolean): void => {
   realm.system().broadcastOn([ TinyChannels.formatChanged ], {
     command,
     state
   });
 };
 
-const init = function (realm, editor: Editor) {
+const init = (realm: MobileRealm, editor: Editor): void => {
   const allFormats = Obj.keys(editor.formatter.get());
-  Arr.each(allFormats, function (command) {
-    editor.formatter.formatChanged(command, function (state) {
+  Arr.each(allFormats, (command) => {
+    editor.formatter.formatChanged(command, (state) => {
       fireChange(realm, command, state);
     });
   });
 
-  Arr.each([ 'ul', 'ol' ], function (command) {
-    editor.selection.selectorChanged(command, function (state, data) {
+  Arr.each([ 'ul', 'ol' ], (command) => {
+    editor.selection.selectorChanged(command, (state, data) => {
       fireChange(realm, command, state);
     });
   });

--- a/modules/tinymce/src/themes/mobile/main/ts/util/RangePreserver.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/RangePreserver.ts
@@ -7,6 +7,7 @@
 
 import { Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
+import Editor from 'tinymce/core/api/Editor';
 
 const platform = PlatformDetection.detect();
 /* At the moment, this is only going to be used for Android. The Google keyboard
@@ -15,13 +16,13 @@ const platform = PlatformDetection.detect();
  *
  * See fiddle: http://fiddle.tinymce.com/xNfaab/3 or http://fiddle.tinymce.com/xNfaab/4
  */
-const preserve = function (f, editor) {
+const preserve = (f: () => void, editor: Editor): void => {
   const rng = editor.selection.getRng();
   f();
   editor.selection.setRng(rng);
 };
 
-const forAndroid = function (editor, f) {
+const forAndroid = (editor: Editor, f: () => void): void => {
   const wrapper = platform.os.isAndroid() ? preserve : Fun.apply;
   wrapper(f, editor);
 };

--- a/modules/tinymce/src/themes/mobile/main/ts/util/Rectangles.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/Rectangles.ts
@@ -6,38 +6,35 @@
  */
 
 import { Arr, Fun } from '@ephox/katamari';
-import { Awareness, Element, Selection, Traverse, WindowSelection } from '@ephox/sugar';
+import { Awareness, Element, RawRect, Selection, StructRect, Traverse, WindowSelection } from '@ephox/sugar';
+import { Range, Window } from '@ephox/dom-globals';
 
 const COLLAPSED_WIDTH = 2;
 
-const collapsedRect = function (rect) {
-  return {
-    left: rect.left,
-    top: rect.top,
-    right: rect.right,
-    bottom: rect.bottom,
-    width: Fun.constant(COLLAPSED_WIDTH),
-    height: rect.height
-  };
-};
+const collapsedRect = (rect: StructRect): StructRect => ({
+  left: rect.left,
+  top: rect.top,
+  right: rect.right,
+  bottom: rect.bottom,
+  width: Fun.constant(COLLAPSED_WIDTH),
+  height: rect.height
+});
 
-const toRect = function (rawRect) {
-  return {
-    left: Fun.constant(rawRect.left),
-    top: Fun.constant(rawRect.top),
-    right: Fun.constant(rawRect.right),
-    bottom: Fun.constant(rawRect.bottom),
-    width: Fun.constant(rawRect.width),
-    height: Fun.constant(rawRect.height)
-  };
-};
+const toRect = (rawRect: RawRect): StructRect => ({
+  left: Fun.constant(rawRect.left),
+  top: Fun.constant(rawRect.top),
+  right: Fun.constant(rawRect.right),
+  bottom: Fun.constant(rawRect.bottom),
+  width: Fun.constant(rawRect.width),
+  height: Fun.constant(rawRect.height)
+});
 
-const getRectsFromRange = function (range) {
+const getRectsFromRange = (range: Range): StructRect[] => {
   if (! range.collapsed) {
     return Arr.map(range.getClientRects(), toRect);
   } else {
     const start = Element.fromDom(range.startContainer);
-    return Traverse.parent(start).bind(function (parent) {
+    return Traverse.parent(start).bind((parent) => {
       const selection = Selection.exact(start, range.startOffset, parent, Awareness.getEnd(parent));
       const optRect = WindowSelection.getFirstRect(range.startContainer.ownerDocument.defaultView, selection);
       return optRect.map(collapsedRect).map(Arr.pure);
@@ -45,7 +42,7 @@ const getRectsFromRange = function (range) {
   }
 };
 
-const getRectangles = function (cWin) {
+const getRectangles = (cWin: Window): StructRect[] => {
   const sel = cWin.getSelection();
   // In the Android WebView for some reason cWin.getSelection returns undefined.
   // The undefined check it is to avoid throwing of a JS error.

--- a/modules/tinymce/src/themes/mobile/main/ts/util/SkinLoaded.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/SkinLoaded.ts
@@ -5,13 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const fireSkinLoaded = function (editor) {
-  const done = function () {
+const fireSkinLoaded = (editor): () => void => {
+  const done = () => {
     editor._skinLoaded = true;
     editor.fire('SkinLoaded');
   };
 
-  return function () {
+  return () => {
     if (editor.initialized) {
       done();
     } else {

--- a/modules/tinymce/src/themes/mobile/main/ts/util/StyleFormats.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/StyleFormats.ts
@@ -12,37 +12,28 @@ import DefaultStyleFormats from '../features/DefaultStyleFormats';
 import * as StylesMenu from '../ui/StylesMenu';
 import * as StyleConversions from './StyleConversions';
 
-const register = function (editor, settings) {
+const register = (editor, settings) => {
 
-  const isSelectedFor = function (format) {
-    return function () {
-      return editor.formatter.match(format);
-    };
-  };
+  const isSelectedFor = (format) => (): boolean =>
+    editor.formatter.match(format);
 
-  const getPreview = function (format) {
-    return function () {
-      const styles = editor.formatter.getCssText(format);
-      return styles;
-    };
-  };
+  const getPreview = (format) => (): string =>
+    editor.formatter.getCssText(format);
 
-  const enrichSupported = function (item) {
-    return Merger.deepMerge(item, {
+  const enrichSupported = (item) =>
+    Merger.deepMerge(item, {
       isSelected: isSelectedFor(item.format),
       getPreview: getPreview(item.format)
     });
-  };
 
   // Item that triggers a submenu
-  const enrichMenu = function (item) {
-    return Merger.deepMerge(item, {
+  const enrichMenu = (item) =>
+    Merger.deepMerge(item, {
       isSelected: Fun.constant(false),
       getPreview: Fun.constant('')
     });
-  };
 
-  const enrichCustom = function (item) {
+  const enrichCustom = (item) => {
     const formatName = Id.generate(item.title);
     const newItem = Merger.deepMerge(item, {
       format: formatName,
@@ -55,52 +46,48 @@ const register = function (editor, settings) {
 
   const formats = Obj.get(settings, 'style_formats').getOr(DefaultStyleFormats);
 
-  const doEnrich = function (items) {
-    return Arr.map(items, function (item) {
-      if (Obj.hasNonNullableKey(item, 'items')) {
-        const newItems = doEnrich(item.items);
-        return Merger.deepMerge(
-          enrichMenu(item),
-          {
-            items: newItems
-          }
-        );
-      } else if (Obj.hasNonNullableKey(item, 'format')) {
-        return enrichSupported(item);
-      } else {
-        return enrichCustom(item);
-      }
-    });
-  };
+  const doEnrich = (items) => Arr.map(items, (item) => {
+    if (Obj.hasNonNullableKey(item, 'items')) {
+      const newItems = doEnrich(item.items);
+      return Merger.deepMerge(
+        enrichMenu(item),
+        {
+          items: newItems
+        }
+      );
+    } else if (Obj.hasNonNullableKey(item, 'format')) {
+      return enrichSupported(item);
+    } else {
+      return enrichCustom(item);
+    }
+  });
 
   return doEnrich(formats);
 };
 
-const prune = function (editor, formats) {
+const prune = (editor, formats) => {
 
-  const doPrune = function (items) {
-    return Arr.bind(items, function (item) {
-      if (item.items !== undefined) {
-        const newItems = doPrune(item.items);
-        return newItems.length > 0 ? [ item ] : [ ];
-      } else {
-        const keep = Obj.hasNonNullableKey(item, 'format') ? editor.formatter.canApply(item.format) : true;
-        return keep ? [ item ] : [ ];
-      }
-    });
-  };
+  const doPrune = (items) => Arr.bind(items, (item) => {
+    if (item.items !== undefined) {
+      const newItems = doPrune(item.items);
+      return newItems.length > 0 ? [ item ] : [];
+    } else {
+      const keep = Obj.hasNonNullableKey(item, 'format') ? editor.formatter.canApply(item.format) : true;
+      return keep ? [ item ] : [];
+    }
+  });
 
   const prunedItems = doPrune(formats);
   return StyleConversions.expand(prunedItems);
 };
 
-const ui = function (editor, formats, onDone) {
+const ui = (editor, formats, onDone) => {
   const pruned = prune(editor, formats);
 
   return StylesMenu.sketch({
     formats: pruned,
-    handle (item, value) {
-      editor.undoManager.transact(function () {
+    handle(item, value) {
+      editor.undoManager.transact(() => {
         if (Toggling.isOn(item)) {
           editor.formatter.remove(value);
         } else {

--- a/modules/tinymce/src/themes/mobile/main/ts/util/TappingEvent.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/TappingEvent.ts
@@ -6,30 +6,30 @@
  */
 
 import { TapEvent } from '@ephox/alloy';
-import { DomEvent } from '@ephox/sugar';
+import { DomEvent, EventUnbinder } from '@ephox/sugar';
 
 // TODO: TapEvent needs to be exposed in alloy's API somehow
-const monitor = function (editorApi) {
+const monitor = (editorApi) => {
   const tapEvent = TapEvent.monitor({
-    triggerEvent (type, evt) {
+    triggerEvent(type, evt) {
       editorApi.onTapContent(evt);
     }
   } as any);
 
   // convenience methods
-  const onTouchend = function () {
-    return DomEvent.bind(editorApi.body(), 'touchend', function (evt) {
+  const onTouchend = (): EventUnbinder => {
+    return DomEvent.bind(editorApi.body(), 'touchend', (evt) => {
       tapEvent.fireIfReady(evt, 'touchend');
     });
   };
 
-  const onTouchmove = function () {
-    return DomEvent.bind(editorApi.body(), 'touchmove', function (evt) {
+  const onTouchmove = (): EventUnbinder => {
+    return DomEvent.bind(editorApi.body(), 'touchmove', (evt) => {
       tapEvent.fireIfReady(evt, 'touchmove');
     });
   };
 
-  const fireTouchstart = function (evt) {
+  const fireTouchstart = (evt): void => {
     tapEvent.fireIfReady(evt, 'touchstart');
   };
 

--- a/modules/tinymce/src/themes/mobile/main/ts/util/Thor.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/Thor.ts
@@ -18,7 +18,7 @@ const bgFallback = 'background-color:rgb(255,255,255)!important;';
 
 const isAndroid = PlatformDetection.detect().os.isAndroid();
 
-const matchColor = function (editorBody) {
+const matchColor = (editorBody): string => {
   // in iOS you can overscroll, sometimes when you overscroll you can reveal the bgcolor of an element beneath,
   // by matching the bg color and clobbering ensures any reveals are 'camouflaged' the same color
   const color = Css.get(editorBody, 'background-color');
@@ -26,24 +26,19 @@ const matchColor = function (editorBody) {
 };
 
 // We clobber all tags, direct ancestors to the editorBody get ancestorStyles, everything else gets siblingStyles
-const clobberStyles = function (container, editorBody) {
-  const gatherSibilings = function (element) {
-    const siblings = SelectorFilter.siblings(element, '*');
-    return siblings;
-  };
+const clobberStyles = (container, editorBody): void => {
+  const gatherSibilings = (element) => SelectorFilter.siblings(element, '*');
 
-  const clobber = function (clobberStyle) {
-    return function (element) {
-      const styles = Attr.get(element, 'style');
-      const backup = styles === undefined ? 'no-styles' : styles.trim();
+  const clobber = (clobberStyle) => (element) => {
+    const styles = Attr.get(element, 'style');
+    const backup = styles === undefined ? 'no-styles' : styles.trim();
 
-      if (backup === clobberStyle) {
-        return;
-      } else {
-        Attr.set(element, attr, backup);
-        Attr.set(element, 'style', clobberStyle);
-      }
-    };
+    if (backup === clobberStyle) {
+      return;
+    } else {
+      Attr.set(element, attr, backup);
+      Attr.set(element, 'style', clobberStyle);
+    }
   };
 
   const ancestors = SelectorFilter.ancestors(container, '*');
@@ -58,9 +53,9 @@ const clobberStyles = function (container, editorBody) {
   clobber(containerStyles + ancestorStyles + bgColor)(container);
 };
 
-const restoreStyles = function () {
+const restoreStyles = (): void => {
   const clobberedEls = SelectorFilter.all('[' + attr + ']');
-  Arr.each(clobberedEls, function (element) {
+  Arr.each(clobberedEls, (element) => {
     const restore = Attr.get(element, attr);
     if (restore !== 'no-styles') {
       Attr.set(element, 'style', restore);

--- a/modules/tinymce/src/themes/mobile/main/ts/util/UiDomFactory.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/UiDomFactory.ts
@@ -9,19 +9,16 @@ import { DomFactory, RawDomSchema } from '@ephox/alloy';
 import { Strings } from '@ephox/katamari';
 import * as Styles from '../style/Styles';
 
-const dom = function (rawHtml): RawDomSchema {
+const dom = (rawHtml: string): RawDomSchema => {
   const html = Strings.supplant(rawHtml, {
     prefix: Styles.prefix
   });
   return DomFactory.fromHtml(html);
 };
 
-const spec = function (rawHtml) {
-  const sDom = dom(rawHtml);
-  return {
-    dom: sDom
-  };
-};
+const spec = (rawHtml) => ({
+  dom: dom(rawHtml)
+});
 
 export {
   dom,

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/theme/TestTheme.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/theme/TestTheme.ts
@@ -5,11 +5,7 @@ import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import ThemeManager from 'tinymce/core/api/ThemeManager';
 import * as Features from 'tinymce/themes/mobile/features/Features';
 import * as FormatChangers from 'tinymce/themes/mobile/util/FormatChangers';
-
-interface Realm {
-  system: () => Gui.GuiSystem;
-  socket: () => AlloyComponent;
-}
+import { MobileRealm } from 'tinymce/themes/mobile/ui/IosRealm';
 
 const strName = 'test';
 
@@ -40,7 +36,16 @@ const setup = function (info, onSuccess, onFailure) {
   alloy.add(toolbar);
   alloy.add(socket);
 
-  const realm = {
+  const realm: MobileRealm = {
+    dropup: Fun.die('not implemented'),
+    element: Fun.die('not implemented'),
+    exit: Fun.die('not implemented'),
+    focusToolbar: Fun.die('not implemented'),
+    init: Fun.die('not implemented'),
+    restoreToolbar: Fun.die('not implemented'),
+    setContextToolbar: Fun.die('not implemented'),
+    setToolbarGroups: Fun.die('not implemented'),
+    updateMode: Fun.die('not implemented'),
     system: Fun.constant(alloy),
     socket: Fun.constant(socket)
   };
@@ -58,7 +63,7 @@ const setup = function (info, onSuccess, onFailure) {
   });
 
   return {
-    use (f: (realm: Realm, apis: TinyApis, toolbar: AlloyComponent, socket: AlloyComponent, buttons, onSuccess: () => void, onFailure: (err?: any) => void) => void) {
+    use (f: (realm: MobileRealm, apis: TinyApis, toolbar: AlloyComponent, socket: AlloyComponent, buttons, onSuccess: () => void, onFailure: (err?: any) => void) => void) {
       TinyLoader.setup(function (editor, onS, onF) {
         const features = Features.setup(realm, editor);
 


### PR DESCRIPTION
This theme is missing a lot of type info, and it was getting in the way of removing an immutableBag reference. I knocked over some of the quick wins. I also converted a bunch of functions to arrow functions while I was in there.