### PR TITLE
TINY-4012: Fixed inline dialogs incorrectly closing when clicking on an opened alert or confirm dialog

### DIFF
--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+# [6.1.0] - 2020-03-16
+
+### Added
+
+- Added new `isExtraPart` property to `InlineView`. This allows the component to declare an external component as part of itself for dismissal events.
+
 # [6.0.1] - 2020-03-02
 
 ### Fixed

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -100,11 +100,10 @@ const makeSandbox = (button: AlloyComponent, spec: FloatingToolbarButtonSpec, de
         Receiving.config({
           channels: {
             ...Dismissal.receivingChannel({
-              isExtraPart: Fun.constant(false),
+              isExtraPart: Fun.never,
               ...detail.fireDismissalEventInstead.map((fe) => ({ fireEventInstead: { event: fe.event }} as any)).getOr({ })
             }),
             ...Reposition.receivingChannel({
-              isExtraPart: Fun.constant(false),
               doReposition: () => {
                 Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox')).each((toolbar) => {
                   position(button, toolbar, detail, spec.layouts);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
@@ -200,11 +200,10 @@ const factory: SingleSketchFactory<InlineViewDetail, InlineViewSpec> = (detail: 
         Receiving.config({
           channels: {
             ...Dismissal.receivingChannel({
-              isExtraPart: Fun.constant(false),
+              isExtraPart: spec.isExtraPart,
               ...detail.fireDismissalEventInstead.map((fe) => ({ fireEventInstead: { event: fe.event }} as any)).getOr({ })
             }),
             ...Reposition.receivingChannel({
-              isExtraPart: Fun.constant(false),
               ...detail.fireRepositionEventInstead.map((fe) => ({ fireEventInstead: { event: fe.event }} as any)).getOr({ }),
               doReposition: reposition
             })
@@ -233,6 +232,7 @@ const InlineView: InlineViewSketcher = Sketcher.single<InlineViewSpec, InlineVie
       FieldSchema.defaulted('event', SystemEvents.repositionRequested())
     ]),
     FieldSchema.defaulted('getRelated', Option.none),
+    FieldSchema.defaulted('isExtraPart', Fun.never),
     FieldSchema.defaulted('eventOrder', Option.none)
   ],
   factory,

--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -228,10 +228,9 @@ const makeSandbox = (detail: CommonDropdownDetail<TieredData>, hotspot: AlloyCom
         Receiving.config({
           channels: {
             ...Dismissal.receivingChannel({
-              isExtraPart: Fun.constant(false)
+              isExtraPart: Fun.never
             }),
             ...Reposition.receivingChannel({
-              isExtraPart: Fun.constant(false),
               doReposition: doRepositionMenus
             })
           }

--- a/modules/alloy/src/main/ts/ephox/alloy/sandbox/Reposition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/sandbox/Reposition.ts
@@ -1,6 +1,5 @@
 import { FieldSchema, ValueSchema } from '@ephox/boulder';
-import { Fun, Option } from '@ephox/katamari';
-import { Element } from '@ephox/sugar';
+import { Option } from '@ephox/katamari';
 
 import { NamedConfiguredBehaviour } from '../api/behaviour/Behaviour';
 import { Receiving } from '../api/behaviour/Receiving';
@@ -12,7 +11,6 @@ import * as Channels from '../api/messages/Channels';
 import { ReceivingConfig, ReceivingConfigSpec } from '../behaviour/receiving/ReceivingTypes';
 
 export interface RepositionReceivingDetail {
-  isExtraPart: (sandbox: AlloyComponent, target: () => Element) => boolean;
   doReposition: (sandbox: AlloyComponent) => void;
   fireEventInstead: Option<{
     event: string;
@@ -20,7 +18,6 @@ export interface RepositionReceivingDetail {
 }
 
 export interface RepositionReceivingSpec {
-  isExtraPart?: (sandbox: AlloyComponent, target: () => Element) => boolean;
   doReposition: (sandbox: AlloyComponent) => void;
   fireEventInstead?: {
     event?: string;
@@ -28,7 +25,6 @@ export interface RepositionReceivingSpec {
 }
 
 const schema = ValueSchema.objOfOnly([
-  FieldSchema.defaulted('isExtraPart', Fun.constant(false)),
   FieldSchema.optionObjOf('fireEventInstead', [
     FieldSchema.defaulted('event', SystemEvents.repositionRequested())
   ]),

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
@@ -20,6 +20,7 @@ export interface InlineViewDetail extends SingleSketchDetail {
   onHide: (component: AlloyComponent) => void;
   onEscape: Option<(component: AlloyComponent) => void>;
   getRelated: (component: AlloyComponent) => Option<AlloyComponent>;
+  isExtraPart: (component: AlloyComponent, target: Element) => boolean;
   lazySink: LazySink;
   eventOrder: Record<string, string[]>;
   fireDismissalEventInstead: Option<{
@@ -40,6 +41,7 @@ export interface InlineViewSpec extends SingleSketchSpec {
   onHide?: (component: AlloyComponent) => void;
   onEscape?: (component: AlloyComponent) => void;
   getRelated?: (component: AlloyComponent) => Option<AlloyComponent>;
+  isExtraPart?: (component: AlloyComponent, target: Element) => boolean;
   eventOrder?: Record<string, string[]>;
   fireDismissalEventInstead?: {
     event?: string

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -12,6 +12,7 @@ Version 5.2.1 (TBD)
     Fixed the `colorinput` popup appearing offscreen on mobile devices #TINY-4711
     Fixed an issue where dragging images could cause them to be duplicated #TINY-4195
     Fixed context toolbars activating without the editor having focus #TINY-4754
+    Fixed inline dialogs incorrectly closing when clicking on an opened alert or confirm dialog #TINY-4012
 Version 5.2.0 (2020-02-13)
     Added the ability to apply formats to spaces #TINY-4200
     Added new `toolbar_location` setting to allow for positioning the menu and toolbar at the bottom of the editor #TINY-4210

--- a/modules/tinymce/src/themes/silver/test/ts/module/DialogUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/DialogUtils.ts
@@ -30,11 +30,15 @@ const cClose = Chain.fromChainsWith(Body.body(), [
 
 const sClose = Chain.asStep({}, [ cClose ]);
 
+const sWaitForOpen = (selector: string = '[role=dialog]') => UiFinder.sWaitForVisible('Wait for the dialog to open', Body.body(), selector);
+
 export {
   sOpen,
   sClose,
 
   cOpen,
   cOpenWithStore,
-  cClose
+  cClose,
+
+  sWaitForOpen
 };


### PR DESCRIPTION
Note: I removed the `isExtraPart` from the repositioning spec, as it wasn't ever being used anyways, so it was just bloating the code.

Fixes #5405 