### PR TITLE
TINY-4838: Fixed a regression caused by accidentally dropping an argument when removing formatting

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -38,7 +38,7 @@ interface RtcRuntimeApi {
   hasRedo: () => boolean;
   transact: (fn: () => void) => void;
   applyFormat: (format: string, vars: Record<string, string>) => void;
-  removeFormat: (format: string, vars: Record<string, string>, similar?: boolean) => void;
+  removeFormat: (format: string, vars: Record<string, string>) => void;
   toggleFormat: (format: string, vars: Record<string, string>) => void;
   getContent: () => Node | null;
   setContent: (node: Node) => void;
@@ -168,7 +168,7 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
     },
     formatter: {
       apply: (name, vars, _node) => rtcEditor.applyFormat(name, defaultVars(vars)),
-      remove: (name, vars, _node, similar) => rtcEditor.removeFormat(name, defaultVars(vars), similar),
+      remove: (name, vars, _node, _similar?) => rtcEditor.removeFormat(name, defaultVars(vars)),
       toggle: (name, vars, _node) => rtcEditor.toggleFormat(name, defaultVars(vars)),
     },
     editor: {

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -8,21 +8,21 @@
 import { Event, Node as DomNode, Range } from '@ephox/dom-globals';
 import { Fun, Obj, Option, Type } from '@ephox/katamari';
 import Editor from './api/Editor';
+import Formatter from './api/Formatter';
 import Node from './api/html/Node';
 import Serializer from './api/html/Serializer';
-import * as FilterNode from './html/FilterNode';
-import * as Operations from './undo/Operations';
-import { Index, Locks, UndoBookmark, UndoLevel, UndoLevelType, UndoManager } from './undo/UndoManagerTypes';
+import { Content } from './content/EditorContent';
+import { ContentFormat, GetContentArgs, getContentInternal } from './content/GetContentImpl';
+import { insertHtmlAtCaret } from './content/InsertContentImpl';
+import { SetContentArgs, setContentInternal } from './content/SetContentImpl';
 import * as ApplyFormat from './fmt/ApplyFormat';
 import * as RemoveFormat from './fmt/RemoveFormat';
 import * as ToggleFormat from './fmt/ToggleFormat';
-import { RangeLikeObject } from './selection/RangeTypes';
-import { Content } from './content/EditorContent';
-import { GetContentArgs, ContentFormat, getContentInternal } from './content/GetContentImpl';
-import { SetContentArgs, setContentInternal } from './content/SetContentImpl';
-import { insertHtmlAtCaret } from './content/InsertContentImpl';
+import * as FilterNode from './html/FilterNode';
 import { getSelectedContentInternal } from './selection/GetSelectionContentImpl';
-import Formatter from './api/Formatter';
+import { RangeLikeObject } from './selection/RangeTypes';
+import * as Operations from './undo/Operations';
+import { Index, Locks, UndoBookmark, UndoLevel, UndoLevelType, UndoManager } from './undo/UndoManagerTypes';
 
 const isTreeNode = (content: any): content is Node => content instanceof Node;
 
@@ -38,7 +38,7 @@ interface RtcRuntimeApi {
   hasRedo: () => boolean;
   transact: (fn: () => void) => void;
   applyFormat: (format: string, vars: Record<string, string>) => void;
-  removeFormat: (format: string, vars: Record<string, string>) => void;
+  removeFormat: (format: string, vars: Record<string, string>, similar?: boolean) => void;
   toggleFormat: (format: string, vars: Record<string, string>) => void;
   getContent: () => Node | null;
   setContent: (node: Node) => void;
@@ -123,7 +123,7 @@ const makePlainAdaptor = (editor: Editor): RtcAdaptor => ({
   },
   formatter: {
     apply: (name, vars?, node?) => ApplyFormat.applyFormat(editor, name, vars, node),
-    remove: (name, vars, node) => RemoveFormat.remove(editor, name, vars, node),
+    remove: (name, vars, node, similar?) => RemoveFormat.remove(editor, name, vars, node, similar),
     toggle: (name, vars, node) => ToggleFormat.toggle(editor, name, vars, node),
   },
   editor: {
@@ -168,7 +168,7 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
     },
     formatter: {
       apply: (name, vars, _node) => rtcEditor.applyFormat(name, defaultVars(vars)),
-      remove: (name, vars, _node) => rtcEditor.removeFormat(name, defaultVars(vars)),
+      remove: (name, vars, _node, similar) => rtcEditor.removeFormat(name, defaultVars(vars), similar),
       toggle: (name, vars, _node) => rtcEditor.toggleFormat(name, defaultVars(vars)),
     },
     editor: {
@@ -309,8 +309,8 @@ export const applyFormat = (
   getRtcInstanceWithError(editor).formatter.apply(name, vars, node);
 };
 
-export const removeFormat = (editor: Editor, name: string, vars?: Record<string, string>, node?: DomNode | Range) => {
-  getRtcInstanceWithError(editor).formatter.remove(name, vars, node);
+export const removeFormat = (editor: Editor, name: string, vars?: Record<string, string>, node?: DomNode | Range, similar?: boolean) => {
+  getRtcInstanceWithError(editor).formatter.remove(name, vars, node, similar);
 };
 
 export const toggleFormat = (editor: Editor, name: string, vars: Record<string, string>, node: DomNode): void => {

--- a/modules/tinymce/src/core/main/ts/api/Formatter.ts
+++ b/modules/tinymce/src/core/main/ts/api/Formatter.ts
@@ -13,10 +13,10 @@ import { FormatRegistry } from '../fmt/FormatRegistry';
 import * as MatchFormat from '../fmt/MatchFormat';
 import * as Preview from '../fmt/Preview';
 import * as FormatShortcuts from '../keyboard/FormatShortcuts';
-import { Format, FormatVars } from './fmt/Format';
+import * as Rtc from '../Rtc';
 import { RangeLikeObject } from '../selection/RangeTypes';
 import Editor from './Editor';
-import * as Rtc from '../Rtc';
+import { Format, FormatVars } from './fmt/Format';
 
 /**
  * Text formatter engine class. This class is used to apply formats like bold, italic, font size
@@ -109,8 +109,8 @@ const Formatter = function (editor: Editor): Formatter {
      * @param {Object} vars Optional list of variables to replace within format before removing it.
      * @param {Node/Range} node Optional node or DOM range to remove the format from defaults to current selection.
      */
-    remove: (name, vars?, node?) => {
-      Rtc.removeFormat(editor, name, vars, node);
+    remove: (name, vars?, node?, similar?) => {
+      Rtc.removeFormat(editor, name, vars, node, similar);
     },
 
     /**

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
@@ -1,9 +1,9 @@
-import { ApproxStructure, Pipeline, Log } from '@ephox/agar';
+import { ApproxStructure, Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import SilverTheme from 'tinymce/themes/silver/Theme';
 import { Unicode } from '@ephox/katamari';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import Env from 'tinymce/core/api/Env';
+import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('TextColorFormattingTest', (success, failure) => {
   if (Env.browser.isIE()) {
@@ -62,6 +62,25 @@ UnitTest.asynctest('TextColorFormattingTest', (success, failure) => {
               ]
             }),
             s.text(str.is('world'))
+          ]
+        })
+      ]
+    }));
+
+  const forecolorTextStruct = ApproxStructure.build((s, str) =>
+    s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.element('span', {
+              styles: {
+                color: str.is('rgb(53, 152, 219)')
+              },
+              children: [
+                s.text(str.is('Hello'))
+              ]
+            }),
+            s.text(str.is(Unicode.nbsp + 'world'))
           ]
         })
       ]
@@ -129,7 +148,20 @@ UnitTest.asynctest('TextColorFormattingTest', (success, failure) => {
         tinyUi.sClickOnUi('click red color', 'div[title="Red"]'),
         tinyApis.sAssertContentStructure(backcolorTitleStruct),
       ]),
-    ], onSuccess, onFailure );
+      Log.stepsAsStep('TINY-4838', 'TextColor: Remove forecolor with collapsed selection', [
+        tinyApis.sFocus(),
+        tinyApis.sSetContent(`Hello${Unicode.nbsp}world`),
+        tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 2),
+        tinyUi.sClickOnToolbar('click forecolor', '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron'),
+        tinyUi.sWaitForUi('wait for color swatch to open', '.tox-swatches'),
+        tinyUi.sClickOnUi('select blue color', 'div[data-mce-color="#3598DB"]'),
+        tinyApis.sAssertContentStructure(forecolorTextStruct),
+        tinyUi.sClickOnToolbar('click forecolor', '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron'),
+        tinyUi.sWaitForUi('wait for color swatch to open', '.tox-swatches'),
+        tinyUi.sClickOnUi('select remove color', 'div[title="Remove color"]'),
+        tinyApis.sAssertContent('<p>Hello&nbsp;world</p>')
+      ])
+    ], onSuccess, onFailure);
 
   }, {
     plugins: '',


### PR DESCRIPTION
The `similar` argument was accidentally dropped with the RTC PR, so this just adds it back as it broke the ability to remove color based formatting.