### PR TITLE
TINY-5935: Fixed an issue where the editor would fail to load if local storage was disabled

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -12,6 +12,7 @@ Version 5.3.0 (TBD)
     Fixed toolbar buttons not set to disabled when the editor is in readonly mode #TINY-4592
     Fixed bug where title, width, height would be set to empty string values when updating an image and removing those using the image dialog #TINY-4786
     Fixed the placeholder not hiding when pasting content into the editor #TINY-4828
+    Fixed an issue where the editor would fail to load if local storage was disabled #TINY-5935
 Version 5.2.2 (2020-04-23)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
     Fixed text decorations (underline, strikethrough) not consistently inheriting the text color #TINY-4757

--- a/modules/tinymce/src/core/main/ts/api/util/LocalStorage.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/LocalStorage.ts
@@ -19,11 +19,15 @@ import * as FakeStorage from './FakeStorage';
 
 let localStorage: Storage;
 
-// IE11 with certain strict security settings will explode when trying to access localStorage
-// so we need to do a try/catch and a simple stub here. #TINY-1782
+// Browsers with certain strict security settings will explode when trying to access localStorage
+// so we need to do a try/catch and a simple stub here. #TINY-1782 & #TINY-5935
 
 try {
+  const test = '__storage_test__';
   localStorage = window.localStorage;
+  // Make sure we can set a value, as storage may also be full
+  localStorage.setItem(test, test);
+  localStorage.removeItem(test);
 } catch (e) {
   localStorage = FakeStorage.create();
 }

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputHistory.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputHistory.ts
@@ -6,7 +6,8 @@
  */
 
 import { Arr, Type, Obj } from '@ephox/katamari';
-import { console, localStorage } from '@ephox/dom-globals';
+import { console } from '@ephox/dom-globals';
+import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 
 const STORAGE_KEY = 'tinymce-url-history';
 const HISTORY_LENGTH = 5;
@@ -19,7 +20,7 @@ const isArrayOfUrl = (a: any): boolean => Type.isArray(a) && a.length <= HISTORY
 const isRecordOfUrlArray = (r: any): boolean => Type.isObject(r) && Obj.find(r, (value) => !isArrayOfUrl(value)).isNone();
 
 const getAllHistory = function (): Record<string, string[]> {
-  const unparsedHistory = localStorage.getItem(STORAGE_KEY);
+  const unparsedHistory = LocalStorage.getItem(STORAGE_KEY);
   if (unparsedHistory === null) {
     return {};
   }
@@ -48,7 +49,7 @@ const setAllHistory = function (history: Record<string, string[]>) {
   if (!isRecordOfUrlArray(history)) {
     throw new Error('Bad format for history:\n' + JSON.stringify(history));
   }
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  LocalStorage.setItem(STORAGE_KEY, JSON.stringify(history));
 };
 
 const getHistory = function (fileType: string): string[] {
@@ -68,7 +69,7 @@ const addToHistory = function (url: string, fileType: string) {
 };
 
 const clearHistory = function () {
-  localStorage.removeItem(STORAGE_KEY);
+  LocalStorage.removeItem(STORAGE_KEY);
 };
 
 export {


### PR DESCRIPTION
Note: No tests for this, as we'd have to pollute the globals to override the default window properties to test (ie monkeypatch) which isn't a good idea and will lead to flaky tests. I should add this is largely just lifted from TBIO.

Fixes #5468