### PR TITLE
Adding additional font related variables for secondary button #TINY-6061

### DIFF
--- a/modules/oxide/src/less/theme/components/button/button-secondary.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary.less
@@ -19,6 +19,10 @@
 @button-secondary-border-style: @button-border-style;
 @button-secondary-border-width: @button-border-width;
 @button-secondary-box-shadow: @button-box-shadow;
+@button-secondary-font-size: @button-font-size;
+@button-secondary-font-style: @button-font-style;
+@button-secondary-font-weight: @button-font-weight;
+@button-secondary-letter-spacing: @button-letter-spacing;
 @button-secondary-outline: none;
 @button-secondary-text-color: contrast(@button-secondary-background-color, @color-black, @color-white);
 @button-secondary-text-decoration: @button-text-decoration;
@@ -60,6 +64,10 @@
     border-width: @button-secondary-border-width;
     box-shadow: @button-secondary-box-shadow;
     color: @button-secondary-text-color;
+    font-size: @button-secondary-font-size;
+    font-style: @button-secondary-font-style;
+    font-weight: @button-secondary-font-weight;
+    letter-spacing: @button-secondary-letter-spacing;
     outline: @button-secondary-outline;
     padding: @button-padding-y @button-padding-x;
     text-decoration: @button-secondary-text-decoration;

--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -20,6 +20,7 @@
 @button-box-shadow: none;
 @button-font-family: @font-stack;
 @button-font-size: @font-size-sm;
+@button-font-style: normal;
 @button-font-weight: @font-weight-bold;
 @button-letter-spacing: normal;
 @button-line-height: @textfield-line-height;
@@ -71,6 +72,7 @@
     display: inline-block;
     font-family: @button-font-family;
     font-size: @button-font-size;
+    font-style: @button-font-style;
     font-weight: @button-font-weight;
     letter-spacing: @button-letter-spacing;
     line-height: @button-line-height;

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.4.0 (TBD)
     Added all table menu items to the UI registry, so they can be used by name in other menus #TINY-4866
+    Added additional font related variables for secondary buttons allowing more specific styling. #TINY-6061
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946
     Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval #TINY-3854


### PR DESCRIPTION


Description of Changes:
* Added variables and related css declarations for font related styles of the secondary button
* Added font-style declaration for primary button (it was missing)
No complex css changed. 

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
_None_