### PR TITLE
TINY-6020: Fixed the image dialog incorrectly closing when closing the upload error dialog

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.3.1 (TBD)
-
+    Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
 Version 5.3.0 (2020-05-21)
     Added html and body height styles to the default oxide content CSS #TINY-5978
     Added `uploadUri` and `blobInfo` to the data returned by `editor.uploadImages()` #TINY-4579

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
@@ -37,7 +37,7 @@ interface Helpers {
   imageSize: (url: string) => Promise<Size>;
   addToBlobCache: (blobInfo: BlobInfo) => void;
   createBlobCache: (file: File, blobUri: string, dataUrl: string) => BlobInfo;
-  alertErr: (api: API, message: string) => void;
+  alertErr: (message: string) => void;
   normalizeCss: (cssText: string) => string;
   parseStyle: (cssText: string) => StyleMap;
   serializeStyle: (stylesArg: StyleMap, name?: string) => string;
@@ -297,7 +297,7 @@ const changeFileInput = (helpers: Helpers, info: ImageDialogInfo, state: ImageDi
             finalize();
           }).catch((err) => {
             finalize();
-            helpers.alertErr(api, err);
+            helpers.alertErr(err);
           });
         } else {
           helpers.addToBlobCache(blobInfo);
@@ -406,9 +406,8 @@ const addToBlobCache = (editor: Editor) => (blobInfo: BlobInfo) => {
   editor.editorUpload.blobCache.add(blobInfo);
 };
 
-const alertErr = (editor: Editor) => (api: API, message: string) => {
-  // TODO: it looks like the intention to close the entire dialog on an error. Is that really a good idea?
-  editor.windowManager.alert(message, api.close);
+const alertErr = (editor: Editor) => (message: string) => {
+  editor.windowManager.alert(message);
 };
 
 const normalizeCss = (editor: Editor) => (cssText: string) => doNormalizeCss(editor, cssText);

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -140,6 +140,20 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       ui.sClickOnUi('Close dialog', 'button:contains("Cancel")')
     ]);
 
+    const uploadWithError = Log.stepsAsStep('TNY-6020', 'Image: Image uploader test with upload error', [
+      api.sSetContent(''),
+      api.sSetSetting('images_upload_handler', (blobInfo, success, failure) => failure('Error occurred')),
+      ui.sClickOnToolbar('Trigger Image dialog', 'button[aria-label="Insert/edit image"]'),
+      ui.sWaitForPopup('Wait for Image dialog', 'div[role="dialog"]'),
+      ui.sClickOnUi('Switch to Upload tab', '.tox-tab:contains("Upload")'),
+      sTriggerUpload,
+      ui.sWaitForUi('Wait for an alert dialog to appear', '.tox-alert-dialog'),
+      ui.sClickOnUi('Switch to Upload tab', '.tox-alert-dialog .tox-button:contains("OK")'),
+      UiFinder.sNotExists(Body.body(), '.tox-alert-dialog'),
+      UiFinder.sExists(Body.body(), '.tox-dialog__body-nav-item--active:contains("Upload")'),
+      ui.sClickOnUi('Close dialog', 'button:contains("Cancel")')
+    ]);
+
     const uploadWithAutomaticUploadsDisabled = Log.stepsAsStep('TBA', 'Image: Image uploader test with automatic uploads disabled', [
       api.sSetContent(''),
       api.sSetSetting('automatic_uploads', false),
@@ -161,6 +175,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       uploadWithCustomRoute,
       uploadWithCustomHandler,
       uploadCustomHandlerBase64String,
+      uploadWithError,
       uploadWithAutomaticUploadsDisabled
     ], onSuccess, onFailure);
   }, {


### PR DESCRIPTION
We introduced a regression in 5.0.0 whereby closing the error alert dialog for a failed image upload would then also close the image dialog. This didn't happen in v4 and doesn't make sense, as the user is likely to want to retry or pick another image.

Fixes #5684