### PR TITLE
Remove caching from Body.body()

### DIFF
--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Body.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Body.ts
@@ -1,5 +1,4 @@
 import { document, Document, HTMLElement, Node as DomNode } from '@ephox/dom-globals';
-import { Thunk } from '@ephox/katamari';
 import Element from './Element';
 import * as Node from './Node';
 
@@ -15,7 +14,7 @@ const inBody = (element: Element<DomNode>) => {
   return dom !== undefined && dom !== null && dom.ownerDocument.body.contains(dom);
 };
 
-const body = Thunk.cached(() => getBody(Element.fromDom(document)));
+const body = () => getBody(Element.fromDom(document));
 
 const getBody = (doc: Element<Document>): Element<HTMLElement> => {
   const b = doc.dom().body;

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -20,6 +20,7 @@ Version 5.3.0 (TBD)
     Fixed `ObjectResized` event firing when an object wasn't resized #TINY-4161
     Fixed the placeholder not hiding when pasting content into the editor #TINY-4828
     Fixed an issue where the editor would fail to load if local storage was disabled #TINY-5935
+    Fixed bug where toolbars and dialogs would not show if the body element was replaced (e.g. with Turbolinks). Patch contributed by spohlenz #GH-5653
 Version 5.2.2 (2020-04-23)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
     Fixed text decorations (underline, strikethrough) not consistently inheriting the text color #TINY-4757


### PR DESCRIPTION
This PR provides a fix for the problem outlined in #5274.

In short, menus, toolbars and dialogs currently stop working if the `body` element is replaced, which happens during a page visit in [Turbolinks](https://github.com/turbolinks/turbolinks/) (potentially in other circumstances too). See the demo at https://jsfiddle.net/hbjpmqgv/1/ for a simulation.

When I originally created the issue, I was unsure of the potential performance implications of this fix. However I have spent some time looking into this further and I don't believe there should be any negative impacts for the following reasons:

1) The call to `Body.body()` is not done very often during the life cycle of a TinyMCE instance, and certainly not in any loops that I could find. From some basic `console.log` debugging, it appears to be called only once on initialization, and then on dialog open/close.

2) `Body.body()` essentially amounts to a call to `document.body` (which is performant) with some wrapping/unwrapping to fit the `Element` interface (so minimal overhead).

This issue has so far been a blocker for upgrading to TinyMCE 5.x as we don't want to give up Turbolinks. It would be great if it can be merged.