### PR TITLE
TINY-6012 Extend mceInsertTable to allow for headerRows and headerColumns to be specified

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -23,7 +23,7 @@ const eq = <T> (t: T) => (a: any): a is T =>
 export const isString: (value: any) => value is string =
   isType('string');
 
-export const isObject: (value: any) => boolean =
+export const isObject: (value: any) => value is Object =
   isType('object');
 
 export const isArray: (value: any) => value is Array<unknown> =

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,3 +1,5 @@
+Version 5.4.0 (TBD)
+    Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -51,8 +51,7 @@ function Plugin(editor: Editor) {
   }
 
   editor.on('remove', function () {
-    resizeHandler.destroy();
-    cellSelection.destroy();
+    resizeHandler.destroy(); 
   });
 
   return getApi(editor, clipboardRows, resizeHandler, selectionTargets);

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -51,7 +51,7 @@ function Plugin(editor: Editor) {
   }
 
   editor.on('remove', function () {
-    resizeHandler.destroy(); 
+    resizeHandler.destroy();
   });
 
   return getApi(editor, clipboardRows, resizeHandler, selectionTargets);

--- a/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
@@ -35,7 +35,7 @@ const fireEvents = (editor: Editor, table) => {
 
 const isPercentage = (width: string) => Type.isString(width) && width.indexOf('%') !== -1;
 
-const insert = (editor: Editor, columns: number, rows: number): HTMLElement => {
+const insert = (editor: Editor, columns: number, rows: number, colHeaders: number, rowHeaders: number): HTMLElement => {
   const defaultStyles = getDefaultStyles(editor);
   const options: TableRender.RenderOptions = {
     styles: defaultStyles,
@@ -43,7 +43,7 @@ const insert = (editor: Editor, columns: number, rows: number): HTMLElement => {
     percentages: isPercentage(defaultStyles.width) && !isPixelsForced(editor)
   };
 
-  const table = TableRender.render(rows, columns, 0, 0, options);
+  const table = TableRender.render(rows, columns, rowHeaders, colHeaders, options);
   Attr.set(table, 'data-mce-id', '__mce');
 
   const html = Html.getOuter(table);

--- a/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
@@ -60,6 +60,21 @@ const insert = (editor: Editor, columns: number, rows: number, colHeaders: numbe
   }).getOr(null);
 };
 
+const insertTableWithDataValidation = (editor: Editor, rows: number, columns: number, options: Record<string, number> = {}, errorMsg: string) => {
+  const checkInput = (val: any) => Type.isNumber(val) && val > 0;
+
+  if (checkInput(rows) && checkInput(columns)) {
+    const headerRows = options.headerRows || 0;
+    const headerColumns = options.headerColumns || 0;
+    return insert(editor, columns, rows, headerColumns, headerRows);
+  } else {
+    // eslint-disable-next-line no-console
+    console.error(errorMsg);
+    return null;
+  }
+};
+
 export {
-  insert
+  insert,
+  insertTableWithDataValidation
 };

--- a/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
@@ -13,13 +13,10 @@ import { HTMLElement } from '@ephox/dom-globals';
 import { ResizeHandler } from '../actions/ResizeHandler';
 import { SelectionTargets } from '../selection/SelectionTargets';
 
-const getClipboardRows = (clipboardRows): HTMLElement[] => clipboardRows.get().fold(function () {
-  return;
-}, function (rows) {
-  return Arr.map(rows, function (row) {
-    return row.dom();
-  });
-});
+const getClipboardRows = (clipboardRows): HTMLElement[] => clipboardRows.get().fold(
+  () => {},
+  (rows) => Arr.map(rows, (row) => row.dom())
+);
 
 const setClipboardRows = (rows: HTMLElement[], clipboardRows) => {
   const sugarRows = Arr.map(rows, Element.fromDom);

--- a/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
@@ -27,7 +27,7 @@ const setClipboardRows = (rows: HTMLElement[], clipboardRows) => {
 };
 
 const getApi = (editor: Editor, clipboardRows: Cell<Option<any>>, resizeHandler: ResizeHandler, selectionTargets: SelectionTargets) => ({
-  insertTable: (columns: number, rows: number) => InsertTable.insert(editor, columns, rows),
+  insertTable: (columns: number, rows: number) => InsertTable.insert(editor, columns, rows, 0, 0),
   setClipboardRows: (rows: HTMLElement[]) => setClipboardRows(rows, clipboardRows),
   getClipboardRows: () => getClipboardRows(clipboardRows),
   resizeHandler,

--- a/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
@@ -24,7 +24,8 @@ const setClipboardRows = (rows: HTMLElement[], clipboardRows) => {
 };
 
 const getApi = (editor: Editor, clipboardRows: Cell<Option<any>>, resizeHandler: ResizeHandler, selectionTargets: SelectionTargets) => ({
-  insertTable: (columns: number, rows: number) => InsertTable.insert(editor, columns, rows, 0, 0),
+  insertTable: (columns: number, rows: number, headerRows: number = 0, headerColumns: number = 0) => 
+    InsertTable.insert(editor, columns, rows, headerColumns, headerRows),
   setClipboardRows: (rows: HTMLElement[]) => setClipboardRows(rows, clipboardRows),
   getClipboardRows: () => getClipboardRows(clipboardRows),
   resizeHandler,

--- a/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
@@ -5,16 +5,16 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Editor from 'tinymce/core/api/Editor';
-import * as InsertTable from '../actions/InsertTable';
-import { Arr, Option, Cell } from '@ephox/katamari';
-import { Element } from '@ephox/sugar';
 import { HTMLElement } from '@ephox/dom-globals';
+import { Arr, Cell, Option } from '@ephox/katamari';
+import { Element } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import { insertTableWithDataValidation } from '../actions/InsertTable';
 import { ResizeHandler } from '../actions/ResizeHandler';
 import { SelectionTargets } from '../selection/SelectionTargets';
 
-const getClipboardRows = (clipboardRows): HTMLElement[] => clipboardRows.get().fold(
-  () => {},
+const getClipboardRows = (clipboardRows: Cell<Option<Element[]>>): HTMLElement[] => clipboardRows.get().fold(
+  () => [],
   (rows) => Arr.map(rows, (row) => row.dom())
 );
 
@@ -23,15 +23,14 @@ const setClipboardRows = (rows: HTMLElement[], clipboardRows) => {
   clipboardRows.set(Option.from(sugarRows));
 };
 
-const getApi = (editor: Editor, clipboardRows: Cell<Option<any>>, resizeHandler: ResizeHandler, selectionTargets: SelectionTargets) => ({
-  insertTable: (columns: number, rows: number, headerRows: number = 0, headerColumns: number = 0) => 
-    InsertTable.insert(editor, columns, rows, headerColumns, headerRows),
+const getApi = (editor: Editor, clipboardRows: Cell<Option<Element[]>>, resizeHandler: ResizeHandler, selectionTargets: SelectionTargets) => ({
+  insertTable: (columns: number, rows: number, options: Record<string, number> = {}) =>
+    insertTableWithDataValidation(editor, rows, columns, options, 'Invalid values for insertTable - rows and columns values are required to insert a table.'),
   setClipboardRows: (rows: HTMLElement[]) => setClipboardRows(rows, clipboardRows),
   getClipboardRows: () => getClipboardRows(clipboardRows),
   resizeHandler,
   selectionTargets
 });
 
-export {
-  getApi
-};
+export { getApi };
+

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -9,17 +9,16 @@ import { Arr, Cell, Fun, Obj, Option, Type } from '@ephox/katamari';
 import { CopyRows, TableFill, TableLookup } from '@ephox/snooker';
 import { Element, Insert, Remove, Replication } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
+import { insertTableWithDataValidation } from '../actions/InsertTable';
 import { TableActions } from '../actions/TableActions';
 import * as Util from '../alien/Util';
 import * as TableTargets from '../queries/TableTargets';
+import { CellSelectionApi } from '../selection/CellSelection';
 import { Selections } from '../selection/Selections';
 import * as TableSelection from '../selection/TableSelection';
 import * as CellDialog from '../ui/CellDialog';
 import * as RowDialog from '../ui/RowDialog';
 import * as TableDialog from '../ui/TableDialog';
-import * as InsertTable from '../actions/InsertTable';
-import { CellSelectionApi } from '../selection/CellSelection';
-import { console } from '@ephox/dom-globals';
 
 const registerCommands = (editor: Editor, actions: TableActions, cellSelection: CellSelectionApi, selections: Selections, clipboardRows: Cell<Option<Element[]>>) => {
   const isRoot = Util.getIsRoot(editor);
@@ -107,18 +106,8 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
   }, (func, name) => editor.addCommand(name, () => func()));
 
   editor.addCommand('mceInsertTable', (_ui, args) => {
-    if (Type.isObject(args)) {
-      const checkInput = (val: any) => Type.isNumber(val) && val > 0;
-      const rows = args.rows;
-      const columns = args.columns;
-      if (checkInput(rows) && checkInput(columns)) {
-        const headerRows = args.options?.headerRows || 0;
-        const headerColumns = args.options?.headerColumns || 0;
-        InsertTable.insert(editor, columns, rows, headerColumns, headerRows);
-      } else {
-        // eslint-disable-next-line no-console
-        console.error('Invalid values for mceInsertTable - rows and columns values are required to insert a table.');
-      }
+    if (Type.isObject(args) && Obj.keys(args).length > 0) {
+      insertTableWithDataValidation(editor, args.rows, args.columns, args.options, 'Invalid values for mceInsertTable - rows and columns values are required to insert a table.');
     } else {
       TableDialog.open(editor, true);
     }

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -5,11 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Cell, Fun, Option } from '@ephox/katamari';
+import { FieldSchema, ValueSchema } from '@ephox/boulder';
+import { Arr, Cell, Fun, Obj, Option } from '@ephox/katamari';
 import { CopyRows, TableFill, TableLookup } from '@ephox/snooker';
 import { Element, Insert, Remove, Replication } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
-import Tools from 'tinymce/core/api/util/Tools';
+import * as InsertTable from '../actions/InsertTable';
 import { TableActions } from '../actions/TableActions';
 import * as Util from '../alien/Util';
 import * as TableTargets from '../queries/TableTargets';
@@ -19,149 +20,117 @@ import * as CellDialog from '../ui/CellDialog';
 import * as RowDialog from '../ui/RowDialog';
 import * as TableDialog from '../ui/TableDialog';
 
-const each = Tools.each;
+interface InsertTableData {
+  rows: number,
+  columns: number,
+  options: {
+    headerRows: number,
+    headerColumns: number
+  }
+}
 
 const registerCommands = (editor: Editor, actions: TableActions, cellSelection, selections: Selections, clipboardRows: Cell<Option<Element[]>>) => {
   const isRoot = Util.getIsRoot(editor);
-  const eraseTable = () => {
-    TableSelection.getSelectionStartCellOrCaption(editor)
-      .each((cellOrCaption) => {
-        const tableOpt = TableLookup.table(cellOrCaption, isRoot);
-        tableOpt.filter(Fun.not(isRoot)).each((table) => {
-          const cursor = Element.fromText('');
-          Insert.after(table, cursor);
-          Remove.remove(table);
+  const eraseTable = () => TableSelection.getSelectionStartCellOrCaption(editor).each((cellOrCaption) => {
+    TableLookup.table(cellOrCaption, isRoot).filter(Fun.not(isRoot)).each((table) => {
+      const cursor = Element.fromText('');
+      Insert.after(table, cursor);
+      Remove.remove(table);
 
-          if (editor.dom.isEmpty(editor.getBody())) {
-            editor.setContent('');
-            editor.selection.setCursorLocation();
-          } else {
-            const rng = editor.dom.createRng();
-            rng.setStart(cursor.dom(), 0);
-            rng.setEnd(cursor.dom(), 0);
-            editor.selection.setRng(rng);
-            editor.nodeChanged();
-          }
-        });
-      });
-  };
+      if (editor.dom.isEmpty(editor.getBody())) {
+        editor.setContent('');
+        editor.selection.setCursorLocation();
+      } else {
+        const rng = editor.dom.createRng();
+        rng.setStart(cursor.dom(), 0);
+        rng.setEnd(cursor.dom(), 0);
+        editor.selection.setRng(rng);
+        editor.nodeChanged();
+      }
+    });
+  });
 
   const getTableFromCell = (cell: Element): Option<Element> => TableLookup.table(cell, isRoot);
 
-  const actOnSelection = (execute) => {
+  const actOnSelection = (execute) => TableSelection.getSelectionStartCell(editor).each((cell) => {
+    getTableFromCell(cell).each((table) => {
+      const targets = TableTargets.forMenu(selections, table, cell);
+      execute(table, targets).each((rng) => {
+        editor.selection.setRng(rng);
+        editor.focus();
+        cellSelection.clear(table);
+        Util.removeDataStyle(table);
+      });
+    });
+  });
+
+  const copyRowSelection = (_execute?) => TableSelection.getSelectionStartCell(editor).map((cell) => getTableFromCell(cell).bind((table) => {
+    const targets = TableTargets.forMenu(selections, table, cell);
+    const generators = TableFill.cellOperations(Fun.noop, Element.fromDom(editor.getDoc()), Option.none());
+    return CopyRows.copyRows(table, targets, generators);
+  }));
+
+  const pasteOnSelection = (execute) => clipboardRows.get().each((rows) => {
+    // If we have clipboard rows to paste
+    const clonedRows = Arr.map(rows, (row) => Replication.deep(row));
     TableSelection.getSelectionStartCell(editor).each((cell) => {
       getTableFromCell(cell).each((table) => {
-        const targets = TableTargets.forMenu(selections, table, cell);
+        const generators = TableFill.paste(Element.fromDom(editor.getDoc()));
+        const targets = TableTargets.pasteRows(selections, table, cell, clonedRows, generators);
         execute(table, targets).each((rng) => {
           editor.selection.setRng(rng);
           editor.focus();
           cellSelection.clear(table);
-          Util.removeDataStyle(table);
         });
       });
     });
-  };
-
-  const copyRowSelection = (_execute?) => TableSelection.getSelectionStartCell(editor).map((cell) => getTableFromCell(cell).bind((table) => {
-    const doc = Element.fromDom(editor.getDoc());
-    const targets = TableTargets.forMenu(selections, table, cell);
-    const generators = TableFill.cellOperations(Fun.noop, doc, Option.none());
-    return CopyRows.copyRows(table, targets, generators);
-  }));
-
-  const pasteOnSelection = (execute) => {
-    // If we have clipboard rows to paste
-    clipboardRows.get().each((rows) => {
-      const clonedRows = Arr.map(rows, (row) => Replication.deep(row));
-      TableSelection.getSelectionStartCell(editor).each((cell) => {
-        getTableFromCell(cell).each((table) => {
-          const doc = Element.fromDom(editor.getDoc());
-          const generators = TableFill.paste(doc);
-          const targets = TableTargets.pasteRows(selections, table, cell, clonedRows, generators);
-          execute(table, targets).each((rng) => {
-            editor.selection.setRng(rng);
-            editor.focus();
-            cellSelection.clear(table);
-          });
-        });
-      });
-    });
-  };
-
-  // Register action commands
-  each({
-    mceTableSplitCells() {
-      actOnSelection(actions.unmergeCells);
-    },
-
-    mceTableMergeCells() {
-      actOnSelection(actions.mergeCells);
-    },
-
-    mceTableInsertRowBefore() {
-      actOnSelection(actions.insertRowsBefore);
-    },
-
-    mceTableInsertRowAfter() {
-      actOnSelection(actions.insertRowsAfter);
-    },
-
-    mceTableInsertColBefore() {
-      actOnSelection(actions.insertColumnsBefore);
-    },
-
-    mceTableInsertColAfter() {
-      actOnSelection(actions.insertColumnsAfter);
-    },
-
-    mceTableDeleteCol() {
-      actOnSelection(actions.deleteColumn);
-    },
-
-    mceTableDeleteRow() {
-      actOnSelection(actions.deleteRow);
-    },
-
-    mceTableCutRow(_grid) {
-      copyRowSelection().each((selection) => {
-        clipboardRows.set(selection);
-        actOnSelection(actions.deleteRow);
-      });
-    },
-
-    mceTableCopyRow(_grid) {
-      copyRowSelection().each((selection) => {
-        clipboardRows.set(selection);
-      });
-    },
-
-    mceTablePasteRowBefore(_grid) {
-      pasteOnSelection(actions.pasteRowsBefore);
-    },
-
-    mceTablePasteRowAfter(_grid) {
-      pasteOnSelection(actions.pasteRowsAfter);
-    },
-
-    mceTableDelete: eraseTable
-  }, (func, name) => {
-    editor.addCommand(name, func);
   });
 
+  // Register action commands
+  Obj.each({
+    mceTableSplitCells: () => actOnSelection(actions.unmergeCells),
+    mceTableMergeCells: () => actOnSelection(actions.mergeCells),
+    mceTableInsertRowBefore: () => actOnSelection(actions.insertRowsBefore),
+    mceTableInsertRowAfter: () => actOnSelection(actions.insertRowsAfter),
+    mceTableInsertColBefore: () => actOnSelection(actions.insertColumnsBefore),
+    mceTableInsertColAfter: () => actOnSelection(actions.insertColumnsAfter),
+    mceTableDeleteCol: () => actOnSelection(actions.deleteColumn),
+    mceTableDeleteRow: () => actOnSelection(actions.deleteRow),
+    mceTableCutRow: (_grid) => copyRowSelection().each((selection) => {
+      clipboardRows.set(selection);
+      actOnSelection(actions.deleteRow);
+    }),
+    mceTableCopyRow: (_grid) => copyRowSelection().each((selection) => clipboardRows.set(selection)),
+    mceTablePasteRowBefore: (_grid) => pasteOnSelection(actions.pasteRowsBefore),
+    mceTablePasteRowAfter: (_grid) => pasteOnSelection(actions.pasteRowsAfter),
+    mceTableDelete: eraseTable
+  }, (func, name) => editor.addCommand(name, func));
+
   // Register dialog commands
-  each({
+  Obj.each({
     // AP-101 TableDialog.open renders a slightly different dialog if isNew is true
-    mceInsertTable: Fun.curry(TableDialog.open, editor, true),
     mceTableProps: Fun.curry(TableDialog.open, editor, false),
     mceTableRowProps: Fun.curry(RowDialog.open, editor),
     mceTableCellProps: Fun.curry(CellDialog.open, editor)
-  }, (func, name) => {
-    editor.addCommand(name, () => {
-      func();
-    });
+  }, (func, name) => editor.addCommand(name, () => func()));
+
+  const validateInsertTableSchema = ValueSchema.objOf([
+    FieldSchema.defaultedNumber('rows', 1),
+    FieldSchema.defaultedNumber('columns', 1),
+    FieldSchema.defaultedObjOf('options', { headerRows: 0, headerColumns: 0 }, [
+      FieldSchema.defaultedNumber('headerRows', 0),
+      FieldSchema.defaultedNumber('headerColumns', 0)
+    ])
+  ]);
+
+  editor.addCommand('mceInsertTable', (_ui, args) => {
+    ValueSchema.asRaw<InsertTableData, any>('insertTableData', validateInsertTableSchema, args).fold(
+      // AP-101 TableDialog.open renders a slightly different dialog if isNew is true
+      () => TableDialog.open(editor, true),
+      (data) => InsertTable.insert(editor, data.columns, data.rows, data.options.headerColumns, data.options.headerRows)
+    );
   });
 };
 
-export {
-  registerCommands
-};
+export { registerCommands };
+

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -19,6 +19,7 @@ import * as RowDialog from '../ui/RowDialog';
 import * as TableDialog from '../ui/TableDialog';
 import * as InsertTable from '../actions/InsertTable';
 import { CellSelectionApi } from '../selection/CellSelection';
+import { console } from '@ephox/dom-globals';
 
 const registerCommands = (editor: Editor, actions: TableActions, cellSelection: CellSelectionApi, selections: Selections, clipboardRows: Cell<Option<Element[]>>) => {
   const isRoot = Util.getIsRoot(editor);
@@ -116,7 +117,6 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
         InsertTable.insert(editor, columns, rows, headerColumns, headerRows);
       } else {
         // eslint-disable-next-line no-console
-        // tslint:disable-next-line:no-console
         console.error('Invalid values for mceInsertTable - rows and columns values are required to insert a table.');
       }
     } else {

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -18,8 +18,9 @@ import * as CellDialog from '../ui/CellDialog';
 import * as RowDialog from '../ui/RowDialog';
 import * as TableDialog from '../ui/TableDialog';
 import * as InsertTable from '../actions/InsertTable';
+import { CellSelectionApi } from '../selection/CellSelection';
 
-const registerCommands = (editor: Editor, actions: TableActions, cellSelection, selections: Selections, clipboardRows: Cell<Option<Element[]>>) => {
+const registerCommands = (editor: Editor, actions: TableActions, cellSelection: CellSelectionApi, selections: Selections, clipboardRows: Cell<Option<Element[]>>) => {
   const isRoot = Util.getIsRoot(editor);
   const eraseTable = () => TableSelection.getSelectionStartCellOrCaption(editor).each((cellOrCaption) => {
     TableLookup.table(cellOrCaption, isRoot).filter(Fun.not(isRoot)).each((table) => {

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -112,8 +112,8 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
       const rows = args.rows;
       const columns = args.columns;
       if (checkInput(rows) && checkInput(columns)) {
-        const headerRows = args?.options?.headerRows || 0;
-        const headerColumns = args?.options?.headerColumns || 0;
+        const headerRows = args.options?.headerRows || 0;
+        const headerColumns = args.options?.headerColumns || 0;
         InsertTable.insert(editor, columns, rows, headerColumns, headerRows);
       } else {
         // eslint-disable-next-line no-console

--- a/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
@@ -33,7 +33,6 @@ interface HandlerStruct {
 
 export interface CellSelectionApi {
   clear: (container: Element) => void;
-  destroy: () => void;
 }
 
 export default function (editor: Editor, lazyResize: () => Option<TableResize>, selectionTargets: SelectionTargets): CellSelectionApi {
@@ -201,19 +200,7 @@ export default function (editor: Editor, lazyResize: () => Option<TableResize>, 
     });
   });
 
-  const destroy = function () {
-    handlers.each(function (_handlers) {
-      // TODO: do we need these? can this be deleted? destroy() is only used in one place atm
-      // editor.off('mousedown', handlers.mousedown());
-      // editor.off('mouseover', handlers.mouseover());
-      // editor.off('mouseup', handlers.mouseup());
-      // editor.off('keyup', handlers.keyup());
-      // editor.off('keydown', handlers.keydown());
-    });
-  };
-
   return {
-    clear: annotations.clear,
-    destroy
+    clear: annotations.clear
   };
 }

--- a/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
@@ -23,22 +23,11 @@ import { SelectionTargets } from './SelectionTargets';
 
 const hasInternalTarget = (e: Event) => Class.has(Element.fromDom(e.target as HTMLElement), 'ephox-snooker-resizer-bar') === false;
 
-interface HandlerStruct {
-  readonly mousedown: (e: MouseEvent) => void;
-  readonly mouseover: (e: MouseEvent) => void;
-  readonly mouseup: (e: MouseEvent) => void;
-  readonly keyup: (e: KeyboardEvent) => void;
-  readonly keydown: (e: KeyboardEvent) => void;
-}
-
 export interface CellSelectionApi {
   clear: (container: Element) => void;
 }
 
 export default function (editor: Editor, lazyResize: () => Option<TableResize>, selectionTargets: SelectionTargets): CellSelectionApi {
-  let handlers: Option<HandlerStruct> = Option.none();
-
-
   const onSelection = (cells: Element[], start: Element, finish: Element) => {
     selectionTargets.targets().each((targets) => {
       const tableOpt = TableLookup.table(start);
@@ -190,14 +179,6 @@ export default function (editor: Editor, lazyResize: () => Option<TableResize>, 
     editor.on('keyup', keyup);
     editor.on('keydown', keydown);
     editor.on('NodeChange', syncSelection);
-
-    handlers = Option.some({
-      mousedown: mouseDown,
-      mouseover: mouseOver,
-      mouseup: mouseUp,
-      keyup,
-      keydown
-    });
   });
 
   return {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -136,7 +136,7 @@ const open = (editor: Editor) => {
   const cellsData: CellData[] = Tools.map(cells,
     (cellElm) => Helpers.extractDataFromCellElement(editor, cellElm, hasAdvancedCellTab(editor))
   );
-  const data: CellData = Helpers.getSharedValues(cellsData);
+  const data = Helpers.getSharedValues<CellData>(cellsData);
 
   const dialogTabPanel: Types.Dialog.TabPanelApi = {
     type: 'tabpanel',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
@@ -12,18 +12,8 @@ import { Option } from '@ephox/katamari';
 import { Types } from '@ephox/bridge';
 
 const getClassList = (editor: Editor) => {
-  const rowClassList = getCellClassList(editor);
-
-  const classes: Types.SelectBox.ExternalSelectBoxItem[] = Helpers.buildListItems(
-    rowClassList,
-    (item) => {
-      if (item.value) {
-        item.textStyle = () => editor.formatter.getCssText({ block: 'tr', classes: [ item.value ] });
-      }
-    }
-  );
-
-  if (rowClassList.length > 0) {
+  const classes = Helpers.buildListItems(getCellClassList(editor));
+  if (classes.length > 0) {
     return Option.some<Types.Dialog.BodyComponentApi>({
       name: 'class',
       type: 'selectbox',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -127,7 +127,7 @@ const getAdvancedTab = (dialogName: 'table' | 'row' | 'cell') => {
 // The extractDataFrom... functions are in this file partly for code reuse and partly so we can test them,
 // because some of these are crazy complicated
 
-const getAlignment = (formats: string[], formatName: string, editor: Editor, elm: Node) => 
+const getAlignment = (formats: string[], formatName: string, editor: Editor, elm: Node) =>
   Arr.find(formats, (name) => editor.formatter.matchNode(elm, formatName + name)).getOr('');
 const getHAlignment = Fun.curry(getAlignment, [ 'left', 'center', 'right' ], 'align');
 const getVAlignment = Fun.curry(getAlignment, [ 'top', 'middle', 'bottom' ], 'valign');

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -152,7 +152,7 @@ const extractDataFromSettings = (editor: Editor, hasAdvTableTab: boolean): Table
   const style = getDefaultStyles(editor);
   const attrs = getDefaultAttributes(editor);
 
-  const extractAdvancedStyleData = (dom) => ({
+  const extractAdvancedStyleData = (dom: DOMUtils) => ({
     borderstyle: Obj.get(style, 'border-style').getOr(''),
     bordercolor: rgbToHex(dom)(Obj.get(style, 'border-color').getOr('')),
     backgroundcolor: rgbToHex(dom)(Obj.get(style, 'background-color').getOr(''))

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -17,7 +17,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets) => {
 
   const insertTableAction = ({ numRows, numColumns }) => {
     editor.undoManager.transact(function () {
-      InsertTable.insert(editor, numColumns, numRows);
+      InsertTable.insert(editor, numColumns, numRows, 0, 0);
     });
 
     editor.addVisual();

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -125,7 +125,7 @@ const open = (editor: Editor) => {
 
   // Get current data and find shared values between rows
   const rowsData: RowData[] = Tools.map(rows, (rowElm) => Helpers.extractDataFromRowElement(editor, rowElm, hasAdvancedRowTab(editor)));
-  const data: RowData = Helpers.getSharedValues(rowsData);
+  const data = Helpers.getSharedValues<RowData>(rowsData);
 
   const dialogTabPanel: Types.Dialog.TabPanelApi = {
     type: 'tabpanel',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
@@ -12,18 +12,8 @@ import { Option } from '@ephox/katamari';
 import { Types } from '@ephox/bridge';
 
 const getClassList = (editor: Editor) => {
-  const rowClassList = getRowClassList(editor);
-
-  const classes: Types.SelectBox.ExternalSelectBoxItem[] = Helpers.buildListItems(
-    rowClassList,
-    (item) => {
-      if (item.value) {
-        item.textStyle = () => editor.formatter.getCssText({ block: 'tr', classes: [ item.value ] });
-      }
-    }
-  );
-
-  if (rowClassList.length > 0) {
+  const classes = Helpers.buildListItems(getRowClassList(editor));
+  if (classes.length > 0) {
     return Option.some<Types.Dialog.BodyComponentApi>({
       name: 'class',
       type: 'selectbox',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -168,9 +168,9 @@ const open = (editor: Editor, insertNewTable: boolean) => {
     }
   }
 
-  const hasClasses = getTableClassList(editor).length > 0;
+  const classes = Helpers.buildListItems(getTableClassList(editor));
 
-  if (hasClasses) {
+  if (classes.length > 0) {
     if (data.class) {
       data.class = data.class.replace(/\s*mce\-item\-table\s*/g, '');
     }
@@ -179,7 +179,7 @@ const open = (editor: Editor, insertNewTable: boolean) => {
   const generalPanel: Types.Dialog.BodyComponentApi = {
     type: 'grid',
     columns: 2,
-    items: TableDialogGeneralTab.getItems(editor, hasClasses, insertNewTable)
+    items: TableDialogGeneralTab.getItems(editor, classes, insertNewTable)
   };
 
   const nonAdvancedForm = (): Types.Dialog.PanelApi => ({

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -104,7 +104,7 @@ const onSubmitTableForm = (editor: Editor, tableElm: Element, api: Types.Dialog.
       const cols = parseInt(data.cols, 10) || 1;
       const rows = parseInt(data.rows, 10) || 1;
       // Cases 1 & 3 - inserting a table
-      tableElm = InsertTable.insert(editor, cols, rows);
+      tableElm = InsertTable.insert(editor, cols, rows, 0, 0);
     }
 
     applyDataToElement(editor, tableElm, data);

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialogGeneralTab.ts
@@ -1,9 +1,8 @@
 import { Types } from '@ephox/bridge';
-import * as Helpers from './Helpers';
-import { getTableClassList, hasAppearanceOptions } from '../api/Settings';
 import Editor from 'tinymce/core/api/Editor';
+import { hasAppearanceOptions } from '../api/Settings';
 
-const getItems = (editor: Editor, hasClasses: boolean, insertNewTable: boolean) => {
+const getItems = (editor: Editor, classes: Types.SelectBox.ExternalSelectBoxItem[], insertNewTable: boolean) => {
   const rowColCountItems: Types.Dialog.BodyComponentApi[] = !insertNewTable ? [] : [
     {
       type: 'input',
@@ -77,25 +76,16 @@ const getItems = (editor: Editor, hasClasses: boolean, insertNewTable: boolean) 
     }
   ];
 
-  const classListItem: Types.Dialog.BodyComponentApi[] = hasClasses ? [
+  const classListItem: Types.Dialog.BodyComponentApi[] = classes.length > 0 ? [
     {
       type: 'selectbox',
       name: 'class',
       label: 'Class',
-      items: Helpers.buildListItems(
-        getTableClassList(editor),
-        (item) => {
-          if (item.value) {
-            item.textStyle = () => editor.formatter.getCssText({ block: 'table', classes: [ item.value ] });
-          }
-        }
-      )
+      items: classes
     }
   ] : [];
 
   return rowColCountItems.concat(alwaysItems).concat(appearanceItems).concat(alignmentItem).concat(classListItem);
 };
 
-export {
-  getItems
-};
+export { getItems };

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableCommandTest.ts
@@ -1,0 +1,136 @@
+import { Logger, Pipeline, Step, Log } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+
+import Plugin from 'tinymce/plugins/table/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.plugins.table.InsertTableCommandTest', (success, failure) => {
+  Plugin();
+  SilverTheme();
+
+  const sInsertTable = (editor, args) => Logger.t('Insert table ', Step.sync(() => editor.execCommand('mceInsertTable', false, args)));
+
+  TinyLoader.setup((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+
+    Pipeline.async({}, [
+      Log.stepsAsStep('TBA', 'Table: Try to insert table with incorrect data', [
+        tinyApis.sSetContent(''),
+        sInsertTable(editor, { incorrect: 'data' }),
+        tinyApis.sAssertContent(''),
+      ]),
+      Log.stepsAsStep('TBA', 'Table: Try to insert table with incorrect rows value', [
+        tinyApis.sSetContent(''),
+        sInsertTable(editor, { rows: 'two' }),
+        tinyApis.sAssertContent(''),
+      ]),
+      Log.stepsAsStep('TBA', 'Table: Insert table 2x2', [
+        tinyApis.sSetContent(''),
+        sInsertTable(editor, { rows: 2, columns: 2 }),
+        tinyApis.sAssertContent(
+          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
+          '<tbody><tr>' +
+          '<td style="width: 50%;">&nbsp;</td>' +
+          '<td style="width: 50%;">&nbsp;</td>' +
+          '</tr><tr>' +
+          '<td style="width: 50%;">&nbsp;</td>' +
+          '<td style="width: 50%;">&nbsp;</td>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
+      ]),
+      Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 1 header row', [
+        tinyApis.sSetContent(''),
+        sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 1 }}),
+        tinyApis.sAssertContent(
+          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
+          '<tbody><tr>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '</tr><tr>' +
+          '<td style="width: 50%;">&nbsp;</td>' +
+          '<td style="width: 50%;">&nbsp;</td>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
+      ]),
+      Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 1 header column', [
+        tinyApis.sSetContent(''),
+        sInsertTable(editor, { rows: 2, columns: 2, options: { headerColumns: 1 }}),
+        tinyApis.sAssertContent(
+          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
+          '<tbody><tr>' +
+          '<th style="width: 50%;" scope="row">&nbsp;</th>' +
+          '<td style="width: 50%;">&nbsp;</td>' +
+          '</tr><tr>' +
+          '<th style="width: 50%;" scope="row">&nbsp;</th>' +
+          '<td style="width: 50%;">&nbsp;</td>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
+      ]),
+      Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 1 header row and 1 header column', [
+        tinyApis.sSetContent(''),
+        sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 1, headerColumns: 1 }}),
+        tinyApis.sAssertContent(
+          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
+          '<tbody><tr>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '</tr><tr>' +
+          '<th style="width: 50%;" scope="row">&nbsp;</th>' +
+          '<td style="width: 50%;">&nbsp;</td>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
+      ]),
+      Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 2 header rows and 2 header columns', [
+        tinyApis.sSetContent(''),
+        sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 2, headerColumns: 2 }}),
+        tinyApis.sAssertContent(
+          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
+          '<tbody><tr>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '</tr><tr>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
+      ]),
+      Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 3 header rows and 3 header columns - should only get 2', [
+        tinyApis.sSetContent(''),
+        sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 3, headerColumns: 3 }}),
+        tinyApis.sAssertContent(
+          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
+          '<tbody><tr>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '</tr><tr>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
+      ]),
+    ], onSuccess, onFailure);
+  }, {
+    plugins: 'table',
+    indent: false,
+    valid_styles: {
+      '*': 'width,height,vertical-align,text-align,float,border-color,' +
+           'background-color,border,padding,border-spacing,border-collapse'
+    },
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+    statusbar: false
+  }, success, failure);
+});


### PR DESCRIPTION
The actual feature I implemented is in Commands.ts and InsertTable.ts. The rest came from me trying to add some types and then finding a heap of weird code. Resisted doing any major refactoring and mostly stuck to the ui folder. Deleted a few pieces of code that are left over from T4 features we haven't implemented in T5 (nested class lists) or that might even be left over from T3. 

If people want I can make another branch for the fixes and cherrypick stuff across. 