### PR TITLE
TINY-4002: Fixed the `selection.setContent()` API not running parser filters

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -4,6 +4,7 @@ Version 5.3.0 (TBD)
     Changed the default icons to be lazy loaded during initialization #TINY-4729
     Changed so base64 encoded urls are converted to blob urls when content is parsed #TINY-4727
     Changed context toolbars so they concatenate when more than one is suitable for the current selection #TINY-4495
+    Fixed the `selection.setContent()` API not running parser filters #TINY-4002
     Fixed the `quickimage` button not restricting the file types to images #TINY-4715
     Fixed resize handlers displaying in the wrong location sometimes for remote images #TINY-4732
     Fixed table picker breaking in Firefox on low zoom levels #TINY-4728

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -19,7 +19,7 @@ import * as ApplyFormat from './fmt/ApplyFormat';
 import * as RemoveFormat from './fmt/RemoveFormat';
 import * as ToggleFormat from './fmt/ToggleFormat';
 import * as FilterNode from './html/FilterNode';
-import { getSelectedContentInternal } from './selection/GetSelectionContentImpl';
+import { getSelectedContentInternal, GetSelectionContentArgs } from './selection/GetSelectionContentImpl';
 import { RangeLikeObject } from './selection/RangeTypes';
 import * as Operations from './undo/Operations';
 import { Index, Locks, UndoBookmark, UndoLevel, UndoLevelType, UndoManager } from './undo/UndoManagerTypes';
@@ -81,7 +81,7 @@ interface RtcAdaptor {
     insertContent: (value: string, details) => void;
   };
   selection: {
-    getContent: (format: ContentFormat, args) => Content;
+    getContent: (format: ContentFormat, args: GetSelectionContentArgs) => Content;
   };
   raw: {
     getModel: () => Option<any>;
@@ -326,5 +326,5 @@ export const setContent = (editor: Editor, content: Content, args: SetContentArg
 export const insertContent = (editor: Editor, value: string, details): void =>
   getRtcInstanceWithFallback(editor).editor.insertContent(value, details);
 
-export const getSelectedContent = (editor: Editor, format: ContentFormat, args): Content =>
+export const getSelectedContent = (editor: Editor, format: ContentFormat, args: GetSelectionContentArgs): Content =>
   getRtcInstanceWithError(editor).selection.getContent(format, args);

--- a/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
@@ -209,7 +209,7 @@ const getPersistentBookmark = function (selection: Selection, filled: boolean): 
   const startBookmarkNode = createBookmarkSpan(dom, id + '_start', filled);
   rangeInsertNode(dom, rng, startBookmarkNode);
 
-  selection.moveToBookmark({ id, keep: 1 });
+  selection.moveToBookmark({ id, keep: true });
 
   return { id };
 };

--- a/modules/tinymce/src/core/main/ts/selection/GetSelectionContent.ts
+++ b/modules/tinymce/src/core/main/ts/selection/GetSelectionContent.ts
@@ -7,13 +7,13 @@
 
 import Editor from '../api/Editor';
 import * as Rtc from '../Rtc';
-import { Content } from '../content/GetContent';
-import { ContentFormat } from '../content/GetContentImpl';
+import { Content, ContentFormat } from '../content/GetContentImpl';
+import { GetSelectionContentArgs } from './GetSelectionContentImpl';
 
-const getContent = (editor: Editor, args: any = {}): Content => {
+const getContent = (editor: Editor, args: GetSelectionContentArgs = {}): Content => {
   const format: ContentFormat = args.format ? args.format : 'html';
 
   return Rtc.getSelectedContent(editor, format, args);
 };
 
-export { getContent };
+export { getContent, GetSelectionContentArgs };

--- a/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
@@ -12,8 +12,13 @@ import * as FragmentReader from './FragmentReader';
 import * as MultiRange from './MultiRange';
 import * as Zwsp from '../text/Zwsp';
 import Editor from '../api/Editor';
-import { Content } from '../content/GetContent';
+import { Content, GetContentArgs } from '../content/GetContent';
 import { ContentFormat } from '../content/GetContentImpl';
+
+export interface GetSelectionContentArgs extends GetContentArgs {
+  selection?: boolean;
+  contextual?: boolean;
+}
 
 const getTextContent = (editor: Editor): string => Option.from(editor.selection.getRng()).map((rng) => {
   const bin = editor.dom.add(editor.getBody(), 'div', {
@@ -26,7 +31,7 @@ const getTextContent = (editor: Editor): string => Option.from(editor.selection.
   return text;
 }).getOr('');
 
-const getSerializedContent = (editor: Editor, args: any): Content => {
+const getSerializedContent = (editor: Editor, args: GetSelectionContentArgs): Content => {
   const rng = editor.selection.getRng(), tmpElm = editor.dom.create('body');
   const sel = editor.selection.getSel();
   const ranges = EventProcessRanges.processRanges(editor, MultiRange.getRanges(sel));
@@ -39,7 +44,7 @@ const getSerializedContent = (editor: Editor, args: any): Content => {
   return editor.selection.serializer.serialize(tmpElm, args);
 };
 
-export const getSelectedContentInternal = (editor: Editor, format: ContentFormat, args: any = {}): Content => {
+export const getSelectedContentInternal = (editor: Editor, format: ContentFormat, args: GetSelectionContentArgs = {}): Content => {
   args.get = true;
   args.format = format;
   args.selection = true;
@@ -59,7 +64,7 @@ export const getSelectedContentInternal = (editor: Editor, format: ContentFormat
     if (args.format === 'tree') {
       return content;
     } else {
-      args.content = editor.selection.isCollapsed() ? '' : content;
+      args.content = editor.selection.isCollapsed() ? '' : content as string;
       editor.fire('GetContent', args);
       return args.content;
     }

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTreeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTreeTest.ts
@@ -1,13 +1,14 @@
 import { Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import Node from 'tinymce/core/api/html/Node';
 import Serializer from 'tinymce/core/api/html/Serializer';
 import Theme from 'tinymce/themes/silver/Theme';
-import { UnitTest } from '@ephox/bedrock-client';
 
 UnitTest.asynctest('browser.tinymce.core.content.EditorGetContentTreeTest', (success, failure) => {
   Theme();
 
-  const toHtml = function (node) {
+  const toHtml = function (node: Node) {
     const htmlSerializer = Serializer({});
     return htmlSerializer.serialize(node);
   };

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -83,6 +83,15 @@ UnitTest.asynctest('browser.tinymce.core.dom.SelectionTest', function (success, 
     editor.selection.setContent('<div>test</div>');
     LegacyUnit.equal(editor.getContent(), '<div>test</div>', 'Set contents at selection');
 
+    // Insert XSS at selection
+    editor.setContent('<p>text</p>');
+    rng = editor.dom.createRng();
+    rng.setStart(editor.getBody(), 0);
+    rng.setEnd(editor.getBody(), 1);
+    editor.selection.setRng(rng);
+    editor.selection.setContent('<img src="a" onerror="alert(1)" />');
+    LegacyUnit.equal(editor.getContent(), '<img src="a" />', 'Set XSS at selection');
+
     // Set contents at selection (collapsed)
     editor.setContent('<p>text</p>');
     rng = editor.dom.createRng();


### PR DESCRIPTION
This also fixes a number of `any` types within the `Selection` interface.

Fixes #5095