### PR TITLE
TINY-4057: Fixed format menu align buttons inconsistently applying to images

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.2.2 (TBD)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
+    Fixed format menu align buttons inconsistently applying to images #TINY-4057
 Version 5.2.1 (2020-03-25)
     Fixed the "is decorative" checkbox in the image dialog clearing after certain dialog events #FOAM-11
     Fixed possible uncaught exception when a `style` attribute is removed using a content filter on `setContent` #TINY-4742

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,6 @@
 Version 5.2.2 (TBD)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
-    Fixed format menu align buttons inconsistently applying to images #TINY-4057
+    Fixed format menu alignment buttons inconsistently applying to images #TINY-4057
 Version 5.2.1 (2020-03-25)
     Fixed the "is decorative" checkbox in the image dialog clearing after certain dialog events #FOAM-11
     Fixed possible uncaught exception when a `style` attribute is removed using a content filter on `setContent` #TINY-4742

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
@@ -1,9 +1,9 @@
 import { Log, Pipeline, Step, ApproxStructure } from '@ephox/agar';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
+import ImagePlugin from 'tinymce/plugins/image/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 type Alignment = 'left' | 'center' | 'right' | 'justify';
 
@@ -70,7 +70,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImageAlignTest', (success, fai
   SilverTheme();
   ImagePlugin();
 
-  TinyLoader.setup(function (editor, onSuccess, onFailure) {
+  TinyLoader.setup((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
     const tinyUi = TinyUi(editor);
 
@@ -87,8 +87,8 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImageAlignTest', (success, fai
       const ariaPressed = isFigure && alignment === 'justify' ? 'false' : 'true';
 
       return Log.stepsAsStep('TINY-4057', 'Verify only one align toolbar button is highlighted', [
-        tinyUi.sWaitForUi(`Check ${ariaLabel} align toolbar button is highlighted`, `button[aria-label="${ariaLabel}"][aria-pressed="${ariaPressed}"]`),
-        ...Arr.map(otherLabels, (label) => tinyUi.sWaitForUi(`Check ${label} align toolbar button is not highlighted`, `button[aria-label="${label}"][aria-pressed="false"]`))
+        tinyUi.sWaitForUi(`Check ${alignment} align toolbar button is highlighted`, `button[aria-label="${ariaLabel}"][aria-pressed="${ariaPressed}"]`),
+        ...Arr.map(otherLabels, (label) => tinyUi.sWaitForUi(`Check ${alignment} align toolbar button is not highlighted`, `button[aria-label="${label}"][aria-pressed="false"]`))
       ]);
     };
 
@@ -100,10 +100,11 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImageAlignTest', (success, fai
         justify: 'Justify'
       };
       const ariaLabel = ariaLabels[alignment];
+
       return Log.stepsAsStep('TINY-4057', `Click ${ariaLabel} align menu button`, [
         tinyUi.sClickOnToolbar(`Open align menu`, `button[aria-label="Align"]`),
         tinyUi.sWaitForUi('Wait for align menu', `div[title="${ariaLabel}"]`),
-        tinyUi.sClickOnUi(`Click ${ariaLabel} align menu button`, `div[title="${ariaLabel}"]`)
+        tinyUi.sClickOnUi(`Click ${alignment} align menu button`, `div[title="${ariaLabel}"]`)
       ]);
     };
 
@@ -115,12 +116,12 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImageAlignTest', (success, fai
         justify: 'Justify'
       };
       const ariaLabel = ariaLabels[alignment];
-      return tinyUi.sClickOnToolbar(`Click ${ariaLabel} align toolbar button`, `button[aria-label="${ariaLabel}"]`);
+      return tinyUi.sClickOnToolbar(`Click ${alignment} align toolbar button`, `button[aria-label="${ariaLabel}"]`);
     };
 
     const sTestConsecutiveAlignments = (label: string, sAlignImage: (alignment: Alignment) => Step<unknown, unknown>, alignments: Alignment[]) => {
       const alignmentSteps = (isFigure: boolean) => Arr.map(alignments, (alignment) => {
-        return Log.stepsAsStep('TINY-4057', `Apply alignment ${alignment} to ${isFigure ? 'figure' : ''} image`, [
+        return Log.stepsAsStep('TINY-4057', `Apply ${alignment} alignment to ${isFigure ? 'figure' : ''} image`, [
           sAlignImage(alignment),
           sCheckToolbarHighlighting(alignment, isFigure),
           tinyApis.sAssertContentStructure(isFigure ? figureImageApproxStructure(alignment) : imageApproxStructure(alignment))
@@ -147,7 +148,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImageAlignTest', (success, fai
         sTestConsecutiveAlignments('Align: right -> center -> right', sAlignImage, ['right', 'center', 'right']),
         sTestConsecutiveAlignments('Align: right -> justify -> right', sAlignImage, ['right', 'justify', 'right']),
         sTestConsecutiveAlignments('Align: center -> justify -> center', sAlignImage, ['center', 'justify', 'center']),
-        sTestConsecutiveAlignments('Align: left -> center -> right -> justify -> right', sAlignImage, ['left', 'center', 'right', 'justify'])
+        sTestConsecutiveAlignments('Align: left -> center -> right -> justify', sAlignImage, ['left', 'center', 'right', 'justify'])
       ]);
 
     Pipeline.async({}, [

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
@@ -1,0 +1,166 @@
+import { Log, Pipeline, Step, ApproxStructure } from '@ephox/agar';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import ImagePlugin from 'tinymce/plugins/image/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Arr, Obj } from '@ephox/katamari';
+
+type Alignment = 'left' | 'center' | 'right' | 'justify';
+
+const figureImageApproxStructure = (alignment: Alignment) => {
+  const alignClasses = (arr) => ({
+    left: arr.has('align-left'),
+    center: arr.has('align-center'),
+    right: arr.has('align-right'),
+    justify: arr.not('align-justify')
+  });
+
+  return ApproxStructure.build((s, str, arr) => {
+    return s.element('body', {
+      children: [
+        s.element('figure', {
+          classes: [
+            arr.has('image'),
+            alignClasses(arr)[alignment]
+          ],
+          children: [
+            s.element('img', {
+              attrs: {
+                src: str.is('image.png'),
+              }
+            }),
+            s.theRest()
+          ]
+        }),
+        s.theRest()
+      ]
+    });
+  });
+};
+
+const imageApproxStructure = (alignment: Alignment) => {
+  const alignStyles = (str) => ({
+    left: { float: str.is('left') },
+    center: { 'display': str.is('block'), 'margin-left': str.is('auto'), 'margin-right': str.is('auto') },
+    right: { float: str.is('right') },
+    justify: {}
+  });
+
+  return ApproxStructure.build((s, str) => {
+    return s.element('body', {
+      children: [
+        s.element('p', {
+          styles: alignment === 'justify' ? { 'text-align': str.is('justify') } : {},
+          children: [
+            s.element('img', {
+              attrs: {
+                src: str.is('image.png'),
+              },
+              styles: alignStyles(str)[alignment]
+            }),
+          ]
+        }),
+        s.theRest()
+      ]
+    });
+  });
+};
+
+UnitTest.asynctest('browser.tinymce.plugins.image.ImageAlignTest', (success, failure) => {
+  SilverTheme();
+  ImagePlugin();
+
+  TinyLoader.setup(function (editor, onSuccess, onFailure) {
+    const tinyApis = TinyApis(editor);
+    const tinyUi = TinyUi(editor);
+
+    const sCheckToolbarHighlighting = (alignment: Alignment, isFigure: boolean) => {
+      const ariaLabels = {
+        left: 'Align left',
+        center: 'Align center',
+        right: 'Align right',
+        justify: 'Justify'
+      };
+      const ariaLabel = ariaLabels[alignment];
+      const otherLabels = Obj.values(Obj.filter(ariaLabels, (_, key) => key !== alignment));
+      // Justify is the default for figures so it never gets highlighted
+      const ariaPressed = isFigure && alignment === 'justify' ? 'false' : 'true';
+
+      return Log.stepsAsStep('TINY-4057', 'Verify only one align toolbar button is highlighted', [
+        tinyUi.sWaitForUi(`Check ${ariaLabel} align toolbar button is highlighted`, `button[aria-label="${ariaLabel}"][aria-pressed="${ariaPressed}"]`),
+        ...Arr.map(otherLabels, (label) => tinyUi.sWaitForUi(`Check ${label} align toolbar button is not highlighted`, `button[aria-label="${label}"][aria-pressed="false"]`))
+      ]);
+    };
+
+    const sApplyAlignmentFromMenu = (alignment: Alignment) => {
+      const ariaLabels = {
+        left: 'Left',
+        center: 'Center',
+        right: 'Right',
+        justify: 'Justify'
+      };
+      const ariaLabel = ariaLabels[alignment];
+      return Log.stepsAsStep('TINY-4057', `Click ${ariaLabel} align menu button`, [
+        tinyUi.sClickOnToolbar(`Open align menu`, `button[aria-label="Align"]`),
+        tinyUi.sWaitForUi('Wait for align menu', `div[title="${ariaLabel}"]`),
+        tinyUi.sClickOnUi(`Click ${ariaLabel} align menu button`, `div[title="${ariaLabel}"]`)
+      ]);
+    };
+
+    const sApplyAlignmentFromToolbar = (alignment: Alignment) => {
+      const ariaLabels = {
+        left: 'Align left',
+        center: 'Align center',
+        right: 'Align right',
+        justify: 'Justify'
+      };
+      const ariaLabel = ariaLabels[alignment];
+      return tinyUi.sClickOnToolbar(`Click ${ariaLabel} align toolbar button`, `button[aria-label="${ariaLabel}"]`);
+    };
+
+    const sTestConsecutiveAlignments = (label: string, sAlignImage: (alignment: Alignment) => Step<unknown, unknown>, alignments: Alignment[]) => {
+      const alignmentSteps = (isFigure: boolean) => Arr.map(alignments, (alignment) => {
+        return Log.stepsAsStep('TINY-4057', `Apply alignment ${alignment} to ${isFigure ? 'figure' : ''} image`, [
+          sAlignImage(alignment),
+          sCheckToolbarHighlighting(alignment, isFigure),
+          tinyApis.sAssertContentStructure(isFigure ? figureImageApproxStructure(alignment) : imageApproxStructure(alignment))
+        ]);
+      });
+
+      return Log.stepsAsStep('TINY-4057', label, [
+        tinyApis.sFocus(),
+        tinyApis.sSetContent('<p><img src="image.png" /></p>'),
+        tinyApis.sSetSelection([0], 0, [0], 1),
+        ...alignmentSteps(false),
+        tinyApis.sFocus(),
+        tinyApis.sSetContent('<figure class="image"><img src="image.png" /><figcaption>Caption</figcaption></figure>'),
+        tinyApis.sSetSelection([], 1, [], 2),
+        ...alignmentSteps(true)
+      ]);
+    };
+
+    const sTestImageAlignment = (alignmentType: 'toolbar' | 'menu', sAlignImage: (alignment: Alignment) => Step<unknown, unknown>) =>
+      Log.stepsAsStep('TINY-4057', `Testing image alignment using the ${alignmentType}`, [
+        sTestConsecutiveAlignments('Align: left -> center -> left', sAlignImage, ['left', 'center', 'left']),
+        sTestConsecutiveAlignments('Align: left -> right -> left', sAlignImage, ['left', 'right', 'left']),
+        sTestConsecutiveAlignments('Align: left -> justify -> left', sAlignImage, ['left', 'justify', 'left']),
+        sTestConsecutiveAlignments('Align: right -> center -> right', sAlignImage, ['right', 'center', 'right']),
+        sTestConsecutiveAlignments('Align: right -> justify -> right', sAlignImage, ['right', 'justify', 'right']),
+        sTestConsecutiveAlignments('Align: center -> justify -> center', sAlignImage, ['center', 'justify', 'center']),
+        sTestConsecutiveAlignments('Align: left -> center -> right -> justify -> right', sAlignImage, ['left', 'center', 'right', 'justify'])
+      ]);
+
+    Pipeline.async({}, [
+      tinyApis.sFocus(),
+      sTestImageAlignment('toolbar', sApplyAlignmentFromToolbar),
+      sTestImageAlignment('menu', sApplyAlignmentFromMenu),
+    ], onSuccess, onFailure);
+  }, {
+    theme: 'silver',
+    plugins: 'image',
+    toolbar: 'image align alignleft aligncenter alignright alignjustify',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    image_caption: true
+  }, success, failure);
+});

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
@@ -10,8 +10,7 @@ import { Arr, Option, Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import { updateMenuIcon } from '../../dropdown/CommonDropdown';
-import { onActionToggleFormat } from './utils/Utils';
-import { createMenuItems, createSelectButton, FormatItem, PreviewSpec, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, FormatItem, PreviewSpec, SelectSpec, FormatterFormatItem } from './BespokeSelect';
 import { buildBasicStaticDataset } from './SelectDatasets';
 import { IsSelectedForType } from './utils/FormatRegister';
 
@@ -21,6 +20,13 @@ const alignMenuItems = [
   { title: 'Right', icon: 'align-right', format: 'alignright' },
   { title: 'Justify', icon: 'align-justify', format: 'alignjustify' }
 ];
+
+const alignCommands = {
+  alignleft: 'JustifyLeft',
+  aligncenter: 'JustifyCenter',
+  alignright: 'JustifyRight',
+  alignjustify: 'JustifyFull'
+};
 
 const getSpec = (editor: Editor): SelectSpec => {
   const getMatchingValue = (): Option<Partial<FormatItem>> => {
@@ -53,7 +59,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     isSelectedFor,
     getCurrentValue: Fun.constant(Option.none()),
     getPreviewFor,
-    onAction: onActionToggleFormat(editor),
+    onAction: (rawItem: FormatterFormatItem) => () => editor.execCommand(alignCommands[rawItem.format]),
     setInitialValue,
     nodeChangeHandler,
     dataset,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
@@ -15,22 +15,15 @@ import { buildBasicStaticDataset } from './SelectDatasets';
 import { IsSelectedForType } from './utils/FormatRegister';
 
 const alignMenuItems = [
-  { title: 'Left', icon: 'align-left', format: 'alignleft'},
-  { title: 'Center', icon: 'align-center', format: 'aligncenter' },
-  { title: 'Right', icon: 'align-right', format: 'alignright' },
-  { title: 'Justify', icon: 'align-justify', format: 'alignjustify' }
+  { title: 'Left', icon: 'align-left', format: 'alignleft', command: 'JustifyLeft' },
+  { title: 'Center', icon: 'align-center', format: 'aligncenter', command: 'JustifyCenter' },
+  { title: 'Right', icon: 'align-right', format: 'alignright', command: 'JustifyRight' },
+  { title: 'Justify', icon: 'align-justify', format: 'alignjustify', command: 'JustifyFull' }
 ];
-
-const alignCommands = {
-  alignleft: 'JustifyLeft',
-  aligncenter: 'JustifyCenter',
-  alignright: 'JustifyRight',
-  alignjustify: 'JustifyFull'
-};
 
 const getSpec = (editor: Editor): SelectSpec => {
   const getMatchingValue = (): Option<Partial<FormatItem>> => {
-    return  Arr.find(alignMenuItems, (item) => editor.formatter.match(item.format));
+    return Arr.find(alignMenuItems, (item) => editor.formatter.match(item.format));
   };
 
   const isSelectedFor: IsSelectedForType = (format: string) => () => editor.formatter.match(format);
@@ -53,13 +46,17 @@ const getSpec = (editor: Editor): SelectSpec => {
 
   const dataset = buildBasicStaticDataset(alignMenuItems);
 
+  const onAction = (rawItem: FormatterFormatItem) => () =>
+    Arr.find(alignMenuItems, (item) => item.format === rawItem.format)
+      .each((item) => editor.execCommand(item.command));
+
   return {
     tooltip: 'Align',
     icon: Option.some('align-left'),
     isSelectedFor,
     getCurrentValue: Fun.constant(Option.none()),
     getPreviewFor,
-    onAction: (rawItem: FormatterFormatItem) => () => editor.execCommand(alignCommands[rawItem.format]),
+    onAction,
     setInitialValue,
     nodeChangeHandler,
     dataset,


### PR DESCRIPTION
The align buttons on the toolbar call a command that removes existing alignments before applying a new alignment. 

This change forces the align menu items to use the commands as well.