### PR TITLE
TINY-6019: Fully revert the min-height CSS as fullpage breaks autoresize since it removes all body styles

### DIFF
--- a/modules/oxide/src/less/skins/content/dark/content.less
+++ b/modules/oxide/src/less/skins/content/dark/content.less
@@ -15,7 +15,6 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   line-height: 1.4;
   margin: 1rem;
-  min-height: calc(100vh - 2rem);
 }
 
 a {

--- a/modules/oxide/src/less/skins/content/default/content.less
+++ b/modules/oxide/src/less/skins/content/default/content.less
@@ -13,7 +13,6 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   line-height: 1.4;
   margin: 1rem;
-  min-height: calc(100vh - 2rem);
 }
 
 table {

--- a/modules/oxide/src/less/skins/content/writer/content.less
+++ b/modules/oxide/src/less/skins/content/writer/content.less
@@ -14,7 +14,6 @@ body {
   line-height: 1.4;
   margin: 1rem auto;
   max-width: 900px;
-  min-height: calc(100vh - 2rem);
 }
 
 table {


### PR DESCRIPTION
Note: The `document` content CSS will still be broken as it was in 5.2.2 and lower.