### PR TITLE
TINY-4709: Fixed formats incorrectly applied or removed when table cells were selected

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -6,6 +6,7 @@ Version 5.3.0 (TBD)
     Changed context toolbars so they concatenate when more than one is suitable for the current selection #TINY-4495
     Changed inline style element formats (strong, b, em, i, u, strike) to convert to a span on format removal if a `style` or `class` attribute is present #TINY-4741
     Fixed the `selection.setContent()` API not running parser filters #TINY-4002
+    Fixed formats incorrectly applied or removed when table cells were selected #TINY-4709
     Fixed the `quickimage` button not restricting the file types to images #TINY-4715
     Fixed resize handlers displaying in the wrong location sometimes for remote images #TINY-4732
     Fixed table picker breaking in Firefox on low zoom levels #TINY-4728

--- a/modules/tinymce/src/core/main/ts/selection/RangeWalk.ts
+++ b/modules/tinymce/src/core/main/ts/selection/RangeWalk.ts
@@ -7,10 +7,7 @@
 
 import { Node } from '@ephox/dom-globals';
 import DOMUtils from '../api/dom/DOMUtils';
-import Tools from '../api/util/Tools';
 import { RangeLikeObject } from './RangeTypes';
-
-const each = Tools.each;
 
 const clampToExistingChildren = (container: Node, index: number) => {
   const childNodes = container.childNodes;
@@ -26,22 +23,11 @@ const clampToExistingChildren = (container: Node, index: number) => {
 
 const getEndChild = (container: Node, index: number) => clampToExistingChildren(container, index - 1);
 
-const walk = function (dom: DOMUtils, rng: RangeLikeObject, callback: (nodes: Node[]) => void) {
+const walk = (dom: DOMUtils, rng: RangeLikeObject, callback: (nodes: Node[]) => void) => {
   let startContainer = rng.startContainer;
   const startOffset = rng.startOffset;
   let endContainer = rng.endContainer;
   const endOffset = rng.endOffset;
-
-  // Handle table cell selection the table plugin enables
-  // you to fake select table cells and perform formatting actions on them
-  const nodes = dom.select('td[data-mce-selected],th[data-mce-selected]');
-  if (nodes.length > 0) {
-    each(nodes, function (node) {
-      callback([ node ]);
-    });
-
-    return;
-  }
 
   /**
    * Excludes start/end text node if they are out side the range

--- a/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
@@ -116,9 +116,9 @@ const hasAnyRanges = (editor: Editor) => {
 };
 
 const runOnRanges = (editor: Editor, executor: (rng: Range, fake: boolean) => void) => {
-  const rng = editor.selection.getRng();
-
-  // If within a fake selection then remove the style for each node instead
+  // Check to see if a fake selection is active. If so then we are simulating a multi range
+  // selection so we should return a range for each selected node.
+  // Note: Currently tables are the only thing supported for fake selections.
   const fakeSelectionNodes = TableCellSelection.getCellsFromEditor(editor);
   if (fakeSelectionNodes.length > 0) {
     Arr.each(fakeSelectionNodes, (elem) => {
@@ -129,7 +129,7 @@ const runOnRanges = (editor: Editor, executor: (rng: Range, fake: boolean) => vo
       executor(fakeNodeRng, true);
     });
   } else {
-    executor(rng, false);
+    executor(editor.selection.getRng(), false);
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
@@ -8,10 +8,15 @@
 import { Range } from '@ephox/dom-globals';
 import { Arr, Fun, Option, Options } from '@ephox/katamari';
 import { Compare, Element, Node, Traverse } from '@ephox/sugar';
-import * as NodeType from '../dom/NodeType';
+import DOMUtils from '../api/dom/DOMUtils';
+import Selection from '../api/dom/Selection';
 import TreeWalker from '../api/dom/TreeWalker';
-import Tools from '../api/util/Tools';
 import Editor from '../api/Editor';
+import Tools from '../api/util/Tools';
+import { IdBookmark, IndexBookmark } from '../bookmark/BookmarkTypes';
+import * as GetBookmark from '../bookmark/GetBookmark';
+import * as NodeType from '../dom/NodeType';
+import * as TableCellSelection from './TableCellSelection';
 
 const getStartNode = function (rng) {
   const sc = rng.startContainer, so = rng.startOffset;
@@ -63,7 +68,7 @@ const hasAllContentsSelected = function (elm, rng) {
   }).getOr(false);
 };
 
-const moveEndPoint = (dom, rng: Range, node, start: boolean): void => {
+const moveEndPoint = (dom: DOMUtils, rng: Range, node, start: boolean): void => {
   const root = node, walker = new TreeWalker(node, root);
   const nonEmptyElementsMap = dom.schema.getNonEmptyElements();
 
@@ -110,8 +115,34 @@ const hasAnyRanges = (editor: Editor) => {
   return sel && sel.rangeCount > 0;
 };
 
+const runOnRanges = (editor: Editor, executor: (rng: Range, fake: boolean) => void) => {
+  const rng = editor.selection.getRng();
+
+  // If within a fake selection then remove the style for each node instead
+  const fakeSelectionNodes = TableCellSelection.getCellsFromEditor(editor);
+  if (fakeSelectionNodes.length > 0) {
+    Arr.each(fakeSelectionNodes, (elem) => {
+      const node = elem.dom();
+      const fakeNodeRng = editor.dom.createRng();
+      fakeNodeRng.setStartBefore(node);
+      fakeNodeRng.setEndAfter(node);
+      executor(fakeNodeRng, true);
+    });
+  } else {
+    executor(rng, false);
+  }
+};
+
+const preserve = (selection: Selection, fillBookmark: boolean, executor: (bookmark: IdBookmark | IndexBookmark) => void) => {
+  const bookmark = GetBookmark.getPersistentBookmark(selection, fillBookmark);
+  executor(bookmark);
+  selection.moveToBookmark(bookmark);
+};
+
 export {
   hasAllContentsSelected,
   moveEndPoint,
-  hasAnyRanges
+  hasAnyRanges,
+  runOnRanges,
+  preserve
 };

--- a/modules/tinymce/src/core/main/ts/selection/TableCellSelection.ts
+++ b/modules/tinymce/src/core/main/ts/selection/TableCellSelection.ts
@@ -5,29 +5,24 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Range } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import { Element, SelectorFilter } from '@ephox/sugar';
+import Editor from '../api/Editor';
 import * as ElementType from '../dom/ElementType';
 import * as MultiRange from './MultiRange';
-import Editor from '../api/Editor';
 
-const getCellsFromRanges = function (ranges) {
-  return Arr.filter(MultiRange.getSelectedNodes(ranges), ElementType.isTableCell);
-};
+const getCellsFromRanges = (ranges: Range[]) => Arr.filter(MultiRange.getSelectedNodes(ranges), ElementType.isTableCell);
 
-const getCellsFromElement = function (elm) {
-  return SelectorFilter.descendants(elm, 'td[data-mce-selected],th[data-mce-selected]');
-};
+const getCellsFromElement = (elm: Element) => SelectorFilter.descendants(elm, 'td[data-mce-selected],th[data-mce-selected]');
 
-const getCellsFromElementOrRanges = function (ranges, element) {
+const getCellsFromElementOrRanges = (ranges: Range[], element: Element) => {
   const selectedCells = getCellsFromElement(element);
-  const rangeCells = getCellsFromRanges(ranges);
-  return selectedCells.length > 0 ? selectedCells : rangeCells;
+  return selectedCells.length > 0 ? selectedCells : getCellsFromRanges(ranges);
 };
 
-const getCellsFromEditor = function (editor: Editor) {
-  return getCellsFromElementOrRanges(MultiRange.getRanges(editor.selection.getSel()), Element.fromDom(editor.getBody()));
-};
+const getCellsFromEditor = (editor: Editor) =>
+  getCellsFromElementOrRanges(MultiRange.getRanges(editor.selection.getSel()), Element.fromDom(editor.getBody()));
 
 export {
   getCellsFromRanges,

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -2141,6 +2141,18 @@ UnitTest.asynctest('browser.tinymce.core.FormatterApplyTest', function (success,
     LegacyUnit.equal(getContent(editor), '<p><span style="background-color: #ff0000;">ab<span style="font-size: 32px;">c<span style="background-color: #00ff00;">d</span></span><strong><span style="background-color: #00ff00;">e</span>f</strong></span></p>');
   });
 
+  suite.test('Apply format to node outside fake table selection', function (editor) {
+    editor.setContent('<p>test</p><table><tbody><tr><td data-mce-selected="1">cell 1</td><td>cell 2</td></tr><tr><td data-mce-selected="1">cell 3</td><td>cell 4</td></tr></tbody></table>');
+    LegacyUnit.setSelection(editor, 'td', 0, 'td', 0);
+    const para = editor.dom.select('p')[0];
+    // Apply to custom node
+    editor.formatter.apply('bold', { }, para);
+    LegacyUnit.equal(getContent(editor), '<p><strong>test</strong></p><table><tbody><tr><td>cell 1</td><td>cell 2</td></tr><tr><td>cell 3</td><td>cell 4</td></tr></tbody></table>');
+    // Apply to current fake table selection
+    editor.formatter.apply('bold');
+    LegacyUnit.equal(getContent(editor), '<p><strong>test</strong></p><table><tbody><tr><td><strong>cell 1</strong></td><td>cell 2</td></tr><tr><td><strong>cell 3</strong></td><td>cell 4</td></tr></tbody></table>');
+  });
+
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
   }, {

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -530,6 +530,18 @@ UnitTest.asynctest('browser.tinymce.core.FormatterRemoveTest', function (success
     );
   });
 
+  suite.test('Remove format on node outside fake table selection', function (editor) {
+    editor.setContent('<p><strong>test</strong></p><table><tbody><tr><td data-mce-selected="1"><strong>cell 1</strong></td><td>cell 2</td></tr><tr><td data-mce-selected="1"><strong>cell 3</strong></td><td>cell 4</td></tr></tbody></table>');
+    LegacyUnit.setSelection(editor, 'td', 0, 'td', 0);
+    const para = editor.dom.select('p')[0];
+    // Remove bold on custom node
+    editor.formatter.remove('bold', { }, para);
+    LegacyUnit.equal(getContent(editor), '<p>test</p><table><tbody><tr><td><strong>cell 1</strong></td><td>cell 2</td></tr><tr><td><strong>cell 3</strong></td><td>cell 4</td></tr></tbody></table>');
+    // Remove bold current fake table selection
+    editor.formatter.remove('bold');
+    LegacyUnit.equal(getContent(editor), '<p>test</p><table><tbody><tr><td>cell 1</td><td>cell 2</td></tr><tr><td>cell 3</td><td>cell 4</td></tr></tbody></table>');
+  });
+
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
   }, {

--- a/modules/tinymce/src/core/test/ts/module/test/AnnotationAsserts.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/AnnotationAsserts.ts
@@ -14,9 +14,9 @@ const sAnnotate = <T> (editor: Editor, name: string, uid: string, data: { }): St
   });
 
 // This will result in an attribute order-insensitive HTML assertion
-const sAssertHtmlContent = <T> (tinyApis: TinyApis, children: string[]): Step<T, T> => tinyApis.sAssertContentStructure(
+const sAssertHtmlContent = <T> (tinyApis: TinyApis, children: string[], allowExtras?: boolean): Step<T, T> => tinyApis.sAssertContentStructure(
   ApproxStructure.build((s, _str, _arr) => s.element('body', {
-    children: Arr.map(children, ApproxStructure.fromHtml)
+    children: Arr.map(children, ApproxStructure.fromHtml).concat(allowExtras ? [ s.theRest() ] : [ ])
   }))
 );
 


### PR DESCRIPTION
Having the fake selection walking logic in `RangeWalk` wasn't really the right place, as it needed to be when getting the ranges from the selection as that's what the fake selection is actually emulating (eg multi range selection). So this fixes a few things: it fixes the original issue and also removing formats from a fake table selection, as that didn't work (found this out when writing tests).

Fixes #5408