### PR TITLE
TINY-4765: Fixed an edge case where the inline more drawer would get offset from the toolbar

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -3,7 +3,7 @@ Version 5.2.1 (TBD)
     Fixed possible uncaught exception when a style attribute is removed using a parser filter #TINY-4742
     Fixed table selection not functioning correctly in Microsoft Edge 44 or higher #TINY-3862
     Fixed table resize handles not functioning correctly in Microsoft Edge #TINY-4160
-    Fixed the floating toolbar disconnecting from the toolbar when adding content in inline mode #TINY-4725
+    Fixed the floating toolbar disconnecting from the toolbar when adding content in inline mode #TINY-4725 #TINY-4765
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948
     Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
     Fixed the editor incorrectly stealing focus during initialization in Microsoft IE #TINY-4697

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -139,11 +139,12 @@ const renderFloatingMoreToolbar = (toolbarSpec: MoreDrawerToolbarSpec) => {
       const headerBounds = Boxes.absolute(headerElem);
       const docElem = Traverse.documentElement(headerElem);
       const docBounds = Boxes.absolute(docElem);
+      const minTop = Math.min(docBounds.y(), headerBounds.x());
       return Boxes.bounds(
         headerBounds.x() + overflowXOffset,
-        docBounds.y(),
+        minTop,
         headerBounds.width() - overflowXOffset * 2,
-        docBounds.height()
+        Math.max(docBounds.height(), headerBounds.bottom() - minTop)
       );
     },
     parts: {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -1,18 +1,31 @@
-import { Chain, Keys, Logger, Pipeline, Step, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { Chain, GeneralSteps, Keys, Log, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
 import { Editor as McEditor, TinyActions, TinyApis, TinyUi } from '@ephox/mcagar';
 import { Body, Css, Element, Location } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
+import { EditorSettings } from 'tinymce/core/api/SettingsTypes';
 import Theme from 'tinymce/themes/silver/Theme';
 import { sAssertFloatingToolbarPosition, sOpenFloatingToolbarAndAssertPosition } from '../../../module/ToolbarUtils';
 
 UnitTest.asynctest('Inline Editor Floating Toolbar Drawer Position test', (success, failure) => {
   Theme();
+  const toolbarHeight = 39;
+  const lineHeight = 30;
 
-  Pipeline.async({}, [
-    Logger.t('Inline Editor Floating Toolbar Drawer Position test', Chain.asStep({}, [
+  const getUiContainerTop = (editor: Editor) => {
+    const uiContainer = Element.fromDom(editor.getContainer());
+    return Location.absolute(uiContainer).top();
+  };
+
+  const sPressEnterNTimes = (tinyApis: TinyApis, tinyActions: TinyActions, times: number) => GeneralSteps.sequence([
+    tinyApis.sFocus(),
+    ...GeneralSteps.repeat(times, tinyActions.sContentKeydown(Keys.enter()))
+  ]);
+
+  const sWithEditor = (settings: EditorSettings, getSteps: (editor: Editor, tinyApis: TinyApis) => Array<Step<any, any>>) => {
+    return Chain.asStep({}, [
       McEditor.cFromSettings({
         theme: 'silver',
         inline: true,
@@ -20,14 +33,12 @@ UnitTest.asynctest('Inline Editor Floating Toolbar Drawer Position test', (succe
         width: 400,
         base_url: '/project/tinymce/js/tinymce',
         toolbar: 'undo redo | styleselect | bold italic underline | strikethrough superscript subscript | alignleft aligncenter alignright aligncenter | outdent indent | cut copy paste | selectall remove',
-        toolbar_mode: 'floating'
+        toolbar_mode: 'floating',
+        ...settings
       }),
-      Chain.async((editor: Editor, onSuccess, onFailure) => {
-        const tinyActions = TinyActions(editor);
+      Chain.async((editor, onSuccess, onFailure) => {
         const tinyApis = TinyApis(editor);
-        const tinyUi = TinyUi(editor);
         const uiContainer = Element.fromDom(editor.getContainer());
-        const initialContainerTop = Cell(Location.absolute(uiContainer).top() + 39);
 
         Pipeline.async({ }, [
           Step.sync(() => {
@@ -35,21 +46,65 @@ UnitTest.asynctest('Inline Editor Floating Toolbar Drawer Position test', (succe
           }),
           tinyApis.sSetContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>'),
           tinyApis.sFocus(),
+          tinyApis.sSetCursor([2, 0], 'Line 3'.length),
           UiFinder.sWaitForVisible('Wait for editor to be visible', Body.body(), '.tox-editor-header button[title="More..."]'),
-          Step.sync(() => {
-            initialContainerTop.set(Location.absolute(uiContainer).top() + 39); // top of ui container + toolbar height
-          }),
-          sOpenFloatingToolbarAndAssertPosition(tinyUi, initialContainerTop.get), // top of ui container + toolbar height
-          sOpenFloatingToolbarAndAssertPosition(tinyUi, initialContainerTop.get, [
-            // Press enter a few times to change the height of the editor
-            tinyActions.sContentKeydown(Keys.enter()),
-            tinyActions.sContentKeydown(Keys.enter()),
-            tinyActions.sContentKeydown(Keys.enter()),
-            sAssertFloatingToolbarPosition(tinyUi, initialContainerTop.get, 105, 465),
-          ])
+          ...getSteps(editor, tinyApis)
         ], () => onSuccess(editor), onFailure);
       }),
       McEditor.cRemove
-    ])),
+    ]);
+  };
+
+  const sTestToolbarTop = Step.label('Test toolbar top positioning', sWithEditor({ }, (editor, tinyApis) => {
+    const tinyActions = TinyActions(editor);
+    const tinyUi = TinyUi(editor);
+    const initialContainerTop = Cell(getUiContainerTop(editor));
+
+    const getExpectedToolbarPos = () => initialContainerTop.get() + toolbarHeight; // top of ui container + toolbar height
+
+    return [
+      Step.sync(() => {
+        initialContainerTop.set(getUiContainerTop(editor)); // Store the original position
+      }),
+      sOpenFloatingToolbarAndAssertPosition(tinyUi, getExpectedToolbarPos),
+      sOpenFloatingToolbarAndAssertPosition(tinyUi, getExpectedToolbarPos, [
+        // Press enter a few times to change the height of the editor
+        sPressEnterNTimes(tinyApis, tinyActions, 3),
+        sAssertFloatingToolbarPosition(tinyUi, getExpectedToolbarPos, 105, 465),
+      ])
+    ];
+  }));
+
+  const sTestToolbarBottom = Step.label('Test toolbar bottom positioning', sWithEditor({ toolbar_location: 'bottom' }, (editor, tinyApis) => {
+    const tinyActions = TinyActions(editor);
+    const tinyUi = TinyUi(editor);
+    const initialContainerTop = Cell(getUiContainerTop(editor));
+
+    const getExpectedToolbarPos = () => initialContainerTop.get() - toolbarHeight * 2; // top of ui container - two toolbar heights
+
+    return [
+      Step.sync(() => {
+        initialContainerTop.set(getUiContainerTop(editor));  // Store the original position
+      }),
+      sOpenFloatingToolbarAndAssertPosition(tinyUi, getExpectedToolbarPos),
+      sOpenFloatingToolbarAndAssertPosition(tinyUi, getExpectedToolbarPos, [
+        // Press enter a few times to change the height of the editor
+        sPressEnterNTimes(tinyApis, tinyActions, 3),
+        Waiter.sTryUntil('Wait for toolbar to move', Step.sync(() => {
+          Assert.eq('Toolbar top position', true, getUiContainerTop(editor) >= initialContainerTop.get() + lineHeight * 3); // Wait for the toolbar to move three lines
+        })),
+        Step.sync(() => {
+          initialContainerTop.set(getUiContainerTop(editor)); // reset the toolbar position
+        }),
+        sAssertFloatingToolbarPosition(tinyUi, getExpectedToolbarPos, 105, 465), // top of ui container - two toolbar heights
+      ])
+    ];
+  }));
+
+  Pipeline.async({}, [
+    Log.stepsAsStep('TINY-4725', 'Inline Editor Floating Toolbar Drawer Position test', [
+      sTestToolbarTop,
+      sTestToolbarBottom
+    ]),
   ], () => success(), failure);
 });


### PR DESCRIPTION
This fixes an edge case @ltrouton found whereby the toolbar would get positioned incorrectly when using inline mode with toolbar bottom. The cause was our bounds weren't accurate for when the toolbar was positioned at the bottom.