### PR TITLE
TINY-3161: Fix edge case where there's no room to render the toolbar bove or below the target element

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -55,15 +55,13 @@ const setupEvents = (editor: Editor, targetElm: Element, ui: InlineHeader) => {
   editor.on('activate', ui.show);
   editor.on('deactivate', ui.hide);
 
-  editor.on('SkinLoaded ResizeWindow', () => {
-    if (ui.isVisible()) {
-      ui.update(true);
-    }
-  });
+  editor.on('SkinLoaded ResizeWindow', () => ui.update(true));
 
   editor.on('NodeChange keydown', (e) => {
     Delay.requestAnimationFrame(() => resizeContent(e));
   });
+
+  editor.on('ScrollWindow', () => ui.updateMode());
 
   // Bind to async load events and trigger a content resize event if the size has changed
   const elementLoad = Singleton.unbindable();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarPositionTest.ts
@@ -251,12 +251,18 @@ UnitTest.asynctest('Inline Editor Toolbar Position test', (success, failure) => 
         Log.stepsAsStep('TINY-3161', 'Select item at the top of content, when there\'s no room to render above (docked position)', [
           Step.sync(() => {
             const editorBody = Element.fromDom(editor.getBody());
-            Css.set(editorBody, 'position', 'fixed');
+            Css.set(editorBody, 'position', 'absolute');
             Css.set(editorBody, 'top', '0');
+            Css.set(editorBody, 'left', '0');
           }),
           sScrollToElementAndActivate(tinyApis, contentAreaContainer, ':first-child'),
           sAssertAbsolutePos(container, contentAreaContainer, 'below'),
           sAssertDockedPos(header, 'bottom'),
+          sScrollToElement(contentAreaContainer, 'p:contains("STOP AND CLICK HERE")'),
+          sAssertDockedPos(header, 'bottom'),
+          sScrollToElement(contentAreaContainer, ':last-child', true),
+          sAssertAbsolutePos(container, contentAreaContainer, 'above'),
+          sAssertDockedPos(header, 'top'),
           sDeactivateEditor(editor),
           Step.sync(() => {
             const editorBody = Element.fromDom(editor.getBody());


### PR DESCRIPTION
I realised when writing up the QA notes and reading the original issue again that my previous PR missed the edge case of where there's no room at the bottom or top. As such this will function in the same way as the previous PR in most cases, except when the page is scrolled to the bottom and there's no room to render the toolbar below. In that case, it'll switch back to rendering at the top until you start to scroll up again.