### PR TITLE
TINY-4161: Fixed `ObjectResized` event incorrectly firing when an object wasn't resized

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -13,6 +13,7 @@ Version 5.3.0 (TBD)
     Fixed supplementary special characters being truncated when inserted into the editor. Patch contributed by mlitwin. #TINY-4791
     Fixed toolbar buttons not set to disabled when the editor is in readonly mode #TINY-4592
     Fixed bug where title, width, height would be set to empty string values when updating an image and removing those using the image dialog #TINY-4786
+    Fixed `ObjectResized` event firing when an object wasn't resized #TINY-4161
     Fixed the placeholder not hiding when pasting content into the editor #TINY-4828
     Fixed an issue where the editor would fail to load if local storage was disabled #TINY-5935
 Version 5.2.2 (2020-04-23)

--- a/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
@@ -1,39 +1,133 @@
-import { GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { Hierarchy, Element } from '@ephox/sugar';
-import Theme from 'tinymce/themes/silver/Theme';
-import { UnitTest } from '@ephox/bedrock-client';
+import { Assertions, Chain, GeneralSteps, Log, Mouse, NamedChain, Pipeline, Step, UiFinder } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { HTMLElement } from '@ephox/dom-globals';
+import { Cell, Obj, Strings } from '@ephox/katamari';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { Css, Element, Hierarchy } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.core.dom.ControlSelectionTest', function (success, failure) {
-
   Theme();
+  const eventCounter = Cell<Record<string, number>>({ });
 
-  const sContextMenuClickInMiddleOf = function (editor, elementPath) {
-    return Step.sync(function () {
-      const element = Hierarchy.follow(Element.fromDom(editor.getBody()), elementPath).getOrDie().dom() as HTMLElement;
-      const rect = element.getBoundingClientRect();
-      const clientX = (rect.left + rect.width / 2), clientY = (rect.top + rect.height / 2);
-      editor.fire('mousedown', { target: element, clientX, clientY, button: 2 });
-      editor.fire('mouseup', { target: element, clientX, clientY, button: 2 });
-      editor.fire('contextmenu', { target: element, clientX, clientY, button: 2 });
-    });
+  const sContextMenuClickInMiddleOf = (editor: Editor, elementPath: number[]) => Step.sync(() => {
+    const element = Hierarchy.follow(Element.fromDom(editor.getBody()), elementPath).getOrDie().dom() as HTMLElement;
+    const rect = element.getBoundingClientRect();
+    const clientX = (rect.left + rect.width / 2), clientY = (rect.top + rect.height / 2);
+    editor.fire('mousedown', { target: element, clientX, clientY, button: 2 });
+    editor.fire('mouseup', { target: element, clientX, clientY, button: 2 });
+    editor.fire('contextmenu', { target: element, clientX, clientY, button: 2 });
+  });
+
+  const sResetEventCounter = Step.sync(() => eventCounter.set({ }));
+
+  const sAssertEventCount = (type: string, count: number) => Step.sync(() => {
+    Assert.eq(`Check ${type} event count is ${count}`, count, Obj.get(eventCounter.get(), type.toLowerCase()).getOr(0));
+  });
+
+  const sResizeAndAssertEventCount = (editorBody: Element, resizeSelector: string, delta: number, expectedCount: number) => GeneralSteps.sequence([
+    Chain.asStep(editorBody, [
+      UiFinder.cWaitForVisible('Wait for resize handlers to show', resizeSelector),
+      Mouse.cMouseDown
+    ]),
+    sAssertEventCount('ObjectResizeStart', expectedCount - 1),
+    sAssertEventCount('ObjectResized', expectedCount - 1),
+    Chain.asStep(editorBody, [
+      UiFinder.cFindIn(resizeSelector),
+      Mouse.cMouseMoveTo(delta, delta),
+      Mouse.cMouseUp
+    ]),
+    sAssertEventCount('ObjectResizeStart', expectedCount),
+    sAssertEventCount('ObjectResized', expectedCount),
+  ]);
+
+  const cGetElementDimensions = (name: string) => Chain.mapper((element: Element): number =>
+    Css.getRaw(element, name).map((v) => parseInt(v, 10)).getOr(0));
+
+  const cAssertElementDimension = (label: string, expectedDimension: number) => Chain.op((dimension: number) => {
+    Assertions.assertEq(label, true, Math.abs(dimension - expectedDimension) < 3);
+  });
+
+  const cGetAndAssertDimensions = (width: number, height: number) => NamedChain.asChain([
+    NamedChain.direct(NamedChain.inputName(), Chain.identity, 'element'),
+    NamedChain.direct('element', cGetElementDimensions('width'), 'elementWidth'),
+    NamedChain.direct('element', cGetElementDimensions('height'), 'elementHeight'),
+    NamedChain.read('elementWidth', cAssertElementDimension('Assert element width', width)),
+    NamedChain.read('elementHeight', cAssertElementDimension('Assert element height', height)),
+    NamedChain.outputInput
+  ]);
+
+  const sResizeAndAssertDimensions = (editorBody: Element, targetSelector: string, resizeSelector: string, delta: number, width: number, height: number) => {
+    const expectedWidth = Strings.endsWith(resizeSelector, 'sw') || Strings.endsWith(resizeSelector, 'nw') ? width - delta : width + delta;
+    const expectedHeight = Strings.endsWith(resizeSelector, 'nw') || Strings.endsWith(resizeSelector, 'ne') ? height - delta : height + delta;
+
+    return Chain.asStep(editorBody, [
+      NamedChain.asChain([
+        NamedChain.direct(NamedChain.inputName(), Chain.identity, 'body'),
+        NamedChain.direct('body', UiFinder.cWaitForVisible('Wait for resize handlers to show', resizeSelector), 'resizeHandle'),
+        NamedChain.direct('body', UiFinder.cFindIn(targetSelector), 'target'),
+        NamedChain.read('resizeHandle', Mouse.cMouseDown),
+        NamedChain.direct('body', UiFinder.cFindIn('.mce-clonedresizable'), 'ghost'),
+        NamedChain.read('ghost', cGetAndAssertDimensions(width, height)),
+        NamedChain.read('resizeHandle', Mouse.cMouseMoveTo(delta, delta)),
+        NamedChain.read('ghost', cGetAndAssertDimensions(expectedWidth, expectedHeight)),
+        NamedChain.read('resizeHandle', Mouse.cMouseUp),
+        NamedChain.read('target', cGetAndAssertDimensions(expectedWidth, expectedHeight)),
+        NamedChain.outputInput
+      ])
+    ]);
   };
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
+    const editorBody = Element.fromDom(editor.getBody());
+    editor.on('ObjectResizeStart ObjectResized', (e) => {
+      const counter = eventCounter.get();
+      counter[e.type] = (counter[e.type] || 0) + 1;
+    });
 
     Pipeline.async({}, [
-      Logger.t('Select image by context menu clicking on it', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Select image by context menu clicking on it', [
+        sResetEventCounter,
         Step.label('Focus editor', tinyApis.sFocus()),
         Step.label('Set editor content to a paragraph with a image within', tinyApis.sSetContent('<p><img src="http://www.google.com/google.jpg" width="100" height="100"></p>')),
         Step.label('Context menu click on the image', sContextMenuClickInMiddleOf(editor, [ 0, 0 ])),
         Step.label('Check that the image is selected', tinyApis.sAssertSelection([ 0 ], 0, [ 0 ], 1))
-      ]))
+      ]),
+      Log.stepsAsStep('TINY-4161', 'Resize events should not be called if the object isn\'t resized', [
+        sResetEventCounter,
+        tinyApis.sSetContent('<p><table><tbody><tr><td>Cell</td><td>Cell</td></tr></tbody></table></p>'),
+        tinyApis.sSelect('td', [ 0 ]),
+        UiFinder.sWaitForVisible('Wait for resize handlers to show', editorBody, '#mceResizeHandlese'),
+        Mouse.sTrueClickOn(editorBody, '#mceResizeHandlese'),
+        sAssertEventCount('ObjectResizeStart', 0),
+        sAssertEventCount('ObjectResized', 0)
+      ]),
+      Log.stepsAsStep('TINY-4161', 'Resize events should be called if the object is resized', [
+        sResetEventCounter,
+        tinyApis.sSetContent('<p><table><tbody><tr><td>Cell</td><td>Cell</td></tr></tbody></table></p>'),
+        tinyApis.sSelect('td', [ 0 ]),
+        sResizeAndAssertEventCount(editorBody, '#mceResizeHandlese', 10, 1),
+        sResizeAndAssertEventCount(editorBody, '#mceResizeHandlese',20, 2)
+      ]),
+      Log.stepsAsStep('TINY-4161', 'Resize ghost element dimensions match target element when using fixed width', [
+        sResetEventCounter,
+        tinyApis.sSetContent('<p><table style="width: 600px; height: 100px"><tbody><tr><td>Cell</td><td>Cell</td></tr></tbody></table></p>'),
+        tinyApis.sSelect('td', [ 0 ]),
+        sResizeAndAssertDimensions(editorBody, 'table', '#mceResizeHandlesw', 10, 600, 100)
+      ]),
+      Log.stepsAsStep('TINY-4161', 'Resize ghost element dimensions match target element when using relative width', [
+        sResetEventCounter,
+        tinyApis.sSetContent('<p><table style="width: 100%; height: 50px"><tbody><tr><td>Cell</td><td>Cell</td></tr></tbody></table></p>'),
+        tinyApis.sSelect('td', [ 0 ]),
+        sResizeAndAssertDimensions(editorBody, 'table', '#mceResizeHandlese', -10, 798, 50)
+      ])
     ], onSuccess, onFailure);
   }, {
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce',
-    content_style: 'body.mce-content-body  { margin: 0 }'
+    content_style: 'body.mce-content-body  { margin: 0 }',
+    width: 800
   }, success, failure);
 });


### PR DESCRIPTION
This was causing the `ObjectResized` handler to fire in the table plugin and because a resize hadn't actually occurred the width/height reported was `0` which would collapse the table.

This also fixes another issue I've wanted to fix for a long time, whereby the "ghost" resize object width is incorrect initially for relative width elements. The fix was just to ensure we set the initial size based on the computed target element width/heights, which is what happened when you started resizing.