### PR TITLE
TINY-5955: Fixed fixed toolbar container getting a max-width assigned

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -130,7 +130,9 @@ export const InlineHeader = (editor: Editor, targetElm: Element, uiComponents: R
     // 4. Inline + fixed_toolbar_container + more drawer: does SplitToolbar
 
     // Update the max width, as the body width may have changed
-    updateChromeWidth();
+    if (!useFixedToolbarContainer) {
+      updateChromeWidth();
+    }
 
     // Refresh split toolbar
     if (isSplitToolbar) {


### PR DESCRIPTION
This fixes the regression introduced in 5.3 whereby the fixed toolbar container was getting a max-width to match the content area.