### PR TITLE
TINY-4771: Fixed a couple production bundles not stripping off the sourcemap includes

### DIFF
--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -26,6 +26,11 @@ let oxideUiSkinMap = {
   'default': 'oxide'
 };
 
+const stripSourceMaps = function (data) {
+  const sourcemap = data.lastIndexOf('/*# sourceMappingURL=');
+  return sourcemap > -1 ? data.slice(0, sourcemap) : data;
+};
+
 module.exports = function (grunt) {
   var packageData = grunt.file.readJSON('package.json');
   var changelogLine = grunt.file.read('changelog.txt').toString().split('\n')[0];
@@ -325,10 +330,7 @@ module.exports = function (grunt) {
           to: 'dist/tinymce_<%= pkg.version %>.zip',
           dataFilter: (args) => {
             if (args.filePath.endsWith('.min.css')) {
-              var sourcemap = args.data.lastIndexOf('/*# sourceMappingURL=');
-              if (sourcemap > -1) {
-                args.data = args.data.slice(0, sourcemap);
-              }
+              args.data = stripSourceMaps(args.data);
             }
           }
         },
@@ -407,6 +409,11 @@ module.exports = function (grunt) {
           },
           pathFilter: function (zipFilePath) {
             return zipFilePath.replace('js/tinymce/', 'dist/');
+          },
+          dataFilter: (args) => {
+            if (args.filePath.endsWith('.min.css')) {
+              args.data = stripSourceMaps(args.data);
+            }
           },
           onBeforeConcat: function (destPath, chunks) {
             // Strip the license from each file and prepend the license, so it only appears once
@@ -562,7 +569,12 @@ module.exports = function (grunt) {
               zipUtils.generateIndex('themes', 'theme')
             );
           },
-          to: 'dist/tinymce_<%= pkg.version %>_component.zip'
+          to: 'dist/tinymce_<%= pkg.version %>_component.zip',
+          dataFilter: (args) => {
+            if (args.filePath.endsWith('.min.css')) {
+              args.data = stripSourceMaps(args.data);
+            }
+          }
         },
         src: [
           'js/tinymce/skins',


### PR DESCRIPTION
No changelog as this doesn't impact TinyMCE itself and instead only a few select bundles. This was just a very quick win and I wasn't too sure if we should throw this in 5.2.1 or 5.3.0, however it has very little risk so I thought it made sense to include it in 5.2.1. If anyone thinks otherwise let me know and I'll change it to 5.3.0.

Fixes #5489 