### PR TITLE
TINY-5991: Fixed zero-width spaces incorrectly included in the `wordcount` plugin character count

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Unicode.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Unicode.ts
@@ -1,3 +1,6 @@
 export const zeroWidth = '\uFEFF';
 export const nbsp = '\u00A0';
 export const softHyphen = '\u00AD';
+
+export const isZwsp = (char: string) => char === zeroWidth;
+export const removeZwsp = (s: string) => s.replace(/\uFEFF/g, '');

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -25,6 +25,7 @@ Version 5.3.0 (TBD)
     Fixed the placeholder not hiding when pasting content into the editor #TINY-4828
     Fixed an issue where the editor would fail to load if local storage was disabled #TINY-5935
     Fixed bug where toolbars and dialogs would not show if the body element was replaced (e.g. with Turbolinks). Patch contributed by spohlenz #GH-5653
+    Fixed zero-width spaces incorrectly included in the `wordcount` plugin character count #TINY-5991
 Version 5.2.2 (2020-04-23)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
     Fixed text decorations (underline, strikethrough) not consistently inheriting the text color #TINY-4757

--- a/modules/tinymce/src/core/main/ts/text/Zwsp.ts
+++ b/modules/tinymce/src/core/main/ts/text/Zwsp.ts
@@ -20,8 +20,8 @@ import { Unicode } from '@ephox/katamari';
 
 // This is technically not a ZWSP but a ZWNBSP or a BYTE ORDER MARK it used to be a ZWSP
 const ZWSP = Unicode.zeroWidth;
-const isZwsp = (chr: string) => chr === ZWSP;
-const trim = (text: string) => text.replace(new RegExp(ZWSP, 'g'), '');
+const isZwsp = Unicode.isZwsp;
+const trim = Unicode.removeZwsp;
 
 export {
   isZwsp,

--- a/modules/tinymce/src/plugins/wordcount/main/ts/core/GetText.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/core/GetText.ts
@@ -5,17 +5,18 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { CharacterData, Node } from '@ephox/dom-globals';
+import { Node, Text } from '@ephox/dom-globals';
+import { Unicode } from '@ephox/katamari';
 import TreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import Schema, { SchemaMap } from 'tinymce/core/api/html/Schema';
+
+const trimZwsp = (text: string) => text.replace(new RegExp(Unicode.zeroWidth, 'g'), '');
 
 const getText = (node: Node, schema: Schema): string[] => {
   const blockElements: SchemaMap = schema.getBlockElements();
   const shortEndedElements: SchemaMap = schema.getShortEndedElements();
 
-  const isNewline = (node: Node) => (
-    blockElements[node.nodeName] || shortEndedElements[node.nodeName]
-  );
+  const isNewline = (node: Node) => blockElements[node.nodeName] || shortEndedElements[node.nodeName];
 
   const textBlocks: string[] = [];
   let txt = '';
@@ -23,7 +24,7 @@ const getText = (node: Node, schema: Schema): string[] => {
 
   while ((node = treeWalker.next())) {
     if (node.nodeType === 3) {
-      txt += (node as CharacterData).data;
+      txt += trimZwsp((node as Text).data);
     } else if (isNewline(node) && txt.length) {
       textBlocks.push(txt);
       txt = '';

--- a/modules/tinymce/src/plugins/wordcount/main/ts/core/GetText.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/core/GetText.ts
@@ -10,8 +10,6 @@ import { Unicode } from '@ephox/katamari';
 import TreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import Schema, { SchemaMap } from 'tinymce/core/api/html/Schema';
 
-const trimZwsp = (text: string) => text.replace(new RegExp(Unicode.zeroWidth, 'g'), '');
-
 const getText = (node: Node, schema: Schema): string[] => {
   const blockElements: SchemaMap = schema.getBlockElements();
   const shortEndedElements: SchemaMap = schema.getShortEndedElements();
@@ -24,7 +22,7 @@ const getText = (node: Node, schema: Schema): string[] => {
 
   while ((node = treeWalker.next())) {
     if (node.nodeType === 3) {
-      txt += trimZwsp((node as Text).data);
+      txt += Unicode.removeZwsp((node as Text).data);
     } else if (isNewline(node) && txt.length) {
       textBlocks.push(txt);
       txt = '';

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/core/GetTextTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/core/GetTextTest.ts
@@ -1,12 +1,12 @@
 import { Pipeline, Step } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader } from '@ephox/mcagar';
 import { Node } from '@ephox/dom-globals';
+import { TinyLoader } from '@ephox/mcagar';
 import Editor from 'tinymce/core/api/Editor';
+import { getText } from 'tinymce/plugins/wordcount/core/GetText';
 
 import Plugin from 'tinymce/plugins/wordcount/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
-import { getText } from 'tinymce/plugins/wordcount/core/GetText';
 
 UnitTest.asynctest('browser.tinymce.plugins.wordcount.GetTextTest', (success, failure) => {
   Plugin();
@@ -25,7 +25,7 @@ UnitTest.asynctest('browser.tinymce.plugins.wordcount.GetTextTest', (success, fa
       sAssertGetText(c('<p></p>'), []),
       sAssertGetText(c('<p>a b</p>'), [ 'a b' ]),
       sAssertGetText(c('<p>a&nbsp;b</p>'), [ 'a\u00a0b' ]),
-      sAssertGetText(c('<p>a\uFEFFb</p>'), [ 'a\uFEFFb' ]),
+      sAssertGetText(c('<p>a\uFEFFb</p>'), [ 'ab' ]),
       sAssertGetText(c('<p><span>a</span> b</p>'), [ 'a b' ]),
       sAssertGetText(c('<p>a</p><p>b</p>'), [ 'a', 'b' ]),
       sAssertGetText(c('<p>a<br>b</p>'), [ 'a', 'b' ])


### PR DESCRIPTION
This strips zero-width spaces when fetching the text-based content from the editor, as they aren't visible and will normally be a fake caret, so they shouldn't be included in the character count.

Fixes #5659