### PR TITLE
TINY-5946: Made undo command filtering code case insensitive.

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.4.0 (TBD)
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
+		Changed the code that filters commands out of the `undo` stack to be case insensitive.
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,6 @@
 Version 5.4.0 (TBD)
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
-		Changed the code that filters commands out of the `undo` stack to be case insensitive.
+    Fixed the code that filters commands out of the `undo` stack. It is now case insensitive.
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,6 @@
 Version 5.4.0 (TBD)
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
-    Fixed filters for screening commands from the undo stack to be properly case-insensitive.
+    Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,6 @@
 Version 5.4.0 (TBD)
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
-    Fixed the code that filters commands out of the `undo` stack. It is now case insensitive.
+    Fixed filters for screening commands from the undo stack to be properly case-insensitive.
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019

--- a/modules/tinymce/src/core/main/ts/undo/Setup.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Setup.ts
@@ -26,9 +26,9 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
 
   // Get position before an execCommand is processed
   editor.on('BeforeExecCommand', (e) => {
-    const cmd = e.command;
+    const cmd = e.command.toLowerCase();
 
-    if (cmd !== 'Undo' && cmd !== 'Redo' && cmd !== 'mceRepaint') {
+    if (cmd !== 'undo' && cmd !== 'redo' && cmd !== 'mcerepaint') {
       endTyping(undoManager, locks);
       undoManager.beforeChange();
     }
@@ -36,9 +36,9 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
 
   // Add undo level after an execCommand call was made
   editor.on('ExecCommand', (e) => {
-    const cmd = e.command;
+    const cmd = e.command.toLowerCase();
 
-    if (cmd !== 'Undo' && cmd !== 'Redo' && cmd !== 'mceRepaint') {
+    if (cmd !== 'undo' && cmd !== 'redo' && cmd !== 'mcerepaint') {
       addNonTypingUndoLevel(e);
     }
   });

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -500,6 +500,12 @@ UnitTest.asynctest('browser.tinymce.core.UndoManager', function (success, failur
     LegacyUnit.equal(editor.getContent(), '<p><em><strong>a</strong></em></p>');
   });
 
+  suite.test('undo filter for mceRepaint is case insensitive', function (editor) {
+    editor.undoManager.clear();
+    editor.execCommand('mceRepaint');
+    LegacyUnit.equal(editor.undoManager.hasUndo(), false);
+  });
+
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
   }, {


### PR DESCRIPTION
This is a formatted version of a community patch (#3586) that makes the undo stack filtering code case insensitive. 

Fixes #3586