### PR TITLE
TINY-5970: Fixed colour picker regression

### DIFF
--- a/modules/acid/src/main/ts/ephox/acid/gui/ColourEvents.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/ColourEvents.ts
@@ -1,15 +1,15 @@
-import { EventFormat, SliderTypes } from '@ephox/alloy';
+import { CustomEvent, SliderTypes } from '@ephox/alloy';
 import { Id } from '@ephox/katamari';
 
 const fieldsUpdate = Id.generate('rgb-hex-update');
 const sliderUpdate = Id.generate('slider-update');
 const paletteUpdate = Id.generate('palette-update');
 
-export interface SliderUpdateEvent extends EventFormat {
+export interface SliderUpdateEvent extends CustomEvent {
   value: () => SliderTypes.SliderValueY;
 }
 
-export interface PaletteUpdateEvent extends EventFormat {
+export interface PaletteUpdateEvent extends CustomEvent {
   value: () => SliderTypes.SliderValueXY;
 }
 

--- a/modules/acid/src/main/ts/ephox/acid/gui/ColourEvents.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/ColourEvents.ts
@@ -1,16 +1,16 @@
+import { EventFormat, SliderTypes } from '@ephox/alloy';
 import { Id } from '@ephox/katamari';
-import { SliderTypes, EventFormat } from '@ephox/alloy';
 
 const fieldsUpdate = Id.generate('rgb-hex-update');
 const sliderUpdate = Id.generate('slider-update');
 const paletteUpdate = Id.generate('palette-update');
 
 export interface SliderUpdateEvent extends EventFormat {
-  value: SliderTypes.SliderValueY;
+  value: () => SliderTypes.SliderValueY;
 }
 
 export interface PaletteUpdateEvent extends EventFormat {
-  value: SliderTypes.SliderValueXY;
+  value: () => SliderTypes.SliderValueXY;
 }
 
 export {

--- a/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
@@ -68,7 +68,7 @@ const makeFactory = (
     const paletteUpdates = () => {
       const updates = [ updateFields ];
       return (form: AlloyComponent, simulatedEvent: SimulatedEvent<ColourEvents.PaletteUpdateEvent>) => {
-        const value = simulatedEvent.event().value;
+        const value = simulatedEvent.event().value();
         const oldRgb = state.paletteRgba.get();
         const hsvColour = HsvColour.fromRgb(oldRgb);
         const newHsvColour = HsvColour.hsvColour(hsvColour.hue, value.x(), (100 - value.y()));
@@ -81,7 +81,7 @@ const makeFactory = (
     const sliderUpdates = () => {
       const updates = [ updatePalette, updateFields ];
       return (form: AlloyComponent, simulatedEvent: SimulatedEvent<ColourEvents.SliderUpdateEvent>) => {
-        const value = simulatedEvent.event().value;
+        const value = simulatedEvent.event().value();
         const hex = calcHex(value.y());
         runUpdates(form, hex, updates);
       };


### PR DESCRIPTION
This was introduced in f40614b, as alloy will map all data passed into fired events such that they become functions so this shouldn't have been unthunked: https://github.com/tinymce/tinymce/blob/2e042bb4f71a349f6eb58a4dab28248221cfdac8/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyTriggers.ts#L29