### PR TITLE
Allow custom UndoManager Class to be passed

### DIFF
--- a/src/core/main/ts/init/InitContentBody.ts
+++ b/src/core/main/ts/init/InitContentBody.ts
@@ -229,7 +229,7 @@ const initContentBody = function (editor: Editor, skipWrite?: boolean) {
   editor.selection = Selection(editor.dom, editor.getWin(), editor.serializer, editor);
   editor.annotator = Annotator(editor);
   editor.formatter = Formatter(editor);
-  editor.undoManager = UndoManager(editor);
+  editor.undoManager = settings.UndoManager ? new settings.UndoManager(editor) : UndoManager(editor);
   editor._nodeChangeDispatcher = new NodeChange(editor);
   editor._selectionOverrides = SelectionOverrides(editor);
 


### PR DESCRIPTION
This allows an app with a TinyMCE instance to override the UndoManager for the purposes of a tighter integration with the apps concept of undo / redo.