### PR TITLE
TINY-4741: Update relevant legacyoutput formats to use preserve_attributes parameter

### DIFF
--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -210,16 +210,11 @@ const removeFormat = (ed: Editor, format: RemoveFormatPartial, vars?: FormatVars
   // Applies to styling elements like strong, em, i, u, etc. so that if they have styling attributes, the attributes can be kept but the styling element is removed
   if (format.inline && format.remove === 'all' && Type.isArray(format.preserve_attributes)) {
     // Remove all attributes except for the attributes specified in preserve_attributes
-    Arr.each(dom.getAttribs(elm), (attr) => {
-      if (attr) {
-        const attrName = attr.nodeName.toLowerCase();
-        if (!Arr.exists(format.preserve_attributes, (pAttr) => pAttr === attrName)) {
-          dom.setAttrib(elm, attrName, '');
-        }
-      }
-    });
+    const attrsToPreserve = Arr.filter(dom.getAttribs(elm), (attr) => Arr.contains(format.preserve_attributes, attr.name.toLowerCase()));
+    dom.removeAllAttribs(elm);
+    Arr.each(attrsToPreserve, (attr) => dom.setAttrib(elm, attr.name, attr.value));
     // Note: If there are no attributes left, the element will be removed as normal at the end of the function
-    if (dom.getAttribs(elm).length > 0) {
+    if (attrsToPreserve.length > 0) {
       // Convert inline element to span if necessary
       ed.dom.rename(node, 'span');
       return true;

--- a/modules/tinymce/src/plugins/legacyoutput/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/demo/ts/demo/Demo.ts
@@ -3,7 +3,7 @@ declare let tinymce: any;
 tinymce.init({
   selector: 'textarea.tinymce',
   plugins: 'legacyoutput code',
-  toolbar: 'legacyoutput fontselect fontsizeselect code',
+  toolbar: 'legacyoutput fontselect fontsizeselect code bold italic underline strikethrough',
   height: 600
 });
 

--- a/modules/tinymce/src/plugins/legacyoutput/main/ts/core/Formats.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/main/ts/core/Formats.ts
@@ -24,21 +24,21 @@ const overrideFormats = (editor: Editor) => {
 
     // Change the basic formatting elements to use deprecated element types
     bold: [
-      { inline: 'b', remove: 'all' },
-      { inline: 'strong', remove: 'all' },
+      { inline: 'b', remove: 'all', preserve_attributes: [ 'class', 'style' ] },
+      { inline: 'strong', remove: 'all', preserve_attributes: [ 'class', 'style' ] },
       { inline: 'span', styles: { fontWeight: 'bold' }}
     ],
     italic: [
-      { inline: 'i', remove: 'all' },
-      { inline: 'em', remove: 'all' },
+      { inline: 'i', remove: 'all', preserve_attributes: [ 'class', 'style' ] },
+      { inline: 'em', remove: 'all', preserve_attributes: [ 'class', 'style' ] },
       { inline: 'span', styles: { fontStyle: 'italic' }}
     ],
     underline: [
-      { inline: 'u', remove: 'all' },
+      { inline: 'u', remove: 'all', preserve_attributes: [ 'class', 'style' ] },
       { inline: 'span', styles: { textDecoration: 'underline' }, exact: true }
     ],
     strikethrough: [
-      { inline: 'strike', remove: 'all' },
+      { inline: 'strike', remove: 'all', preserve_attributes: [ 'class', 'style' ] },
       { inline: 'span', styles: { textDecoration: 'line-through' }, exact: true }
     ],
 

--- a/modules/tinymce/src/plugins/legacyoutput/test/ts/browser/LegacyOutputPluginTest.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/test/ts/browser/LegacyOutputPluginTest.ts
@@ -119,11 +119,18 @@ UnitTest.asynctest(
       LegacyUnit.equal(editor.getContent(), '<p>text</p>');
     });
 
+    suite.test('TestCase-TINY-4741: LegacyOutput: Convert bold to span if styling attributes are present on format removal', function (editor) {
+      editor.setContent('<p><b class="abc" style="color: red; font-size: 20px;" data-test="2">text</b></p>');
+      LegacyUnit.setSelection(editor, 'b', 0, 'b', 4);
+      editor.execCommand('bold');
+      LegacyUnit.equal(editor.getContent(), '<p><span class="abc" style="color: red; font-size: 20px;">text</span></p>');
+    });
+
     suite.test('TestCase-TBA: LegacyOutput: Formats registered before loading initial content', () => {
       const formats = formatsCell.get();
-      LegacyUnit.equal(formats.bold[0], { inline: 'b', remove: 'all', deep: true, split: true });
-      LegacyUnit.equal(formats.italic[0], { inline: 'i', remove: 'all', deep: true, split: true });
-      LegacyUnit.equal(formats.underline[0], { inline: 'u', remove: 'all', deep: true, split: true });
+      LegacyUnit.equal(formats.bold[0], { inline: 'b', remove: 'all', deep: true, split: true, preserve_attributes: [ 'class', 'style' ] });
+      LegacyUnit.equal(formats.italic[0], { inline: 'i', remove: 'all', deep: true, split: true, preserve_attributes: [ 'class', 'style' ] });
+      LegacyUnit.equal(formats.underline[0], { inline: 'u', remove: 'all', deep: true, split: true, preserve_attributes: [ 'class', 'style' ] });
       LegacyUnit.equal(formats.fontname[0], { inline: 'font', toggle: false, attributes: { face: '%value' }, deep: true, split: true });
     });
 

--- a/modules/tinymce/src/plugins/legacyoutput/test/ts/browser/LegacyOutputPluginTest.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/test/ts/browser/LegacyOutputPluginTest.ts
@@ -119,7 +119,7 @@ UnitTest.asynctest(
       LegacyUnit.equal(editor.getContent(), '<p>text</p>');
     });
 
-    suite.test('TestCase-TINY-4741: LegacyOutput: Convert bold to span if styling attributes are present on format removal', function (editor) {
+    suite.test('TestCase-TINY-4741: LegacyOutput: Convert bold to span if styling attributes are present on format removal', (editor) => {
       editor.setContent('<p><b class="abc" style="color: red; font-size: 20px;" data-test="2">text</b></p>');
       LegacyUnit.setSelection(editor, 'b', 0, 'b', 4);
       editor.execCommand('bold');


### PR DESCRIPTION
In a previous PR for this ticket, I missed updating the formats registered in the `legacyoutput` plugin. This PR updates the relevant formats in `legacyoutput`.