### PR TITLE
TINY-6049: Fixed an issue where removing formatting in a table cell would cause IE 11 to scroll to the end of the table

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.4.0 (TBD)
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
+    Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -488,6 +488,14 @@ UnitTest.asynctest('browser.tinymce.core.FormatterRemoveTest', function (success
     LegacyUnit.equal(getContent(editor), '<table><tbody><tr><td>ab cd</td></tr></tbody></table>', 'Should have removed format.');
   });
 
+  suite.test('Remove format from last position in table cell', function (editor) {
+    editor.formatter.register('format', { inline: 'b' });
+    editor.getBody().innerHTML = '<table><tbody><tr><td>ab <b>cd</b></td></tr></tbody></table>';
+    LegacyUnit.setSelection(editor, 'b', 0, 'tr', 2);
+    editor.formatter.remove('format');
+    LegacyUnit.equal(getContent(editor), '<table><tbody><tr><td>ab cd</td></tr></tbody></table>', 'Should have removed format.');
+  });
+
   suite.test('Inline element on selected text with preserve_attributes flag (bold)', (editor) => {
     editor.formatter.register('format', { inline: 'b', preserve_attributes: [ 'class', 'style' ], remove: 'all' });
     editor.getBody().innerHTML = '<p><b class="abc" style="color: red;" data-test="1">1234</b></p>';


### PR DESCRIPTION
We were moving the start container if between a table cell/row, however we weren't doing that for the end container when removing formats. This caused the `td` to be wrapped in a span, which in turn caused IE 11 to scroll to the bottom of the table. As such, this just adds the same normalization behaviour to the endContainer.

For reference, here's the HTML it was creating that caused IE 11 to scroll:
```
<tr style="height: 21px;" data-mce-style="height: 21px;">
  <td style="width: 50%; height: 21px;" data-mce-style="width: 50%; height: 21px;">this is test</td>
  <span id="_end" data-mce-type="bookmark">
    <td style="width: 50%; height: 21px;" data-mce-style="width: 50%; height: 21px;">
      this is <span id="mce_2_start" style="line-height: 0px; overflow: hidden;" data-mce-type="bookmark" data-mce-style="overflow:hidden;line-height:0px"></span><span id="_start" data-mce-type="bookmark">test</span><span id="mce_2_end" style="line-height: 0px; overflow: hidden;" data-mce-type="bookmark" data-mce-style="overflow:hidden;line-height:0px"></span>
    </td>
  </span>
</tr>
```