### PR TITLE
TINY-6006: Added API and menu items to allow cut/copy/paste operations on columns

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
@@ -1,25 +1,39 @@
+import { HTMLTableRowElement } from '@ephox/dom-globals';
+import { Arr, Option } from '@ephox/katamari';
+import { Attr, Element, InsertAll, Replication } from '@ephox/sugar';
 import * as DetailsList from '../model/DetailsList';
 import { onCells, TargetSelection } from '../model/RunOperation';
-import * as Transitions from '../model/Transitions';
 import { Warehouse } from '../model/Warehouse';
-import { Element, Replication, InsertAll } from '@ephox/sugar';
-import { Generators } from './Generators';
-import { Arr } from '@ephox/katamari';
+import * as CellUtils from '../util/CellUtils';
 
-const copyCols = function (table: Element, target: TargetSelection, generators: Generators) {
+const constrainSpan = (element: Element, property: 'colspan' | 'rowspan', value: number) => {
+  const currentColspan = CellUtils.getSpan(element, property);
+  if (value === 1 || currentColspan <= 1) {
+    Attr.remove(element, property);
+  } else {
+    Attr.set(element, property, Math.min(value, currentColspan));
+  }
+};
+
+const copyCols = (table: Element, target: TargetSelection): Option<Element<HTMLTableRowElement>[]> => {
   const list = DetailsList.fromTable(table);
   const house = Warehouse.generate(list);
   const details = onCells(house, target);
   return details.map((selectedCells) => {
-    const grid = Transitions.toGrid(house, generators, false);
-    const slicedGrid = Arr.map(grid, (row) => {
-      const cellsToCopy = row.cells().slice(selectedCells[0].column(), selectedCells[selectedCells.length - 1].column() + selectedCells[selectedCells.length -1 ].colspan());
-      const copiedCells = Arr.map(cellsToCopy, (cell) => Replication.deep(cell.element()));
+    const lastSelectedCell = selectedCells[selectedCells.length - 1];
+    const minColRange = selectedCells[0].column();
+    const maxColRange = lastSelectedCell.column() + lastSelectedCell.colspan();
+    return Arr.map(house.all, (row) => {
+      const cellsToCopy = Arr.filter(row.cells(), (cell) => cell.column() >= minColRange && cell.column() < maxColRange);
+      const copiedCells = Arr.map(cellsToCopy, (cell) => {
+        const clonedCell = Replication.deep(cell.element());
+        constrainSpan(clonedCell, 'colspan', maxColRange - minColRange);
+        return clonedCell;
+      });
       const fakeTR = Element.fromTag('tr');
       InsertAll.append(fakeTR, copiedCells);
       return fakeTR;
     });
-    return slicedGrid;
   });
 };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
@@ -1,0 +1,28 @@
+import * as DetailsList from '../model/DetailsList';
+import { onCells, TargetSelection } from '../model/RunOperation';
+import * as Transitions from '../model/Transitions';
+import { Warehouse } from '../model/Warehouse';
+import { Element, Replication, InsertAll } from '@ephox/sugar';
+import { Generators } from './Generators';
+import { Arr } from '@ephox/katamari';
+
+const copyCols = function (table: Element, target: TargetSelection, generators: Generators) {
+  const list = DetailsList.fromTable(table);
+  const house = Warehouse.generate(list);
+  const details = onCells(house, target);
+  return details.map((selectedCells) => {
+    const grid = Transitions.toGrid(house, generators, false);
+    const slicedGrid = Arr.map(grid, (row) => {
+      const cellsToCopy = row.cells().slice(selectedCells[0].column(), selectedCells[selectedCells.length - 1].column() + selectedCells[selectedCells.length -1 ].colspan());
+      const copiedCells = Arr.map(cellsToCopy, (cell) => Replication.deep(cell.element()));
+      const fakeTR = Element.fromTag('tr');
+      InsertAll.append(fakeTR, copiedCells);
+      return fakeTR;
+    });
+    return slicedGrid;
+  });
+};
+
+export {
+  copyCols
+};

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyRows.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyRows.ts
@@ -1,12 +1,14 @@
+import { HTMLTableRowElement } from '@ephox/dom-globals';
+import { Option } from '@ephox/katamari';
+import { Element } from '@ephox/sugar';
 import * as DetailsList from '../model/DetailsList';
-import { toDetailList, onCells, TargetSelection } from '../model/RunOperation';
+import { onCells, TargetSelection, toDetailList } from '../model/RunOperation';
 import * as Transitions from '../model/Transitions';
 import { Warehouse } from '../model/Warehouse';
 import * as Redraw from '../operate/Redraw';
-import { Element } from '@ephox/sugar';
 import { Generators } from './Generators';
 
-const copyRows = function (table: Element, target: TargetSelection, generators: Generators) {
+const copyRows = function (table: Element, target: TargetSelection, generators: Generators): Option<Element<HTMLTableRowElement>[]> {
   const list = DetailsList.fromTable(table);
   const house = Warehouse.generate(list);
   const details = onCells(house, target);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Main.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Main.ts
@@ -2,6 +2,7 @@ import { CellLocation } from './CellLocation';
 import * as CellMutations from './CellMutations';
 import * as CellNavigation from './CellNavigation';
 import * as CellProperties from './CellProperties';
+import * as CopyCols from './CopyCols';
 import * as CopyRows from './CopyRows';
 import * as CopySelected from './CopySelected';
 import { Generators } from './Generators';
@@ -27,6 +28,7 @@ export {
   CellMutations,
   CellNavigation,
   CellProperties,
+  CopyCols,
   CopyRows,
   CopySelected,
   Generators,

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -1,7 +1,9 @@
 import { Arr, Fun, Option } from '@ephox/katamari';
-import { Remove, Element } from '@ephox/sugar';
+import { Element, Remove } from '@ephox/sugar';
 import * as DetailsList from '../model/DetailsList';
-import { run, onCell, onCells, onMergable, onUnmergable, onPaste, onPasteByEditor, ExtractPasteRows, ExtractPaste, ExtractMergable } from '../model/RunOperation';
+import {
+  ExtractMergable, ExtractPaste, ExtractPasteRows, onCell, onCells, onMergable, onPaste, onPasteByEditor, onUnmergable, run
+} from '../model/RunOperation';
 import * as TableMerge from '../model/TableMerge';
 import * as Transitions from '../model/Transitions';
 import { Warehouse } from '../model/Warehouse';
@@ -9,7 +11,7 @@ import * as MergingOperations from '../operate/MergingOperations';
 import * as ModificationOperations from '../operate/ModificationOperations';
 import * as TransformOperations from '../operate/TransformOperations';
 import * as Adjustments from '../resize/Adjustments';
-import { GeneratorsModification, GeneratorsTransform, GeneratorsMerging, Generators, SimpleGenerators } from './Generators';
+import { Generators, GeneratorsMerging, GeneratorsModification, GeneratorsTransform, SimpleGenerators } from './Generators';
 import * as Structs from './Structs';
 import * as TableContent from './TableContent';
 import * as TableLookup from './TableLookup';
@@ -222,8 +224,8 @@ const gridifyRows = function (rows: Element[], generators: Generators, example: 
   return Transitions.toGrid(wh, generators, true);
 };
 
-const opPasteColsBefore = function (grid: Structs.RowCells[], pasteDetails: ExtractPasteRows, comparator: CompElm, _genWrappers: GeneratorsModification) {
-  const example = grid[pasteDetails.cells[0].column()];
+const opPasteColsBefore = (grid: Structs.RowCells[], pasteDetails: ExtractPasteRows, comparator: CompElm, _genWrappers: GeneratorsModification) => {
+  const example = grid[pasteDetails.cells[0].row()];
   const index = pasteDetails.cells[0].column();
   const gridB = gridifyRows(pasteDetails.clipboard(), pasteDetails.generators(), example);
   const mergedGrid = TableMerge.insertCols(index, grid, gridB, pasteDetails.generators(), comparator);
@@ -231,8 +233,8 @@ const opPasteColsBefore = function (grid: Structs.RowCells[], pasteDetails: Extr
   return outcome(mergedGrid, cursor);
 };
 
-const opPasteColsAfter = function (grid: Structs.RowCells[], pasteDetails: ExtractPasteRows, comparator: CompElm, _genWrappers: GeneratorsModification) {
-  const example = grid[pasteDetails.cells[0].column()];
+const opPasteColsAfter = (grid: Structs.RowCells[], pasteDetails: ExtractPasteRows, comparator: CompElm, _genWrappers: GeneratorsModification) => {
+  const example = grid[pasteDetails.cells[0].row()];
   const index = pasteDetails.cells[pasteDetails.cells.length - 1].column() + pasteDetails.cells[pasteDetails.cells.length - 1].colspan();
   const gridB = gridifyRows(pasteDetails.clipboard(), pasteDetails.generators(), example);
   const mergedGrid = TableMerge.insertCols(index, grid, gridB, pasteDetails.generators(), comparator);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -1,7 +1,7 @@
 import { Arr, Fun, Option } from '@ephox/katamari';
 import { Remove, Element } from '@ephox/sugar';
 import * as DetailsList from '../model/DetailsList';
-import { run, onCell, onCells, onMergable, onUnmergable, onPaste, onPasteRows, ExtractPasteRows, ExtractPaste, ExtractMergable } from '../model/RunOperation';
+import { run, onCell, onCells, onMergable, onUnmergable, onPaste, onPasteByEditor, ExtractPasteRows, ExtractPaste, ExtractMergable } from '../model/RunOperation';
 import * as TableMerge from '../model/TableMerge';
 import * as Transitions from '../model/Transitions';
 import { Warehouse } from '../model/Warehouse';
@@ -222,11 +222,29 @@ const gridifyRows = function (rows: Element[], generators: Generators, example: 
   return Transitions.toGrid(wh, generators, true);
 };
 
+const opPasteColsBefore = function (grid: Structs.RowCells[], pasteDetails: ExtractPasteRows, comparator: CompElm, _genWrappers: GeneratorsModification) {
+  const example = grid[pasteDetails.cells[0].column()];
+  const index = pasteDetails.cells[0].column();
+  const gridB = gridifyRows(pasteDetails.clipboard(), pasteDetails.generators(), example);
+  const mergedGrid = TableMerge.insertCols(index, grid, gridB, pasteDetails.generators(), comparator);
+  const cursor = elementFromGrid(mergedGrid, pasteDetails.cells[0].row(), pasteDetails.cells[0].column());
+  return outcome(mergedGrid, cursor);
+};
+
+const opPasteColsAfter = function (grid: Structs.RowCells[], pasteDetails: ExtractPasteRows, comparator: CompElm, _genWrappers: GeneratorsModification) {
+  const example = grid[pasteDetails.cells[0].column()];
+  const index = pasteDetails.cells[pasteDetails.cells.length - 1].column() + pasteDetails.cells[pasteDetails.cells.length - 1].colspan();
+  const gridB = gridifyRows(pasteDetails.clipboard(), pasteDetails.generators(), example);
+  const mergedGrid = TableMerge.insertCols(index, grid, gridB, pasteDetails.generators(), comparator);
+  const cursor = elementFromGrid(mergedGrid, pasteDetails.cells[0].row(), pasteDetails.cells[0].column());
+  return outcome(mergedGrid, cursor);
+};
+
 const opPasteRowsBefore = function (grid: Structs.RowCells[], pasteDetails: ExtractPasteRows, comparator: CompElm, _genWrappers: GeneratorsModification) {
   const example = grid[pasteDetails.cells[0].row()];
   const index = pasteDetails.cells[0].row();
   const gridB = gridifyRows(pasteDetails.clipboard(), pasteDetails.generators(), example);
-  const mergedGrid = TableMerge.insert(index, grid, gridB, pasteDetails.generators(), comparator);
+  const mergedGrid = TableMerge.insertRows(index, grid, gridB, pasteDetails.generators(), comparator);
   const cursor = elementFromGrid(mergedGrid, pasteDetails.cells[0].row(), pasteDetails.cells[0].column());
   return outcome(mergedGrid, cursor);
 };
@@ -235,7 +253,7 @@ const opPasteRowsAfter = function (grid: Structs.RowCells[], pasteDetails: Extra
   const example = grid[pasteDetails.cells[0].row()];
   const index = pasteDetails.cells[pasteDetails.cells.length - 1].row() + pasteDetails.cells[pasteDetails.cells.length - 1].rowspan();
   const gridB = gridifyRows(pasteDetails.clipboard(), pasteDetails.generators(), example);
-  const mergedGrid = TableMerge.insert(index, grid, gridB, pasteDetails.generators(), comparator);
+  const mergedGrid = TableMerge.insertRows(index, grid, gridB, pasteDetails.generators(), comparator);
   const cursor = elementFromGrid(mergedGrid, pasteDetails.cells[0].row(), pasteDetails.cells[0].column());
   return outcome(mergedGrid, cursor);
 };
@@ -262,5 +280,7 @@ export const unmakeRowHeader = run(opUnmakeRowHeader, onCell, Fun.noop, Fun.noop
 export const mergeCells = run(opMergeCells, onMergable, Fun.noop, Fun.noop, Generators.merging);
 export const unmergeCells = run(opUnmergeCells, onUnmergable, resize, Fun.noop, Generators.merging);
 export const pasteCells = run(opPasteCells, onPaste, resize, Fun.noop, Generators.modification);
-export const pasteRowsBefore = run(opPasteRowsBefore, onPasteRows, Fun.noop, Fun.noop, Generators.modification);
-export const pasteRowsAfter = run(opPasteRowsAfter, onPasteRows, Fun.noop, Fun.noop, Generators.modification);
+export const pasteColsBefore = run(opPasteColsBefore, onPasteByEditor, Fun.noop, Fun.noop, Generators.modification);
+export const pasteColsAfter = run(opPasteColsAfter, onPasteByEditor, Fun.noop, Fun.noop, Generators.modification);
+export const pasteRowsBefore = run(opPasteRowsBefore, onPasteByEditor, Fun.noop, Fun.noop, Generators.modification);
+export const pasteRowsAfter = run(opPasteRowsAfter, onPasteByEditor, Fun.noop, Fun.noop, Generators.modification);

--- a/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
@@ -1,8 +1,8 @@
 import { Arr, Fun, Result } from '@ephox/katamari';
+import { SimpleGenerators } from '../api/Generators';
 import * as Structs from '../api/Structs';
 import * as Util from '../util/Util';
 import * as GridRow from './GridRow';
-import { SimpleGenerators } from '../api/Generators';
 
 export interface Delta {
   readonly colDelta: number;
@@ -22,7 +22,7 @@ export interface Delta {
     - assumptions: All grids used by this module should be rectangular
 */
 
-const measure = function (startAddress: Structs.Address, gridA: Structs.RowCells[], gridB: Structs.RowCells[]): Result<Delta, string> {
+const measure = (startAddress: Structs.Address, gridA: Structs.RowCells[], gridB: Structs.RowCells[]): Result<Delta, string> => {
   if (startAddress.row() >= gridA.length || startAddress.column() > GridRow.cellLength(gridA[0])) {
     return Result.error(
       'invalid start address out of table bounds, row: ' + startAddress.row() + ', column: ' + startAddress.column()
@@ -39,7 +39,7 @@ const measure = function (startAddress: Structs.Address, gridA: Structs.RowCells
   });
 };
 
-const measureWidth = function (gridA: Structs.RowCells[], gridB: Structs.RowCells[]): Delta {
+const measureWidth = (gridA: Structs.RowCells[], gridB: Structs.RowCells[]): Delta => {
   const colLengthA = GridRow.cellLength(gridA[0]);
   const colLengthB = GridRow.cellLength(gridB[0]);
 
@@ -49,7 +49,7 @@ const measureWidth = function (gridA: Structs.RowCells[], gridB: Structs.RowCell
   };
 };
 
-const measureHeight = function (gridA: Structs.RowCells[], gridB: Structs.RowCells[]): Delta {
+const measureHeight = (gridA: Structs.RowCells[], gridB: Structs.RowCells[]): Delta => {
   const rowLengthA = gridA.length;
   const rowLengthB = gridB.length;
 
@@ -59,25 +59,15 @@ const measureHeight = function (gridA: Structs.RowCells[], gridB: Structs.RowCel
   };
 };
 
-const fill = function <T> (cells: T[], generator: SimpleGenerators) {
-  return Arr.map(cells, function () {
-    return Structs.elementnew(generator.cell(), true);
-  });
-};
+const fill = <T> (cells: T[], generator: SimpleGenerators) => Arr.map(cells, () => Structs.elementnew(generator.cell(), true));
 
-const rowFill = function (grid: Structs.RowCells[], amount: number, generator: SimpleGenerators): Structs.RowCells[] {
-  return grid.concat(Util.repeat(amount, function (_row) {
-    return GridRow.setCells(grid[grid.length - 1], fill(grid[grid.length - 1].cells(), generator));
-  }));
-};
+const rowFill = (grid: Structs.RowCells[], amount: number, generator: SimpleGenerators): Structs.RowCells[] =>
+  grid.concat(Util.repeat(amount, () => GridRow.setCells(grid[grid.length - 1], fill(grid[grid.length - 1].cells(), generator))));
 
-const colFill = function (grid: Structs.RowCells[], amount: number, generator: SimpleGenerators): Structs.RowCells[] {
-  return Arr.map(grid, function (row) {
-    return GridRow.setCells(row, row.cells().concat(fill(Util.range(0, amount), generator)));
-  });
-};
+const colFill = (grid: Structs.RowCells[], amount: number, generator: SimpleGenerators): Structs.RowCells[] =>
+  Arr.map(grid, (row) => GridRow.setCells(row, row.cells().concat(fill(Util.range(0, amount), generator))));
 
-const tailor = function (gridA: Structs.RowCells[], delta: Delta, generator: SimpleGenerators): Structs.RowCells[] {
+const tailor = (gridA: Structs.RowCells[], delta: Delta, generator: SimpleGenerators): Structs.RowCells[] => {
   const fillCols = delta.colDelta < 0 ? colFill : Fun.identity;
   const fillRows = delta.rowDelta < 0 ? rowFill : Fun.identity;
 

--- a/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
@@ -49,6 +49,16 @@ const measureWidth = function (gridA: Structs.RowCells[], gridB: Structs.RowCell
   };
 };
 
+const measureHeight = function (gridA: Structs.RowCells[], gridB: Structs.RowCells[]): Delta {
+  const rowLengthA = gridA.length;
+  const rowLengthB = gridB.length;
+
+  return {
+    rowDelta: rowLengthA - rowLengthB,
+    colDelta: 0
+  };
+};
+
 const fill = function <T> (cells: T[], generator: SimpleGenerators) {
   return Arr.map(cells, function () {
     return Structs.elementnew(generator.cell(), true);
@@ -78,5 +88,6 @@ const tailor = function (gridA: Structs.RowCells[], delta: Delta, generator: Sim
 export {
   measure,
   measureWidth,
+  measureHeight,
   tailor
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
@@ -143,7 +143,7 @@ const onPaste = (warehouse: Warehouse, target: TargetPaste): Option<ExtractPaste
   return value;
 }));
 
-const onPasteRows = (warehouse: Warehouse, target: TargetPasteRows): Option<ExtractPasteRows> => {
+const onPasteByEditor = (warehouse: Warehouse, target: TargetPasteRows): Option<ExtractPasteRows> => {
   const details = Arr.map(target.selection(), (cell) => TableLookup.cell(cell).bind((lc) => findInWarehouse(warehouse, lc)));
   const cells = Options.cat(details);
   return cells.length > 0 ? Option.some(
@@ -173,7 +173,7 @@ export {
   onCell,
   onCells,
   onPaste,
-  onPasteRows,
+  onPasteByEditor,
   onMergable,
   onUnmergable
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/model/TableMerge.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/TableMerge.ts
@@ -1,12 +1,12 @@
-import { Fun, Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
+import { Element } from '@ephox/sugar';
+import { SimpleGenerators } from '../api/Generators';
 import * as Structs from '../api/Structs';
+import * as MergingOperations from '../operate/MergingOperations';
 import * as Fitment from './Fitment';
 import * as GridRow from './GridRow';
-import * as MergingOperations from '../operate/MergingOperations';
-import { SimpleGenerators } from '../api/Generators';
-import { Element } from '@ephox/sugar';
 
-const isSpanning = function (grid: Structs.RowCells[], row: number, col: number, comparator: (a: Element, b: Element) => boolean) {
+const isSpanning = (grid: Structs.RowCells[], row: number, col: number, comparator: (a: Element, b: Element) => boolean) => {
   const candidate = GridRow.getCell(grid[row], col);
   const matching = Fun.curry(comparator, candidate.element());
   const currentRow = grid[row];
@@ -25,7 +25,7 @@ const isSpanning = function (grid: Structs.RowCells[], row: number, col: number,
     );
 };
 
-const mergeTables = function (startAddress: Structs.Address, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean) {
+const mergeTables = (startAddress: Structs.Address, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean) => {
   // Assumes
   //  - gridA is square and gridB is square
   const startRow = startAddress.row();
@@ -49,15 +49,15 @@ const mergeTables = function (startAddress: Structs.Address, gridA: Structs.RowC
   return gridA;
 };
 
-const merge = function (startAddress: Structs.Address, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean) {
+const merge = (startAddress: Structs.Address, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean) => {
   const result = Fitment.measure(startAddress, gridA, gridB);
-  return result.map(function (delta) {
+  return result.map((delta) => {
     const fittedGrid = Fitment.tailor(gridA, delta, generator);
     return mergeTables(startAddress, fittedGrid, gridB, generator, comparator);
   });
 };
 
-const insertCols = function (index: number, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean): Structs.RowCells[] {
+const insertCols = (index: number, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean): Structs.RowCells[] => {
   MergingOperations.splitCols(gridA, index, comparator, generator.cell);
 
   const delta = Fitment.measureHeight(gridB, gridA);
@@ -72,7 +72,7 @@ const insertCols = function (index: number, gridA: Structs.RowCells[], gridB: St
   });
 };
 
-const insertRows = function (index: number, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean): Structs.RowCells[] {
+const insertRows = (index: number, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean): Structs.RowCells[] => {
   MergingOperations.splitRows(gridA, index, comparator, generator.cell);
 
   const delta = Fitment.measureWidth(gridB, gridA);

--- a/modules/snooker/src/main/ts/ephox/snooker/model/TableMerge.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/TableMerge.ts
@@ -1,4 +1,4 @@
-import { Fun } from '@ephox/katamari';
+import { Fun, Arr } from '@ephox/katamari';
 import * as Structs from '../api/Structs';
 import * as Fitment from './Fitment';
 import * as GridRow from './GridRow';
@@ -57,7 +57,22 @@ const merge = function (startAddress: Structs.Address, gridA: Structs.RowCells[]
   });
 };
 
-const insert = function (index: number, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean): Structs.RowCells[] {
+const insertCols = function (index: number, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean): Structs.RowCells[] {
+  MergingOperations.splitCols(gridA, index, comparator, generator.cell);
+
+  const delta = Fitment.measureHeight(gridB, gridA);
+  const fittedNewGrid = Fitment.tailor(gridB, delta, generator);
+
+  const secondDelta = Fitment.measureHeight(gridA, fittedNewGrid);
+  const fittedOldGrid = Fitment.tailor(gridA, secondDelta, generator);
+
+  return Arr.map(fittedOldGrid, (gridRow, i) => {
+    const newCells = gridRow.cells().slice(0, index).concat(fittedNewGrid[i].cells()).concat(gridRow.cells().slice(index, gridRow.cells().length));
+    return GridRow.setCells(gridRow, newCells);
+  });
+};
+
+const insertRows = function (index: number, gridA: Structs.RowCells[], gridB: Structs.RowCells[], generator: SimpleGenerators, comparator: (a: Element, b: Element) => boolean): Structs.RowCells[] {
   MergingOperations.splitRows(gridA, index, comparator, generator.cell);
 
   const delta = Fitment.measureWidth(gridB, gridA);
@@ -71,5 +86,6 @@ const insert = function (index: number, gridA: Structs.RowCells[], gridB: Struct
 
 export {
   merge,
-  insert
+  insertCols,
+  insertRows
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/MergingOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/MergingOperations.ts
@@ -1,7 +1,7 @@
 import { Arr, Option } from '@ephox/katamari';
+import { Element } from '@ephox/sugar';
 import * as Structs from '../api/Structs';
 import * as GridRow from '../model/GridRow';
-import { Element } from '@ephox/sugar';
 
 type CompElm = (e1: Element, e2: Element) => boolean;
 type Subst = () => Element;
@@ -49,23 +49,16 @@ const uniqueCells = function (row: Structs.ElementNew[], comparator: CompElm) {
   }, [] as Structs.ElementNew[]);
 };
 
-const splitCols = function (grid: Structs.RowCells[], index: number, comparator: CompElm, substitution: Subst) {
+const splitCols = (grid: Structs.RowCells[], index: number, comparator: CompElm, substitution: Subst) => {
   // We don't need to split rows if we're inserting at the first or last row of the old table
   if (index > 0 && index < grid[0].cells().length) {
     Arr.each(grid, (row) => {
-      // only make a sub when we have to
-      let replacement = Option.none<Element>();
       const prevCell = row.cells()[index - 1];
       const current = row.cells()[index];
       const isToReplace = comparator(current.element(), prevCell.element());
 
       if (isToReplace) {
-        if (replacement.isNone()) {
-          replacement = Option.some(substitution());
-        }
-        replacement.each(function (sub) {
-          GridRow.mutateCell(row, index, Structs.elementnew(sub, true));
-        });
+        GridRow.mutateCell(row, index, Structs.elementnew(substitution(), true));
       }
     });
   }

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/MergingOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/MergingOperations.ts
@@ -49,6 +49,30 @@ const uniqueCells = function (row: Structs.ElementNew[], comparator: CompElm) {
   }, [] as Structs.ElementNew[]);
 };
 
+const splitCols = function (grid: Structs.RowCells[], index: number, comparator: CompElm, substitution: Subst) {
+  // We don't need to split rows if we're inserting at the first or last row of the old table
+  if (index > 0 && index < grid[0].cells().length) {
+    Arr.each(grid, (row) => {
+      // only make a sub when we have to
+      let replacement = Option.none<Element>();
+      const prevCell = row.cells()[index - 1];
+      const current = row.cells()[index];
+      const isToReplace = comparator(current.element(), prevCell.element());
+
+      if (isToReplace) {
+        if (replacement.isNone()) {
+          replacement = Option.some(substitution());
+        }
+        replacement.each(function (sub) {
+          GridRow.mutateCell(row, index, Structs.elementnew(sub, true));
+        });
+      }
+    });
+  }
+
+  return grid;
+};
+
 const splitRows = function (grid: Structs.RowCells[], index: number, comparator: CompElm, substitution: Subst) {
   // We don't need to split rows if we're inserting at the first or last row of the old table
   if (index > 0 && index < grid.length) {
@@ -81,5 +105,6 @@ const splitRows = function (grid: Structs.RowCells[], index: number, comparator:
 export {
   merge,
   unmerge,
+  splitCols,
   splitRows
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
@@ -1,7 +1,7 @@
+import { HTMLTableRowElement } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import { Attr, Element, Insert, InsertAll, Remove, Replication, SelectorFind, Traverse } from '@ephox/sugar';
 import { Detail, DetailNew, RowDataNew } from '../api/Structs';
-import { Node as DomNode } from '@ephox/dom-globals';
 
 const setIfNot = function (element: Element, property: string, value: number, ignore: number): void {
   if (value === ignore) {
@@ -89,19 +89,17 @@ const render = function <T extends DetailNew> (table: Element, grid: RowDataNew<
   };
 };
 
-const copy = function <T extends Detail> (grid: RowDataNew<T>[]): Element<DomNode>[] {
-  return Arr.map(grid, function (row) {
-    // Shallow copy the row element
-    const tr = Replication.shallow(row.element());
-    Arr.each(row.cells(), function (cell) {
-      const clonedCell = Replication.deep(cell.element());
-      setIfNot(clonedCell, 'colspan', cell.colspan(), 1);
-      setIfNot(clonedCell, 'rowspan', cell.rowspan(), 1);
-      Insert.append(tr, clonedCell);
-    });
-    return tr;
+const copy = <T extends Detail> (grid: RowDataNew<T>[]): Element<HTMLTableRowElement>[] => Arr.map(grid, (row) => {
+  // Shallow copy the row element
+  const tr = Replication.shallow(row.element());
+  Arr.each(row.cells(), (cell) => {
+    const clonedCell = Replication.deep(cell.element());
+    setIfNot(clonedCell, 'colspan', cell.colspan(), 1);
+    setIfNot(clonedCell, 'rowspan', cell.rowspan(), 1);
+    Insert.append(tr, clonedCell);
   });
-};
+  return tr;
+});
 
 export {
   render,

--- a/modules/snooker/src/test/ts/browser/CopyColumnsTest.ts
+++ b/modules/snooker/src/test/ts/browser/CopyColumnsTest.ts
@@ -1,0 +1,122 @@
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { HTMLTableElement } from '@ephox/dom-globals';
+import { Arr, Fun } from '@ephox/katamari';
+import { Body, Element, Hierarchy, Html, Insert, Remove } from '@ephox/sugar';
+import { copyCols } from 'ephox/snooker/api/CopyCols';
+
+UnitTest.test('CopyColumnsTest', () => {
+  const check = (
+    inputHtml: string,
+    expectedHtml: string,
+    section: number,
+    row: number,
+    column: number
+  ) => {
+    const table = Element.fromHtml<HTMLTableElement>(inputHtml);
+    Insert.append(Body.body(), table);
+
+    const rows = copyCols(table, {
+      selection: Fun.constant([ Hierarchy.follow(table, [ section, row, column, 0 ]).getOrDie() ]),
+    }).getOrDie();
+    const copiedHtml = Arr.map(rows, Html.getOuter).join('');
+
+    Assert.eq('Copied HTML should match', expectedHtml, copiedHtml);
+    Remove.remove(table);
+  };
+
+  check(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+    (
+      '<tr><td>H2</td></tr>' +
+      '<tr><td>B2</td></tr>' +
+      '<tr><td>B3</td></tr>' +
+      '<tr><td>F2</td></tr>'
+    ),
+    0, 0, 1
+  );
+
+  check(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td rowspan="2">A2</td><td>B2</td></tr>' +
+      '<tr><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+    (
+      '<tr><td>H1</td></tr>' +
+      '<tr><td rowspan="2">A2</td></tr>' +
+      '<tr></tr>' +
+      '<tr><td>F1</td></tr>'
+    ),
+    1, 0, 0
+  );
+
+  check(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td colspan="2">A3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+    (
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td colspan="2">A3</td></tr>' +
+      '<tr><td>F1</td><td>F2</td></tr>'
+    ),
+    1, 1, 0
+  );
+
+  check(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td colspan="2">A3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+    (
+      '<tr><td>H1</td></tr>' +
+      '<tr><td>A2</td></tr>' +
+      '<tr><td>A3</td></tr>' +
+      '<tr><td>F1</td></tr>'
+    ),
+    1, 0, 0
+  );
+});

--- a/modules/snooker/src/test/ts/browser/CopyRowsTest.ts
+++ b/modules/snooker/src/test/ts/browser/CopyRowsTest.ts
@@ -1,0 +1,125 @@
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { HTMLTableElement } from '@ephox/dom-globals';
+import { Arr, Fun } from '@ephox/katamari';
+import { Body, Element, Hierarchy, Html, Insert, Remove } from '@ephox/sugar';
+import { copyRows } from 'ephox/snooker/api/CopyRows';
+import * as Bridge from 'ephox/snooker/test/Bridge';
+
+UnitTest.test('CopyColumnsTest', () => {
+  const check = (
+    inputHtml: string,
+    expectedHtml: string,
+    section: number,
+    row: number,
+    column: number
+  ) => {
+    const table = Element.fromHtml<HTMLTableElement>(inputHtml);
+    Insert.append(Body.body(), table);
+
+    const rows = copyRows(table, {
+      selection: Fun.constant([ Hierarchy.follow(table, [ section, row, column, 0 ]).getOrDie() ]),
+    }, Bridge.generators).getOrDie();
+    const copiedHtml = Arr.map(rows, Html.getOuter).join('');
+
+    Assert.eq('Copied HTML should match', expectedHtml, copiedHtml);
+    Remove.remove(table);
+  };
+
+  check(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+    '<tr><td>H1</td><td>H2</td></tr>',
+    0, 0, 0
+  );
+
+  check(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+    '<tr><td>F1</td><td>F2</td></tr>',
+    2, 0, 1
+  );
+
+  check(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td colspan="2">A3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+    '<tr><td colspan="2">A3</td></tr>',
+    1, 1, 0
+  );
+
+  check(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td rowspan="2">A2</td><td>B2</td></tr>' +
+      '<tr><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+    (
+      '<tr><td rowspan="2">A2</td><td>B2</td></tr>' +
+      '<tr><td>B3</td></tr>'
+    ),
+    1, 0, 0
+  );
+
+  check(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td rowspan="2">A2</td><td>B2</td></tr>' +
+      '<tr><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+    '<tr><td>A2</td><td>B3</td></tr>',
+    1, 1, 0
+  );
+});

--- a/modules/snooker/src/test/ts/browser/PasteColumnOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/PasteColumnOperationsTest.ts
@@ -1,0 +1,223 @@
+import { UnitTest } from '@ephox/bedrock-client';
+import * as TableOperations from 'ephox/snooker/api/TableOperations';
+import * as Assertions from 'ephox/snooker/test/Assertions';
+
+UnitTest.test('PasteColumnOperationsTest', () => {
+  Assertions.checkPaste(
+    (
+      '<table>' +
+        '<thead>' +
+          '<tr><td>H1</td><td>X1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+          '<tr><td>A2</td><td>X2</td><td>B2</td></tr>' +
+          '<tr><td>A3</td><td>X3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+          '<tr><td>F1</td><td>X4</td><td>F2</td></tr>' +
+        '</tfoot>' +
+      '</table>'
+    ),
+
+    (
+      '<table>' +
+        '<thead>' +
+          '<tr><td>H1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+          '<tr><td>A2</td><td>B2</td></tr>' +
+          '<tr><td>A3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+          '<tr><td>F1</td><td>F2</td></tr>' +
+        '</tfoot>' +
+      '</table>'
+    ),
+
+    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+
+    TableOperations.pasteColsAfter, 0, 0, 0
+  );
+
+  Assertions.checkPaste(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td><td>X1</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td><td>X2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td><td>X3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td><td>X4</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+
+    TableOperations.pasteColsAfter, 1, 1, 1
+  );
+
+  Assertions.checkPaste(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>X1</td><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>X2</td><td>A2</td><td>B2</td></tr>' +
+      '<tr><td>X3</td><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>X4</td><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+
+    TableOperations.pasteColsBefore, 0, 0, 0
+  );
+
+  Assertions.checkPaste(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>X1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>X2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>X3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>X4</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+
+    TableOperations.pasteColsBefore, 1, 1, 1
+  );
+
+  // Colspan
+  Assertions.checkPaste(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td colspan="2">X1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>X2</td><td>Y2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>X3</td><td>Y3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>X4</td><td>Y4</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    '<tr><td colspan="2">X1</td></tr><tr><td>X2</td><td>Y2</td></tr><tr><td>X3</td><td>Y3</td></tr><tr><td>X4</td><td>Y4</td></tr>',
+
+    TableOperations.pasteColsAfter, 0, 0, 0
+  );
+
+  // Rowspan
+  Assertions.checkPaste(
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>X1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td rowspan="2">X2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>X4</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    (
+      '<table>' +
+      '<thead>' +
+      '<tr><td>H1</td><td>H2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td></tr>' +
+      '</tbody>' +
+      '<tfoot>' +
+      '<tr><td>F1</td><td>F2</td></tr>' +
+      '</tfoot>' +
+      '</table>'
+    ),
+
+    '<tr><td>X1</td></tr><tr><td rowspan="2">X2</td></tr><tr></tr><tr><td>X4</td></tr>',
+
+    TableOperations.pasteColsBefore, 1, 0, 1
+  );
+});

--- a/modules/snooker/src/test/ts/browser/PasteRowOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/PasteRowOperationsTest.ts
@@ -1,8 +1,8 @@
+import { UnitTest } from '@ephox/bedrock-client';
 import * as TableOperations from 'ephox/snooker/api/TableOperations';
 import * as Assertions from 'ephox/snooker/test/Assertions';
-import { UnitTest } from '@ephox/bedrock-client';
 
-UnitTest.test('PasteOperationsTest', function () {
+UnitTest.test('PasteRowOperationsTest', () => {
   Assertions.checkPaste(
     (
       '<table>' +

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
@@ -1,18 +1,16 @@
-/* eslint-disable max-len */
 import { assert } from '@ephox/bedrock-client';
+import { HTMLTableDataCellElement, HTMLTableElement, HTMLTableHeaderCellElement } from '@ephox/dom-globals';
 import { Arr, Fun, Option, Options } from '@ephox/katamari';
-import { Attr, Body, Css, Element, Hierarchy, Html, Insert, Remove, SelectorFilter, SelectorFind, Traverse } from '@ephox/sugar';
+import { PlatformDetection } from '@ephox/sand';
+import { Attr, Body, Css, Element, Hierarchy, Html, Insert, Remove, SelectorFilter, Traverse } from '@ephox/sugar';
+import { Generators, SimpleGenerators } from 'ephox/snooker/api/Generators';
 import { ResizeDirection } from 'ephox/snooker/api/ResizeDirection';
 import { ResizeWire } from 'ephox/snooker/api/ResizeWire';
 import * as TableOperations from 'ephox/snooker/api/TableOperations';
+import { RunOperationOutput, TargetElement, TargetPasteRows, TargetSelection } from 'ephox/snooker/model/RunOperation';
+import { BarPositions, ColInfo } from 'ephox/snooker/resize/BarPositions';
 import * as Bars from 'ephox/snooker/resize/Bars';
 import * as Bridge from 'ephox/snooker/test/Bridge';
-import { BarPositions, ColInfo } from 'ephox/snooker/resize/BarPositions';
-import { PlatformDetection } from '@ephox/sand';
-import { RunOperationOutput, TargetSelection, TargetElement, TargetPasteRows } from 'ephox/snooker/model/RunOperation';
-import { SimpleGenerators, Generators } from 'ephox/snooker/api/Generators';
-import { HTMLTableElement, HTMLTableDataCellElement, HTMLTableHeaderCellElement } from '@ephox/dom-globals';
-/* eslint-enable max-len */
 
 type Op<T> = (
   wire: ResizeWire,
@@ -74,7 +72,7 @@ const checkPaste = (
     table,
     {
       selection: Fun.constant([ Hierarchy.follow(table, [ section, row, column, 0 ]).getOrDie() ]),
-      clipboard: Fun.constant([ SelectorFind.descendant(pasteTable, 'tr').getOrDie() ]),
+      clipboard: Fun.constant(SelectorFilter.descendants(pasteTable, 'tr')),
       // Impossible type! This might work in some restricted circumstances.
       generators: Fun.constant(Bridge.generators as SimpleGenerators)
     },

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,8 @@
 Version 5.4.0 (TBD)
     Added all table menu items to the UI registry, so they can be used by name in other menus #TINY-4866
+    Added new table cut, copy and paste column editor commands and menu items #TINY-6006
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
+    Fixed table `Paste row after` and `Paste row before` menu items not disabled when nothing was available to paste #TINY-6006
     Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946
     Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval #TINY-3854
 Version 5.3.1 (2020-05-27)

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -31,8 +31,9 @@ function Plugin(editor: Editor) {
   const cellSelection = CellSelection(editor, resizeHandler.lazyResize, selectionTargets);
   const actions = TableActions(editor, resizeHandler.lazyWire);
   const clipboardRows = Cell(Option.none<Element<any>[]>());
+  const clipboardCols = Cell(Option.none<Element<any>[]>());
 
-  Commands.registerCommands(editor, actions, cellSelection, selections, clipboardRows);
+  Commands.registerCommands(editor, actions, cellSelection, selections, clipboardRows, clipboardCols);
   Clipboard.registerEvents(editor, selections, actions, cellSelection);
 
   MenuItems.addMenuItems(editor, selectionTargets);

--- a/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
@@ -27,6 +27,8 @@ export interface TableActions {
   insertColumnsAfter: (table: any, target: any) => any;
   mergeCells: (table: any, target: any) => any;
   unmergeCells: (table: any, target: any) => any;
+  pasteColsBefore: (table: any, target: any) => any;
+  pasteColsAfter: (table: any, target: any) => any;
   pasteRowsBefore: (table: any, target: any) => any;
   pasteRowsAfter: (table: any, target: any) => any;
   pasteCells: (table: any, target: any) => any;
@@ -91,6 +93,10 @@ export const TableActions = function (editor: Editor, lazyWire) {
 
   const unmergeCells = execute(TableOperations.unmergeCells, Fun.always, Fun.noop, lazyWire);
 
+  const pasteColsBefore = execute(TableOperations.pasteColsBefore, Fun.always, Fun.noop, lazyWire);
+
+  const pasteColsAfter = execute(TableOperations.pasteColsAfter, Fun.always, Fun.noop, lazyWire);
+
   const pasteRowsBefore = execute(TableOperations.pasteRowsBefore, Fun.always, Fun.noop, lazyWire);
 
   const pasteRowsAfter = execute(TableOperations.pasteRowsAfter, Fun.always, Fun.noop, lazyWire);
@@ -106,6 +112,8 @@ export const TableActions = function (editor: Editor, lazyWire) {
     insertColumnsAfter,
     mergeCells,
     unmergeCells,
+    pasteColsBefore,
+    pasteColsAfter,
     pasteRowsBefore,
     pasteRowsAfter,
     pasteCells

--- a/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { HTMLTableRowElement } from '@ephox/dom-globals';
+import { Cell, Option } from '@ephox/katamari';
+import { Element } from '@ephox/sugar';
+
+export interface Clipboard {
+  getRows: () => Option<Element<HTMLTableRowElement>[]>;
+  setRows: (rows: Option<Element<HTMLTableRowElement>[]>) => void;
+  clearRows: () => void;
+
+  getColumns: () => Option<Element<HTMLTableRowElement>[]>;
+  setColumns: (columns: Option<Element<HTMLTableRowElement>[]>) => void;
+  clearColumns: () => void;
+}
+
+export const Clipboard = (): Clipboard => {
+  const rows = Cell(Option.none<Element<HTMLTableRowElement>[]>());
+  const cols = Cell(Option.none<Element<HTMLTableRowElement>[]>());
+
+  return {
+    getRows: rows.get,
+    setRows: rows.set,
+    clearRows: () => rows.set(Option.none()),
+    getColumns: cols.get,
+    setColumns: cols.set,
+    clearColumns: () => cols.set(Option.none())
+  };
+};

--- a/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
@@ -23,12 +23,22 @@ export const Clipboard = (): Clipboard => {
   const rows = Cell(Option.none<Element<HTMLTableRowElement>[]>());
   const cols = Cell(Option.none<Element<HTMLTableRowElement>[]>());
 
+  const clearClipboard = (clipboard: Cell<Option<Element<any>[]>>) => {
+    clipboard.set(Option.none());
+  };
+
   return {
     getRows: rows.get,
-    setRows: rows.set,
-    clearRows: () => rows.set(Option.none()),
+    setRows: (r: Option<Element<HTMLTableRowElement>[]>) => {
+      rows.set(r);
+      clearClipboard(cols);
+    },
+    clearRows: () => clearClipboard(rows),
     getColumns: cols.get,
-    setColumns: cols.set,
-    clearColumns: () => cols.set(Option.none())
+    setColumns: (c: Option<Element<HTMLTableRowElement>[]>) => {
+      cols.set(c);
+      clearClipboard(rows);
+    },
+    clearColumns: () => clearClipboard(cols)
   };
 };

--- a/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
@@ -58,6 +58,9 @@ export const getSelectionTargets = (editor: Editor, selections: Selections) => {
 
   const onSetupTable = (api) => onSetup(api, (_) => false);
   const onSetupCellOrRow = (api) => onSetup(api, (targets) => Node.name(targets.element()) === 'caption');
+  const onSetupPasteable = (getClipboardData: () => Option<Element[]>) => (api) => onSetup(api, (targets) =>
+    Node.name(targets.element()) === 'caption' || getClipboardData().isNone()
+  );
   const onSetupMergeable = (api) => onSetup(api, (targets) => targets.mergable().isNone());
   const onSetupUnmergeable = (api) => onSetup(api, (targets) => targets.unmergable().isNone());
 
@@ -66,6 +69,7 @@ export const getSelectionTargets = (editor: Editor, selections: Selections) => {
   return {
     onSetupTable,
     onSetupCellOrRow,
+    onSetupPasteable,
     onSetupMergeable,
     onSetupUnmergeable,
     resetTargets,

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
@@ -8,9 +8,10 @@
 import { Node } from '@ephox/dom-globals';
 import Editor from 'tinymce/core/api/Editor';
 import { getToolbar } from '../api/Settings';
+import { Clipboard } from '../core/Clipboard';
 import { SelectionTargets } from '../selection/SelectionTargets';
 
-const addButtons = (editor: Editor, selectionTargets: SelectionTargets) => {
+const addButtons = (editor: Editor, selectionTargets: SelectionTargets, clipboard: Clipboard) => {
   editor.ui.registry.addMenuButton('table', {
     tooltip: 'Table',
     icon: 'table',
@@ -103,33 +104,61 @@ const addButtons = (editor: Editor, selectionTargets: SelectionTargets) => {
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
-  // TODO: Need icons!!
+  // TODO: TINY-6062 Need icons!!
   editor.ui.registry.addButton('tablecutrow', {
     tooltip: 'Cut row',
+    icon: 'table-cut-row',
     onAction: cmd('mceTableCutRow'),
-    icon: 'temporary-placeholder',
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
   editor.ui.registry.addButton('tablecopyrow', {
     tooltip: 'Copy row',
+    icon: 'table-copy-row',
     onAction: cmd('mceTableCopyRow'),
-    icon: 'temporary-placeholder',
-    onSetup: selectionTargets.onSetupCellOrRow
+    onSetup: selectionTargets.onSetupPasteable(clipboard.getRows)
   });
 
   editor.ui.registry.addButton('tablepasterowbefore', {
     tooltip: 'Paste row before',
+    icon: 'table-paste-row-before',
     onAction: cmd('mceTablePasteRowBefore'),
-    icon: 'temporary-placeholder',
-    onSetup: selectionTargets.onSetupCellOrRow
+    onSetup: selectionTargets.onSetupPasteable(clipboard.getRows)
   });
 
   editor.ui.registry.addButton('tablepasterowafter', {
     tooltip: 'Paste row after',
+    icon: 'table-paste-row-after',
     onAction: cmd('mceTablePasteRowAfter'),
-    icon: 'temporary-placeholder',
     onSetup: selectionTargets.onSetupCellOrRow
+  });
+
+  editor.ui.registry.addButton('tablecutcol', {
+    tooltip: 'Cut column',
+    icon: 'table-cut-column',
+    onAction: cmd('mceTableCutCol'),
+    onSetup: selectionTargets.onSetupCellOrRow
+  });
+
+  editor.ui.registry.addButton('tablecopycol', {
+    tooltip: 'Copy column',
+    icon: 'table-copy-column',
+    onAction: cmd('mceTableCopyCol'),
+    onSetup: selectionTargets.onSetupCellOrRow
+  });
+
+  editor.ui.registry.addButton('tablepastecolbefore', {
+    tooltip: 'Paste column before',
+    icon: 'table-paste-column-before',
+    onAction: cmd('mceTablePasteColBefore'),
+    onSetup: selectionTargets.onSetupPasteable(clipboard.getColumns)
+  });
+
+  editor.ui.registry.addButton('tablepastecolafter', {
+    tooltip: 'Paste column after',
+    icon: 'table-paste-column-after',
+    onAction: cmd('mceTablePasteColAfter'),
+    onSetup: selectionTargets.onSetupPasteable(clipboard.getColumns)
   });
 
   editor.ui.registry.addButton('tableinsertdialog', {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -10,9 +10,10 @@ import { Node } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import * as InsertTable from '../actions/InsertTable';
 import { hasTableGrid } from '../api/Settings';
+import { Clipboard } from '../core/Clipboard';
 import { SelectionTargets } from '../selection/SelectionTargets';
 
-const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets) => {
+const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipboard: Clipboard) => {
   const cmd = (command) => () => editor.execCommand(command);
 
   const insertTableAction = ({ numRows, numColumns }) => {
@@ -61,25 +62,30 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets) => {
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
+  // TODO: TINY-6062 Need icons!!
   editor.ui.registry.addMenuItem('tablecutrow', {
     text: 'Cut row',
+    // icon: 'table-cut-row',
     onAction: cmd('mceTableCutRow'),
     onSetup: selectionTargets.onSetupCellOrRow
   });
   editor.ui.registry.addMenuItem('tablecopyrow', {
     text: 'Copy row',
+    // icon: 'table-copy-row',
     onAction: cmd('mceTableCopyRow'),
     onSetup: selectionTargets.onSetupCellOrRow
   });
   editor.ui.registry.addMenuItem('tablepasterowbefore', {
     text: 'Paste row before',
+    // icon: 'table-paste-row-before',
     onAction: cmd('mceTablePasteRowBefore'),
-    onSetup: selectionTargets.onSetupCellOrRow
+    onSetup: selectionTargets.onSetupPasteable(clipboard.getRows)
   });
   editor.ui.registry.addMenuItem('tablepasterowafter', {
     text: 'Paste row after',
+    // icon: 'table-paste-row-after',
     onAction: cmd('mceTablePasteRowAfter'),
-    onSetup: selectionTargets.onSetupCellOrRow
+    onSetup: selectionTargets.onSetupPasteable(clipboard.getRows)
   });
 
   const row: Menu.NestedMenuItemApi = {
@@ -107,10 +113,33 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets) => {
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
+  // TODO: TINY-6062 Need icons!!
+  editor.ui.registry.addMenuItem('tablecutcolumn', {
+    text: 'Cut column',
+    onAction: cmd('mceTableCutCol'),
+    onSetup: selectionTargets.onSetupCellOrRow
+  });
+  editor.ui.registry.addMenuItem('tablecopycolumn', {
+    text: 'Copy column',
+    onAction: cmd('mceTableCopyCol'),
+    onSetup: selectionTargets.onSetupCellOrRow
+  });
+  editor.ui.registry.addMenuItem('tablepastecolumnbefore', {
+    text: 'Paste column before',
+    onAction: cmd('mceTablePasteColBefore'),
+    onSetup: selectionTargets.onSetupPasteable(clipboard.getColumns)
+  });
+  editor.ui.registry.addMenuItem('tablepastecolumnafter', {
+    text: 'Paste column after',
+    onAction: cmd('mceTablePasteColAfter'),
+    onSetup: selectionTargets.onSetupPasteable(clipboard.getColumns)
+  });
+
   const column: Menu.NestedMenuItemApi = {
     type: 'nestedmenuitem',
     text: 'Column',
-    getSubmenuItems: () => 'tableinsertcolumnbefore tableinsertcolumnafter tabledeletecolumn'
+    // TODO: Add the column cut/copy/paste menu items in TinyMCE 5.5 or whenever we are able to get them translated
+    getSubmenuItems: () => 'tableinsertcolumnbefore tableinsertcolumnafter tabledeletecolumn' // | tablecutcolumn tablecopycolumn tablepastecolumnbefore tablepastecolumnafter'
   };
 
   editor.ui.registry.addMenuItem('tablecellprops', {

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,3 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
-katamari@6.0.0
-sugar@6.0.0
-alloy@7.0.0
+snooker@5.2.0


### PR DESCRIPTION
Description of Changes:
* This adds the ability to cut, copy and paste columns in the same manner as the existing row functionality.

**Note:** No icons are available for this yet.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
