### PR TITLE
TINY-4780: Enable lint @typescript-eslint/member-delimiter-style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,6 @@
       "FunctionExpression": { "parameters": "first" },
       "SwitchCase": 1
     }],
-    "@typescript-eslint/member-delimiter-style": "off",
     "@typescript-eslint/member-ordering": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-inferrable-types": [ "error", { "ignoreParameters": true, "ignoreProperties": true }], // this will be added to the plugin

--- a/modules/agar/src/main/ts/ephox/agar/api/Cursors.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Cursors.ts
@@ -17,14 +17,14 @@ export interface CursorPath {
   foffset: () => number;
 }
 
-const range = (obj: { start: Element<any>; soffset: number; finish: Element<any>; foffset: number; }): CursorRange => ({
+const range = (obj: { start: Element<any>; soffset: number; finish: Element<any>; foffset: number }): CursorRange => ({
   start: Fun.constant(obj.start),
   soffset: Fun.constant(obj.soffset),
   finish: Fun.constant(obj.finish),
   foffset: Fun.constant(obj.foffset)
 });
 
-const path = (obj: { startPath: number[]; soffset: number; finishPath: number[]; foffset: number; }): CursorPath => ({
+const path = (obj: { startPath: number[]; soffset: number; finishPath: number[]; foffset: number }): CursorPath => ({
   startPath: Fun.constant(obj.startPath),
   soffset: Fun.constant(obj.soffset),
   finishPath: Fun.constant(obj.finishPath),

--- a/modules/agar/src/test/ts/browser/KeyboardTest.ts
+++ b/modules/agar/src/test/ts/browser/KeyboardTest.ts
@@ -34,7 +34,7 @@ UnitTest.asynctest('KeyboardTest', (success, failure) => {
 
   const listenOn = (type, f, code, modifiers) =>
     Step.control(
-      Step.raw((value: { container: any; }, next, die, logs) => {
+      Step.raw((value: { container: any }, next, die, logs) => {
         const listener = DomEvent.bind(value.container, type, (event) => {
           const raw = event.raw();
           listener.unbind();
@@ -48,7 +48,7 @@ UnitTest.asynctest('KeyboardTest', (success, failure) => {
     );
 
   const listenOnKeystroke = (code, modifiers) => Step.control(
-    Step.raw((value: { container: any; }, next, die, initLogs) => {
+    Step.raw((value: { container: any }, next, die, initLogs) => {
       const keydownListener = DomEvent.bind(value.container, 'keydown', (dEvent) => {
         keydownListener.unbind();
 

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/TabSectionDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/TabSectionDemo.ts
@@ -17,7 +17,7 @@ export default (): void => {
   Class.add(gui.element(), 'gui-root-demo-container');
   Attachment.attachSystem(body, gui);
 
-  const makeTab = (tabSpec: { view: () => PremadeSpec[]; value: string; text: string; }) => {
+  const makeTab = (tabSpec: { view: () => PremadeSpec[]; value: string; text: string }) => {
     return {
       view: tabSpec.view,
       value: tabSpec.value,

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/TypeaheadDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/TypeaheadDemo.ts
@@ -65,9 +65,9 @@ export default (): void => {
   };
 
   const sketchTypeahead = (model: {
-    selectsOver: boolean,
-    getDisplayText: (data: TypeaheadData) => string,
-    populateFromBrowse: boolean
+    selectsOver: boolean;
+    getDisplayText: (data: TypeaheadData) => string;
+    populateFromBrowse: boolean;
   }) => {
     return Typeahead.sketch({
       minChars: 1,

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/forms/DemoFields.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/forms/DemoFields.ts
@@ -76,7 +76,7 @@ const textMunger = (spec: TextMungerSpec): SketchSpec => {
   return FormField.sketch(m);
 };
 
-const selectMunger = (spec: { label: string; options: Array<{ value: string, text: string }> }): SketchSpec => {
+const selectMunger = (spec: { label: string; options: Array<{ value: string; text: string }> }): SketchSpec => {
   const pLabel = FormField.parts().label({
     dom: { tag: 'label', innerHtml: spec.label }
   });

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/forms/DemoRenders.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/forms/DemoRenders.ts
@@ -17,7 +17,7 @@ export interface DemoItem {
       text: string;
 
       [key: string]: string;
-    }
+    };
   };
 
   [key: string]: any;
@@ -31,7 +31,7 @@ export interface DemoSeparatorItem {
     meta?: {
       text: string;
       [key: string]: string;
-    }
+    };
   };
 }
 
@@ -89,7 +89,7 @@ const demoGridMenu = ValueSchema.objOf([
 
 const demoChoice = ValueSchema.objOf([ ]);
 
-const choice = (choiceSpec: { value: string; text: string; }) => {
+const choice = (choiceSpec: { value: string; text: string }) => {
   const spec = ValueSchema.asRawOrDie('DemoRenders.choice', demoChoice, choiceSpec);
   return {
     dom: DomFactory.fromHtml(
@@ -259,7 +259,7 @@ const orb = (spec: DemoItem): ItemSpec => {
   };
 };
 
-const toolbarItem = (spec: { text: string; action: () => void; }) => {
+const toolbarItem = (spec: { text: string; action: () => void }) => {
   return {
     dom: {
       tag: 'span',

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/CssPosition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/CssPosition.ts
@@ -7,8 +7,8 @@ export interface CssPositionAdt {
     absolute: (point: Position, sx: number, sy: number) => T
   ) => T;
   match: <T> (branches: {
-    screen: (point: Position) => T,
-    absolute: (point: Position, sx: number, sy: number) => T
+    screen: (point: Position) => T;
+    absolute: (point: Position, sx: number, sy: number) => T;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
@@ -44,9 +44,9 @@ const text = (textContent: string): PremadeSpec => {
 };
 
 // Rename.
-export interface ExternalElement { uid ?: string; element: Element; }
+export interface ExternalElement { uid ?: string; element: Element }
 const external = (spec: ExternalElement): PremadeSpec => {
-  const extSpec: { uid: Option<string>, element: Element } = ValueSchema.asRawOrDie('external.component', ValueSchema.objOfOnly([
+  const extSpec: { uid: Option<string>; element: Element } = ValueSchema.asRawOrDie('external.component', ValueSchema.objOfOnly([
     FieldSchema.strict('element'),
     FieldSchema.option('uid')
   ]), spec);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/SpecTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/SpecTypes.ts
@@ -35,7 +35,7 @@ export interface ComponentDetail {
   dom: RawDomSchema;
   components: AlloyComponent[];
   events: {
-    events: AlloyEventRecord
+    events: AlloyEventRecord;
   };
   apis?: {};
   behaviours?: AlloyBehaviourRecord;

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/Gui.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/Gui.ts
@@ -160,7 +160,7 @@ const takeover = (root: AlloyComponent): GuiSystem => {
     Remove.remove(root.element());
   };
 
-  const broadcastData = (data: { universal: () => boolean, data: () => any, channels?: () => string[] }) => {
+  const broadcastData = (data: { universal: () => boolean; data: () => any; channels?: () => string[] }) => {
     const receivers = registry.filter(SystemEvents.receive());
     Arr.each(receivers, (receiver) => {
       const descHandler = receiver.descHandler();

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/CustomList.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/CustomList.ts
@@ -50,7 +50,7 @@ const factory: CompositeSketchFactory<CustomListDetail, CustomListSpec> = (detai
 
   // In shell mode, the group overrides need to be added to the main container, and there can be no children
   const extra: {
-    behaviours: Array<NamedConfiguredBehaviour<any, any>>,
+    behaviours: Array<NamedConfiguredBehaviour<any, any>>;
     components: AlloySpec[];
   } = detail.shell ? { behaviours: [ Replacing.config({ }) ], components: [ ] } : { behaviours: [ ], components };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/Dockables.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/Dockables.ts
@@ -19,9 +19,9 @@ export interface MorphAdt {
     fixed: FixedMorph<T>
   ) => T;
   match: <T> (branches: {
-    static: StaticMorph<T>,
-    absolute: AbsoluteMorph<T>,
-    fixed: FixedMorph<T>,
+    static: StaticMorph<T>;
+    absolute: AbsoluteMorph<T>;
+    fixed: FixedMorph<T>;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/InvalidateTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/InvalidateTypes.ts
@@ -35,7 +35,7 @@ export interface InvalidatingConfigSpec extends Behaviour.BehaviourConfigSpec {
 export interface InvalidatingConfig extends Behaviour.BehaviourConfigDetail {
   invalidClass: string;
   notify: Option<{
-    aria: string,
+    aria: string;
     getContainer: (input: AlloyComponent) => Option<Element>;
     onValid: (comp: AlloyComponent) => void;
     validHtml: string;
@@ -46,6 +46,6 @@ export interface InvalidatingConfig extends Behaviour.BehaviourConfigDetail {
   validator: Option<{
     validate: (input: AlloyComponent) => Future<Result<any, string>>;
     onEvent: string;
-    validateOnLoad?: boolean
+    validateOnLoad?: boolean;
   }>;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/receiving/ReceivingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/receiving/ReceivingTypes.ts
@@ -12,7 +12,7 @@ export interface ReceivingConfig extends Behaviour.BehaviourConfigDetail {
     [ key: string ]: {
       schema: Processor;
       onReceive: (comp: AlloyComponent, message: any) => void;
-    }
+    };
   };
 }
 
@@ -21,6 +21,6 @@ export interface ReceivingConfigSpec extends Behaviour.BehaviourConfigSpec {
     [ key: string]: {
       onReceive: (comp: AlloyComponent, message: any) => void;
       schema?: Processor;
-    }
+    };
   };
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingTypes.ts
@@ -47,7 +47,7 @@ export interface SlidingState extends BehaviourState {
 
 export interface SlidingConfigSpec extends Behaviour.BehaviourConfigSpec {
   dimension: {
-    property: string
+    property: string;
   };
   closedClass: string;
   openClass: string;

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/TransitionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/TransitionApis.ts
@@ -24,7 +24,7 @@ const getTransition = (comp: AlloyComponent, transConfig: TransitioningConfig, t
   });
 };
 
-const getTransitionOf = (comp: AlloyComponent, transConfig: TransitioningConfig, transState: Stateless, route: TransitionRoute): Option<{ transition: { property: string; transitionClass: string }, route: TransitionProperties }> => {
+const getTransitionOf = (comp: AlloyComponent, transConfig: TransitioningConfig, transState: Stateless, route: TransitionRoute): Option<{ transition: { property: string; transitionClass: string }; route: TransitionProperties }> => {
   return findRoute(comp, transConfig, transState, route).bind((r: TransitionProperties) => {
     return r.transition.map((t) => {
       return {

--- a/modules/alloy/src/main/ts/ephox/alloy/construct/ComponentEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/construct/ComponentEvents.ts
@@ -32,8 +32,8 @@ import * as EventHandler from './EventHandler';
 type Info = Record<string, () => Option<BehaviourBlob.BehaviourConfigAndState<any, BehaviourState>>>;
 
 type BehaviourTuple<T extends EventFormat> = {
-  name: () => string,
-  handler: () => AlloyEventHandler<T>
+  name: () => string;
+  handler: () => AlloyEventHandler<T>;
 };
 
 const behaviourTuple = <T extends EventFormat>(name: string, handler: AlloyEventHandler<T>): BehaviourTuple<T> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/debugging/Debugging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/debugging/Debugging.ts
@@ -67,7 +67,7 @@ const eventConfig = Cell<Record<string, EventConfiguration>>({ });
 export type EventProcessor = (logger: DebuggerLogger) => boolean;
 
 const makeEventLogger = (eventName: string, initialTarget: Element): DebuggerLogger => {
-  const sequence: Array<{ outcome: string, target: Element, purpose?: string }> = [ ];
+  const sequence: Array<{ outcome: string; target: Element; purpose?: string }> = [ ];
   const startTime = new Date().getTime();
 
   return {

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DraggingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DraggingTypes.ts
@@ -78,7 +78,7 @@ export interface DraggingConfig<E> {
   readonly getBounds: () => Bounds;
   readonly blockerClass: string;
   readonly dragger: {
-    readonly handlers: (dragConfig: DraggingConfig<E>, dragState: DraggingState) => AlloyEvents.AlloyEventRecord
+    readonly handlers: (dragConfig: DraggingConfig<E>, dragState: DraggingState) => AlloyEvents.AlloyEventRecord;
   };
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
@@ -9,7 +9,7 @@ export type MenuDirectory = Record<string, string[]>;
 
 // A tuple of (item, menu). This can be used to refresh the menu and position them next to the right
 // triggering items.
-export interface LayeredItemTrigger { triggeringItem: AlloyComponent; triggeredMenu: AlloyComponent; triggeringPath: string[]; }
+export interface LayeredItemTrigger { triggeringItem: AlloyComponent; triggeredMenu: AlloyComponent; triggeringPath: string[] }
 
 export interface LayeredState {
   setContents: (sPrimary: string, sMenus: Record<string, MenuPreparation>, sExpansions: Record<string, string>, dir: MenuDirectory) => void;

--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/MatrixNavigation.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/MatrixNavigation.ts
@@ -1,9 +1,9 @@
 import { Num, Option } from '@ephox/katamari';
 
 export type MatrixNavigationOutcome<A> = {
-  readonly rowIndex: number,
-  readonly columnIndex: number,
-  readonly cell: A
+  readonly rowIndex: number;
+  readonly columnIndex: number;
+  readonly cell: A;
 };
 
 export type MatrixNavigationFunc<A> = (matrix: A[][], startRow: number, startCol: number) => Option<MatrixNavigationOutcome<A>>;

--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/WrapArrNavigation.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/WrapArrNavigation.ts
@@ -1,6 +1,6 @@
 import { Fun, Num, Option } from '@ephox/katamari';
 
-export type WrapArrNavigationOutcome = { row: () => number, column: () => number};
+export type WrapArrNavigationOutcome = { row: () => number; column: () => number};
 export type ArrNavigationFunc<A> = (values: A[], index: number, numRows: number, numCols: number) => Option<A>;
 
 const withGrid = <A>(values: A[], index: number, numCols: number, f: (oldRow: number, oldColumn: number) => Option<WrapArrNavigationOutcome>): Option<A> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
@@ -10,7 +10,7 @@ export interface RepositionDecision {
   readonly direction: DirectionAdt;
   readonly classes: {
     off: string[];
-    on: string[]
+    on: string[];
   };
   readonly label: string;
   readonly candidateYforTest: number;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FormFieldSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FormFieldSchema.ts
@@ -18,7 +18,7 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
     name: 'label'
   }),
 
-  PartType.optional<FormFieldDetail, { text: string; }>({
+  PartType.optional<FormFieldDetail, { text: string }>({
     factory: {
       sketch(spec) {
         return {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
@@ -12,7 +12,7 @@ export interface FloatingToolbarButtonDetail extends CompositeSketchDetail, HasL
   fetch: () => Future<AlloySpec[]>;
   getBounds: Option<() => Bounds>;
   fireDismissalEventInstead: Option<{
-    event: string
+    event: string;
   }>;
 
   markers: {
@@ -32,7 +32,7 @@ export interface FloatingToolbarButtonSpec extends CompositeSketchSpec, HasLayou
   fetch: () => Future<AlloySpec[]>;
   getBounds?: () => Bounds;
   fireDismissalEventInstead?: {
-    event?: string
+    event?: string;
   };
 
   markers: {
@@ -40,8 +40,8 @@ export interface FloatingToolbarButtonSpec extends CompositeSketchSpec, HasLayou
   };
 
   parts: {
-    'button': Partial<SimpleOrSketchSpec>
-    'toolbar': Partial<ToolbarSpec>
+    'button': Partial<SimpleOrSketchSpec>;
+    'toolbar': Partial<ToolbarSpec>;
   };
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/HtmlSelectTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/HtmlSelectTypes.ts
@@ -20,7 +20,7 @@ export interface HtmlSelectSpec extends SingleSketchSpec {
   uid?: string;
   dom: Partial<RawDomSchema>;
   components?: AlloySpec[];
-  options: Array<{ value: string, text: string }>;
+  options: Array<{ value: string; text: string }>;
   selectBehaviours?: AlloyBehaviourRecord;
   selectAttributes?: Record<string, any>;
   selectClasses?: string[];

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
@@ -24,10 +24,10 @@ export interface InlineViewDetail extends SingleSketchDetail {
   lazySink: LazySink;
   eventOrder: Record<string, string[]>;
   fireDismissalEventInstead: Option<{
-    event: string
+    event: string;
   }>;
   fireRepositionEventInstead: Option<{
-    event: string
+    event: string;
   }>;
 }
 
@@ -44,10 +44,10 @@ export interface InlineViewSpec extends SingleSketchSpec {
   isExtraPart?: (component: AlloyComponent, target: Element) => boolean;
   eventOrder?: Record<string, string[]>;
   fireDismissalEventInstead?: {
-    event?: string
+    event?: string;
   };
   fireRepositionEventInstead?: {
-    event?: string
+    event?: string;
   };
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/ModalDialogTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/ModalDialogTypes.ts
@@ -44,7 +44,7 @@ export interface ModalDialogSpec extends CompositeSketchSpec {
     blocker: {
       dom?: Partial<RawDomSchema>;
       components?: AlloySpec[];
-    }
+    };
   };
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitFloatingToolbarTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitFloatingToolbarTypes.ts
@@ -33,9 +33,9 @@ export interface SplitFloatingToolbarSpec extends SplitToolbarBaseSpec {
   };
 
   parts: {
-    'overflow-group': Partial<ToolbarGroupSpec>,
-    'overflow-button': Partial<SimpleOrSketchSpec>,
-    'overflow': Partial<ToolbarSpec>
+    'overflow-group': Partial<ToolbarGroupSpec>;
+    'overflow-button': Partial<SimpleOrSketchSpec>;
+    'overflow': Partial<ToolbarSpec>;
   };
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitSlidingToolbarTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitSlidingToolbarTypes.ts
@@ -29,8 +29,8 @@ export interface SplitSlidingToolbarSpec extends SplitToolbarBaseSpec {
   onClosed?: (comp: AlloyComponent) => void;
 
   parts: {
-    'overflow-group': Partial<ToolbarGroupSpec>,
-    'overflow-button': Partial<SimpleOrSketchSpec>
+    'overflow-group': Partial<ToolbarGroupSpec>;
+    'overflow-button': Partial<SimpleOrSketchSpec>;
   };
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
@@ -28,8 +28,8 @@ export interface SplitToolbarBaseSpec extends CompositeSketchSpec {
   splitToolbarBehaviours?: AlloyBehaviourRecord;
 
   parts: {
-    'overflow-group': Partial<ToolbarGroupSpec>,
-    'overflow-button': Partial<SimpleOrSketchSpec>
+    'overflow-group': Partial<ToolbarGroupSpec>;
+    'overflow-button': Partial<SimpleOrSketchSpec>;
   };
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/TouchMenuTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/TouchMenuTypes.ts
@@ -54,7 +54,7 @@ export interface TouchMenuSpec extends CompositeSketchSpec {
   onExecute?: (sandbox: AlloyComponent, menu: AlloyComponent, item: AlloyComponent, value: ItemDataTuple) => void;
   onTap?: (comp: AlloyComponent) => void;
 
-  menuTransition?: { property: string, transitionClass: string };
+  menuTransition?: { property: string; transitionClass: string };
 
   onOpen?: (anchor: AnchorSpec, comp: AlloyComponent, menu: AlloyComponent) => void;
   onClosed?: (sandbox: AlloyComponent, inline: AlloyComponent) => void;
@@ -68,9 +68,9 @@ export interface TouchMenuSpec extends CompositeSketchSpec {
   useMinWidth?: boolean;
 
   parts: {
-    menu: PartialMenuSpec,
-    view: Partial<TabviewSpec>,
-    sink?: SimpleOrSketchSpec
+    menu: PartialMenuSpec;
+    view: Partial<TabviewSpec>;
+    sink?: SimpleOrSketchSpec;
   };
 
   getAnchor?: (comp: AlloyComponent) => AnchorSpec;

--- a/modules/alloy/src/test/ts/atomic/navigation/ArrNavigationTest.ts
+++ b/modules/alloy/src/test/ts/atomic/navigation/ArrNavigationTest.ts
@@ -52,7 +52,7 @@ UnitTest.test('ArrNavigationTest', () => {
   Jsc.property(
     'Cycling should always be possible in a >= 2 length array',
     arbTestCase,
-    (testCase: { values: number[]; index: number; }) => {
+    (testCase: { values: number[]; index: number }) => {
       ArrNavigation.cycleNext(testCase.values, testCase.index, Fun.constant(true)).getOrDie(
         'Should always be able to cycle next on a >= 2 length array'
       );
@@ -63,7 +63,7 @@ UnitTest.test('ArrNavigationTest', () => {
   Jsc.property(
     'Cycling should never be possible in a >= 2 length array if predicate is never',
     arbTestCase,
-    (testCase: { values: number[]; index: number; }) => {
+    (testCase: { values: number[]; index: number }) => {
       ArrNavigation.cycleNext(testCase.values, testCase.index, Fun.constant(false)).each((_) => {
         throw new Error('Should not have navigatied to: ' + _);
       });
@@ -74,7 +74,7 @@ UnitTest.test('ArrNavigationTest', () => {
   Jsc.property(
     'Cycling across a list of unique numbers of size 2 or greater should be symmetric: after(before(x)) === x',
     arbUniqueNumTestCase,
-    (testCase: { values: number[]; index: number; }) => {
+    (testCase: { values: number[]; index: number }) => {
       const initial = testCase.index;
       const before = ArrNavigation.cyclePrev<number>(testCase.values, initial, Fun.constant(true)).getOrDie(
         'Should always be able to cycle prev on a >= 2 length array'
@@ -91,7 +91,7 @@ UnitTest.test('ArrNavigationTest', () => {
   Jsc.property(
     'Cycling across a list of unique numbers of size 2 or greater should be symmetric: before(after(x)) === x',
     arbUniqueNumTestCase,
-    (testCase: { values: number[]; index: number; }) => {
+    (testCase: { values: number[]; index: number }) => {
       const initial = testCase.index;
       const after = ArrNavigation.cycleNext<number>(testCase.values, initial, Fun.constant(true)).getOrDie(
         'Should always be able to cycle next on a >= 2 length array'
@@ -108,7 +108,7 @@ UnitTest.test('ArrNavigationTest', () => {
   Jsc.property(
     'Cycling next makes an index of 0, or one higher',
     arbUniqueNumTestCase,
-    (testCase: { values: number[]; index: number; }) => {
+    (testCase: { values: number[]; index: number }) => {
       const after = ArrNavigation.cycleNext(testCase.values, testCase.index, Fun.constant(true)).getOrDie(
         'Should always be able to cycle next on a >= 2 length array'
       );
@@ -120,7 +120,7 @@ UnitTest.test('ArrNavigationTest', () => {
   Jsc.property(
     'Cycling prev makes an index of values.length - 1, or one lower',
     arbUniqueNumTestCase,
-    (testCase: { values: number[]; index: number; }) => {
+    (testCase: { values: number[]; index: number }) => {
       const before = ArrNavigation.cyclePrev(testCase.values, testCase.index, Fun.constant(true)).getOrDie(
         'Should always be able to cycle prev on a >= 2 length array'
       );
@@ -132,7 +132,7 @@ UnitTest.test('ArrNavigationTest', () => {
   Jsc.property(
     'Unique: Try next should be some(+1) or none',
     arbUniqueNumTestCase,
-    (testCase: { values: number[]; index: number; }) => {
+    (testCase: { values: number[]; index: number }) => {
       return ArrNavigation.tryNext(testCase.values, testCase.index, Fun.constant(true)).fold(() => {
         // Nothing, so we must be at the last index position
         return Jsc.eq(testCase.index, testCase.values.length - 1);
@@ -145,7 +145,7 @@ UnitTest.test('ArrNavigationTest', () => {
   Jsc.property(
     'Unique: Try prev should be some(-1) or none',
     arbUniqueNumTestCase,
-    (testCase: { values: number[]; index: number; }) => {
+    (testCase: { values: number[]; index: number }) => {
       return ArrNavigation.tryPrev(testCase.values, testCase.index, Fun.constant(true)).fold(() => {
         // Nothing, so we must be at the first index position
         return Jsc.eq(testCase.index, 0);

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderCalcRepositionTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderCalcRepositionTest.ts
@@ -42,7 +42,7 @@ UnitTest.test('BounderCalcRepositionTest', () => {
   Jsc.property(
     'Check that all values have something visible within bounds',
     arbTestCase,
-    (input: { newX: number, newY: number, width: number, height: number, boundsX: number, boundsY: number, boundsW: number, boundsH: number}) => {
+    (input: { newX: number; newY: number; width: number; height: number; boundsX: number; boundsY: number; boundsW: number; boundsH: number}) => {
       const bounds = makeBounds(input.boundsX, input.boundsY, input.boundsW, input.boundsH);
       const output = Bounder.calcReposition(input.newX, input.newY, input.width, input.height, bounds);
 

--- a/modules/alloy/src/test/ts/atomic/spec/PartSubstitutesTest.ts
+++ b/modules/alloy/src/test/ts/atomic/spec/PartSubstitutesTest.ts
@@ -99,7 +99,7 @@ UnitTest.test('PartSubstitutesTest', () => {
       const internals = substitutes.internals();
       const externals = substitutes.externals();
 
-      const checkSinglePart = (label: string, expected: { required: boolean, spec: any, factory: any }, part: UiSubstitutes.UiSubstitutesAdt) => {
+      const checkSinglePart = (label: string, expected: { required: boolean; spec: any; factory: any }, part: UiSubstitutes.UiSubstitutesAdt) => {
         Logger.sync('Checking: ' + label, () => {
           part.match({
             single: (required, valueThunk) => {

--- a/modules/alloy/src/test/ts/browser/events/EventRegistryTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/EventRegistryTest.ts
@@ -8,7 +8,7 @@ import * as DescribedHandler from 'ephox/alloy/events/DescribedHandler';
 import EventRegistry, { ElementAndHandler } from 'ephox/alloy/events/EventRegistry';
 import * as Tagger from 'ephox/alloy/registry/Tagger';
 
-type ExpectedType = { id?: string; handler: string; target?: string; purpose?: string; };
+type ExpectedType = { id?: string; handler: string; target?: string; purpose?: string };
 
 UnitTest.asynctest('EventRegistryTest', (success, failure) => {
   const body = Element.fromDom(document.body);

--- a/modules/alloy/src/test/ts/browser/parts/PartSchemasTest.ts
+++ b/modules/alloy/src/test/ts/browser/parts/PartSchemasTest.ts
@@ -6,7 +6,7 @@ import Jsc from '@ephox/wrap-jsverify';
 import * as AlloyParts from 'ephox/alloy/parts/AlloyParts';
 import * as PartType from 'ephox/alloy/parts/PartType';
 
-type TestSpec = { defaultValue: number; overriddenValue: number; };
+type TestSpec = { defaultValue: number; overriddenValue: number };
 
 UnitTest.test('Atomic Test: parts.SchemasTest', () => {
   const internal = PartType.required<any, TestSpec>({

--- a/modules/alloy/src/test/ts/browser/position/NodeInFramePositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/NodeInFramePositionTest.ts
@@ -63,7 +63,7 @@ UnitTest.asynctest('SelectionInFramePositionTest', (success, failure) => {
       return frame.element().dom().contentWindow;
     });
 
-    const cSetPath = (rawPath: { startPath: number[]; soffset: number; finishPath: number[]; foffset: number; }) => {
+    const cSetPath = (rawPath: { startPath: number[]; soffset: number; finishPath: number[]; foffset: number }) => {
       const path = Cursors.path(rawPath);
 
       return Chain.binder((win: Window) => {

--- a/modules/alloy/src/test/ts/browser/position/SelectionInFramePositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/SelectionInFramePositionTest.ts
@@ -59,7 +59,7 @@ UnitTest.asynctest('SelectionInFramePositionTest', (success, failure) => {
       return frame.element().dom().contentWindow;
     });
 
-    const cSetPath = (rawPath: { startPath: number[]; soffset: number; finishPath: number[]; foffset: number; }) => {
+    const cSetPath = (rawPath: { startPath: number[]; soffset: number; finishPath: number[]; foffset: number }) => {
       const path = Cursors.path(rawPath);
 
       return Chain.binder((win: Window) => {

--- a/modules/alloy/src/test/ts/browser/ui/form/FieldsTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/form/FieldsTest.ts
@@ -21,7 +21,7 @@ import * as RepresentPipes from 'ephox/alloy/test/behaviour/RepresentPipes';
 
 UnitTest.asynctest('FieldsTest', (success, failure) => {
 
-  const renderChoice = (choiceSpec: { value: string; text: string; }): AlloySpec & { value: string } => {
+  const renderChoice = (choiceSpec: { value: string; text: string }): AlloySpec & { value: string } => {
     return {
       value: choiceSpec.value,
       dom: {

--- a/modules/alloy/src/test/ts/browser/ui/input/InputTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/input/InputTest.ts
@@ -43,7 +43,7 @@ UnitTest.asynctest('InputTest', (success, failure) => {
       );
     });
 
-    const sCheckInputSelection = (label: string, expected: { start: number; end: number; }) => {
+    const sCheckInputSelection = (label: string, expected: { start: number; end: number }) => {
       return Step.sync(() => {
         Assertions.assertEq(
           label + '\nChecking selectionStart',

--- a/modules/alloy/src/test/ts/browser/ui/slider/TwoDSliderTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/slider/TwoDSliderTest.ts
@@ -188,7 +188,7 @@ UnitTest.asynctest('Browser Test: ui.slider.TwoDSliderTest', (success, failure) 
       );
     });
 
-    const cCheckValue = (expected: { x: number; y: number; }) => {
+    const cCheckValue = (expected: { x: number; y: number }) => {
       return Chain.op((parts: any) => {
         const v = Representing.getValue(parts.sliderComp);
         Assert.eq('Checking slider value', expected.x, v.x());
@@ -196,7 +196,7 @@ UnitTest.asynctest('Browser Test: ui.slider.TwoDSliderTest', (success, failure) 
       });
     };
 
-    const sAssertValue = (label: string, expected: { x: number; y: number; }) => {
+    const sAssertValue = (label: string, expected: { x: number; y: number }) => {
       return Logger.t(label, Step.sync(() => {
         const v = Representing.getValue(component);
         Assert.eq(label, expected.x, v.x());

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
@@ -27,7 +27,7 @@ const renderMenu = (spec: { value: string; text?: string; items: ItemSpec[] }): 
   };
 };
 
-const renderItem = (spec: { type: any, widget?: any, data: { value: string, meta: any }, hasSubmenu?: boolean}): ItemSpec => {
+const renderItem = (spec: { type: any; widget?: any; data: { value: string; meta: any }; hasSubmenu?: boolean}): ItemSpec => {
   return spec.type === 'widget' ? {
     type: 'widget',
     data: spec.data,

--- a/modules/alloy/src/test/ts/touch/ui/touch/TouchMenuTest.ts
+++ b/modules/alloy/src/test/ts/touch/ui/touch/TouchMenuTest.ts
@@ -18,7 +18,7 @@ interface TestItemSpec {
     value: string;
     meta: {
       text: string;
-    }
+    };
   };
 }
 

--- a/modules/boulder/src/main/ts/ephox/boulder/alien/SimpleResult.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/alien/SimpleResult.ts
@@ -19,7 +19,7 @@ const fold = <B, E, A>(res: SimpleResult<E, A>, onError: (err: E) => B, onValue:
   return res.stype === SimpleResultType.Error ? onError(res.serror) : onValue(res.svalue);
 };
 
-const partition = <E, A>(results: Array<SimpleResult<E[], any>>): { values: any[], errors: E[][] } => {
+const partition = <E, A>(results: Array<SimpleResult<E[], any>>): { values: any[]; errors: E[][] } => {
   const values = [ ];
   const errors = [ ];
   Arr.each(results, (obj) => {

--- a/modules/boulder/src/main/ts/ephox/boulder/api/FieldPresence.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/api/FieldPresence.ts
@@ -16,7 +16,7 @@ export interface FieldPresenceAdt {
   match: <T>(branches: {
     strict: StrictField<T>;
     defaultedThunk: DefaultedThunkField<T>;
-    asOption: AsOptionField<T>,
+    asOption: AsOptionField<T>;
     asDefaultedOptionThunk: AsDefaultedOptionThunkField<T>;
     mergeWithThunk: MergeWithThunkField<T>;
   }) => T;

--- a/modules/boulder/src/main/ts/ephox/boulder/core/ValueProcessor.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/ValueProcessor.ts
@@ -25,8 +25,8 @@ export interface ValueProcessorAdt {
     state: StateValueProcessor<T>
   ) => T;
   match: <T>(branches: {
-    field: FieldValueProcessor<T>,
-    state: StateValueProcessor<T>
+    field: FieldValueProcessor<T>;
+    state: StateValueProcessor<T>;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/bridge/src/demo/ts/dialogs/ImageDialog.ts
+++ b/modules/bridge/src/demo/ts/dialogs/ImageDialog.ts
@@ -103,7 +103,7 @@ export const createImageDialog = () => {
         } else if (details.name === 'size') {
           // Notice that the size has a more complex json output separating
           // width/height the constrain logic should be done at implementation level
-          const value = data.size as { width: string, height: string };
+          const value = data.size as { width: string; height: string };
           console.log(value.width, value.height);
         }
       },

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/FancyMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/FancyMenuItem.ts
@@ -14,7 +14,7 @@ export interface FancyMenuItem {
 }
 
 export interface FancyActionArgsMap {
-  'inserttable': { numRows: Number, numColumns: Number };
+  'inserttable': { numRows: Number; numColumns: Number };
   'colorswatch': { value: string };
 }
 

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
@@ -18,8 +18,8 @@ export interface Retries {
     retry: RetryHandler<T>
   ) => T;
   match: <T>(branches: {
-    none: NoneHandler<T>,
-    retry: RetryHandler<T>
+    none: NoneHandler<T>;
+    retry: RetryHandler<T>;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/darwin/src/main/ts/ephox/darwin/navigation/BeforeAfter.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/navigation/BeforeAfter.ts
@@ -16,10 +16,10 @@ export interface BeforeAfter {
     failedDown: FailedDownHandler<T>,
   ) => T;
   match: <T>(branches: {
-    none: NoneHandler<T>,
-    success: SuccessHandler<T>,
-    failedUp: FailedUpHandler<T>,
-    failedDown: FailedDownHandler<T>,
+    none: NoneHandler<T>;
+    success: SuccessHandler<T>;
+    failedUp: FailedUpHandler<T>;
+    failedDown: FailedDownHandler<T>;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/dragster/src/main/ts/ephox/dragster/core/Dragging.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/core/Dragging.ts
@@ -7,8 +7,8 @@ import { Element, EventArgs } from '@ephox/sugar';
 
 interface DragActionEvents {
   registry: {
-    start: Bindable<{}>,
-    stop: Bindable<{}>
+    start: Bindable<{}>;
+    stop: Bindable<{}>;
   };
   trigger: {
     start: () => void;

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/InDrag.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/InDrag.ts
@@ -9,7 +9,7 @@ export interface InDragEvent {
 
 interface InDragEvents {
   registry: {
-    move: Bindable<InDragEvent>
+    move: Bindable<InDragEvent>;
   };
   trigger: {
     move: (info: Position) => void;

--- a/modules/imagetools/src/main/ts/ephox/imagetools/assets/ImageAssetTypes.ts
+++ b/modules/imagetools/src/main/ts/ephox/imagetools/assets/ImageAssetTypes.ts
@@ -22,8 +22,8 @@ export interface ImageAssetAdt {
     url: UrlCallback<T>
   ) => T;
   match: <T> (branches: {
-    blob: BlobCallback<T>,
-    url: UrlCallback<T>
+    blob: BlobCallback<T>;
+    url: UrlCallback<T>;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Adt.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Adt.ts
@@ -5,7 +5,7 @@ import { console } from '@ephox/dom-globals';
 
 export interface Adt {
   fold: <T> (...caseHandlers: ((...data: any[]) => T)[]) => T;
-  match: <T> (branches: { [branch: string]: (...data: any[]) => T; }) => T;
+  match: <T> (branches: { [branch: string]: (...data: any[]) => T }) => T;
   log: (label: string) => void;
 }
 

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -87,7 +87,7 @@ export const eachr = <T>(xs: ArrayLike<T>, f: ArrayMorphism<T, void>): void => {
   }
 };
 
-export const partition = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): { pass: T[], fail: T[] } => {
+export const partition = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): { pass: T[]; fail: T[] } => {
   const pass: T[] = [];
   const fail: T[] = [];
   for (let i = 0, len = xs.length; i < len; i++) {
@@ -100,7 +100,7 @@ export const partition = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): {
 
 export const filter: {
   <T, Q extends T>(xs: ArrayLike<T>, pred: (x: T, i: number) => x is Q): Q[];
-  <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): T[]
+  <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): T[];
 } = <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): T[] => {
   const r: T[] = [];
   for (let i = 0, len = xs.length; i < len; i++) {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
@@ -25,7 +25,7 @@ export const map = function <T, R> (obj: T, f: (value: T[keyof T], key: string) 
   }));
 };
 
-export const tupleMap = function <R, T> (obj: T, f: (value: T[keyof T], key: string) => {k: string, v: any}): R {
+export const tupleMap = function <R, T> (obj: T, f: (value: T[keyof T], key: string) => {k: string; v: any}): R {
   const r: Record<string, any> = {};
   each(obj, function (x, i) {
     const tuple = f(x, i);
@@ -46,7 +46,7 @@ const internalFilter = function <V> (obj: Record<string, V>, pred: (value: V, ke
   return r;
 };
 
-export const bifilter = function <V> (obj: Record<string, V>, pred: (value: V, key: string) => boolean): {t: Record<string, V>, f: Record<string, V>} {
+export const bifilter = function <V> (obj: Record<string, V>, pred: (value: V, key: string) => boolean): {t: Record<string, V>; f: Record<string, V>} {
   const t: Record<string, V> = {};
   const f: Record<string, V> = {};
   internalFilter(obj, pred, objAcc(t), objAcc(f));

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Results.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Results.ts
@@ -10,7 +10,7 @@ const comparison = Adt.generate([
 ]);
 
 /** partition :: [Result a] -> { errors: [String], values: [a] } */
-export const partition = function <T, E> (results: Result<T, E>[]): { values: T[], errors: E[] } {
+export const partition = function <T, E> (results: Result<T, E>[]): { values: T[]; errors: E[] } {
   const errors: E[] = [];
   const values: T[] = [];
 

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Singleton.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Singleton.ts
@@ -29,19 +29,19 @@ const revocable = function <T> (doRevoke: (data: T) => void) {
   };
 };
 
-export const destroyable = function <T extends { destroy: () => void; }> () {
+export const destroyable = function <T extends { destroy: () => void }> () {
   return revocable<T>(function (s) {
     s.destroy();
   });
 };
 
-export const unbindable = function <T extends { unbind: () => void; }> () {
+export const unbindable = function <T extends { unbind: () => void }> () {
   return revocable<T>(function (s) {
     s.unbind();
   });
 };
 
-export const api = function <T extends { destroy: () => void; }> () {
+export const api = function <T extends { destroy: () => void }> () {
   const subject = Cell(Option.none<T>());
 
   const revoke = function () {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Zip.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Zip.ts
@@ -18,7 +18,7 @@ export const zipToTuples = function <K, V> (keys: K[], values: V[]) {
   if (keys.length !== values.length) {
     throw new Error(`Assertion failed: keys.length !== values.length (${keys.length} !== ${values.length})`);
   }
-  const r: { k: K, v: V }[] = [];
+  const r: { k: K; v: V }[] = [];
   for (let i = 0; i < keys.length; i++) {
     r.push({ k: keys[i], v: values[i] });
   }

--- a/modules/katamari/src/test/ts/atomic/api/arr/ZipTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ZipTest.ts
@@ -7,7 +7,7 @@ import { UnitTest, Assert } from '@ephox/bedrock-client';
 import fc from 'fast-check';
 
 UnitTest.test('Zip: unit tests', () => {
-  const check1 = (expectedZipToObject: Option<Record<string, string>>, expectedZipToTuples: Option<Array<{ k: string, v: string }>>, keys: string[], values: string[]) => {
+  const check1 = (expectedZipToObject: Option<Record<string, string>>, expectedZipToTuples: Option<Array<{ k: string; v: string }>>, keys: string[], values: string[]) => {
     const sort = <T>(a: T[], ord: (a: T, b: T) => -1 | 0 | 1) => {
       const c = a.slice();
       c.sort(ord);
@@ -18,7 +18,7 @@ UnitTest.test('Zip: unit tests', () => {
     const lt = -1;
     const gt = 1;
 
-    const sortTuples = (a: Array<{ k: string, v: string }>) => sort(a, (a: { k: string, v: string }, b: { k: string, v: string }) => (
+    const sortTuples = (a: Array<{ k: string; v: string }>) => sort(a, (a: { k: string; v: string }, b: { k: string; v: string }) => (
       a.k === b.k ? a.v === b.v ? eq
         : a.v > b.v ? gt
           : lt

--- a/modules/katamari/src/test/ts/atomic/api/obj/ObjEachTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/obj/ObjEachTest.ts
@@ -3,8 +3,8 @@ import fc from 'fast-check';
 import { UnitTest, Assert } from '@ephox/bedrock-client';
 
 UnitTest.test('ObjEachTest', function () {
-  const check = function <T> (expected: Array<{index: string, value: T}>, input: Record<string, T>) {
-    const values: Array<{index: string, value: T}> = [];
+  const check = function <T> (expected: Array<{index: string; value: T}>, input: Record<string, T>) {
+    const values: Array<{index: string; value: T}> = [];
     Obj.each(input, function (x, i) {
       values.push({ index: i, value: x });
     });

--- a/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
@@ -21,7 +21,7 @@ export interface Editor {
   selection: Selection;
   windowManager: any;
   ui: {
-    registry: any
+    registry: any;
   };
 
   getBody: () => HTMLElement;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyScenarios.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyScenarios.ts
@@ -4,9 +4,9 @@ import Jsc from '@ephox/wrap-jsverify';
 import { Editor } from '../alien/EditorTypes';
 
 type ContentGenerator = any;
-type SelectionExclusions = { containers: (container: Element) => boolean; };
+type SelectionExclusions = { containers: (container: Element) => boolean };
 type ArbScenarioOptions = { exclusions: SelectionExclusions };
-type AsyncPropertyOptions = { scenario: ArbScenarioOptions, property: Record<string, any> };
+type AsyncPropertyOptions = { scenario: ArbScenarioOptions; property: Record<string, any> };
 
 interface Scenario {
   input: string;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/UiChains.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/UiChains.ts
@@ -34,7 +34,7 @@ const cGetToolbarRoot: Chain<Editor, Element> = NamedChain.asChain([
   NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
   NamedChain.direct('editor', cToolstripRoot, 'container'),
   NamedChain.merge([ 'editor', 'container' ], 'data'),
-  NamedChain.direct('data', Chain.binder((data: { editor: Editor, container: Element<HTMLElement> }) => {
+  NamedChain.direct('data', Chain.binder((data: { editor: Editor; container: Element<HTMLElement> }) => {
     return UiFinder.findIn(data.container, getThemeSelectors().toolBarSelector(data.editor));
   }), 'toolbar'),
   NamedChain.output('toolbar')

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/data/InjectPosition.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/data/InjectPosition.ts
@@ -12,11 +12,11 @@ export interface InjectPosition<E> {
     onInvalid: InvalidHandler<E, U>
   ) => U;
   match: <U> (branches: {
-    before: InjectPositionHandler<E, U>,
-    after: InjectPositionHandler<E, U>,
-    rest: InjectPositionHandler<E, U>,
-    last: InjectPositionHandler<E, U>,
-    invalid: InvalidHandler<E, U>,
+    before: InjectPositionHandler<E, U>;
+    after: InjectPositionHandler<E, U>;
+    rest: InjectPositionHandler<E, U>;
+    last: InjectPositionHandler<E, U>;
+    invalid: InvalidHandler<E, U>;
   }) => U;
   log: (label: string) => void;
 }

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Types.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Types.ts
@@ -46,9 +46,9 @@ export interface Traverse<E> {
 }
 
 export type Successor = {
-  readonly current: Transition,
-  readonly next: Transition,
-  readonly fallback: Option<Transition>
+  readonly current: Transition;
+  readonly next: Transition;
+  readonly fallback: Option<Transition>;
 };
 
 export interface Wrapter<E> {

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Gather.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Gather.ts
@@ -25,7 +25,7 @@ const seekLeft: SeekLeftApi = Seeker.left;
 type SeekRightApi = <E, D>(universe: Universe<E, D>, item: E, predicate: (e: E) => boolean, isRoot: (e: E) => boolean) => Option<E>;
 const seekRight: SeekRightApi = Seeker.right;
 
-type WalkersApi = () => { left: () => Direction; right: () => Direction; };
+type WalkersApi = () => { left: () => Direction; right: () => Direction };
 const walkers: WalkersApi = () => ({ left: Walkers.left, right: Walkers.right });
 
 type WalkApi = <E, D>(universe: Universe<E, D>, item: E, mode: Transition, direction: Direction, rules?: Successor[]) => Option<Traverse<E>>;

--- a/modules/phoenix/src/test/ts/atomic/api/extract/FindTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/extract/FindTest.ts
@@ -27,7 +27,7 @@ UnitTest.test('api.Extract.find', function () {
     ])
   );
 
-  const check = function (expected: Option<{ id: string, offset: number }>, topId: string, offset: number) {
+  const check = function (expected: Option<{ id: string; offset: number }>, topId: string, offset: number) {
     const top = Finder.get(doc, topId);
     const actual = Extract.find(doc, top, offset);
     expected.fold(function () {

--- a/modules/polaris/src/main/ts/ephox/polaris/api/PositionArray.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/PositionArray.ts
@@ -5,7 +5,7 @@ import * as Split from '../parray/Split';
 import * as Translate from '../parray/Translate';
 import { PRange } from '../pattern/Types';
 
-type GenerateApi = <T, R extends { finish: () => number; }>(xs: T[], f: (x: T, offset: number) => Option<R>, start?: number) => R[];
+type GenerateApi = <T, R extends { finish: () => number }>(xs: T[], f: (x: T, offset: number) => Option<R>, start?: number) => R[];
 const generate: GenerateApi = Generator.make;
 
 type GetApi = <T extends PRange>(parray: T[], offset: number) => Option<T>;

--- a/modules/polaris/src/main/ts/ephox/polaris/api/Search.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/Search.ts
@@ -5,7 +5,7 @@ import * as Sleuth from '../search/Sleuth';
 type FindallApi = (input: string, pattern: PRegExp) => PRange[];
 const findall: FindallApi = Find.all;
 
-type FindmanyApi = <T extends { pattern: () => PRegExp; }>(text: string, targets: T[]) => (T & PRange)[];
+type FindmanyApi = <T extends { pattern: () => PRegExp }>(text: string, targets: T[]) => (T & PRange)[];
 const findmany: FindmanyApi = Sleuth.search;
 
 export {

--- a/modules/polaris/src/main/ts/ephox/polaris/api/Splitting.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/Splitting.ts
@@ -9,9 +9,9 @@ export interface Splitting<T> {
     onExcludeWithout: SplittingHandler<T, U>
   ) => U;
   match: <U> (branches: {
-    include: SplittingHandler<T, U>,
-    excludeWith: SplittingHandler<T, U>,
-    excludeWithout: SplittingHandler<T, U>,
+    include: SplittingHandler<T, U>;
+    excludeWith: SplittingHandler<T, U>;
+    excludeWithout: SplittingHandler<T, U>;
   }) => U;
   log: (label: string) => void;
 }

--- a/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
@@ -14,7 +14,7 @@ UnitTest.test('api.Search.findall (using api.Pattern)', function () {
       assert.eq(exp[1], actual[i].finish());
     });
   };
-  const testData: (pattern: PRegExp, name: string) => { pattern: () => PRegExp, name: () => string } = Struct.immutable('pattern', 'name');
+  const testData: (pattern: PRegExp, name: string) => { pattern: () => PRegExp; name: () => string } = Struct.immutable('pattern', 'name');
 
   const checkMany = function (expected: [number, number, string][], text: string, targets: ReturnType<typeof testData>[]) {
     const actual = Search.findmany(text, targets);

--- a/modules/robin/src/main/ts/ephox/robin/api/general/ZonePosition.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/ZonePosition.ts
@@ -7,9 +7,9 @@ export interface ZonePosition<E> {
     belowView: (item: E) => T
   ) => T;
   match: <T> (branches: {
-    aboveView: (item: E) => T,
-    inView: (item: E) => T,
-    belowView: (item: E) => T
+    aboveView: (item: E) => T;
+    inView: (item: E) => T;
+    belowView: (item: E) => T;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/robin/src/main/ts/ephox/robin/clumps/Clumps.ts
+++ b/modules/robin/src/main/ts/ephox/robin/clumps/Clumps.ts
@@ -18,19 +18,19 @@ interface ClumpsScan<E> {
     finished: (element: E, mode: Transition) => T
   ) => T;
   match: <T> (branches: {
-    none: (last: E, mode: Transition) => T,
-    running: (next: E, mode: Transition) => T,
-    split: (boundary: E, last: E, mode: Transition) => T,
-    finished: (element: E, mode: Transition) => T
+    none: (last: E, mode: Transition) => T;
+    running: (next: E, mode: Transition) => T;
+    split: (boundary: E, last: E, mode: Transition) => T;
+    finished: (element: E, mode: Transition) => T;
   }) => T;
   log: (label: string) => void;
 }
 
 const adt: {
-  none: <E> (last: E, mode: Transition) => ClumpsScan<E>,
-  running: <E> (next: E, mode: Transition) => ClumpsScan<E>,
-  split: <E> (boundary: E, last: E, mode: Transition) => ClumpsScan<E>,
-  finished: <E> (element: E, mode: Transition) => ClumpsScan<E>
+  none: <E> (last: E, mode: Transition) => ClumpsScan<E>;
+  running: <E> (next: E, mode: Transition) => ClumpsScan<E>;
+  split: <E> (boundary: E, last: E, mode: Transition) => ClumpsScan<E>;
+  finished: <E> (element: E, mode: Transition) => ClumpsScan<E>;
 } = Adt.generate([
   { none: [ 'last', 'mode' ] },
   { running: [ 'next', 'mode' ] },

--- a/modules/robin/src/main/ts/ephox/robin/clumps/EntryPoints.ts
+++ b/modules/robin/src/main/ts/ephox/robin/clumps/EntryPoints.ts
@@ -9,17 +9,17 @@ interface EntryPoint<E> {
     rightEdge: (element: E) => T
   ) => T;
   match: <T> (branches: {
-    leftEdge: (element: E) => T,
-    between: (before: E, after: E) => T,
-    rightEdge: (element: E) => T
+    leftEdge: (element: E) => T;
+    between: (before: E, after: E) => T;
+    rightEdge: (element: E) => T;
   }) => T;
   log: (label: string) => void;
 }
 
 const adt: {
-  leftEdge: <E> (element: E) => EntryPoint<E>,
-  between: <E> (before: E, after: E) => EntryPoint<E>,
-  rightEdge: <E> (element: E) => EntryPoint<E>
+  leftEdge: <E> (element: E) => EntryPoint<E>;
+  between: <E> (before: E, after: E) => EntryPoint<E>;
+  rightEdge: <E> (element: E) => EntryPoint<E>;
 } = Adt.generate([
   { leftEdge: [ 'element' ] },
   { between: [ 'before', 'after' ] },

--- a/modules/robin/src/main/ts/ephox/robin/textdata/TextSeeker.ts
+++ b/modules/robin/src/main/ts/ephox/robin/textdata/TextSeeker.ts
@@ -10,9 +10,9 @@ export interface TextSeekerPhase<E> {
     finish: (info: SpotPoint<E>) => T
   ) => T;
   match: <T> (branches: {
-    abort: () => T,
-    kontinue: () => T,
-    finish: (info: SpotPoint<E>) => T
+    abort: () => T;
+    kontinue: () => T;
+    finish: (info: SpotPoint<E>) => T;
   }) => T;
   log: (label: string) => void;
 }
@@ -24,9 +24,9 @@ export interface TextSeekerOutcome<E> {
     success: (info: SpotPoint<E>) => T
   ) => T;
   match: <T> (branches: {
-    aborted: () => T,
-    edge: (element: E) => T,
-    success: (info: SpotPoint<E>) => T
+    aborted: () => T;
+    edge: (element: E) => T;
+    success: (info: SpotPoint<E>) => T;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/robin/src/main/ts/ephox/robin/zone/ZoneWalker.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/ZoneWalker.ts
@@ -16,11 +16,11 @@ interface ZoneWalkerState<E> {
     concluded: (item: E, mode: Transition) => T
   ) => T;
   match: <T> (branches: {
-    inline: (item: E, mode: Transition, lang: Option<string>) => T,
-    text: (item: E, mode: Transition) => T,
-    empty: (item: E, mode: Transition) => T,
-    boundary: (item: E, mode: Transition, lang: Option<string>) => T,
-    concluded: (item: E, mode: Transition) => T
+    inline: (item: E, mode: Transition, lang: Option<string>) => T;
+    text: (item: E, mode: Transition) => T;
+    empty: (item: E, mode: Transition) => T;
+    boundary: (item: E, mode: Transition, lang: Option<string>) => T;
+    concluded: (item: E, mode: Transition) => T;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/robin/src/test/ts/atomic/util/CurrentWordTest.ts
+++ b/modules/robin/src/test/ts/atomic/util/CurrentWordTest.ts
@@ -3,7 +3,7 @@ import { Option } from '@ephox/katamari';
 import * as CurrentWord from 'ephox/robin/util/CurrentWord';
 
 UnitTest.test('CurrentWordTest', function () {
-  const check = function (expected: { before: Option<number>, after: Option<number> }, text: string, position: number) {
+  const check = function (expected: { before: Option<number>; after: Option<number> }, text: string, position: number) {
     const actual = CurrentWord.around(text, position);
     Assert.eq(
       'Checking before :: Option',

--- a/modules/robin/src/test/ts/browser/api/DomTextSearchTest.ts
+++ b/modules/robin/src/test/ts/browser/api/DomTextSearchTest.ts
@@ -202,7 +202,7 @@ UnitTest.test('DomTextSearchTest', function () {
       KAssert.eqNone('There should be no scanning (' + label + ')', DomTextSearch.scanRight(start, offset));
     };
 
-    const checkScan = function (label: string, expected: { element: Element, offset: number }, start: Element, offset: number) {
+    const checkScan = function (label: string, expected: { element: Element; offset: number }, start: Element, offset: number) {
       const actual = DomTextSearch.scanRight(start, offset).getOrDie('Could not find scan result for: ' + label);
       Assert.eq('eq', expected.offset, actual.offset());
       Assert.eq('Element did not match scan: (' + label + ')', true, Compare.eq(expected.element, actual.element()));

--- a/modules/robin/src/test/ts/browser/api/DomTextdataTest.ts
+++ b/modules/robin/src/test/ts/browser/api/DomTextdataTest.ts
@@ -12,7 +12,7 @@ UnitTest.test('DomTextdataTest', function () {
   const e = Element.fromText('epsilon');
   const f = Element.fromText('foo');
 
-  const check = function (expected: { text: string, cursor: Option<number> }, elements: Element[], current: Element, offset: number) {
+  const check = function (expected: { text: string; cursor: Option<number> }, elements: Element[], current: Element, offset: number) {
     const actual = DomTextdata.from(elements, current, offset);
     Assert.eq('eq', expected.text, actual.text);
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CellLocation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CellLocation.ts
@@ -20,10 +20,10 @@ export interface CellLocation {
     last: LastHandler<T>
   ) => T;
   match: <T> (branches: {
-    none: NoneHandler<T>,
-    first: FirstHandler<T>,
-    middle: MiddleHandler<T>,
-    last: LastHandler<T>
+    none: NoneHandler<T>;
+    first: FirstHandler<T>;
+    middle: MiddleHandler<T>;
+    last: LastHandler<T>;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableResize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableResize.ts
@@ -17,9 +17,9 @@ export interface AfterTableResizeEvent {
 }
 
 type TableResizeEventRegistry = {
-  readonly beforeResize: Bindable<BeforeTableResizeEvent>,
-  readonly afterResize: Bindable<AfterTableResizeEvent>,
-  readonly startDrag: Bindable<{}>
+  readonly beforeResize: Bindable<BeforeTableResizeEvent>;
+  readonly afterResize: Bindable<AfterTableResizeEvent>;
+  readonly startDrag: Bindable<{}>;
 };
 
 interface TableResizeEvents {

--- a/modules/snooker/src/main/ts/ephox/snooker/calc/ColumnContext.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/calc/ColumnContext.ts
@@ -15,11 +15,11 @@ export interface ColumnContext {
     right: RightHandler<T>,
   ) => T;
   match: <T> (branches: {
-    none: NoneHandler<T>,
-    only: OnlyHandler<T>,
-    left: LeftHandler<T>,
-    middle: MiddleHandler<T>,
-    right: RightHandler<T>,
+    none: NoneHandler<T>;
+    only: OnlyHandler<T>;
+    left: LeftHandler<T>;
+    middle: MiddleHandler<T>;
+    right: RightHandler<T>;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarMutation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarMutation.ts
@@ -9,7 +9,7 @@ export interface DragEvent extends DragDistanceEvent {
 
 interface DragDistanceEvents {
   registry: {
-    drag: Bindable<DragEvent>
+    drag: Bindable<DragEvent>;
   };
   trigger: {
     drag: (xDelta: number, yDelta: number, target: Element) => void;

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Mutation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Mutation.ts
@@ -7,7 +7,7 @@ export interface DragDistanceEvent {
 
 interface DragDistanceEvents {
   registry: {
-    drag: Bindable<DragDistanceEvent>
+    drag: Bindable<DragDistanceEvent>;
   };
   trigger: {
     drag: (xDelta: number, yDelta: number) => void;

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Size.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Size.ts
@@ -7,9 +7,9 @@ export interface Size {
     percent: (value: number) => T
   ) => T;
   match: <T> (branches: {
-    invalid: (raw: string) => T,
-    pixels: (value: number) => T,
-    percent: (value: number) => T
+    invalid: (raw: string) => T;
+    pixels: (value: number) => T;
+    percent: (value: number) => T;
   }) => T;
   log: (label: string) => void;
 }

--- a/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
@@ -177,7 +177,7 @@ UnitTest.test('FitmentIVTest', function () {
       }
     };
 
-    const queryliser2000 = function (result: Result<Structs.RowCells[], string>, s: Structs.Address, specA: { rows: () => number, cols: () => number, grid: () => Structs.ElementNew[][] }, specB: { rows: () => number, cols: () => number, grid: () => Structs.ElementNew[][] }) {
+    const queryliser2000 = function (result: Result<Structs.RowCells[], string>, s: Structs.Address, specA: { rows: () => number; cols: () => number; grid: () => Structs.ElementNew[][] }, specB: { rows: () => number; cols: () => number; grid: () => Structs.ElementNew[][] }) {
       // expect to see some cell from specB at some address on specA
       const offsetRow = s.row();
       const offsetCol = s.column();

--- a/modules/snooker/src/test/ts/atomic/model/TableGridTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/TableGridTest.ts
@@ -8,7 +8,7 @@ UnitTest.test('TableGrid.subgrid test', function () {
   const r = Structs.rowcells;
   const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as any as Element, isNew);
 
-  const check = function (expected: { colspan: number, rowspan: number }, row: number, column: number, grid: Structs.RowCells[]) {
+  const check = function (expected: { colspan: number; rowspan: number }, row: number, column: number, grid: Structs.RowCells[]) {
     const actual = TableGrid.subgrid(grid, row, column, Fun.tripleEquals);
     assert.eq(expected.rowspan, actual.rowspan);
     assert.eq(expected.colspan, actual.colspan);

--- a/modules/snooker/src/test/ts/atomic/resize/RecalculationsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/resize/RecalculationsTest.ts
@@ -19,7 +19,7 @@ UnitTest.test('RecalculationsTest', function () {
     }>;
   }
 
-  const expectedParts: (widths: {element: string, width: number}[], heights: {element: string, height: number}[]) => Parts = Struct.immutable('widths', 'heights');
+  const expectedParts: (widths: {element: string; width: number}[], heights: {element: string; height: number}[]) => Parts = Struct.immutable('widths', 'heights');
 
   const check = function (expected: Parts[], input: Structs.RowData<Structs.Detail>[], sizes: Structs.Dimensions) {
     const warehouse = Warehouse.generate(input);

--- a/modules/snooker/src/test/ts/browser/RuntimeSizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/RuntimeSizeTest.ts
@@ -38,7 +38,7 @@ UnitTest.test('Runtime Size Test', function () {
     Css.set(table, 'height', value);
   };
 
-  const resizeTableBy = function (table: Element, setSize: (e: Element, v: string) => void, tableInfo: { total: number, cells: number[] }, delta: number) {
+  const resizeTableBy = function (table: Element, setSize: (e: Element, v: string) => void, tableInfo: { total: number; cells: number[] }, delta: number) {
     setSize(table, '');
     Arr.map(SelectorFilter.descendants(table, 'td'), function (cell, i) {
       setSize(cell, (tableInfo.cells[i] + delta) + 'px');
@@ -50,7 +50,7 @@ UnitTest.test('Runtime Size Test', function () {
     assert.eq(true, Math.abs(a - b) <= 1, msg);
   };
 
-  const assertSize = function (s1: { total: number, cells: number[] }, table: Element, getOuterSize: (e: Element) => number, message: string) {
+  const assertSize = function (s1: { total: number; cells: number[] }, table: Element, getOuterSize: (e: Element) => number, message: string) {
     const s2 = measureTable(table, getOuterSize);
     const cellAssertEq = platform.browser.isIE() || platform.browser.isEdge() ? fuzzyAssertEq : assert.eq;
 
@@ -182,7 +182,7 @@ UnitTest.test('Runtime Size Test', function () {
     return table;
   };
 
-  const resizeModel = function (size: { total: number, cells: number[] }, delta: number) {
+  const resizeModel = function (size: { total: number; cells: number[] }, delta: number) {
     const deltaTotal = delta * size.cells.length;
     const cells = Arr.map(size.cells, function (cz) {
       return cz + delta;

--- a/modules/snooker/src/test/ts/browser/TableMergeContentTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableMergeContentTest.ts
@@ -4,7 +4,7 @@ import { Body, Element, Html, Insert, Remove } from '@ephox/sugar';
 import * as TableContent from 'ephox/snooker/api/TableContent';
 
 UnitTest.test('TableMergeContentTest', function () {
-  const mergeContentTest = function (specs: { label: string; html: string; expected: string; }[]) {
+  const mergeContentTest = function (specs: { label: string; html: string; expected: string }[]) {
     const table = Element.fromTag('table');
     const row = Element.fromTag('tr');
     Insert.append(table, row);

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
@@ -14,7 +14,7 @@ import { HTMLTableElement, HTMLTableDataCellElement, HTMLTableHeaderCellElement 
 
 type Op<T> = (wire: ResizeWire, table: Element, target: T, generators: Generators, direction: BarPositions<ColInfo>) => Option<RunOperationOutput>;
 
-const checkOld = function <T> (expCell: { section: number, row: number, column: number }, expectedHtml: string, input: string, operation: Op<TargetElement>, section: number, row: number, column: number, direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
+const checkOld = function <T> (expCell: { section: number; row: number; column: number }, expectedHtml: string, input: string, operation: Op<TargetElement>, section: number, row: number, column: number, direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
   const table = Element.fromHtml<HTMLTableElement>(input);
   Insert.append(Body.body(), table);
   const wire = ResizeWire.only(Body.body());
@@ -59,7 +59,7 @@ const checkPaste = function (expectedHtml: string, input: string, pasteHtml: str
   Bars.destroy(wire);
 };
 
-const checkStructure = function (expCell: { section: number, row: number, column: number}, expected: string[][], input: string, operation: Op<TargetElement>, section: number, row: number, column: number, direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
+const checkStructure = function (expCell: { section: number; row: number; column: number}, expected: string[][], input: string, operation: Op<TargetElement>, section: number, row: number, column: number, direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
   const table = Element.fromHtml<HTMLTableElement>(input);
   Insert.append(Body.body(), table);
   const wire = ResizeWire.only(Body.body());
@@ -79,7 +79,7 @@ const checkStructure = function (expCell: { section: number, row: number, column
   Bars.destroy(wire);
 };
 
-const checkDelete = function (optExpCell: Option<{ section: number, row: number, column: number }>, optExpectedHtml: Option<{ ie: string, normal: string }>, input: string, operation: Op<TargetSelection>, cells: { section: number, row: number, column: number }[], platform: ReturnType<typeof PlatformDetection.detect>, direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
+const checkDelete = function (optExpCell: Option<{ section: number; row: number; column: number }>, optExpectedHtml: Option<{ ie: string; normal: string }>, input: string, operation: Op<TargetSelection>, cells: { section: number; row: number; column: number }[], platform: ReturnType<typeof PlatformDetection.detect>, direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
   const table = Element.fromHtml<HTMLTableElement>(input);
   Insert.append(Body.body(), table);
   const wire = ResizeWire.only(Body.body());
@@ -120,7 +120,7 @@ const checkDelete = function (optExpCell: Option<{ section: number, row: number,
   Bars.destroy(wire);
 };
 
-const checkMerge = function (label: string, expected: string, input: string, selection: {section: number, row: number, column: number}[], bounds: {startRow: number, startCol: number, finishRow: number, finishCol: number}, direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
+const checkMerge = function (label: string, expected: string, input: string, selection: {section: number; row: number; column: number}[], bounds: {startRow: number; startCol: number; finishRow: number; finishCol: number}, direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
   const table = Element.fromHtml<HTMLTableElement>(input);
   const expectedDom = Element.fromHtml(expected);
 
@@ -147,7 +147,7 @@ const checkMerge = function (label: string, expected: string, input: string, sel
   Bars.destroy(wire);
 };
 
-const checkUnmerge = function (expected: string, input: string, unmergablePaths: { section: number, row: number, column: number }[], direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
+const checkUnmerge = function (expected: string, input: string, unmergablePaths: { section: number; row: number; column: number }[], direction: BarPositions<ColInfo> = ResizeDirection.ltr) {
   const table = Element.fromHtml<HTMLTableElement>(input);
   Insert.append(Body.body(), table);
   const wire = ResizeWire.only(Body.body());

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
@@ -6,7 +6,7 @@ import { TargetMergable } from '../../../../../../main/ts/ephox/snooker/model/Ru
 
 // Mock/Stub out helper functions
 
-const targetStub = function (selection: { section: number, row: number, column: number}[], bounds: { startRow: number, startCol: number, finishRow: number, finishCol: number}, table: Element): TargetMergable {
+const targetStub = function (selection: { section: number; row: number; column: number}[], bounds: { startRow: number; startCol: number; finishRow: number; finishCol: number}, table: Element): TargetMergable {
   const cells = Options.cat(Arr.map(selection, function (path) {
     return Hierarchy.follow(table, [ path.section, path.row, path.column ]);
   }));

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Fitment.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Fitment.ts
@@ -21,7 +21,7 @@ const assertGrids = function (expected: Structs.RowCells[], actual: Structs.RowC
   });
 };
 
-const measureTest = function (expected: { error: string } | {rowDelta: number, colDelta: number }, startAddress: Structs.Address, gridA: () => Structs.ElementNew[][], gridB: () => Structs.ElementNew[][]) {
+const measureTest = function (expected: { error: string } | {rowDelta: number; colDelta: number }, startAddress: Structs.Address, gridA: () => Structs.ElementNew[][], gridB: () => Structs.ElementNew[][]) {
   // Try put gridB into gridA at the startAddress
   // returns a delta,
   // colDelta = -3 means gridA is 3 columns too short
@@ -51,7 +51,7 @@ const tailorTest = function (expected: Structs.ElementNew[][], startAddress: Str
   assertGrids(mapToStructGrid(expected), tailoredGrid);
 };
 
-const tailorIVTest = function (expected: { rows: number, cols: number }, startAddress: Structs.Address, gridA: () => Structs.ElementNew[][], delta: Fitment.Delta, generator: () => SimpleGenerators) {
+const tailorIVTest = function (expected: { rows: number; cols: number }, startAddress: Structs.Address, gridA: () => Structs.ElementNew[][], delta: Fitment.Delta, generator: () => SimpleGenerators) {
   const tailoredGrid = Fitment.tailor(mapToStructGrid(gridA()), delta, generator());
   const rows = tailoredGrid.length;
   const cols = tailoredGrid[0].cells().length;

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
@@ -41,13 +41,13 @@ const mergeTest = function (expected: Structs.ElementNew[][] | { error: string }
   });
 };
 
-const mergeIVTest = function (asserter: (result: Result<Structs.RowCells[], string>, s: Structs.Address, specA: { rows: () => number; cols: () => number; grid: () => Structs.ElementNew[][]; }, specB: { rows: () => number; cols: () => number; grid: () => Structs.ElementNew[][]; }) => void, startAddress: Structs.Address, gridSpecA: { rows: () => number, cols: () => number, grid: () => Structs.ElementNew[][] }, gridSpecB: { rows: () => number, cols: () => number, grid: () => Structs.ElementNew[][] }, generator: () => SimpleGenerators, comparator: (a: Element, b: Element) => boolean) {
+const mergeIVTest = function (asserter: (result: Result<Structs.RowCells[], string>, s: Structs.Address, specA: { rows: () => number; cols: () => number; grid: () => Structs.ElementNew[][] }, specB: { rows: () => number; cols: () => number; grid: () => Structs.ElementNew[][] }) => void, startAddress: Structs.Address, gridSpecA: { rows: () => number; cols: () => number; grid: () => Structs.ElementNew[][] }, gridSpecB: { rows: () => number; cols: () => number; grid: () => Structs.ElementNew[][] }, generator: () => SimpleGenerators, comparator: (a: Element, b: Element) => boolean) {
   // The last step, merge cells from gridB into gridA
   const nuGrid = TableMerge.merge(startAddress, mapToStructGrid(gridSpecA.grid()), mapToStructGrid(gridSpecB.grid()), generator(), comparator);
   asserter(nuGrid, startAddress, gridSpecA, gridSpecB);
 };
 
-const suite = function (label: string, startAddress: Structs.Address, gridA: () => Structs.ElementNew[][], gridB: () => Structs.ElementNew[][], generator: () => SimpleGenerators, comparator: (a: Element, b: Element) => boolean, expectedMeasure: {rowDelta: number, colDelta: number }, expectedTailor: Structs.ElementNew[][], expectedMergeGrids: Structs.ElementNew[][]) {
+const suite = function (label: string, startAddress: Structs.Address, gridA: () => Structs.ElementNew[][], gridB: () => Structs.ElementNew[][], generator: () => SimpleGenerators, comparator: (a: Element, b: Element) => boolean, expectedMeasure: {rowDelta: number; colDelta: number }, expectedTailor: Structs.ElementNew[][], expectedMergeGrids: Structs.ElementNew[][]) {
   Fitment.measureTest(expectedMeasure, startAddress, gridA, gridB);
   Fitment.tailorTest(expectedTailor, startAddress, gridA, expectedMeasure, generator);
   mergeTest(expectedMergeGrids, startAddress, gridA, gridB, generator, comparator);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Selection.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Selection.ts
@@ -12,18 +12,18 @@ export interface Selection {
     exact: (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => U
   ) => U;
   match: <U> (branches: {
-    domRange: (rng: Range) => U,
-    relative: (startSitu: Situ, finishSitu: Situ) => U,
-    exact: (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => U
+    domRange: (rng: Range) => U;
+    relative: (startSitu: Situ, finishSitu: Situ) => U;
+    exact: (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => U;
   }) => U;
   log: (label: string) => void;
 }
 
 // Consider adding a type for "element"
 const adt: {
-  domRange: (rng: Range) => Selection,
-  relative: (startSitu: Situ, finishSitu: Situ) => Selection,
-  exact: (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => Selection
+  domRange: (rng: Range) => Selection;
+  relative: (startSitu: Situ, finishSitu: Situ) => Selection;
+  exact: (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => Selection;
 } = Adt.generate([
   { domRange: [ 'rng' ] },
   { relative: [ 'startSitu', 'finishSitu' ] },

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Situ.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Situ.ts
@@ -9,17 +9,17 @@ export interface Situ {
     after: (element: Element<DomNode>) => U
   ) => U;
   match: <U> (branches: {
-    before: (element: Element<DomNode>) => U,
-    on: (element: Element<DomNode>, offset: number) => U,
-    after: (element: Element<DomNode>) => U,
+    before: (element: Element<DomNode>) => U;
+    on: (element: Element<DomNode>, offset: number) => U;
+    after: (element: Element<DomNode>) => U;
   }) => U;
   log: (label: string) => void;
 }
 
 const adt: {
-  before: (element: Element<DomNode>) => Situ,
-  on: (element: Element<DomNode>, offset: number) => Situ,
-  after: (element: Element<DomNode>) => Situ
+  before: (element: Element<DomNode>) => Situ;
+  on: (element: Element<DomNode>, offset: number) => Situ;
+  after: (element: Element<DomNode>) => Situ;
 } = Adt.generate([
   { before: [ 'element' ] },
   { on: [ 'element', 'offset' ] },

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/core/SelectionDirection.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/core/SelectionDirection.ts
@@ -12,8 +12,8 @@ export interface SelectionDirection {
     rtl: SelectionDirectionHandler<U>
   ) => U;
   match: <U> (branches: {
-    ltr: SelectionDirectionHandler<U>,
-    rtl: SelectionDirectionHandler<U>
+    ltr: SelectionDirectionHandler<U>;
+    rtl: SelectionDirectionHandler<U>;
   }) => U;
   log: (label: string) => void;
 }
@@ -21,8 +21,8 @@ export interface SelectionDirection {
 type SelectionDirectionConstructor = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => SelectionDirection;
 
 const adt: {
-  ltr: SelectionDirectionConstructor,
-  rtl: SelectionDirectionConstructor
+  ltr: SelectionDirectionConstructor;
+  rtl: SelectionDirectionConstructor;
 } = Adt.generate([
   { ltr: [ 'start', 'soffset', 'finish', 'foffset' ] },
   { rtl: [ 'start', 'soffset', 'finish', 'foffset' ] }

--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
@@ -14,7 +14,7 @@ export interface AnnotationChanges {
   addListener: (name: string, f: AnnotationListener) => void;
 }
 
-export type AnnotationListener = (state: boolean, name: string, data?: { uid: string, nodes: any[] }) => void;
+export type AnnotationListener = (state: boolean, name: string, data?: { uid: string; nodes: any[] }) => void;
 
 export interface AnnotationListenerData {
   listeners: AnnotationListener[];

--- a/modules/tinymce/src/core/main/ts/annotate/Identification.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/Identification.ts
@@ -13,7 +13,7 @@ import * as Markings from './Markings';
 
 // Given the current editor selection, identify the uid of any current
 // annotation
-const identify = (editor: Editor, annotationName: Option<string>): Option<{uid: string, name: string, elements: any[]}> => {
+const identify = (editor: Editor, annotationName: Option<string>): Option<{uid: string; name: string; elements: any[]}> => {
   const rng = editor.selection.getRng();
 
   const start = Element.fromDom(rng.startContainer);

--- a/modules/tinymce/src/core/main/ts/annotate/Wrapping.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/Wrapping.ts
@@ -23,8 +23,8 @@ export type Decorator = (
   uid: string,
   data: DecoratorData
 ) => {
-  attributes?: { },
-  classes?: string[]
+  attributes?: { };
+  classes?: string[];
 };
 
 const applyWordGrab = (editor: Editor, rng: Range): void => {

--- a/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
@@ -77,7 +77,7 @@ import I18n from './util/I18n';
  * });
  */
 
-export interface UrlObject { prefix: string; resource: string; suffix: string; }
+export interface UrlObject { prefix: string; resource: string; suffix: string }
 
 type WaitState = 'added' | 'loaded';
 
@@ -90,7 +90,7 @@ interface AddOnManager<T> {
   items: AddOnConstructor<T>[];
   urls: Record<string, string>;
   lookup: Record<string, { instance: AddOnConstructor<T>; dependencies?: string[] }>;
-  _listeners: { name: string, state: WaitState, callback: () => void }[];
+  _listeners: { name: string; state: WaitState; callback: () => void }[];
   get (name: string): AddOnConstructor<T>;
   dependencies (name: string): string[];
   requireLangPack (name: string, languages: string): void;

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -22,7 +22,7 @@ import Tools from './util/Tools';
 import URI from './util/URI';
 import { EditorManagerEventMap } from './EventTypes';
 
-declare const window: Window & { tinymce: any; tinyMCEPreInit: any; };
+declare const window: Window & { tinymce: any; tinyMCEPreInit: any };
 
 /**
  * This class used as a factory for manager for tinymce.Editor instances.

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -13,34 +13,34 @@ import { UndoLevel } from '../undo/UndoManagerTypes';
 import Editor from './Editor';
 import { NativeEventMap } from './util/EventDispatcher';
 
-export type ExecCommandEvent = { command: string, ui?: boolean, value?: any };
+export type ExecCommandEvent = { command: string; ui?: boolean; value?: any };
 
 // TODO Figure out if these properties should be on the ContentArgs types
-export type GetContentEvent = GetContentArgs & { source_view: boolean, selection: boolean, save: boolean };
-export type SetContentEvent = SetContentArgs & { paste: boolean, selection: boolean };
+export type GetContentEvent = GetContentArgs & { source_view: boolean; selection: boolean; save: boolean };
+export type SetContentEvent = SetContentArgs & { paste: boolean; selection: boolean };
 
 export type NewBlockEvent = { newBlock: Element };
 
-export type NodeChangedEvent = { element: Element, parents: Node[], selectionChange?: boolean, initial?: boolean };
+export type NodeChangedEvent = { element: Element; parents: Node[]; selectionChange?: boolean; initial?: boolean };
 
-export type ObjectResizedEvent = { target: HTMLElement, width: number, height: number };
+export type ObjectResizedEvent = { target: HTMLElement; width: number; height: number };
 
-export type ObjectSelectedEvent = { target: Node, targetClone?: Node };
+export type ObjectSelectedEvent = { target: Node; targetClone?: Node };
 
-export type ScrollIntoViewEvent = { elm: HTMLElement, alignToTop: boolean };
+export type ScrollIntoViewEvent = { elm: HTMLElement; alignToTop: boolean };
 
-export type SetSelectionRangeEvent = { range: Range, forward: boolean };
+export type SetSelectionRangeEvent = { range: Range; forward: boolean };
 
-export type ShowCaretEvent = { target: Node, direction: number, before: boolean };
+export type ShowCaretEvent = { target: Node; direction: number; before: boolean };
 
 export type SwitchModeEvent = { mode: string };
 
-export type AddUndoEvent = { level: UndoLevel, lastLevel: UndoLevel, originalEvent: Event };
+export type AddUndoEvent = { level: UndoLevel; lastLevel: UndoLevel; originalEvent: Event };
 export type UndoRedoEvent = { level: UndoLevel };
 
 export type WindowEvent<T extends Types.Dialog.DialogData> = { dialog: Types.Dialog.DialogInstanceApi<T> };
 
-export type ProgressStateEvent = { state: boolean, time?: number };
+export type ProgressStateEvent = { state: boolean; time?: number };
 
 export type PlaceholderToggleEvent = { state: boolean };
 

--- a/modules/tinymce/src/core/main/ts/api/PluginManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/PluginManager.ts
@@ -8,7 +8,7 @@
 import AddOnManager from './AddOnManager';
 
 export interface Plugin {
-  getMetadata? (): { name: string, url: string };
+  getMetadata? (): { name: string; url: string };
 
   // Allow custom apis
   [key: string]: any;

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -23,7 +23,7 @@ export type SetupCallback = (editor: Editor) => void;
 
 export type FilePickerCallback = (callback: Function, value: any, meta: Record<string, any>) => void;
 export type FilePickerValidationStatus = 'valid' | 'unknown' | 'invalid' | 'none';
-export type FilePickerValidationCallback = (info: { type: string, url: string }, callback: (validation: { status: FilePickerValidationStatus, message: string}) => void) => void;
+export type FilePickerValidationCallback = (info: { type: string; url: string }, callback: (validation: { status: FilePickerValidationStatus; message: string}) => void) => void;
 
 // dom-globals is outdated and missing a number of valid values
 export type ReferrerPolicy = DomReferrerPolicy | 'origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin';
@@ -127,7 +127,7 @@ export interface RawEditorSettings {
   language_url?: string;
   max_height?: number;
   max_width?: number;
-  menu?: Record<string, { title: string, items: string }>;
+  menu?: Record<string, { title: string; items: string }>;
   menubar?: boolean | string;
   min_height?: number;
   min_width?: number;

--- a/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
@@ -17,7 +17,7 @@ export type Theme = {
   execCommand? (command: string, ui?: boolean, value?: any): boolean;
   destroy? (): void;
   init? (editor: Editor, url: string, $: DomQueryConstructor);
-  renderUI? (): { iframeContainer?: HTMLIFrameElement, editorContainer: HTMLElement };
+  renderUI? (): { iframeContainer?: HTMLIFrameElement; editorContainer: HTMLElement };
   getNotificationManagerImpl? (): NotificationManagerImpl;
   getWindowManagerImpl? (): WindowManagerImpl;
 };

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -473,7 +473,7 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     return $elm[0] && $elm[0].style ? $elm[0].style[name] : undefined;
   };
 
-  const getSize = (elm: HTMLElement | string): {w: number, h: number} => {
+  const getSize = (elm: HTMLElement | string): {w: number; h: number} => {
     let w, h;
 
     elm = get(elm);

--- a/modules/tinymce/src/core/main/ts/api/dom/DomQuery.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DomQuery.ts
@@ -52,9 +52,9 @@ export interface DomQueryConstructor {
     attrHandle: {};
     find: {};
     relative: Record<string, { dir: string; first?: boolean }>;
-    preFilter: Record<string, any>
-    filter: Record<string, any>
-    pseudos: Record<string, any>
+    preFilter: Record<string, any>;
+    filter: Record<string, any>;
+    pseudos: Record<string, any>;
   };
 
   // Tools

--- a/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
@@ -255,7 +255,7 @@ class EventUtils {
   private readonly expando;
   private hasFocusIn: boolean;
   private hasMouseEnterLeave: boolean;
-  private mouseEnterLeave: { mouseenter: 'mouseover', mouseleave: 'mouseout' };
+  private mouseEnterLeave: { mouseenter: 'mouseover'; mouseleave: 'mouseout' };
   private count: number = 1;
 
   public constructor() {

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -74,8 +74,8 @@ class ScriptLoader {
   private settings: Partial<ScriptLoaderSettings>;
   private states: Record<string, number> = {};
   private queue: string[] = [];
-  private scriptLoadedCallbacks: Record<string, Array<{success: () => void, failure: () => void, scope: any}>> = {};
-  private queueLoadedCallbacks: Array<{success: () => void, failure: (urls: string[]) => void, scope: any}> = [];
+  private scriptLoadedCallbacks: Record<string, Array<{success: () => void; failure: () => void; scope: any}>> = {};
+  private queueLoadedCallbacks: Array<{success: () => void; failure: (urls: string[]) => void; scope: any}> = [];
   private loading = 0;
 
   public constructor(settings: Partial<ScriptLoaderSettings> = {}) {

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -521,7 +521,7 @@ const Selection = function (dom: DOMUtils, win: Window, serializer: Serializer, 
    * @param {String} selector CSS selector to check for.
    * @param {function} callback Callback with state and args when the selector is matches or not.
    */
-  const selectorChanged = (selector: string, callback: (active: boolean, args: { node: Node, selector: String, parents: Element[] }) => void) => {
+  const selectorChanged = (selector: string, callback: (active: boolean, args: { node: Node; selector: String; parents: Element[] }) => void) => {
     selectorChangedWithUnbind(selector, callback);
     return exports;
   };

--- a/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
@@ -23,7 +23,7 @@ const deleteFromCallbackMap = (callbackMap, selector, callback) => {
   }
 };
 
-type SelectorChangedCallback = (active: boolean, args: { node: Node; selector: String; parents: Element[]; }) => void;
+type SelectorChangedCallback = (active: boolean, args: { node: Node; selector: String; parents: Element[] }) => void;
 
 export default (dom: DOMUtils, editor: Editor) => {
   let selectorChangedData: Record<string, SelectorChangedCallback[]>;

--- a/modules/tinymce/src/core/main/ts/api/html/Entities.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Entities.ts
@@ -8,7 +8,7 @@
 import { Element } from '@ephox/sugar';
 import Tools from '../util/Tools';
 
-export interface EntitiesMap { [name: string]: string; }
+export interface EntitiesMap { [name: string]: string }
 
 interface Entities {
   encodeRaw (text: string, attr?: boolean): string;

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -7,7 +7,7 @@
 
 import { SchemaMap } from './Schema';
 
-export type Attributes = Array<{ name: string; value: string; }> & { map: Record<string, string> };
+export type Attributes = Array<{ name: string; value: string }> & { map: Record<string, string> };
 
 const whiteSpaceRegExp = /^[ \t\r\n]*$/;
 const typeLookup = {

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -52,7 +52,7 @@ import { extractBase64DataUris, restoreDataUris, Base64Extract } from '../../htm
  * @version 3.4
  */
 
-type AttrList = Array<{ name: string, value: string }> & { map: Record<string, string> };
+type AttrList = Array<{ name: string; value: string }> & { map: Record<string, string> };
 
 export interface SaxParserSettings {
   allow_conditional_comments?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -54,8 +54,8 @@ export interface SchemaElement extends ElementRule {
   pattern?: RegExp;
 }
 
-export type SchemaMap = { [name: string]: {}; };
-export type SchemaRegExpMap = { [name: string]: RegExp; };
+export type SchemaMap = { [name: string]: {} };
+export type SchemaRegExpMap = { [name: string]: RegExp };
 
 interface Schema {
   children: Record<string, {}>;

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -27,7 +27,7 @@
 import { Unicode } from '@ephox/katamari';
 import Schema from './Schema';
 
-export interface StyleMap { [s: string]: string | number; }
+export interface StyleMap { [s: string]: string | number }
 interface Styles {
   toHex(color: string): string;
   parse(css: string): Record<string, string>;

--- a/modules/tinymce/src/core/main/ts/api/util/Delay.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Delay.ts
@@ -9,7 +9,7 @@ import { clearInterval, clearTimeout, document, HTMLElement, setInterval, setTim
 import Editor from '../Editor';
 import Promise from './Promise';
 
-type DebounceFunc = (...args: any[]) => { stop: () => void; };
+type DebounceFunc = (...args: any[]) => { stop: () => void };
 
 interface Delay {
   requestAnimationFrame (callback: () => void, element?: HTMLElement): void;

--- a/modules/tinymce/src/core/main/ts/api/util/JSONRequest.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/JSONRequest.ts
@@ -41,7 +41,7 @@ const extend = Tools.extend;
 
 export interface JSONRequestSettings {
   crossDomain?: boolean;
-  requestheaders?: Record<string, { key: string, value: string}>;
+  requestheaders?: Record<string, { key: string; value: string}>;
   type?: string;
   url?: string;
   error_scope?: {};

--- a/modules/tinymce/src/core/main/ts/api/util/XHR.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/XHR.ts
@@ -16,7 +16,7 @@ export interface XHRSettings {
   content_type?: string;
   crossDomain?: boolean;
   data?: string;
-  requestheaders?: Record<string, { key: string, value: string}>;
+  requestheaders?: Record<string, { key: string; value: string}>;
   scope?: {};
   type?: string;
   url: string;

--- a/modules/tinymce/src/core/main/ts/dom/ScrollIntoView.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ScrollIntoView.ts
@@ -34,7 +34,7 @@ const fireAfterScrollIntoViewEvent = (editor: Editor, data: ScrollIntoViewEvent)
   editor.fire('AfterScrollIntoView', data);
 };
 
-const descend = (element: SugarElement, offset: number): { element: SugarElement, offset: number } => {
+const descend = (element: SugarElement, offset: number): { element: SugarElement; offset: number } => {
   const children = Traverse.children(element);
   if (children.length === 0 || excludeFromDescend(element)) {
     return { element, offset };

--- a/modules/tinymce/src/core/main/ts/fmt/FormatChanged.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatChanged.ts
@@ -12,9 +12,9 @@ import Tools from '../api/util/Tools';
 import * as FormatUtils from './FormatUtils';
 import * as MatchFormat from './MatchFormat';
 
-export type FormatChangeCallback = (state: boolean, data: { node: Node, format: string, parents: any }) => void;
+export type FormatChangeCallback = (state: boolean, data: { node: Node; format: string; parents: any }) => void;
 type FormatCallbacks = Record<string, FormatChangeCallback[]>;
-type FormatData = { similar?: boolean, callbacks: FormatChangeCallback[] };
+type FormatData = { similar?: boolean; callbacks: FormatChangeCallback[] };
 type RegisteredFormats = Record<string, FormatData>;
 
 const setup = (registeredFormatListeners: Cell<RegisteredFormats>, editor: Editor) => {

--- a/modules/tinymce/src/core/main/ts/html/FilterNode.ts
+++ b/modules/tinymce/src/core/main/ts/html/FilterNode.ts
@@ -14,7 +14,7 @@ interface FilterMatch {
   nodes: Node[];
 }
 
-interface FilterMatchMap { [key: string]: FilterMatch; }
+interface FilterMatchMap { [key: string]: FilterMatch }
 
 const traverse = (node: Node, fn: (node: Node) => void): void => {
   fn(node);

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
@@ -11,15 +11,15 @@ UnitTest.asynctest('browser.tinymce.core.annotate.AnnotationChangedTest', (succe
 
   Theme();
 
-  const changes: Cell<Array<{state: boolean, name: string, uid: string}>> = Cell([ ]);
+  const changes: Cell<Array<{state: boolean; name: string; uid: string}>> = Cell([ ]);
 
-  const sAssertChanges = <T> (message: string, expected: Array<{uid: string, state: boolean, name: string}>): Step<T, T> =>
+  const sAssertChanges = <T> (message: string, expected: Array<{uid: string; state: boolean; name: string}>): Step<T, T> =>
     Logger.t(
       message,
       // Use a chain so that changes.get() can be evaluated at run-time.
       Chain.asStep({ }, [
         Chain.injectThunked(changes.get),
-        Chain.op((cs: Array<{uid: string, name: string}>) => {
+        Chain.op((cs: Array<{uid: string; name: string}>) => {
           Assertions.assertEq('Checking changes', expected, cs);
         })
       ])
@@ -33,7 +33,7 @@ UnitTest.asynctest('browser.tinymce.core.annotate.AnnotationChangedTest', (succe
   TinyLoader.setupLight(function (editor: Editor, onSuccess, onFailure) {
     const tinyApis = TinyApis(editor);
 
-    const sTestAnnotationEvents = <T> (label: string, start: number[], soffset: number, expected: Array<{ uid: string, name: string, state: boolean}>): Step<T, T> => {
+    const sTestAnnotationEvents = <T> (label: string, start: number[], soffset: number, expected: Array<{ uid: string; name: string; state: boolean}>): Step<T, T> => {
       return StepSequence.sequenceSame<T>([
         tinyApis.sSetSelection(start, soffset, start, soffset),
         Waiter.sTryUntil(

--- a/modules/tinymce/src/core/test/ts/module/test/AnnotationAsserts.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/AnnotationAsserts.ts
@@ -24,7 +24,7 @@ const sAssertHtmlContent = <T> (tinyApis: TinyApis, children: string[]): Step<T,
   );
 };
 
-const assertMarker = (editor: Editor, expected: { uid: string, name: string}, nodes: Element[]) => {
+const assertMarker = (editor: Editor, expected: { uid: string; name: string}, nodes: Element[]) => {
   const { uid, name } = expected;
   Arr.each(nodes, (node) => {
     Assertions.assertEq('Wrapper must be in content', true, editor.getBody().contains(node));

--- a/modules/tinymce/src/plugins/charmap/main/ts/core/CharMap.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/CharMap.ts
@@ -15,8 +15,8 @@ const isArray = Tools.isArray;
 export const UserDefined = 'User Defined';
 
 export type CharMap = {
-  name: string,
-  characters: [number, string][]
+  name: string;
+  characters: [number, string][];
 };
 
 const getDefaultCharMap = function (): CharMap[] {

--- a/modules/tinymce/src/plugins/emoticons/main/ts/core/Lookup.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/core/Lookup.ts
@@ -13,7 +13,7 @@ const emojiMatches = (emoji: EmojiEntry, lowerCasePattern: string): boolean => {
   return Strings.contains(emoji.title.toLowerCase(), lowerCasePattern) || Arr.exists(emoji.keywords, (k) => Strings.contains(k.toLowerCase(), lowerCasePattern));
 };
 
-const emojisFrom = (list: EmojiEntry[], pattern: string, maxResults: Option<number>): Array<{value: string, icon: string, text: string }> => {
+const emojisFrom = (list: EmojiEntry[], pattern: string, maxResults: Option<number>): Array<{value: string; icon: string; text: string }> => {
   const matches = [];
   const lowerCasePattern = pattern.toLowerCase();
   const reachedLimit = maxResults.fold(() => Fun.never, (max) => (size) => size >= max);

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -52,7 +52,7 @@ const tab = (editor: Editor): Types.Dialog.TabApi => {
       '</div>';
   };
 
-  const makeLink = (p: {name: string, url: string}): string =>
+  const makeLink = (p: {name: string; url: string}): string =>
     `<a href="${p.url}" target="_blank" rel="noopener">${p.name}</a>`;
 
   const maybeUrlize = (editor, key: string) => {

--- a/modules/tinymce/src/plugins/image/main/ts/ui/DialogTypes.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/DialogTypes.ts
@@ -62,7 +62,7 @@ export interface ImageDialogData {
       hspace?: string;
       borderstyle?: string;
       isDecorative?: boolean;
-    }
+    };
   };
   images: string;
   alt: string;

--- a/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
@@ -7,21 +7,21 @@ import { TinyUi } from '@ephox/mcagar';
 
 export type ImageDialogData = {
   src: {
-    value: string
-  },
-  alt: string,
-  decorative: boolean
+    value: string;
+  };
+  alt: string;
+  decorative: boolean;
   dimensions: {
-    width: string,
-    height: string
-  },
-  caption: boolean,
-  classIndex: number, // because the DOM api is setSelectedIndex
-  border: string,
-  hspace: string,
-  style: string,
-  vspace: string,
-  borderstyle: string,
+    width: string;
+    height: string;
+  };
+  caption: boolean;
+  classIndex: number; // because the DOM api is setSelectedIndex
+  border: string;
+  hspace: string;
+  style: string;
+  vspace: string;
+  borderstyle: string;
 };
 
 export const generalTabSelectors = {

--- a/modules/tinymce/src/plugins/imagetools/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/core/Utils.ts
@@ -24,7 +24,7 @@ const traverse = function (json, path) {
 };
 
 const requestUrlAsBlob = function (url: string, headers: Record<string, string>, withCredentials: boolean) {
-  return new Promise<{status: number, blob: Blob}>(function (resolve) {
+  return new Promise<{status: number; blob: Blob}>(function (resolve) {
     let xhr;
 
     xhr = new XMLHttpRequest();

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Dialog.ts
@@ -13,8 +13,8 @@ import { Types } from '@ephox/bridge';
 import { Blob, URL } from '@ephox/dom-globals';
 
 type ImageToolsState = {
-  blob: Blob,
-  url: string
+  blob: Blob;
+  url: string;
 };
 
 const createState = (blob: Blob): ImageToolsState => {

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -19,8 +19,8 @@ interface Group {
   selectors: {};
   filter: (value: string) => boolean;
   item: {
-    text: string,
-    menu: []
+    text: string;
+    menu: [];
   };
 }
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
@@ -22,7 +22,7 @@ UnitTest.asynctest('browser.tinymce.plugins.link.DialogSectionsTest', (success, 
   };
 
   interface TestSection {
-    setting: { key: string, value: Option<any> };
+    setting: { key: string; value: Option<any> };
     selector: string;
     exists: boolean;
   }
@@ -77,7 +77,7 @@ UnitTest.asynctest('browser.tinymce.plugins.link.DialogSectionsTest', (success, 
       ])
     );
 
-    const sCheckRelSection = (exists: boolean, value: Option<Array<{ value: string, title: string }>>) => Log.step('TBA', 'Link: sCheckRelSection',
+    const sCheckRelSection = (exists: boolean, value: Option<Array<{ value: string; title: string }>>) => Log.step('TBA', 'Link: sCheckRelSection',
       sCheckSections([
         {
           setting: { key: 'rel_list', value },
@@ -87,7 +87,7 @@ UnitTest.asynctest('browser.tinymce.plugins.link.DialogSectionsTest', (success, 
       ])
     );
 
-    const sCheckClassSection = (exists: boolean, value: Option<Array<{ value: string, title: string }>>) => Log.step('TBA', 'Link: sCheckClassSection',
+    const sCheckClassSection = (exists: boolean, value: Option<Array<{ value: string; title: string }>>) => Log.step('TBA', 'Link: sCheckClassSection',
       sCheckSections([
         {
           setting: { key: 'link_class_list', value },
@@ -97,7 +97,7 @@ UnitTest.asynctest('browser.tinymce.plugins.link.DialogSectionsTest', (success, 
       ])
     );
 
-    const sCheckLinkListSection = (exists: boolean, value: Option<Array<{ value: string, title: string }>>) => Log.step('TBA', 'Link: sCheckLinkListSection',
+    const sCheckLinkListSection = (exists: boolean, value: Option<Array<{ value: string; title: string }>>) => Log.step('TBA', 'Link: sCheckLinkListSection',
       sCheckSections([
         {
           setting: { key: 'link_list', value },

--- a/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
@@ -13,7 +13,7 @@ import { MediaData } from './Types';
 
 const cache = {};
 const embedPromise = function (data: MediaData, dataToHtml: DataToHtml.DataToHtmlCallback, handler) {
-  return new Promise<{url: string, html: string}>(function (res, rej) {
+  return new Promise<{url: string; html: string}>(function (res, rej) {
     const wrappedResolve = function (response) {
       if (response.html) {
         cache[data.source] = response;
@@ -32,7 +32,7 @@ const embedPromise = function (data: MediaData, dataToHtml: DataToHtml.DataToHtm
 };
 
 const defaultPromise = function (data: MediaData, dataToHtml: DataToHtml.DataToHtmlCallback) {
-  return new Promise<{url: string, html: string}>(function (res) {
+  return new Promise<{url: string; html: string}>(function (res) {
     res({ html: dataToHtml(data), url: data.source });
   });
 };

--- a/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
@@ -15,7 +15,7 @@ import { MediaData } from './Types';
 
 const DOM = DOMUtils.DOM;
 
-type AttrList = Array<{ name: string, value: string }> & { map: Record<string, string> };
+type AttrList = Array<{ name: string; value: string }> & { map: Record<string, string> };
 
 const setAttributes = function (attrs: AttrList, updatedAttrs: Record<string, any>) {
   let name;

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Newlines.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Newlines.ts
@@ -8,7 +8,7 @@
 import Tools from 'tinymce/core/api/util/Tools';
 import Entities from 'tinymce/core/api/html/Entities';
 
-export interface RootAttrs {[key: string]: string; }
+export interface RootAttrs {[key: string]: string }
 
 /**
  * Newlines class contains utilities to convert newlines (\n or \r\n) tp BRs or to a combination of the specified block element and BRs

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -111,7 +111,7 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
     }
   });
 
-  interface CellSize { cell: HTMLTableCellElement; width: string; }
+  interface CellSize { cell: HTMLTableCellElement; width: string }
 
   editor.on('ObjectResized', function (e) {
     const targetElm = e.target;

--- a/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
@@ -12,7 +12,7 @@ export interface StringMap {
   [key: string]: string;
 }
 
-type ClassList = Array<{title: string, value: string}>;
+type ClassList = Array<{title: string; value: string}>;
 type ColorPickerCallback = (editor: Editor, pickValue: (value: string) => void, value: string) => void;
 
 const defaultTableToolbar = 'tableprops tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol';

--- a/modules/tinymce/src/plugins/textpattern/main/ts/core/InlinePattern.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/core/InlinePattern.ts
@@ -222,7 +222,7 @@ const applyPatternWithContent = (editor: Editor, pattern: InlinePattern, startMa
   applyPattern(editor, pattern, patternRange);
 };
 
-const addMarkers = (dom: DOMUtils, matches: InlinePatternMatch[]): (InlinePatternMatch & { endMarker: Marker, startMarker: Marker })[] => {
+const addMarkers = (dom: DOMUtils, matches: InlinePatternMatch[]): (InlinePatternMatch & { endMarker: Marker; startMarker: Marker })[] => {
   const markerPrefix = Id.generate('mce_textpattern');
 
   // Add end markers

--- a/modules/tinymce/src/plugins/textpattern/main/ts/utils/PathRange.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/utils/PathRange.ts
@@ -40,7 +40,7 @@ const generatePathRange = (root: Node, startNode: Node, startOffset: number, end
   return { start, end };
 };
 
-const resolvePath = (root: Node, path: number[]): Option<{node: Node, offset: number}> => {
+const resolvePath = (root: Node, path: number[]): Option<{node: Node; offset: number}> => {
   const nodePath = path.slice();
   const offset = nodePath.pop();
   return Arr.foldl(nodePath, (optNode: Option<Node>, index: number) => {

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosSetup.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosSetup.ts
@@ -38,7 +38,7 @@ const register = function (toolstrip, socket, container, outerWindow, structure,
       return outside ? Option.some({
         top: Fun.constant(viewTop),
         bottom: Fun.constant(viewTop + rect.height())
-      }) : Option.none<{top: () => number, bottom: () => number}>();
+      }) : Option.none<{top: () => number; bottom: () => number}>();
     });
   };
 

--- a/modules/tinymce/src/themes/silver/demo/ts/dialogs/spec/ImageDialogSpec.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/dialogs/spec/ImageDialogSpec.ts
@@ -105,7 +105,7 @@ export default {
     } else if (details.name === 'size') {
       // Notice that the size has a more complex json output separating
       // width/height the constrain logic should be done at implementation level
-      const value = details.value as { width: string, height: string };
+      const value = details.value as { width: string; height: string };
       console.log(value.width, value.height);
     }
   },

--- a/modules/tinymce/src/themes/silver/main/ts/autocomplete/AutocompleteEditorEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/autocomplete/AutocompleteEditorEvents.ts
@@ -14,7 +14,7 @@ import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as AutocompleteTag from './AutocompleteTag';
 
 export interface AutocompleterUiApi {
-  onKeypress: { cancel: () => void, throttle: (evt: Event) => void };
+  onKeypress: { cancel: () => void; throttle: (evt: Event) => void };
   getView: () => Option<AlloyComponent>;
   isMenuOpen: () => boolean;
   isActive: () => boolean;

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -35,10 +35,10 @@ export interface UiFactoryBackstageShared {
   providers?: UiFactoryBackstageProviders;
   interpreter?: (spec: BridgedType) => AlloySpec;
   anchors?: {
-    inlineDialog: () => HotspotAnchorSpec | NodeAnchorSpec,
-    banner: () => HotspotAnchorSpec | NodeAnchorSpec,
-    cursor: () => SelectionAnchorSpec,
-    node: (elem: Option<Element>) => NodeAnchorSpec
+    inlineDialog: () => HotspotAnchorSpec | NodeAnchorSpec;
+    banner: () => HotspotAnchorSpec | NodeAnchorSpec;
+    cursor: () => SelectionAnchorSpec;
+    node: (elem: Option<Element>) => NodeAnchorSpec;
   };
   formInterpreter?: (parts: FormTypes.FormParts, spec: BridgedType, backstage: UiFactoryBackstage) => AlloySpec;
   getSink?: () => Result<AlloyComponent, any>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/FlatgridAutodetect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/FlatgridAutodetect.ts
@@ -9,7 +9,7 @@ import { AlloyComponent } from '@ephox/alloy';
 import { Arr, Option } from '@ephox/katamari';
 import { SelectorFilter } from '@ephox/sugar';
 
-const detectSize = (comp: AlloyComponent, margin: number, selectorClass: string): Option<{ numColumns: number, numRows: number}> => {
+const detectSize = (comp: AlloyComponent, margin: number, selectorClass: string): Option<{ numColumns: number; numRows: number}> => {
   const descendants = SelectorFilter.descendants(comp.element(), '.' + selectorClass);
 
   // TODO: This seems to cause performance issues in the emoji dialog

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
@@ -11,7 +11,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { window } from '@ephox/dom-globals';
 import * as Settings from '../../api/Settings';
 
-const getHorizontalBounds = (contentAreaBox: Bounds, viewportBounds: Bounds): { x: number, width: number } => {
+const getHorizontalBounds = (contentAreaBox: Bounds, viewportBounds: Bounds): { x: number; width: number } => {
   const x = Math.max(viewportBounds.x, contentAreaBox.x);
   const contentBoxWidth = contentAreaBox.right - x;
   const maxViewportWidth = viewportBounds.width - (x - viewportBounds.x);
@@ -19,7 +19,7 @@ const getHorizontalBounds = (contentAreaBox: Bounds, viewportBounds: Bounds): { 
   return { x, width };
 };
 
-const getVerticalBounds = (editor: Editor, contentAreaBox: Bounds, viewportBounds: Bounds): { y: number, bottom: number } => {
+const getVerticalBounds = (editor: Editor, contentAreaBox: Bounds, viewportBounds: Bounds): { y: number; bottom: number } => {
   const container = Element.fromDom(editor.getContainer());
   const header = SelectorFind.descendant(container, '.tox-editor-header').getOr(container);
   const headerBox = Boxes.box(header);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarLookup.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarLookup.ts
@@ -13,7 +13,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import { ScopedToolbars } from './ContextToolbarScopes';
 
-export type LookupResult = { toolbarApi: Toolbar.ContextToolbar | Toolbar.ContextForm, elem: Element };
+export type LookupResult = { toolbarApi: Toolbar.ContextToolbar | Toolbar.ContextForm; elem: Element };
 
 const matchTargetWith = (elem: Element, toolbars: Array<Toolbar.ContextToolbar | Toolbar.ContextForm>): Option<LookupResult> => {
   return Arr.findMap(toolbars, (toolbarApi) =>

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -27,7 +27,7 @@ export interface ChangeSlideEvent extends CustomEvent {
 
 const resizingClass = 'tox-pop--resizing';
 
-const renderContextToolbar = (spec: { onEscape: () => Option<boolean>, sink: AlloyComponent }) => {
+const renderContextToolbar = (spec: { onEscape: () => Option<boolean>; sink: AlloyComponent }) => {
   const stack = Cell([ ]);
 
   return InlineView.sketch({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
@@ -44,7 +44,7 @@ const toLegacy = (fontSize: string): string => Obj.get(legacyFontSizes, fontSize
 
 const getSpec = (editor: Editor): SelectSpec => {
   const getMatchingValue = () => {
-    let matchOpt = Option.none<{ title: string; format: string; }>();
+    let matchOpt = Option.none<{ title: string; format: string }>();
     const items = dataset.data;
 
     const fontSize = editor.queryCommandValue('FontSize');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
@@ -9,7 +9,7 @@ import { Arr, Obj } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { SelectData } from './BespokeSelect';
 
-const process = (rawFormats): Array<{ title: string, format: string}> => {
+const process = (rawFormats): Array<{ title: string; format: string}> => {
   return Arr.map(rawFormats, (item) => {
     let title = item, format = item;
     // Allow text=value block formats

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
@@ -73,7 +73,7 @@ const isSelectorFormat = (format: AllowedFormat): format is SelectorStyleFormat 
 type FormatTypes = Separator | FormatReference | NestedFormatting;
 
 interface CustomFormatMapping {
-  customFormats: { name: string, format: StyleFormat }[];
+  customFormats: { name: string; format: StyleFormat }[];
   formats: FormatTypes[];
 }
 
@@ -102,7 +102,7 @@ const mapFormats = (userFormats: AllowedFormat[]): CustomFormatMapping => {
 const registerCustomFormats = (editor: Editor, userFormats: AllowedFormat[]): FormatTypes[] => {
   const result = mapFormats(userFormats);
 
-  const registerFormats = (customFormats: {name: string, format: StyleFormat}[]) => {
+  const registerFormats = (customFormats: {name: string; format: StyleFormat}[]) => {
     Arr.each(customFormats, (fmt) => {
       // Only register the custom format with the editor, if it's not already registered
       if (!editor.formatter.has(fmt.name)) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
@@ -14,7 +14,7 @@ import { FormatItem, FormatterFormatItem, PreviewSpec, SubMenuFormatItem } from 
 export type IsSelectedForType = (format: string) => (currentValue: Option<any>) => boolean;
 export type GetPreviewForType = (format: string) => () => Option<PreviewSpec>;
 
-const processBasic = (item: { format: string, title: string }, isSelectedFor, getPreviewFor): FormatterFormatItem => {
+const processBasic = (item: { format: string; title: string }, isSelectedFor, getPreviewFor): FormatterFormatItem => {
   const formatterSpec: Omit<FormatterFormatItem, 'format'> = {
     type: 'formatter',
     isSelected: isSelectedFor(item.format),
@@ -25,12 +25,12 @@ const processBasic = (item: { format: string, title: string }, isSelectedFor, ge
 
 // TODO: This is adapted from StyleFormats in the mobile theme. Consolidate.
 const register = (editor: Editor, formats, isSelectedFor: IsSelectedForType, getPreviewFor: GetPreviewForType) => {
-  const enrichSupported = (item: { format: string, title: string }): FormatterFormatItem => {
+  const enrichSupported = (item: { format: string; title: string }): FormatterFormatItem => {
     return processBasic(item, isSelectedFor, getPreviewFor);
   };
 
   // Item that triggers a submenu
-  const enrichMenu = (item: { title: TranslateIfNeeded; getStyleItems: () => FormatItem[]; }): SubMenuFormatItem => {
+  const enrichMenu = (item: { title: TranslateIfNeeded; getStyleItems: () => FormatItem[] }): SubMenuFormatItem => {
     const submenuSpec = {
       type: 'submenu' as 'submenu'
     };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -125,7 +125,7 @@ export interface TextField {
   disabled: boolean;
   validation: Option<{
     validator: Validator;
-    validateOnLoad?: boolean
+    validateOnLoad?: boolean;
   }>;
   maximized: boolean;
 }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/Utils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/Utils.ts
@@ -24,7 +24,7 @@ const traverse = function (json, path) {
 };
 
 const requestUrlAsBlob = function (url: string, headers: Record<string, string>, withCredentials: boolean) {
-  return new Promise<{status: number, blob: Blob}>(function (resolve) {
+  return new Promise<{status: number; blob: Blob}>(function (resolve) {
     let xhr;
 
     xhr = new XMLHttpRequest();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/FormValues.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/FormValues.ts
@@ -8,7 +8,7 @@
 import { Form, Invalidating, Representing } from '@ephox/alloy';
 import { Arr, Future, Futures, Merger, Obj, Option, Result, Results } from '@ephox/katamari';
 
-export interface FormValidator { 'value': string | number; 'text': string; }
+export interface FormValidator { 'value': string | number; 'text': string }
 
 const toValidValues = function <T> (values: { [key: string]: Option<T[keyof T]> }) {
   const errors: string[] = [];
@@ -55,7 +55,7 @@ const extract = <T>(form) => {
     return Future.pure(Result.error([]));
   }, function (vs) {
     const keys: string[] = Obj.keys(vs);
-    const validations: Array<Future<Result<any, { field: any, message: string }>>> = Arr.map(keys, function (key: string) {
+    const validations: Array<Future<Result<any, { field: any; message: string }>>> = Arr.map(keys, function (key: string) {
       // TODO: This should be fine because we just got the value.
       const field = Form.getField(form, key).getOrDie('Could not find field: ' + key);
       // TODO: check this refactored line if it breaks.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -145,7 +145,7 @@ const rtlTransform = [
 ];
 
 // TODO: Maybe need aria-label
-const renderItemStructure = <T>(info: ItemStructureSpec, providersBackstage: UiFactoryBackstageProviders, renderIcons: boolean, fallbackIcon: Option<string> = Option.none()): { dom: RawDomSchema, optComponents: Array<Option<AlloySpec>> } => {
+const renderItemStructure = <T>(info: ItemStructureSpec, providersBackstage: UiFactoryBackstageProviders, renderIcons: boolean, fallbackIcon: Option<string> = Option.none()): { dom: RawDomSchema; optComponents: Array<Option<AlloySpec>> } => {
   // If RTL and icon is in whitelist, add RTL icon class for icons that don't have a `-rtl` icon available.
   // Use `-rtl` icon suffix for icons that do.
   const getIconName = (iconName: Option<string>): Option<string> => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -29,7 +29,7 @@ const defaultMenus = {
   help: { title: 'Help', items: 'help' }
 };
 
-const make = (menu: {title: string, items: string[]}, registry: MenuRegistry, editor): MenubarItemSpec => {
+const make = (menu: {title: string; items: string[]}, registry: MenuRegistry, editor): MenubarItemSpec => {
   const removedMenuItems = getRemovedMenuItems(editor).split(/[ ,]/);
   return {
     text: menu.title,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
@@ -17,7 +17,7 @@ import { bodyChannel } from './DialogChannels';
 
 // TypeScript allows some pretty weird stuff.
 type WindowBodySpec = {
-  body: Types.Dialog.Dialog<unknown>['body']
+  body: Types.Dialog.Dialog<unknown>['body'];
 };
 
 // ariaAttrs is being passed through to silver inline dialog

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -13,7 +13,7 @@ UnitTest.asynctest('ToolbarBottomTest - assert direction that menus open in when
   interface Scenario {
     message: string;
     settings: EditorSettings;
-    initial: Array<{ clickOn: string, waitFor: string }>;
+    initial: Array<{ clickOn: string; waitFor: string }>;
     assertAbove: string;
     assertBelow: string;
   }

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -58,8 +58,8 @@ UnitTest.asynctest('ContextToolbarBoundsTest', (success, failure) => {
     label: string;
     settings: Record<string, any>;
     scroll?: {
-      relativeTop: boolean,
-      delta: number
+      relativeTop: boolean;
+      delta: number;
     };
     assertBounds: (currentBounds: TestBounds) => {
       x: number;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
@@ -17,7 +17,7 @@ UnitTest.asynctest('WindowManager:simple-dialog access Test', (success, failure)
     const currentApi = Cell<Types.Dialog.DialogInstanceApi<any>>({ } as any);
     const store = TestHelpers.TestStore();
 
-    const dialogSpec: Types.Dialog.DialogApi<{ fieldA: string; }> = {
+    const dialogSpec: Types.Dialog.DialogApi<{ fieldA: string }> = {
       title: 'Silver Test Access Dialog',
       body: {
         type: 'panel',
@@ -57,7 +57,7 @@ UnitTest.asynctest('WindowManager:simple-dialog access Test', (success, failure)
           api.unblock();
           api.showTab('new tab');
           // Currently, it is only going to validate it if the dialog is still open
-          const redialSpec: Types.Dialog.DialogApi<{ fieldA: string; }> = {
+          const redialSpec: Types.Dialog.DialogApi<{ fieldA: string }> = {
             title: 'temporary redial to check the API',
             body: {
               type: 'panel',


### PR DESCRIPTION
This lint converts all separators in interfaces into semicolons.