### PR TITLE
Pin Travis CI build to use NodeJS 13, as chromedriver currently doesnt work on NodeJS 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 os: linux
 
 node_js:
-  - node
+  - 13
 
 cache: yarn
 


### PR DESCRIPTION
There's a GitHub issue linked against chromedriver already, but since this is causing all PR's to show as having errors I wanted to get this working and we can move back to latest when it's supported.