### PR TITLE
TINY-5986: Fixed leading and trailing spaces lost when using `editor.selection.getContent({ format: 'text' })`

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -4,6 +4,7 @@ Version 5.4.0 (TBD)
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946
     Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval #TINY-3854
+    Fixed leading and trailing spaces lost when using `editor.selection.getContent({ format: 'text' })` #TINY-5986
     Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020

--- a/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
@@ -5,10 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { HTMLElement } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 import { Element } from '@ephox/sugar';
 import Editor from '../api/Editor';
+import Env from '../api/Env';
 import { Content, ContentFormat, GetContentArgs } from '../content/ContentTypes';
+import * as CharType from '../text/CharType';
 import * as Zwsp from '../text/Zwsp';
 import * as EventProcessRanges from './EventProcessRanges';
 import * as FragmentReader from './FragmentReader';
@@ -19,15 +22,43 @@ export interface GetSelectionContentArgs extends GetContentArgs {
   contextual?: boolean;
 }
 
+const trimLeadingCollapsibleText = (text: string) => text.replace(/^[ \f\n\r\t\v]+/, '');
+const isCollapsibleWhitespace = (text: string, index: number) => index >= 0 && index < text.length && CharType.isWhiteSpace(text.charAt(index));
+
+const getInnerText = (bin: HTMLElement) => {
+  const text = Zwsp.trim(bin.innerText);
+  // Trim leading collapsible whitespace on IE 11, as on IE 11 innerText doesn't consider how it'll render.
+  // Firefox, IE and Edge also actually render trailing spaces in some cases, so don't trim trailing whitespace.
+  return Env.browser.isIE() ? trimLeadingCollapsibleText(text) : text;
+};
+
 const getTextContent = (editor: Editor): string => Option.from(editor.selection.getRng()).map((rng) => {
   const bin = editor.dom.add(editor.getBody(), 'div', {
     'data-mce-bogus': 'all',
     'style': 'overflow: hidden; opacity: 0;'
   }, rng.cloneContents());
+  const text = getInnerText(bin);
 
-  const text = Zwsp.trim(bin.innerText);
+  // textContent will not strip leading/trailing spaces since it doesn't consider how it'll render
+  const nonRenderedText = Zwsp.trim(bin.textContent);
   editor.dom.remove(bin);
-  return text;
+
+  if (isCollapsibleWhitespace(nonRenderedText, 0) || isCollapsibleWhitespace(nonRenderedText, nonRenderedText.length - 1)) {
+    // If the bin contains a trailing/leading space, then we need to inspect the parent block to see if we should include the spaces
+    const parentBlock = editor.dom.getParent(rng.commonAncestorContainer, editor.dom.isBlock) as HTMLElement;
+    const parentBlockText = getInnerText(parentBlock);
+    const textIndex = parentBlockText.indexOf(text);
+
+    if (textIndex !== -1) {
+      const hasProceedingSpace = isCollapsibleWhitespace(parentBlockText, textIndex - 1);
+      const hasTrailingSpace = isCollapsibleWhitespace(parentBlockText, textIndex + text.length);
+      return (hasProceedingSpace ? ' ' : '') + text + (hasTrailingSpace ? ' ' : '');
+    } else {
+      return text;
+    }
+  } else {
+    return text;
+  }
 }).getOr('');
 
 const getSerializedContent = (editor: Editor, args: GetSelectionContentArgs): Content => {


### PR DESCRIPTION
Description of Changes:

This fixes the `editor.selection.getContent({ format: 'text' })` API so that leading/trailing spaces are retained when used in an inline context, whereby the spaces aren't collapsible whitespace.

This wasn't the easiest to solve, since we need to pull the selection out to get the content, which means that we then need to compare it to the original location and see if the rendered version of the parent block element contained the leading/trailing spaces. Added to that, some browsers render trailing spaces differently in specific edge cases, so we discussed this on slack and decided we should try and follow what's rendered in the different browsers since that's what users would see and expect the output to be.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
