### PR TITLE
TINY-4829: Fixed `ObjectResized` and `ObjectResizeStart` events incorrectly fired

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -18,6 +18,7 @@ Version 5.3.0 (TBD)
     Fixed toolbar buttons not set to disabled when the editor is in readonly mode #TINY-4592
     Fixed bug where title, width, height would be set to empty string values when updating an image and removing those using the image dialog #TINY-4786
     Fixed `ObjectResized` event firing when an object wasn't resized #TINY-4161
+    Fixed `ObjectResized` and `ObjectResizeStart` events incorrectly fired when adding or removing table rows and columns #TINY-4829
     Fixed the placeholder not hiding when pasting content into the editor #TINY-4828
     Fixed an issue where the editor would fail to load if local storage was disabled #TINY-5935
 Version 5.2.2 (2020-04-23)

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -5,20 +5,19 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Option, Cell } from '@ephox/katamari';
+import { Arr, Cell, Fun, Option } from '@ephox/katamari';
 import { CopyRows, TableFill, TableLookup } from '@ephox/snooker';
 import { Element, Insert, Remove, Replication } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
+import { TableActions } from '../actions/TableActions';
 import * as Util from '../alien/Util';
 import * as TableTargets from '../queries/TableTargets';
+import { Selections } from '../selection/Selections';
+import * as TableSelection from '../selection/TableSelection';
 import * as CellDialog from '../ui/CellDialog';
 import * as RowDialog from '../ui/RowDialog';
 import * as TableDialog from '../ui/TableDialog';
-import { TableActions } from '../actions/TableActions';
-import { Selections } from '../selection/Selections';
-import * as TableSelection from '../selection/TableSelection';
-import * as Events from '../api/Events';
 
 const each = Tools.each;
 
@@ -49,27 +48,11 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection, 
 
   const getTableFromCell = (cell: Element): Option<Element> => TableLookup.table(cell, isRoot);
 
-  const getSize = (table) => ({
-    width: Util.getPixelWidth(table.dom()),
-    height: Util.getPixelWidth(table.dom())
-  });
-
-  const resizeChange = (editor: Editor, oldSize, table) => {
-    const newSize = getSize(table);
-
-    if (oldSize.width !== newSize.width || oldSize.height !== newSize.height) {
-      Events.fireObjectResizeStart(editor, table.dom(), oldSize.width, oldSize.height);
-      Events.fireObjectResized(editor, table.dom(), newSize.width, newSize.height);
-    }
-  };
-
   const actOnSelection = (execute) => {
     TableSelection.getSelectionStartCell(editor).each((cell) => {
       getTableFromCell(cell).each((table) => {
         const targets = TableTargets.forMenu(selections, table, cell);
-        const beforeSize = getSize(table);
         execute(table, targets).each((rng) => {
-          resizeChange(editor, beforeSize, table);
           editor.selection.setRng(rng);
           editor.focus();
           cellSelection.clear(table);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertRowTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertRowTableResizeTest.ts
@@ -1,0 +1,212 @@
+import { Assertions, Chain, Guard, Log, NamedChain, TestLogs, UiFinder } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Editor, TinyDom } from '@ephox/mcagar';
+import { SelectorFind } from '@ephox/sugar';
+
+import Plugin from 'tinymce/plugins/table/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+import * as TableTestUtils from '../module/test/TableTestUtils';
+
+UnitTest.asynctest('browser.tinymce.plugins.table.InsertRowTableResizeTest', (success, failure) => {
+
+  Plugin();
+  SilverTheme();
+
+  interface TestData {
+    html: string;
+  }
+
+  const emptyTable = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<td></td>' +
+                '<td></td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td></td>' +
+                '<td></td>' +
+              '</tr>' +
+            '</tbody>' +
+            '</table>'
+  };
+
+  const contentsInSomeCells = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>a1</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td></td>' +
+                '<td></td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const contentsInAllCells = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>a1</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a2</td>' +
+                '<td>b2</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a3</td>' +
+                '<td>b3</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const tableWithHeadings = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<th>a1</th>' +
+                '<th>b1</th>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a1</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a2</td>' +
+                '<td>b2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const tableWithCaption = {
+    html: '<table style = "width: 100%;">' +
+            '<caption>alphabet</caption>' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>a1</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a2</td>' +
+                '<td>b2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const nestedTables = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>a1' +
+                  '<table style = "width: 100%;">' +
+                  '<tbody>' +
+                    '<tr>' +
+                      '<td></td>' +
+                      '<td></td>' +
+                    '</tr>' +
+                    '<tr>' +
+                      '<td></td>' +
+                      '<td></td>' +
+                    '</tr>' +
+                  '</tbody>' +
+                  '</table>' +
+                '</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a2</td>' +
+                '<td>b2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const cInsertTable = (label: string, table: string) => Chain.control(
+    Chain.mapper((editor: any) => {
+      editor.setContent(table);
+      const bodyElem = TinyDom.fromDom(editor.getBody());
+      const tableElem = UiFinder.findIn(bodyElem, 'table').getOr(bodyElem);
+      SelectorFind.descendant(tableElem, 'td,th').each((cell) => {
+        editor.selection.select(cell.dom(), true);
+        editor.selection.collapse(true);
+      });
+      return tableElem;
+    }),
+    Guard.addLogging(`Insert ${label}`)
+  );
+
+  const cInsertRowMeasureWidth = (label: string, data: TestData) => Log.chain('TBA', 'Insert row before, insert row after, erase row and measure table widths', NamedChain.asChain(
+    [
+      NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
+      Chain.label('Insert table', NamedChain.direct('editor', cInsertTable(label, data.html), 'element')),
+      Chain.label('Store width before split', NamedChain.write('widthBefore', TableTestUtils.cGetWidth)),
+      Chain.label('Store cell width before split', NamedChain.write('cellWidthBefore', TableTestUtils.cGetCellWidth(0, 0))),
+      Chain.label('Insert column before', NamedChain.read('editor', TableTestUtils.cInsertRowBefore)),
+      Chain.label('Insert column after', NamedChain.read('editor', TableTestUtils.cInsertRowAfter)),
+      Chain.label('Delete column', NamedChain.read('editor', TableTestUtils.cDeleteRow)),
+      Chain.label('Store width after split', NamedChain.write('widthAfter', TableTestUtils.cGetWidth)),
+      Chain.label('Store cell width before split', NamedChain.write('cellWidthAfter', TableTestUtils.cGetCellWidth(0, 0))),
+      NamedChain.merge([ 'widthBefore', 'cellWidthBefore', 'widthAfter', 'cellWidthAfter' ], 'widths'),
+      NamedChain.output('widths')
+    ]
+  ));
+
+  const cAssertWidths = Chain.label(
+    'Assert widths before and after insert row are equal',
+    Chain.op((input: any) => {
+      if (input.widthBefore.isPercent) {
+        // due to rounding errors we can be off by one pixel for percentage tables
+        const actualDiff = Math.abs(input.widthBefore.px - input.widthAfter.px);
+        Assert.eq(`table width should be approx (within 1px): ${input.widthBefore.raw}% (${input.widthBefore.px}px) ~= ${input.widthAfter.raw}% (${input.widthAfter.px}px)`, true,  actualDiff <= 1);
+      } else {
+        Assertions.assertEq('table width should not change', input.widthBefore, input.widthAfter);
+      }
+
+      Assertions.assertEq('table cell widths should not change', input.cellWidthBefore, input.cellWidthAfter);
+    })
+  );
+
+  const cAssertWidth = (label: string, data: TestData) => Chain.label(
+    `Assert width of table ${label} after inserting row`,
+    NamedChain.asChain([
+      NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
+      NamedChain.direct('editor', cInsertRowMeasureWidth(label, data), 'widths'),
+      NamedChain.read('widths', cAssertWidths)
+    ])
+  );
+
+  let objectResizedCounter = 0;
+
+  NamedChain.pipeline(Log.chains('TBA', 'Table: Insert rows, erase row and assert the table width and cell widths does not change', [
+    NamedChain.write('editor', Editor.cFromSettings({
+      plugins: 'table',
+      width: 400,
+      theme: 'silver',
+      base_url: '/project/tinymce/js/tinymce',
+      setup: (editor) => {
+        editor.on('ObjectResized', () => objectResizedCounter++);
+      }
+    })),
+
+    NamedChain.read('editor', cAssertWidth('which is empty', emptyTable)),
+    NamedChain.read('editor', cAssertWidth('with contents in some cells', contentsInSomeCells)),
+    NamedChain.read('editor', cAssertWidth('with contents in all cells', contentsInAllCells)),
+    NamedChain.read('editor', cAssertWidth('with headings', tableWithHeadings)),
+    NamedChain.read('editor', cAssertWidth('with caption', tableWithCaption)),
+    NamedChain.read('editor', cAssertWidth('with nested tables', nestedTables)),
+
+    NamedChain.read('editor', Chain.op(() => {
+      Assertions.assertEq('ObjectResized shouldn\'t have fired', 0, objectResizedCounter);
+    })),
+
+    NamedChain.read('editor', Editor.cRemove)
+  ]),
+  success, failure, TestLogs.init());
+});


### PR DESCRIPTION
These events were being fired when adding or removing table rows and columns, or generally any table width/change. This however was incorrect and inconsistent, as these events only normally fire when a user resizes using a resize handle everywhere else. As an example, when you change the dimension of an image these wouldn't fire.