### PR TITLE
TINY-5987/TINY-5988: Fix image upload regression and different image types being treated as the same

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.3.0 (TBD)
     Added `uploadUri` and `blobInfo` to `editorUpload.uploadImages` return type #TINY-4579
+    Added new function to the `BlobCache` API to lookup a blob based on the base64 data and mime type #TINY-5988
     Added the ability to search and replace within a selection #TINY-4549
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710
     Changed the default icons to be lazy loaded during initialization #TINY-4729
@@ -22,6 +23,7 @@ Version 5.3.0 (TBD)
     Fixed `ObjectResized` and `ObjectResizeStart` events incorrectly fired when adding or removing table rows and columns #TINY-4829
     Fixed the placeholder not hiding when pasting content into the editor #TINY-4828
     Fixed an issue where the editor would fail to load if local storage was disabled #TINY-5935
+    Fixed an issue where an uploaded image would reuse a cached image with a different mime type #TINY-5988
     Fixed bug where toolbars and dialogs would not show if the body element was replaced (e.g. with Turbolinks). Patch contributed by spohlenz #GH-5653
 Version 5.2.2 (2020-04-23)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788

--- a/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
+++ b/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
@@ -5,16 +5,17 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import * as Uuid from '../../util/Uuid';
 import { Blob, URL } from '@ephox/dom-globals';
-import { Type, Fun, Arr } from '@ephox/katamari';
+import { Arr, Fun, Type } from '@ephox/katamari';
+import * as Uuid from '../../util/Uuid';
 
 export interface BlobCache {
   create: (o: string | BlobInfoData, blob?: Blob, base64?: string, filename?: string) => BlobInfo;
   add: (blobInfo: BlobInfo) => void;
-  get: (id: string) => BlobInfo;
-  getByUri: (blobUri: string) => BlobInfo;
-  findFirst: (predicate: (blobInfo: BlobInfo) => boolean) => any;
+  get: (id: string) => BlobInfo | undefined;
+  getByUri: (blobUri: string) => BlobInfo | undefined;
+  getByData: (base64: string, type: string) => BlobInfo | undefined;
+  findFirst: (predicate: (blobInfo: BlobInfo) => boolean) => BlobInfo | undefined;
   removeByUri: (blobUri: string) => void;
   destroy: () => void;
 }
@@ -38,10 +39,10 @@ export interface BlobInfo {
   uri: () => string;
 }
 
-export const BlobCache = function (): BlobCache {
+export const BlobCache = (): BlobCache => {
   let cache: BlobInfo[] = [];
 
-  const mimeToExt = function (mime) {
+  const mimeToExt = (mime: string) => {
     const mimes = {
       'image/jpeg': 'jpg',
       'image/jpg': 'jpg',
@@ -52,7 +53,7 @@ export const BlobCache = function (): BlobCache {
     return mimes[mime.toLowerCase()] || 'dat';
   };
 
-  const create = function (o: BlobInfoData | string, blob?: Blob, base64?: string, filename?: string): BlobInfo {
+  const create = (o: BlobInfoData | string, blob?: Blob, base64?: string, filename?: string): BlobInfo => {
     if (Type.isString(o)) {
       const id = o;
 
@@ -69,7 +70,7 @@ export const BlobCache = function (): BlobCache {
     }
   };
 
-  const toBlobInfo = function (o: BlobInfoData): BlobInfo {
+  const toBlobInfo = (o: BlobInfoData): BlobInfo => {
     let id, name;
 
     if (!o.blob || !o.base64) {
@@ -90,30 +91,25 @@ export const BlobCache = function (): BlobCache {
     };
   };
 
-  const add = function (blobInfo: BlobInfo) {
+  const add = (blobInfo: BlobInfo) => {
     if (!get(blobInfo.id())) {
       cache.push(blobInfo);
     }
   };
 
-  const get = function (id: string): BlobInfo {
-    return findFirst(function (cachedBlobInfo) {
-      return cachedBlobInfo.id() === id;
-    });
-  };
+  const findFirst = (predicate: (blobInfo: BlobInfo) => boolean) => Arr.find(cache, predicate).getOrUndefined();
 
-  const findFirst = function (predicate: (blobInfo: BlobInfo) => boolean) {
-    return Arr.filter(cache, predicate)[0];
-  };
+  const get = (id: string) =>
+    findFirst((cachedBlobInfo) => cachedBlobInfo.id() === id);
 
-  const getByUri = function (blobUri: string): BlobInfo {
-    return findFirst(function (blobInfo) {
-      return blobInfo.blobUri() === blobUri;
-    });
-  };
+  const getByUri = (blobUri: string) =>
+    findFirst((blobInfo) => blobInfo.blobUri() === blobUri);
 
-  const removeByUri = function (blobUri: string) {
-    cache = Arr.filter(cache, function (blobInfo) {
+  const getByData = (base64: string, type: string) =>
+    findFirst((blobInfo) => blobInfo.base64() === base64 && blobInfo.blob().type === type);
+
+  const removeByUri = (blobUri: string) => {
+    cache = Arr.filter(cache, (blobInfo) => {
       if (blobInfo.blobUri() === blobUri) {
         URL.revokeObjectURL(blobInfo.blobUri());
         return false;
@@ -123,8 +119,8 @@ export const BlobCache = function (): BlobCache {
     });
   };
 
-  const destroy = function () {
-    Arr.each(cache, function (cachedBlobInfo) {
+  const destroy = () => {
+    Arr.each(cache, (cachedBlobInfo) => {
       URL.revokeObjectURL(cachedBlobInfo.blobUri());
     });
 
@@ -136,6 +132,7 @@ export const BlobCache = function (): BlobCache {
     add,
     get,
     getByUri,
+    getByData,
     findFirst,
     removeByUri,
     destroy

--- a/modules/tinymce/src/core/main/ts/file/ImageScanner.ts
+++ b/modules/tinymce/src/core/main/ts/file/ImageScanner.ts
@@ -6,11 +6,11 @@
  */
 
 import { HTMLElement, HTMLImageElement } from '@ephox/dom-globals';
-import { Fun, Arr } from '@ephox/katamari';
-import Promise from '../api/util/Promise';
-import * as Conversions from './Conversions';
+import { Arr, Fun } from '@ephox/katamari';
 import Env from '../api/Env';
 import { BlobCache, BlobInfo } from '../api/file/BlobCache';
+import Promise from '../api/util/Promise';
+import * as Conversions from './Conversions';
 
 export interface BlobInfoImagePair {
   image: HTMLImageElement;
@@ -65,10 +65,9 @@ const imageToBlobInfo = function (blobCache: BlobCache, img: HTMLImageElement, r
     return;
   }
 
-  base64 = Conversions.parseDataUri(img.src).data;
-  blobInfo = blobCache.findFirst(function (cachedBlobInfo) {
-    return cachedBlobInfo.base64() === base64;
-  });
+  const { data, type } = Conversions.parseDataUri(img.src);
+  base64 = data;
+  blobInfo = blobCache.getByData(base64, type);
 
   if (blobInfo) {
     resolve({

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -26,16 +26,15 @@ const registerBase64ImageFilter = (parser: DomParser, settings: DomParserSetting
       return;
     }
 
-    parseDataUri(inputSrc).bind(({ type, data }) => {
-      const cachedBlobInfo = blobCache.findFirst((blobInfo) => blobInfo.base64() === data);
-      return Option.from(cachedBlobInfo).orThunk(() =>
+    parseDataUri(inputSrc).bind(({ type, data }) =>
+      Option.from(blobCache.getByData(data, type)).orThunk(() =>
         Conversions.buildBlob(type, data).map((blob) => {
           const blobInfo = blobCache.create(uniqueId(), blob, data);
           blobCache.add(blobInfo);
           return blobInfo;
         })
-      );
-    }).each((blobInfo) => {
+      )
+    ).each((blobInfo) => {
       img.attr('src', blobInfo.blobUri());
     });
   };

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -5,15 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Tools from '../api/util/Tools';
-import { isEmpty, paddEmptyNode } from './ParserUtils';
-import Node from '../api/html/Node';
-import { Unicode, Arr } from '@ephox/katamari';
-import DomParser, { DomParserSettings } from '../api/html/DomParser';
-import { uniqueId } from '../file/ImageScanner';
-import * as Conversions from '../file/Conversions';
-import { parseDataUri } from './Base64Uris';
+import { Arr, Option, Unicode } from '@ephox/katamari';
 import Env from '../api/Env';
+import DomParser, { DomParserSettings } from '../api/html/DomParser';
+import Node from '../api/html/Node';
+import Tools from '../api/util/Tools';
+import * as Conversions from '../file/Conversions';
+import { uniqueId } from '../file/ImageScanner';
+import { parseDataUri } from './Base64Uris';
+import { isEmpty, paddEmptyNode } from './ParserUtils';
 
 const isInternalImageSource = (src: string) => src === Env.transparentSrc;
 
@@ -26,13 +26,18 @@ const registerBase64ImageFilter = (parser: DomParser, settings: DomParserSetting
       return;
     }
 
-    parseDataUri(inputSrc).map(({ type, data }) => Conversions.buildBlob(type, data).each(
-      (blob) => {
-        const blobInfo = blobCache.create(uniqueId(), blob, data);
-        blobCache.add(blobInfo);
-        img.attr('src', blobInfo.blobUri());
-      }
-    ));
+    parseDataUri(inputSrc).bind(({ type, data }) => {
+      const cachedBlobInfo = blobCache.findFirst((blobInfo) => blobInfo.base64() === data);
+      return Option.from(cachedBlobInfo).orThunk(() =>
+        Conversions.buildBlob(type, data).map((blob) => {
+          const blobInfo = blobCache.create(uniqueId(), blob, data);
+          blobCache.add(blobInfo);
+          return blobInfo;
+        })
+      );
+    }).each((blobInfo) => {
+      img.attr('src', blobInfo.blobUri());
+    });
   };
 
   if (blobCache) {

--- a/modules/tinymce/src/core/test/ts/browser/file/BlobCacheTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/file/BlobCacheTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
-import { BlobCache, BlobInfoData } from 'tinymce/core/api/file/BlobCache';
 import { UnitTest } from '@ephox/bedrock-client';
 import { atob, Blob } from '@ephox/dom-globals';
+import { BlobCache, BlobInfoData } from 'tinymce/core/api/file/BlobCache';
 
 UnitTest.test('browser.tinymce.core.file.BlobCacheTest', function () {
   const uriToBlob = function (base64, type) {
@@ -17,7 +17,8 @@ UnitTest.test('browser.tinymce.core.file.BlobCacheTest', function () {
 
   const id = 'blob0';
   const base64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='; // 1x1 transparent png
-  const blob = uriToBlob(base64, 'image/png');
+  const type = 'image/png';
+  const blob = uriToBlob(base64, type);
   const name = 'blank';
   const filename = 'blank.png';
   const uri = 'http://localhost/blank.png';
@@ -36,6 +37,7 @@ UnitTest.test('browser.tinymce.core.file.BlobCacheTest', function () {
   Assertions.assertEq('Testing get()', blobInfo, blobCache.get(id));
   Assertions.assertEq('BlobInfo instance has blobUri() accessor', true, blobInfo.blobUri().indexOf('blob:') === 0);
   Assertions.assertEq('Testing getByUri(), findFirst()', blobInfo, blobCache.getByUri(blobInfo.blobUri()));
+  Assertions.assertEq('Testing getByData()', blobInfo, blobCache.getByData(base64, type));
 
   blobCache.removeByUri(blobInfo.blobUri());
   Assertions.assertEq('Testing removeByUri()', undefined, blobCache.getByUri(blobInfo.blobUri()));

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -743,9 +743,10 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
     const blobCache = BlobCache();
     const parser = DomParser({ blob_cache: blobCache });
     const base64 = 'R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==';
-    const base64Uri = `data:image/gif;base64,${base64}`;
-    const image = `<img src="${base64Uri}" />`;
-    const serializedHtml = serializer.serialize(parser.parse(`<p>${image}</p><p>${image}</p>`));
+    const gifBase64Uri = `data:image/gif;base64,${base64}`;
+    const pngBase64Uri = `data:image/png;base64,${base64}`;
+    const images = `<img src="${gifBase64Uri}" /><img src="${pngBase64Uri}" />`;
+    const serializedHtml = serializer.serialize(parser.parse(`<p>${images}</p><p>${images}</p>`));
     let count = 0;
     blobCache.findFirst((bi) => {
       if (bi.base64() === base64) {
@@ -754,7 +755,7 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
       return false;
     });
 
-    Assertions.assertEq('Only one image should be in the blob cache', 1, count);
+    Assertions.assertEq('Only one image per mime type should be in the blob cache', 2, count);
     Assertions.assertEq('HTML shouldn\'t include a base64 data URI', true, serializedHtml.indexOf(base64) === -1);
     blobCache.destroy();
   });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -2,11 +2,11 @@ import { Assertions, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { LegacyUnit } from '@ephox/mcagar';
+import Env from 'tinymce/core/api/Env';
+import { BlobCache } from 'tinymce/core/api/file/BlobCache';
 import DomParser from 'tinymce/core/api/html/DomParser';
 import Schema from 'tinymce/core/api/html/Schema';
 import Serializer from 'tinymce/core/api/html/Serializer';
-import { BlobCache } from 'tinymce/core/api/file/BlobCache';
-import Env from 'tinymce/core/api/Env';
 
 UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success, failure) {
   const suite = LegacyUnit.createSuite();
@@ -736,6 +736,26 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
       serializedHtml
     );
 
+    blobCache.destroy();
+  });
+
+  suite.test('duplicate base64 uris added only once to blobcache if blob cache is provided', () => {
+    const blobCache = BlobCache();
+    const parser = DomParser({ blob_cache: blobCache });
+    const base64 = 'R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==';
+    const base64Uri = `data:image/gif;base64,${base64}`;
+    const image = `<img src="${base64Uri}" />`;
+    const serializedHtml = serializer.serialize(parser.parse(`<p>${image}</p><p>${image}</p>`));
+    let count = 0;
+    blobCache.findFirst((bi) => {
+      if (bi.base64() === base64) {
+        count++;
+      }
+      return false;
+    });
+
+    Assertions.assertEq('Only one image should be in the blob cache', 1, count);
+    Assertions.assertEq('HTML shouldn\'t include a base64 data URI', true, serializedHtml.indexOf(base64) === -1);
     blobCache.destroy();
   });
 


### PR DESCRIPTION
This fixes the regression we introduced in an earlier 5.3 PR whereby duplicate images would be added to the blob cache twice with different ids.

It also fixes a customer reported issue where images with the same data, but different mime types were using the same cached blob info. This meant that images often were being uploaded to the server with the wrong file extension and therefore may not have rendered when downloaded (eg say someone accidentally uploaded an image with a `.gif` extension, but then corrected the extension and uploaded it again as a `.png`).