### PR TITLE
hiding empty dom.controlselection pg

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -32,6 +32,7 @@ interface ControlSelection {
  * that can be resized and needs to be selected as a whole. It adds custom resize handles
  * to all browser engines that support properly disabling the built in resize logic.
  *
+ * @private
  * @class tinymce.dom.ControlSelection
  */
 


### PR DESCRIPTION
Related Ticket: https://github.com/tinymce/tinymce-docs/issues/1397

Description of Changes:
* Marking the empty `tinymce.dom.controlselection` API Docs page as private: https://www.tiny.cloud/docs/api/tinymce.dom/tinymce.dom.controlselection/

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): https://github.com/tinymce/tinymce-docs/issues/1397
