### PR TITLE
TINY-5954: Made a few minor performance improvements

### DIFF
--- a/modules/boulder/src/main/ts/ephox/boulder/core/ValueProcessor.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/ValueProcessor.ts
@@ -180,12 +180,7 @@ const value = function (validator: ValueValidator): Processor {
 };
 
 // This is because Obj.keys can return things where the key is set to undefined.
-const getSetKeys = function (obj) {
-  const keys = Obj.keys(obj);
-  return Arr.filter(keys, function (k) {
-    return Obj.hasNonNullableKey(obj, k);
-  });
-};
+const getSetKeys = (obj) => Obj.keys(Obj.filter(obj, (value) => value !== undefined && value !== null));
 
 const objOfOnly = function (fields: ValueProcessorAdt[]): Processor {
   const delegate = objOf(fields);


### PR DESCRIPTION
While doing some performance profiling on the spellchecker, I found these couple of small performance improvements.

The boulder change is fairly minimal at ~1ms or less depending on the browser. However, the `FakeCaret` change is much more so, as it saves ~4-5ms and that is on `setRng` calls (not every call, but most of them), so it ends up saving quite a bit of time. As an example, with spellchecker it saves ~400-500ms per scan (eg NodeChange) of the document that I'm currently profiling.

Pictures for reference:
**Before:**
![Selection_191](https://user-images.githubusercontent.com/1575550/81063275-de511980-8f1a-11ea-865c-a329789c49f8.png)
**After:**
![Selection_190](https://user-images.githubusercontent.com/1575550/81063307-e7da8180-8f1a-11ea-9f77-0815de660b72.png)

