### PR TITLE
Support shadow roots in SelectorFind.descendant.

### DIFF
--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Selectors.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Selectors.ts
@@ -1,10 +1,7 @@
-import { document, Document, Element as DomElement, Node as DomNode } from '@ephox/dom-globals';
+import { document, Document, DocumentFragment, Element as DomElement, Node as DomNode } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
 import Element from '../node/Element';
-import * as NodeTypes from '../node/NodeTypes';
-
-const ELEMENT = NodeTypes.ELEMENT;
-const DOCUMENT = NodeTypes.DOCUMENT;
+import { ELEMENT, DOCUMENT, DOCUMENT_FRAGMENT } from '../node/NodeTypes';
 
 const is = <T extends DomElement = DomElement> (element: Element<DomNode>, selector: string): element is Element<T> => {
   const dom = element.dom();
@@ -28,10 +25,11 @@ const is = <T extends DomElement = DomElement> (element: Element<DomNode>, selec
 };
 
 const bypassSelector = (dom: DomNode) =>
-  // Only elements and documents support querySelector
-  dom.nodeType !== ELEMENT && dom.nodeType !== DOCUMENT ||
+  // Only elements, documents and shadow roots support querySelector
+  // shadow root element type is DOCUMENT_FRAGMENT
+  dom.nodeType !== ELEMENT && dom.nodeType !== DOCUMENT && dom.nodeType !== DOCUMENT_FRAGMENT ||
     // IE fix for complex queries on empty nodes: http://jsfiddle.net/spyder/fv9ptr5L/
-    (dom as DomElement | Document).childElementCount === 0;
+    (dom as DomElement | Document | DocumentFragment).childElementCount === 0;
 
 const all = <T extends DomElement = DomElement> (selector: string, scope?: Element<DomNode>): Element<T>[] => {
   const base = scope === undefined ? document : scope.dom();

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -5,6 +5,12 @@ import * as Insert from 'ephox/sugar/api/dom/Insert';
 import { Element as DomElement, ShadowRoot } from '@ephox/dom-globals';
 import * as SelectorFind from 'ephox/sugar/api/search/SelectorFind';
 
+const shadowDomTest = (name: string, fn: () => void) => {
+  if (DomElement.prototype.hasOwnProperty('attachShadow')) {
+    UnitTest.test(name, fn);
+  }
+};
+
 const mkShadow = (): Element<ShadowRoot> => {
   const body = Body.body();
   const e = Element.fromHtml<DomElement>('<div />');
@@ -14,7 +20,7 @@ const mkShadow = (): Element<ShadowRoot> => {
   return Element.fromDom(shadow);
 };
 
-UnitTest.test('ShadowDom - SelectorFind.descendant', () => {
+shadowDomTest('ShadowDom - SelectorFind.descendant', () => {
   const ss = mkShadow();
   const inner = Element.fromHtml('<div><p>hello<span id="frog">iamthefrog</span></p></div>');
   Insert.append(ss, inner);

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -5,6 +5,7 @@ import * as Insert from 'ephox/sugar/api/dom/Insert';
 import { Element as DomElement, ShadowRoot } from '@ephox/dom-globals';
 import * as SelectorFind from 'ephox/sugar/api/search/SelectorFind';
 import fc, { Arbitrary } from 'fast-check';
+import * as Remove from 'ephox/sugar/api/dom/Remove';
 
 const shadowDomTest = (name: string, fn: () => void) => {
   if (DomElement.prototype.hasOwnProperty('attachShadow')) {
@@ -12,13 +13,19 @@ const shadowDomTest = (name: string, fn: () => void) => {
   }
 };
 
-const mkShadow = (): Element<ShadowRoot> => {
+const withShadow = (f: (shadow: Element<ShadowRoot>) => void): void => {
   const body = Body.body();
   const e = Element.fromHtml<DomElement>('<div />');
   Insert.append(body, e);
 
   const shadow: ShadowRoot = e.dom().attachShadow({ mode: 'open' });
-  return Element.fromDom(shadow);
+  const shadowE: Element<ShadowRoot> = Element.fromDom(shadow);
+
+  try {
+    f(shadowE);
+  } finally {
+    Remove.remove(e);
+  }
 };
 
 const htmlBlockTagName = (): Arbitrary<string> =>
@@ -31,12 +38,13 @@ const htmlInlineTagName = (): Arbitrary<string> =>
 
 shadowDomTest('ShadowDom - SelectorFind.descendant', () => {
   fc.assert(fc.property(htmlBlockTagName(), htmlInlineTagName(), fc.hexaString(), (block, inline, text) => {
-    const ss = mkShadow();
-    const id = 'theid';
-    const inner = Element.fromHtml(`<${block}><p>hello<${inline} id="${id}">${text}</${inline}></p></${block}>`);
-    Insert.append(ss, inner);
+    withShadow((ss) => {
+      const id = 'theid';
+      const inner = Element.fromHtml(`<${block}><p>hello<${inline} id="${id}">${text}</${inline}></p></${block}>`);
+      Insert.append(ss, inner);
 
-    const frog: Element<DomElement> = SelectorFind.descendant(ss, `#${id}`).getOrDie('Element not found');
-    Assert.eq('textcontent', text, frog.dom().textContent);
+      const frog: Element<DomElement> = SelectorFind.descendant(ss, `#${id}`).getOrDie('Element not found');
+      Assert.eq('textcontent', text, frog.dom().textContent);
+    });
   }));
 });

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -1,0 +1,21 @@
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import Element from 'ephox/sugar/api/node/Element';
+import * as Body from 'ephox/sugar/api/node/Body';
+import * as Insert from 'ephox/sugar/api/dom/Insert';
+import { Element as DomElement, ShadowRoot, window } from '@ephox/dom-globals';
+import * as SelectorFind from 'ephox/sugar/api/search/SelectorFind';
+
+UnitTest.test('ShadowDom - SelectorFind.descendant', () => {
+  const body = Body.body();
+  const e = Element.fromHtml<DomElement>('<div />');
+  Insert.append(body, e);
+
+  const shadow: ShadowRoot = e.dom().attachShadow({ mode: 'open' });
+  const ss: Element<ShadowRoot> = Element.fromDom(shadow);
+  const inner = Element.fromHtml('<div><p>hello<span id="frog">iamthefrog</span></p></div>');
+  (window as any).myshadow = shadow;
+  Insert.append(ss, inner);
+
+  const frog: Element<DomElement> = SelectorFind.descendant(ss, '#frog').getOrDie('Element not found');
+  Assert.eq('textcontent', 'iamthefrog', frog.dom().textContent);
+});

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -2,18 +2,21 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import Element from 'ephox/sugar/api/node/Element';
 import * as Body from 'ephox/sugar/api/node/Body';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
-import { Element as DomElement, ShadowRoot, window } from '@ephox/dom-globals';
+import { Element as DomElement, ShadowRoot } from '@ephox/dom-globals';
 import * as SelectorFind from 'ephox/sugar/api/search/SelectorFind';
 
-UnitTest.test('ShadowDom - SelectorFind.descendant', () => {
+const mkShadow = (): Element<ShadowRoot> => {
   const body = Body.body();
   const e = Element.fromHtml<DomElement>('<div />');
   Insert.append(body, e);
 
   const shadow: ShadowRoot = e.dom().attachShadow({ mode: 'open' });
-  const ss: Element<ShadowRoot> = Element.fromDom(shadow);
+  return Element.fromDom(shadow);
+};
+
+UnitTest.test('ShadowDom - SelectorFind.descendant', () => {
+  const ss = mkShadow();
   const inner = Element.fromHtml('<div><p>hello<span id="frog">iamthefrog</span></p></div>');
-  (window as any).myshadow = shadow;
   Insert.append(ss, inner);
 
   const frog: Element<DomElement> = SelectorFind.descendant(ss, '#frog').getOrDie('Element not found');


### PR DESCRIPTION
Related Ticket: TINY-6067

Description of Changes:
* The bypassSelector function was not considering that shadow roots support querySelector.

Pre-checks:
* [x] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
n/a