### PR TITLE
TINY-6064 Enforce table section order in Snooker's Redraw.ts

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
@@ -41,7 +41,7 @@ export interface DetailExt extends Detail {
   readonly column: () => number;
 }
 
-type Section = 'tfoot' | 'thead' | 'tbody';
+export type Section = 'tfoot' | 'thead' | 'tbody';
 
 export interface RowCells {
   readonly cells: () => ElementNew[];

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
@@ -1,5 +1,5 @@
-import { Arr } from '@ephox/katamari';
-import { Attr, Element, Insert, InsertAll, Remove, Replication, SelectorFind, Traverse } from '@ephox/sugar';
+import { Arr, Fun } from '@ephox/katamari';
+import { Attr, Element, Insert, InsertAll, Remove, Replication, SelectorFind, Traverse, SelectorFilter } from '@ephox/sugar';
 import { Detail, DetailNew, RowDataNew } from '../api/Structs';
 import { Node as DomNode } from '@ephox/dom-globals';
 
@@ -20,10 +20,15 @@ const render = function <T extends DetailNew> (table: Element, grid: RowDataNew<
   const newRows: Element[] = [];
   const newCells: Element[] = [];
 
+  const insertThead = Arr.last(SelectorFilter.children(table, 'caption,colgroup')).fold(
+    () => Fun.curry(Insert.prepend, table),
+    (c) => Fun.curry(Insert.after, c)
+  );
+
   const renderSection = function (gridSection: RowDataNew<T>[], sectionName: 'thead' | 'tbody' | 'tfoot') {
     const section = SelectorFind.child(table, sectionName).getOrThunk(function () {
       const tb = Element.fromTag(sectionName, Traverse.owner(table).dom());
-      Insert.append(table, tb);
+      sectionName === 'thead' ? insertThead(tb) : Insert.append(table, tb); // mutation
       return tb;
     });
 

--- a/modules/snooker/src/test/ts/browser/RedrawSectionOrderTest.ts
+++ b/modules/snooker/src/test/ts/browser/RedrawSectionOrderTest.ts
@@ -1,0 +1,200 @@
+import { ApproxStructure, Assertions, Logger, Pipeline, Step } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Arr, Unicode } from '@ephox/katamari';
+import { Compare, Element, Traverse } from '@ephox/sugar';
+import * as DetailsList from 'ephox/snooker/model/DetailsList';
+import * as Transitions from 'ephox/snooker/model/Transitions';
+import { Warehouse } from 'ephox/snooker/model/Warehouse';
+import * as Redraw from 'ephox/snooker/operate/Redraw';
+import * as Bridge from 'ephox/snooker/test/Bridge';
+import * as Structs from 'ephox/snooker/api/Structs';
+
+UnitTest.asynctest('Redraw Section Order Test', (success, failure) => {
+
+  const getRowData = (table: Element) => {
+    const findRow = (details: Structs.DetailNew[]) => {
+      const rowOfCells = Arr.findMap(details, (detail) =>
+        Traverse.parent(detail.element()).map((row) =>
+          Structs.elementnew(row, false)));
+      return rowOfCells.getOrThunk(() => Structs.elementnew(Bridge.generators.row(), true));
+    };
+
+    const input = DetailsList.fromTable(table);
+    const warehouse = Warehouse.generate(input);
+    const model = Transitions.toGrid(warehouse, Bridge.generators, false);
+    const rendered = Transitions.toDetails(model, Compare.eq);
+
+    return Arr.map(rendered, (details) => {
+      const row = findRow(details.details());
+      return Structs.rowdatanew(row.element(), details.details(), details.section(), row.isNew());
+    });
+  };
+
+  const changeTableSections = (table: Element<any>, rowIndex: number, newSection: Structs.Section) => {
+    const updatedModelData = Arr.map(getRowData(table), (row, i) =>
+      i === rowIndex ? Structs.rowdatanew(row.element(), row.cells(), newSection, row.isNew()) : row);
+    Redraw.render(table, updatedModelData);
+  };
+
+  const basicRowStructure = (s: any, str: any, text: string) => s.element('tr', {
+    children: [
+      s.element('td', {
+        children: [ s.text(str.is(text)) ]
+      }),
+      s.element('td', {
+        children: [ s.text(str.is(Unicode.nbsp)) ]
+      }),
+      s.element('td', {
+        children: [ s.text(str.is(Unicode.nbsp)) ]
+      })
+    ]
+  });
+
+  Pipeline.async({}, [
+    Logger.t('Assert that changing section types maintains correct section order', Step.sync(() => {
+      const table = Element.fromHtml(`<table><tbody><tr><td>one</td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>two</td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>three</td><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table>`);
+
+      Assertions.assertStructure('Should be a basic table', ApproxStructure.build((s, str, _arr) => s.element('table', {
+        children: [
+          s.element('tbody', {
+            children: [
+              basicRowStructure(s, str, 'one'),
+              basicRowStructure(s, str, 'two'),
+              basicRowStructure(s, str, 'three'),
+            ]
+          })
+        ]
+      })), table);
+
+      changeTableSections(table, 1, 'thead');
+
+      Assertions.assertStructure('Should be a table with a thead', ApproxStructure.build((s, str, _arr) => s.element('table', {
+        children: [
+          s.element('thead', {
+            children: [
+              basicRowStructure(s, str, 'two')
+            ]
+          }),
+          s.element('tbody', {
+            children: [
+              basicRowStructure(s, str, 'one'),
+              basicRowStructure(s, str, 'three'),
+            ]
+          })
+        ]
+      })), table);
+
+      changeTableSections(table, 1, 'tfoot');
+
+      Assertions.assertStructure('Should be a table with a thead and a tfoot', ApproxStructure.build((s, str, _arr) => s.element('table', {
+        children: [
+          s.element('thead', {
+            children: [
+              basicRowStructure(s, str, 'two')
+            ]
+          }),
+          s.element('tbody', {
+            children: [
+              basicRowStructure(s, str, 'three'),
+            ]
+          }),
+          s.element('tfoot', {
+            children: [
+              basicRowStructure(s, str, 'one'),
+            ]
+          })
+        ]
+      })), table);
+
+      changeTableSections(table, 0, 'tbody');
+
+      Assertions.assertStructure('Thead should have become top row of tbody', ApproxStructure.build((s, str, _arr) => s.element('table', {
+        children: [
+          s.element('tbody', {
+            children: [
+              basicRowStructure(s, str, 'two'),
+              basicRowStructure(s, str, 'three'),
+            ]
+          }),
+          s.element('tfoot', {
+            children: [
+              basicRowStructure(s, str, 'one'),
+            ]
+          })
+        ]
+      })), table);
+    })),
+    Logger.t('Assert that theads go after colgroup elements', Step.sync(() => {
+      const table = Element.fromHtml(`<table><colgroup><col style="width: 50%"><col style="width: 50%"></colgroup><tbody><tr><td>one</td><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table>`);
+
+      Assertions.assertStructure('Should be a basic table with a colgroup', ApproxStructure.build((s, str, _arr) => s.element('table', {
+        children: [
+          s.element('colgroup', {
+            children: [
+              s.element('col', { styles: { width: str.is('50%') }}),
+              s.element('col', { styles: { width: str.is('50%') }})
+            ]
+          }),
+          s.element('tbody', {
+            children: [
+              basicRowStructure(s, str, 'one')
+            ]
+          })
+        ]
+      })), table);
+
+      changeTableSections(table, 0, 'thead');
+
+      Assertions.assertStructure('Should be a table with a colgroup and a thead', ApproxStructure.build((s, str, _arr) => s.element('table', {
+        children: [
+          s.element('colgroup', {
+            children: [
+              s.element('col', { styles: { width: str.is('50%') }}),
+              s.element('col', { styles: { width: str.is('50%') }})
+            ]
+          }),
+          s.element('thead', {
+            children: [
+              basicRowStructure(s, str, 'one')
+            ]
+          })
+        ]
+      })), table);
+    })),
+    Logger.t('Assert that theads go after caption elements', Step.sync(() => {
+      const table = Element.fromHtml(`<table><caption>some caption</caption<tbody><tr><td>one</td><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table>`);
+
+      Assertions.assertStructure('Should be a basic table with a caption', ApproxStructure.build((s, str, _arr) => s.element('table', {
+        children: [
+          s.element('caption', {
+            children: [
+              s.text(str.is('some caption'))
+            ]
+          }),
+          s.element('tbody', {
+            children: [
+              basicRowStructure(s, str, 'one')
+            ]
+          })
+        ]
+      })), table);
+
+      changeTableSections(table, 0, 'thead');
+
+      Assertions.assertStructure('Should be a table with a caption and a thead', ApproxStructure.build((s, str, _arr) => s.element('table', {
+        children: [
+          s.element('caption', {
+            children: [
+              s.text(str.is('some caption'))
+            ]
+          }),
+          s.element('thead', {
+            children: [
+              basicRowStructure(s, str, 'one')
+            ]
+          })
+        ]
+      })), table);
+    }))
+  ], success, failure);
+});


### PR DESCRIPTION
Related Ticket: TINY-6064

Description of Changes:
* I was looking into thead/tfoot operations using Snooker and realised Redraw.ts didn't enforce correct section order (caption, colgroups, thead, tbody/trs, tfoot) because I was getting output with tbody then thead, etc. This fixes that.

Pre-checks:
* [x] Changelog entry added - No changelog in Snooker, and TinyMCE's table plugin doesn't use Snooker for theads and such (yet) so unnecessary?
* [x] Tests have been added 
* [x] Branch prefixed with `feature/` for new features (if applicable) - N/A
* [x] License headers added on new files (if applicable) - N/A

Review:
* [x] Milestone set
* [x] Review comments resolved
