### PR TITLE
TINY-3438: Fixed the editor selection incorrectly changing when removing caret format containers

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -14,6 +14,7 @@ Version 5.3.0 (TBD)
     Fixed issue with loading or pasting contents with large base64 encoded images on Safari #TINY-4715
     Fixed supplementary special characters being truncated when inserted into the editor. Patch contributed by mlitwin. #TINY-4791
     Fixed toolbar buttons not set to disabled when the editor is in readonly mode #TINY-4592
+    Fixed the editor selection incorrectly changing when removing caret format containers #TINY-3438
     Fixed bug where title, width, height would be set to empty string values when updating an image and removing those using the image dialog #TINY-4786
     Fixed `ObjectResized` event firing when an object wasn't resized #TINY-4161
     Fixed the placeholder not hiding when pasting content into the editor #TINY-4828


### PR DESCRIPTION
The logic that was trying to restore the selection offsets here was happening after the range had already been mutated and then unwrapped the node, which caused the range to change again. So this just stores the offsets before mutating the dom and restores it how it was previously attempting to after doing the dom mutation.

Fixes #4875