### PR TITLE
TINY-3345: Implement new checkmark menu design

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/ToggleMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/ToggleMenuItem.ts
@@ -1,10 +1,11 @@
 import { FieldSchema, ValueSchema } from '@ephox/boulder';
-import { Fun, Result } from '@ephox/katamari';
+import { Fun, Result, Option } from '@ephox/katamari';
 
 import { CommonMenuItem, CommonMenuItemApi, commonMenuItemFields, CommonMenuItemInstanceApi } from './CommonMenuItem';
 
 export interface ToggleMenuItemApi extends CommonMenuItemApi {
   type?: 'togglemenuitem';
+  icon?: string;
   active?: boolean;
   onSetup?: (api: ToggleMenuItemInstanceApi) => void;
   onAction: (api: ToggleMenuItemInstanceApi) => void;
@@ -17,6 +18,7 @@ export interface ToggleMenuItemInstanceApi extends CommonMenuItemInstanceApi {
 
 export interface ToggleMenuItem extends CommonMenuItem {
   type: 'togglemenuitem';
+  icon: Option<string>;
   active: boolean;
   onSetup: (api: ToggleMenuItemInstanceApi) => (api: ToggleMenuItemInstanceApi) => void;
   onAction: (api: ToggleMenuItemInstanceApi) => void;
@@ -24,6 +26,7 @@ export interface ToggleMenuItem extends CommonMenuItem {
 
 export const toggleMenuItemSchema = ValueSchema.objOf([
   FieldSchema.strictString('type'),
+  FieldSchema.optionString('icon'),
   FieldSchema.defaultedBoolean('active', false),
   FieldSchema.defaultedFunction('onSetup', () => Fun.noop),
   FieldSchema.strictFunction('onAction')

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -177,7 +177,8 @@
     cursor: not-allowed;
   }
 
-  .tox-collection__item-icon {
+  .tox-collection__item-icon,
+  .tox-collection__item-checkmark {
     align-items: center;
     display: flex;
     height: @collection-item-list-icon-height;
@@ -234,7 +235,12 @@
   }
 
   // Tickable items that are not ticked hide the check mark SVG (not the entire icon so there is still a gap)
-  .tox-collection__item[role="menuitemcheckbox"]:not(.tox-collection__item--enabled) .tox-collection__item-checkmark svg {
+  .tox-collection--list .tox-collection__item:not(.tox-collection__item--enabled) .tox-collection__item-checkmark svg {
+    display: none;
+  }
+
+  // Tickable items that are not ticked and have an adjacent shortcut hide the check mark completely (gap is removed)
+  .tox-collection--list .tox-collection__item:not(.tox-collection__item--enabled) .tox-collection__item-accessory + .tox-collection__item-checkmark {
     display: none;
   }
 

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,8 @@
 Version 5.3.0 (TBD)
     Added `uploadUri` and `blobInfo` to `editorUpload.uploadImages` return type #TINY-4579
     Added the ability to search and replace within a selection #TINY-4549
+    Added `icon` as an optional config option to the toggle menu item API #TINY-3345
+    Changed toggle menu items and choice menu items to have a dedicated icon with the checkmark displayed on the far right side of the menu item #TINY-3345
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
     Changed the default icons to be lazy loaded during initialization #TINY-4729
     Changed so base64 encoded urls are converted to blob urls when content is parsed #TINY-4727

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
@@ -18,6 +18,7 @@ const makeSetupHandler = (editor: Editor, fullscreenState: Cell<object>) => (api
 const register = (editor: Editor, fullscreenState: Cell<object>) => {
   editor.ui.registry.addToggleMenuItem('fullscreen', {
     text: 'Fullscreen',
+    icon: 'fullscreen',
     shortcut: 'Meta+Shift+F',
     onAction: () => editor.execCommand('mceFullScreen'),
     onSetup: makeSetupHandler(editor, fullscreenState)

--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
@@ -16,7 +16,7 @@ UnitTest.asynctest('browser.tinymce.plugins.importcss.ImportCssTest', (success, 
 
       const tinyUi = TinyUi(editor);
 
-      const sAssertMenu = (label: string, expected, hasIcons) => Chain.asStep(Body.body(), [
+      const sAssertMenu = (label: string, expected) => Chain.asStep(Body.body(), [
         UiFinder.cWaitForVisible('Waiting for styles menu to appear', '[role="menu"]'),
         Assertions.cAssertStructure('Checking structure', ApproxStructure.build((s, str, arr) => s.element('div', {
           classes: [ arr.has('tox-menu') ],
@@ -26,7 +26,6 @@ UnitTest.asynctest('browser.tinymce.plugins.importcss.ImportCssTest', (success, 
               children: Arr.map(expected, (exp) => s.element('div', {
                 classes: [ arr.has('tox-collection__item') ],
                 children: [
-                  ...hasIcons ? [ s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }) ] : [ ],
                   s.element('div', exp.submenu ? {
                     classes: [ arr.has('tox-collection__item-label') ],
                     html: str.is(exp.html)
@@ -36,7 +35,7 @@ UnitTest.asynctest('browser.tinymce.plugins.importcss.ImportCssTest', (success, 
                       s.element(exp.tag, { html: str.is(exp.html) })
                     ]
                   })
-                ].concat(exp.submenu ? [ s.anything() ] : [ ])
+                ].concat(exp.submenu ? [ s.anything() ] : [ s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] }) ])
               }))
             })
           ]
@@ -49,7 +48,7 @@ UnitTest.asynctest('browser.tinymce.plugins.importcss.ImportCssTest', (success, 
 
       Pipeline.async({}, [
         sOpenStyleMenu,
-        sAssertMenu('Checking stuff', assertions.menuContents, assertions.menuHasIcons)
+        sAssertMenu('Checking stuff', assertions.menuContents)
       ].concat(assertions.choice.map((c) => [
         Assertions.sAssertPresence(
           `${c} should NOT be present before clicking`,
@@ -93,7 +92,6 @@ UnitTest.asynctest('browser.tinymce.plugins.importcss.ImportCssTest', (success, 
             { tag: 'p', html: 'p.other', submenu: false },
             { tag: 'span', html: 'span.inline', submenu: false }
           ],
-          menuHasIcons: true,
           choice: Option.some('h1.red')
         },
         {

--- a/modules/tinymce/src/plugins/paste/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/ui/Buttons.ts
@@ -26,6 +26,7 @@ const register = function (editor: Editor, clipboard: Clipboard) {
 
   editor.ui.registry.addToggleMenuItem('pastetext', {
     text: 'Paste as text',
+    icon: 'paste-text',
     onAction: () => editor.execCommand('mceTogglePlainTextPaste'),
     onSetup: makeSetupHandler(editor, clipboard)
   });

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/ui/Buttons.ts
@@ -88,6 +88,7 @@ const register = function (editor: Editor, pluginUrl: string, startedState: Cell
 
   editor.ui.registry.addToggleMenuItem('spellchecker', {
     text: 'Spellcheck',
+    icon: 'spell-check',
     onSetup: (menuApi) => {
       menuApi.setActive(startedState.get());
       const setMenuItemCheck = () => {

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/ui/Buttons.ts
@@ -25,6 +25,7 @@ const register = (editor: Editor, enabledState: Cell<boolean>) => {
 
   editor.ui.registry.addToggleMenuItem('visualblocks', {
     text: 'Show blocks',
+    icon: 'visualblocks',
     onAction: () => editor.execCommand('mceVisualBlocks'),
     onSetup: toggleActiveState(editor, enabledState)
   });

--- a/modules/tinymce/src/plugins/visualchars/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/ui/Buttons.ts
@@ -25,6 +25,7 @@ const register = (editor: Editor, toggleState: Cell<boolean>) => {
 
   editor.ui.registry.addToggleMenuItem('visualchars', {
     text: 'Show invisible characters',
+    icon: 'visualchars',
     onAction: () => editor.execCommand('mceVisualChars'),
     onSetup: toggleActiveState(editor, toggleState)
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -27,6 +27,7 @@ export interface FormatterFormatItem {
   type: 'formatter';
   title?: TranslateIfNeeded;
   format: string;
+  icon?: string;
   isSelected: (value: Option<any>) => boolean;
   getStylePreview: () => Option<PreviewSpec>;
 }
@@ -107,6 +108,7 @@ const generateSelectItems = (_editor: Editor, backstage: UiFactoryBackstage, spe
         // If this type ever changes, we'll need to change that too
         type: 'togglemenuitem',
         text: translatedText,
+        icon: rawItem.icon,
         active: rawItem.isSelected(value),
         disabled,
         onAction: spec.onAction(rawItem),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
@@ -24,6 +24,7 @@ const process = (rawFormats): Array<{ title: string; format: string}> => Arr.map
 export interface BasicSelectItem {
   title: string;
   format: string;
+  icon?: string;
 }
 
 export interface BasicSelectDataset {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
@@ -30,7 +30,7 @@ export const defaultStyleFormats: AllowedFormat[] = [
       { title: 'Strikethrough', icon: 'strike-through', format: 'strikethrough' },
       { title: 'Superscript', icon: 'superscript', format: 'superscript' },
       { title: 'Subscript', icon: 'subscript', format: 'subscript' },
-      { title: 'Code', icon: 'code', format: 'code' }
+      { title: 'Code', icon: 'sourcecode', format: 'code' }
     ]
   },
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
@@ -24,13 +24,13 @@ export const defaultStyleFormats: AllowedFormat[] = [
 
   {
     title: 'Inline', items: [
-      { title: 'Bold', icon: 'bold', format: 'bold' },
-      { title: 'Italic', icon: 'italic', format: 'italic' },
-      { title: 'Underline', icon: 'underline', format: 'underline' },
-      { title: 'Strikethrough', icon: 'strike-through', format: 'strikethrough' },
-      { title: 'Superscript', icon: 'superscript', format: 'superscript' },
-      { title: 'Subscript', icon: 'subscript', format: 'subscript' },
-      { title: 'Code', icon: 'sourcecode', format: 'code' }
+      { title: 'Bold', format: 'bold' },
+      { title: 'Italic', format: 'italic' },
+      { title: 'Underline', format: 'underline' },
+      { title: 'Strikethrough', format: 'strikethrough' },
+      { title: 'Superscript', format: 'superscript' },
+      { title: 'Subscript', format: 'subscript' },
+      { title: 'Code', format: 'code' }
     ]
   },
 
@@ -45,10 +45,10 @@ export const defaultStyleFormats: AllowedFormat[] = [
 
   {
     title: 'Align', items: [
-      { title: 'Left', icon: 'align-left', format: 'alignleft' },
-      { title: 'Center', icon: 'align-center', format: 'aligncenter' },
-      { title: 'Right', icon: 'align-right', format: 'alignright' },
-      { title: 'Justify', icon: 'align-justify', format: 'alignjustify' }
+      { title: 'Left', format: 'alignleft' },
+      { title: 'Center', format: 'aligncenter' },
+      { title: 'Right', format: 'alignright' },
+      { title: 'Justify', format: 'alignjustify' }
     ]
   }
 ];

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
@@ -15,7 +15,15 @@ import { renderCheckmark } from '../structure/ItemSlices';
 import { renderItemStructure } from '../structure/ItemStructure';
 import { buildData, renderCommonItem } from './CommonMenuItem';
 
-const renderChoiceItem = (spec: Menu.ChoiceMenuItem, useText: boolean, presets: Types.PresetItemTypes, onItemValueHandler: (itemValue: string) => void, isSelected: boolean, itemResponse: ItemResponse, providersBackstage: UiFactoryBackstageProviders) => {
+const renderChoiceItem = (
+  spec: Menu.ChoiceMenuItem,
+  useText: boolean,
+  presets: Types.PresetItemTypes,
+  onItemValueHandler: (itemValue: string) => void,
+  isSelected: boolean, itemResponse: ItemResponse,
+  providersBackstage: UiFactoryBackstageProviders,
+  renderIcons: boolean = true
+) => {
   const getApi = (component): Menu.ToggleMenuItemInstanceApi => ({
     setActive: (state) => {
       Toggling.set(component, state);
@@ -39,7 +47,7 @@ const renderChoiceItem = (spec: Menu.ChoiceMenuItem, useText: boolean, presets: 
     checkMark: useText ? Option.some(renderCheckmark(providersBackstage.icons)) : Option.none(),
     caret: Option.none(),
     value: spec.value
-  }, providersBackstage, true);
+  }, providersBackstage, renderIcons);
 
   return Merger.deepMerge(
     renderCommonItem({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
@@ -15,7 +15,12 @@ import { renderCheckmark } from '../structure/ItemSlices';
 import { renderItemStructure } from '../structure/ItemStructure';
 import { buildData, renderCommonItem } from './CommonMenuItem';
 
-const renderToggleMenuItem = (spec: Menu.ToggleMenuItem, itemResponse: ItemResponse, providersBackstage: UiFactoryBackstageProviders): ItemTypes.ItemSpec => {
+const renderToggleMenuItem = (
+  spec: Menu.ToggleMenuItem,
+  itemResponse: ItemResponse,
+  providersBackstage: UiFactoryBackstageProviders,
+  renderIcons: boolean = true
+): ItemTypes.ItemSpec => {
   const getApi = (component): Menu.ToggleMenuItemInstanceApi => ({
     setActive: (state) => {
       Toggling.set(component, state);
@@ -28,7 +33,7 @@ const renderToggleMenuItem = (spec: Menu.ToggleMenuItem, itemResponse: ItemRespo
   // BespokeSelects use meta to pass through styling information. Bespokes should only
   // be togglemenuitems hence meta is only passed through in this MenuItem.
   const structure = renderItemStructure({
-    iconContent: Option.none(),
+    iconContent: spec.icon,
     textContent: spec.text,
     htmlContent: Option.none(),
     ariaLabel: spec.text,
@@ -37,7 +42,7 @@ const renderToggleMenuItem = (spec: Menu.ToggleMenuItem, itemResponse: ItemRespo
     shortcutContent: spec.shortcut,
     presets: 'normal',
     meta: spec.meta
-  }, providersBackstage, true);
+  }, providersBackstage, renderIcons);
 
   return Merger.deepMerge(
     renderCommonItem({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemSlices.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemSlices.ts
@@ -67,7 +67,7 @@ const renderShortcut = (shortcut: string): AlloySpec => ({
 const renderCheckmark = (icons: IconProvider): AlloySpec => ({
   dom: {
     tag: 'div',
-    classes: [ ItemClasses.iconClass, ItemClasses.checkmarkClass ],
+    classes: [ ItemClasses.checkmarkClass ],
     innerHtml: getIcon('checkmark', icons)
   }
 });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -92,8 +92,10 @@ const renderColorStructure = (itemText: Option<string>, itemValue: string, iconS
 
 // TODO: Maybe need aria-label
 const renderNormalItemStructure = (info: NormalItemSpec, icon: Option<string>, renderIcons: boolean, textRender: (text: string) => AlloySpec, rtlClass: boolean): ItemStructure => {
-  // checkmark has priority, otherwise render icon if we have one, otherwise empty icon for spacing
-  const leftIcon: Option<AlloySpec> = renderIcons ? info.checkMark.orThunk(() => icon.or(Option.some('')).map(renderIcon)) : Option.none();
+  // Note: renderIcons indicates if any icons are present in the menu - if false then the icon column will not be present for the whole menu
+  const leftIcon: Option<AlloySpec> = renderIcons ? icon.or(Option.some('')).map(renderIcon) : Option.none();
+  // TINY-3345: Dedicated columns for icon and checkmark if applicable
+  const checkmark = info.checkMark;
   const domTitle = info.ariaLabel.map((label): {attributes?: {title: string}} => ({
     attributes: {
       // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
@@ -118,6 +120,7 @@ const renderNormalItemStructure = (info: NormalItemSpec, icon: Option<string>, r
       leftIcon,
       content,
       info.shortcutContent.map(renderShortcut),
+      checkmark,
       info.caret
     ]
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuChoice.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuChoice.ts
@@ -4,8 +4,10 @@ import { Arr, Option, Options } from '@ephox/katamari';
 import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderChoiceItem } from '../item/build/ChoiceItem';
 import ItemResponse from '../item/ItemResponse';
-import { createPartialMenuWithAlloyItems, handleError, menuHasIcons, PartialMenuSpec } from './MenuUtils';
+import * as MenuUtils from './MenuUtils';
 import { SingleMenuItemApi } from './SingleMenuTypes';
+
+type PartialMenuSpec = MenuUtils.PartialMenuSpec;
 
 export const createPartialChoiceMenu = (
   value: string,
@@ -17,10 +19,10 @@ export const createPartialChoiceMenu = (
   select: (value: string) => boolean,
   providersBackstage: UiFactoryBackstageProviders
 ): PartialMenuSpec => {
-  const hasIcons = menuHasIcons(items);
+  const hasIcons = MenuUtils.menuHasIcons(items);
   const presetItemTypes = presets !== 'color' ? 'normal' : 'color';
   const alloyItems = createChoiceItems(items, onItemValueHandler, columns, presetItemTypes, itemResponse, select, providersBackstage);
-  return createPartialMenuWithAlloyItems(value, hasIcons, alloyItems, columns, presets);
+  return MenuUtils.createPartialMenuWithAlloyItems(value, hasIcons, alloyItems, columns, presets);
 };
 
 export const createChoiceItems = (
@@ -35,8 +37,16 @@ export const createChoiceItems = (
   Arr.map(items, (item) => {
     if (item.type === 'choiceitem') {
       return BridgeMenu.createChoiceMenuItem(item).fold(
-        handleError,
-        (d: BridgeMenu.ChoiceMenuItem) => Option.some(renderChoiceItem(d, columns === 1, itemPresets, onItemValueHandler, select(item.value), itemResponse, providersBackstage))
+        MenuUtils.handleError,
+        (d: BridgeMenu.ChoiceMenuItem) => Option.some(renderChoiceItem(
+          d, columns === 1,
+          itemPresets,
+          onItemValueHandler,
+          select(item.value),
+          itemResponse,
+          providersBackstage,
+          MenuUtils.menuHasIcons(items)
+        ))
       );
     } else {
       return Option.none();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuUtils.ts
@@ -1,6 +1,6 @@
 import { ItemTypes, MenuTypes } from '@ephox/alloy';
 import { ValueSchema } from '@ephox/boulder';
-import { Types } from '@ephox/bridge';
+import { Types, InlineContent } from '@ephox/bridge';
 import { console } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
 import { components as menuComponents, dom as menuDom } from './MenuParts';
@@ -8,8 +8,7 @@ import { components as menuComponents, dom as menuDom } from './MenuParts';
 import { forCollection, forHorizontalCollection, forSwatch, forToolbar } from './MenuStructures';
 import { SingleMenuItemApi } from './SingleMenuTypes';
 
-export const hasIcon = (item) => item.icon !== undefined || item.type === 'togglemenuitem' || item.type === 'choicemenuitem';
-export const menuHasIcons = (xs: SingleMenuItemApi[]) => Arr.exists(xs, hasIcon);
+export const menuHasIcons = (xs: Array<SingleMenuItemApi | InlineContent.AutocompleterItemApi>) => Arr.exists(xs, (item) => 'icon' in item && item.icon !== undefined);
 
 export interface PartialMenuSpec {
   value: string;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
@@ -16,16 +16,15 @@ import ItemResponse from '../item/ItemResponse';
 import * as MenuItems from '../item/MenuItems';
 import { deriveMenuMovement } from './MenuMovement';
 import { markers as getMenuMarkers } from './MenuParts';
-import { createHorizontalPartialMenuWithAlloyItems, createPartialMenuWithAlloyItems, handleError, PartialMenuSpec } from './MenuUtils';
+import * as MenuUtils from './MenuUtils';
 import { SingleMenuItemApi } from './SingleMenuTypes';
 /* eslint-enable max-len */
+
+type PartialMenuSpec = MenuUtils.PartialMenuSpec;
 
 export type ItemChoiceActionHandler = (value: string) => void;
 
 export enum FocusMode { ContentFocus, UiFocus }
-
-const hasIcon = (item) => item.icon !== undefined || item.type === 'togglemenuitem' || item.type === 'choicemenuitem';
-const menuHasIcons = (xs: Array<SingleMenuItemApi | InlineContent.AutocompleterContents>) => Arr.exists(xs, hasIcon);
 
 const createMenuItemFromBridge = (
   item: SingleMenuItemApi,
@@ -45,7 +44,7 @@ const createMenuItemFromBridge = (
   switch (item.type) {
     case 'menuitem':
       return BridgeMenu.createMenuItem(item).fold(
-        handleError,
+        MenuUtils.handleError,
         (d) => Option.some(MenuItems.normal(
           parseForHorizontalMenu(d),
           itemResponse,
@@ -56,7 +55,7 @@ const createMenuItemFromBridge = (
 
     case 'nestedmenuitem':
       return BridgeMenu.createNestedMenuItem(item).fold(
-        handleError,
+        MenuUtils.handleError,
         (d) => Option.some(MenuItems.nested(
           parseForHorizontalMenu(d),
           itemResponse,
@@ -68,17 +67,22 @@ const createMenuItemFromBridge = (
 
     case 'togglemenuitem':
       return BridgeMenu.createToggleMenuItem(item).fold(
-        handleError,
-        (d) => Option.some(MenuItems.toggle(parseForHorizontalMenu(d), itemResponse, providersBackstage))
+        MenuUtils.handleError,
+        (d) => Option.some(MenuItems.toggle(
+          parseForHorizontalMenu(d),
+          itemResponse,
+          providersBackstage,
+          menuHasIcons
+        ))
       );
     case 'separator':
       return BridgeMenu.createSeparatorMenuItem(item).fold(
-        handleError,
+        MenuUtils.handleError,
         (d) => Option.some(MenuItems.separator(d))
       );
     case 'fancymenuitem':
       return BridgeMenu.createFancyMenuItem(item).fold(
-        handleError,
+        MenuUtils.handleError,
         (d) => MenuItems.fancy(parseForHorizontalMenu(d), backstage)
       );
     default: {
@@ -99,17 +103,17 @@ export const createAutocompleteItems = (
 ) => {
   // Render text and icons if we're using a single column, otherwise only render icons
   const renderText = columns === 1;
-  const renderIcons = !renderText || menuHasIcons(items);
+  const renderIcons = !renderText || MenuUtils.menuHasIcons(items);
   return Options.cat(
     Arr.map(items, (item) => {
       if (item.type === 'separator') {
         return InlineContent.createSeparatorItem(item).fold(
-          handleError,
+          MenuUtils.handleError,
           (d) => Option.some(MenuItems.separator(d))
         );
       } else {
         return InlineContent.createAutocompleterItem(item).fold(
-          handleError,
+          MenuUtils.handleError,
           (d: InlineContent.AutocompleterItem) => Option.some(MenuItems.autocomplete(
             d,
             matchText,
@@ -133,14 +137,14 @@ export const createPartialMenu = (
   backstage: UiFactoryBackstage,
   isHorizontalMenu: boolean
 ): PartialMenuSpec => {
-  const hasIcons = menuHasIcons(items);
+  const hasIcons = MenuUtils.menuHasIcons(items);
 
   const alloyItems = Options.cat(
     Arr.map(items, (item: SingleMenuItemApi) => {
       // Have to check each item for an icon, instead of as part of hasIcons above,
       // else in horizontal menus, items with an icon but without text will display
       // with neither
-      const itemHasIcon = (i) => isHorizontalMenu ? !i.hasOwnProperty('text') : hasIcons;
+      const itemHasIcon = (i: SingleMenuItemApi) => isHorizontalMenu ? !i.hasOwnProperty('text') : hasIcons;
       const createItem = (i: SingleMenuItemApi) => createMenuItemFromBridge(
         i,
         itemResponse,
@@ -156,8 +160,8 @@ export const createPartialMenu = (
     })
   );
   const createPartial = isHorizontalMenu ?
-    createHorizontalPartialMenuWithAlloyItems :
-    createPartialMenuWithAlloyItems;
+    MenuUtils.createHorizontalPartialMenuWithAlloyItems :
+    MenuUtils.createPartialMenuWithAlloyItems;
   return createPartial(value, hasIcons, alloyItems, 1, 'normal');
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
@@ -44,37 +44,37 @@ UnitTest.asynctest('OxideFontFormatMenuTest', (success, failure) => {
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             children: [
                               s.element('h1', { html: str.is('Title') })
                             ]
-                          })
+                          }),
+                          s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] })
                         ]
                       }),
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             children: [
                               s.element('h2', { html: str.is('Main heading') })
                             ]
-                          })
+                          }),
+                          s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] })
                         ]
                       }),
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             children: [
                               s.element('h3', { html: str.is('Sub heading') })
                             ]
-                          })
+                          }),
+                          s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] })
                         ]
                       })
                     ]
@@ -90,43 +90,42 @@ UnitTest.asynctest('OxideFontFormatMenuTest', (success, failure) => {
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             children: [
                               s.element('p', { html: str.is('Paragraph') })
                             ]
-                          })
+                          }),
+                          s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] })
                         ]
                       }),
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             children: [
                               s.element('blockquote', { html: str.is('Blockquote') })
                             ]
-                          })
+                          }),
+                          s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] })
                         ]
                       }),
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             children: [
                               s.element('pre', { html: str.is('Code') })
                             ]
-                          })
+                          }),
+                          s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] })
                         ]
                       }),
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             html: str.is('Others')
@@ -139,7 +138,6 @@ UnitTest.asynctest('OxideFontFormatMenuTest', (success, failure) => {
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             children: [
@@ -150,13 +148,13 @@ UnitTest.asynctest('OxideFontFormatMenuTest', (success, failure) => {
                                 }
                               })
                             ]
-                          })
+                          }),
+                          s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] })
                         ]
                       }),
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             children: [
@@ -167,19 +165,20 @@ UnitTest.asynctest('OxideFontFormatMenuTest', (success, failure) => {
                                 }
                               })
                             ]
-                          })
+                          }),
+                          s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] })
                         ]
                       }),
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item') ],
                         children: [
-                          s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-label') ],
                             children: [
                               s.element('div', { html: str.is('Table row 1') })
                             ]
-                          })
+                          }),
+                          s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] })
                         ]
                       })
                     ]

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
@@ -44,7 +44,7 @@ UnitTest.asynctest('OxideListCollectionMenuTest', (success, failure) => {
                         },
                         children: [
                           s.element('div', {
-                            classes: [ arr.has('tox-collection__item-icon'), arr.has('tox-collection__item-checkmark') ],
+                            classes: [ arr.has('tox-collection__item-icon') ],
                             children: [
                               s.element('svg', {})
                             ]
@@ -54,7 +54,13 @@ UnitTest.asynctest('OxideListCollectionMenuTest', (success, failure) => {
                           }),
                           s.element('div', {
                             classes: [ arr.has('tox-collection__item-accessory') ]
-                          })
+                          }),
+                          s.element('div', {
+                            classes: [ arr.has('tox-collection__item-checkmark') ],
+                            children: [
+                              s.element('svg', {})
+                            ]
+                          }),
                         ]
                       }),
                       s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/sketchers/SilverMenubarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/sketchers/SilverMenubarTest.ts
@@ -62,7 +62,7 @@ UnitTest.asynctest('SilverMenubar Test', (success, failure) => {
         Chain.asStep(sink, [
           UiFinder.cFindIn('.tox-selected-menu [role=menuitemcheckbox]:contains("' + itemText + '")'),
           Chain.op((_menu) => {
-            const checkMarks = Selectors.all('.tox-collection__item-icon');
+            const checkMarks = Selectors.all('.tox-collection__item-checkmark');
             Assertions.assertEq('only one check mark is displayed for active toggled menu items', 1, checkMarks.length);
           })
         ]);
@@ -94,7 +94,7 @@ UnitTest.asynctest('SilverMenubar Test', (success, failure) => {
           UiFinder.sNotExists(sink, '.tox-menu')
         );
 
-      const sAssertMenuItemGroups = (label: string, groups: string[][]) => Logger.t(
+      const sAssertMenuItemGroups = (label: string, groups: string[][], hasIcons: boolean, hasCheckmark: boolean) => Logger.t(
         label,
         Chain.asStep(sink, [
           UiFinder.cFindIn('.tox-selected-menu'),
@@ -109,14 +109,14 @@ UnitTest.asynctest('SilverMenubar Test', (success, failure) => {
                   return s.element('div', {
                     classes: [ arr.has('tox-collection__item') ],
                     children: [
-                      s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }),
+                      ...hasIcons ? [ s.element('div', { classes: [ arr.has('tox-collection__item-icon') ] }) ] : [],
                       s.element('div', {
                         classes: [ arr.has('tox-collection__item-label') ],
                         html: str.is(hasCaret ? itemText.substring(0, itemText.length - 1) : itemText)
                       })
                     ].concat(hasCaret ? [
                       s.element('div', { classes: [ arr.has('tox-collection__item-caret') ] })
-                    ] : [ ])
+                    ] : hasCheckmark ? [ s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] }) ] : [])
                   });
                 })
               }))
@@ -290,7 +290,7 @@ UnitTest.asynctest('SilverMenubar Test', (success, failure) => {
           ),
           sAssertMenuItemGroups('After clicking on "Changes"', [
             [ 'Remember me' ]
-          ]),
+          ], false, true),
           Mouse.sHoverOn(menubar.element(), 'button[role="menuitem"]:contains("Basic Menu Button")'),
           UiFinder.sWaitForVisible(
             'Waiting for basic menu',
@@ -308,7 +308,7 @@ UnitTest.asynctest('SilverMenubar Test', (success, failure) => {
           sAssertMenuItemGroups('After hovering on Basic (after another menu was open)', [
             [ 'Item1' ],
             [ 'Item2', 'Nested menu>' ]
-          ])
+          ], true, false)
         ])
       ];
     }, () => {


### PR DESCRIPTION
This PR allows menu items, specifically toggle and choice items to display a dedicated icon on the left side of the item with a checkmark on the far right side of the item. If a shortcut is present and the checkmark is toggled off, the shortcut will shift over to the edge of the menu item.

![new-checkmark-design](https://user-images.githubusercontent.com/46954949/81515628-5c2c7f00-9378-11ea-83c7-dccd2a5d4e77.png)
