### PR TITLE
TINY-3161: Fixed more missed edge cases

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -47,6 +47,7 @@ const setupEvents = (editor: Editor, targetElm: Element, ui: InlineHeader) => {
       if (prevPos !== pos) {
         ui.update(true);
       } else if (hasResized) {
+        ui.updateMode();
         ui.repositionPopups();
       }
     }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -64,7 +64,8 @@ export const InlineHeader = (editor: Editor, targetElm: Element, uiComponents: R
         if (roomAtTop) {
           return 'top';
         } else {
-          const docHeight = Height.get(Traverse.documentElement(targetElm));
+          const doc = Traverse.documentElement(targetElm);
+          const docHeight = Math.max(doc.dom().scrollHeight, Height.get(doc));
           const roomAtBottom = targetBounds.bottom < docHeight - toolbarHeight;
 
           // If there isn't ever room to add the toolbar above the target element, then place the toolbar at the bottom.


### PR DESCRIPTION
I used the wrong height here again :facepalm: as I needed to use the document scroll height, not the offset height. As such sometimes it thought there wasn't any room to render below the content area. Also missed a case whereby if you deleted content then it wouldn't adjust back to being below the editor content.

Hopefully this is the last PR for this issue sorry all!