### PR TITLE
TINY-4087: Backported fix for TinyMCE failing to initialize if a script tag was used inside an SVG

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 Version 4.9.9 (TBD)
     Fixed table selection not functioning correctly in Edge 44 or higher #TINY-3862
-    Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
     Fixed table resize handles not functioning correctly in Microsoft Edge #TINY-4160
+    Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
+    Fixed failing to initialize if a script tag was used inside an SVG #TINY-4087
 Version 4.9.8 (2020-01-28)
     Fixed the `mobile` theme failing to load due to a bundling issue #TINY-4613
     Fixed security issue related to parsing HTML comments and CDATA #TINY-4544

--- a/src/core/main/ts/api/EditorManager.ts
+++ b/src/core/main/ts/api/EditorManager.ts
@@ -178,7 +178,7 @@ EditorManager = {
 
   setup () {
     const self = this;
-    let baseURL, documentBaseURL, suffix = '', preInit, src;
+    let baseURL, documentBaseURL, suffix = '';
 
     // Get base URL for the current document
     documentBaseURL = URI.getDocumentBaseUrl(document.location);
@@ -194,7 +194,7 @@ EditorManager = {
     }
 
     // If tinymce is defined and has a base use that or use the old tinyMCEPreInit
-    preInit = window.tinymce || window.tinyMCEPreInit;
+    const preInit = window.tinymce || window.tinyMCEPreInit;
     if (preInit) {
       baseURL = preInit.base || preInit.baseURL;
       suffix = preInit.suffix;
@@ -202,7 +202,10 @@ EditorManager = {
       // Get base where the tinymce script is located
       const scripts = document.getElementsByTagName('script');
       for (let i = 0; i < scripts.length; i++) {
-        src = scripts[i].src;
+        const src = scripts[i].src || '';
+        if (src === '') {
+          continue;
+        }
 
         // Script types supported:
         // tinymce.js tinymce.min.js tinymce.dev.js
@@ -222,7 +225,7 @@ EditorManager = {
       // We didn't find any baseURL by looking at the script elements
       // Try to use the document.currentScript as a fallback
       if (!baseURL && document.currentScript) {
-        src = (<any> document.currentScript).src;
+        const src = (<any> document.currentScript).src;
 
         if (src.indexOf('.min') !== -1) {
           suffix = '.min';

--- a/src/core/test/ts/browser/EditorManagerSetupTest.ts
+++ b/src/core/test/ts/browser/EditorManagerSetupTest.ts
@@ -1,0 +1,42 @@
+import { Assertions, Logger, Pipeline, Step } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { window } from '@ephox/dom-globals';
+import EditorManager from 'tinymce/core/api/EditorManager';
+import ViewBlock from '../module/test/ViewBlock';
+import Theme from 'tinymce/themes/modern/Theme';
+
+UnitTest.asynctest('browser.tinymce.core.EditorManagerSetupTest', (success, failure) => {
+  const viewBlock = ViewBlock();
+
+  Theme();
+
+  viewBlock.attach();
+
+  // Store the original data
+  const origBaseURL = EditorManager.baseURL;
+  const origBaseURI = EditorManager.baseURI;
+  const origSuffix = EditorManager.suffix;
+  const origDocumentBaseURL = EditorManager.documentBaseURL;
+  const origTinyMCE = (window as any).tinymce;
+  delete (window as any).tinymce;
+
+  Pipeline.async({}, [
+    Logger.t('script baseURL and suffix with script in svg', Step.sync(() => {
+      viewBlock.update('<svg><script>!function(){}();</script></svg><script src="http://localhost/nonexistant/tinymce.min.js" type="application/javascript"></script>');
+      EditorManager.setup();
+      Assertions.assertEq('BaseURL is interpreted from the script src', EditorManager.baseURL, 'http://localhost/nonexistant');
+      Assertions.assertEq('Suffix is interpreted from the script src', EditorManager.suffix, '.min');
+    }))
+  ], () => {
+    viewBlock.detach();
+
+    // Restore the original values
+    EditorManager.baseURL = origBaseURL;
+    EditorManager.baseURI = origBaseURI;
+    EditorManager.documentBaseURL = origDocumentBaseURL;
+    EditorManager.suffix = origSuffix;
+    (window as any).tinymce = origTinyMCE;
+
+    success();
+  }, failure);
+});


### PR DESCRIPTION
This backports a fix we did a while back (5.0.16). I wasn't 100% sure whether we should backport this, and no one seemed to know when I asked on Slack, however given this causes the editor to completely fail to load I thought it had a high enough priority even if it was an edge case issue.

Fixes #5475 