### PR TITLE
TINY-4757: Improved merging of text decoration styles with colour styles

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.2.2 (TBD)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
+    Fixed text decorations (underline, strikethrough) not consistently inheriting the text color #TINY-4757
     Fixed format menu alignment buttons inconsistently applying to images #TINY-4057
 Version 5.2.1 (2020-03-25)
     Fixed the "is decorative" checkbox in the image dialog clearing after certain dialog events #FOAM-11

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -297,6 +297,9 @@ const applyFormat = function (ed: Editor, name: string, vars?: FormatVars, node?
         MergeFormats.mergeSubSup(dom, format, vars, node);
         MergeFormats.mergeSiblings(dom, format, vars, node);
       }
+      if (format.styles) {
+        MergeFormats.mergeTextDecorationsAndColor(dom, format, vars, node);
+      }
     });
   };
 
@@ -341,9 +344,9 @@ const applyFormat = function (ed: Editor, name: string, vars?: FormatVars, node?
         bookmark = GetBookmark.getPersistentBookmark(ed.selection, true);
         applyRngStyle(dom, ExpandRange.expandRng(ed, selection.getRng(), formatList), bookmark);
 
-        if (format.styles) {
-          MergeFormats.mergeUnderlineAndColor(dom, format, vars, curSelNode);
-        }
+        // if (format.styles) {
+        //   MergeFormats.mergeUnderlineAndColor(dom, format, vars, curSelNode);
+        // }
 
         selection.moveToBookmark(bookmark);
         FormatUtils.moveStart(dom, selection, selection.getRng());

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -294,11 +294,9 @@ const applyFormat = function (ed: Editor, name: string, vars?: FormatVars, node?
         MergeFormats.mergeWithChildren(ed, formatList, vars, node);
         MergeFormats.mergeWithParents(ed, format, name, vars, node);
         MergeFormats.mergeBackgroundColorAndFontSize(dom, format, vars, node);
+        MergeFormats.mergeTextDecorationsAndColor(dom, format, vars, node);
         MergeFormats.mergeSubSup(dom, format, vars, node);
         MergeFormats.mergeSiblings(dom, format, vars, node);
-      }
-      if (format.styles) {
-        MergeFormats.mergeTextDecorationsAndColor(dom, format, vars, node);
       }
     });
   };
@@ -343,10 +341,6 @@ const applyFormat = function (ed: Editor, name: string, vars?: FormatVars, node?
         ed.selection.setRng(RangeNormalizer.normalize(ed.selection.getRng()));
         bookmark = GetBookmark.getPersistentBookmark(ed.selection, true);
         applyRngStyle(dom, ExpandRange.expandRng(ed, selection.getRng(), formatList), bookmark);
-
-        // if (format.styles) {
-        //   MergeFormats.mergeUnderlineAndColor(dom, format, vars, curSelNode);
-        // }
 
         selection.moveToBookmark(bookmark);
         FormatUtils.moveStart(dom, selection, selection.getRng());

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -123,7 +123,7 @@ const processTextDecorationsAndColor = function (dom: DOMUtils, node: Node) {
 
 const mergeTextDecorationsAndColor = function (dom: DOMUtils, format, vars: FormatVars, node: Node) {
   // Colored nodes should be underlined so that the color of the underline matches the text color.
-  if (format.styles.color || format.styles.textDecoration) {
+  if (format.styles && (format.styles.color || format.styles.textDecoration)) {
     Tools.walk(node, Fun.curry(processTextDecorationsAndColor, dom), 'childNodes');
     processTextDecorationsAndColor(dom, node);
   }

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -111,9 +111,8 @@ const unwrapEmptySpan = function (dom: DOMUtils, node: Node) {
 };
 
 const processTextDecorationsAndColor = function (dom: DOMUtils, node: Node) {
-  let textDecoration;
   if (node.nodeType === 1 && node.parentNode && node.parentNode.nodeType === 1) {
-    textDecoration = FormatUtils.getTextDecoration(dom, node.parentNode);
+    const textDecoration = FormatUtils.getTextDecoration(dom, node.parentNode);
     if (dom.getStyle(node, 'color') && textDecoration) {
       dom.setStyle(node, 'text-decoration', textDecoration);
     } else if (dom.getStyle(node, 'text-decoration') === textDecoration) {

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -110,7 +110,7 @@ const unwrapEmptySpan = function (dom: DOMUtils, node: Node) {
   }
 };
 
-const processUnderlineAndColor = function (dom: DOMUtils, node: Node) {
+const processTextDecorationsAndColor = function (dom: DOMUtils, node: Node) {
   let textDecoration;
   if (node.nodeType === 1 && node.parentNode && node.parentNode.nodeType === 1) {
     textDecoration = FormatUtils.getTextDecoration(dom, node.parentNode);
@@ -122,11 +122,11 @@ const processUnderlineAndColor = function (dom: DOMUtils, node: Node) {
   }
 };
 
-const mergeUnderlineAndColor = function (dom: DOMUtils, format, vars: FormatVars, node: Node) {
+const mergeTextDecorationsAndColor = function (dom: DOMUtils, format, vars: FormatVars, node: Node) {
   // Colored nodes should be underlined so that the color of the underline matches the text color.
   if (format.styles.color || format.styles.textDecoration) {
-    Tools.walk(node, Fun.curry(processUnderlineAndColor, dom), 'childNodes');
-    processUnderlineAndColor(dom, node);
+    Tools.walk(node, Fun.curry(processTextDecorationsAndColor, dom), 'childNodes');
+    processTextDecorationsAndColor(dom, node);
   }
 };
 
@@ -212,7 +212,7 @@ const mergeWithParents = function (editor: Editor, format, name: string, vars: F
 
 export {
   mergeWithChildren,
-  mergeUnderlineAndColor,
+  mergeTextDecorationsAndColor,
   mergeBackgroundColorAndFontSize,
   mergeSubSup,
   mergeSiblings,

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -31,8 +31,6 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
 
     const toggleInlineStyle = (style: string) => tinyUi.sClickOnToolbar(`click ${style}`, `[aria-label="${style}"]`);
 
-
-
     const sAssertEditorContent = (content: string) => {
       const contentStructure = ApproxStructure.build((s, str, arr) => {
         return s.element('body', {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -34,75 +34,78 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', function 
 
     type Selection = {startPath: number[], sOffset: number, finishPath: number[], fOffset: number};
 
-    const sMergeForecolorAndTextDecoration = (toolbarLabel: string, textDecoration: string, selectedText: string, restText: string, selection: Selection) =>
-      Log.stepsAsStep('', `Merge forecolor and ${toolbarLabel} with text: ${selectedText + restText}`, [
+    const sMergeForecolorAndTextDecoration = (toolbarLabel: string, textDecoration: string, text: {bText: string, mText: string, aText: string}, selection: Selection) =>
+      Log.stepsAsStep('', `Merge forecolor and ${toolbarLabel} with text: ${text.bText + text.mText + text.aText}`, [
         Log.stepsAsStep('TBA', 'Apply forecolor then text-decoration then unapply them', [
-          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sSetContent(`<p>${text.bText + text.mText + text.aText}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           applyForecolor(),
-          tinyApis.sAssertContent(`<p><span style="color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span style="color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p><span style="text-decoration: ${textDecoration};"><span style="color: #bfedd2; text-decoration: ${textDecoration};">${selectedText}</span></span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span style="text-decoration: ${textDecoration};"><span style="color: #bfedd2; text-decoration: ${textDecoration};">${text.mText}</span></span>${text.aText}</p>`),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p><span style="color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span style="color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText + text.mText + text.aText}</p>`),
         ]),
         Log.stepsAsStep('TBA', 'Apply text-decoration then forecolor then unapply them', [
-          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sSetContent(`<p>${text.bText + text.mText + text.aText}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p><span style="text-decoration: ${textDecoration};">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span style="text-decoration: ${textDecoration};">${text.mText}</span>${text.aText}</p>`),
           applyForecolor(),
           // This is different to above - need to investigate this
           // Probably should use Structure builder
-          tinyApis.sAssertContent(`<p><span style="text-decoration: ${textDecoration}; color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span style="text-decoration: ${textDecoration}; color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p><span style="text-decoration: ${textDecoration};">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span style="text-decoration: ${textDecoration};">${text.mText}</span>${text.aText}</p>`),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText + text.mText + text.aText}</p>`),
         ]),
         Log.stepsAsStep('TBA', 'Apply forecolor and custom format then unapply them', [
-          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sSetContent(`<p>${text.bText + text.mText + text.aText}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           applyForecolor(),
-          tinyApis.sAssertContent(`<p><span style="color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span style="color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
           applyCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p><span class="abc" style="color: #bfedd2; text-decoration: underline;">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span class="abc" style="color: #bfedd2; text-decoration: underline;">${text.mText}</span>${text.aText}</p>`),
           removeCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p><span style="color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span style="color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
           removeForecolor(),
-          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText + text.mText + text.aText}</p>`),
         ]),
         // Apply custom format then forecolor
         Log.stepsAsStep('TBA', 'Apply custom format and forecolor then unapply them', [
-          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sSetContent(`<p>${text.bText + text.mText + text.aText}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           applyCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p><span class="abc" style="text-decoration: underline;">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span class="abc" style="text-decoration: underline;">${text.mText}</span>${text.aText}</p>`),
           applyForecolor(),
-          tinyApis.sAssertContent(`<p><span class="abc" style="text-decoration: underline; color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span class="abc" style="text-decoration: underline; color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p><span class="abc" style="text-decoration: underline;">${selectedText}</span>${restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText}<span class="abc" style="text-decoration: underline;">${text.mText}</span>${text.aText}</p>`),
           removeCustomFormat('custom_format'),
-          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.bText + text.mText + text.aText}</p>`),
         ]),
       ]);
 
     Pipeline.async({}, [
       // Collapsed selections
-      sMergeForecolorAndTextDecoration('Underline', 'underline', 'abc', '', {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
-      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', 'abc', '', {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
+      sMergeForecolorAndTextDecoration('Underline', 'underline', {bText: '', mText: 'abc', aText: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
+      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', {bText: '', mText: 'abc', aText: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
       // Ranged selections (single word)
-      sMergeForecolorAndTextDecoration('Underline', 'underline', 'abc', ' def', {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
-      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', 'abc', ' def', {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
+      sMergeForecolorAndTextDecoration('Underline', 'underline', {bText: '', mText: 'abc', aText: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
+      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', {bText: '', mText: 'abc', aText: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
+      // Ranged selections (part of word)
+      sMergeForecolorAndTextDecoration('Underline', 'underline', {bText: 'a', mText: 'b', aText: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
+      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', {bText: 'a', mText: 'b', aText: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
       // Ranged selections (multiple words)
-      sMergeForecolorAndTextDecoration('Underline', 'underline', 'abc def', '', {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
-      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', 'abc def', '', {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
+      sMergeForecolorAndTextDecoration('Underline', 'underline', {bText: '', mText: 'abc def', aText: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
+      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', {bText: '', mText: 'abc def', aText: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
     ], onSuccess, onFailure);
   }, {
     plugins: '',

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -115,7 +115,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
     plugins: '',
     toolbar: 'forecolor backcolor | bold italic underline strikethrough',
     formats: {
-      custom_format: { inline: 'span', classes: 'abc', styles: { 'text-decoration': 'underline' } }
+      custom_format: { inline: 'span', classes: 'abc', styles: { textDecoration: 'underline' } }
     },
     base_url: '/project/tinymce/js/tinymce'
   }, success, failure);

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -17,13 +17,13 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
 
     const textColorHex = '#bfedd2';
 
-    const applyForecolor = () => Log.stepsAsStep('TBA', 'Apply forecolor to text', [
+    const applyForecolor = () => Log.stepsAsStep('TINY-4757', 'Apply forecolor to text', [
       tinyUi.sClickOnToolbar('click forecolor', '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron'),
       tinyUi.sWaitForUi('wait for color swatch to open', '.tox-swatches'),
       tinyUi.sClickOnUi('click color', `div[data-mce-color="${textColorHex.toUpperCase()}"]`)
     ]);
 
-    const removeForecolor = () => Log.stepsAsStep('TBA', 'Remove forecolor from text', [
+    const removeForecolor = () => Log.stepsAsStep('TINY-4757', 'Remove forecolor from text', [
       tinyUi.sClickOnToolbar('click forecolor', '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron'),
       tinyUi.sWaitForUi('wait for color swatch to open', '.tox-swatches'),
       tinyUi.sClickOnUi('click remove color', '.tox-swatch--remove'),
@@ -51,8 +51,8 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
       const startText = `<p>${text.before + text.selected + text.after}</p>`;
       const sSelectText = () => tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset);
 
-      return Log.stepsAsStep('TBA', `Merge forecolor and ${toolbarLabel} with text: ${text.before + text.selected + text.after}`, [
-        Log.stepsAsStep('TBA', 'Apply forecolor then text-decoration then unapply them', [
+      return Log.stepsAsStep('TINY-4757', `Merge forecolor and ${toolbarLabel} with text: ${text.before + text.selected + text.after}`, [
+        Log.stepsAsStep('TINY-4757', 'Apply forecolor then text-decoration then unapply them', [
           tinyApis.sSetContent(startText),
           tinyApis.sFocus(),
           sSelectText(),
@@ -66,7 +66,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
           removeForecolor(),
           sAssertEditorContent(startText),
         ]),
-        Log.stepsAsStep('TBA', 'Apply text-decoration then forecolor then unapply them', [
+        Log.stepsAsStep('TINY-4757', 'Apply text-decoration then forecolor then unapply them', [
           tinyApis.sSetContent(startText),
           tinyApis.sFocus(),
           sSelectText(),
@@ -79,7 +79,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
           toggleInlineStyle(toolbarLabel),
           sAssertEditorContent(startText),
         ]),
-        Log.stepsAsStep('TBA', 'Apply bold, forecolor then text-decoration then unapply them', [
+        Log.stepsAsStep('TINY-4757', 'Apply bold, forecolor then text-decoration then unapply them', [
           tinyApis.sSetContent(startText),
           tinyApis.sFocus(),
           sSelectText(),
@@ -97,7 +97,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
           toggleInlineStyle('Bold'),
           sAssertEditorContent(startText),
         ]),
-        Log.stepsAsStep('TBA', 'Apply bold, text-decoration then forecolor then unapply them', [
+        Log.stepsAsStep('TINY-4757', 'Apply bold, text-decoration then forecolor then unapply them', [
           tinyApis.sSetContent(startText),
           tinyApis.sFocus(),
           sSelectText(),
@@ -121,8 +121,8 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
       const startText = `<p>${text.before + text.selected + text.after}</p>`;
       const sSelectText = () => tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset);
 
-      return Log.stepsAsStep('TBA', `Merge forecolor and text decorations with text: ${text.before + text.selected + text.after}`, [
-        Log.stepsAsStep('TBA', 'Apply forecolor and custom format then unapply them', [
+      return Log.stepsAsStep('TINY-4757', `Merge forecolor and text decorations with text: ${text.before + text.selected + text.after}`, [
+        Log.stepsAsStep('TINY-4757', 'Apply forecolor and custom format then unapply them', [
           tinyApis.sSetContent(startText),
           tinyApis.sFocus(),
           sSelectText(),
@@ -135,7 +135,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
           removeForecolor(),
           sAssertEditorContent(startText),
         ]),
-        Log.stepsAsStep('TBA', 'Apply custom format and forecolor then unapply them', [
+        Log.stepsAsStep('TINY-4757', 'Apply custom format and forecolor then unapply them', [
           tinyApis.sSetContent(startText),
           tinyApis.sFocus(),
           sSelectText(),
@@ -152,7 +152,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
     };
 
     const sTestMergeForecolorAndTextDecoration = (label: string, text: Text, selection: Selection) =>
-      Log.stepsAsStep('TBA', label, [
+      Log.stepsAsStep('TINY-4757', label, [
         sMergeForecolorAndTextDecoration('Underline', 'underline', text, selection),
         sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', text, selection),
         sMergeForecolorAndTextDecorations(text, selection)

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -34,7 +34,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', function 
 
     type Selection = {startPath: number[], sOffset: number, finishPath: number[], fOffset: number};
 
-    const sMergeForecolorAndTextDecoration = (toolbarLabel: string, textDecoration: string, text: {bText: string, mText: string, aText: string}, selection: Selection) =>
+    const sMergeForecolorAndTextDecoration = (toolbarLabel: string, textDecoration: string) => (text: {bText: string, mText: string, aText: string}, selection: Selection) =>
       Log.stepsAsStep('', `Merge forecolor and ${toolbarLabel} with text: ${text.bText + text.mText + text.aText}`, [
         Log.stepsAsStep('TBA', 'Apply forecolor then text-decoration then unapply them', [
           tinyApis.sSetContent(`<p>${text.bText + text.mText + text.aText}</p>`),
@@ -93,19 +93,22 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', function 
         ]),
       ]);
 
+    const sMergeForecolorAndUnderline = sMergeForecolorAndTextDecoration('Underline', 'underline');
+    const sMergeForecolorAndStrikethrough = sMergeForecolorAndTextDecoration('Strikethrough', 'line-through');
+
     Pipeline.async({}, [
       // Collapsed selections
-      sMergeForecolorAndTextDecoration('Underline', 'underline', {bText: '', mText: 'abc', aText: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
-      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', {bText: '', mText: 'abc', aText: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
+      sMergeForecolorAndUnderline({bText: '', mText: 'abc', aText: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
+      sMergeForecolorAndStrikethrough({bText: '', mText: 'abc', aText: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
       // Ranged selections (single word)
-      sMergeForecolorAndTextDecoration('Underline', 'underline', {bText: '', mText: 'abc', aText: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
-      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', {bText: '', mText: 'abc', aText: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
+      sMergeForecolorAndUnderline({bText: '', mText: 'abc', aText: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
+      sMergeForecolorAndStrikethrough({bText: '', mText: 'abc', aText: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
       // Ranged selections (part of word)
-      sMergeForecolorAndTextDecoration('Underline', 'underline', {bText: 'a', mText: 'b', aText: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
-      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', {bText: 'a', mText: 'b', aText: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
+      sMergeForecolorAndUnderline({bText: 'a', mText: 'b', aText: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
+      sMergeForecolorAndStrikethrough({bText: 'a', mText: 'b', aText: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
       // Ranged selections (multiple words)
-      sMergeForecolorAndTextDecoration('Underline', 'underline', {bText: '', mText: 'abc def', aText: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
-      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', {bText: '', mText: 'abc def', aText: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
+      sMergeForecolorAndUnderline({bText: '', mText: 'abc def', aText: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
+      sMergeForecolorAndStrikethrough({bText: '', mText: 'abc def', aText: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
     ], onSuccess, onFailure);
   }, {
     plugins: '',

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -1,11 +1,11 @@
-import { Pipeline, Log, Step } from '@ephox/agar';
+import { Pipeline, Log, Step, ApproxStructure } from '@ephox/agar';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import { UnitTest } from '@ephox/bedrock-client';
 import Theme from 'tinymce/themes/silver/Theme';
 import Editor from 'tinymce/core/api/Editor';
 
-type Selection = {startPath: number[], sOffset: number, finishPath: number[], fOffset: number};
-type Text = {before: string, selected: string, after: string};
+type Selection = { startPath: number[], sOffset: number, finishPath: number[], fOffset: number };
+type Text = { before: string, selected: string, after: string };
 
 UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success, failure) => {
   Theme();
@@ -31,80 +31,87 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success,
 
     const toggleInlineStyle = (style: string) => tinyUi.sClickOnToolbar(`click ${style}`, `[aria-label="${style}"]`);
 
-    const sMergeForecolorAndTextDecoration = (toolbarLabel: string, textDecoration: string) => (text: Text, selection: Selection) =>
+
+
+    const sAssertEditorContent = (content: string) => {
+      const contentStructure = ApproxStructure.build((s, str, arr) => {
+        return s.element('body', {
+          children: [
+            ApproxStructure.fromHtml(content)
+          ]
+        });
+      });
+      return tinyApis.sAssertContentStructure(contentStructure);
+    };
+
+    const sMergeForecolorAndTextDecoration = (toolbarLabel: string, textDecoration: string, text: Text, selection: Selection) =>
       Log.stepsAsStep('TBA', `Merge forecolor and ${toolbarLabel} with text: ${text.before + text.selected + text.after}`, [
         Log.stepsAsStep('TBA', 'Apply forecolor then text-decoration then unapply them', [
           tinyApis.sSetContent(`<p>${text.before + text.selected + text.after}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           applyForecolor(),
-          tinyApis.sAssertContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p>${text.before}<span style="text-decoration: ${textDecoration};"><span style="color: #bfedd2; text-decoration: ${textDecoration};">${text.selected}</span></span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span style="text-decoration: ${textDecoration};"><span style="color: #bfedd2; text-decoration: ${textDecoration};">${text.selected}</span></span>${text.after}</p>`),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p>${text.before + text.selected + text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before + text.selected + text.after}</p>`),
         ]),
         Log.stepsAsStep('TBA', 'Apply text-decoration then forecolor then unapply them', [
           tinyApis.sSetContent(`<p>${text.before + text.selected + text.after}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p>${text.before}<span style="text-decoration: ${textDecoration};">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span style="text-decoration: ${textDecoration};">${text.selected}</span>${text.after}</p>`),
           applyForecolor(),
           // This is different to above - need to investigate this
-          tinyApis.sAssertContent(`<p>${text.before}<span style="text-decoration: ${textDecoration}; color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span style="text-decoration: ${textDecoration}; color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p>${text.before}<span style="text-decoration: ${textDecoration};">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span style="text-decoration: ${textDecoration};">${text.selected}</span>${text.after}</p>`),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p>${text.before + text.selected + text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before + text.selected + text.after}</p>`),
         ]),
         Log.stepsAsStep('TBA', 'Apply forecolor and custom format then unapply them', [
           tinyApis.sSetContent(`<p>${text.before + text.selected + text.after}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           applyForecolor(),
-          tinyApis.sAssertContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           applyCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p>${text.before}<span class="abc" style="color: #bfedd2; text-decoration: underline;">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span class="abc" style="color: #bfedd2; text-decoration: underline;">${text.selected}</span>${text.after}</p>`),
           removeCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p>${text.before + text.selected + text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before + text.selected + text.after}</p>`),
         ]),
-        // Apply custom format then forecolor
         Log.stepsAsStep('TBA', 'Apply custom format and forecolor then unapply them', [
           tinyApis.sSetContent(`<p>${text.before + text.selected + text.after}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           applyCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p>${text.before}<span class="abc" style="text-decoration: underline;">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span class="abc" style="text-decoration: underline;">${text.selected}</span>${text.after}</p>`),
           applyForecolor(),
-          tinyApis.sAssertContent(`<p>${text.before}<span class="abc" style="text-decoration: underline; color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span class="abc" style="text-decoration: underline; color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p>${text.before}<span class="abc" style="text-decoration: underline;">${text.selected}</span>${text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before}<span class="abc" style="text-decoration: underline;">${text.selected}</span>${text.after}</p>`),
           removeCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p>${text.before + text.selected + text.after}</p>`),
+          sAssertEditorContent(`<p>${text.before + text.selected + text.after}</p>`),
         ]),
       ]);
 
-    const sMergeForecolorAndUnderline = sMergeForecolorAndTextDecoration('Underline', 'underline');
-    const sMergeForecolorAndStrikethrough = sMergeForecolorAndTextDecoration('Strikethrough', 'line-through');
+    const sTestMergeForecolorAndTextDecoration = (label: string, text: Text, selection: Selection) =>
+      Log.stepsAsStep('TBA', label, [
+        sMergeForecolorAndTextDecoration('Underline', 'underline', text, selection),
+        sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', text, selection),
+      ]);
 
     Pipeline.async({}, [
-      // Collapsed selections
-      sMergeForecolorAndUnderline({before: '', selected: 'abc', after: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
-      sMergeForecolorAndStrikethrough({before: '', selected: 'abc', after: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
-      // Ranged selections (single word)
-      sMergeForecolorAndUnderline({before: '', selected: 'abc', after: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
-      sMergeForecolorAndStrikethrough({before: '', selected: 'abc', after: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
-      // Ranged selections (part of word)
-      sMergeForecolorAndUnderline({before: 'a', selected: 'b', after: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
-      sMergeForecolorAndStrikethrough({before: 'a', selected: 'b', after: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
-      // Ranged selections (multiple words)
-      sMergeForecolorAndUnderline({before: '', selected: 'abc def', after: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
-      sMergeForecolorAndStrikethrough({before: '', selected: 'abc def', after: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
+      sTestMergeForecolorAndTextDecoration('Collpased selection', { before: '', selected: 'abc', after: '' }, { startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1 }),
+      sTestMergeForecolorAndTextDecoration('Ranged selection: whole word', { before: '', selected: 'abc', after: ' def' }, { startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length }),
+      sTestMergeForecolorAndTextDecoration('Ranged selection: part of word', { before: 'a', selected: 'b', after: 'c def' }, { startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2 }),
+      sTestMergeForecolorAndTextDecoration('Ranged selection: multiple words', { before: '', selected: 'abc def', after: '' }, { startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length }),
     ], onSuccess, onFailure);
   }, {
     plugins: '',

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -1,0 +1,115 @@
+import { Pipeline, Log, Step } from '@ephox/agar';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import Theme from 'tinymce/themes/silver/Theme';
+import { UnitTest } from '@ephox/bedrock-client';
+import Editor from 'tinymce/core/api/Editor';
+
+UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', function (success, failure) {
+
+  Theme();
+
+  // TODO: Add test step for custom formatter
+  // TODO: Need tests for ranged selections including over multiple words
+
+  TinyLoader.setupLight(function (editor: Editor, onSuccess, onFailure) {
+    const tinyApis = TinyApis(editor);
+    const tinyUi = TinyUi(editor);
+
+    const applyForecolor = () => Log.stepsAsStep('TBA', 'Apply forecolor to text', [
+      tinyUi.sClickOnToolbar('click forecolor', '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron'),
+      tinyUi.sWaitForUi('wait for color swatch to open', '.tox-swatches'),
+      tinyUi.sClickOnUi('click color', 'div[data-mce-color="#BFEDD2"]')
+    ]);
+
+    const removeForecolor = () => Log.stepsAsStep('TBA', 'Apply forecolor to text', [
+      tinyUi.sClickOnToolbar('click forecolor', '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron'),
+      tinyUi.sWaitForUi('wait for color swatch to open', '.tox-swatches'),
+      tinyUi.sClickOnUi('click remove color', '.tox-swatch--remove'),
+    ]);
+
+    const applyCustomFormat = (format: string) => Step.sync(() => editor.formatter.apply(format));
+    const removeCustomFormat = (format: string) => Step.sync(() => editor.formatter.remove(format));
+
+    const toggleInlineStyle = (style: string) => tinyUi.sClickOnToolbar(`click ${style}`, `[aria-label="${style}"]`);
+
+    type Selection = {startPath: number[], sOffset: number, finishPath: number[], fOffset: number};
+
+    const sMergeForecolorAndTextDecoration = (toolbarLabel: string, textDecoration: string, selectedText: string, restText: string, selection: Selection) =>
+      Log.stepsAsStep('', `Merge forecolor and ${toolbarLabel} with text: ${selectedText + restText}`, [
+        Log.stepsAsStep('TBA', 'Apply forecolor then text-decoration then unapply them', [
+          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sFocus(),
+          tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
+          applyForecolor(),
+          tinyApis.sAssertContent(`<p><span style="color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          toggleInlineStyle(toolbarLabel),
+          tinyApis.sAssertContent(`<p><span style="text-decoration: ${textDecoration};"><span style="color: #bfedd2; text-decoration: ${textDecoration};">${selectedText}</span></span>${restText}</p>`),
+          toggleInlineStyle(toolbarLabel),
+          tinyApis.sAssertContent(`<p><span style="color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          removeForecolor(),
+          tinyApis.sAssertContent(`<p>${selectedText + restText}</p>`),
+        ]),
+        Log.stepsAsStep('TBA', 'Apply text-decoration then forecolor then unapply them', [
+          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sFocus(),
+          tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
+          toggleInlineStyle(toolbarLabel),
+          tinyApis.sAssertContent(`<p><span style="text-decoration: ${textDecoration};">${selectedText}</span>${restText}</p>`),
+          applyForecolor(),
+          // This is different to above - need to investigate this
+          // Probably should use Structure builder
+          tinyApis.sAssertContent(`<p><span style="text-decoration: ${textDecoration}; color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          removeForecolor(),
+          tinyApis.sAssertContent(`<p><span style="text-decoration: ${textDecoration};">${selectedText}</span>${restText}</p>`),
+          toggleInlineStyle(toolbarLabel),
+          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+        ]),
+        Log.stepsAsStep('TBA', 'Apply forecolor and custom format then unapply them', [
+          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sFocus(),
+          tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
+          applyForecolor(),
+          tinyApis.sAssertContent(`<p><span style="color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          applyCustomFormat('custom_format'),
+          tinyApis.sAssertContent(`<p><span class="abc" style="color: #bfedd2; text-decoration: underline;">${selectedText}</span>${restText}</p>`),
+          removeCustomFormat('custom_format'),
+          tinyApis.sAssertContent(`<p><span style="color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          removeForecolor(),
+          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+        ]),
+        // Apply custom format then forecolor
+        Log.stepsAsStep('TBA', 'Apply custom format and forecolor then unapply them', [
+          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+          tinyApis.sFocus(),
+          tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
+          applyCustomFormat('custom_format'),
+          tinyApis.sAssertContent(`<p><span class="abc" style="text-decoration: underline;">${selectedText}</span>${restText}</p>`),
+          applyForecolor(),
+          tinyApis.sAssertContent(`<p><span class="abc" style="text-decoration: underline; color: #bfedd2;">${selectedText}</span>${restText}</p>`),
+          removeForecolor(),
+          tinyApis.sAssertContent(`<p><span class="abc" style="text-decoration: underline;">${selectedText}</span>${restText}</p>`),
+          removeCustomFormat('custom_format'),
+          tinyApis.sSetContent(`<p>${selectedText + restText}</p>`),
+        ]),
+      ]);
+
+    Pipeline.async({}, [
+      // Collapsed selections
+      sMergeForecolorAndTextDecoration('Underline', 'underline', 'abc', '', {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
+      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', 'abc', '', {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
+      // Ranged selections (single word)
+      sMergeForecolorAndTextDecoration('Underline', 'underline', 'abc', ' def', {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
+      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', 'abc', ' def', {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
+      // Ranged selections (multiple words)
+      sMergeForecolorAndTextDecoration('Underline', 'underline', 'abc def', '', {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
+      sMergeForecolorAndTextDecoration('Strikethrough', 'line-through', 'abc def', '', {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
+    ], onSuccess, onFailure);
+  }, {
+    plugins: '',
+    toolbar: 'forecolor backcolor | bold italic underline strikethrough',
+    formats: {
+      custom_format: { inline: 'span', classes: 'abc', styles: { 'text-decoration': 'underline' } }
+    },
+    base_url: '/project/tinymce/js/tinymce'
+  }, success, failure);
+});

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -1,17 +1,16 @@
 import { Pipeline, Log, Step } from '@ephox/agar';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import Theme from 'tinymce/themes/silver/Theme';
 import { UnitTest } from '@ephox/bedrock-client';
+import Theme from 'tinymce/themes/silver/Theme';
 import Editor from 'tinymce/core/api/Editor';
 
-UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', function (success, failure) {
+type Selection = {startPath: number[], sOffset: number, finishPath: number[], fOffset: number};
+type Text = {before: string, selected: string, after: string};
 
+UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', (success, failure) => {
   Theme();
 
-  // TODO: Add test step for custom formatter
-  // TODO: Need tests for ranged selections including over multiple words
-
-  TinyLoader.setupLight(function (editor: Editor, onSuccess, onFailure) {
+  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
     const tinyUi = TinyUi(editor);
 
@@ -32,64 +31,61 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', function 
 
     const toggleInlineStyle = (style: string) => tinyUi.sClickOnToolbar(`click ${style}`, `[aria-label="${style}"]`);
 
-    type Selection = {startPath: number[], sOffset: number, finishPath: number[], fOffset: number};
-
-    const sMergeForecolorAndTextDecoration = (toolbarLabel: string, textDecoration: string) => (text: {bText: string, mText: string, aText: string}, selection: Selection) =>
-      Log.stepsAsStep('', `Merge forecolor and ${toolbarLabel} with text: ${text.bText + text.mText + text.aText}`, [
+    const sMergeForecolorAndTextDecoration = (toolbarLabel: string, textDecoration: string) => (text: Text, selection: Selection) =>
+      Log.stepsAsStep('TBA', `Merge forecolor and ${toolbarLabel} with text: ${text.before + text.selected + text.after}`, [
         Log.stepsAsStep('TBA', 'Apply forecolor then text-decoration then unapply them', [
-          tinyApis.sSetContent(`<p>${text.bText + text.mText + text.aText}</p>`),
+          tinyApis.sSetContent(`<p>${text.before + text.selected + text.after}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           applyForecolor(),
-          tinyApis.sAssertContent(`<p>${text.bText}<span style="color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p>${text.bText}<span style="text-decoration: ${textDecoration};"><span style="color: #bfedd2; text-decoration: ${textDecoration};">${text.mText}</span></span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span style="text-decoration: ${textDecoration};"><span style="color: #bfedd2; text-decoration: ${textDecoration};">${text.selected}</span></span>${text.after}</p>`),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p>${text.bText}<span style="color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p>${text.bText + text.mText + text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before + text.selected + text.after}</p>`),
         ]),
         Log.stepsAsStep('TBA', 'Apply text-decoration then forecolor then unapply them', [
-          tinyApis.sSetContent(`<p>${text.bText + text.mText + text.aText}</p>`),
+          tinyApis.sSetContent(`<p>${text.before + text.selected + text.after}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p>${text.bText}<span style="text-decoration: ${textDecoration};">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span style="text-decoration: ${textDecoration};">${text.selected}</span>${text.after}</p>`),
           applyForecolor(),
           // This is different to above - need to investigate this
-          // Probably should use Structure builder
-          tinyApis.sAssertContent(`<p>${text.bText}<span style="text-decoration: ${textDecoration}; color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span style="text-decoration: ${textDecoration}; color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p>${text.bText}<span style="text-decoration: ${textDecoration};">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span style="text-decoration: ${textDecoration};">${text.selected}</span>${text.after}</p>`),
           toggleInlineStyle(toolbarLabel),
-          tinyApis.sAssertContent(`<p>${text.bText + text.mText + text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before + text.selected + text.after}</p>`),
         ]),
         Log.stepsAsStep('TBA', 'Apply forecolor and custom format then unapply them', [
-          tinyApis.sSetContent(`<p>${text.bText + text.mText + text.aText}</p>`),
+          tinyApis.sSetContent(`<p>${text.before + text.selected + text.after}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           applyForecolor(),
-          tinyApis.sAssertContent(`<p>${text.bText}<span style="color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           applyCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p>${text.bText}<span class="abc" style="color: #bfedd2; text-decoration: underline;">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span class="abc" style="color: #bfedd2; text-decoration: underline;">${text.selected}</span>${text.after}</p>`),
           removeCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p>${text.bText}<span style="color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span style="color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p>${text.bText + text.mText + text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before + text.selected + text.after}</p>`),
         ]),
         // Apply custom format then forecolor
         Log.stepsAsStep('TBA', 'Apply custom format and forecolor then unapply them', [
-          tinyApis.sSetContent(`<p>${text.bText + text.mText + text.aText}</p>`),
+          tinyApis.sSetContent(`<p>${text.before + text.selected + text.after}</p>`),
           tinyApis.sFocus(),
           tinyApis.sSetSelection(selection.startPath, selection.sOffset, selection.finishPath, selection.fOffset),
           applyCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p>${text.bText}<span class="abc" style="text-decoration: underline;">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span class="abc" style="text-decoration: underline;">${text.selected}</span>${text.after}</p>`),
           applyForecolor(),
-          tinyApis.sAssertContent(`<p>${text.bText}<span class="abc" style="text-decoration: underline; color: #bfedd2;">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span class="abc" style="text-decoration: underline; color: #bfedd2;">${text.selected}</span>${text.after}</p>`),
           removeForecolor(),
-          tinyApis.sAssertContent(`<p>${text.bText}<span class="abc" style="text-decoration: underline;">${text.mText}</span>${text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before}<span class="abc" style="text-decoration: underline;">${text.selected}</span>${text.after}</p>`),
           removeCustomFormat('custom_format'),
-          tinyApis.sAssertContent(`<p>${text.bText + text.mText + text.aText}</p>`),
+          tinyApis.sAssertContent(`<p>${text.before + text.selected + text.after}</p>`),
         ]),
       ]);
 
@@ -98,17 +94,17 @@ UnitTest.asynctest('browser.tinymce.core.fmt.TextDecorationColorTest', function 
 
     Pipeline.async({}, [
       // Collapsed selections
-      sMergeForecolorAndUnderline({bText: '', mText: 'abc', aText: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
-      sMergeForecolorAndStrikethrough({bText: '', mText: 'abc', aText: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
+      sMergeForecolorAndUnderline({before: '', selected: 'abc', after: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
+      sMergeForecolorAndStrikethrough({before: '', selected: 'abc', after: ''}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 1}),
       // Ranged selections (single word)
-      sMergeForecolorAndUnderline({bText: '', mText: 'abc', aText: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
-      sMergeForecolorAndStrikethrough({bText: '', mText: 'abc', aText: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
+      sMergeForecolorAndUnderline({before: '', selected: 'abc', after: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
+      sMergeForecolorAndStrikethrough({before: '', selected: 'abc', after: ' def'}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc'.length}),
       // Ranged selections (part of word)
-      sMergeForecolorAndUnderline({bText: 'a', mText: 'b', aText: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
-      sMergeForecolorAndStrikethrough({bText: 'a', mText: 'b', aText: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
+      sMergeForecolorAndUnderline({before: 'a', selected: 'b', after: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
+      sMergeForecolorAndStrikethrough({before: 'a', selected: 'b', after: 'c def'}, {startPath: [0, 0], sOffset: 1, finishPath: [0, 0], fOffset: 2}),
       // Ranged selections (multiple words)
-      sMergeForecolorAndUnderline({bText: '', mText: 'abc def', aText: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
-      sMergeForecolorAndStrikethrough({bText: '', mText: 'abc def', aText: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
+      sMergeForecolorAndUnderline({before: '', selected: 'abc def', after: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
+      sMergeForecolorAndStrikethrough({before: '', selected: 'abc def', after: ''}, {startPath: [0, 0], sOffset: 0, finishPath: [0, 0], fOffset: 'abc def'.length}),
     ], onSuccess, onFailure);
   }, {
     plugins: '',


### PR DESCRIPTION
This change makes it so that a text decoration should always inherit the text colour irrespective of order of operations or selection ranges.

There are still a couple of issues that will need to be resolved in the future.
- Occasionally, there are additional redundant text decoration spans. Although, this was the case before my change and trying to fix this could easily cause breakages. 
- There is still an issue when applying multiple text decorations i.e. forecolor -> underline -> strikethrough. The strikethrough doesn't get the correct text colour. Fixing this will likely require a bit of work so will create a separate ticket for that.