### PR TITLE
TINY-4865: Remap sand PlatformDetection to tinymce Env to reduce bundle size

### DIFF
--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -1,5 +1,6 @@
 /*eslint-env node */
 
+let path = require('path');
 let zipUtils = require('./tools/modules/zip-helper');
 let gruntUtils = require('./tools/modules/grunt-utils');
 let gruntWebPack = require('./tools/modules/grunt-webpack');
@@ -28,6 +29,14 @@ let oxideUiSkinMap = {
 const stripSourceMaps = function (data) {
   const sourcemap = data.lastIndexOf('/*# sourceMappingURL=');
   return sourcemap > -1 ? data.slice(0, sourcemap) : data;
+};
+
+const remapSandPlatformDetection = (importee) => {
+  if (importee.endsWith('ephox/sand/api/PlatformDetection.js')) {
+    return path.resolve('./lib/globals/sand/api/PlatformDetection.js');
+  } else {
+    return importee;
+  }
 };
 
 module.exports = function (grunt) {
@@ -99,7 +108,8 @@ module.exports = function (grunt) {
                 ]),
                 mappers: [
                   swag.mappers.replaceDir('./lib/core/main/ts/api', './lib/globals/tinymce/core/api'),
-                  swag.mappers.invalidDir('./lib/core/main/ts')
+                  swag.mappers.invalidDir('./lib/core/main/ts'),
+                  remapSandPlatformDetection
                 ]
               }),
               swag.remapImports()
@@ -125,7 +135,8 @@ module.exports = function (grunt) {
                 ]),
                 mappers: [
                   swag.mappers.replaceDir('./lib/core/main/ts/api', './lib/globals/tinymce/core/api'),
-                  swag.mappers.invalidDir('./lib/core/main/ts')
+                  swag.mappers.invalidDir('./lib/core/main/ts'),
+                  remapSandPlatformDetection
                 ]
               }),
               swag.remapImports()
@@ -281,6 +292,14 @@ module.exports = function (grunt) {
           {
             src: '../../README.md',
             dest: 'js/tinymce/readme.md'
+          }
+        ]
+      },
+      'platform-detection': {
+        files: [
+          {
+            src: 'src/core/main/js/PlatformDetection.js',
+            dest: 'lib/globals/sand/api/PlatformDetection.js',
           }
         ]
       },
@@ -843,6 +862,7 @@ module.exports = function (grunt) {
     'shell:tsc',
     'eslint',
     'globals',
+    'copy:platform-detection',
     'rollup',
     'unicode',
     'concat',
@@ -861,6 +881,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('dev', [
     'globals',
+    'copy:platform-detection',
     'unicode',
     // TODO: Make webpack use the oxide CSS directly
     // as well as making development easier, then we can update 'yarn dev' to run 'oxide-build' in parallel with 'tinymce-grunt dev'

--- a/modules/tinymce/src/core/main/js/PlatformDetection.js
+++ b/modules/tinymce/src/core/main/js/PlatformDetection.js
@@ -1,0 +1,4 @@
+var envGlobal = tinymce.util.Tools.resolve('tinymce.Env');
+export var detect = function () { return envGlobal; };
+// Note: Don't implement override, as it shouldn't be used in production
+// so excluding it here will prevent that


### PR DESCRIPTION
This remaps sands `PlatformDetection` to use the TinyMCE global `Env` API instead which implements the same interface (or it does at this stage). This helps with the following plugins:
- fullscreen
- imagetools
- lists
- quickbars
- table

and the following themes:
- mobile
- silver

This ends up saving ~9kb in the final compressed zip, or ~4kb per minified JS file above:
```
Before:
661466 tinymce_5.3.0.zip
404871 silver/theme.min.js

After:
652605 tinymce_5.3.0.zip
400979 silver/theme.min.js
```

Note: We don't have to merge this, as it does heavily rely on `Env` exposing the same interface as `PlatformDetection`, or us being able to remap it to `Env` via the `PlatformDetection.js` file. Additionally, if there are issues it won't currently be caught when the TinyMCE automated test suite runs (since it uses webpack), so there are some minimal risks there. Anyways, I just thought I'd put it up and see what others thought.