### PR TITLE
TINY-2788: Allow anchors to be inserted on empty lines

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -12,6 +12,7 @@ Version 5.2.1 (TBD)
     Fixed the context toolbar overlapping with the menu bar and toolbar #TINY-4586
     Fixed notification and inline dialog positioning issues when using the bottom toolbar #TINY-4586
     Fixed the `colorinput` popup appearing offscreen on mobile devices #TINY-4711
+    Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
     Fixed special characters not being found when searching by whole words only #TINY-4522
     Fixed an issue where dragging images could cause them to be duplicated #TINY-4195
     Fixed context toolbars activating without the editor having focus #TINY-4754

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1050,6 +1050,12 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
             return false;
           }
 
+          // Keep anchor in empty block
+          const isAnchor = name && !getAttrib(node, 'href') && (getAttrib(node, 'id') || getAttrib(node, 'name'));
+          if (isAnchor) {
+            return false;
+          }
+
           // Keep elements with data-bookmark attributes or name attribute like <a name="1"></a>
           attributes = getAttribs(node);
           i = attributes.length;

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1050,18 +1050,13 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
             return false;
           }
 
-          // Keep anchor in empty block
-          const isAnchor = name && !getAttrib(node, 'href') && (getAttrib(node, 'id') || getAttrib(node, 'name'));
-          if (isAnchor) {
-            return false;
-          }
-
-          // Keep elements with data-bookmark attributes or name attribute like <a name="1"></a>
+          // Keep elements with data-bookmark attributes, name attributes or are named anchors
           attributes = getAttribs(node);
           i = attributes.length;
           while (i--) {
+            const isNamedAnchor = node.nodeName === 'A' && !getAttrib(node, 'href') && getAttrib(node, 'id');
             name = attributes[i].nodeName;
-            if (name === 'name' || name === 'data-mce-bookmark') {
+            if (name === 'name' || name === 'data-mce-bookmark' || isNamedAnchor) {
               return false;
             }
           }

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1017,8 +1017,30 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     return styles.toHex(Tools.trim(rgbVal));
   };
 
+  // Check if element has a data-bookmark attribute, name attribute or is a named anchor
+  const isNonEmptyElement = (node: Node) => {
+    if (NodeType.isElement(node)) {
+      const attributes = getAttribs(node);
+      let i = attributes.length;
+      while (i--) {
+        const isNamedAnchor = node.nodeName === 'A' && !getAttrib(node, 'href') && getAttrib(node, 'id');
+        const name = attributes[i].nodeName;
+        if (name === 'name' || name === 'data-mce-bookmark' || isNamedAnchor) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+
   const isEmpty = (node: Node, elements?: Record<string, any>) => {
-    let i, attributes, type, name, brCount = 0;
+    let type: number, name: string, brCount = 0;
+
+    // Keep elements with data-bookmark attributes, name attributes or are named anchors
+    if (isNonEmptyElement(node)) {
+      return false;
+    }
 
     node = node.firstChild;
     if (node) {
@@ -1051,14 +1073,8 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
           }
 
           // Keep elements with data-bookmark attributes, name attributes or are named anchors
-          attributes = getAttribs(node);
-          i = attributes.length;
-          while (i--) {
-            const isNamedAnchor = node.nodeName === 'A' && !getAttrib(node, 'href') && getAttrib(node, 'id');
-            name = attributes[i].nodeName;
-            if (name === 'name' || name === 'data-mce-bookmark' || isNamedAnchor) {
-              return false;
-            }
+          if (isNonEmptyElement(node)) {
+            return false;
           }
         }
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1020,17 +1020,11 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
   // Check if element has a data-bookmark attribute, name attribute or is a named anchor
   const isNonEmptyElement = (node: Node) => {
     if (NodeType.isElement(node)) {
-      const attributes = getAttribs(node);
-      let i = attributes.length;
-      while (i--) {
-        const isNamedAnchor = node.nodeName === 'A' && !getAttrib(node, 'href') && getAttrib(node, 'id');
-        const name = attributes[i].nodeName;
-        if (name === 'name' || name === 'data-mce-bookmark' || isNamedAnchor) {
-          return true;
-        }
+      const isNamedAnchor = node.nodeName === 'A' && !getAttrib(node, 'href') && getAttrib(node, 'id');
+      if (getAttrib(node, 'name') || getAttrib(node, 'data-mce-bookmark') || isNamedAnchor) {
+        return true;
       }
     }
-
     return false;
   };
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1020,7 +1020,7 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
   // Check if element has a data-bookmark attribute, name attribute or is a named anchor
   const isNonEmptyElement = (node: Node) => {
     if (NodeType.isElement(node)) {
-      const isNamedAnchor = node.nodeName === 'A' && !getAttrib(node, 'href') && getAttrib(node, 'id');
+      const isNamedAnchor = node.nodeName.toLowerCase() === 'a' && !getAttrib(node, 'href') && getAttrib(node, 'id');
       if (getAttrib(node, 'name') || getAttrib(node, 'data-mce-bookmark') || isNamedAnchor) {
         return true;
       }

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -655,19 +655,16 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
           }
 
           if (elementRule.removeEmpty && isEmpty(schema, nonEmptyElements, whiteSpaceElements, node)) {
-            // Leave nodes that have a name like <a name="name">
-            if (!node.attr('name') && !node.attr('id')) {
-              tempNode = node.parent;
+            tempNode = node.parent;
 
-              if (blockElements[node.name]) {
-                node.empty().remove();
-              } else {
-                node.unwrap();
-              }
-
-              node = tempNode;
-              return;
+            if (blockElements[node.name]) {
+              node.empty().remove();
+            } else {
+              node.unwrap();
             }
+
+            node = tempNode;
+            return;
           }
 
           if (elementRule.paddEmpty && (isPaddedWithNbsp(node) || isEmpty(schema, nonEmptyElements, whiteSpaceElements, node))) {

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -491,6 +491,12 @@ class Node {
             return false;
           }
 
+          // Keep anchor in empty block
+          const isAnchor = !node.attr('href') && (node.attr('id') || node.attr('name'));
+          if (isAnchor) {
+            return false;
+          }
+
           // Keep bookmark nodes and name attribute like <a name="1"></a>
           let i = node.attributes.length;
           while (i--) {

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -491,17 +491,12 @@ class Node {
             return false;
           }
 
-          // Keep anchor in empty block
-          const isAnchor = !node.attr('href') && (node.attr('id') || node.attr('name'));
-          if (isAnchor) {
-            return false;
-          }
-
-          // Keep bookmark nodes and name attribute like <a name="1"></a>
+          // Keep nodes with data-bookmark attributes, name attributes or are named anchors
           let i = node.attributes.length;
           while (i--) {
+            const isNamedAnchor = node.name === 'a' && !node.attr('href') && node.attr('id');
             const name = node.attributes[i].name;
-            if (name === 'name' || name.indexOf('data-mce-bookmark') === 0) {
+            if (name === 'name' || name.indexOf('data-mce-bookmark') === 0 || isNamedAnchor) {
               return false;
             }
           }

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -63,6 +63,19 @@ const isEmptyTextNode = (node: Node) => {
   return true;
 };
 
+// Check if node contains data-bookmark attribute, name attribute, id attribute or is a named anchor
+const isExemptElement = (node: Node) => {
+  const isNamedAnchor = node.name === 'a' && !node.attr('href') && node.attr('id');
+  let i = node.attributes ? node.attributes.length : 0;
+  while (i--) {
+    const name = node.attributes[i].name;
+    if (name === 'name' || (name === 'id' && !node.firstChild) || name.indexOf('data-mce-bookmark') === 0 || isNamedAnchor) {
+      return true;
+    }
+  }
+  return false;
+};
+
 /**
  * This class is a minimalistic implementation of a DOM like node used by the DomParser class.
  *
@@ -478,6 +491,10 @@ class Node {
     const self = this;
     let node = self.firstChild;
 
+    if (isExemptElement(self)) {
+      return false;
+    }
+
     if (node) {
       do {
         if (node.type === 1) {
@@ -491,14 +508,8 @@ class Node {
             return false;
           }
 
-          // Keep nodes with data-bookmark attributes, name attributes or are named anchors
-          let i = node.attributes.length;
-          while (i--) {
-            const isNamedAnchor = node.name === 'a' && !node.attr('href') && node.attr('id');
-            const name = node.attributes[i].name;
-            if (name === 'name' || name.indexOf('data-mce-bookmark') === 0 || isNamedAnchor) {
-              return false;
-            }
+          if (isExemptElement(node)) {
+            return false;
           }
         }
 

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -64,7 +64,7 @@ const isEmptyTextNode = (node: Node) => {
 };
 
 // Check if node contains data-bookmark attribute, name attribute, id attribute or is a named anchor
-const isExemptElement = (node: Node) => {
+const isNonEmptyElement = (node: Node) => {
   const isNamedAnchor = node.name === 'a' && !node.attr('href') && node.attr('id');
   let i = node.attributes ? node.attributes.length : 0;
   while (i--) {
@@ -491,7 +491,7 @@ class Node {
     const self = this;
     let node = self.firstChild;
 
-    if (isExemptElement(self)) {
+    if (isNonEmptyElement(self)) {
       return false;
     }
 
@@ -508,7 +508,7 @@ class Node {
             return false;
           }
 
-          if (isExemptElement(node)) {
+          if (isNonEmptyElement(node)) {
             return false;
           }
         }

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -66,14 +66,7 @@ const isEmptyTextNode = (node: Node) => {
 // Check if node contains data-bookmark attribute, name attribute, id attribute or is a named anchor
 const isNonEmptyElement = (node: Node) => {
   const isNamedAnchor = node.name === 'a' && !node.attr('href') && node.attr('id');
-  let i = node.attributes ? node.attributes.length : 0;
-  while (i--) {
-    const name = node.attributes[i].name;
-    if (name === 'name' || (name === 'id' && !node.firstChild) || name.indexOf('data-mce-bookmark') === 0 || isNamedAnchor) {
-      return true;
-    }
-  }
-  return false;
+  return (node.attr('name') || (node.attr('id') && !node.firstChild) || node.attr('data-mce-bookmark') || isNamedAnchor);
 };
 
 /**

--- a/modules/tinymce/src/plugins/anchor/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/anchor/demo/ts/demo/Demo.ts
@@ -5,6 +5,7 @@ tinymce.init({
   plugins: 'anchor code',
   toolbar: 'anchor code',
   height: 600,
+  forced_root_block: false
 });
 
 export {};

--- a/modules/tinymce/src/plugins/anchor/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/anchor/demo/ts/demo/Demo.ts
@@ -4,8 +4,7 @@ tinymce.init({
   selector: 'textarea.tinymce',
   plugins: 'anchor code',
   toolbar: 'anchor code',
-  height: 600,
-  forced_root_block: false
+  height: 600
 });
 
 export {};

--- a/modules/tinymce/src/plugins/anchor/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/Plugin.ts
@@ -11,7 +11,7 @@ import FilterContent from './core/FilterContent';
 import Buttons from './ui/Buttons';
 
 export default function () {
-  PluginManager.add('anchor', function (editor) {
+  PluginManager.add('anchor', (editor) => {
     FilterContent.setup(editor);
     Commands.register(editor);
     Buttons.register(editor);

--- a/modules/tinymce/src/plugins/anchor/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/api/Commands.ts
@@ -7,8 +7,8 @@
 
 import Dialog from '../ui/Dialog';
 
-const register = function (editor) {
-  editor.addCommand('mceAnchor', function () {
+const register = (editor) => {
+  editor.addCommand('mceAnchor', () => {
     Dialog.open(editor);
   });
 };

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
@@ -6,31 +6,33 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import { Element } from '@ephox/dom-globals';
 
-const isValidId = function (id: string) {
+const isAnchor = (editor: Editor, node: Element) => node.tagName === 'A' && editor.dom.getAttrib(node, 'href') === '';
+
+const isValidId = (id: string) => {
   // Follows HTML4 rules: https://www.w3.org/TR/html401/types.html#type-id
   return /^[A-Za-z][A-Za-z0-9\-:._]*$/.test(id);
 };
 
-const getId = function (editor: Editor) {
+const getId = (editor: Editor) => {
   const selectedNode = editor.selection.getNode();
-  const isAnchor = selectedNode.tagName === 'A' && editor.dom.getAttrib(selectedNode, 'href') === '';
-  return isAnchor ? (selectedNode.getAttribute('id') || selectedNode.getAttribute('name')) : '';
+  return isAnchor(editor, selectedNode) ? (selectedNode.getAttribute('id') || selectedNode.getAttribute('name')) : '';
 };
 
-const insert = function (editor: Editor, id: string) {
+const insert = (editor: Editor, id: string) => {
   const selectedNode = editor.selection.getNode();
-  const isAnchor = selectedNode.tagName === 'A' && editor.dom.getAttrib(selectedNode, 'href') === '';
 
-  if (isAnchor) {
+  if (isAnchor(editor, selectedNode)) {
     selectedNode.removeAttribute('name');
     selectedNode.id = id;
     editor.undoManager.add();
   } else {
     editor.focus();
     editor.selection.collapse(true);
-    editor.execCommand('mceInsertContent', false, editor.dom.createHTML('a', {
-      id
+    editor.insertContent(editor.dom.createHTML('a', {
+      id,
+      contenteditable: 'false'
     }));
   }
 };

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
@@ -8,7 +8,7 @@
 import Editor from 'tinymce/core/api/Editor';
 import { Element } from '@ephox/dom-globals';
 
-const isAnchor = (editor: Editor, node: Element) => node.tagName === 'A' && editor.dom.getAttrib(node, 'href') === '';
+const isNamedAnchor = (editor: Editor, node: Element) => node.tagName === 'A' && editor.dom.getAttrib(node, 'href') === '';
 
 const isValidId = (id: string) => {
   // Follows HTML4 rules: https://www.w3.org/TR/html401/types.html#type-id
@@ -17,13 +17,13 @@ const isValidId = (id: string) => {
 
 const getId = (editor: Editor) => {
   const selectedNode = editor.selection.getNode();
-  return isAnchor(editor, selectedNode) ? (selectedNode.getAttribute('id') || selectedNode.getAttribute('name')) : '';
+  return isNamedAnchor(editor, selectedNode) ? (selectedNode.getAttribute('id') || selectedNode.getAttribute('name')) : '';
 };
 
 const insert = (editor: Editor, id: string) => {
   const selectedNode = editor.selection.getNode();
 
-  if (isAnchor(editor, selectedNode)) {
+  if (isNamedAnchor(editor, selectedNode)) {
     selectedNode.removeAttribute('name');
     selectedNode.id = id;
     editor.undoManager.add();
@@ -31,8 +31,7 @@ const insert = (editor: Editor, id: string) => {
     editor.focus();
     editor.selection.collapse(true);
     editor.insertContent(editor.dom.createHTML('a', {
-      id,
-      contenteditable: 'false'
+      id
     }));
   }
 };

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
@@ -5,20 +5,22 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr } from '@ephox/katamari';
 import Node from 'tinymce/core/api/html/Node';
 import Editor from 'tinymce/core/api/Editor';
 
-const isAnchorNode = (node: Node) => {
-  return !node.attr('href') && (node.attr('id') || node.attr('name'));
+// Note: node.firstChild check is for the 'allow_html_in_named_anchor' setting
+// Only want to add contenteditable attributes if there is no text within the anchor
+const isNamedAnchorNode = (node: Node) => {
+  return !node.attr('href') && (node.attr('id') || node.attr('name')) && !node.firstChild;
 };
 
-const setContentEditable = (state: string | null) => (nodes: Node[]) =>
-  Arr.each((nodes), (node) => {
-    if (isAnchorNode(node)) {
-      node.attr('contenteditable', state);
+const setContentEditable = (state: string | null) => (nodes: Node[]) => {
+  for (let i = 0; i < nodes.length; i++) {
+    if (isNamedAnchorNode(nodes[i])) {
+      nodes[i].attr('contenteditable', state);
     }
-  });
+  }
+};
 
 const setup = (editor: Editor) => {
   editor.on('PreInit', () => {

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
@@ -5,22 +5,23 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const isAnchorNode = function (node) {
-  return !node.attr('href') && (node.attr('id') || node.attr('name')) && !node.firstChild;
+import { Arr } from '@ephox/katamari';
+import Node from 'tinymce/core/api/html/Node';
+import Editor from 'tinymce/core/api/Editor';
+
+const isAnchorNode = (node: Node) => {
+  return !node.attr('href') && (node.attr('id') || node.attr('name'));
 };
 
-const setContentEditable = function (state) {
-  return function (nodes) {
-    for (let i = 0; i < nodes.length; i++) {
-      if (isAnchorNode(nodes[i])) {
-        nodes[i].attr('contenteditable', state);
-      }
+const setContentEditable = (state: string | null) => (nodes: Node[]) =>
+  Arr.each((nodes), (node) => {
+    if (isAnchorNode(node)) {
+      node.attr('contenteditable', state);
     }
-  };
-};
+  });
 
-const setup = function (editor) {
-  editor.on('PreInit', function () {
+const setup = (editor: Editor) => {
+  editor.on('PreInit', () => {
     editor.parser.addNodeFilter('a', setContentEditable('false'));
     editor.serializer.addNodeFilter('a', setContentEditable(null));
   });

--- a/modules/tinymce/src/plugins/anchor/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addToggleButton('anchor', {
     icon: 'bookmark',
     tooltip: 'Anchor',

--- a/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
@@ -8,19 +8,19 @@
 import Editor from 'tinymce/core/api/Editor';
 import Anchor from '../core/Anchor';
 
-const insertAnchor = function (editor: Editor, newId: string) {
+const insertAnchor = (editor: Editor, newId: string) => {
   if (!Anchor.isValidId(newId)) {
     editor.windowManager.alert(
       'Id should start with a letter, followed only by letters, numbers, dashes, dots, colons or underscores.'
     );
-    return true;
+    return false;
   } else {
     Anchor.insert(editor, newId);
-    return false;
+    return true;
   }
 };
 
-const open = function (editor: Editor) {
+const open = (editor: Editor) => {
   const currentId = Anchor.getId(editor);
 
   editor.windowManager.open({
@@ -53,8 +53,8 @@ const open = function (editor: Editor) {
     initialData: {
       id: currentId
     },
-    onSubmit (api) {
-      if (!insertAnchor(editor, api.getData().id)) { // TODO we need a better way to do validation
+    onSubmit(api) {
+      if (insertAnchor(editor, api.getData().id)) { // TODO we need a better way to do validation
         api.close();
       }
     }

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
@@ -1,13 +1,13 @@
 import { Pipeline, Step, Log, Waiter, UiFinder } from '@ephox/agar';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import AchorPlugin from 'tinymce/plugins/anchor/Plugin';
+import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
 import { Element } from '@ephox/sugar';
 
 UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorAlertTest', (success, failure) => {
-  AchorPlugin();
+  AnchorPlugin();
   Theme();
 
   const sType = (text: string) =>
@@ -33,7 +33,7 @@ UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorAlertTest', (success, f
     const alertDialogSelector = 'div[role="dialog"].tox-dialog.tox-alert-dialog';
 
     Pipeline.async({},
-      Log.steps('TBA', 'Anchor: Add anchor with invalid id, check alert appears', [
+      Log.steps('TINY-2788', 'Anchor: Add anchor with invalid id, check alert appears', [
         tinyApis.sSetContent(''),
         sAddAnchor(tinyUi, ''),
         tinyUi.sWaitForPopup('Wait for alert window', alertDialogSelector),
@@ -43,8 +43,7 @@ UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorAlertTest', (success, f
         tinyUi.sClickOnUi('Click on Cancel button', 'button.tox-button:contains(Cancel)'),
         Waiter.sTryUntil('Anchor Dialog should close', UiFinder.sNotExists(docBody, dialogSelector)),
         tinyApis.sAssertContent(''),
-      ])
-      , onSuccess, onFailure);
+      ]), onSuccess, onFailure);
   }, {
     theme: 'silver',
     plugins: 'anchor',

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
@@ -1,0 +1,54 @@
+import { Pipeline, Step, Log, Waiter, UiFinder } from '@ephox/agar';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import AchorPlugin from 'tinymce/plugins/anchor/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { UnitTest } from '@ephox/bedrock-client';
+import { document } from '@ephox/dom-globals';
+import { Element } from '@ephox/sugar';
+
+UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorAlertTest', (success, failure) => {
+  AchorPlugin();
+  Theme();
+
+  const sType = (text: string) =>
+    Log.step('TBA', 'Add anchor id', Step.sync(() => {
+      const elm: any = document.querySelector('div[role="dialog"].tox-dialog  input');
+      elm.value = text;
+    }));
+
+  const sAddAnchor = (tinyUi: TinyUi, id: string) =>
+    Log.stepsAsStep('TBA', 'Add anchor', [
+      tinyUi.sClickOnToolbar('click anchor button', 'button[aria-label="Anchor"]'),
+      tinyUi.sWaitForPopup('wait for window', 'div[role="dialog"].tox-dialog  input'),
+      sType(id),
+      tinyUi.sClickOnUi('click on Save btn', 'div.tox-dialog__footer button.tox-button:not(.tox-button--secondary)'),
+    ]);
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyUi = TinyUi(editor);
+    const tinyApis = TinyApis(editor);
+
+    const docBody = Element.fromDom(document.body);
+    const dialogSelector = 'div[role="dialog"].tox-dialog';
+    const alertDialogSelector = 'div[role="dialog"].tox-dialog.tox-alert-dialog';
+
+    Pipeline.async({},
+      Log.steps('TBA', 'Anchor: Add anchor with invalid id, check alert appears', [
+        tinyApis.sSetContent(''),
+        sAddAnchor(tinyUi, ''),
+        tinyUi.sWaitForPopup('Wait for alert window', alertDialogSelector),
+        tinyUi.sClickOnUi('Click on OK button', 'button.tox-button:contains(OK)'),
+        Waiter.sTryUntil('Alert dialog should close', UiFinder.sNotExists(docBody, alertDialogSelector)),
+        Waiter.sTryUntil('Anchor Dialog should not close', UiFinder.sExists(docBody, dialogSelector)),
+        tinyUi.sClickOnUi('Click on Cancel button', 'button.tox-button:contains(Cancel)'),
+        Waiter.sTryUntil('Anchor Dialog should close', UiFinder.sNotExists(docBody, dialogSelector)),
+        tinyApis.sAssertContent(''),
+      ])
+      , onSuccess, onFailure);
+  }, {
+    theme: 'silver',
+    plugins: 'anchor',
+    toolbar: 'anchor',
+    base_url: '/project/tinymce/js/tinymce',
+  }, success, failure);
+});

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorContentEditableTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorContentEditableTest.ts
@@ -1,0 +1,67 @@
+import { Pipeline, Log, Assertions, ApproxStructure } from '@ephox/agar';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Element } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+
+UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorContentEditableTest', (success, failure) => {
+  AnchorPlugin();
+  SilverTheme();
+
+  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+
+    Pipeline.async({}, [
+      Log.stepsAsStep('TINY-2788', 'Anchor: Add anchor without inner html, check contenteditable is false', [
+        tinyApis.sSetContent('<p><a id="abc"></a></p>'),
+        Assertions.sAssertStructure('Checking content structure',
+          ApproxStructure.build((s, str, arr) => {
+            return s.element('body', {
+              children: [
+                s.element('p', {
+                  children: [
+                    s.element('a', {
+                      attrs: { contenteditable: str.is('false'), id: str.is('abc') },
+                      classes: [arr.has('mce-item-anchor')]
+                    }),
+                  ]
+                })
+              ]
+            });
+          }),
+          Element.fromDom(editor.getBody())
+        ),
+      ]),
+      // Note: The next step should pass becuase of the allow_html_in_named_anchor setting
+      Log.stepsAsStep('TINY-2788', 'Anchor: Add anchor with inner html, check contenteditable is not present and inner html is present', [
+        tinyApis.sSetContent('<p><a id="abc">abc</a></p>'),
+        Assertions.sAssertStructure('Checking content structure',
+          ApproxStructure.build((s, str, arr) => {
+            return s.element('body', {
+              children: [
+                s.element('p', {
+                  children: [
+                    s.element('a', {
+                      html: str.is('abc'),
+                      attrs: { contenteditable: str.none(), id: str.is('abc') },
+                      classes: [arr.has('mce-item-anchor')]
+                    }),
+                  ]
+                })
+              ]
+            });
+          }),
+          Element.fromDom(editor.getBody())
+        ),
+      ]),
+    ], onSuccess, onFailure);
+  }, {
+    theme: 'silver',
+    plugins: 'anchor',
+    toolbar: 'anchor',
+    allow_html_in_named_anchor: true,
+    base_url: '/project/tinymce/js/tinymce',
+  }, success, failure);
+});

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorContentEditableTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorContentEditableTest.ts
@@ -26,6 +26,7 @@ UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorContentEditableTest', (
                       attrs: { contenteditable: str.is('false'), id: str.is('abc') },
                       classes: [arr.has('mce-item-anchor')]
                     }),
+                    s.theRest()
                   ]
                 })
               ]
@@ -48,6 +49,7 @@ UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorContentEditableTest', (
                       attrs: { contenteditable: str.none(), id: str.is('abc') },
                       classes: [arr.has('mce-item-anchor')]
                     }),
+                    s.theRest()
                   ]
                 })
               ]

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorEditTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorEditTest.ts
@@ -1,12 +1,12 @@
 import { Pipeline, Step, Log } from '@ephox/agar';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import AchorPlugin from 'tinymce/plugins/anchor/Plugin';
+import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
 
 UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorEditTest', (success, failure) => {
-  AchorPlugin();
+  AnchorPlugin();
   Theme();
 
   const sType = (text: string) =>

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorEditTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorEditTest.ts
@@ -1,4 +1,4 @@
-import { Pipeline, Step, Logger, Log } from '@ephox/agar';
+import { Pipeline, Step, Log } from '@ephox/agar';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import AchorPlugin from 'tinymce/plugins/anchor/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
@@ -9,19 +9,18 @@ UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorEditTest', (success, fa
   AchorPlugin();
   Theme();
 
-  const sType = function (text) {
-    return Logger.t('Add anchor' + text, Step.sync(function () {
-      const elm: any = document.querySelector('div[role="dialog"].tox-dialog input');
+  const sType = (text: string) =>
+    Log.step('TBA', 'Add anchor', Step.sync(() => {
+      const elm: any = document.querySelector('div[role="dialog"].tox-dialog  input');
       elm.value = text;
     }));
-  };
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
     const tinyUi = TinyUi(editor);
     const tinyApis = TinyApis(editor);
 
     Pipeline.async({},
-      Log.steps('TBA', 'Anchor: Add anchor, change anchor, undo anchor then the anchor should be there as first entered', [
+      Log.steps('TBA', 'Anchor: Add anchor, change anchor, undo anchor change then the anchor should be there as first entered', [
         tinyApis.sFocus(),
         tinyApis.sSetContent('abc'),
         tinyApis.sExecCommand('mceAnchor'),
@@ -30,6 +29,7 @@ UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorEditTest', (success, fa
         tinyUi.sClickOnUi('click on Save btn', '.tox-dialog__footer .tox-button:not(.tox-button--secondary)'),
         tinyApis.sAssertContentPresence({ 'a.mce-item-anchor#abc': 1 }),
         tinyApis.sSelect('a.mce-item-anchor', []),
+        tinyUi.sWaitForUi('Anchor toolbar button is highlighted', 'button[aria-label="Anchor"][aria-pressed="true"]'),
         tinyApis.sExecCommand('mceAnchor'),
         tinyUi.sWaitForPopup('wait for window', 'div[role="dialog"].tox-dialog'),
         sType('def'),
@@ -37,9 +37,10 @@ UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorEditTest', (success, fa
         tinyApis.sAssertContentPresence({ 'a.mce-item-anchor#def': 1 }),
         tinyApis.sExecCommand('undo'),
         tinyApis.sSetCursor([], 0),
-        tinyApis.sAssertContentPresence({ 'a.mce-item-anchor#abc': 1 })
+        tinyApis.sAssertContentPresence({ 'a.mce-item-anchor#abc': 1 }),
+        tinyUi.sWaitForUi('Anchor toolbar button is not highlighted', 'button[aria-label="Anchor"][aria-pressed="false"]'),
       ])
-    , onSuccess, onFailure);
+      , onSuccess, onFailure);
   }, {
     theme: 'silver',
     plugins: 'anchor',

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorInlineTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorInlineTest.ts
@@ -7,7 +7,6 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
 
 UnitTest.asynctest('Browser Test: .AnchorInlineTest', (success, failure) => {
-
   AnchorPlugin();
   SilverTheme();
 

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
@@ -1,41 +1,67 @@
-import { Pipeline, Step, Waiter, Logger, Log } from '@ephox/agar';
-import { TinyApis, TinyLoader, TinyUi  } from '@ephox/mcagar';
+import { Pipeline, Step, Waiter, Log } from '@ephox/agar';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import AchorPlugin from 'tinymce/plugins/anchor/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
 
 UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorSanityTest.js', (success, failure) => {
-
   AchorPlugin();
   SilverTheme();
 
-  const sType = function (text) {
-    return Logger.t('Add anchor' + text, Step.sync(function () {
+  const sType = (text: string) =>
+    Log.step('TBA', 'Add anchor id', Step.sync(() => {
       const elm: any = document.querySelector('div[role="dialog"].tox-dialog  input');
       elm.value = text;
     }));
-  };
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  const sAddAnchor = (tinyApis: TinyApis, tinyUi: TinyUi, id: string, numAnchors = 1) =>
+    Log.stepsAsStep('TBA', 'Add anchor', [
+      tinyUi.sClickOnToolbar('click anchor button', 'button[aria-label="Anchor"]'),
+      tinyUi.sWaitForPopup('wait for window', 'div[role="dialog"].tox-dialog  input'),
+      sType(id),
+      tinyUi.sClickOnUi('click on Save btn', 'div.tox-dialog__footer button.tox-button:not(.tox-button--secondary)'),
+      Waiter.sTryUntil('wait for anchor',
+        tinyApis.sAssertContentPresence(
+          { 'a.mce-item-anchor': numAnchors }
+        )
+      ),
+    ]);
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
     const tinyUi = TinyUi(editor);
     const tinyApis = TinyApis(editor);
 
-    Pipeline.async({},
-      Log.steps('TBA', 'Anchor: Add anchor, then check if that anchor is present in the editor', [
+    Pipeline.async({}, [
+      Log.stepsAsStep('TBA', 'Anchor: Add text and anchor, then check if that anchor is present in the editor', [
         tinyApis.sSetContent('abc'),
         tinyApis.sFocus(),
-        tinyUi.sClickOnToolbar('click anchor button', 'button[aria-label="Anchor"]'),
-        tinyUi.sWaitForPopup('wait for window', 'div[role="dialog"].tox-dialog  input'),
-        sType('abc'),
-        tinyUi.sClickOnUi('click on Save btn', 'div.tox-dialog__footer button.tox-button:not(.tox-button--secondary)'),
-        Waiter.sTryUntil('wait for anchor',
-          tinyApis.sAssertContentPresence(
-            { 'a.mce-item-anchor': 1 }
-          )
-        )
-    ])
-    , onSuccess, onFailure);
+        sAddAnchor(tinyApis, tinyUi, 'abc'),
+        tinyApis.sAssertContent('<p><a id="abc"></a>abc</p>')
+      ]),
+      Log.stepsAsStep('TBA', 'Anchor: Add anchor to empty editor, then check if that anchor is present in the editor', [
+        tinyApis.sSetContent(''),
+        tinyApis.sFocus(),
+        sAddAnchor(tinyApis, tinyUi, 'abc'),
+        tinyApis.sAssertContent('<p><a id="abc"></a></p>')
+      ]),
+      Log.stepsAsStep('TBA', 'Anchor: Add anchor to empty line, then check if that anchor is present in the editor', [
+        tinyApis.sSetContent('<p>abc</p><p></p><p>def</p>'),
+        tinyApis.sFocus(),
+        tinyApis.sSetCursor([1], 0),
+        sAddAnchor(tinyApis, tinyUi, 'abc'),
+        tinyApis.sAssertContent('<p>abc</p>\n<p><a id="abc"></a></p>\n<p>def</p>')
+      ]),
+      Log.stepsAsStep('TBA', 'Anchor: Add two anchors side by side, then check if they are present in the editor', [
+        tinyApis.sSetContent(''),
+        tinyApis.sFocus(),
+        sAddAnchor(tinyApis, tinyUi, 'abc'),
+        tinyApis.sAssertContent('<p><a id="abc"></a></p>'),
+        sAddAnchor(tinyApis, tinyUi, 'def', 2),
+        tinyApis.sAssertContent('<p><a id="abc"></a><a id="def"></a></p>'),
+      ])
+    ]
+      , onSuccess, onFailure);
   }, {
     theme: 'silver',
     plugins: 'anchor',

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
@@ -1,12 +1,12 @@
 import { Pipeline, Step, Waiter, Log } from '@ephox/agar';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import AchorPlugin from 'tinymce/plugins/anchor/Plugin';
+import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
 
-UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorSanityTest.js', (success, failure) => {
-  AchorPlugin();
+UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorSanityTest', (success, failure) => {
+  AnchorPlugin();
   SilverTheme();
 
   const sType = (text: string) =>
@@ -39,20 +39,20 @@ UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorSanityTest.js', (succes
         sAddAnchor(tinyApis, tinyUi, 'abc'),
         tinyApis.sAssertContent('<p><a id="abc"></a>abc</p>')
       ]),
-      Log.stepsAsStep('TBA', 'Anchor: Add anchor to empty editor, then check if that anchor is present in the editor', [
+      Log.stepsAsStep('TINY-2788', 'Anchor: Add anchor to empty editor, then check if that anchor is present in the editor', [
         tinyApis.sSetContent(''),
         tinyApis.sFocus(),
         sAddAnchor(tinyApis, tinyUi, 'abc'),
         tinyApis.sAssertContent('<p><a id="abc"></a></p>')
       ]),
-      Log.stepsAsStep('TBA', 'Anchor: Add anchor to empty line, then check if that anchor is present in the editor', [
+      Log.stepsAsStep('TINY-2788', 'Anchor: Add anchor to empty line, then check if that anchor is present in the editor', [
         tinyApis.sSetContent('<p>abc</p><p></p><p>def</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([1], 0),
         sAddAnchor(tinyApis, tinyUi, 'abc'),
         tinyApis.sAssertContent('<p>abc</p>\n<p><a id="abc"></a></p>\n<p>def</p>')
       ]),
-      Log.stepsAsStep('TBA', 'Anchor: Add two anchors side by side, then check if they are present in the editor', [
+      Log.stepsAsStep('TINY-2788', 'Anchor: Add two anchors side by side, then check if they are present in the editor', [
         tinyApis.sSetContent(''),
         tinyApis.sFocus(),
         sAddAnchor(tinyApis, tinyUi, 'abc'),
@@ -60,8 +60,7 @@ UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorSanityTest.js', (succes
         sAddAnchor(tinyApis, tinyUi, 'def', 2),
         tinyApis.sAssertContent('<p><a id="abc"></a><a id="def"></a></p>'),
       ])
-    ]
-      , onSuccess, onFailure);
+    ], onSuccess, onFailure);
   }, {
     theme: 'silver',
     plugins: 'anchor',


### PR DESCRIPTION
The main changes to allow anchors on new lines are in DomUtils.ts and Node.ts. Also cleaned up the Anchor plugin a bit.