### PR TITLE
TINY-1044: Fixed table cell delete edge case

### DIFF
--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -40,12 +40,15 @@ const deleteCellContents = (editor: Editor, rng: Range, cell: Element) => {
     PaddingBr.fillWithPaddingBr(lastBlock);
     editor.selection.setCursorLocation(lastBlock.dom(), 0);
   }
-  // Clean up any additional leftover nodes
-  Arr.each(Traverse.children(cell), (node) =>{
-    if (!Compare.eq(node, lastBlock) && !Compare.contains(node, lastBlock)) {
-      Remove.remove(node);
-    }
-  });
+  // Clean up any additional leftover nodes. If the last block wasn't a direct child, then we also need to clean up siblings
+  if (!Compare.eq(cell, lastBlock)) {
+    const additionalCleanupNodes = Traverse.parent(lastBlock).is(cell) ? [] : Traverse.siblings(lastBlock);
+    Arr.each(additionalCleanupNodes.concat(Traverse.children(cell)), (node) => {
+      if (!Compare.eq(node, lastBlock) && !Compare.contains(node, lastBlock)) {
+        Remove.remove(node);
+      }
+    });
+  }
   return true;
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -154,10 +154,18 @@ UnitTest.asynctest('browser.tinymce.core.delete.TableDeleteTest', (success, fail
         ])),
 
         Logger.t('All content selected in single cell with list deletes only content', GeneralSteps.sequence([
-          tinyApis.sSetContent('<table><tbody><tr><td><ul><li>a</li></ul></td></tr></tbody></table>'),
-          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1),
+          tinyApis.sSetContent('<table><tbody><tr><td><ul><li>a</li><li>b</li></ul></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 1, 0 ], 1),
           sDelete(editor),
           tinyApis.sAssertContent('<table><tbody><tr><td><ul><li>&nbsp;</li></ul></td></tr></tbody></table>'),
+          tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 0)
+        ])),
+
+        Logger.t('All content selected in single cell with list + start attribute deletes only content', GeneralSteps.sequence([
+          tinyApis.sSetContent('<table><tbody><tr><td><ol start="2"><li>a</li><li>b</li></ol></td></tr></tbody></table>'),
+          tinyApis.sSetSelection([ 0, 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 1, 0 ], 1),
+          sDelete(editor),
+          tinyApis.sAssertContent('<table><tbody><tr><td><ol start="2"><li>&nbsp;</li></ol></td></tr></tbody></table>'),
           tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 0)
         ])),
 


### PR DESCRIPTION
This fixes the edge case @ltrouton found and also changes the table delete override logic to only run on single cell tables, to reduce the risk of breaking under any other potential edge cases.