### PR TITLE
TINY-5949: Update monorepo for 5.3.0 release

### DIFF
--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@ephox/acid",
   "description": "Color library including Alloy UI component for a color picker",
-  "version": "1.0.73",
+  "version": "1.0.74",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
   },
   "dependencies": {
-    "@ephox/alloy": "^6.0.6",
-    "@ephox/boulder": "^4.0.3",
+    "@ephox/alloy": "^7.0.0",
+    "@ephox/boulder": "^4.0.4",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/sugar": "^5.1.3",
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/sugar": "^6.0.0",
     "tslib": "^1.9.3"
   },
   "author": "Ephox Corporation",

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/agar",
-  "version": "4.15.3",
+  "version": "4.15.4",
   "description": "Testing infrastructure",
   "repository": {
     "type": "git",
@@ -25,14 +25,14 @@
   "dependencies": {
     "@ephox/bedrock-client": "^9.3.2",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/jax": "^4.1.31",
-    "@ephox/sand": "^3.1.6",
-    "@ephox/sugar": "^5.1.3",
+    "@ephox/jax": "^4.1.32",
+    "@ephox/sand": "^3.1.7",
+    "@ephox/sugar": "^6.0.0",
     "@ephox/wrap-jsverify": "^2.0.1",
     "@ephox/wrap-sizzle": "^4.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.4"
+    "@ephox/katamari-assertions": "^1.0.5"
   },
   "files": [
     "lib/main",

--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -6,15 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
-
-- Added new `getModes` and `setModes` API to the docking behaviour.
-
-# [6.1.0] - 2020-03-16
+# [7.0.0] - 2020-05-20
 
 ### Added
-
 - Added new `isExtraPart` property to `InlineView`. This allows the component to declare an external component as part of itself for dismissal events.
+- Added new `getModes` and `setModes` API to the docking behaviour.
+- Exposed the `AriaVoice` voice module in the API.
+
+### Changed
+- The `AriaOwner` module, `Boxes` module, `Pinching` behaviour and `SnapConfig`/`SnapOutput` specs no longer use thunked functions and instead use the variable directly.
+- All uses of `Struct.immutableBag` and `Struct.immutable` have been replaced with readonly interfaces.
 
 # [6.0.1] - 2020-03-02
 

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ephox/alloy",
-  "version": "6.0.6",
+  "version": "7.0.0",
   "description": "Ui Framework",
   "dependencies": {
-    "@ephox/agar": "^4.15.3",
-    "@ephox/boulder": "^4.0.3",
+    "@ephox/agar": "^4.15.4",
+    "@ephox/boulder": "^4.0.4",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/sand": "^3.1.6",
-    "@ephox/sugar": "^5.1.3"
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/sand": "^3.1.7",
+    "@ephox/sugar": "^6.0.0"
   },
   "files": [
     "lib/main",

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/boss",
   "description": "Generic wrapper to document models - DomUniverse vs TestUniverse",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -19,12 +19,12 @@
   ],
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/sugar": "^5.1.3",
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/sugar": "^6.0.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.4"
+    "@ephox/katamari-assertions": "^1.0.5"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/boulder/package.json
+++ b/modules/boulder/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ephox/boulder",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Basic javascript object validation",
   "dependencies": {
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/sand": "^3.1.6"
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/sand": "^3.1.7"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.4"
+    "@ephox/katamari-assertions": "^1.0.5"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test/ts",

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/bridge",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Ui API for TinyMCE 5",
   "repository": {
     "type": "git",
@@ -12,9 +12,9 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
   "dependencies": {
-    "@ephox/boulder": "^4.0.3",
+    "@ephox/boulder": "^4.0.4",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2"
+    "@ephox/katamari": "^6.0.0"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/darwin",
   "description": "This project's purpose is to handle selection and cursor navigation.",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -19,12 +19,12 @@
   ],
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/phoenix": "^5.1.4",
-    "@ephox/robin": "^7.0.51",
-    "@ephox/sand": "^3.1.6",
-    "@ephox/snooker": "^5.1.12",
-    "@ephox/sugar": "^5.1.3"
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/phoenix": "^5.1.5",
+    "@ephox/robin": "^7.0.52",
+    "@ephox/sand": "^3.1.7",
+    "@ephox/snooker": "^5.1.13",
+    "@ephox/sugar": "^6.0.0"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/dragster",
   "description": "This project handles dragging.",
-  "version": "4.0.46",
+  "version": "4.0.47",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -19,9 +19,9 @@
   ],
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/porkbun": "^4.0.33",
-    "@ephox/sugar": "^5.1.3"
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/porkbun": "^4.0.34",
+    "@ephox/sugar": "^6.0.0"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test",

--- a/modules/imagetools/package.json
+++ b/modules/imagetools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/imagetools",
-  "version": "3.2.10",
+  "version": "3.3.0",
   "description": "Image tools for tinymce and textbox.io",
   "keywords": [
     "image",

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/jax",
-  "version": "4.1.31",
+  "version": "4.1.32",
   "description": "AJAX library",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
+    "@ephox/katamari": "^6.0.0",
     "tslib": "^1.9.3"
   },
   "files": [

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari-assertions",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Bedrock test assertions for Katamari",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "@ephox/bedrock-client": "^9.3.2",
     "@ephox/dispute": "^1.0.3",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
+    "@ephox/katamari": "^6.0.0",
     "@ephox/wrap-promise-polyfill": "^2.2.0",
     "tslib": "^1.9.3"
   },

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "Basic data type library",
   "repository": {
     "type": "git",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/mcagar",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "Tinymce agar wrapper",
   "repository": {
     "type": "git",
@@ -23,11 +23,11 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/agar": "^4.15.3",
+    "@ephox/agar": "^4.15.4",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/sand": "^3.1.6",
-    "@ephox/sugar": "^5.1.3",
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/sand": "^3.1.7",
+    "@ephox/sugar": "^6.0.0",
     "@ephox/wrap-jsverify": "^2.0.1"
   },
   "main": "./lib/main/ts/ephox/mcagar/api/Main.js",

--- a/modules/oxide-icons-default/package.json
+++ b/modules/oxide-icons-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide-icons-default",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "The default icon pack for TinyMCE",
   "main": "dist/js/icons.js",
   "scripts": {

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "TinyMCE 5 Oxide skin",
   "scripts": {
     "test": "echo 'No tests'",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/phoenix",
   "description": "DOM node text gathering library, rose from the ashes of some other projects we can't remember the names of now (edit: seek, sherlock, gift)",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,14 +18,14 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^3.1.3",
+    "@ephox/boss": "^3.1.4",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/polaris": "^3.0.48",
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/polaris": "^3.0.49",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.4"
+    "@ephox/katamari-assertions": "^1.0.5"
   },
   "scripts": {
     "test-manual": "bedrock -d src/test",

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/polaris",
   "description": "This project does data manipulation on arrays and strings.",
-  "version": "3.0.48",
+  "version": "3.0.49",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -19,11 +19,11 @@
   ],
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
+    "@ephox/katamari": "^6.0.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.4"
+    "@ephox/katamari-assertions": "^1.0.5"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/porkbun",
   "description": "Event framework for JavaScript",
-  "version": "4.0.33",
+  "version": "4.0.34",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,7 +18,7 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^5.0.2"
+    "@ephox/katamari": "^6.0.0"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test/ts",

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/robin",
   "description": "This project is for grouping sibling DOM nodes together by boundary points, for example the list of elements and nodes representing a word.",
-  "version": "7.0.51",
+  "version": "7.0.52",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,14 +18,14 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^3.1.3",
+    "@ephox/boss": "^3.1.4",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/phoenix": "^5.1.4",
-    "@ephox/polaris": "^3.0.48"
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/phoenix": "^5.1.5",
+    "@ephox/polaris": "^3.0.49"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.4"
+    "@ephox/katamari-assertions": "^1.0.5"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sand",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Platform detection library",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2"
+    "@ephox/katamari": "^6.0.0"
   },
   "main": "./lib/main/ts/ephox/sand/api/Main.js",
   "module": "./lib/main/ts/ephox/sand/api/Main.js",

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/snooker",
   "description": "This project implements the table model.",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "files": [
     "lib/main",
     "lib/demo",
@@ -19,11 +19,11 @@
   },
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/dragster": "^4.0.46",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/porkbun": "^4.0.33",
-    "@ephox/robin": "^7.0.51",
-    "@ephox/sugar": "^5.1.3"
+    "@ephox/dragster": "^4.0.47",
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/porkbun": "^4.0.34",
+    "@ephox/robin": "^7.0.52",
+    "@ephox/sugar": "^6.0.0"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sugar",
-  "version": "5.1.3",
+  "version": "6.0.0",
   "description": "Basic DOM manipulation",
   "repository": {
     "type": "git",
@@ -22,11 +22,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^5.0.2",
-    "@ephox/sand": "^3.1.6"
+    "@ephox/katamari": "^6.0.0",
+    "@ephox/sand": "^3.1.7"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.4"
+    "@ephox/katamari-assertions": "^1.0.5"
   },
   "files": [
     "lib/main",

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,4 @@
-Version 5.3.0 (TBD)
+Version 5.3.0 (2020-05-20)
     Added html and body height styles to the default oxide content CSS #TINY-5978
     Added `uploadUri` and `blobInfo` to the data returned by `editor.uploadImages()` #TINY-4579
     Added a new function to the `BlobCache` API to lookup a blob based on the base64 data and mime type #TINY-5988


### PR DESCRIPTION
- [ ] Don't merge until other 5.3 PRs/blockers have been resolved