### PR TITLE
TINY-5995/TINY-5999: Fixed issues with collecting text nodes from nested contenteditable elements

### DIFF
--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
@@ -7,22 +7,29 @@
 
 import { Node, Range, Text } from '@ephox/dom-globals';
 import { Arr, Fun, Obj } from '@ephox/katamari';
+import { Node as SandNode } from '@ephox/sand';
 import { Element, SelectorFilter, Traverse } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import TreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import { TextSection } from './Types';
 
-type CollectContentEditableFn = (node: Node) => TextSection[];
-type CollectTextFn = (node: Text, section: TextSection) => void;
 interface WalkerCallbacks {
   boundary: (node: Node) => boolean;
   cef: (node: Node) => boolean;
   text: (node: Text) => void;
 }
 
-const isBoundary = (dom: DOMUtils, node: Node) => dom.isBlock(node) || Obj.has(dom.schema.getShortEndedElements(), node.nodeName);
+interface CollectSettings {
+  cef?: (node: Node) => TextSection[];
+  text?: (node: Text, section: TextSection) => void;
+  skipStart: boolean;
+}
+
+const isSimpleBoundary = (dom: DOMUtils, node: Node) => dom.isBlock(node) || Obj.has(dom.schema.getShortEndedElements(), node.nodeName);
 const isContentEditableFalse = (dom: DOMUtils, node: Node) => dom.getContentEditable(node) === 'false';
+const isContentEditableTrueInCef = (dom: DOMUtils, node: Node) => dom.getContentEditable(node) === 'true' && dom.getContentEditableParent(node.parentNode) === 'false';
 const isHidden = (dom: DOMUtils, node: Node) => !dom.isBlock(node) && Obj.has(dom.schema.getWhiteSpaceElements(), node.nodeName);
+const isBoundary = (dom: DOMUtils, node: Node) => isSimpleBoundary(dom, node) || isContentEditableFalse(dom, node) || isHidden(dom, node) || isContentEditableTrueInCef(dom, node);
 const isText = (node: Node): node is Text => node.nodeType === 3;
 
 const nuSection = (): TextSection => ({
@@ -46,7 +53,7 @@ const walk = (dom: DOMUtils, walkerFn: (shallow?: boolean) => Node, startNode: N
         next = walkerFn(true);
         continue;
       }
-    } else if (isBoundary(dom, next)) {
+    } else if (isSimpleBoundary(dom, next)) {
       if (callbacks.boundary(next)) {
         break;
       }
@@ -88,7 +95,7 @@ const collectTextToBoundary = (dom: DOMUtils, section: TextSection, node: Node, 
   });
 };
 
-const collect = (dom: DOMUtils, rootNode: Node, startNode: Node, endNode?: Node, text?: CollectTextFn, cef?: CollectContentEditableFn, skipStart: boolean = true) => {
+const collect = (dom: DOMUtils, rootNode: Node, startNode: Node, endNode: Node, settings: CollectSettings) => {
   const walker = new TreeWalker(startNode, rootNode);
   const sections: TextSection[] = [];
   let current: TextSection = nuSection();
@@ -111,18 +118,18 @@ const collect = (dom: DOMUtils, rootNode: Node, startNode: Node, endNode?: Node,
     cef: (node) => {
       finishSection();
       // Collect additional nested contenteditable true content
-      if (cef) {
-        sections.push(...cef(node));
+      if (settings.cef) {
+        sections.push(...settings.cef(node));
       }
       return false;
     },
     text: (next) => {
       current.elements.push(Element.fromDom(next));
-      if (text) {
-        text(next, current);
+      if (settings.text) {
+        settings.text(next, current);
       }
     }
-  }, endNode, skipStart);
+  }, endNode, settings.skipStart);
 
   // Find any text between the end node and the closest boundary, then finalise the section
   if (endNode) {
@@ -139,17 +146,26 @@ const collectRangeSections = (dom: DOMUtils, rng: Range): TextSection[] => {
   const end = toLeaf(rng.endContainer, rng.endOffset);
   const endNode = end.element().dom();
 
-  return collect(dom, rng.commonAncestorContainer, startNode, endNode, (node, section) => {
-    // Set the start/end offset of the section
-    if (node === endNode) {
-      section.fOffset += node.length - end.offset();
-    } else if (node === startNode) {
-      section.sOffset += start.offset();
-    }
-  }, (node) => Arr.bind(SelectorFilter.descendants(Element.fromDom(node), '*[contenteditable=true]'), (e) => {
-    const ceTrueNode = e.dom();
-    return collect(dom, ceTrueNode, ceTrueNode);
-  }), false);
+  return collect(dom, rng.commonAncestorContainer, startNode, endNode, {
+    text: (node, section) => {
+      // Set the start/end offset of the section
+      if (node === endNode) {
+        section.fOffset += node.length - end.offset();
+      } else if (node === startNode) {
+        section.sOffset += start.offset();
+      }
+    },
+    cef: (node) => {
+      // Collect the sections and then order them appropriately, as nested sections maybe out of order
+      // TODO: See if we can improve this to avoid the sort overhead
+      const sections = Arr.bind(SelectorFilter.descendants(Element.fromDom(node), '*[contenteditable=true]'), (e) => {
+        const ceTrueNode = e.dom();
+        return collect(dom, ceTrueNode, ceTrueNode, undefined, { skipStart: true });
+      });
+      return Arr.sort(sections, (a, b) => (SandNode.documentPositionPreceding(a.elements[0].dom(), b.elements[0].dom())) ? 1 : -1);
+    },
+    skipStart: false
+  });
 };
 
 const fromRng = (dom: DOMUtils, rng: Range): TextSection[] => rng.collapsed ? [] : collectRangeSections(dom, rng);

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
@@ -162,7 +162,14 @@ UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplacePluginTes
       '<span contenteditable="false">NonEditable <span contenteditable="true">Editable </span>NonEditable </span>' +
       'Editable </span>NonEditable </span>' +
       'Editable</p>');
-    LegacyUnit.equal(5, editor.plugins.searchreplace.find('Editable'));
+    LegacyUnit.equal(5, editor.plugins.searchreplace.find('Editable', true, true));
+    LegacyUnit.equal(HtmlUtils.normalizeHtml(editor.getBody().innerHTML), (
+      '<p><span class="mce-match-marker mce-match-marker-selected" data-mce-bogus="1" data-mce-index="0">Editable</span> '+
+      '<span contenteditable="false">NonEditable <span contenteditable="true"><span class="mce-match-marker" data-mce-bogus="1" data-mce-index="1">Editable</span> ' +
+      '<span contenteditable="false">NonEditable <span contenteditable="true"><span class="mce-match-marker" data-mce-bogus="1" data-mce-index="2">Editable</span> </span>NonEditable </span>' +
+      '<span class="mce-match-marker" data-mce-bogus="1" data-mce-index="3">Editable</span> </span>NonEditable </span>' +
+      '<span class="mce-match-marker" data-mce-bogus="1" data-mce-index="4">Editable</span></p>'
+    ));
     LegacyUnit.equal(editor.plugins.searchreplace.replace('x', true, true), false);
     LegacyUnit.equal(editor.getContent(), '<p>x '+
       '<span contenteditable="false">NonEditable <span contenteditable="true">x ' +


### PR DESCRIPTION
This fixes the 2 issues identified during QA with the searching within content editable fix. The cause of TINY-5999 was it was walking back inside the contenteditable false elements and using that as an offset.