### PR TITLE
TINY-5978: Added html and body height styles to the default oxide content css

### DIFF
--- a/modules/oxide/src/less/skins/content/dark/content.less
+++ b/modules/oxide/src/less/skins/content/dark/content.less
@@ -9,10 +9,15 @@
 // Place your HTML here
 //
 
+html {
+  height: 100%;
+}
+
 body {
   background-color: #2f3742;
   color: #dfe0e4;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  height: calc(100% - 2rem);
   line-height: 1.4;
   margin: 1rem;
 }

--- a/modules/oxide/src/less/skins/content/default/content.less
+++ b/modules/oxide/src/less/skins/content/default/content.less
@@ -9,8 +9,13 @@
 // Place your HTML here
 //
 
+html {
+  height: 100%;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  height: calc(100% - 2rem);
   line-height: 1.4;
   margin: 1rem;
 }

--- a/modules/oxide/src/less/skins/content/document/content.less
+++ b/modules/oxide/src/less/skins/content/document/content.less
@@ -14,6 +14,7 @@ html {
 
   @media screen {
     background: #f4f4f4;
+    height: 100%;
   }
 }
 
@@ -24,9 +25,9 @@ body {
     background-color: #fff;
     box-shadow: 0 0 4px fade(#000, 15%);
     box-sizing: border-box;
+    height: calc(100% - 1rem);
     margin: 1rem auto 0;
     max-width: 820px;
-    min-height: calc(100vh - 1rem);
     padding: 4rem 6rem 6rem 6rem;
   }
 }

--- a/modules/oxide/src/less/skins/content/writer/content.less
+++ b/modules/oxide/src/less/skins/content/writer/content.less
@@ -9,8 +9,13 @@
 // Place your HTML here
 //
 
+html {
+  height: 100%;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  height: calc(100% - 2rem);
   line-height: 1.4;
   margin: 1rem auto;
   max-width: 900px;

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.3.0 (TBD)
     Added `uploadUri` and `blobInfo` to `editorUpload.uploadImages` return type #TINY-4579
     Added the ability to search and replace within a selection #TINY-4549
+    Added html and body height styles to the default oxide content CSS #TINY-5978
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
     Changed the default icons to be lazy loaded during initialization #TINY-4729
     Changed so base64 encoded urls are converted to blob urls when content is parsed #TINY-4727

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -7,9 +7,9 @@
 
 import { Element } from '@ephox/dom-globals';
 import { Cell } from '@ephox/katamari';
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Delay from 'tinymce/core/api/util/Delay';
 import * as Events from '../api/Events';
 import * as Settings from '../api/Settings';
@@ -138,6 +138,11 @@ const setup = (editor: Editor, oldSize: Cell<number>) => {
   editor.on('init', () => {
     const overflowPadding = Settings.getAutoResizeOverflowPadding(editor);
     const dom = editor.dom;
+
+    // Disable height 100% on the root document element otherwise we'll end up resizing indefinitely
+    dom.setStyles(editor.getDoc().documentElement, {
+      height: 'auto'
+    });
 
     dom.setStyles(editor.getBody(), {
       'paddingLeft': overflowPadding,


### PR DESCRIPTION
This is needed, as anything that uses relative heights won't render as expected within the editor otherwise (or on the users site).

Note: The calcs on the body are required due to the margins currently defined.