### PR TITLE
TINY-4014: Fixed dialogs stealing focus when opening an alert/confirm via an onAction callback

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,6 +7,7 @@ Version 5.2.1 (TBD)
     Fixed `readonly` mode not returning appropriate boolean value #TINY-3948
     Fixed `forced_root_block_attrs` setting not applying to new blocks consistently #TINY-4564
     Fixed the editor incorrectly stealing focus during initialization in Microsoft IE #TINY-4697
+    Fixed dialogs stealing focus when opening an alert/confirm via an onAction callback #TINY-4014
     Fixed the context toolbar overlapping with the menu bar and toolbar #TINY-4586
     Fixed notification and inline dialog positioning issues when using the bottom toolbar #TINY-4586
     Fixed the `colorinput` popup appearing offscreen on mobile devices #TINY-4711

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
@@ -1,12 +1,12 @@
-import { FocusTools, GeneralSteps, Keyboard, Keys, Log, Logger, Pipeline, Step, UiControls, UiFinder, Chain } from '@ephox/agar';
+import { Chain, FocusTools, GeneralSteps, Keyboard, Keys, Log, Logger, Pipeline, Step, UiControls, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
-import { TinyLoader, TinyUi, TinyApis } from '@ephox/mcagar';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import { Element } from '@ephox/sugar';
 
+import Tools from 'tinymce/core/api/util/Tools';
 import SearchReplacePlugin from 'tinymce/plugins/searchreplace/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
-import Tools from 'tinymce/core/api/util/Tools';
 
 UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationTest', function (success, failure) {
   SilverTheme();
@@ -96,6 +96,20 @@ UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardN
         sPressEnter,
         sAssertFocused('Find input', '.tox-textfield[placeholder="Find"]'),
         sPressEsc,
+      ]),
+      Log.stepsAsStep('TINY-4014', 'Find and replace: Dialog keyboard focus is returned to find input after displaying an alert', [
+        tinyApis.sSetContent('<p>fish fish fish</p>'),
+        sOpenDialog(tinyUi),
+        sAssertFocused('Find input', '.tox-textfield[placeholder="Find"]'),
+        Chain.asStep(body, [
+          UiFinder.cFindIn('input.tox-textfield[placeholder="Find"]'),
+          UiControls.cSetValue('notfound')
+        ]),
+        sPressEnter,
+        sAssertFocused('Alert dialog OK button', '.tox-alert-dialog .tox-button[title="OK"]'),
+        sPressEnter,
+        sAssertFocused('Find input', '.tox-textfield[placeholder="Find"]'),
+        sPressEsc
       ])
     ], onSuccess, onFailure);
   }, {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -11,10 +11,10 @@ import { Option } from '@ephox/katamari';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderModalBody } from './SilverDialogBody';
+import * as SilverDialogCommon from './SilverDialogCommon';
 import { SilverDialogEvents } from './SilverDialogEvents';
 import { renderModalFooter } from './SilverDialogFooter';
 import { getDialogApi } from './SilverDialogInstanceApi';
-import * as SilverDialogCommon from './SilverDialogCommon';
 
 const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverDialogCommon.WindowExtra, backstage: UiFactoryBackstage) => {
   const header = SilverDialogCommon.getHeader(dialogInit.internalDialog.title, backstage);
@@ -31,7 +31,11 @@ const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverD
     buttons: storagedMenuButtons
   }, backstage);
 
-  const dialogEvents = SilverDialogEvents.initDialog(() => instanceApi, SilverDialogCommon.getEventExtras(() => dialog, extra));
+  const dialogEvents = SilverDialogEvents.initDialog(
+    () => instanceApi,
+    SilverDialogCommon.getEventExtras(() => dialog, extra),
+    backstage.shared.getSink
+  );
 
   const dialogSize = dialogInit.internalDialog.size !== 'normal'
     ? dialogInit.internalDialog.size === 'large'

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
@@ -5,37 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import {
-  AlloyComponent,
-  AlloyEvents,
-  AlloyTriggers,
-  CustomEvent,
-  NativeEvents,
-  Reflecting,
-  Representing,
-  Keying,
-} from '@ephox/alloy';
+import { AlloyComponent, AlloyEvents, AlloyTriggers, CustomEvent, Keying, NativeEvents, Reflecting, Representing, } from '@ephox/alloy';
 import { DialogManager, Types } from '@ephox/bridge';
-import { Focus, Compare, Attr } from '@ephox/sugar';
+import { HTMLElement } from '@ephox/dom-globals';
+import { Result } from '@ephox/katamari';
+import { Attr, Compare, Element, Focus } from '@ephox/sugar';
 
-import {
-  formActionEvent,
-  FormActionEvent,
-  formBlockEvent,
-  formCancelEvent,
-  FormCancelEvent,
-  FormChangeEvent,
-  formChangeEvent,
-  FormCloseEvent,
-  formCloseEvent,
-  FormBlockEvent,
-  FormSubmitEvent,
-  formSubmitEvent,
-  formUnblockEvent,
-  FormUnblockEvent,
-  formTabChangeEvent,
-  FormTabChangeEvent
-} from '../general/FormEvents';
+import { formActionEvent, FormActionEvent, formBlockEvent, FormBlockEvent, formCancelEvent, FormCancelEvent, FormChangeEvent, formChangeEvent, FormCloseEvent, formCloseEvent, FormSubmitEvent, formSubmitEvent, formTabChangeEvent, FormTabChangeEvent, formUnblockEvent, FormUnblockEvent } from '../general/FormEvents';
 import NavigableObject from '../general/NavigableObject';
 
 export interface ExtraListeners {
@@ -90,7 +66,7 @@ const initUrlDialog = <T>(getInstanceApi: () => Types.UrlDialog.UrlDialogInstanc
   ];
 };
 
-const initDialog = <T>(getInstanceApi: () => Types.Dialog.DialogInstanceApi<T>, extras: ExtraListeners) => {
+const initDialog = <T>(getInstanceApi: () => Types.Dialog.DialogInstanceApi<T>, extras: ExtraListeners, getSink: () => Result<AlloyComponent, any>) => {
   const fireApiEvent = <E extends CustomEvent>(eventName: string, f: (api: Types.Dialog.DialogInstanceApi<T>, spec: Types.Dialog.Dialog<T>, e: E, c: AlloyComponent) => void) => {
     return AlloyEvents.run<E>(eventName, (c, se) => {
       withSpec(c, (spec, _c) => {
@@ -116,19 +92,23 @@ const initDialog = <T>(getInstanceApi: () => Types.Dialog.DialogInstanceApi<T>, 
 
     fireApiEvent<FormActionEvent>(formActionEvent, (api, spec, event, component) => {
       const focusIn = () => Keying.focusIn(component);
+      const isDisabled = (focused: Element<HTMLElement>) => Attr.has(focused, 'disabled') || Attr.getOpt(focused, 'aria-disabled').exists((val) => val === 'true');
       const current = Focus.active();
 
       spec.onAction(api, { name: event.name(), value: event.value() });
 
-      Focus.active().fold(() => {
-        focusIn();
-      }, (focused) => {
+      Focus.active().fold(focusIn, (focused) => {
         // We need to check if the focused element is disabled because apparently firefox likes to leave focus on disabled elements.
-        if (!Compare.contains(component.element(), focused) || Attr.has(focused, 'disabled')) {
+        if (isDisabled(focused)) {
           focusIn();
-          // And we need the below check for IE, which likes to leave focus on the parent of disabled elements
-        } else if (Compare.contains(focused, current.getOrNull()) && Attr.has(current.getOrDie(), 'disabled')) {
+        // And we need the below check for IE, which likes to leave focus on the parent of disabled elements
+        } else if (current.exists((cur) => Compare.contains(focused, cur) && isDisabled(cur))) {
           focusIn();
+        // Lastly if something outside the sink has focus then return the focus back to the dialog
+        } else {
+          getSink().toOption()
+            .filter((sink) => !Compare.contains(sink.element(), focused))
+            .each(focusIn);
         }
       });
     }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -76,7 +76,8 @@ const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: S
       onBlock: () => { },
       onUnblock: () => { },
       onClose: () => extra.closeWindow()
-    }
+    },
+    backstage.shared.getSink
   );
 
   // TODO: Disable while validating?


### PR DESCRIPTION
The core change here, is that we were only checking if something inside the dialog component had focus and if not then it'd return the focus to the dialog. However with this change, it'll only return the focus to the dialog if the focused element is outside the sink. I also improved the disabled check, to handle things that aren't allowed the disabled attribute, meaning they'd be using the `aria-disabled` attribute instead.

Note: I've pulled this in as it's a regression introduced in 5.0.14 and is closely related to https://github.com/tinymce/tinymce/pull/5497 since the dialog loses focus so you can't use a keyboard to close the alert dialog.