### PR TITLE
TINY-4780: Enabled lint guard-for-in and manually fixed errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,6 @@
     "@typescript-eslint/prefer-for-of": "off",
     "@typescript-eslint/prefer-regexp-exec": "off",
     "@typescript-eslint/quotes": "off",
-    "@typescript-eslint/type-annotation-spacing": "off",
     "@typescript-eslint/unbound-method": "off",
     "arrow-body-style": "off",
     "no-empty": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,6 @@
     "@typescript-eslint/type-annotation-spacing": "off",
     "@typescript-eslint/unbound-method": "off",
     "arrow-body-style": "off",
-    "guard-for-in": "off",
     "no-empty": "off",
     "no-shadow": "off",
     "no-underscore-dangle": "off",

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
@@ -44,7 +44,7 @@ const text = (textContent: string): PremadeSpec => {
 };
 
 // Rename.
-export interface ExternalElement { uid ?: string; element: Element }
+export interface ExternalElement { uid?: string; element: Element }
 const external = (spec: ExternalElement): PremadeSpec => {
   const extSpec: { uid: Option<string>; element: Element } = ValueSchema.asRawOrDie('external.component', ValueSchema.objOfOnly([
     FieldSchema.strict('element'),

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -6,7 +6,7 @@
  */
 
 import { document, Element, HTMLFormElement, Window, BeforeUnloadEvent } from '@ephox/dom-globals';
-import { Arr, Type } from '@ephox/katamari';
+import { Arr, Type, Obj } from '@ephox/katamari';
 import AddOnManager from './AddOnManager';
 import Editor from './Editor';
 import { RawEditorSettings } from './SettingsTypes';
@@ -337,9 +337,9 @@ const EditorManager: EditorManager = {
     this.defaultSettings = defaultSettings;
 
     const pluginBaseUrls = defaultSettings.plugin_base_urls;
-    for (const name in pluginBaseUrls) {
-      AddOnManager.PluginManager.urls[name] = pluginBaseUrls[name];
-    }
+    Obj.each(pluginBaseUrls, (pluginBaseUrl, pluginName) => {
+      AddOnManager.PluginManager.urls[pluginName] = pluginBaseUrl;
+    });
   },
 
   /**

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -337,9 +337,11 @@ const EditorManager: EditorManager = {
     this.defaultSettings = defaultSettings;
 
     const pluginBaseUrls = defaultSettings.plugin_base_urls;
-    Obj.each(pluginBaseUrls, (pluginBaseUrl, pluginName) => {
-      AddOnManager.PluginManager.urls[pluginName] = pluginBaseUrl;
-    });
+    if (pluginBaseUrls !== undefined) {
+      Obj.each(pluginBaseUrls, (pluginBaseUrl, pluginName) => {
+        AddOnManager.PluginManager.urls[pluginName] = pluginBaseUrl;
+      });
+    }
   },
 
   /**

--- a/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
@@ -12,6 +12,7 @@ import Tools from './util/Tools';
 import Editor from './Editor';
 import { EditorEventMap } from './EventTypes';
 import { isReadOnly, preventReadOnlyEvents } from '../mode/Readonly';
+import { Obj } from '@ephox/katamari';
 
 /**
  * This mixin contains the event logic for the tinymce.Editor class.
@@ -91,13 +92,11 @@ const bindEventDelegate = function (editor: Editor, eventName: string) {
     if (!customEventRootDelegates) {
       customEventRootDelegates = {};
       editor.editorManager.on('removeEditor', function () {
-        let name;
-
         if (!editor.editorManager.activeEditor) {
           if (customEventRootDelegates) {
-            for (name in customEventRootDelegates) {
+            Obj.each(customEventRootDelegates, (_value, name) => {
               editor.dom.unbind(getEventTarget(editor, name));
-            }
+            });
 
             customEventRootDelegates = null;
           }
@@ -196,12 +195,11 @@ const EditorObservable: EditorObservable = {
     const self = this;
     const body = self.getBody();
     const dom: DOMUtils = self.dom;
-    let name;
 
     if (self.delegates) {
-      for (name in self.delegates) {
-        self.dom.unbind(getEventTarget(self, name), name, self.delegates[name]);
-      }
+      Obj.each(self.delegates, (value, name) => {
+        self.dom.unbind(getEventTarget(self, name), name, value);
+      });
 
       delete self.delegates;
     }

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -17,6 +17,7 @@ import Delay from '../util/Delay';
 import Tools from '../util/Tools';
 import VK from '../util/VK';
 import Selection from './Selection';
+import { Obj } from '@ephox/katamari';
 
 interface ControlSelection {
   isResizable (elm: Element): boolean;
@@ -351,21 +352,19 @@ const ControlSelection = (selection: Selection, editor: Editor): ControlSelectio
   };
 
   const hideResizeRect = function () {
-    let name, handleElm;
-
     unbindResizeHandleEvents();
 
     if (selectedElm) {
       selectedElm.removeAttribute('data-mce-selected');
     }
 
-    for (name in resizeHandles) {
-      handleElm = dom.get('mceResizeHandle' + name);
+    Obj.each(resizeHandles, (value, name) => {
+      const handleElm = dom.get('mceResizeHandle' + name);
       if (handleElm) {
         dom.unbind(handleElm);
         dom.remove(handleElm);
       }
-    }
+    });
   };
 
   const updateResizeRect = function (e) {
@@ -412,14 +411,12 @@ const ControlSelection = (selection: Selection, editor: Editor): ControlSelectio
   };
 
   const unbindResizeHandleEvents = function () {
-    for (const name in resizeHandles) {
-      const handle = resizeHandles[name];
-
+    Obj.each(resizeHandles, (handle) => {
       if (handle.elm) {
         dom.unbind(handle.elm);
         delete handle.elm;
       }
-    }
+    });
   };
 
   const disableGeckoResize = function () {

--- a/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
@@ -8,6 +8,7 @@
 import { document, HTMLElementEventMap, window } from '@ephox/dom-globals';
 import Env from '../Env';
 import Delay from '../util/Delay';
+import { Obj } from '@ephox/katamari';
 
 export type EventUtilsCallback<T> = (event: EventUtilsEvent<T>) => void;
 
@@ -463,17 +464,18 @@ class EventUtils {
         }
       } else {
         // All events for a specific element
-        for (name in eventMap) {
-          callbackList = eventMap[name];
+        Obj.each(eventMap, (callbackList, name) => {
           removeEvent(target, callbackList.fakeName || name, callbackList.nativeHandler, callbackList.capture);
-        }
+        });
 
         eventMap = {};
       }
 
       // Check if object is empty, if it isn't then we won't remove the expando map
       for (name in eventMap) {
-        return this;
+        if (Object.prototype.hasOwnProperty.call(eventMap, name)) {
+          return this;
+        }
       }
 
       // Delete event object

--- a/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
@@ -473,7 +473,7 @@ class EventUtils {
 
       // Check if object is empty, if it isn't then we won't remove the expando map
       for (name in eventMap) {
-        if (Object.prototype.hasOwnProperty.call(eventMap, name)) {
+        if (Obj.has(eventMap, name)) {
           return this;
         }
       }

--- a/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
@@ -1442,9 +1442,11 @@ Expr = Sizzle.selectors = {
 Expr.pseudos.nth = Expr.pseudos.eq;
 
 // Add button/input type pseudos
+// eslint-disable-next-line guard-for-in
 for (i in { radio: true, checkbox: true, file: true, password: true, image: true }) {
   Expr.pseudos[i] = createInputPseudo(i);
 }
+// eslint-disable-next-line guard-for-in
 for (i in { submit: true, reset: true }) {
   Expr.pseudos[i] = createButtonPseudo(i);
 }

--- a/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
@@ -6,6 +6,7 @@
  */
 
 import { window } from '@ephox/dom-globals';
+import { Arr } from '@ephox/katamari';
 
 /* jshint bitwise:false, expr:true, noempty:false, sub:true, eqnull:true, latedef:false, maxlen:255 */
 
@@ -1442,14 +1443,12 @@ Expr = Sizzle.selectors = {
 Expr.pseudos.nth = Expr.pseudos.eq;
 
 // Add button/input type pseudos
-// eslint-disable-next-line guard-for-in
-for (i in { radio: true, checkbox: true, file: true, password: true, image: true }) {
+Arr.each([ 'radio', 'checkbox', 'file', 'password', 'image' ], (i) => {
   Expr.pseudos[i] = createInputPseudo(i);
-}
-// eslint-disable-next-line guard-for-in
-for (i in { submit: true, reset: true }) {
+});
+Arr.each([ 'submit', 'reset' ], (i) => {
   Expr.pseudos[i] = createButtonPseudo(i);
-}
+});
 
 // Easy API for creating new setFilters
 function setFilters() { }

--- a/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
@@ -29,8 +29,7 @@ import { Arr } from '@ephox/katamari';
 
 /* tslint:disable */
 
-let i,
-  support,
+let support,
   Expr,
   getText,
   isXML,

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -171,9 +171,11 @@ class Node {
     let attrs: Attributes;
 
     if (typeof name !== 'string') {
-      Obj.each(name, (value, key) => {
-        self.attr(key, value);
-      });
+      if (name !== undefined && name !== null) {
+        Obj.each(name, (value, key) => {
+          self.attr(key, value);
+        });
+      }
 
       return self;
     }

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -6,6 +6,7 @@
  */
 
 import { SchemaMap } from './Schema';
+import { Obj } from '@ephox/katamari';
 
 export type Attributes = Array<{ name: string; value: string }> & { map: Record<string, string> };
 
@@ -89,9 +90,9 @@ class Node {
 
     // Add attributes if needed
     if (attrs) {
-      for (const attrName in attrs) {
-        node.attr(attrName, attrs[attrName]);
-      }
+      Obj.each(attrs, (value, attrName) => {
+        node.attr(attrName, value);
+      });
     }
 
     return node;
@@ -170,9 +171,9 @@ class Node {
     let attrs: Attributes;
 
     if (typeof name !== 'string') {
-      for (const key in name) {
-        self.attr(key, name[key]);
-      }
+      Obj.each(name, (value, key) => {
+        self.attr(key, value);
+      });
 
       return self;
     }

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -488,7 +488,7 @@ function Schema(settings?: SchemaSettings): Schema {
   // This function is a bit hard to read since it's heavily optimized for speed
   const addValidElements = (validElements: string) => {
     let ei, el, ai, al, matches, element, attr, attrData, elementName, attrName, attrType, attributes, attributesOrder,
-      prefix, outputName, globalAttributes, globalAttributesOrder, key, value;
+      prefix, outputName, globalAttributes, globalAttributesOrder, value;
     const elementRuleRegExp = /^([#+\-])?([^\[!\/]+)(?:\/([^\[!]+))?(?:(!?)\[([^\]]+)\])?$/,
       attrRuleRegExp = /^([!\-])?(\w+[\\:]:\w+|[^=:<]+)?(?:([=:<])(.*))?$/,
       hasPatternsRegExp = /[*?+]/;

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -6,6 +6,7 @@
  */
 
 import Tools from '../util/Tools';
+import { Obj } from '@ephox/katamari';
 
 export type SchemaType = 'html4' | 'html5' | 'html5-strict';
 
@@ -538,9 +539,9 @@ function Schema(settings?: SchemaSettings): Schema {
 
           // Copy attributes from global rule into current rule
           if (globalAttributes) {
-            for (key in globalAttributes) {
-              attributes[key] = globalAttributes[key];
-            }
+            Obj.each(globalAttributes, (value, key) => {
+              attributes[key] = value;
+            });
 
             attributesOrder.push.apply(attributesOrder, globalAttributesOrder);
           }

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -24,7 +24,7 @@
  * @version 3.4
  */
 
-import { Unicode } from '@ephox/katamari';
+import { Unicode, Obj } from '@ephox/katamari';
 import Schema from './Schema';
 
 export interface StyleMap { [s: string]: string | number }
@@ -329,7 +329,7 @@ const Styles = function (settings?, schema?: Schema): Styles {
      * @return {String} String representation of the style object for example: border: 1px solid red.
      */
     serialize(styles: StyleMap, elementName?: string): string {
-      let css = '', name, value;
+      let css = '';
 
       const serializeStyles = (name: string) => {
         let styleList, i, l, value;
@@ -364,13 +364,11 @@ const Styles = function (settings?, schema?: Schema): Styles {
         serializeStyles(elementName);
       } else {
         // Output the styles in the order they are inside the object
-        for (name in styles) {
-          value = styles[name];
-
+        Obj.each(styles, (value, name) => {
           if (value && (!invalidStyles || isValid(name, elementName))) {
             css += (css.length > 0 ? ' ' : '') + name + ': ' + value + ';';
           }
-        }
+        });
       }
 
       return css;

--- a/modules/tinymce/src/core/main/ts/api/util/Class.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Class.ts
@@ -6,6 +6,7 @@
  */
 
 import Tools from './Tools';
+import { Obj } from '@ephox/katamari';
 
 /**
  * This utility class is used for easier inheritance.
@@ -53,7 +54,7 @@ const Class: Class = function () {
 Class.extend = extendClass = function (prop: Prop): ExtendedClass {
   const self = this;
   const _super = self.prototype;
-  let prototype, name, member;
+  let prototype;
 
   // The dummy class constructor
   const Class = function () {
@@ -166,15 +167,13 @@ Class.extend = extendClass = function (prop: Prop): ExtendedClass {
   }
 
   // Copy the properties over onto the new prototype
-  for (name in prop) {
-    member = prop[name];
-
+  Obj.each(prop, (member, name) => {
     if (typeof member === 'function' && _super[name]) {
       prototype[name] = createMethod(name, member);
     } else {
       prototype[name] = member;
     }
-  }
+  });
 
   // Populate our constructed prototype object
   Class.prototype = prototype;

--- a/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
@@ -7,7 +7,7 @@
 
 import { ClipboardEvent, DataTransfer, DragEvent, Event, FocusEvent, KeyboardEvent, MouseEvent, PointerEvent, TouchEvent, WheelEvent } from '@ephox/dom-globals';
 import Tools from './Tools';
-import { Fun } from '@ephox/katamari';
+import { Fun, Obj } from '@ephox/katamari';
 
 // InputEvent is experimental so we don't have an actual type
 // See https://developer.mozilla.org/en-US/docs/Web/API/InputEvent
@@ -282,7 +282,7 @@ class EventDispatcher<T extends NativeEventMap> {
   public off <U = any>(name: string, callback: (event: EditorEvent<U>) => void): this;
   public off (name?: string): this;
   public off(name?: string, callback?: (event: EditorEvent<any>) => void): this {
-    let i, handlers, bindingName, names, hi;
+    let i, handlers, names, hi;
 
     if (name) {
       names = name.toLowerCase().split(' ');
@@ -293,10 +293,10 @@ class EventDispatcher<T extends NativeEventMap> {
 
         // Unbind all handlers
         if (!name) {
-          for (bindingName in this.bindings) {
+          Obj.each(this.bindings, (_value, bindingName) => {
             this.toggleEvent(bindingName, false);
             delete this.bindings[bindingName];
-          }
+          });
 
           return this;
         }
@@ -323,9 +323,9 @@ class EventDispatcher<T extends NativeEventMap> {
         }
       }
     } else {
-      for (name in this.bindings) {
+      Obj.each(this.bindings, (_value, name) => {
         this.toggleEvent(name, false);
-      }
+      });
 
       this.bindings = {};
     }

--- a/modules/tinymce/src/core/test/ts/browser/AddOnManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AddOnManagerTest.ts
@@ -5,6 +5,7 @@ import AddOnManager from 'tinymce/core/api/AddOnManager';
 import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
 import PluginManager from 'tinymce/core/api/PluginManager';
 import I18n from 'tinymce/core/api/util/I18n';
+import { Obj } from '@ephox/katamari';
 
 UnitTest.asynctest('browser.tinymce.core.AddOnManagerTest', (success, failure) => {
   const suite = LegacyUnit.createSuite();
@@ -42,9 +43,9 @@ UnitTest.asynctest('browser.tinymce.core.AddOnManagerTest', (success, failure) =
       proto[name] = originalFuncs[name];
       delete originalFuncs[name];
     } else {
-      for (const key in originalFuncs) {
-        proto[key] = originalFuncs[key];
-      }
+      Obj.each(originalFuncs, (value, key) => {
+        proto[key] = value;
+      });
 
       delete proto.__originalFuncs;
     }

--- a/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
@@ -12,19 +12,18 @@ import Schema from 'tinymce/core/api/html/Schema';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import * as Size from './Size';
 import { MediaData } from './Types';
+import { Obj } from '@ephox/katamari';
 
 const DOM = DOMUtils.DOM;
 
 type AttrList = Array<{ name: string; value: string }> & { map: Record<string, string> };
 
 const setAttributes = function (attrs: AttrList, updatedAttrs: Record<string, any>) {
-  let name;
   let i;
-  let value;
   let attr;
 
-  for (name in updatedAttrs) {
-    value = '' + updatedAttrs[name];
+  Obj.each(updatedAttrs, (value, name) => {
+    value = '' + value;
 
     if (attrs.map[name]) {
       i = attrs.length;
@@ -49,7 +48,7 @@ const setAttributes = function (attrs: AttrList, updatedAttrs: Record<string, an
 
       attrs.map[name] = value;
     }
-  }
+  });
 };
 
 const normalizeHtml = function (html: string): string {

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Data.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Data.ts
@@ -5,30 +5,31 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Obj } from '@ephox/katamari';
+
 export const charMap = {
   '\u00a0': 'nbsp',
   '\u00ad': 'shy'
 };
 
 export const charMapToRegExp = function (charMap, global?) {
-  let key, regExp = '';
+  let regExp = '';
 
-  for (key in charMap) {
+  Obj.each(charMap, (_value, key) => {
     regExp += key;
-  }
+  });
 
   return new RegExp('[' + regExp + ']', global ? 'g' : '');
 };
 
 export const charMapToSelector = function (charMap) {
-  let key, selector = '';
-
-  for (key in charMap) {
+  let selector = '';
+  Obj.each(charMap, (value) => {
     if (selector) {
       selector += ',';
     }
-    selector += 'span.mce-' + charMap[key];
-  }
+    selector += 'span.mce-' + value;
+  });
 
   return selector;
 };


### PR DESCRIPTION
Also enabled lint @typescript-eslint/type-annotation-spacing which I missed in the previous spacing lints PR. It only changes one file.