### PR TITLE
TINY-4837: Fixed floating toolbar drawer issues

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
@@ -38,10 +38,10 @@ const factory: CompositeSketchFactory<SplitFloatingToolbarDetail, SplitFloatingT
         });
       },
       layouts: {
-        onLtr: () => [ Layout.southwest ],
-        onRtl: () => [ Layout.southeast ],
-        onBottomLtr: () => [ Layout.northwest ],
-        onBottomRtl: () => [ Layout.northeast ]
+        onLtr: () => [ Layout.southwest, Layout.southeast ],
+        onRtl: () => [ Layout.southeast, Layout.southwest ],
+        onBottomLtr: () => [ Layout.northwest, Layout.northeast ],
+        onBottomRtl: () => [ Layout.northeast, Layout.northwest ]
       },
       getBounds: spec.getOverflowBounds,
       lazySink: detail.lazySink,

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/Editor.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/Editor.ts
@@ -1,10 +1,10 @@
-import { Global, Id, Strings, Type } from '@ephox/katamari';
-import { Attr, Element, Insert, Remove, Selectors } from '@ephox/sugar';
 import { Chain } from '@ephox/agar';
+import { setTimeout } from '@ephox/dom-globals';
+import { Global, Id, Strings, Type } from '@ephox/katamari';
+import { Attr, Body, Element, Insert, Remove, Selectors } from '@ephox/sugar';
 import 'tinymce';
-import { document, setTimeout } from '@ephox/dom-globals';
-import { setTinymceBaseUrl } from '../loader/Urls';
 import { Editor as EditorType } from '../alien/EditorTypes';
+import { setTinymceBaseUrl } from '../loader/Urls';
 
 const cFromElement = function <T extends EditorType = EditorType>(element: Element, settings: Record<string, any>): Chain<any, T> {
   return Chain.async<any, T>(function (_, next, die) {
@@ -16,7 +16,9 @@ const cFromElement = function <T extends EditorType = EditorType>(element: Eleme
     const randomId = Id.generate('tiny-loader');
 
     Attr.set(element, 'id', randomId);
-    Insert.append(Element.fromDom(document.body), element);
+    if (!Body.inBody(element)) {
+      Insert.append(Body.body(), element);
+    }
 
     const tinymce = Global.tinymce;
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/RemoteTinyLoader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/RemoteTinyLoader.ts
@@ -1,5 +1,5 @@
 import { TestLogs } from '@ephox/agar';
-import { Arr, FutureResult, Result } from '@ephox/katamari';
+import { Arr, FutureResult, Option, Result } from '@ephox/katamari';
 import { Attr, Body, DomEvent, Element, Insert } from '@ephox/sugar';
 import * as Loader from '../loader/Loader';
 import { setTinymceBaseUrl } from '../loader/Urls';
@@ -48,10 +48,22 @@ const setup = (callback: Loader.RunCallback, urls: string[], settings: Record<st
       run: callback,
       success,
       failure
-    }, settings);
+    }, settings, Option.none());
+  }, failure);
+};
+
+const setupFromElement = (callback: Loader.RunCallback, urls: string[], settings: Record<string, any>, element: Element, success: Loader.SuccessCallback, failure: Loader.FailureCallback) => {
+  loadScripts(urls, () => {
+    Loader.setup({
+      preInit: setupBaseUrl,
+      run: callback,
+      success,
+      failure
+    }, settings, Option.some(element));
   }, failure);
 };
 
 export {
-  setup
+  setup,
+  setupFromElement
 };

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyLoader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyLoader.ts
@@ -1,4 +1,5 @@
-import { Strings, Type } from '@ephox/katamari';
+import { Option, Strings, Type } from '@ephox/katamari';
+import { Element } from '@ephox/sugar';
 import 'tinymce';
 import * as Loader from '../loader/Loader';
 import { setTinymceBaseUrl } from '../loader/Urls';
@@ -24,7 +25,7 @@ const setupLight = (callback: Loader.RunCallback, settings: Record<string, any>,
     run: callback,
     success,
     failure
-  }, nuSettings);
+  }, nuSettings, Option.none());
 };
 
 const setup = (callback: Loader.RunCallback, settings: Record<string, any>, success: Loader.SuccessCallback, failure: Loader.FailureCallback) => {
@@ -33,10 +34,20 @@ const setup = (callback: Loader.RunCallback, settings: Record<string, any>, succ
     run: callback,
     success,
     failure
-  }, settings);
+  }, settings, Option.none());
+};
+
+const setupFromElement = (callback: Loader.RunCallback, settings: Record<string, any>, element: Element, success: Loader.SuccessCallback, failure: Loader.FailureCallback) => {
+  Loader.setup({
+    preInit: setupBaseUrl,
+    run: callback,
+    success,
+    failure
+  }, settings, Option.some(element));
 };
 
 export {
   setup,
-  setupLight
+  setupLight,
+  setupFromElement
 };

--- a/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
@@ -1,7 +1,7 @@
 import { TestLogs } from '@ephox/agar';
 import { console, document, setTimeout } from '@ephox/dom-globals';
-import { Arr, Fun, Global, Id } from '@ephox/katamari';
-import { Attr, Element, Insert, Remove, SelectorFilter } from '@ephox/sugar';
+import { Arr, Fun, Global, Id, Option } from '@ephox/katamari';
+import { Attr, Body, Element, Insert, Remove, SelectorFilter } from '@ephox/sugar';
 import { Editor } from '../alien/EditorTypes';
 
 export type SuccessCallback = (v?: any, logs?: TestLogs) => void;
@@ -15,10 +15,7 @@ interface Callbacks {
   failure: FailureCallback;
 }
 
-const createTarget = function (inline: boolean) {
-  const target = Element.fromTag(inline ? 'div' : 'textarea');
-  return target;
-};
+const createTarget = (inline: boolean) => Element.fromTag(inline ? 'div' : 'textarea');
 
 const removeTinymceElements = () => {
   // NOTE: Don't remove the link/scripts added, as those are part of the global tinymce which we don't clean up
@@ -32,12 +29,14 @@ const removeTinymceElements = () => {
   Arr.each(elements, Remove.remove);
 };
 
-const setup = (callbacks: Callbacks, settings: Record<string, any>) => {
-  const target = createTarget(settings.inline);
+const setup = (callbacks: Callbacks, settings: Record<string, any>, elementOpt: Option<Element>) => {
+  const target = elementOpt.getOrThunk(() => createTarget(settings.inline));
   const randomId = Id.generate('tiny-loader');
   Attr.set(target, 'id', randomId);
 
-  Insert.append(Element.fromDom(document.body), target);
+  if (!Body.inBody(target)) {
+    Insert.append(Body.body(), target);
+  }
 
   const teardown = () => {
     tinymce.remove();

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,6 +2,7 @@ Version 5.2.2 (TBD)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
     Fixed text decorations (underline, strikethrough) not consistently inheriting the text color #TINY-4757
     Fixed format menu alignment buttons inconsistently applying to images #TINY-4057
+    Fixed the more drawer height collapsing when the editor is rendered in modal dialogs #TINY-4837
 Version 5.2.1 (2020-03-25)
     Fixed the "is decorative" checkbox in the image dialog clearing after certain dialog events #FOAM-11
     Fixed possible uncaught exception when a `style` attribute is removed using a content filter on `setContent` #TINY-4742

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -134,17 +134,17 @@ const renderFloatingMoreToolbar = (toolbarSpec: MoreDrawerToolbarSpec) => {
     ...baseSpec,
     lazySink: toolbarSpec.getSink,
     getOverflowBounds: () => {
-      // Restrict the left/right bounds to the editor header width, but don't restrict the top/height
+      // Restrict the left/right bounds to the editor header width, but don't restrict the top/bottom
       const headerElem = toolbarSpec.moreDrawerData.lazyHeader().element();
       const headerBounds = Boxes.absolute(headerElem);
       const docElem = Traverse.documentElement(headerElem);
       const docBounds = Boxes.absolute(docElem);
-      const minTop = Math.min(docBounds.y(), headerBounds.x());
+      const height = Math.max(docElem.dom().scrollHeight, docBounds.height());
       return Boxes.bounds(
         headerBounds.x() + overflowXOffset,
-        minTop,
+        docBounds.y(),
         headerBounds.width() - overflowXOffset * 2,
-        Math.max(docBounds.height(), headerBounds.bottom() - minTop)
+        height
       );
     },
     parts: {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerFloatingPositionTest.ts
@@ -1,45 +1,94 @@
-import { Chain, Logger, Pipeline, Step } from '@ephox/agar';
+import { Log, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Editor as McEditor, TinyUi } from '@ephox/mcagar';
-import { Css, Element, Location, Scroll } from '@ephox/sugar';
+import { window } from '@ephox/dom-globals';
+import { TinyLoader, TinyUi } from '@ephox/mcagar';
+import { PlatformDetection } from '@ephox/sand';
+import { Body, Css, Element, Insert, Location, Scroll } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
-import { sOpenFloatingToolbarAndAssertPosition } from '../../../module/ToolbarUtils';
+import { sAssertFloatingToolbarHeight, sOpenFloatingToolbarAndAssertPosition } from '../../../module/ToolbarUtils';
 
 UnitTest.asynctest('Editor Floating Toolbar Drawer Position test', (success, failure) => {
   Theme();
+  const toolbarHeight = 39;
+  const toolbarDrawerHeight = 80;
+  const windowBottomOffset = window.innerHeight - 100;
+
   const sScrollTo = (x: number, y: number) => Step.sync(() => Scroll.to(x, y));
 
-  Pipeline.async({}, [
-    Logger.t('Editor Floating Toolbar Drawer Position test', Chain.asStep({}, [
-      McEditor.cFromSettings({
-        theme: 'silver',
-        menubar: false,
-        width: 400,
-        base_url: '/project/tinymce/js/tinymce',
-        toolbar: 'undo redo | styleselect | bold italic underline | strikethrough superscript subscript | alignleft aligncenter alignright aligncenter | outdent indent | cut copy paste | selectall remove',
-        toolbar_mode: 'floating'
-      }),
-      Chain.async((editor: Editor, onSuccess, onFailure) => {
-        const tinyUi = TinyUi(editor);
-        const uiContainer = Element.fromDom(editor.getContainer());
-        const initialContainerPos = Location.absolute(uiContainer);
+  // Setup the element to render to
+  const rootElement = Element.fromTag('div');
+  const editorElement = Element.fromTag('textarea');
+  Css.set(rootElement, 'margin-left', '100px');
+  Insert.append(rootElement, editorElement);
+  Insert.append(Body.body(), rootElement);
 
-        Pipeline.async({ }, [
-          Step.sync(() => {
-            Css.set(uiContainer, 'margin-left', '100px');
-          }),
-          sOpenFloatingToolbarAndAssertPosition(tinyUi, () => initialContainerPos.top() + 39), // top of ui container + toolbar height
-          Step.sync(() => {
-            Css.set(uiContainer, 'margin-top', '2000px');
-            Css.set(uiContainer, 'margin-bottom', '2000px');
-          }),
-          sScrollTo(0, 2000),
-          sOpenFloatingToolbarAndAssertPosition(tinyUi, () => initialContainerPos.top() + 39 + 2000), // top of ui container + toolbar height + scroll pos
-        ], () => onSuccess(editor), onFailure);
-      }),
-      McEditor.cRemove
-    ])),
-  ], () => success(), failure);
+  TinyLoader.setupFromElement((editor: Editor, onSuccess, onFailure) => {
+    const tinyUi = TinyUi(editor);
+    const uiContainer = Element.fromDom(editor.getContainer());
+    const initialContainerPos = Location.absolute(uiContainer);
+
+    const sAddMargins = Step.sync(() => {
+      Css.set(uiContainer, 'margin-top', '2000px');
+      Css.set(uiContainer, 'margin-bottom', '2000px');
+    });
+
+    const sRemoveMargins = Step.sync(() => {
+      Css.remove(uiContainer, 'margin-top');
+      Css.remove(uiContainer, 'margin-bottom');
+    });
+
+    Pipeline.async({ }, [
+      // Firefox requires a small wait, otherwise the initial toolbar position is incorrect
+      ...PlatformDetection.detect().browser.isFirefox() ? [ Step.wait(100) ] : [ ],
+      Log.stepsAsStep('TBA', 'Editor in the page', [
+        // Top of screen
+        sOpenFloatingToolbarAndAssertPosition(tinyUi, () => initialContainerPos.top() + toolbarHeight, [ // top of ui container + toolbar height
+          sAssertFloatingToolbarHeight(tinyUi, toolbarDrawerHeight)
+        ]),
+        sAddMargins,
+        // Top of screen + scrolled
+        sScrollTo(0, initialContainerPos.top() + 2000),
+        sOpenFloatingToolbarAndAssertPosition(tinyUi, () => initialContainerPos.top() + toolbarHeight + 2000, [ // top of ui container + toolbar height + scroll pos
+          sAssertFloatingToolbarHeight(tinyUi, toolbarDrawerHeight)
+        ]),
+        // Bottom of screen + scrolled
+        sScrollTo(0, initialContainerPos.top() + 2000 - windowBottomOffset),
+        sOpenFloatingToolbarAndAssertPosition(tinyUi, () => initialContainerPos.top() + toolbarHeight + 2000, [ // top of ui container + toolbar height + scroll pos
+          sAssertFloatingToolbarHeight(tinyUi, toolbarDrawerHeight)
+        ]),
+        sRemoveMargins
+      ]),
+      Log.stepsAsStep('TINY-4837', 'Editor in floating element (eg dialog)', [
+        Step.sync(() => {
+          Css.set(rootElement, 'position', 'absolute');
+        }),
+        sScrollTo(0, 0),
+        // Top of screen
+        sOpenFloatingToolbarAndAssertPosition(tinyUi, () => initialContainerPos.top() + toolbarHeight, [ // top of ui container + toolbar height
+          sAssertFloatingToolbarHeight(tinyUi, toolbarDrawerHeight)
+        ]),
+        sAddMargins,
+        // Top of screen + scrolled
+        sScrollTo(0, initialContainerPos.top() + 2000),
+        sOpenFloatingToolbarAndAssertPosition(tinyUi, () => initialContainerPos.top() + toolbarHeight + 2000, [ // top of ui container + toolbar height + scroll pos
+          sAssertFloatingToolbarHeight(tinyUi, toolbarDrawerHeight)
+        ]),
+        // Bottom of screen + scrolled
+        sScrollTo(0, initialContainerPos.top() + 2000 - windowBottomOffset),
+        sOpenFloatingToolbarAndAssertPosition(tinyUi, () => initialContainerPos.top() + toolbarHeight + 2000, [ // top of ui container + toolbar height + scroll pos
+          sAssertFloatingToolbarHeight(tinyUi, toolbarDrawerHeight)
+        ]),
+        sRemoveMargins
+      ])
+    ], onSuccess, onFailure);
+  }, {
+    theme: 'silver',
+    menubar: false,
+    width: 400,
+    base_url: '/project/tinymce/js/tinymce',
+    toolbar: 'undo redo | styleselect | bold italic underline | strikethrough superscript subscript | alignleft aligncenter alignright aligncenter | outdent indent | cut copy paste | selectall remove',
+    toolbar_mode: 'floating'
+  }, editorElement, success, failure);
 });

--- a/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
@@ -1,6 +1,6 @@
 import { Assertions, Chain, GeneralSteps, Step } from '@ephox/agar';
 import { TinyUi } from '@ephox/mcagar';
-import { Body, Location, Width } from '@ephox/sugar';
+import { Body, Height, Location, Width } from '@ephox/sugar';
 
 import { ToolbarMode } from 'tinymce/themes/silver/api/Settings';
 import { sCloseMore, sOpenMore } from './MenuUtils';
@@ -18,6 +18,14 @@ const sAssertFloatingToolbarPosition = (tinyUi: TinyUi, getTop: () => number, ex
   })
 ]);
 
+const sAssertFloatingToolbarHeight = (tinyUi: TinyUi, expectedHeight: number) => Chain.asStep(Body.body(), [
+  tinyUi.cWaitForUi('Wait for drawer to be visible', '.tox-toolbar__overflow'),
+  Chain.op((toolbar) => {
+    const height = Height.get(toolbar);
+    Assertions.assertEq(`Drawer height ${height}px should be ~${expectedHeight}px`, true, Math.abs(height - expectedHeight) <= 1);
+  })
+]);
+
 const sOpenFloatingToolbarAndAssertPosition = (tinyUi: TinyUi, getTop: () => number, additionalSteps: Array<Step<any, any>> = []) => GeneralSteps.sequence([
   sOpenMore(ToolbarMode.floating),
   sAssertFloatingToolbarPosition(tinyUi, getTop, 105, 465),
@@ -26,6 +34,7 @@ const sOpenFloatingToolbarAndAssertPosition = (tinyUi: TinyUi, getTop: () => num
 ]);
 
 export {
+  sAssertFloatingToolbarHeight,
   sAssertFloatingToolbarPosition,
   sOpenFloatingToolbarAndAssertPosition
 };


### PR DESCRIPTION
This fixes an issue where the bounds was being calculated incorrectly and also fixes an issue where the toolbar would render in a vertical line since we didn't have a fallback for the layouts when everything in the toolbar was collapsed.

I've specifically still used the document bounds instead of the window (though I'm also using scrollHeight which will account for floating elements), as we don't want to restrict the height if the editor is just scrolled near the bottom of the page. In that case it should overflow outside the window, so when the user scrolls the window all the toolbar buttons are visible.

Note: To be able to test this, I needed a way to render the editor in a specific location with a wrapper. To do that I've added a new `mcagar` function to be able to pass in the element to use when rendering.

Fixes #5577