### PR TITLE
TINY-6014: Fixed issues with switching modes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
   chrome: stable
 
 before_script:
-  - npm install -g chromedriver
+  - npm install -g chromedriver --detect_chromedriver_version
 
 script:
   - yarn eslint

--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added new `getModes` and `setModes` API to the docking behaviour.
 
+### Changed
+
+- Changed the `Disabling` behaviour to use a lazy `disabled` configuration to determine if the component should be disabled on initial load.
+
 # [6.1.0] - 2020-03-16
 
 ### Added

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
@@ -14,7 +14,8 @@ const nativeDisabled = [
 ];
 
 const onLoad = (component: AlloyComponent, disableConfig: DisableConfig, disableState: Stateless): void => {
-  if (disableConfig.disabled) { disable(component, disableConfig, disableState); }
+  const f = disableConfig.disabled() ? disable : enable;
+  f(component, disableConfig, disableState);
 };
 
 const hasNative = (component: AlloyComponent, config: DisableConfig): boolean => config.useNative === true && Arr.contains(nativeDisabled, Node.name(component.element()));

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableSchema.ts
@@ -1,9 +1,10 @@
-import { FieldSchema, FieldProcessorAdt } from '@ephox/boulder';
+import { FieldProcessorAdt, FieldSchema } from '@ephox/boulder';
+import { Fun } from '@ephox/katamari';
 
 import * as Fields from '../../data/Fields';
 
 export default [
-  FieldSchema.defaulted('disabled', false),
+  FieldSchema.defaultedFunction('disabled', Fun.never),
   FieldSchema.defaulted('useNative', true),
   FieldSchema.option('disableClass'),
   Fields.onHandler('onDisabled'),

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableTypes.ts
@@ -13,7 +13,7 @@ export interface DisableBehaviour extends Behaviour.AlloyBehaviour<DisableConfig
 }
 
 export interface DisableConfig extends Behaviour.BehaviourConfigDetail {
-  disabled: boolean;
+  disabled: () => boolean;
   disableClass: Option<string>;
   useNative: boolean;
   onEnabled: (comp: AlloyComponent) => void;
@@ -21,7 +21,7 @@ export interface DisableConfig extends Behaviour.BehaviourConfigDetail {
 }
 
 export interface DisableConfigSpec extends Behaviour.BehaviourConfigSpec {
-  disabled?: boolean;
+  disabled?: () => boolean;
   disableClass?: string;
   useNative?: boolean;
   onEnabled?: (comp: AlloyComponent) => void;

--- a/modules/alloy/src/test/ts/browser/behaviour/DisablingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/DisablingTest.ts
@@ -7,9 +7,9 @@ import { Disabling } from 'ephox/alloy/api/behaviour/Disabling';
 import * as GuiFactory from 'ephox/alloy/api/component/GuiFactory';
 import * as Memento from 'ephox/alloy/api/component/Memento';
 import * as AlloyEvents from 'ephox/alloy/api/events/AlloyEvents';
+import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 import { Button } from 'ephox/alloy/api/ui/Button';
 import { Container } from 'ephox/alloy/api/ui/Container';
-import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 
 UnitTest.asynctest('DisablingTest', (success, failure) => {
 
@@ -21,7 +21,7 @@ UnitTest.asynctest('DisablingTest', (success, failure) => {
       },
       buttonBehaviours: Behaviour.derive([
         Disabling.config({
-          disabled: true
+          disabled: () => true
         })
       ])
     })

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/SerialisedDialog.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/SerialisedDialog.ts
@@ -6,10 +6,11 @@
  */
 
 import {
-  AddEventsBehaviour, AlloyEvents, AlloyTriggers, Behaviour, Button, Container, Disabling, Form,
-  Highlighting, Keying, Memento, NativeEvents, Representing
+  AddEventsBehaviour, AlloyEvents, AlloyTriggers, Behaviour, Button, Container, Disabling, Form, Highlighting, Keying, Memento,
+  NativeEvents, Representing
 } from '@ephox/alloy';
 import { FieldSchema, ValueSchema } from '@ephox/boulder';
+import { HTMLElement } from '@ephox/dom-globals';
 import { Arr, Cell, Option, Singleton } from '@ephox/katamari';
 import { Css, SelectorFilter, SelectorFind, Width } from '@ephox/sugar';
 
@@ -17,7 +18,6 @@ import * as Receivers from '../channels/Receivers';
 import * as SwipingModel from '../model/SwipingModel';
 import * as Styles from '../style/Styles';
 import * as UiDomFactory from '../util/UiDomFactory';
-import { HTMLElement } from '@ephox/dom-globals';
 
 const sketch = function (rawSpec) {
   const navigateEvent = 'navigateEvent';
@@ -50,7 +50,7 @@ const sketch = function (rawSpec) {
       buttonBehaviours: Behaviour.derive([
         Disabling.config({
           disableClass: Styles.resolve('toolbar-navigation-disabled'),
-          disabled: !enabled
+          disabled: () => !enabled
         })
       ])
     });

--- a/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
@@ -2,10 +2,10 @@ import { Attachment, Behaviour, Channels, Debugging, DomFactory, Gui, GuiFactory
 import { console, document, window } from '@ephox/dom-globals';
 import { Fun, Future, Id, Option, Result } from '@ephox/katamari';
 import { Body, Class } from '@ephox/sugar';
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
-import { LinkInformation, ApiUrlData, UrlValidationHandler } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
-import I18n from 'tinymce/core/api/util/I18n';
 import Editor from 'tinymce/core/api/Editor';
+import I18n from 'tinymce/core/api/util/I18n';
+import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import { ApiUrlData, LinkInformation, UrlValidationHandler } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
 
 const setupDemo = () => {
 
@@ -105,7 +105,7 @@ const setupDemo = () => {
         icons: () => <Record<string, string>> {},
         menuItems: () => <Record<string, any>> {},
         translate: I18n.translate,
-        isReadonly: () => false
+        isReadOnly: () => false
       },
       interpreter: (x) => x,
       getSink: () => Result.value(sink),

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -17,8 +17,8 @@ import { IconProvider } from '../ui/icons/Icons';
 import * as Anchors from './Anchors';
 import { ColorInputBackstage, UiFactoryBackstageForColorInput } from './ColorInputBackstage';
 import { DialogBackstage, UiFactoryBackstageForDialog } from './DialogBackstage';
-import { init as initStyleFormatBackstage } from './StyleFormatsBackstage';
 import { HeaderBackstage, UiFactoryBackstageForHeader } from './HeaderBackstage';
+import { init as initStyleFormatBackstage } from './StyleFormatsBackstage';
 import { UiFactoryBackstageForUrlInput, UrlInputBackstage } from './UrlInputBackstage';
 
 // INVESTIGATE: Make this a body component API ?
@@ -28,7 +28,7 @@ export interface UiFactoryBackstageProviders {
   icons: IconProvider;
   menuItems: () => Record<string, Menu.MenuItemApi | Menu.NestedMenuItemApi | Menu.ToggleMenuItemApi>;
   translate: (any) => TranslatedString;
-  isReadonly: () => boolean;
+  isReadOnly: () => boolean;
 }
 
 type UiFactoryBackstageForStyleButton = SelectData;
@@ -66,7 +66,7 @@ const init = (sink: AlloyComponent, editor: Editor, lazyAnchorbar: () => AlloyCo
         icons: () => editor.ui.registry.getAll().icons,
         menuItems: () => editor.ui.registry.getAll().menuItems,
         translate: I18n.translate,
-        isReadonly: () => editor.mode.isReadOnly()
+        isReadOnly: () => editor.mode.isReadOnly()
       },
       interpreter: (s) => UiFactory.interpretWithoutForm(s, backstage),
       anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/DisablingConfigs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/DisablingConfigs.ts
@@ -7,21 +7,21 @@
 
 import { Disabling } from '@ephox/alloy';
 
-const item = (disabled: boolean) => Disabling.config({
+const item = (disabled: () => boolean) => Disabling.config({
   disabled,
   disableClass: 'tox-collection__item--state-disabled'
 });
 
-const button = (disabled: boolean) => Disabling.config({
+const button = (disabled: () => boolean) => Disabling.config({
   disabled
 });
 
-const splitButton = (disabled: boolean) => Disabling.config({
+const splitButton = (disabled: () => boolean) => Disabling.config({
   disabled,
   disableClass: 'tox-tbtn--disabled'
 });
 
-const toolbarButton = (disabled: boolean) => Disabling.config({
+const toolbarButton = (disabled: () => boolean) => Disabling.config({
   disabled,
   disableClass: 'tox-tbtn--disabled',
   useNative: false

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
@@ -5,22 +5,25 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, EventFormat, FormField as AlloyFormField, Keying, NativeEvents, Replacing, Representing, SimulatedEvent, SketchSpec, SystemEvents, Tabstopping, Disabling } from '@ephox/alloy';
+import {
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Disabling, EventFormat, FormField as AlloyFormField, Keying,
+  NativeEvents, Replacing, Representing, SimulatedEvent, SketchSpec, SystemEvents, Tabstopping
+} from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
 import { HTMLElement } from '@ephox/dom-globals';
 import { Arr, Fun } from '@ephox/katamari';
 
-import { Attr, Class, Element, EventArgs, Focus, Html, SelectorFind, SelectorFilter } from '@ephox/sugar';
+import { Attr, Class, Element, EventArgs, Focus, Html, SelectorFilter, SelectorFind } from '@ephox/sugar';
 import I18n from 'tinymce/core/api/util/I18n';
 import { renderFormFieldWith, renderLabel } from 'tinymce/themes/silver/ui/alien/FieldLabeller';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as ReadOnly from '../../ReadOnly';
 
 import { detectSize } from '../alien/FlatgridAutodetect';
 import { formActionEvent, formResizeEvent } from '../general/FormEvents';
 import * as ItemClasses from '../menus/item/ItemClasses';
 import { deriveCollectionMovement } from '../menus/menu/MenuMovement';
 import { Omit } from '../Omit';
-import * as ReadOnly from '../../ReadOnly';
 
 type CollectionSpec = Omit<Types.Collection.Collection, 'type'>;
 
@@ -60,7 +63,7 @@ export const renderCollection = (spec: CollectionSpec, providersBackstage: UiFac
       // But if only the title attribute is used instead, the names are read out twice. i.e., the description followed by the item.text.
       const ariaLabel = itemText.replace(/\_| \- |\-/g, (match) => mapItemName[match]);
 
-      const readonlyClass = providersBackstage.isReadonly() ? ' tox-collection__item--state-disabled' : '';
+      const readonlyClass = providersBackstage.isReadOnly() ? ' tox-collection__item--state-disabled' : '';
       return `<div class="tox-collection__item${readonlyClass}" tabindex="-1" data-collection-item-value="${escapeAttribute(item.value)}" title="${ariaLabel}" aria-label="${ariaLabel}">${iconContent}${textContent}</div>`;
     });
 
@@ -72,7 +75,7 @@ export const renderCollection = (spec: CollectionSpec, providersBackstage: UiFac
 
   const onClick = runOnItem((comp, se, tgt, itemValue) => {
     se.stop();
-    if (!providersBackstage.isReadonly()) {
+    if (!providersBackstage.isReadOnly()) {
       AlloyTriggers.emitWith(comp, formActionEvent, {
         name: spec.name,
         value: itemValue
@@ -117,7 +120,7 @@ export const renderCollection = (spec: CollectionSpec, providersBackstage: UiFac
     factory: { sketch: Fun.identity },
     behaviours: Behaviour.derive([
       Disabling.config({
-        disabled: providersBackstage.isReadonly(),
+        disabled: providersBackstage.isReadOnly,
         onDisabled: (comp) => {
           iterCollectionItems(comp, (childElm) => {
             Class.add(childElm, 'tox-collection__item--state-disabled');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
@@ -6,24 +6,8 @@
  */
 
 import {
-  AddEventsBehaviour,
-  AlloyEvents,
-  AlloySpec,
-  AlloyTriggers,
-  Behaviour,
-  Composing,
-  CustomEvent,
-  Focusing,
-  FormField,
-  Input,
-  Invalidating,
-  Layout,
-  Memento,
-  Representing,
-  SimpleSpec,
-  Tabstopping,
-  AlloyComponent,
-  Disabling
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Composing, CustomEvent, Disabling, Focusing,
+  FormField, Input, Invalidating, Layout, Memento, Representing, SimpleSpec, Tabstopping
 } from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
 import { Future, Id, Option, Result } from '@ephox/katamari';
@@ -31,13 +15,13 @@ import { Css, Element, Traverse } from '@ephox/sugar';
 
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 import { UiFactoryBackstageForColorInput } from '../../backstage/ColorInputBackstage';
+import * as ReadOnly from '../../ReadOnly';
 import { renderLabel } from '../alien/FieldLabeller';
 import * as ColorSwatch from '../core/color/ColorSwatch';
 import * as Settings from '../core/color/Settings';
-import { renderPanelButton } from '../general/PanelButton';
 import { formChangeEvent } from '../general/FormEvents';
+import { renderPanelButton } from '../general/PanelButton';
 import { Omit } from '../Omit';
-import * as ReadOnly from '../../ReadOnly';
 
 const colorInputChangeEvent = Id.generate('color-input-change');
 const colorSwatchChangeEvent = Id.generate('color-swatch-change');
@@ -65,7 +49,9 @@ export const renderColorInput = (spec: ColorInputSpec, sharedBackstage: UiFactor
     onSetValue: (c) => Invalidating.run(c).get(() => { }),
 
     inputBehaviours: Behaviour.derive([
-      Disabling.config({ disabled: sharedBackstage.providers.isReadonly() }),
+      Disabling.config({
+        disabled: sharedBackstage.providers.isReadOnly
+      }),
       ReadOnly.receivingConfig(),
       Tabstopping.config({ }),
       Invalidating.config({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -5,20 +5,23 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Button, Disabling, FormField as AlloyFormField, Memento, NativeEvents, Representing, SimpleSpec, SimulatedEvent, SystemEvents, Tabstopping, Toggling } from '@ephox/alloy';
+import {
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Button, Disabling, FormField as AlloyFormField, Memento,
+  NativeEvents, Representing, SimpleSpec, SimulatedEvent, SystemEvents, Tabstopping, Toggling
+} from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
 import { DragEvent, FileList } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import { EventArgs } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as ReadOnly from '../../ReadOnly';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
+import { DisablingConfigs } from '../alien/DisablingConfigs';
 import { renderFormFieldWith, renderLabel } from '../alien/FieldLabeller';
 import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 import { formChangeEvent } from '../general/FormEvents';
 import { Omit } from '../Omit';
-import { DisablingConfigs } from '../alien/DisablingConfigs';
-import * as ReadOnly from '../../ReadOnly';
 
 const extensionsAccepted = '.jpg,.jpeg,.png,.gif';
 
@@ -135,7 +138,7 @@ export const renderDropZone = (spec: DropZoneSpec, providersBackstage: UiFactory
             },
             buttonBehaviours: Behaviour.derive([
               Tabstopping.config({ }),
-              DisablingConfigs.button(providersBackstage.isReadonly()),
+              DisablingConfigs.button(providersBackstage.isReadOnly),
               ReadOnly.receivingConfig()
             ])
           })

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
@@ -6,28 +6,18 @@
  */
 
 import {
-  AddEventsBehaviour,
-  AlloyEvents,
-  AlloySpec,
-  AlloyTriggers,
-  Behaviour,
-  Disabling,
-  FormField as AlloyFormField,
-  HtmlSelect as AlloyHtmlSelect,
-  NativeEvents,
-  SimpleSpec,
-  SketchSpec,
-  Tabstopping
+  AddEventsBehaviour, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Disabling, FormField as AlloyFormField,
+  HtmlSelect as AlloyHtmlSelect, NativeEvents, SimpleSpec, SketchSpec, Tabstopping
 } from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
 import { Arr, Option } from '@ephox/katamari';
 import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderLabel } from 'tinymce/themes/silver/ui/alien/FieldLabeller';
 import * as Icons from 'tinymce/themes/silver/ui/icons/Icons';
+import * as ReadOnly from '../../ReadOnly';
 
 import { formChangeEvent } from '../general/FormEvents';
 import { Omit } from '../Omit';
-import * as ReadOnly from '../../ReadOnly';
 
 type SelectBoxSpec = Omit<Types.SelectBox.SelectBox, 'type'>;
 
@@ -49,7 +39,9 @@ export const renderSelectBox = (spec: SelectBoxSpec, providersBackstage: UiFacto
     options: translatedOptions,
     factory: AlloyHtmlSelect,
     selectBehaviours: Behaviour.derive([
-      Disabling.config({ disabled: spec.disabled }),
+      Disabling.config({
+        disabled: () => spec.disabled || providersBackstage.isReadOnly()
+      }),
       Tabstopping.config({ }),
       AddEventsBehaviour.config('selectbox-change', [
         AlloyEvents.run(NativeEvents.change(), (component, _) => {
@@ -84,7 +76,7 @@ export const renderSelectBox = (spec: SelectBoxSpec, providersBackstage: UiFacto
     components: Arr.flatten<AlloySpec>([ pLabel.toArray(), [ selectWrap ]]),
     fieldBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: spec.disabled || providersBackstage.isReadonly(),
+        disabled: () => spec.disabled || providersBackstage.isReadOnly(),
         onDisabled: (comp) => {
           AlloyFormField.getField(comp).each(Disabling.disable);
         },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -6,30 +6,19 @@
  */
 
 import {
-  AddEventsBehaviour,
-  AlloyEvents,
-  AlloyTriggers,
-  Behaviour,
-  CustomEvent,
-  FormCoupledInputs as AlloyFormCoupledInputs,
-  FormField as AlloyFormField,
-  Input as AlloyInput,
-  NativeEvents,
-  Representing,
-  SketchSpec,
-  Tabstopping,
-  Disabling,
-  AlloyComponent
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, CustomEvent, Disabling,
+  FormCoupledInputs as AlloyFormCoupledInputs, FormField as AlloyFormField, Input as AlloyInput, NativeEvents, Representing, SketchSpec,
+  Tabstopping
 } from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
 import { Id } from '@ephox/katamari';
 import { formChangeEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import * as Icons from '../icons/Icons';
-import { formatSize, makeRatioConverter, noSizeConversion, parseSize, SizeConversion } from '../sizeinput/SizeInputModel';
-import { Omit } from '../Omit';
 import * as ReadOnly from '../../ReadOnly';
+import * as Icons from '../icons/Icons';
+import { Omit } from '../Omit';
+import { formatSize, makeRatioConverter, noSizeConversion, parseSize, SizeConversion } from '../sizeinput/SizeInputModel';
 
 interface RatioEvent extends CustomEvent {
   isField1: () => boolean;
@@ -67,7 +56,9 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
       }
     ],
     buttonBehaviours: Behaviour.derive([
-      Disabling.config({ disabled: spec.disabled || providersBackstage.isReadonly() }),
+      Disabling.config({
+        disabled: () => spec.disabled || providersBackstage.isReadOnly()
+      }),
       ReadOnly.receivingConfig(),
       Tabstopping.config({})
     ])
@@ -85,7 +76,9 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     factory: AlloyInput,
     inputClasses: [ 'tox-textfield' ],
     inputBehaviours: Behaviour.derive([
-      Disabling.config({ disabled: spec.disabled || providersBackstage.isReadonly() }),
+      Disabling.config({
+        disabled: () => spec.disabled || providersBackstage.isReadOnly()
+      }),
       ReadOnly.receivingConfig(),
       Tabstopping.config({}),
       AddEventsBehaviour.config('size-input-events', [
@@ -154,7 +147,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     },
     coupledFieldBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: spec.disabled || providersBackstage.isReadonly(),
+        disabled: () => spec.disabled || providersBackstage.isReadOnly(),
         onDisabled: (comp) => {
           AlloyFormCoupledInputs.getField1(comp).bind(AlloyFormField.getField).each(Disabling.disable);
           AlloyFormCoupledInputs.getField2(comp).bind(AlloyFormField.getField).each(Disabling.disable);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -6,20 +6,8 @@
  */
 
 import {
-  AddEventsBehaviour,
-  AlloyEvents,
-  AlloyTriggers,
-  Behaviour,
-  Disabling,
-  FormField as AlloyFormField,
-  Input as AlloyInput,
-  Invalidating,
-  Keying,
-  NativeEvents,
-  Representing,
-  SketchSpec,
-  Tabstopping,
-  SystemEvents
+  AddEventsBehaviour, AlloyEvents, AlloyTriggers, Behaviour, Disabling, FormField as AlloyFormField, Input as AlloyInput, Invalidating,
+  Keying, NativeEvents, Representing, SketchSpec, SystemEvents, Tabstopping
 } from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
 import { Arr, Fun, Future, Option, Result } from '@ephox/katamari';
@@ -27,15 +15,17 @@ import { Traverse } from '@ephox/sugar';
 import { renderFormFieldWith, renderLabel } from 'tinymce/themes/silver/ui/alien/FieldLabeller';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as ReadOnly from '../../ReadOnly';
 import { formChangeEvent, formSubmitEvent } from '../general/FormEvents';
 import { Omit } from '../Omit';
-import * as ReadOnly from '../../ReadOnly';
 
 const renderTextField = function (spec: TextField, providersBackstage: UiFactoryBackstageProviders) {
   const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
 
   const baseInputBehaviours = [
-    Disabling.config({ disabled: spec.disabled || providersBackstage.isReadonly() }),
+    Disabling.config({
+      disabled: () => spec.disabled || providersBackstage.isReadOnly()
+    }),
     ReadOnly.receivingConfig(),
     Keying.config({
       mode: 'execution',
@@ -99,7 +89,7 @@ const renderTextField = function (spec: TextField, providersBackstage: UiFactory
 
   const extraBehaviours = [
     Disabling.config({
-      disabled: spec.disabled || providersBackstage.isReadonly(),
+      disabled: () => spec.disabled || providersBackstage.isReadOnly(),
       onDisabled: (comp) => {
         AlloyFormField.getField(comp).each(Disabling.disable);
       },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -6,49 +6,28 @@
  */
 
 import {
-  AddEventsBehaviour,
-  AlloyEvents,
-  AlloySpec,
-  AlloyTriggers,
-  Behaviour,
-  Composing,
-  CustomEvent,
-  Disabling,
-  FormField as AlloyFormField,
-  Invalidating,
-  Memento,
-  NativeEvents,
-  Representing,
-  SketchSpec,
-  Tabstopping,
-  Typeahead as AlloyTypeahead,
-  AlloyComponent,
-  SystemEvents
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Composing, CustomEvent, Disabling,
+  FormField as AlloyFormField, Invalidating, Memento, NativeEvents, Representing, SketchSpec, SystemEvents, Tabstopping,
+  Typeahead as AlloyTypeahead
 } from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
-import { Arr, Future, FutureResult, Id, Option, Result, Fun } from '@ephox/katamari';
-import { Traverse, Attr } from '@ephox/sugar';
+import { Arr, Fun, Future, FutureResult, Id, Option, Result } from '@ephox/katamari';
+import { Attr, Traverse } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { UiFactoryBackstageForUrlInput } from '../../backstage/UrlInputBackstage';
+import * as ReadOnly from '../../ReadOnly';
 import { renderFormFieldDom, renderLabel } from '../alien/FieldLabeller';
+import { renderButton } from '../general/Button';
 import { formChangeEvent, formSubmitEvent } from '../general/FormEvents';
 import * as Icons from '../icons/Icons';
+import ItemResponse from '../menus/item/ItemResponse';
 import * as MenuParts from '../menus/menu/MenuParts';
 import * as NestedMenus from '../menus/menu/NestedMenus';
-import {
-  anchorTargetBottom,
-  anchorTargets,
-  anchorTargetTop,
-  filterByQuery,
-  headerTargets,
-  historyTargets,
-  joinMenuLists,
-} from '../urlinput/Completions';
-import ItemResponse from '../menus/item/ItemResponse';
 import { Omit } from '../Omit';
-import { renderButton } from '../general/Button';
-import * as ReadOnly from '../../ReadOnly';
+import {
+  anchorTargetBottom, anchorTargets, anchorTargetTop, filterByQuery, headerTargets, historyTargets, joinMenuLists,
+} from '../urlinput/Completions';
 
 type UrlInputSpec = Omit<Types.UrlInput.UrlInput, 'type'>;
 
@@ -141,7 +120,9 @@ export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage
         })
       ).toArray(),
       [
-        Disabling.config({ disabled: spec.disabled }),
+        Disabling.config({
+          disabled: () => spec.disabled || providersBackstage.isReadOnly()
+        }),
         Tabstopping.config({}),
         AddEventsBehaviour.config('urlinput-events', Arr.flatten([
           // We want to get fast feedback for the link dialog, but not sure about others
@@ -235,7 +216,9 @@ export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage
       },
       components: [ pField, memStatus.asSpec() ],
       behaviours: Behaviour.derive([
-        Disabling.config({ disabled: spec.disabled })
+        Disabling.config({
+          disabled: () => spec.disabled || providersBackstage.isReadOnly()
+        })
       ])
     }
   );
@@ -283,7 +266,7 @@ export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage
     ]),
     fieldBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: spec.disabled || providersBackstage.isReadonly(),
+        disabled: () => spec.disabled || providersBackstage.isReadOnly(),
         onDisabled: (comp) => {
           AlloyFormField.getField(comp).each(Disabling.disable);
           memUrlPickerButton.getOpt(comp).each(Disabling.disable);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -6,20 +6,23 @@
  */
 
 /* eslint-disable max-len */
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, CustomEvent, Dropdown as AlloyDropdown, Focusing, GuiFactory, Keying, Memento, Replacing, Representing, SimulatedEvent, SketchSpec, TieredData, Unselecting } from '@ephox/alloy';
+import {
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, CustomEvent, Dropdown as AlloyDropdown, Focusing, GuiFactory,
+  Keying, Memento, Replacing, Representing, SimulatedEvent, SketchSpec, TieredData, Unselecting
+} from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
 import { Arr, Cell, Fun, Future, Id, Merger, Option } from '@ephox/katamari';
 import { EventArgs } from '@ephox/sugar';
 import { toolbarButtonEventOrder } from 'tinymce/themes/silver/ui/toolbar/button/ButtonEvents';
 
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import * as ReadOnly from '../../ReadOnly';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
 import { renderLabel, renderReplacableIconFromPack } from '../button/ButtonSlices';
 import { onControlAttached, onControlDetached, OnDestroy } from '../controls/Controls';
 import * as Icons from '../icons/Icons';
 import { componentRenderPipeline } from '../menus/item/build/CommonMenuItem';
 import * as MenuParts from '../menus/menu/MenuParts';
-import * as ReadOnly from '../../ReadOnly';
 /* eslint-enable max-len */
 
 export const updateMenuText = Id.generate('update-menu-text');
@@ -127,7 +130,7 @@ const renderCommonDropdown = <T>(
       // TODO: Not quite working. Can still get the button focused.
       dropdownBehaviours: Behaviour.derive([
         ...spec.dropdownBehaviours,
-        DisablingConfigs.button(spec.disabled || sharedBackstage.providers.isReadonly()),
+        DisablingConfigs.button(() => spec.disabled || sharedBackstage.providers.isReadOnly()),
         ReadOnly.receivingConfig(),
         Unselecting.config({ }),
         Replacing.config({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -6,35 +6,25 @@
  */
 
 import {
-  AddEventsBehaviour,
-  AlloyComponent,
-  AlloyEvents,
-  AlloySpec,
-  AlloyTriggers,
-  Behaviour,
-  Button as AlloyButton,
-  FormField as AlloyFormField,
-  SketchSpec,
-  Tabstopping,
-  Memento,
-  SimpleOrSketchSpec
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Button as AlloyButton, FormField as AlloyFormField,
+  Memento, SimpleOrSketchSpec, SketchSpec, Tabstopping
 } from '@ephox/alloy';
+import { Types } from '@ephox/bridge';
 import { console } from '@ephox/dom-globals';
 import { Fun, Merger, Option } from '@ephox/katamari';
 import { formActionEvent, formCancelEvent, formSubmitEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
-import { UiFactoryBackstageProviders, UiFactoryBackstage } from '../../backstage/Backstage';
+import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as ReadOnly from '../../ReadOnly';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
+import { renderFormField } from '../alien/FieldLabeller';
 import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 import { renderIconFromPack } from '../button/ButtonSlices';
-import { renderMenuButton, getFetch, StoragedMenuButton } from '../button/MenuButton';
+import { getFetch, renderMenuButton, StoragedMenuButton } from '../button/MenuButton';
 import { componentRenderPipeline } from '../menus/item/build/CommonMenuItem';
-import { ToolbarButtonClasses } from '../toolbar/button/ButtonClasses';
-import { Types } from '@ephox/bridge';
 import { Omit } from '../Omit';
-import { renderFormField } from '../alien/FieldLabeller';
-import * as ReadOnly from '../../ReadOnly';
+import { ToolbarButtonClasses } from '../toolbar/button/ButtonClasses';
 
 type ButtonSpec = Omit<Types.Button.Button, 'type'>;
 type FooterButtonSpec = Omit<Types.Dialog.DialogNormalButton, 'type'> | Omit<Types.Dialog.DialogMenuButton, 'type'>;
@@ -50,7 +40,7 @@ const renderCommonSpec = (spec, actionOpt: Option<(comp: AlloyComponent) => void
 
   const common = {
     buttonBehaviours: Behaviour.derive([
-      DisablingConfigs.button(spec.disabled || providersBackstage.isReadonly()),
+      DisablingConfigs.button(() => spec.disabled || providersBackstage.isReadOnly()),
       ReadOnly.receivingConfig(),
       Tabstopping.config({}),
       AddEventsBehaviour.config('button press', [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -6,32 +6,19 @@
  */
 
 import {
-  AddEventsBehaviour,
-  AlloyComponent,
-  AlloyEvents,
-  AlloyTriggers,
-  Behaviour,
-  Disabling,
-  Focusing,
-  FormField as AlloyFormField,
-  Keying,
-  Memento,
-  NativeEvents,
-  Representing,
-  SimpleSpec,
-  Tabstopping,
-  Unselecting
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Disabling, Focusing, FormField as AlloyFormField, Keying,
+  Memento, NativeEvents, Representing, SimpleSpec, Tabstopping, Unselecting
 } from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
 import { HTMLInputElement } from '@ephox/dom-globals';
 import { Fun, Option } from '@ephox/katamari';
+import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as ReadOnly from '../../ReadOnly';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import * as Icons from '../icons/Icons';
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import { formChangeEvent } from './FormEvents';
 import { Omit } from '../Omit';
-import * as ReadOnly from '../../ReadOnly';
+import { formChangeEvent } from './FormEvents';
 
 type CheckboxSpec = Omit<Types.Checkbox.Checkbox, 'type'>;
 
@@ -67,7 +54,9 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
 
     behaviours: Behaviour.derive([
       ComposingConfigs.self(),
-      Disabling.config({ disabled: spec.disabled }),
+      Disabling.config({
+        disabled: () => spec.disabled || providerBackstage.isReadOnly()
+      }),
       Tabstopping.config({}),
       Focusing.config({ }),
       repBehaviour,
@@ -132,7 +121,7 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
     ],
     fieldBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: spec.disabled || providerBackstage.isReadonly(),
+        disabled: () => spec.disabled || providerBackstage.isReadOnly(),
         disableClass: 'tox-checkbox--disabled',
         onDisabled: (comp) => {
           AlloyFormField.getField(comp).each(Disabling.disable);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
@@ -6,27 +6,19 @@
  */
 
 import {
-  AlloySpec,
-  Behaviour,
-  Dropdown as AlloyDropdown,
-  RawDomSchema,
-  SketchSpec,
-  Unselecting,
-  Tabstopping,
-  AlloyComponent,
-  Layouts
+  AlloyComponent, AlloySpec, Behaviour, Dropdown as AlloyDropdown, Layouts, RawDomSchema, SketchSpec, Tabstopping, Unselecting
 } from '@ephox/alloy';
 import { Types } from '@ephox/bridge';
-import { Future, Id, Option, Merger } from '@ephox/katamari';
+import { Future, Id, Merger, Option } from '@ephox/katamari';
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import * as ReadOnly from '../../ReadOnly';
+import { DisablingConfigs } from '../alien/DisablingConfigs';
+import ItemResponse from '../menus/item/ItemResponse';
+import { createPartialChoiceMenu } from '../menus/menu/MenuChoice';
+import { deriveMenuMovement } from '../menus/menu/MenuMovement';
 
 import * as MenuParts from '../menus/menu/MenuParts';
 import { createTieredDataFrom } from '../menus/menu/SingleMenu';
-import { createPartialChoiceMenu } from '../menus/menu/MenuChoice';
-import { deriveMenuMovement } from '../menus/menu/MenuMovement';
-import ItemResponse from '../menus/item/ItemResponse';
-import { DisablingConfigs } from '../alien/DisablingConfigs';
-import * as ReadOnly from '../../ReadOnly';
 
 export interface SwatchPanelButtonSpec {
   dom: RawDomSchema;
@@ -46,7 +38,7 @@ export const renderPanelButton = (spec: SwatchPanelButtonSpec, sharedBackstage: 
   toggleClass: 'mce-active',
 
   dropdownBehaviours: Behaviour.derive([
-    DisablingConfigs.button(sharedBackstage.providers.isReadonly()),
+    DisablingConfigs.button(sharedBackstage.providers.isReadOnly),
     ReadOnly.receivingConfig(),
     Unselecting.config({}),
     Tabstopping.config({})

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
@@ -5,16 +5,18 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Focusing, ItemTypes, NativeEvents, Replacing } from '@ephox/alloy';
+import {
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Focusing, ItemTypes, NativeEvents, Replacing
+} from '@ephox/alloy';
 import { Arr, Cell, Fun, Option } from '@ephox/katamari';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import * as ReadOnly from 'tinymce/themes/silver/ReadOnly';
 
 import { DisablingConfigs } from 'tinymce/themes/silver/ui/alien/DisablingConfigs';
 import { onControlAttached, onControlDetached, OnDestroy } from 'tinymce/themes/silver/ui/controls/Controls';
 import { menuItemEventOrder, onMenuItemExecute } from '../ItemEvents';
 import ItemResponse from '../ItemResponse';
 import { ItemStructure } from '../structure/ItemStructure';
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
-import * as ReadOnly from 'tinymce/themes/silver/ReadOnly';
 
 export const componentRenderPipeline = (xs: Array<Option<AlloySpec>>) =>
   Arr.bind(xs, (o) => o.toArray());
@@ -46,7 +48,7 @@ const renderCommonItem = <T>(spec: CommonMenuItemSpec<T>, structure: ItemStructu
           onControlAttached(spec, editorOffCell),
           onControlDetached(spec, editorOffCell)
         ]),
-        DisablingConfigs.item(spec.disabled || providersbackstage.isReadonly()),
+        DisablingConfigs.item(() => spec.disabled || providersbackstage.isReadOnly()),
         ReadOnly.receivingConfig(),
         Replacing.config({ })
       ].concat(spec.itemBehaviours)
@@ -73,7 +75,7 @@ const renderCommonChoice = <T>(spec: CommonCollectionItemSpec, structure: ItemSt
       AddEventsBehaviour.config('item-events', [
         AlloyEvents.run(NativeEvents.mouseover(), Focusing.focus)
       ]),
-      DisablingConfigs.item(spec.disabled || providersbackstage.isReadonly()),
+      DisablingConfigs.item(() => spec.disabled || providersbackstage.isReadOnly()),
       ReadOnly.receivingConfig()
     ]
   ),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AddEventsBehaviour, AlloyEvents, Behaviour, Button, Keying, Replacing, Tabstopping, Disabling } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, Button, Disabling, Keying, Replacing, Tabstopping } from '@ephox/alloy';
 import { Arr } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
@@ -52,7 +52,7 @@ const renderElementPath = (editor: Editor, settings, providersBackstage: UiFacto
         editor.nodeChanged();
       },
       buttonBehaviours: Behaviour.derive([
-        DisablingConfigs.button(providersBackstage.isReadonly()),
+        DisablingConfigs.button(providersBackstage.isReadOnly),
         ReadOnly.receivingConfig()
       ])
     }));
@@ -114,7 +114,9 @@ const renderElementPath = (editor: Editor, settings, providersBackstage: UiFacto
         mode: 'flow',
         selector: 'div[role=button]'
       }),
-      Disabling.config({ disabled: providersBackstage.isReadonly() }),
+      Disabling.config({
+        disabled: providersBackstage.isReadOnly
+      }),
       ReadOnly.receivingConfig(),
       Tabstopping.config({ }),
       Replacing.config({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
@@ -5,11 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AddEventsBehaviour, AlloyEvents, Behaviour, Button, GuiFactory, Replacing, Representing, SimpleSpec, Tabstopping } from '@ephox/alloy';
+import {
+  AddEventsBehaviour, AlloyEvents, Behaviour, Button, GuiFactory, Replacing, Representing, SimpleSpec, Tabstopping
+} from '@ephox/alloy';
 import Editor from 'tinymce/core/api/Editor';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import { DisablingConfigs } from '../alien/DisablingConfigs';
 import * as ReadOnly from '../../ReadOnly';
+import { DisablingConfigs } from '../alien/DisablingConfigs';
 
 const enum WordCountMode {
   Words = 'words',
@@ -28,7 +30,7 @@ export const renderWordCount = (editor: Editor, providersBackstage: UiFactoryBac
     },
     components: [ ],
     buttonBehaviours: Behaviour.derive([
-      DisablingConfigs.button(providersBackstage.isReadonly()),
+      DisablingConfigs.button(providersBackstage.isReadOnly),
       ReadOnly.receivingConfig(),
       Tabstopping.config({ }),
       Replacing.config({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -6,16 +6,20 @@
  */
 
 // eslint-disable-next-line max-len
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Boxes, Focusing, Keying, SplitFloatingToolbar as AlloySplitFloatingToolbar, SplitSlidingToolbar as AlloySplitSlidingToolbar, Tabstopping, Toolbar as AlloyToolbar, ToolbarGroup as AlloyToolbarGroup } from '@ephox/alloy';
+import {
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Boxes, Focusing, Keying,
+  SplitFloatingToolbar as AlloySplitFloatingToolbar, SplitSlidingToolbar as AlloySplitSlidingToolbar, Tabstopping, Toolbar as AlloyToolbar,
+  ToolbarGroup as AlloyToolbarGroup
+} from '@ephox/alloy';
 import { Arr, Option, Result } from '@ephox/katamari';
 import { Traverse } from '@ephox/sugar';
 import { ToolbarMode } from '../../api/Settings';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as Channels from '../../Channels';
+import * as ReadOnly from '../../ReadOnly';
+import { DisablingConfigs } from '../alien/DisablingConfigs';
 import { renderIconButtonSpec } from '../general/Button';
 import { ToolbarButtonClasses } from './button/ButtonClasses';
-import { DisablingConfigs } from '../alien/DisablingConfigs';
-import * as ReadOnly from '../../ReadOnly';
 
 export interface MoreDrawerData {
   lazyMoreButton: () => AlloyComponent;
@@ -79,7 +83,7 @@ const getToolbarbehaviours = (toolbarSpec: ToolbarSpec, modeName) => {
   });
 
   return Behaviour.derive([
-    DisablingConfigs.toolbarButton(toolbarSpec.providers.isReadonly()),
+    DisablingConfigs.toolbarButton(toolbarSpec.providers.isReadOnly),
     ReadOnly.receivingConfig(),
     Keying.config({
       // Tabs between groups

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -6,10 +6,9 @@
  */
 
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour,
-  Button as AlloyButton, Disabling, FloatingToolbarButton, Focusing, Keying,
-  NativeEvents, Reflecting, Replacing, SketchSpec, SplitDropdown as AlloySplitDropdown,
-  SystemEvents, TieredData, TieredMenuTypes, Toggling, Unselecting
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Button as AlloyButton, Disabling, FloatingToolbarButton,
+  Focusing, Keying, NativeEvents, Reflecting, Replacing, SketchSpec, SplitDropdown as AlloySplitDropdown, SystemEvents, TieredData,
+  TieredMenuTypes, Toggling, Unselecting
 } from '@ephox/alloy';
 import { Toolbar, Types } from '@ephox/bridge';
 import { Arr, Cell, Fun, Future, Id, Merger, Option } from '@ephox/katamari';
@@ -17,6 +16,7 @@ import { Attr, SelectorFind } from '@ephox/sugar';
 
 import I18n from 'tinymce/core/api/util/I18n';
 import { UiFactoryBackstage, UiFactoryBackstageProviders, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
+import * as ReadOnly from '../../../ReadOnly';
 import { ToolbarGroupSetting } from '../../../Render';
 import { DisablingConfigs } from '../../alien/DisablingConfigs';
 import { detectSize } from '../../alien/FlatgridAutodetect';
@@ -34,7 +34,6 @@ import { createTieredDataFrom } from '../../menus/menu/SingleMenu';
 import { ToolbarButtonClasses } from '../button/ButtonClasses';
 import { onToolbarButtonExecute, toolbarButtonEventOrder } from '../button/ButtonEvents';
 import { renderToolbarGroup, ToolbarGroup } from '../CommonToolbar';
-import * as ReadOnly from '../../../ReadOnly';
 
 interface Specialisation<T> {
   toolbarButtonBehaviours: Array<Behaviour.NamedConfiguredBehaviour<Behaviour.BehaviourConfigSpec, Behaviour.BehaviourConfigDetail>>;
@@ -124,7 +123,7 @@ const renderCommonStructure = (
 
     buttonBehaviours: Behaviour.derive(
       [
-        DisablingConfigs.toolbarButton(providersBackstage.isReadonly()),
+        DisablingConfigs.toolbarButton(providersBackstage.isReadOnly),
         ReadOnly.receivingConfig(),
         AddEventsBehaviour.config('common-button-display-events', [
           AlloyEvents.run(NativeEvents.mousedown(), (button, se) => {
@@ -188,7 +187,7 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
           onControlAttached(specialisation, editorOffCell),
           onControlDetached(specialisation, editorOffCell),
         ]),
-        DisablingConfigs.toolbarButton(spec.disabled || providersBackstage.isReadonly()),
+        DisablingConfigs.toolbarButton(() => spec.disabled || providersBackstage.isReadOnly()),
         ReadOnly.receivingConfig()
       ].concat(specialisation.toolbarButtonBehaviours)
     )
@@ -309,7 +308,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
     onItemExecute: (_a, _b, _c) => { },
 
     splitDropdownBehaviours: Behaviour.derive([
-      DisablingConfigs.splitButton(sharedBackstage.providers.isReadonly()),
+      DisablingConfigs.splitButton(sharedBackstage.providers.isReadOnly),
       ReadOnly.receivingConfig(),
       AddEventsBehaviour.config('split-dropdown-events', [
         AlloyEvents.run(focusButtonEvent, Focusing.focus),
@@ -345,7 +344,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
           innerHtml: Icons.get('chevron-down', sharedBackstage.providers.icons)
         },
         buttonBehaviours: Behaviour.derive([
-          DisablingConfigs.splitButton(sharedBackstage.providers.isReadonly()),
+          DisablingConfigs.splitButton(sharedBackstage.providers.isReadOnly),
           ReadOnly.receivingConfig()
         ]),
       }),

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -1,56 +1,67 @@
-import { Pipeline, Chain, Log, NamedChain, ApproxStructure, Assertions, StructAssert, Mouse, UiFinder, Guard } from '@ephox/agar';
+import { ApproxStructure, Assertions, Chain, Guard, Log, Mouse, NamedChain, Pipeline, StructAssert, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyLoader } from '@ephox/mcagar';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-import { cResizeToPos } from '../../../module/UiChainUtils';
-import { Element, Body } from '@ephox/sugar';
+import { Body } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
+import { ToolbarMode } from 'tinymce/themes/silver/api/Settings';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+import { sOpenMore } from '../../../module/MenuUtils';
+import { cResizeToPos } from '../../../module/UiChainUtils';
 
 UnitTest.asynctest('Toolbar with toolbar drawer readonly mode test', (success, failure) => {
   SilverTheme();
 
   TinyLoader.setup(
     (editor: Editor, onSuccess, onFailure) => {
-      const cGetUiContainer = Chain.mapper(() => Element.fromDom(editor.getContainer()));
+      const cChangeModes = (mode: string) => Chain.op(() => {
+        editor.mode.set(mode);
+      });
 
-      const cAssertToolbarButtonDisabled = (label, f: (s, str, arr) => StructAssert[]) => NamedChain.asChain([
-        NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
-        NamedChain.direct('editor', cGetUiContainer, 'editorContainer'),
-        NamedChain.direct('editorContainer', Assertions.cAssertStructure(
-          label,
-          ApproxStructure.build((s, str, arr) => s.element('div', {
-            classes: [ arr.has('tox-tinymce') ],
-            children: [
-              s.element('div', {
-                classes: [ arr.has('tox-editor-container') ],
-                children: [
-                  s.element('div', {
-                    classes: [ arr.has('tox-editor-header') ],
-                    children: [
-                      s.element('div', {
-                        classes: [ arr.has('tox-toolbar-overlord'), arr.has('tox-tbtn--disabled') ],
-                        attrs: { 'aria-disabled': str.is('true') },
-                        children: [
-                          s.element('div', {
-                            classes: [ arr.has('tox-toolbar__primary') ],
-                            children: f(s, str, arr)
-                          })
-                        ]
-                      }),
-                      s.theRest()
-                    ]
-                  }),
-                  s.theRest()
-                ]
-              }),
-              s.theRest()
-            ]
-          }))
-        ), 'assertion'),
-        NamedChain.output('editor')
+      const cResizeTo = (sx: number, sy: number, dx: number, dy: number) => NamedChain.asChain([
+        NamedChain.writeValue('body', Body.body()),
+        NamedChain.direct('body', UiFinder.cFindIn('.tox-statusbar__resize-handle'), 'resizeHandle'),
+        NamedChain.direct('resizeHandle', Mouse.cMouseDown, '_'),
+        NamedChain.direct('body', cResizeToPos(sx, sy, dx, dy), '_')
       ]);
 
-      const buttonStruct = (s, str, arr, buttonName: string) => s.element('div', {
+      const cAssertToolbarButtonState = (label: string, disabled: boolean, f: ApproxStructure.Builder<StructAssert[]>) => Chain.fromChainsWith(Body.body(),[
+        UiFinder.cFindIn('.tox-toolbar-overlord'),
+        Chain.control(
+          Assertions.cAssertStructure(label, ApproxStructure.build((s, str, arr) =>
+            s.element('div', {
+              classes: [
+                arr.has('tox-toolbar-overlord'),
+                disabled ? arr.has('tox-tbtn--disabled') : arr.not('tox-tbtn--disabled')
+              ],
+              attrs: { 'aria-disabled': str.is(disabled + '') },
+              children: [
+                s.element('div', {
+                  classes: [ arr.has('tox-toolbar__primary') ],
+                  children: f(s, str, arr)
+                })
+              ]
+            })
+          )),
+          Guard.tryUntil('Waiting for toolbar state')
+        )
+      ]);
+
+      const cAssertToolbarDrawerButtonState = (label: string, f: (s, str, arr) => StructAssert[]) => Chain.fromChainsWith(Body.body(),[
+        UiFinder.cFindIn('.tox-toolbar__overflow'),
+        Chain.control(
+          Assertions.cAssertStructure(label, ApproxStructure.build((s, str, arr) =>
+            s.element('div', {
+              classes: [
+                arr.has('tox-toolbar__overflow')
+              ],
+              children: f(s, str, arr)
+            })
+          )),
+          Guard.tryUntil('Waiting for toolbar state')
+        )
+      ]);
+
+      const disabledButtonStruct = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi, arr: ApproxStructure.ArrayApi, buttonName: string) => s.element('div', {
         classes: [ arr.has('tox-toolbar__group') ],
         children: [
           s.element('button', {
@@ -63,36 +74,91 @@ UnitTest.asynctest('Toolbar with toolbar drawer readonly mode test', (success, f
         ]
       });
 
+      const enabledButtonStruct = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi, arr: ApproxStructure.ArrayApi, buttonName: string) => s.element('div', {
+        classes: [ arr.has('tox-toolbar__group') ],
+        children: [
+          s.element('button', {
+            classes: [ arr.has('tox-tbtn'), arr.not('tox-tbtn--disabled') ],
+            attrs: {
+              'title': str.is(buttonName),
+              'aria-disabled': str.is('false')
+            }
+          })
+        ]
+      });
+
       Pipeline.async({ }, [
         Chain.asStep({}, Log.chains('TBA', 'Test if the toolbar buttons are disabled in readonly mode when toolbar drawer is present', [
-          cAssertToolbarButtonDisabled('Assert the first toolbar button, Bold is disabled', (s, str, arr) => [ buttonStruct(s, str, arr, 'Bold'), s.theRest() ]),
+          cAssertToolbarButtonState('Assert the first toolbar button, Bold is disabled', true, (s, str, arr) => [
+            disabledButtonStruct(s, str, arr, 'Bold'),
+            s.theRest()
+          ]),
 
-          Chain.control(
-            NamedChain.asChain([
-              NamedChain.writeValue('body', Body.body()),
-              NamedChain.direct('body', UiFinder.cFindIn('.tox-statusbar__resize-handle'), 'resizeHandle'),
-              NamedChain.direct('resizeHandle', Mouse.cMouseDown, '_'),
-              NamedChain.direct('body', cResizeToPos(300, 400, 400, 400), '_')
-            ]),
-            Guard.addLogging('Resize the editor so that the overflowing toolbar buttons are redrawn')
-          ),
+          cResizeTo(300, 400, 400, 400),
 
-          cAssertToolbarButtonDisabled('Assert the last toolbar button, Indent is disabled after resizing the editor', (s, str, arr) => [
-            buttonStruct(s, str, arr, 'Bold'),
-            buttonStruct(s, str, arr, 'Italic'),
-            buttonStruct(s, str, arr, 'Underline'),
-            buttonStruct(s, str, arr, 'Cut'),
-            buttonStruct(s, str, arr, 'Copy'),
-            buttonStruct(s, str, arr, 'Paste'),
-            buttonStruct(s, str, arr, 'Increase indent')
+          cAssertToolbarButtonState('Assert the toolbar buttons are disabled after resizing the editor', true, (s, str, arr) => [
+            disabledButtonStruct(s, str, arr, 'Bold'),
+            disabledButtonStruct(s, str, arr, 'Italic'),
+            disabledButtonStruct(s, str, arr, 'Underline'),
+            disabledButtonStruct(s, str, arr, 'Strikethrough'),
+            disabledButtonStruct(s, str, arr, 'Cut'),
+            disabledButtonStruct(s, str, arr, 'Copy'),
+            disabledButtonStruct(s, str, arr, 'Paste'),
+            disabledButtonStruct(s, str, arr, 'Increase indent'),
+            s.theRest()
           ])
-        ]))
-      ] , onSuccess, onFailure);
+        ])),
+        Chain.asStep({}, Log.chains('TINY-6014', 'Test buttons become enabled again when disabling readonly mode and resizing', [
+          cAssertToolbarButtonState('Assert the first toolbar button, Bold is disabled', true, (s, str, arr) => [
+            disabledButtonStruct(s, str, arr, 'Bold'),
+            s.theRest()
+          ]),
+          cChangeModes('design'),
+          Chain.runStepsOnValue(() => [
+            sOpenMore(ToolbarMode.floating)
+          ]),
+          cAssertToolbarButtonState('Assert the toolbar buttons are enabled', false, (s, str, arr) => [
+            enabledButtonStruct(s, str, arr, 'Bold'),
+            enabledButtonStruct(s, str, arr, 'Italic'),
+            enabledButtonStruct(s, str, arr, 'Underline'),
+            enabledButtonStruct(s, str, arr, 'Strikethrough'),
+            enabledButtonStruct(s, str, arr, 'Cut'),
+            enabledButtonStruct(s, str, arr, 'Copy'),
+            enabledButtonStruct(s, str, arr, 'Paste'),
+            enabledButtonStruct(s, str, arr, 'Increase indent'),
+            s.theRest()
+          ]),
+          cAssertToolbarDrawerButtonState('Assert the toolbar drawer buttons are enabled', (s, str, arr) => [
+            enabledButtonStruct(s, str, arr, 'Subscript'),
+            enabledButtonStruct(s, str, arr, 'Superscript'),
+            enabledButtonStruct(s, str, arr, 'Clear formatting')
+          ]),
+
+          cResizeTo(400, 400, 450, 400),
+
+          cAssertToolbarButtonState('Assert the toolbar buttons are enabled and now include subscript', false, (s, str, arr) => [
+            enabledButtonStruct(s, str, arr, 'Bold'),
+            enabledButtonStruct(s, str, arr, 'Italic'),
+            enabledButtonStruct(s, str, arr, 'Underline'),
+            enabledButtonStruct(s, str, arr, 'Strikethrough'),
+            enabledButtonStruct(s, str, arr, 'Cut'),
+            enabledButtonStruct(s, str, arr, 'Copy'),
+            enabledButtonStruct(s, str, arr, 'Paste'),
+            enabledButtonStruct(s, str, arr, 'Increase indent'),
+            enabledButtonStruct(s, str, arr, 'Subscript'),
+            s.theRest()
+          ]),
+          cAssertToolbarDrawerButtonState('Assert the toolbar drawer buttons are enabled', (s, str, arr) => [
+            enabledButtonStruct(s, str, arr, 'Superscript'),
+            enabledButtonStruct(s, str, arr, 'Clear formatting')
+          ]),
+        ])),
+      ], onSuccess, onFailure);
     },
     {
       theme: 'silver',
       base_url: '/project/tinymce/js/tinymce',
-      toolbar: 'bold | italic | underline | cut | copy | paste | indent',
+      toolbar: 'bold | italic | underline | strikethrough | cut | copy | paste | indent | subscript | superscript | removeformat',
       toolbar_mode: 'floating',
       menubar: false,
       width: 300,

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -4,5 +4,5 @@ export default {
   icons: () => <Record<string, string>> {},
   menuItems: () => <Record<string, any>> {},
   translate: I18n.translate,
-  isReadonly: () => false
+  isReadOnly: () => false
 };

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
@@ -1,9 +1,9 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { GuiFactory, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
+import I18n from 'tinymce/core/api/util/I18n';
 
 import { renderAlertBanner } from 'tinymce/themes/silver/ui/general/AlertBanner';
-import I18n from 'tinymce/core/api/util/I18n';
 
 UnitTest.asynctest('AlertBanner component Test', (success, failure) => {
   const providers = {
@@ -13,7 +13,7 @@ UnitTest.asynctest('AlertBanner component Test', (success, failure) => {
     },
     menuItems: () => <Record<string, any>> {},
     translate: I18n.translate,
-    isReadonly: () => false
+    isReadOnly: () => false
   };
 
   TestHelpers.GuiSetup.setup(

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/checkbox/BasicCheckboxTest.ts
@@ -2,9 +2,9 @@ import { ApproxStructure, Assertions, Chain, Keyboard, Keys, Logger, Step, UiFin
 import { GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
 import { HTMLInputElement } from '@ephox/dom-globals';
+import I18n from 'tinymce/core/api/util/I18n';
 
 import { renderCheckbox } from 'tinymce/themes/silver/ui/general/Checkbox';
-import I18n from 'tinymce/core/api/util/I18n';
 import { DisablingSteps } from '../../../module/DisablingSteps';
 
 UnitTest.asynctest('Checkbox component Test', (success, failure) => {
@@ -15,7 +15,7 @@ UnitTest.asynctest('Checkbox component Test', (success, failure) => {
     },
     menuItems: () => <Record<string, any>> {},
     translate: I18n.translate,
-    isReadonly: () => false
+    isReadOnly: () => false
   };
 
   TestHelpers.GuiSetup.setup(

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
@@ -1,9 +1,9 @@
-import { Logger, Mouse, Pipeline, Step, Waiter, UiFinder } from '@ephox/agar';
+import { Logger, Mouse, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
 import { Behaviour, GuiFactory, ModalDialog, Positioning, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
 import { ValueSchema } from '@ephox/boulder';
 import { DialogManager } from '@ephox/bridge';
-import { Fun, Result, Option } from '@ephox/katamari';
+import { Fun, Option, Result } from '@ephox/katamari';
 import { Body } from '@ephox/sugar';
 
 import I18n from 'tinymce/core/api/util/I18n';
@@ -85,7 +85,7 @@ UnitTest.asynctest('SilverDialog Event Test', (success, failure) => {
                 icons: () => <Record<string, string>> {},
                 menuItems: () => <Record<string, any>> {},
                 translate: I18n.translate,
-                isReadonly: () => false
+                isReadOnly: () => false
               }
             },
             dialog: {


### PR DESCRIPTION
This changes the `Disabling` behaviour to use a lazy evaluated disabled check in the config. This means that when the component is added back into the alloy world, we can fetch the current disabled state it should be in and render appropriately.

This is what was needed, as the component is removed from the world when the toolbar drawer is closed and then when added back it was using the disabled state from when the spec was originally created (which was always either enabled or disabled, which didn't match the current state).