### PR TITLE
TINY-5998: Fixed a regression introduced in 5.2.0 with mobile defaults

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -30,6 +30,7 @@ Version 5.3.0 (TBD)
     Fixed an issue where an uploaded image would reuse a cached image with a different mime type #TINY-5988
     Fixed bug where toolbars and dialogs would not show if the body element was replaced (e.g. with Turbolinks). Patch contributed by spohlenz #GH-5653
     Fixed zero-width spaces incorrectly included in the `wordcount` plugin character count #TINY-5991
+    Fixed a regression introduced in 5.2.0 whereby the desktop `toolbar_mode` setting would incorrectly override the mobile default setting #TINY-5998
 Version 5.2.2 (2020-04-23)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
     Fixed text decorations (underline, strikethrough) not consistently inheriting the text color #TINY-4757

--- a/modules/tinymce/src/core/main/ts/EditorSettings.ts
+++ b/modules/tinymce/src/core/main/ts/EditorSettings.ts
@@ -128,10 +128,10 @@ const getDefaultSettings = function (settings: RawEditorSettings, id: string, do
   };
 };
 
-const getDefaultMobileSettings = (settings: RawEditorSettings, isPhone: boolean): RawEditorSettings => {
+const getDefaultMobileSettings = (mobileSettings: RawEditorSettings, isPhone: boolean): RawEditorSettings => {
   const defaultMobileSettings: RawEditorSettings = {
     resize: false,               // Editor resize doesn't make sense on mobile
-    toolbar_mode: getToolbarMode(settings, 'scrolling'),   // Use the default side-scrolling toolbar for tablets/phones
+    toolbar_mode: getToolbarMode(mobileSettings, 'scrolling'),   // Use the default side-scrolling toolbar for tablets/phones
     toolbar_sticky: false        // Only enable sticky toolbar on desktop by default
   };
 
@@ -187,7 +187,7 @@ const isOnMobile = function (isMobileDevice: boolean, sectionResult: SectionResu
 
 const combineSettings = (isMobileDevice: boolean, isPhone: boolean,  defaultSettings: RawEditorSettings, defaultOverrideSettings: RawEditorSettings, settings: RawEditorSettings): EditorSettings => {
   // Use mobile mode by default on phones, so patch in the default mobile settings
-  const defaultDeviceSettings = isMobileDevice ? { mobile: getDefaultMobileSettings(settings, isPhone) } : { };
+  const defaultDeviceSettings = isMobileDevice ? { mobile: getDefaultMobileSettings(settings.mobile || {}, isPhone) } : { };
   const sectionResult = extractSections([ 'mobile' ], Merger.deepMerge(defaultDeviceSettings, settings));
 
   const extendedSettings = Tools.extend(

--- a/modules/tinymce/src/core/test/ts/browser/EditorSettingsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorSettingsTest.ts
@@ -84,6 +84,22 @@ UnitTest.asynctest('browser.tinymce.core.EditorSettingsTest', function (success,
         });
       })),
 
+      Logger.t('desktop settings should not override mobile default settings', Step.sync(() => {
+        const settings: RawEditorSettings = {
+          toolbar_mode: 'sliding',
+          table_grid: true,
+          object_resizing: true,
+          toolbar_sticky: true,
+          resize: 'both',
+          menubar: true
+        };
+
+        const mobileSettings = EditorSettings.combineSettings(true, true, {}, {}, settings);
+        Obj.each(expectedPhoneDefaultSettings, (value, key) => {
+          Assertions.assertEq(`Should have default ${key} setting`, value, Obj.get(mobileSettings, key).getOrUndefined());
+        });
+      })),
+
       Logger.t('getEditorSettings tests', GeneralSteps.sequence([
         Logger.t('Override defaults plugins', Step.sync(function () {
           const settings = EditorSettings.getEditorSettings(


### PR DESCRIPTION
This was introduced in cac78fe9810e5271d854ec296b47e8c29dfcf79c as the incorrect settings object was being passed when looking up the mobile defaults for the `toolbar_mode`/`toolbar_drawer`. So this just makes sure it's the mobile settings being passed in, instead of the top level settings.