### PR TITLE
TINY-3915: Added the ability to set the list start position for ordered lists

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -1,6 +1,7 @@
+import { Eq } from '@ephox/dispute';
+import * as Fun from './Fun';
 import { Option } from './Option';
 import * as Type from './Type';
-import { Eq } from '@ephox/dispute';
 
 type ArrayMorphism<T, U> = (x: T, i: number) => U;
 type ArrayPredicate<T> = ArrayMorphism<T, boolean>;
@@ -160,15 +161,19 @@ export const foldl = <T = any, U = any>(xs: ArrayLike<T>, f: (acc: U, x: T) => U
   return acc;
 };
 
-export const find = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Option<T> => {
+export const findUntil = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>, until: ArrayPredicate<T>): Option<T> => {
   for (let i = 0, len = xs.length; i < len; i++) {
     const x = xs[i];
     if (pred(x, i)) {
       return Option.some(x);
+    } else if (until(x, i)) {
+      break;
     }
   }
   return Option.none();
 };
+
+export const find = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Option<T> => findUntil(xs, pred, Fun.never);
 
 export const findIndex = <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Option<number> => {
   for (let i = 0, len = xs.length; i < len; i++) {

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,7 +1,7 @@
 Version 5.3.0 (TBD)
     Added `uploadUri` and `blobInfo` to `editorUpload.uploadImages` return type #TINY-4579
     Added the ability to search and replace within a selection #TINY-4549
-    Added the ability to set the list start position for ordered lists #TINY-3915
+    Added the ability to set the list start position for ordered lists and added new `lists` context menu item #TINY-3915
     Added `icon` as an optional config option to the toggle menu item API #TINY-3345
     Changed toggle menu items and choice menu items to have a dedicated icon with the checkmark displayed on the far right side of the menu item #TINY-3345
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.3.0 (TBD)
     Added `uploadUri` and `blobInfo` to `editorUpload.uploadImages` return type #TINY-4579
     Added the ability to search and replace within a selection #TINY-4549
+    Added the ability to set the list start position for ordered lists #TINY-3915
     Added `icon` as an optional config option to the toggle menu item API #TINY-3345
     Changed toggle menu items and choice menu items to have a dedicated icon with the checkmark displayed on the far right side of the menu item #TINY-3345
     Changed the `link`, `image` and `paste` plugins to use Promises to reduce the bundle size #TINY-4710

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -114,6 +114,7 @@ export default function () {
     autosave_ask_before_unload: false,
     toolbar: 'undo redo sidebar1 | bold italic | alignleft aligncenter alignright alignjustify | align fontsizeselect fontselect formatselect styleselect insertfile | styleselect | ' +
     'bullist numlist outdent indent | link image | print preview media fullpage | forecolor backcolor emoticons table codesample code | ltr rtl',
+    contextmenu: 'link linkchecker image imagetools table lists spellchecker configurepermanentpen',
 
     // Multiple toolbar array
     // toolbar: ['undo redo sidebar1 align fontsizeselect insertfile | fontselect formatselect styleselect insertfile | styleselect | bold italic',

--- a/modules/tinymce/src/plugins/lists/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/Plugin.ts
@@ -8,9 +8,10 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Api from './api/Api';
 import * as Commands from './api/Commands';
+import { hasRtcPlugin } from './core/DetectRtc';
 import * as Keyboard from './core/Keyboard';
 import * as Buttons from './ui/Buttons';
-import { hasRtcPlugin } from './core/DetectRtc';
+import * as MenuItems from './ui/MenuItems';
 
 export default () => {
   PluginManager.add('lists', (editor) => {
@@ -20,6 +21,7 @@ export default () => {
     }
 
     Buttons.register(editor);
+    MenuItems.register(editor);
 
     return Api.get(editor);
   });

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
@@ -5,8 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { flattenListSelection, indentListSelection, outdentListSelection } from '../actions/Indendation';
 import * as ToggleList from '../actions/ToggleList';
-import { indentListSelection, outdentListSelection, flattenListSelection } from '../actions/Indendation';
+import * as Dialog from '../ui/Dialog';
 
 const queryListCommandState = function (editor, listName) {
   return function () {
@@ -40,6 +41,10 @@ const register = function (editor) {
 
   editor.addCommand('RemoveList', () => {
     flattenListSelection(editor);
+  });
+
+  editor.addCommand('mceListProps', () => {
+    Dialog.open(editor);
   });
 
   editor.addQueryStateHandler('InsertUnorderedList', queryListCommandState(editor, 'UL'));

--- a/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
@@ -5,28 +5,28 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Element, Node, Text } from '@ephox/dom-globals';
+import { Element, HTMLBRElement, HTMLDListElement, HTMLElement, HTMLLIElement, HTMLOListElement, HTMLTableCellElement, HTMLTableHeaderCellElement, HTMLUListElement, Node, Text } from '@ephox/dom-globals';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 
-const matchNodeName = (name: string) => (node: Node) => node && node.nodeName.toLowerCase() === name;
-const matchNodeNames = (regex: RegExp) => (node: Node) => node && regex.test(node.nodeName);
+const matchNodeName = <T extends Node = Node>(name: string) => (node: Node): node is T => node && node.nodeName.toLowerCase() === name;
+const matchNodeNames = <T extends Node = Node>(regex: RegExp) => (node: Node): node is T => node && regex.test(node.nodeName);
 
 const isTextNode = (node: Node): node is Text => node && node.nodeType === 3;
 
-const isListNode = matchNodeNames(/^(OL|UL|DL)$/);
+const isListNode = matchNodeNames<HTMLOListElement | HTMLUListElement | HTMLDListElement>(/^(OL|UL|DL)$/);
 
-const isOlUlNode = matchNodeNames(/^(OL|UL)$/);
+const isOlUlNode = matchNodeNames<HTMLOListElement | HTMLUListElement>(/^(OL|UL)$/);
 
-const isOlNode = matchNodeName('ol');
+const isOlNode = matchNodeName<HTMLOListElement>('ol');
 
-const isListItemNode = matchNodeNames(/^(LI|DT|DD)$/);
+const isListItemNode = matchNodeNames<HTMLLIElement | HTMLElement>(/^(LI|DT|DD)$/);
 
-const isDlItemNode = matchNodeNames(/^(DT|DD)$/);
+const isDlItemNode = matchNodeNames<HTMLElement>(/^(DT|DD)$/);
 
-const isTableCellNode = matchNodeNames(/^(TH|TD)$/);
+const isTableCellNode = matchNodeNames<HTMLTableHeaderCellElement | HTMLTableCellElement>(/^(TH|TD)$/);
 
-const isBr = matchNodeName('br');
+const isBr = matchNodeName<HTMLBRElement>('br');
 
 const isFirstChild = (node: Node) => node.parentNode.firstChild === node;
 
@@ -36,7 +36,7 @@ const isTextBlock = (editor: Editor, node: Node) => node && !!editor.schema.getT
 
 const isBlock = (node: Node, blockElements: Record<string, any>) => node && node.nodeName in blockElements;
 
-const isBogusBr = (dom, node: Node) => {
+const isBogusBr = (dom: DOMUtils, node: Node) => {
   if (!isBr(node)) {
     return false;
   }

--- a/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
@@ -5,53 +5,38 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Node, Text } from '@ephox/dom-globals';
+import { Element, Node, Text } from '@ephox/dom-globals';
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import Editor from 'tinymce/core/api/Editor';
 
-const isTextNode = function (node: Node): node is Text {
-  return node && node.nodeType === 3;
-};
+const matchNodeName = (name: string) => (node: Node) => node && node.nodeName.toLowerCase() === name;
+const matchNodeNames = (regex: RegExp) => (node: Node) => node && regex.test(node.nodeName);
 
-const isListNode = function (node: Node) {
-  return node && (/^(OL|UL|DL)$/).test(node.nodeName);
-};
+const isTextNode = (node: Node): node is Text => node && node.nodeType === 3;
 
-const isOlUlNode = function (node: Node) {
-  return node && (/^(OL|UL)$/).test(node.nodeName);
-};
+const isListNode = matchNodeNames(/^(OL|UL|DL)$/);
 
-const isListItemNode = function (node: Node) {
-  return node && /^(LI|DT|DD)$/.test(node.nodeName);
-};
+const isOlUlNode = matchNodeNames(/^(OL|UL)$/);
 
-const isDlItemNode = function (node: Node) {
-  return node && /^(DT|DD)$/.test(node.nodeName);
-};
+const isOlNode = matchNodeName('ol');
 
-const isTableCellNode = function (node: Node) {
-  return node && /^(TH|TD)$/.test(node.nodeName);
-};
+const isListItemNode = matchNodeNames(/^(LI|DT|DD)$/);
 
-const isBr = function (node: Node) {
-  return node && node.nodeName === 'BR';
-};
+const isDlItemNode = matchNodeNames(/^(DT|DD)$/);
 
-const isFirstChild = function (node: Node) {
-  return node.parentNode.firstChild === node;
-};
+const isTableCellNode = matchNodeNames(/^(TH|TD)$/);
 
-const isLastChild = function (node: Node) {
-  return node.parentNode.lastChild === node;
-};
+const isBr = matchNodeName('br');
 
-const isTextBlock = function (editor, node: Node) {
-  return node && !!editor.schema.getTextBlockElements()[node.nodeName];
-};
+const isFirstChild = (node: Node) => node.parentNode.firstChild === node;
 
-const isBlock = function (node: Node, blockElements) {
-  return node && node.nodeName in blockElements;
-};
+const isLastChild = (node: Node) => node.parentNode.lastChild === node;
 
-const isBogusBr = function (dom, node: Node) {
+const isTextBlock = (editor: Editor, node: Node) => node && !!editor.schema.getTextBlockElements()[node.nodeName];
+
+const isBlock = (node: Node, blockElements: Record<string, any>) => node && node.nodeName in blockElements;
+
+const isBogusBr = (dom, node: Node) => {
   if (!isBr(node)) {
     return false;
   }
@@ -63,7 +48,7 @@ const isBogusBr = function (dom, node: Node) {
   return false;
 };
 
-const isEmpty = function (dom, elm, keepBookmarks?) {
+const isEmpty = (dom: DOMUtils, elm: Node, keepBookmarks?: boolean) => {
   const empty = dom.isEmpty(elm);
 
   if (keepBookmarks && dom.select('span[data-mce-type=bookmark]', elm).length > 0) {
@@ -73,14 +58,13 @@ const isEmpty = function (dom, elm, keepBookmarks?) {
   return empty;
 };
 
-const isChildOfBody = function (dom, elm) {
-  return dom.isChildOf(elm, dom.getRoot());
-};
+const isChildOfBody = (dom: DOMUtils, elm: Element) => dom.isChildOf(elm, dom.getRoot());
 
 export {
   isTextNode,
   isListNode,
   isOlUlNode,
+  isOlNode,
   isDlItemNode,
   isListItemNode,
   isTableCellNode,

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
@@ -13,8 +13,8 @@ import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as NodeType from './NodeType';
 
-const getParentList = function (editor) {
-  const selectionStart = editor.selection.getStart(true);
+const getParentList = (editor: Editor, node?: Node) => {
+  const selectionStart = node || editor.selection.getStart(true);
 
   return editor.dom.getParent(selectionStart, 'OL,UL,DL', getClosestListRootElm(editor, selectionStart));
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
@@ -8,7 +8,6 @@
 import { HTMLElement } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
-import Tools from 'tinymce/core/api/util/Tools';
 import * as NodeType from './NodeType';
 
 export const isCustomList = (list: HTMLElement) => /\btox\-/.test(list.className);
@@ -16,10 +15,10 @@ export const isCustomList = (list: HTMLElement) => /\btox\-/.test(list.className
 export const listState = (editor: Editor, listName: string, activate: (active: boolean) => void) =>
   () => {
     const nodeChangeHandler = (e) => {
-      const tableCellIndex = Arr.findIndex(e.parents, NodeType.isTableCellNode);
-      const parents = tableCellIndex.map((idx) => e.parents.slice(0, idx)).getOr(e.parents);
-      const lists = Tools.grep(parents, NodeType.isListNode);
-      activate(lists.length > 0 && lists[0].nodeName === listName && !isCustomList(lists[0]));
+      const inList = Arr.findUntil(e.parents, NodeType.isListNode, NodeType.isTableCellNode)
+        .filter((list: HTMLElement) => list.nodeName === listName && !isCustomList(list))
+        .isSome();
+      activate(inList);
     };
 
     editor.on('NodeChange', nodeChangeHandler);

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
 import { HTMLElement } from '@ephox/dom-globals';
+import { Arr } from '@ephox/katamari';
+import Editor from 'tinymce/core/api/Editor';
+import Tools from 'tinymce/core/api/util/Tools';
+import * as NodeType from './NodeType';
 
 export const isCustomList = (list: HTMLElement) => /\btox\-/.test(list.className);
+
+export const listState = (editor: Editor, listName: string, activate: (active: boolean) => void) =>
+  () => {
+    const nodeChangeHandler = (e) => {
+      const tableCellIndex = Arr.findIndex(e.parents, NodeType.isTableCellNode);
+      const parents = tableCellIndex.map((idx) => e.parents.slice(0, idx)).getOr(e.parents);
+      const lists = Tools.grep(parents, NodeType.isListNode);
+      activate(lists.length > 0 && lists[0].nodeName === listName && !isCustomList(lists[0]));
+    };
+
+    editor.on('NodeChange', nodeChangeHandler);
+
+    return () => editor.off('NodeChange', nodeChangeHandler);
+  };

--- a/modules/tinymce/src/plugins/lists/main/ts/listModel/Entry.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listModel/Entry.ts
@@ -5,8 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Element, Traverse, Replication, Attr, Node } from '@ephox/sugar';
 import { Arr, Option } from '@ephox/katamari';
+import { Attr, Element, Node, Replication, Traverse } from '@ephox/sugar';
 import { hasLastChildList, ListType } from './Util';
 
 /*
@@ -26,6 +26,7 @@ General workflow: Parse lists to entries -> Manipulate entries -> Compose entrie
 
 export interface Entry {
   depth: number;
+  dirty: boolean;
   content: Element[];
   isSelected: boolean;
   listType: ListType;
@@ -45,6 +46,7 @@ const cloneItemContent = (li: Element): Element[] => {
 
 const createEntry = (li: Element, depth: number, isSelected: boolean): Option<Entry> => Traverse.parent(li).filter(Node.isElement).map((list) => ({
   depth,
+  dirty: false,
   isSelected,
   content: cloneItemContent(li),
   itemAttributes: Attr.clone(li),

--- a/modules/tinymce/src/plugins/lists/main/ts/listModel/Indentation.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listModel/Indentation.ts
@@ -26,4 +26,5 @@ export const indentEntry = (indentation: Indentation, entry: Entry): void => {
     case Indentation.Flatten:
       entry.depth = 0;
   }
+  entry.dirty = true;
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/listModel/ListsIndendation.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listModel/ListsIndendation.ts
@@ -19,14 +19,17 @@ import { normalizeEntries } from './NormalizeEntries';
 import { EntrySet, ItemSelection, parseLists } from './ParseLists';
 import { hasFirstChildList } from './Util';
 
-const outdentedComposer = (editor: Editor, entries: Entry[]): Element[] => Arr.map(entries, (entry) => {
-  const content = Fragment.fromElements(entry.content);
-  return Element.fromDom(createTextBlock(editor, content.dom()));
-});
+const outdentedComposer = (editor: Editor, entries: Entry[]): Element[] => {
+  const normalizedEntries = normalizeEntries(entries);
+  return Arr.map(normalizedEntries, (entry) => {
+    const content = Fragment.fromElements(entry.content);
+    return Element.fromDom(createTextBlock(editor, content.dom()));
+  });
+};
 
 const indentedComposer = (editor: Editor, entries: Entry[]): Element[] => {
-  normalizeEntries(entries);
-  return composeList(editor.contentDocument, entries).toArray();
+  const normalizedEntries = normalizeEntries(entries);
+  return composeList(editor.contentDocument, normalizedEntries).toArray();
 };
 
 const composeEntries = (editor, entries: Entry[]): Element[] => Arr.bind(Arr.groupBy(entries, isIndented), (entries) => {

--- a/modules/tinymce/src/plugins/lists/main/ts/listModel/NormalizeEntries.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listModel/NormalizeEntries.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Option } from '@ephox/katamari';
+import { Arr, Obj, Option } from '@ephox/katamari';
 import { Entry } from './Entry';
 
 const cloneListProperties = (target: Entry, source: Entry): void => {
@@ -13,26 +13,36 @@ const cloneListProperties = (target: Entry, source: Entry): void => {
   target.listAttributes = { ...source.listAttributes };
 };
 
-// Closest entry above in the same list
-const previousSiblingEntry = (entries: Entry[], start: number): Option<Entry> => {
-  const depth = entries[start].depth;
-  for (let i = start - 1; i >= 0; i--) {
-    if (entries[i].depth === depth) {
-      return Option.some(entries[i]);
-    }
-    if (entries[i].depth < depth) {
-      break;
-    }
-  }
-  return Option.none();
+const cleanListProperties = (entry: Entry): void => {
+  // Remove the start attribute if generating a new list
+  entry.listAttributes = Obj.filter(entry.listAttributes, (_value, key) => key !== 'start');
 };
 
-const normalizeEntries = (entries: Entry[]): void => {
+// Closest entry above/below in the same list
+const closestSiblingEntry = (entries: Entry[], start: number): Option<Entry> => {
+  const depth = entries[start].depth;
+  // Ignore dirty items as they've been moved and won't have the right list data yet
+  const matches = (entry: Entry) => entry.depth === depth && !entry.dirty;
+  const until = (entry: Entry) => entry.depth < depth;
+
+  // Check in reverse to see if there's an entry as the same depth before the current entry
+  // but if not, then try to walk forwards as well
+  return Arr.findUntil(Arr.reverse(entries.slice(0, start)), matches, until)
+    .orThunk(() => Arr.findUntil(entries.slice(start + 1), matches, until));
+};
+
+const normalizeEntries = (entries: Entry[]): Entry[] => {
   Arr.each(entries, (entry, i) => {
-    previousSiblingEntry(entries, i).each((matchingEntry) => {
-      cloneListProperties(entry, matchingEntry);
-    });
+    closestSiblingEntry(entries, i).fold(
+      () => {
+        if (entry.dirty) {
+          cleanListProperties(entry);
+        }
+      },
+      (matchingEntry) => cloneListProperties(entry, matchingEntry)
+    );
   });
+  return entries;
 };
 
 export {

--- a/modules/tinymce/src/plugins/lists/main/ts/listModel/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listModel/Util.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Element, Traverse, Compare } from '@ephox/sugar';
+import { Compare, Element, Traverse } from '@ephox/sugar';
 
 export const enum ListType {
   OL = 'ol',

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/Buttons.ts
@@ -5,36 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Tools from 'tinymce/core/api/util/Tools';
-import * as NodeType from '../core/NodeType';
 import Editor from 'tinymce/core/api/Editor';
-import { isCustomList } from '../core/Util';
-
-const findIndex = function (list, predicate) {
-  for (let index = 0; index < list.length; index++) {
-    const element = list[index];
-
-    if (predicate(element)) {
-      return index;
-    }
-  }
-  return -1;
-};
-
-const listState = function (editor: Editor, listName) {
-  return function (buttonApi) {
-    const nodeChangeHandler = (e) => {
-      const tableCellIndex = findIndex(e.parents, NodeType.isTableCellNode);
-      const parents = tableCellIndex !== -1 ? e.parents.slice(0, tableCellIndex) : e.parents;
-      const lists = Tools.grep(parents, NodeType.isListNode);
-      buttonApi.setActive(lists.length > 0 && lists[0].nodeName === listName && !isCustomList(lists[0]));
-    };
-
-    editor.on('NodeChange', nodeChangeHandler);
-
-    return () => editor.off('NodeChange', nodeChangeHandler);
-  };
-};
+import Tools from 'tinymce/core/api/util/Tools';
+import * as Util from '../core/Util';
 
 const register = function (editor: Editor) {
   const hasPlugin = function (editor, plugin) {
@@ -50,7 +23,7 @@ const register = function (editor: Editor) {
       active: false,
       tooltip: 'Numbered list',
       onAction: exec('InsertOrderedList'),
-      onSetup: listState(editor, 'OL')
+      onSetup: (api) => Util.listState(editor, 'OL', api.setActive)
     });
 
     editor.ui.registry.addToggleButton('bullist', {
@@ -58,7 +31,7 @@ const register = function (editor: Editor) {
       active: false,
       tooltip: 'Bullet list',
       onAction: exec('InsertUnorderedList'),
-      onSetup: listState(editor, 'UL')
+      onSetup: (api) => Util.listState(editor, 'UL', api.setActive)
     });
   }
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import Editor from 'tinymce/core/api/Editor';
+import { isOlNode } from '../core/NodeType';
+import { getParentList } from '../core/Selection';
+
+const open = (editor: Editor) => {
+  const dom = editor.dom;
+
+  // Find the current list and skip opening if the selection isn't in an ordered list
+  const parentList = getParentList(editor);
+  if (!isOlNode(parentList)) {
+    return;
+  }
+
+  editor.windowManager.open({
+    title: 'List Properties',
+    body: {
+      type: 'panel',
+      items: [
+        {
+          type: 'input',
+          name: 'start',
+          label: 'Start list at number',
+          inputMode: 'numeric'
+        }
+      ]
+    },
+    initialData: {
+      start: dom.getAttrib(parentList, 'start') || '1'
+    },
+    buttons: [
+      {
+        type: 'cancel',
+        name: 'cancel',
+        text: 'Cancel'
+      },
+      {
+        type: 'submit',
+        name: 'save',
+        text: 'Save',
+        primary: true
+      }
+    ],
+    onSubmit: (api) => {
+      const data = api.getData();
+      editor.undoManager.transact(() => {
+        dom.setAttrib(parentList, 'start', data.start === '1' ? '' : data.start);
+      });
+      api.close();
+    }
+  });
+};
+
+export {
+  open
+};

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
@@ -13,8 +13,8 @@ const open = (editor: Editor) => {
   const dom = editor.dom;
 
   // Find the current list and skip opening if the selection isn't in an ordered list
-  const parentList = getParentList(editor);
-  if (!isOlNode(parentList)) {
+  const currentList = getParentList(editor);
+  if (!isOlNode(currentList)) {
     return;
   }
 
@@ -32,7 +32,7 @@ const open = (editor: Editor) => {
       ]
     },
     initialData: {
-      start: dom.getAttrib(parentList, 'start') || '1'
+      start: dom.getAttrib(currentList, 'start') || '1'
     },
     buttons: [
       {
@@ -50,7 +50,7 @@ const open = (editor: Editor) => {
     onSubmit: (api) => {
       const data = api.getData();
       editor.undoManager.transact(() => {
-        dom.setAttrib(parentList, 'start', data.start === '1' ? '' : data.start);
+        dom.setAttrib(getParentList(editor), 'start', data.start === '1' ? '' : data.start);
       });
       api.close();
     }

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/MenuItems.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Menu } from '@ephox/bridge';
+import Editor from 'tinymce/core/api/Editor';
+import { isOlNode } from '../core/NodeType';
+import { getParentList } from '../core/Selection';
+import * as Util from '../core/Util';
+import * as Dialog from './Dialog';
+
+const register = (editor: Editor) => {
+  const listProperties: Menu.MenuItemApi = {
+    text: 'List properties...',
+    icon: 'ordered-list',
+    onAction: () => Dialog.open(editor),
+    onSetup: (api) => Util.listState(editor, 'OL', (active) => api.setDisabled(!active))
+  };
+
+  editor.ui.registry.addMenuItem('listprops', listProperties);
+
+  editor.ui.registry.addContextMenu('lists', {
+    update: (node) => {
+      const parentList = getParentList(editor, node);
+      return isOlNode(parentList) ? [ 'listprops' ] : [ ];
+    }
+  });
+};
+
+export {
+  register
+};

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -1,4 +1,4 @@
-import { Pipeline, Log } from '@ephox/agar';
+import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
@@ -380,6 +380,60 @@ UnitTest.asynctest('tinymce.lists.browser.IndentTest', (success, failure) => {
     );
   });
 
+  suite.test('TestCase-TBA: Lists: Indent single LI in OL with start attribute', (editor) => {
+    editor.getBody().innerHTML = LegacyUnit.trimBrs(
+      '<ol start="5">' +
+      '<li>a</li>' +
+      '</ol>'
+    );
+
+    editor.focus();
+    LegacyUnit.setSelection(editor, 'li', 0);
+    LegacyUnit.execCommand(editor, 'Indent');
+
+    LegacyUnit.equal(editor.getContent(),
+      '<ol>' +
+      '<li style="list-style-type: none;">' +
+      '<ol>' +
+      '<li>a</li>' +
+      '</ol>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    LegacyUnit.equal(editor.selection.getNode().nodeName, 'LI');
+  });
+
+  suite.test('TestCase-TBA: Lists: Indent first LI and nested LI OL with start attributes', function (editor) {
+    editor.getBody().innerHTML = LegacyUnit.trimBrs(
+      '<ol start="2">' +
+      '<li>a</li>' +
+      '<li>' +
+      '<ol start="5">' +
+      '<li>b</li>' +
+      '</ol>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    editor.focus();
+    LegacyUnit.setSelection(editor, 'li', 0);
+    LegacyUnit.execCommand(editor, 'Indent');
+
+    LegacyUnit.equal(editor.getContent(),
+      '<ol>' +
+      '<li style="list-style-type: none;">' +
+      '<ol start="5">' +
+      '<li>a</li>' +
+      '<li>b</li>' +
+      '</ol>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    LegacyUnit.equal(editor.selection.getNode().nodeName, 'LI');
+  });
+
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, Log.steps('TBA', 'Lists: List indent tests', suite.toSteps(editor)), onSuccess, onFailure);
   }, {
@@ -389,7 +443,7 @@ UnitTest.asynctest('tinymce.lists.browser.IndentTest', (success, failure) => {
     indent: false,
     entities: 'raw',
     valid_elements:
-      'li[style|class|data-custom],ol[style|class|data-custom],' +
+      'li[style|class|data-custom],ol[style|class|data-custom|start],' +
       'ul[style|class|data-custom],dl,dt,dd,em,strong,span,#p,div,br,table,tr,td',
     valid_styles: {
       '*': 'color,font-size,font-family,background-color,font-weight,' +

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -1,0 +1,119 @@
+import { Assertions, Chain, FocusTools, GeneralSteps, Keyboard, Keys, Log, Pipeline, UiControls, UiFinder } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { document } from '@ephox/dom-globals';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { Body, Element, Value } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('tinymce.lists.browser.ListPropertiesTest', (success, failure) => {
+  Plugin();
+  Theme();
+
+  const contentMenuSelector = '.tox-tinymce-aux .tox-menu .tox-collection__item:contains("List properties...")';
+  const inputSelector = 'label:contains(Start list at number) + input.tox-textfield';
+
+  const sOpenContextMenu = (editor: Editor, tinyUi: TinyUi, target: string) => Chain.asStep(editor, [
+    tinyUi.cTriggerContextMenu('trigger context menu', target, '.tox-silver-sink [role="menuitem"]'),
+    Chain.wait(0)
+  ]);
+
+  const sOpenDialog = (editor: Editor, tinyUi: TinyUi, contextMenuSelector: string) => {
+    const doc = Element.fromDom(document);
+    return GeneralSteps.sequence([
+      sOpenContextMenu(editor, tinyUi, contextMenuSelector),
+      FocusTools.sTryOnSelector('Wait for the context menu to be focused', doc, contentMenuSelector),
+      Keyboard.sKeydown(doc, Keys.enter(), {}),
+      tinyUi.sWaitForUi('Wait for the dialog to appear', '[role=dialog]'),
+    ]);
+  };
+
+  const sUpdateStart = (currentValue: string, newValue: string) => {
+    const doc = Element.fromDom(document);
+    return GeneralSteps.sequence([
+      FocusTools.sIsOnSelector('Check focus is on the input field', doc, inputSelector),
+      Chain.asStep(doc, [
+        FocusTools.cGetFocused,
+        Chain.op((input) => {
+          Assertions.assertEq('Assert initial start value', currentValue, Value.get(input));
+        }),
+        UiControls.cSetValue(newValue)
+      ]),
+    ]);
+  };
+
+  const sOpenAndUpdateDialog = (editor: Editor, tinyUi: TinyUi, contextMenuSelector: string, currentValue: string, newValue: string) => GeneralSteps.sequence([
+    sOpenDialog(editor, tinyUi, contextMenuSelector),
+    sUpdateStart(currentValue, newValue),
+    tinyUi.sSubmitDialog('[role=dialog]')
+  ]);
+
+  const sAssertListPropMenuNotVisible = UiFinder.sNotExists(Body.body(), contentMenuSelector);
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+    const tinyUi = TinyUi(editor);
+
+    Pipeline.async({}, [
+      tinyApis.sFocus(),
+      Log.stepsAsStep('TINY-3915', 'List properties context menu not shown for DL', [
+        tinyApis.sSetContent('<dl><dt>Item 1</dt><dt>Item 2</dt></dl>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        sOpenContextMenu(editor, tinyUi, 'dl > dt'),
+        sAssertListPropMenuNotVisible
+      ]),
+      Log.stepsAsStep('TINY-3915', 'List properties context menu not shown for UL', [
+        tinyApis.sSetContent('<ul><li>Item 1</li><li>Item 2</li></ul>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        sOpenContextMenu(editor, tinyUi, 'ul > li'),
+        sAssertListPropMenuNotVisible
+      ]),
+      Log.stepsAsStep('TINY-3915', 'List properties context menu not shown for UL in OL', [
+        tinyApis.sSetContent('<ol><li>Root Item<ul><li>Item 1</li><li>Item 2</li></ul></li></ol>'),
+        tinyApis.sSetCursor([ 0, 0, 1, 0, 0 ], 0),
+        sOpenContextMenu(editor, tinyUi, 'ul > li'),
+        sAssertListPropMenuNotVisible
+      ]),
+      Log.stepsAsStep('TINY-3915', 'List properties shown for OL and can change start value', [
+        tinyApis.sSetContent('<ol><li>Item 1</li><li>Item 2</li></ol>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        sOpenAndUpdateDialog(editor, tinyUi, 'ol > li', '1', '5'),
+        tinyApis.sAssertContent('<ol start="5"><li>Item 1</li><li>Item 2</li></ol>'),
+        sOpenAndUpdateDialog(editor, tinyUi, 'ol > li', '5', '1'),
+        tinyApis.sAssertContent('<ol><li>Item 1</li><li>Item 2</li></ol>')
+      ]),
+      Log.stepsAsStep('TINY-3915', 'List properties shown for OL in UL and can change start value', [
+        tinyApis.sSetContent('<ul><li>Root Item<ol><li>Item 1</li><li>Item 2</li></ol></li></ul>'),
+        tinyApis.sSetCursor([ 0, 0, 1, 0, 0 ], 0),
+        sOpenAndUpdateDialog(editor, tinyUi, 'ol > li',  '1', '5'),
+        tinyApis.sAssertContent('<ul><li>Root Item<ol start="5"><li>Item 1</li><li>Item 2</li></ol></li></ul>'),
+        sOpenAndUpdateDialog(editor, tinyUi, 'ol > li', '5', '1'),
+        tinyApis.sAssertContent('<ul><li>Root Item<ol><li>Item 1</li><li>Item 2</li></ol></li></ul>')
+      ]),
+      Log.stepsAsStep('TINY-3915', 'List properties shown for nested OL and can change start value', [
+        tinyApis.sSetContent('<ol><li>Root Item<ol><li>Item 1</li><li>Item 2</li></ol></li></ol>'),
+        tinyApis.sSetCursor([ 0, 0, 1, 0, 0 ], 0),
+        sOpenAndUpdateDialog(editor, tinyUi, 'ol ol > li', '1', '5'),
+        tinyApis.sAssertContent('<ol><li>Root Item<ol start="5"><li>Item 1</li><li>Item 2</li></ol></li></ol>'),
+        sOpenAndUpdateDialog(editor, tinyUi, 'ol ol > li', '5', '1'),
+        tinyApis.sAssertContent('<ol><li>Root Item<ol><li>Item 1</li><li>Item 2</li></ol></li></ol>')
+      ]),
+      Log.stepsAsStep('TINY-3915', 'List properties command', [
+        tinyApis.sSetContent('<ol><li>Root Item<ol><li>Item 1</li><li>Item 2</li></ol></li></ol>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        tinyApis.sExecCommand('mceListProps'),
+        sUpdateStart('1', '10'),
+        tinyUi.sSubmitDialog('[role=dialog]'),
+        tinyApis.sAssertContent('<ol start="10"><li>Root Item<ol><li>Item 1</li><li>Item 2</li></ol></li></ol>')
+      ])
+    ], onSuccess, onFailure);
+  }, {
+    plugins: 'lists',
+    contextmenu: 'lists bold',
+    indent: false,
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce'
+  }, success, failure);
+});

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
@@ -1,4 +1,4 @@
-import { Pipeline, Log } from '@ephox/agar';
+import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
@@ -403,6 +403,66 @@ UnitTest.asynctest('tinymce.lists.browser.OutdentTest', (success, failure) => {
     );
   });
 
+  suite.test('TestCase-TBA: Lists: Outdent inside LI in beginning of OL in LI with start attribute', (editor) => {
+    editor.getBody().innerHTML = LegacyUnit.trimBrs(
+      '<ol>' +
+      '<li>a' +
+      '<ol start="5">' +
+      '<li>b</li>' +
+      '<li>c</li>' +
+      '</ol>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    editor.focus();
+    LegacyUnit.setSelection(editor, 'li li', 1);
+    LegacyUnit.execCommand(editor, 'Outdent');
+
+    LegacyUnit.equal(editor.getContent(),
+      '<ol>' +
+      '<li>a</li>' +
+      '<li>b' +
+      '<ol start="5">' +
+      '<li>c</li>' +
+      '</ol>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    LegacyUnit.equal(editor.selection.getNode().nodeName, 'LI');
+  });
+
+  suite.test('TestCase-TBA: Lists: Outdent inside LI in beginning of OL in LI with start attribute on both OL', (editor) => {
+    editor.getBody().innerHTML = LegacyUnit.trimBrs(
+      '<ol start="2">' +
+      '<li>a' +
+      '<ol start="5">' +
+      '<li>b</li>' +
+      '<li>c</li>' +
+      '</ol>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    editor.focus();
+    LegacyUnit.setSelection(editor, 'li li', 1);
+    LegacyUnit.execCommand(editor, 'Outdent');
+
+    LegacyUnit.equal(editor.getContent(),
+      '<ol start="2">' +
+      '<li>a</li>' +
+      '<li>b' +
+      '<ol start="5">' +
+      '<li>c</li>' +
+      '</ol>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    LegacyUnit.equal(editor.selection.getNode().nodeName, 'LI');
+  });
+
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, Log.steps('TBA', 'Lists: Outdent tests', suite.toSteps(editor)), onSuccess, onFailure);
   }, {
@@ -412,7 +472,7 @@ UnitTest.asynctest('tinymce.lists.browser.OutdentTest', (success, failure) => {
     indent: false,
     entities: 'raw',
     valid_elements:
-      'li[style|class|data-custom],ol[style|class|data-custom],' +
+      'li[style|class|data-custom],ol[style|class|data-custom|start],' +
       'ul[style|class|data-custom],dl,dt,dd,em,strong,span,#p,div,br',
     valid_styles: {
       '*': 'color,font-size,font-family,background-color,font-weight,' +


### PR DESCRIPTION
This adds the new feature to be able to configure the start number for ordered lists.

Fixes #5387

Note: This hasn't been added to the default context menu list intentionally, as we wanted to make this opt-in at this stage. That's why I've added it to the full demo instead.