### PR TITLE
TINY-4495 Fix and improve context toolbar prioritisation

### DIFF
--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPositionPriorityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPositionPriorityTest.ts
@@ -3,11 +3,9 @@ import { UnitTest, Assert } from '@ephox/bedrock-client';
 import { ContextTypes } from 'tinymce/themes/silver/ContextToolbar';
 import { Arr } from '@ephox/katamari';
 import { Toolbar } from '@ephox/bridge';
-import { filterToolbarsByPosition } from 'tinymce/themes/silver/ui/context/ContextToolbarLookup';
+import { filterByPositionForStartNode, filterByPositionForAncestorNode } from 'tinymce/themes/silver/ui/context/ContextToolbarLookup';
 
 UnitTest.asynctest('Context toolbar lookup priority by position test', (success, failure) => {
-  // Test prioritise position by 'selection' -> 'node' -> 'line'
-
   const createToolbars = (positions: string[]): ContextTypes[] => Arr.map(positions, (p) => ({
     type: 'contexttoolbar',
     items: 'bold italic',
@@ -16,23 +14,27 @@ UnitTest.asynctest('Context toolbar lookup priority by position test', (success,
     scope: 'node'
   } as Toolbar.ContextToolbar));
 
-  const sAssertPositionIsPrioritised = (positions: string[], priority: string) => Step.sync(() => {
+  const sAssertPositionIsPrioritised = (positions: string[], priorities: string[], isStartNode: boolean) => Step.sync(() => {
     const toolbars = createToolbars(positions);
-    const prioritisedToolbars = filterToolbarsByPosition(toolbars);
-    Arr.map(prioritisedToolbars, (t) => Assert.eq(`Assert priority is ${priority}`, priority, t.position));
+    const prioritisedToolbars = isStartNode ? filterByPositionForStartNode(toolbars) : filterByPositionForAncestorNode(toolbars);
+    Arr.each(prioritisedToolbars, (t, i) => {
+      Assert.eq(`Assert priority is ${priorities[i]}`, priorities[i], t.position);
+    });
   });
 
   Pipeline.async({ }, [
-    Log.step('TINY-4495', 'Test array of 1 toolbar is returned as is', sAssertPositionIsPrioritised([ 'selection' ], 'selection')),
+    Log.step('TINY-4495', 'Test array of 1 toolbar is returned as is', sAssertPositionIsPrioritised([ 'selection' ], [ 'selection' ], true)),
 
     Log.stepsAsStep('TINY-4495', 'Test multiple positions returned correctly', [
-      sAssertPositionIsPrioritised([ 'selection', 'selection' ], 'selection'),
-      sAssertPositionIsPrioritised([ 'node', 'node' ], 'node'),
-      sAssertPositionIsPrioritised([ 'line', 'line' ], 'line'),
+      sAssertPositionIsPrioritised([ 'selection', 'selection' ], [ 'selection', 'selection' ], true),
+      sAssertPositionIsPrioritised([ 'node', 'node' ], [ 'node', 'node' ], true),
+      sAssertPositionIsPrioritised([ 'line', 'line' ], [ 'line', 'line' ], true),
     ]),
 
-    Log.step('TINY-4495', 'Test selection is prioritised over others', sAssertPositionIsPrioritised([ 'line', 'node', 'selection' ], 'selection')),
+    Log.step('TINY-4495', 'Test selection AND node are prioritised over line for start node, and switched to node', sAssertPositionIsPrioritised([ 'selection', 'node', 'line' ], [ 'node', 'node' ], true)),
+    Log.step('TINY-4495', 'Test selection is prioritised over others for ancestor node', sAssertPositionIsPrioritised([ 'selection', 'node', 'line' ], [ 'selection' ], false)),
 
-    Log.step('TINY-4495', 'Test node is prioritised over line', sAssertPositionIsPrioritised([ 'line', 'node' ], 'node')),
+    Log.step('TINY-4495', 'Test node is prioritised over line for start node', sAssertPositionIsPrioritised([ 'line', 'node' ], [ 'node' ], true)),
+    Log.step('TINY-4495', 'Test node is prioritised over line for ancestor node', sAssertPositionIsPrioritised([ 'line', 'node' ], [ 'node' ], false)),
   ], success, failure);
 });


### PR DESCRIPTION
Realised we weren't running the "filter by position" logic when running lookup on ancestor nodes. Also realised that on the initial node it probably makes sense to combine `selection` and `node` toolbars (QA found weirdness). So, overall, changed the logic so that:
- if running on the initial node, will combine `selection` and `node` toolbars, and if it finds none _then_ go looking for `line` toolbars
- if running on an ancestor node, will look for `selection` then `node` then `line` toolbars

A little worried about performance from all the array iterations? Tried a couple things, this was the best I could think of.