### PR TITLE
TINY-5967: Fixed search and replace skipping nested contenteditable nodes

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -10,6 +10,7 @@ Version 5.3.0 (TBD)
     Fixed the `selection.setContent()` API not running parser filters #TINY-4002
     Fixed formats incorrectly applied or removed when table cells were selected #TINY-4709
     Fixed the `quickimage` button not restricting the file types to images #TINY-4715
+    Fixed search and replace ignoring text in nested contenteditable elements #TINY-5967
     Fixed resize handlers displaying in the wrong location sometimes for remote images #TINY-4732
     Fixed table picker breaking in Firefox on low zoom levels #TINY-4728
     Fixed issue with loading or pasting contents with large base64 encoded images on Safari #TINY-4715

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
@@ -156,11 +156,26 @@ UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplacePluginTes
     ));
   });
 
+  suite.test('TestCase-TINY-5967: SearchReplace: Find and replace all in nested contenteditable elements', (editor) => {
+    editor.setContent('<p>Editable '+
+      '<span contenteditable="false">NonEditable <span contenteditable="true">Editable ' +
+      '<span contenteditable="false">NonEditable <span contenteditable="true">Editable </span>NonEditable </span>' +
+      'Editable </span>NonEditable </span>' +
+      'Editable</p>');
+    LegacyUnit.equal(5, editor.plugins.searchreplace.find('Editable'));
+    LegacyUnit.equal(editor.plugins.searchreplace.replace('x', true, true), false);
+    LegacyUnit.equal(editor.getContent(), '<p>x '+
+      '<span contenteditable="false">NonEditable <span contenteditable="true">x ' +
+      '<span contenteditable="false">NonEditable <span contenteditable="true">x </span>NonEditable </span>' +
+      'x </span>NonEditable </span>' +
+      'x</p>');
+  });
+
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, Log.steps('TBA', 'SearchReplace: Find and replace matches', suite.toSteps(editor)), onSuccess, onFailure);
   }, {
     plugins: 'searchreplace',
-    valid_elements: 'b,i,br',
+    valid_elements: 'b,i,br,span[contenteditable]',
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     theme: 'silver'


### PR DESCRIPTION
This just fixes an issue I knew about with the current search and replace plugin and since I've rewritten a fair bit to do the find in selection feature, I thought I should probably fix it as well.

Fixes #4650