### PR TITLE
TINY-4828: Fixed the placeholder not hiding when pasting content into the editor

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -9,7 +9,8 @@ Version 5.3.0 (TBD)
     Fixed issue with loading or pasting contents with large base64 encoded images on Safari #TINY-4715
     Fixed supplementary special characters being truncated when inserted into the editor. Patch contributed by mlitwin. #TINY-4791
     Fixed toolbar buttons not set to disabled when the editor is in readonly mode #TINY-4592
-    Fixed bug where title, width, height would be set to empty string values when updating an image and removing those using the image dialog. #TINY-4786
+    Fixed bug where title, width, height would be set to empty string values when updating an image and removing those using the image dialog #TINY-4786
+    Fixed the placeholder not hiding when pasting content into the editor #TINY-4828
 Version 5.2.2 (TBD)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
 Version 5.2.1 (2020-03-25)

--- a/modules/tinymce/src/core/main/ts/content/Placeholder.ts
+++ b/modules/tinymce/src/core/main/ts/content/Placeholder.ts
@@ -13,6 +13,7 @@ import Editor from '../api/Editor';
 import Env from '../api/Env';
 import * as Events from '../api/Events';
 import * as Settings from '../api/Settings';
+import Delay from '../api/util/Delay';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import VK from '../api/util/VK';
 import * as Empty from '../dom/Empty';
@@ -113,6 +114,10 @@ const setup = (editor: Editor) => {
       // Setup the initial state
       updatePlaceholder(e, true);
       editor.on('change SetContent ExecCommand', updatePlaceholder);
+
+      // TINY-4828: Update the placeholder after pasting content. This needs to use a timeout as
+      // the browser doesn't update the dom until after the paste event has fired
+      editor.on('paste', (e) => Delay.setEditorTimeout(editor, () => updatePlaceholder(e)));
 
       // Remove the placeholder attributes on remove
       editor.on('remove', () => {

--- a/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
@@ -104,6 +104,17 @@ UnitTest.asynctest('webdriver.tinymce.core.content.PlaceholderTest', (success, f
         tinyApi.sExecCommand('InsertOrderedList'),
         sAssertPlaceholderNotExists,
         sAssertCount(1)
+      ]),
+      Log.stepsAsStep('TINY-4828', 'Check placeholder hides when pasting content into the editor', [
+        sSetContent('<p></p>'),
+        sAssertPlaceholderExists,
+        // Note: This fakes a paste event
+        Step.sync(() => {
+          editor.fire('paste');
+          editor.getBody().innerHTML = '<p>Pasted content</p>';
+        }),
+        sAssertPlaceholderNotExists,
+        sAssertCount(1)
       ])
     ].concat(browserSpecificTests), onSuccess, onFailure);
   }, {


### PR DESCRIPTION
This issue has highlighted a larger issue that pasted content when not using the paste/powerpaste plugin doesn't run through the filtering/content parsing logic so I'll be logging an issue to investigate/address that. However that's a much larger issue so this is an interim solution to make sure the placeholder is cleared when pasting content.

Fixes #5561 