### PR TITLE
TINY-3854: Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
@@ -49,7 +49,7 @@ export const create = (): Registry => {
   const contextMenus: Record<string, ContextMenuApi> = {};
   const contextToolbars: Record<string, ContextToolbarApi | ContextFormApi> = {};
   const sidebars: Record<string, SidebarApi> = {};
-  const add = (collection, type: string) => (name: string, spec: any): void => collection[name.toLowerCase()] = { ...spec, type };
+  const add = (collection, type: string) => (name: string, spec: any): void => collection[name.toLowerCase()] = { ...(() => {if (spec.icon !== undefined) {spec.icon = spec.icon.toLowerCase();};return spec;})(), type };
   const addIcon = (name: string, svgData: string) => icons[name.toLowerCase()] = svgData;
 
   return {

--- a/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
@@ -49,7 +49,7 @@ export const create = (): Registry => {
   const contextMenus: Record<string, ContextMenuApi> = {};
   const contextToolbars: Record<string, ContextToolbarApi | ContextFormApi> = {};
   const sidebars: Record<string, SidebarApi> = {};
-  const add = (collection, type: string) => (name: string, spec: any): void => collection[name.toLowerCase()] = { ...(() => {if (spec.icon !== undefined) {spec.icon = spec.icon.toLowerCase();};return spec;})(), type };
+  const add = (collection, type: string) => (name: string, spec: any): void => collection[name.toLowerCase()] = { ...spec, type };
   const addIcon = (name: string, svgData: string) => icons[name.toLowerCase()] = svgData;
 
   return {

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,6 +2,7 @@ Version 5.4.0 (TBD)
     Added all table menu items to the UI registry, so they can be used by name in other menus #TINY-4866
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946
+    Fixed handling of mixed-case icon names by adding a filter to registry entry #TINY-3854
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,7 +2,7 @@ Version 5.4.0 (TBD)
     Added all table menu items to the UI registry, so they can be used by name in other menus #TINY-4866
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946
-    Fixed handling of mixed-case icon names by adding a filter to registry entry #TINY-3854
+    Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval #TINY-3854
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019

--- a/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
@@ -11,11 +11,11 @@ export type IconProvider = () => Record<string, string>;
 
 const defaultIcon = (icons: IconProvider): string => Option.from(icons()['temporary-placeholder']).getOr('!not found!');
 
-const get = (name: string, icons: IconProvider): string => Option.from(icons()[name]).getOrThunk(() => defaultIcon(icons));
+const get = (name: string, icons: IconProvider): string => Option.from(icons()[name.toLowerCase()]).getOrThunk(() => defaultIcon(icons));
 
-const getOr = (name: string, icons: IconProvider, fallback: Option<string>): string => Option.from(icons()[name]).or(fallback).getOrThunk(() => defaultIcon(icons));
+const getOr = (name: string, icons: IconProvider, fallback: Option<string>): string => Option.from(icons()[name.toLowerCase()]).or(fallback).getOrThunk(() => defaultIcon(icons));
 
-const getFirst = (names: string[], icons: IconProvider): string => Arr.findMap(names, (name) => Option.from(icons()[name])).getOrThunk(() => defaultIcon(icons));
+const getFirst = (names: string[], icons: IconProvider): string => Arr.findMap(names, (name) => Option.from(icons()[name.toLowerCase()])).getOrThunk(() => defaultIcon(icons));
 
 export {
   getFirst,

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/icons/IconsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/icons/IconsTest.ts
@@ -11,15 +11,23 @@ UnitTest.asynctest('IconsTest', (success, failure) => {
   TinyLoader.setupLight((editor, onSuccess, onFailure) => {
     const iconIndent = getAllOxide().indent;
     const iconDefault = getAllOxide()['temporary-placeholder'];
+    const myCustomIcon = '<svg></svg>';
 
     const iconProvider = () => editor.ui.registry.getAll().icons;
     const emptyIconProvider: IconProvider = () => ({ });
+    const lowerCaseProvider: IconProvider = () => ({ mycustomicon: '<svg></svg>' });
 
     const getTest = Step.sync(() => {
       Assertions.assertEq(
         'When an icon exists as a default icon or provided, it should be returned',
         iconIndent,
         get('indent', iconProvider)
+      );
+
+      Assertions.assertEq(
+        'When a lowercase version of a mixed-case name exists, it should be returned',
+        myCustomIcon,
+        get('myCustomIcon', lowerCaseProvider)
       );
 
       Assertions.assertEq(

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
@@ -8,7 +8,7 @@ import { renderAlertBanner } from 'tinymce/themes/silver/ui/general/AlertBanner'
 UnitTest.asynctest('AlertBanner component Test', (success, failure) => {
   const providers = {
     icons: () => <Record<string, string>> {
-      helpA: 'provided-for-help',
+      helpa: 'provided-for-help',
       close: 'provided-for-close'
     },
     menuItems: () => <Record<string, any>> {},


### PR DESCRIPTION
This PR fixes an issue with mixed-case icon names. Currently, icon names are downcased before entry into the registry. However, the `icon` key of a UI element (e.g. a button ) specification is not. This means that consistent capitalisation on the part of the user can lead to missing icons in the interface. Take this excerpt from [http://fiddle.tinymce.com/ILgaab/1](http://fiddle.tinymce.com/ILgaab/1) as an example:

    tinymce.IconManager.add('custom', {
      icons: {
        myCustomIcon: '<svg width="24" height="24"><circle cx="12" cy="12" r="10" stroke="green" stroke-width="4" fill="yellow" /></svg>'
      }
    });
    
    tinymce.PluginManager.add('adbplugins', function(editor, url) {
      editor.ui.registry.addButton('customButton', {
        tooltip: 'A sample custom button',
        icon: 'myCustomIcon',
        onAction: function(buttonApi) { }
      });
    });

Here, the user consistently refers to "myCustomIcon" in both the icon and button definitions. The icon name will be automatically downcased and the reference in the button definition won't be. Thus when the time comes to use the button definition to retrieve an icon, none will be found. There won't be any "myCustomIcon" icon in the registry, only a "mycustomicon" icon.

My fix is a short filter on "icon" key names when adding specifications to the registry. 

    const add = (collection, type: string) => (name: string, spec: any): void => collection[name.toLowerCase()] = { ...(() => {if (spec.icon !== undefined) {spec.icon = spec.icon.toLowerCase();};return spec;})(), type };

instead of:

    const add = (collection, type: string) => (name: string, spec: any): void => collection[name.toLowerCase()] = { ...spec, type };

I hate to use such ugly syntax, but I did not want to add a Katamari dependency to Registry.ts.

My understanding is that this needs to be handled at the registry level because user written themes retrieve both UI elements and `iconPack`s and *then* handle the mappings between elements and icons themselves. Our own silver theme does this, for example. Thus the names need to be made consistent as they sit in the registry.

This PR should resolve #5059.