### PR TITLE
TINY-1044: Fixed issues with single cell tables getting deleted when all content is selected

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -31,6 +31,7 @@ Version 5.3.0 (TBD)
     Fixed bug where toolbars and dialogs would not show if the body element was replaced (e.g. with Turbolinks). Patch contributed by spohlenz #GH-5653
     Fixed zero-width spaces incorrectly included in the `wordcount` plugin character count #TINY-5991
     Fixed a regression introduced in 5.2.0 whereby the desktop `toolbar_mode` setting would incorrectly override the mobile default setting #TINY-5998
+    Fixed an issue where deleting all content in a single cell table would delete the entire table #TINY-1044
 Version 5.2.2 (2020-04-23)
     Fixed an issue where anchors could not be inserted on empty lines #TINY-2788
     Fixed text decorations (underline, strikethrough) not consistently inheriting the text color #TINY-4757

--- a/modules/tinymce/src/core/main/ts/caret/CaretFinder.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretFinder.ts
@@ -5,13 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Element, Node, Text } from '@ephox/dom-globals';
 import { Fun, Option } from '@ephox/katamari';
+import * as NodeType from '../dom/NodeType';
 import * as CaretCandidate from './CaretCandidate';
 import CaretPosition from './CaretPosition';
 import * as CaretUtils from './CaretUtils';
 import { CaretWalker } from './CaretWalker';
-import * as NodeType from '../dom/NodeType';
-import { Node, Element, Text } from '@ephox/dom-globals';
 
 const walkToPositionIn = (forward: boolean, root: Node, start: Node) => {
   const position = forward ? CaretPosition.before(start) : CaretPosition.after(start);
@@ -94,8 +94,8 @@ const positionIn = (forward: boolean, element: Node): Option<CaretPosition> => {
 const nextPosition = Fun.curry(fromPosition, true) as (root: Node, pos: CaretPosition) => Option<CaretPosition>;
 const prevPosition = Fun.curry(fromPosition, false) as (root: Node, pos: CaretPosition) => Option<CaretPosition>;
 
-const firstPositionIn = Fun.curry(positionIn, true) as (element: Element) => Option<CaretPosition>;
-const lastPositionIn = Fun.curry(positionIn, false) as (element: Element) => Option<CaretPosition>;
+const firstPositionIn = Fun.curry(positionIn, true) as (element: Node) => Option<CaretPosition>;
+const lastPositionIn = Fun.curry(positionIn, false) as (element: Node) => Option<CaretPosition>;
 
 export {
   fromPosition,

--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -166,5 +166,6 @@ const backspaceDelete = (editor: Editor, forward?: boolean) => {
 };
 
 export {
-  backspaceDelete
+  backspaceDelete,
+  deleteCellContents
 };

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -125,6 +125,17 @@ UnitTest.asynctest('browser.tinymce.core.content.InsertContentTest', (success, f
     assertSelection(editor, 'li', 1);
   });
 
+  suite.test('insertAtCaret - content into single table cell with all content selected', (editor) => {
+    editor.getBody().innerHTML = '<table class="mce-item-table"><tbody><tr><td>content</td></tr></tbody></table>';
+    editor.focus();
+    const rng = editor.dom.createRng();
+    rng.setStart(editor.dom.select('td')[0].firstChild, 0);
+    rng.setEnd(editor.dom.select('td')[0].firstChild, 7);
+    editor.selection.setRng(rng);
+    InsertContent.insertAtCaret(editor, { content: 'replace', paste: true });
+    LegacyUnit.equal(editor.getBody().innerHTML, '<table class="mce-item-table"><tbody><tr><td>replace</td></tr></tbody></table>');
+  });
+
   suite.test('insertAtCaret - empty paragraph pad the empty element with br on insert and nbsp on save', function (editor) {
     editor.setContent('<p>ab</p>');
     editor.focus();

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -1,11 +1,11 @@
-import { Assertions, GeneralSteps, Logger, Pipeline, Step, Keyboard, Keys } from '@ephox/agar';
+import { Assertions, GeneralSteps, Keyboard, Keys, Logger, Pipeline, Step } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { Remove, Replication, Element, Attr, Html, SelectorFilter } from '@ephox/sugar';
+import { Attr, Element, Html, Remove, Replication, SelectorFilter } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
 import * as TableDelete from 'tinymce/core/delete/TableDelete';
 import Theme from 'tinymce/themes/silver/Theme';
-import { UnitTest } from '@ephox/bedrock-client';
-import Editor from 'tinymce/core/api/Editor';
 
 UnitTest.asynctest('browser.tinymce.core.delete.TableDeleteTest', (success, failure) => {
   Theme();
@@ -60,11 +60,43 @@ UnitTest.asynctest('browser.tinymce.core.delete.TableDeleteTest', (success, fail
         ])),
 
         Logger.t('Range in only one cell should be noop', GeneralSteps.sequence([
-          tinyApis.sSetContent('<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>'),
+          tinyApis.sSetContent('<table><tbody><tr><td>ab</td><td>cd</td></tr></tbody></table>'),
           tinyApis.sSetSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1),
           sDeleteNoop(editor),
-          tinyApis.sAssertContent('<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>'),
+          tinyApis.sAssertContent('<table><tbody><tr><td>ab</td><td>cd</td></tr></tbody></table>'),
           tinyApis.sAssertSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1)
+        ])),
+
+        Logger.t('All content selected in single cell deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td>a</td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td>&nbsp;</td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with paragraph deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><p>a</p></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><p>&nbsp;</p></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with list deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><ul><li>a</li></ul></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><ul><li>&nbsp;</li></ul></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with complex selection deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><p>a</p><ul><li style="list-style-type: none;"><ul><li>b</li></ul></li><li><strong>c</strong></li></ul></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 1, 1, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><ul><li>&nbsp;</li></ul></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 0)
         ])),
 
         Logger.t('Select all content in all cells removes table', GeneralSteps.sequence([

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -67,38 +67,6 @@ UnitTest.asynctest('browser.tinymce.core.delete.TableDeleteTest', (success, fail
           tinyApis.sAssertSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1)
         ])),
 
-        Logger.t('All content selected in single cell deletes only content', GeneralSteps.sequence([
-          tinyApis.sSetContent('<table><tbody><tr><td>a</td></tr></tbody></table>'),
-          tinyApis.sSetSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1),
-          sDelete(editor),
-          tinyApis.sAssertContent('<table><tbody><tr><td>&nbsp;</td></tr></tbody></table>'),
-          tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
-        ])),
-
-        Logger.t('All content selected in single cell with paragraph deletes only content', GeneralSteps.sequence([
-          tinyApis.sSetContent('<table><tbody><tr><td><p>a</p></td></tr></tbody></table>'),
-          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1),
-          sDelete(editor),
-          tinyApis.sAssertContent('<table><tbody><tr><td><p>&nbsp;</p></td></tr></tbody></table>'),
-          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 0)
-        ])),
-
-        Logger.t('All content selected in single cell with list deletes only content', GeneralSteps.sequence([
-          tinyApis.sSetContent('<table><tbody><tr><td><ul><li>a</li></ul></td></tr></tbody></table>'),
-          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1),
-          sDelete(editor),
-          tinyApis.sAssertContent('<table><tbody><tr><td><ul><li>&nbsp;</li></ul></td></tr></tbody></table>'),
-          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 0)
-        ])),
-
-        Logger.t('All content selected in single cell with complex selection deletes only content', GeneralSteps.sequence([
-          tinyApis.sSetContent('<table><tbody><tr><td><p>a</p><ul><li style="list-style-type: none;"><ul><li>b</li></ul></li><li><strong>c</strong></li></ul></td></tr></tbody></table>'),
-          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 1, 1, 0, 0 ], 1),
-          sDelete(editor),
-          tinyApis.sAssertContent('<table><tbody><tr><td><ul><li>&nbsp;</li></ul></td></tr></tbody></table>'),
-          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 0)
-        ])),
-
         Logger.t('Select all content in all cells removes table', GeneralSteps.sequence([
           tinyApis.sSetContent('<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>'),
           tinyApis.sSetSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 1, 0 ], 1),
@@ -149,6 +117,80 @@ UnitTest.asynctest('browser.tinymce.core.delete.TableDeleteTest', (success, fail
           tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 1, [ 0, 0, 0, 1, 0, 0 ], 1),
           sKeyboardBackspace(editor),
           sAssertRawNormalizedContent(editor, '<table><tbody><tr><td><br data-mce-bogus="1"></td><td><br data-mce-bogus="1"></td><td><p>cc</p></td></tr></tbody></table>')
+        ]))
+      ])),
+
+      Logger.t('Delete all single cell content', GeneralSteps.sequence([
+        Logger.t('All content selected in single cell with only text deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td>a</td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td>&nbsp;</td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with only text deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td>a</td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1),
+          sBackspace(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td>&nbsp;</td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with paragraph deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><p>a</p></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><p>&nbsp;</p></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with multiple paragraphs deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><p>a</p><p>b</p><p>c</p></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 2, 0 ], 1),
+          sBackspace(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><p>&nbsp;</p></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with list deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><ul><li>a</li></ul></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><ul><li>&nbsp;</li></ul></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with indented text deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><div style="padding-left: 40px;">a</div></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><div style="padding-left: 40px;">&nbsp;</div></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with complex selection (1) deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><p>a</p><ul><li style="list-style-type: none;"><ul><li>b</li></ul></li><li><strong>c</strong></li></ul></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 1, 1, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><ul><li>&nbsp;</li></ul></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with complex selection (2) deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><p class="abc">a</p><p><strong>c</strong></p></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 1, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><p>&nbsp;</p></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with complex selection (3) deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><div><p class="abc"><span style="text-decoration: underline;">a</span></p></div><div style="font-size: 12px;"><p class="def"><span style="color: red">c</span></p></div></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 1, 0, 0, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><div style="font-size: 12px;"><p class="def">&nbsp;</p></div></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 0)
         ]))
       ])),
 


### PR DESCRIPTION
This fixes two issues with single cell tables:
- Pressing delete/backspace with all cell content selected would delete the table
- Inserting content with all cell content selected would replace the table

This works by adding an override to the native browser delete behaviour, so that if all the contents of a cell is selected, then it'll manually delete the contents of the table while preserving the last block element. This was done so that it's consistent with regular deletion behaviour when selecting all content within a multicell table.