### PR TITLE
Add links to docs for context toolbars/forms/menus

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -44,6 +44,7 @@ const registry = () => {
      * of a contextual form is the link plugin when the configuration
      * { link_context_toolbar: true } is used. When the cursor is on a link, a
      * contextual input form appears allowing for quick changes to the url field.
+     * <br>
      * For information on creating context forms, see:
      * <a href="https://www.tiny.cloud/docs/ui-components/contextform/">
      * UI Components - Context forms</a>.
@@ -58,6 +59,7 @@ const registry = () => {
     /**
      * Registers a new context menu section that only appears when a content predicate is matched,
      * for example, the cursor is inside a table.
+     * <br>
      * For information on creating context menus, see:
      * <a href="https://www.tiny.cloud/docs/ui-components/contextmenu/">
      * UI Components - Context Menu</a>.
@@ -72,6 +74,7 @@ const registry = () => {
     /**
      * Registers a new context toolbar that only appears when a content predicate is matched for example
      * the cursor is on an image element.
+     * <br>
      * For information on creating context toolbars, see:
      * <a href="https://www.tiny.cloud/docs/ui-components/contexttoolbar/">
      * UI Components - Context Toolbar</a>.

--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -41,9 +41,9 @@ const registry = () => {
      * Registers a new contextual form item.
      * Similar to a context menu item, a contextual form is an item with an input
      * form element appearing when a content predicate is matched. An example
-     * us of a contextual form is the link plugin when the configuration
+     * of a contextual form is the link plugin when the configuration
      * { link_context_toolbar: true } is used. When the cursor is on a link, a
-     * contextual input form appears allowing for quick changes to the url field.
+     * contextual input form appears allowing for quick changes to the url field. For information on creating context forms, see: <a href="https://www.tiny.cloud/docs/ui-components/contextform/">UI Components - Context forms</a>.
      *
      * @method addContextForm
      * @param {String} name Unique name identifying the new contextual form item.
@@ -53,7 +53,7 @@ const registry = () => {
     addContextForm: bridge.addContextForm,
 
     /**
-     * Registers a new context menu section that only appears when a content predicate is matched for example the cursor is inside a table.
+     * Registers a new context menu section that only appears when a content predicate is matched, for example, the cursor is inside a table. For information on creating context menus, see: <a href="https://www.tiny.cloud/docs/ui-components/contextmenu/">UI Components - Context Menu</a>.
      *
      * @method addContextMenu
      * @param {String} name Unique name identifying the new context menu.
@@ -63,7 +63,7 @@ const registry = () => {
     addContextMenu: bridge.addContextMenu,
 
     /**
-     * Registers a new context toolbar that only appears when a content predicate is matched for example the cursor is on an image element.
+     * Registers a new context toolbar that only appears when a content predicate is matched for example the cursor is on an image element. For information on creating context toolbars, see: <a href="https://www.tiny.cloud/docs/ui-components/contexttoolbar/">UI Components - Context Toolbar</a>.
      *
      * @method addContextToolbar
      * @param {String} name Unique name identifying the new context toolbar.

--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -43,7 +43,10 @@ const registry = () => {
      * form element appearing when a content predicate is matched. An example
      * of a contextual form is the link plugin when the configuration
      * { link_context_toolbar: true } is used. When the cursor is on a link, a
-     * contextual input form appears allowing for quick changes to the url field. For information on creating context forms, see: <a href="https://www.tiny.cloud/docs/ui-components/contextform/">UI Components - Context forms</a>.
+     * contextual input form appears allowing for quick changes to the url field.
+     * For information on creating context forms, see:
+     * <a href="https://www.tiny.cloud/docs/ui-components/contextform/">
+     * UI Components - Context forms</a>.
      *
      * @method addContextForm
      * @param {String} name Unique name identifying the new contextual form item.
@@ -53,7 +56,11 @@ const registry = () => {
     addContextForm: bridge.addContextForm,
 
     /**
-     * Registers a new context menu section that only appears when a content predicate is matched, for example, the cursor is inside a table. For information on creating context menus, see: <a href="https://www.tiny.cloud/docs/ui-components/contextmenu/">UI Components - Context Menu</a>.
+     * Registers a new context menu section that only appears when a content predicate is matched,
+     * for example, the cursor is inside a table.
+     * For information on creating context menus, see:
+     * <a href="https://www.tiny.cloud/docs/ui-components/contextmenu/">
+     * UI Components - Context Menu</a>.
      *
      * @method addContextMenu
      * @param {String} name Unique name identifying the new context menu.
@@ -63,7 +70,11 @@ const registry = () => {
     addContextMenu: bridge.addContextMenu,
 
     /**
-     * Registers a new context toolbar that only appears when a content predicate is matched for example the cursor is on an image element. For information on creating context toolbars, see: <a href="https://www.tiny.cloud/docs/ui-components/contexttoolbar/">UI Components - Context Toolbar</a>.
+     * Registers a new context toolbar that only appears when a content predicate is matched for example
+     * the cursor is on an image element.
+     * For information on creating context toolbars, see:
+     * <a href="https://www.tiny.cloud/docs/ui-components/contexttoolbar/">
+     * UI Components - Context Toolbar</a>.
      *
      * @method addContextToolbar
      * @param {String} name Unique name identifying the new context toolbar.


### PR DESCRIPTION
Related Ticket: https://github.com/tinymce/tinymce-docs/issues/1461

Description of Changes:
* Updating API docs for `addContextForm`, `addContextMenu`, and `addContextToolbar` to include a link to the relevant docs pages.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): https://github.com/tinymce/tinymce-docs/issues/1461
