### PR TITLE
TINY-6019: Revert part of default content css changes done in 47b2b8a

### DIFF
--- a/modules/oxide/src/less/skins/content/dark/content.less
+++ b/modules/oxide/src/less/skins/content/dark/content.less
@@ -9,17 +9,13 @@
 // Place your HTML here
 //
 
-html {
-  height: 100%;
-}
-
 body {
   background-color: #2f3742;
   color: #dfe0e4;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  height: calc(100% - 2rem);
   line-height: 1.4;
   margin: 1rem;
+  min-height: calc(100vh - 2rem);
 }
 
 a {

--- a/modules/oxide/src/less/skins/content/default/content.less
+++ b/modules/oxide/src/less/skins/content/default/content.less
@@ -9,15 +9,11 @@
 // Place your HTML here
 //
 
-html {
-  height: 100%;
-}
-
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  height: calc(100% - 2rem);
   line-height: 1.4;
   margin: 1rem;
+  min-height: calc(100vh - 2rem);
 }
 
 table {

--- a/modules/oxide/src/less/skins/content/document/content.less
+++ b/modules/oxide/src/less/skins/content/document/content.less
@@ -14,7 +14,7 @@ html {
 
   @media screen {
     background: #f4f4f4;
-    height: 100%;
+    min-height: 100%;
   }
 }
 
@@ -25,9 +25,9 @@ body {
     background-color: #fff;
     box-shadow: 0 0 4px fade(#000, 15%);
     box-sizing: border-box;
-    height: calc(100% - 1rem);
     margin: 1rem auto 0;
     max-width: 820px;
+    min-height: calc(100vh - 1rem);
     padding: 4rem 6rem 6rem 6rem;
   }
 }

--- a/modules/oxide/src/less/skins/content/writer/content.less
+++ b/modules/oxide/src/less/skins/content/writer/content.less
@@ -9,16 +9,12 @@
 // Place your HTML here
 //
 
-html {
-  height: 100%;
-}
-
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  height: calc(100% - 2rem);
   line-height: 1.4;
   margin: 1rem auto;
   max-width: 900px;
+  min-height: calc(100vh - 2rem);
 }
 
 table {

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.3.1 (TBD)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
+    Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019
 Version 5.3.0 (2020-05-21)
     Added html and body height styles to the default oxide content CSS #TINY-5978
     Added `uploadUri` and `blobInfo` to the data returned by `editor.uploadImages()` #TINY-4579


### PR DESCRIPTION
This reverts the heights added for TINY-5978, as it causes scrolling issues on Firefox since the body is smaller than the content. This does unfortunately mean we still don't have a solution to relative heights for tables, since the CSS spec doesn't treat min-height as an explicit height.