### PR TITLE
TINY-1170: Fix format removal on empty lines and end of lines

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
@@ -1,3 +1,4 @@
+import { Eq } from '@ephox/dispute';
 import { Option } from './Option';
 import * as Fun from './Fun';
 
@@ -107,3 +108,6 @@ export const isEmpty = (r: Record<any, any>): boolean => {
   }
   return true;
 };
+
+export const equal = <T>(a1: Record<string, T>, a2:  Record<string, T>, eq: Eq.Eq<T> = Eq.eqAny) =>
+  Eq.eqRecord(eq).eq(a1, a2);

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -29,6 +29,7 @@ Version 5.3.0 (TBD)
     Fixed an issue where the editor would fail to load if local storage was disabled #TINY-5935
     Fixed an issue where an uploaded image would reuse a cached image with a different mime type #TINY-5988
     Fixed bug where toolbars and dialogs would not show if the body element was replaced (e.g. with Turbolinks). Patch contributed by spohlenz #GH-5653
+    Fixed an issue where multiple formats would be removed when removing a single format at the end of lines or on empty lines #TINY-1170
     Fixed zero-width spaces incorrectly included in the `wordcount` plugin character count #TINY-5991
     Fixed a regression introduced in 5.2.0 whereby the desktop `toolbar_mode` setting would incorrectly override the mobile default setting #TINY-5998
 Version 5.2.2 (2020-04-23)

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -112,7 +112,7 @@ export default function () {
     // rtl_ui: true,
     add_unload_trigger: false,
     autosave_ask_before_unload: false,
-    toolbar: 'undo redo sidebar1 | bold italic | alignleft aligncenter alignright alignjustify | align fontsizeselect fontselect formatselect styleselect insertfile | styleselect | ' +
+    toolbar: 'undo redo sidebar1 | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align fontsizeselect fontselect formatselect styleselect insertfile | styleselect | ' +
     'bullist numlist outdent indent | link image | print preview media fullpage | forecolor backcolor emoticons table codesample code | ltr rtl',
     contextmenu: 'link linkchecker image imagetools table lists spellchecker configurepermanentpen',
 

--- a/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
@@ -8,7 +8,6 @@
 import { Document, Node, Range } from '@ephox/dom-globals';
 import { Arr, Fun } from '@ephox/katamari';
 import { Attr, Element, Insert, Node as SugarNode, Remove } from '@ephox/sugar';
-import Selection from '../api/dom/Selection';
 import TreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import { FormatVars } from '../api/fmt/Format';
@@ -30,7 +29,7 @@ const importNode = function (ownerDocument: Document, node: Node) {
 };
 
 const getEmptyCaretContainers = function (node: Node) {
-  const nodes = [];
+  const nodes: Node[] = [];
 
   while (node) {
     if ((node.nodeType === 3 && node.nodeValue !== ZWSP) || node.childNodes.length > 1) {
@@ -173,13 +172,13 @@ const insertFormatNodesIntoCaretContainer = function (formatNodes: Node[], caret
 };
 
 const applyCaretFormat = function (editor: Editor, name: string, vars: FormatVars) {
-  let rng, caretContainer, textNode, offset, bookmark, container, text;
+  let caretContainer: Node, textNode: Node;
   const selection = editor.selection;
 
-  rng = selection.getRng();
-  offset = rng.startOffset;
-  container = rng.startContainer;
-  text = container.nodeValue;
+  const selectionRng = selection.getRng();
+  let offset = selectionRng.startOffset;
+  const container = selectionRng.startContainer;
+  const text = container.nodeValue;
 
   caretContainer = getParentCaretContainer(editor.getBody(), selection.getStart());
   if (caretContainer) {
@@ -191,13 +190,13 @@ const applyCaretFormat = function (editor: Editor, name: string, vars: FormatVar
   if (text && offset > 0 && offset < text.length &&
     wordcharRegex.test(text.charAt(offset)) && wordcharRegex.test(text.charAt(offset - 1))) {
     // Get bookmark of caret position
-    bookmark = selection.getBookmark();
+    const bookmark = selection.getBookmark();
 
     // Collapse bookmark range (WebKit)
-    rng.collapse(true);
+    selectionRng.collapse(true);
 
     // Expand the range to the closest word and split it at those points
-    rng = ExpandRange.expandRng(editor, rng, editor.formatter.get(name));
+    let rng = ExpandRange.expandRng(editor, selectionRng, editor.formatter.get(name));
     rng = SplitRange.split(rng);
 
     // Apply the format to the range
@@ -211,7 +210,7 @@ const applyCaretFormat = function (editor: Editor, name: string, vars: FormatVar
       caretContainer = importNode(editor.getDoc(), createCaretContainer(true).dom());
       textNode = caretContainer.firstChild;
 
-      rng.insertNode(caretContainer);
+      selectionRng.insertNode(caretContainer);
       offset = 1;
 
       editor.formatter.apply(name, vars, caretContainer);
@@ -225,14 +224,14 @@ const applyCaretFormat = function (editor: Editor, name: string, vars: FormatVar
 };
 
 const removeCaretFormat = function (editor: Editor, name: string, vars: FormatVars, similar: boolean) {
-  const dom = editor.dom, selection: Selection = editor.selection;
-  let container, offset, bookmark;
-  let hasContentAfter, node, formatNode;
-  const parents = [], rng = selection.getRng();
-  let caretContainer;
+  const dom = editor.dom;
+  const selection = editor.selection;
+  let hasContentAfter: boolean, node: Node, formatNode: Node;
+  const parents: Node[] = [];
+  const rng = selection.getRng();
 
-  container = rng.startContainer;
-  offset = rng.startOffset;
+  const container = rng.startContainer;
+  const offset = rng.startOffset;
   node = container;
 
   if (container.nodeType === 3) {
@@ -264,7 +263,7 @@ const removeCaretFormat = function (editor: Editor, name: string, vars: FormatVa
 
   // Is there contents after the caret then remove the format on the element
   if (hasContentAfter) {
-    bookmark = selection.getBookmark();
+    const bookmark = selection.getBookmark();
 
     // Collapse bookmark range (WebKit)
     rng.collapse(true);
@@ -275,12 +274,23 @@ const removeCaretFormat = function (editor: Editor, name: string, vars: FormatVa
 
     // TODO: Figure out how on earth this works, as it shouldn't since remove format
     //  definitely seems to require an actual Range
-    editor.formatter.remove(name, vars, expandedRng as Range);
+    editor.formatter.remove(name, vars, expandedRng as Range, similar);
     selection.moveToBookmark(bookmark);
   } else {
-    caretContainer = getParentCaretContainer(editor.getBody(), formatNode);
+    const caretContainer = getParentCaretContainer(editor.getBody(), formatNode);
     const newCaretContainer = createCaretContainer(false).dom();
-    const caretNode = insertFormatNodesIntoCaretContainer(parents, newCaretContainer);
+
+    // Find all formats present on the format node
+    const matchedFormats = FormatUtils.getFormatNamesPresent(editor, formatNode, [ 'removeformat', name ]);
+    // Filter out any matched formats that are 'visually' equivalent to the 'name' format since they are not unique formats on the node
+    const uniqueFormats = Arr.filter(matchedFormats, (fmtName) => !FormatUtils.areSimilarFormats(editor, fmtName, name));
+    // If more than one format is present, push formatNode on to parents array so that it can be appended to the caret container
+    // As a result formatter.remove() below can deal with removing the 'name' format safely
+    if (uniqueFormats.length > 0) {
+      parents.push(formatNode);
+    }
+
+    const caretTextNode = insertFormatNodesIntoCaretContainer(parents, newCaretContainer);
 
     if (caretContainer) {
       insertCaretContainerNode(editor, newCaretContainer, caretContainer);
@@ -289,7 +299,12 @@ const removeCaretFormat = function (editor: Editor, name: string, vars: FormatVa
     }
 
     removeCaretContainerNode(editor, caretContainer, false);
-    selection.setCursorLocation(caretNode, 1);
+
+    if (uniqueFormats.length > 0) {
+      editor.formatter.remove(name, vars, newCaretContainer, similar);
+    }
+
+    selection.setCursorLocation(caretTextNode, 1);
 
     if (dom.isEmpty(formatNode)) {
       dom.remove(formatNode);

--- a/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
@@ -12,7 +12,7 @@ import Tools from '../api/util/Tools';
 import Editor from '../api/Editor';
 
 export interface FormatRegistry {
-  get (name?: string): Formats | Format[];
+  get (name?: string): Format[] | Record<string, Format[]>;
   has (name: string): boolean;
   register (name: string | Formats, format?: Format[] | Format): void;
   unregister (name: string): Formats;
@@ -21,7 +21,7 @@ export interface FormatRegistry {
 export function FormatRegistry(editor: Editor): FormatRegistry {
   const formats: Record<string, Format[]> = {};
 
-  const get = (name?: string): Formats | Format[] => name ? formats[name] : formats;
+  const get = (name?: string) => name ? formats[name] : formats;
 
   const has = (name: string): boolean => Obj.has(formats, name);
 

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -12,7 +12,7 @@ import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import * as NodeType from '../dom/NodeType';
 import { FormatAttrOrStyleValue, FormatVars, Format } from '../api/fmt/Format';
-import { Obj, Arr } from '@ephox/katamari';
+import { Obj, Arr, Type } from '@ephox/katamari';
 
 const isNode = (node: any): node is Node => !!(node).nodeType;
 
@@ -173,47 +173,23 @@ const getParents = function (dom: DOMUtils, node: Node, selector?: string) {
 const isVariableFormatName = (editor: Editor, formatName: string): boolean => {
   const hasVariableValues = (format: Format) => {
     const isVariableValue = (val: string): boolean => val.length > 1 && val.charAt(0) === '%';
-    const stylesFieldHas = Obj.get(format, 'styles').exists((stylesField) => Arr.exists(Obj.values(stylesField), isVariableValue));
-    const attributesFieldHas = Obj.get(format, 'attributes').exists((attributesField) => Arr.exists(Obj.values(attributesField), isVariableValue));
-    return stylesFieldHas || attributesFieldHas;
+    return Arr.exists([ 'styles', 'attributes' ], (key: 'styles' | 'attributes') =>
+      Obj.get(format, key).exists((field) => {
+        const fieldValues = Type.isArray(field) ? field : Obj.values(field);
+        return Arr.exists(fieldValues, isVariableValue);
+      }));
   };
-  return Arr.exists(editor.formatter.get(formatName) as Format[], (format) => hasVariableValues(format));
-};
-
-/**
- *  Get all of the format names present on the specifed node
- */
-const getFormatNamesPresent = (editor: Editor, node: Node, blacklist: string[] = [ 'removeformat' ], deep: boolean = false): string[] => {
-  const validFormats = Arr.filter(Obj.keys(editor.formatter.get()), (name) => !Arr.exists(blacklist, (blacklistedName) => blacklistedName === name));
-  const formats = Arr.map(validFormats, (name) => ({
-    name,
-    matchSimilar: isVariableFormatName(editor, name),
-    checked: false
-  }));
-  const matchedFormatNames: string[] = [];
-
-  const checkNodeForFormats = (currentNode: Node) => {
-    Arr.each(formats, (format) => {
-      if (!format.checked && editor.formatter.matchNode(currentNode, format.name, {}, format.matchSimilar)) {
-        format.checked = true;
-        matchedFormatNames.push(format.name);
-      }
-    });
-    if (deep) {
-      Arr.each(currentNode.childNodes, (child) => checkNodeForFormats(child));
-    }
-  };
-
-  checkNodeForFormats(node);
-  return matchedFormatNames;
+  return Arr.exists(editor.formatter.get(formatName) as Format[], hasVariableValues);
 };
 
 /**
  * Checks if the two formats are similar based on the format type, attributes, styles and classes
  */
 const areSimilarFormats = (editor: Editor, formatName: string, otherFormatName: string) => {
+  // Note: MatchFormat.matchNode() uses these parameters to check if a format matches a node
+  // Therefore, these are ideal to check if two formats are similar
   const validKeys = [ 'inline', 'block', 'selector', 'attributes', 'styles', 'classes' ];
-  const filterObj = (format) => Obj.filter(format, (_, key) => Arr.exists(validKeys, (validKey) => validKey === key));
+  const filterObj = (format: Record<string, any>) => Obj.filter(format, (_, key) => Arr.exists(validKeys, (validKey) => validKey === key));
   return Arr.exists(editor.formatter.get(formatName) as Format[], (fmt1) => {
     const filteredFmt1 = filterObj(fmt1);
     return Arr.exists(editor.formatter.get(otherFormatName) as Format[], (fmt2) => {
@@ -238,6 +214,6 @@ export {
   getStyle,
   getTextDecoration,
   getParents,
-  getFormatNamesPresent,
+  isVariableFormatName,
   areSimilarFormats
 };

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -10,6 +10,7 @@ import Editor from '../api/Editor';
 import { Format, FormatVars, SelectorFormat } from '../api/fmt/Format';
 import { Node } from '@ephox/dom-globals';
 import DOMUtils from '../api/dom/DOMUtils';
+import { Arr } from '@ephox/katamari';
 
 const isEq = FormatUtils.isEq;
 
@@ -161,17 +162,14 @@ const match = function (editor: Editor, name: string, vars: FormatVars, node) {
 };
 
 const matchAll = function (editor: Editor, names: string[], vars: FormatVars) {
-  let startElement;
-  const matchedFormatNames = [];
-  const checkedMap = {};
+  const matchedFormatNames: string[] = [];
+  const checkedMap: Record<string, boolean> = {};
 
   // Check start of selection for formats
-  startElement = editor.selection.getStart();
+  const startElement = editor.selection.getStart();
   editor.dom.getParent(startElement, function (node) {
-    let i, name;
-
-    for (i = 0; i < names.length; i++) {
-      name = names[i];
+    for (let i = 0; i < names.length; i++) {
+      const name = names[i];
 
       if (!checkedMap[name] && matchNode(editor, node, name, vars)) {
         checkedMap[name] = true;
@@ -212,11 +210,25 @@ const canApply = function (editor: Editor, name: string) {
   return false;
 };
 
+/**
+ *  Get all of the format names present on the specified node
+ */
+const matchAllOnNode = (editor: Editor, node: Node, formatNames: string[]) =>
+  Arr.foldl(formatNames, (acc, name) => {
+    const matchSimilar = FormatUtils.isVariableFormatName(editor, name);
+    if (editor.formatter.matchNode(node, name, {}, matchSimilar)) {
+      return acc.concat([ name ]);
+    } else {
+      return acc;
+    }
+  }, [] as string[]);
+
 export {
   matchNode,
   matchName,
   match,
   matchAll,
+  matchAllOnNode,
   canApply,
   matchesUnInheritedFormatSelector
 };

--- a/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
@@ -445,7 +445,92 @@ UnitTest.asynctest('browser.tinymce.core.fmt.CaretFormatTest', function (success
         Assertions.assertEq('Should not be format element', false, CaretFormat.isFormatElement(editor, Element.fromHtml('<a href="#"></a>')));
         Assertions.assertEq('Should not be format element', false, CaretFormat.isFormatElement(editor, Element.fromHtml('<span data-mce-bogus="1"></span>')));
         Assertions.assertEq('Should not be format element', false, CaretFormat.isFormatElement(editor, Element.fromHtml('<span id="_mce_caret"></span>')));
-      }))
+      })),
+      Logger.t('Remove single format on multiple format span (End of line) (TINY-1170)', GeneralSteps.sequence([
+        tinyApis.sSetContent('<p><span style="text-decoration: underline; font-size: 18px;">a</span></p>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 1),
+        sRemoveCaretFormat(editor, 'underline', {}),
+        TypeText.sTypeContentAtSelection(Element.fromDom(editor.getDoc()), 'x'),
+        tinyApis.sAssertContent('<p><span style="text-decoration: underline; font-size: 18px;">a</span><span style="font-size: 18px;">x</span></p>'),
+        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str) => s.element('body', {
+          children: [
+            s.element('p', {
+              children: [
+                s.element('span', { children: [ s.text(str.is('a')) ] }),
+                s.element('span', {
+                  attrs: {
+                    'id': str.is('_mce_caret'),
+                    'data-mce-bogus': str.is('1')
+                  },
+                  children: [
+                    s.element('span', {
+                      styles: { 'font-size': str.is('18px') },
+                      children: [ s.text(str.is(Zwsp.ZWSP + 'x')) ]
+                    })
+                  ]
+                })
+              ]
+            })
+          ]
+        }))),
+        tinyApis.sAssertSelection([ 0, 1, 0, 0 ], 2, [ 0, 1, 0, 0 ], 2)
+      ])),
+      Logger.t('Remove single format on multiple format span (Empty line) (TINY-1170)', GeneralSteps.sequence([
+        tinyApis.sSetContent('<p><span style="text-decoration: underline; font-size: 18px;"><br></span></p>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        sRemoveCaretFormat(editor, 'underline', {}),
+        TypeText.sTypeContentAtSelection(Element.fromDom(editor.getDoc()), 'x'),
+        tinyApis.sAssertContent('<p><span style="font-size: 18px;">x</span></p>'),
+        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str) => s.element('body', {
+          children: [
+            s.element('p', {
+              children: [
+                s.element('span', {
+                  attrs: {
+                    'id': str.is('_mce_caret'),
+                    'data-mce-bogus': str.is('1')
+                  },
+                  children: [
+                    s.element('span', {
+                      styles: { 'font-size': str.is('18px') },
+                      children: [ s.text(str.is(Zwsp.ZWSP + 'x')) ]
+                    })
+                  ]
+                })
+              ]
+            })
+          ]
+        }))),
+        tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 2, [ 0, 0, 0, 0 ], 2)
+      ])),
+      Logger.t('Remove text decoration format on text color, text decoration span (Empty line) (TINY-1170)', GeneralSteps.sequence([
+        tinyApis.sSetContent('<p><span style="text-decoration: underline;"><span style="color: red; text-decoration: underline;"><br></span></span></p>'),
+        tinyApis.sSetCursor([ 0, 0, 0, 0 ], 0),
+        sRemoveCaretFormat(editor, 'underline', {}),
+        TypeText.sTypeContentAtSelection(Element.fromDom(editor.getDoc()), 'x'),
+        tinyApis.sAssertContent('<p><span style="color: red;">x</span></p>'),
+        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str) => s.element('body', {
+          children: [
+            s.element('p', {
+              children: [
+                s.element('span', {
+                  attrs: {
+                    'id': str.is('_mce_caret'),
+                    'data-mce-bogus': str.is('1')
+                  },
+                  children: [
+                    s.element('span', {
+                      styles: { color: str.is('red') },
+                      children: [ s.text(str.is(Zwsp.ZWSP + 'x')) ]
+                    })
+                  ]
+                })
+              ]
+            })
+          ]
+        }))),
+        tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 2, [ 0, 0, 0, 0 ], 2)
+      ])),
     ], onSuccess, onFailure);
   }, {
     plugins: '',


### PR DESCRIPTION
This fixes an issue where if multiple formats were in a single span, they would both be removed when removing a single format at the end of lines or on empty lines.