### PR TITLE
Tiny 2711: Removed editor.settings-calls to editor.getParam

### DIFF
--- a/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
@@ -40,6 +40,7 @@ export interface Editor {
   focus: () => void;
   hasFocus: () => boolean;
   remove: () => void;
+  getParam: <T>(key: string, defaultValue?: T, type?: string) => T;
 
   setProgressState: (state: boolean, time?: number) => void;
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
@@ -26,7 +26,7 @@ const ModernThemeSelectors: ThemeSelectors = {
 };
 
 const SilverThemeSelectors: ThemeSelectors = {
-  toolBarSelector: (editor: Editor) => Arr.exists([ editor.settings.toolbar_mode, editor.settings.toolbar_drawer ], (s) => s === 'floating' || s === 'sliding') ? '.tox-toolbar-overlord' : '.tox-toolbar',
+  toolBarSelector: (editor: Editor) => Arr.exists([ editor.getParam('toolbar_mode'), editor.getParam('toolbar_drawer') ], (s) => s === 'floating' || s === 'sliding') ? '.tox-toolbar-overlord' : '.tox-toolbar',
   menuBarSelector: '.tox-menubar',
   dialogCloseSelector: '.tox-button:contains("Cancel")',
   dialogSubmitSelector: '.tox-button:contains("Save")'

--- a/modules/tinymce/src/core/main/ts/NodeChange.ts
+++ b/modules/tinymce/src/core/main/ts/NodeChange.ts
@@ -10,6 +10,7 @@ import Editor from './api/Editor';
 import Env from './api/Env';
 import Delay from './api/util/Delay';
 import * as RangeCompare from './selection/RangeCompare';
+import * as Settings from './api/Settings';
 import { hasAnyRanges } from './selection/SelectionUtils';
 
 /**
@@ -101,7 +102,7 @@ class NodeChange {
     let node, parents, root;
 
     // Fix for bug #1896577 it seems that this can not be fired while the editor is loading
-    if (this.editor.initialized && selection && !this.editor.settings.disable_nodechange && !this.editor.mode.isReadOnly()) {
+    if (this.editor.initialized && selection && !Settings.shouldDisableNodeChange(this.editor) && !this.editor.mode.isReadOnly()) {
       // Get start node
       root = this.editor.getBody();
       node = selection.getStart(true) || root;

--- a/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
@@ -10,6 +10,7 @@ import { Obj } from '@ephox/katamari';
 import { isReadOnly, preventReadOnlyEvents } from '../mode/Readonly';
 import DOMUtils from './dom/DOMUtils';
 import Editor from './Editor';
+import * as Settings from './Settings';
 import { EditorEventMap } from './EventTypes';
 import Observable from './util/Observable';
 import Tools from './util/Tools';
@@ -46,9 +47,11 @@ const getEventTarget = function (editor: Editor, eventName: string): Node {
   }
 
   // Bind to event root instead of body if it's defined
-  if (editor.settings.event_root) {
+  const eventRoot = Settings.getEventRoot(editor);
+
+  if (eventRoot) {
     if (!editor.eventRoot) {
-      editor.eventRoot = DOM.select(editor.settings.event_root)[0];
+      editor.eventRoot = DOM.select(eventRoot)[0];
     }
 
     return editor.eventRoot;
@@ -88,7 +91,7 @@ const bindEventDelegate = function (editor: Editor, eventName: string) {
 
   const eventRootElm = getEventTarget(editor, eventName);
 
-  if (editor.settings.event_root) {
+  if (Settings.getEventRoot(editor)) {
     if (!customEventRootDelegates) {
       customEventRootDelegates = {};
       editor.editorManager.on('removeEditor', function () {

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -9,6 +9,7 @@ import { Element } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
 import * as EditorView from '../EditorView';
 import { NotificationManagerImpl } from '../ui/NotificationManagerImpl';
+import * as Settings from './Settings';
 import Editor from './Editor';
 import Delay from './util/Delay';
 
@@ -130,7 +131,7 @@ function NotificationManager(editor: Editor): NotificationManager {
 
   const registerEvents = function (editor: Editor) {
     editor.on('SkinLoaded', function () {
-      const serviceMessage = editor.settings.service_message;
+      const serviceMessage = Settings.getServiceMessage(editor);
 
       if (serviceMessage) {
         open({

--- a/modules/tinymce/src/core/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/core/main/ts/api/Settings.ts
@@ -16,6 +16,8 @@ import Tools from './util/Tools';
 
 const DOM = DOMUtils.DOM;
 
+const defaultPreviewStyles = 'font-family font-size font-weight font-style text-decoration text-transform color background-color border border-radius outline text-shadow';
+
 const getBodySetting = (editor: Editor, name: string, defaultValue: string) => {
   const value = editor.getParam(name, defaultValue);
 
@@ -104,7 +106,7 @@ const shouldIndentUseMargin = (editor: Editor): boolean => editor.getParam('inde
 const getIndentation = (editor: Editor): string => editor.getParam('indentation', '40px', 'string');
 
 const getContentCss = (editor: Editor): string[] => {
-  const contentCss = editor.settings.content_css;
+  const contentCss = editor.getParam('content_css');
 
   if (Type.isString(contentCss)) {
     return Arr.map(contentCss.split(','), Strings.trim);
@@ -128,6 +130,58 @@ const getResizeImgProportional = (editor: Editor): boolean => editor.getParam('r
 const getPlaceholder = (editor: Editor): string =>
   // Fallback to the original elements placeholder if not set in the settings
   editor.getParam('placeholder', DOM.getAttrib(editor.getElement(), 'placeholder'), 'string');
+
+const getEventRoot = (editor: Editor): string => editor.getParam('event_root');
+
+const getServiceMessage = (editor: Editor): string => editor.getParam('service_message');
+
+const getTheme = (editor: Editor) => editor.getParam('theme');
+
+const shouldValidate = (editor: Editor): boolean => editor.getParam('validate');
+
+const isInlineBoundariesEnabled = (editor: Editor): boolean => editor.getParam('inline_boundaries') !== false;
+
+const getFormats = (editor: Editor) => editor.getParam('formats');
+
+const getPreviewStyles = (editor: Editor): string => {
+  const style = editor.getParam('preview_styles', defaultPreviewStyles);
+
+  if (Type.isString(style)) {
+    return style;
+  } else {
+    return '';
+  }
+};
+
+const getCustomUiSelector = (editor: Editor): string => editor.getParam('custom_ui_selector', '', 'string');
+
+const getThemeUrl = (editor: Editor): string => editor.getParam('theme_url');
+
+const isInline = (editor: Editor): boolean => editor.getParam('inline');
+
+const hasHiddenInput = (editor: Editor): boolean => editor.getParam('hidden_input');
+
+const shouldPatchSubmit = (editor: Editor): boolean => editor.getParam('submit_patch');
+
+const isEncodingXml = (editor: Editor): boolean => editor.getParam('encoding') === 'xml';
+
+const shouldAddFormSubmitTrigger = (editor: Editor): boolean => editor.getParam('add_form_submit_trigger');
+
+const shouldAddUnloadTrigger = (editor: Editor): boolean => editor.getParam('add_unload_trigger');
+
+const hasForcedRootBlock = (editor: Editor): boolean => getForcedRootBlock(editor) !== '';
+
+const getCustomUndoRedoLevels = (editor: Editor): number => editor.getParam('custom_undo_redo_levels', 0, 'number');
+
+const shouldDisableNodeChange = (editor: Editor): boolean => editor.getParam('disable_nodechange');
+
+const isReadOnly = (editor: Editor): boolean => editor.getParam('readonly');
+
+const hasContentCssCors = (editor: Editor): boolean => editor.getParam('content_css_cors');
+
+const getPlugins = (editor: Editor) => editor.getParam('plugins');
+
+const getExternalPlugins = (editor: Editor) => editor.getParam('external_plugins');
 
 export {
   getIframeAttrs,
@@ -166,5 +220,27 @@ export {
   getInlineBoundarySelector,
   getObjectResizing,
   getResizeImgProportional,
-  getPlaceholder
+  getPlaceholder,
+  getEventRoot,
+  getServiceMessage,
+  getTheme,
+  shouldValidate,
+  isInlineBoundariesEnabled,
+  getFormats,
+  getPreviewStyles,
+  getCustomUiSelector,
+  getThemeUrl,
+  isInline,
+  hasHiddenInput,
+  shouldPatchSubmit,
+  isEncodingXml,
+  shouldAddFormSubmitTrigger,
+  shouldAddUnloadTrigger,
+  hasForcedRootBlock,
+  getCustomUndoRedoLevels,
+  shouldDisableNodeChange,
+  isReadOnly,
+  hasContentCssCors,
+  getPlugins,
+  getExternalPlugins
 };

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -24,6 +24,7 @@ import * as PaddingBr from '../dom/PaddingBr';
 import * as RangeNormalizer from '../selection/RangeNormalizer';
 import * as SelectionUtils from '../selection/SelectionUtils';
 import * as InsertList from './InsertList';
+import * as Settings from '../api/Settings';
 import { isAfterNbsp, trimNbspAfterDeleteAndPadValue, trimOrPadLeftRight } from './NbspTrim';
 
 const isTableCell = NodeType.matchNodeNames([ 'td', 'th' ]);
@@ -230,7 +231,7 @@ export const insertHtmlAtCaret = function (editor: Editor, value: string, detail
   const merge = details.merge;
 
   const serializer = Serializer({
-    validate: editor.settings.validate
+    validate: Settings.shouldValidate(editor)
   }, editor.schema);
   const bookmarkHtml = '<span id="mce_marker" data-mce-type="bookmark">&#xFEFF;&#x200B;</span>';
 

--- a/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
@@ -60,7 +60,7 @@ const setContentString = (editor: Editor, body: HTMLElement, content: string, ar
     // Check if forcedRootBlock is configured and that the block is a valid child of the body
     if (forcedRootBlockName && editor.schema.isValidChild(body.nodeName.toLowerCase(), forcedRootBlockName.toLowerCase())) {
       content = padd;
-      content = editor.dom.createHTML(forcedRootBlockName, editor.settings.forced_root_block_attrs, content);
+      content = editor.dom.createHTML(forcedRootBlockName, Settings.getForcedRootBlockAttrs(editor), content);
     } else if (!content) {
       // We need to add a BR when forced_root_block is disabled on non IE browsers to place the caret
       content = '<br data-mce-bogus="1">';

--- a/modules/tinymce/src/core/main/ts/delete/InlineBoundaryDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/InlineBoundaryDelete.ts
@@ -16,11 +16,8 @@ import * as BoundaryCaret from '../keyboard/BoundaryCaret';
 import * as BoundaryLocation from '../keyboard/BoundaryLocation';
 import * as BoundarySelection from '../keyboard/BoundarySelection';
 import * as InlineUtils from '../keyboard/InlineUtils';
+import * as Settings from '../api/Settings';
 import Editor from '../api/Editor';
-
-const isFeatureEnabled = function (editor: Editor) {
-  return editor.settings.inline_boundaries !== false;
-};
 
 const rangeFromPositions = function (from, to) {
   const range = document.createRange();
@@ -131,7 +128,7 @@ const backspaceDeleteCollapsed = function (editor: Editor, caret, forward: boole
 };
 
 const backspaceDelete = function (editor: Editor, caret, forward?: boolean) {
-  if (editor.selection.isCollapsed() && isFeatureEnabled(editor)) {
+  if (editor.selection.isCollapsed() && Settings.isInlineBoundariesEnabled(editor)) {
     const from = CaretPosition.fromRangeStart(editor.selection.getRng());
     return backspaceDeleteCollapsed(editor, caret, forward, from);
   }

--- a/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
@@ -7,6 +7,7 @@
 
 import { Obj, Type } from '@ephox/katamari';
 import * as DefaultFormats from './DefaultFormats';
+import * as Settings from '../api/Settings';
 import { Format, Formats } from '../api/fmt/Format';
 import Tools from '../api/util/Tools';
 import Editor from '../api/Editor';
@@ -80,7 +81,7 @@ export function FormatRegistry(editor: Editor): FormatRegistry {
   };
 
   register(DefaultFormats.get(editor.dom));
-  register(editor.settings.formats);
+  register(Settings.getFormats(editor));
 
   return {
     get,

--- a/modules/tinymce/src/core/main/ts/focus/FocusController.ts
+++ b/modules/tinymce/src/core/main/ts/focus/FocusController.ts
@@ -13,6 +13,7 @@ import EditorManager from '../api/EditorManager';
 import FocusManager from '../api/FocusManager';
 import Delay from '../api/util/Delay';
 import * as SelectionRestore from '../selection/SelectionRestore';
+import * as Settings from '../api/Settings';
 
 let documentFocusInHandler;
 const DOM = DOMUtils.DOM;
@@ -34,7 +35,7 @@ const isEditorContentAreaElement = function (elm: Element) {
 };
 
 const isUIElement = function (editor: Editor, elm: Element) {
-  const customSelector = editor ? editor.settings.custom_ui_selector : '';
+  const customSelector = Settings.getCustomUiSelector(editor);
   const parent = DOM.getParent(elm, function (elm) {
     return (
       isEditorUIElement(elm) ||

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -59,7 +59,7 @@ const trimLegacyPrefix = function (name: string) {
 const initPlugins = function (editor: Editor) {
   const initializedPlugins = [];
 
-  Tools.each(editor.settings.plugins.split(/[ ,]/), function (name) {
+  Tools.each(Settings.getPlugins(editor).split(/[ ,]/), function (name) {
     initPlugin(editor, initializedPlugins, trimLegacyPrefix(name));
   });
 };
@@ -81,11 +81,11 @@ const initIcons = (editor: Editor) => {
   });
 };
 
-const initTheme = function (editor: Editor) {
-  const theme = editor.settings.theme;
+const initTheme = (editor: Editor) => {
+  const theme = Settings.getTheme(editor);
 
   if (Type.isString(theme)) {
-    editor.settings.theme = trimLegacyPrefix(theme);
+    editor.settings.theme = trimLegacyPrefix(theme); // Kept until a proper API can be made. TINY-6142
 
     const Theme = ThemeManager.get(theme);
     editor.theme = new Theme(editor, ThemeManager.urls[theme]);
@@ -106,7 +106,7 @@ const renderFromLoadedTheme = function (editor: Editor) {
 
 const renderFromThemeFunc = function (editor: Editor) {
   const elm = editor.getElement();
-  const theme = editor.settings.theme as ThemeInitFunc;
+  const theme = Settings.getTheme(editor) as ThemeInitFunc;
   const info = theme(editor, elm);
 
   if (info.editorContainer.nodeType) {
@@ -147,9 +147,9 @@ const renderThemeUi = function (editor: Editor) {
 
   editor.orgDisplay = elm.style.display;
 
-  if (Type.isString(editor.settings.theme)) {
+  if (Type.isString(Settings.getTheme(editor))) {
     return renderFromLoadedTheme(editor);
-  } else if (Type.isFunction(editor.settings.theme)) {
+  } else if (Type.isFunction(Settings.getTheme(editor))) {
     return renderFromThemeFunc(editor);
   } else {
     return renderThemeFalse(editor);

--- a/modules/tinymce/src/core/main/ts/keyboard/BoundarySelection.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/BoundarySelection.ts
@@ -17,6 +17,7 @@ import * as WordSelection from '../selection/WordSelection';
 import * as BoundaryCaret from './BoundaryCaret';
 import * as BoundaryLocation from './BoundaryLocation';
 import * as InlineUtils from './InlineUtils';
+import * as Settings from '../api/Settings';
 
 const setCaretPosition = function (editor: Editor, pos: CaretPosition) {
   const rng = editor.dom.createRng();
@@ -26,10 +27,6 @@ const setCaretPosition = function (editor: Editor, pos: CaretPosition) {
 };
 
 type NodePredicate = (node: Node) => boolean;
-
-const isFeatureEnabled = function (editor: Editor) {
-  return editor.settings.inline_boundaries !== false;
-};
 
 const setSelected = function (state: boolean, elm: HTMLElement) {
   if (state) {
@@ -88,13 +85,13 @@ const renderInsideInlineCaret = function (isInlineTarget: NodePredicate, editor:
 
 const move = function (editor: Editor, caret: Cell<Text>, forward: boolean) {
   return function () {
-    return isFeatureEnabled(editor) ? findLocation(editor, caret, forward).isSome() : false;
+    return Settings.isInlineBoundariesEnabled(editor) ? findLocation(editor, caret, forward).isSome() : false;
   };
 };
 
 const moveWord = function (forward: boolean, editor: Editor, _caret: Cell<Text>) {
   return function () {
-    return isFeatureEnabled(editor) ? WordSelection.moveByWord(forward, editor) : false;
+    return Settings.isInlineBoundariesEnabled(editor) ? WordSelection.moveByWord(forward, editor) : false;
   };
 };
 
@@ -107,7 +104,7 @@ const setupSelectedState = function (editor: Editor): Cell<Text> {
     // as such we should ignore the first node change, as we don't want the editor to steal focus
     // during the initial load. If the content is changed afterwords then we are okay with it
     // stealing focus since it likely means the editor is being interacted with.
-    if (isFeatureEnabled(editor) && !(Env.browser.isIE() && e.initial)) {
+    if (Settings.isInlineBoundariesEnabled(editor) && !(Env.browser.isIE() && e.initial)) {
       toggleInlines(isInlineTarget, editor.dom, e.parents);
       safeRemoveCaretContainer(editor, caret);
       renderInsideInlineCaret(isInlineTarget, editor, caret, e.parents);

--- a/modules/tinymce/src/core/main/ts/keyboard/CefNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/CefNavigation.ts
@@ -139,7 +139,7 @@ const exitPreBlock = (editor: Editor, direction: HDirection, range: Range): void
   const getNextVisualCaretPosition = Fun.curry(CaretUtils.getVisualCaretPosition, caretWalker.next);
   const getPrevVisualCaretPosition = Fun.curry(CaretUtils.getVisualCaretPosition, caretWalker.prev);
 
-  if (range.collapsed && editor.settings.forced_root_block) {
+  if (range.collapsed && Settings.hasForcedRootBlock(editor)) {
     pre = editor.dom.getParent(range.startContainer, 'PRE');
     if (!pre) {
       return;

--- a/modules/tinymce/src/core/main/ts/undo/Operations.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Operations.ts
@@ -12,6 +12,7 @@ import { Event } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 import { UndoManager, Locks, Index, UndoLevel, UndoBookmark } from './UndoManagerTypes';
 import * as GetBookmark from '../bookmark/GetBookmark';
+import * as Settings from '../api/Settings';
 import { setTyping, endTyping } from './TypingState';
 import { isUnlocked } from './Locks';
 
@@ -22,7 +23,6 @@ export const beforeChange = (editor: Editor, locks: Locks, beforeBookmark: UndoB
 };
 
 export const addUndoLevel = (editor: Editor, undoManager: UndoManager, index: Index, locks: Locks, beforeBookmark: UndoBookmark, level?: UndoLevel, event?: Event) => {
-  const settings = editor.settings;
   const currentLevel = Levels.createFromEditor(editor);
 
   level = level || {} as UndoLevel;
@@ -50,8 +50,10 @@ export const addUndoLevel = (editor: Editor, undoManager: UndoManager, index: In
   }
 
   // Time to compress
-  if (settings.custom_undo_redo_levels) {
-    if (undoManager.data.length > settings.custom_undo_redo_levels) {
+  const customUndoRedoLevels = Settings.getCustomUndoRedoLevels(editor);
+
+  if (customUndoRedoLevels) {
+    if (undoManager.data.length > customUndoRedoLevels) {
       for (let i = 0; i < undoManager.data.length - 1; i++) {
         undoManager.data[i] = undoManager.data[i + 1];
       }

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -30,8 +30,7 @@ interface Quirks {
 
 const Quirks = function (editor: Editor): Quirks {
   const each = Tools.each;
-  const BACKSPACE = VK.BACKSPACE, DELETE = VK.DELETE, dom = editor.dom, selection: Selection = editor.selection,
-    settings = editor.settings, parser = editor.parser;
+  const BACKSPACE = VK.BACKSPACE, DELETE = VK.DELETE, dom = editor.dom, selection: Selection = editor.selection, parser = editor.parser;
   const isGecko = Env.gecko, isIE = Env.ie, isWebKit = Env.webkit;
   const mceInternalUrlPrefix = 'data:text/mce-internal,';
   const mceInternalDataType = isIE ? 'Text' : 'URL';
@@ -455,19 +454,19 @@ const Quirks = function (editor: Editor): Quirks {
   /**
    * Sets various Gecko editing options on mouse down and before a execCommand to disable inline table editing that is broken etc.
    */
-  const setGeckoEditingOptions = function () {
-    const setOpts = function () {
+  const setGeckoEditingOptions = () => {
+    const setOpts = () => {
       refreshContentEditable();
 
       setEditorCommandState('StyleWithCSS', false);
       setEditorCommandState('enableInlineTableEditing', false);
 
-      if (!settings.object_resizing) {
+      if (!Settings.getObjectResizing(editor)) {
         setEditorCommandState('enableObjectResizing', false);
       }
     };
 
-    if (!settings.readonly) {
+    if (!Settings.isReadOnly(editor)) {
       editor.on('BeforeExecCommand mousedown', setOpts);
     }
   };
@@ -513,9 +512,9 @@ const Quirks = function (editor: Editor): Quirks {
    * WebKit will produce DIV elements here and there by default. But since TinyMCE uses paragraphs by
    * default we want to change that behavior.
    */
-  const setDefaultBlockType = function () {
-    if (settings.forced_root_block) {
-      editor.on('init', function () {
+  const setDefaultBlockType = () => {
+    if (Settings.getForcedRootBlock(editor)) {
+      editor.on('init', () => {
         setEditorCommandState('DefaultParagraphSeparator', Settings.getForcedRootBlock(editor));
       });
     }

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Settings.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import Editor from 'tinymce/core/api/Editor';
+
+const getInline = (editor: Editor) => editor.getParam('inline');
+
+export {
+  getInline
+};

--- a/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
@@ -218,7 +218,7 @@ const renderMobileTheme = (editor: Editor) => {
       };
 
       const features = Features.setup(realm, editor);
-      const items = Features.detect(editor.settings, features);
+      const items = Features.detect(editor, features);
 
       const actionGroup = {
         label: 'the action group',

--- a/modules/tinymce/src/themes/mobile/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/api/Settings.ts
@@ -6,14 +6,26 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import DefaultStyleFormats from '../features/DefaultStyleFormats';
 
-const isSkinDisabled = (editor: Editor): boolean => editor.settings.skin === false;
+const defaults = [ 'undo', 'bold', 'italic', 'link', 'image', 'bullist', 'styleselect' ];
+
+const isSkinDisabled = (editor: Editor): boolean => editor.getParam('skin') === false;
 
 const readOnlyOnInit = (_editor: Editor) =>
-  // Intentional short circuit, TODO: implement editor.settings.mobile
+  // Intentional short circuit because stub. Was meant to reference a setting for readonly on init in mobile theme
   false;
+
+const getToolbar = (editor: Editor): string[] => editor.getParam('toolbar', defaults, 'array');
+
+const getStyleFormats = (editor: Editor): any[] => editor.getParam('style_formats', DefaultStyleFormats, 'array');
+
+const getSkinUrl = (editor: Editor) => editor.getParam('skin_url');
 
 export {
   isSkinDisabled,
-  readOnlyOnInit
+  readOnlyOnInit,
+  getToolbar,
+  getStyleFormats,
+  getSkinUrl
 };

--- a/modules/tinymce/src/themes/mobile/main/ts/util/CssUrls.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/CssUrls.ts
@@ -7,7 +7,8 @@
 
 import EditorManager from 'tinymce/core/api/EditorManager';
 import Editor from 'tinymce/core/api/Editor';
-import { Obj } from '@ephox/katamari';
+import { Option } from '@ephox/katamari';
+import * as Settings from '../api/Settings';
 
 export interface CssUrls {
   readonly content: string;
@@ -15,7 +16,7 @@ export interface CssUrls {
 }
 
 const derive = (editor: Editor): CssUrls => {
-  const base = Obj.get(editor.settings, 'skin_url').fold(
+  const base = Option.from(Settings.getSkinUrl(editor)).fold(
     () => EditorManager.baseURL + '/skins/ui/oxide',
     (url) => url
   );

--- a/modules/tinymce/src/themes/mobile/main/ts/util/StyleFormats.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/StyleFormats.ts
@@ -8,11 +8,12 @@
 import { Toggling } from '@ephox/alloy';
 import { Arr, Fun, Id, Merger, Obj } from '@ephox/katamari';
 
-import DefaultStyleFormats from '../features/DefaultStyleFormats';
 import * as StylesMenu from '../ui/StylesMenu';
 import * as StyleConversions from './StyleConversions';
+import Editor from 'tinymce/core/api/Editor';
+import * as Settings from '../api/Settings';
 
-const register = (editor, settings) => {
+const register = (editor: Editor) => {
 
   const isSelectedFor = (format) => (): boolean =>
     editor.formatter.match(format);
@@ -44,8 +45,6 @@ const register = (editor, settings) => {
     return newItem;
   };
 
-  const formats = Obj.get(settings, 'style_formats').getOr(DefaultStyleFormats);
-
   const doEnrich = (items) => Arr.map(items, (item) => {
     if (Obj.hasNonNullableKey(item, 'items')) {
       const newItems = doEnrich(item.items);
@@ -62,10 +61,10 @@ const register = (editor, settings) => {
     }
   });
 
-  return doEnrich(formats);
+  return doEnrich(Settings.getStyleFormats(editor));
 };
 
-const prune = (editor, formats) => {
+const prune = (editor: Editor, formats) => {
 
   const doPrune = (items) => Arr.bind(items, (item) => {
     if (item.items !== undefined) {

--- a/modules/tinymce/src/themes/mobile/test/ts/phantom/features/FeatureDetectTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/phantom/features/FeatureDetectTest.ts
@@ -3,17 +3,15 @@ import { Fun } from '@ephox/katamari';
 import * as Features from 'tinymce/themes/mobile/features/Features';
 import { UnitTest } from '@ephox/bedrock-client';
 
-UnitTest.test('features.FeatureDetectTest', function () {
+UnitTest.test('features.FeatureDetectTest', () => {
   /*
    * Check that if the feature is not known, it skips over it
    *
    */
-  const testFeature = function (name, supported) {
-    return {
-      isSupported: Fun.constant(supported),
-      sketch: Fun.constant(name)
-    };
-  };
+  const testFeature = (name: string, supported: boolean) => ({
+    isSupported: Fun.constant(supported),
+    sketch: Fun.constant(name)
+  });
 
   const features = {
     alpha: testFeature('alpha', true),
@@ -22,8 +20,11 @@ UnitTest.test('features.FeatureDetectTest', function () {
     delta: testFeature('delta', true)
   };
 
-  const check = function (label, expected, toolbar) {
-    const actual = Features.detect({ toolbar }, features);
+  const check = (label: string, expected: string[], toolbar: string | string[]) => {
+    const dummyEditor = {
+      getParam: () => toolbar
+    };
+    const actual = Features.detect(dummyEditor as any, features);
     Assertions.assertEq(label, expected, actual);
   };
 

--- a/modules/tinymce/src/themes/mobile/test/ts/phantom/features/IdentifyToolbarTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/phantom/features/IdentifyToolbarTest.ts
@@ -3,26 +3,29 @@ import * as Features from 'tinymce/themes/mobile/features/Features';
 import { UnitTest } from '@ephox/bedrock-client';
 
 UnitTest.test('features.IdentifyToolbarTest', function () {
-  const check = function (label, expected, input) {
-    const actual = Features.identify(input);
+  const check = function (label: string, expected: string[], input: string | string[] | string[][] | undefined) {
+    const dummyEditor = {
+      getParam: (_name: string, defaultValue: any) => input !== undefined ? input : defaultValue
+    };
+    const actual = Features.identify(dummyEditor as any);
     Assertions.assertEq(label, expected, actual);
   };
 
-  check('Default toolbar', [ 'undo', 'bold', 'italic', 'link', 'image', 'bullist', 'styleselect' ], { });
-  check('Empty toolbar', [ ], { toolbar: '' });
-  check('Empty toolbar (array)', [ ], { toolbar: [ ] });
+  check('Default toolbar', [ 'undo', 'bold', 'italic', 'link', 'image', 'bullist', 'styleselect' ], undefined);
+  check('Empty toolbar', [ ], '' );
+  check('Empty toolbar (array)', [ ], [ ] );
 
-  check('Flat toolbar', [ 'undo', 'bold' ], { toolbar: 'undo bold' });
-  check('Flat toolbar (array)', [ 'undo', 'bold' ], { toolbar: [ 'undo', 'bold' ] });
+  check('Flat toolbar', [ 'undo', 'bold' ], 'undo bold' );
+  check('Flat toolbar (array)', [ 'undo', 'bold' ], [ 'undo', 'bold' ] );
 
-  check('Nested toolbar (array)', [ 'undo', 'bold', 'italic' ], { toolbar: [[ 'undo' ], [ 'bold', 'italic' ]] });
+  check('Nested toolbar (array)', [ 'undo', 'bold', 'italic' ], [[ 'undo' ], [ 'bold', 'italic' ]] );
 
-  check('Mixed toolbar (array)', [ 'undo', 'bold', 'redo', 'italic' ], { toolbar: [[ 'undo' ], [ ], [ 'bold redo', 'italic' ]] });
+  check('Mixed toolbar (array)', [ 'undo', 'bold', 'redo', 'italic' ], [[ 'undo' ], [ ], [ 'bold redo', 'italic' ]] );
 
-  check('Toolbar with pipes', [ 'undo', 'bold', 'italic', 'bullist', 'styleselect' ], { toolbar: [[ 'undo | bold | italic' ], [ 'bullist styleselect' ]] });
+  check('Toolbar with pipes', [ 'undo', 'bold', 'italic', 'bullist', 'styleselect' ], [[ 'undo | bold | italic' ], [ 'bullist styleselect' ]] );
 
   check('Unknown identifiers', [
     'undo', 'redo', 'styleselect', 'bold', 'italic', 'alignleft', 'aligncenter', 'alignright', 'alignjustify',
     'bullist', 'numlist', 'outdent', 'indent', 'link', 'image'
-  ], { toolbar: 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image' });
+  ], 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image' );
 });

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -55,7 +55,7 @@ export interface RenderUiComponents {
   outerContainer: AlloyComponent;
 }
 
-export type ToolbarConfig = Array<string | ToolbarGroupSetting> | string | boolean;
+export type ToolbarConfig = Array<string | Settings.ToolbarGroupSetting> | string | boolean;
 
 export interface RenderToolbarConfig {
   toolbar: ToolbarConfig;
@@ -68,11 +68,6 @@ export interface RenderUiConfig extends RenderToolbarConfig {
   menus;
   menubar;
   sidebar: Sidebar.SidebarConfig;
-}
-
-export interface ToolbarGroupSetting {
-  name?: string;
-  items: string[];
 }
 
 export interface RenderArgs {
@@ -376,9 +371,9 @@ const setup = (editor: Editor): RenderInfo => {
     const rawUiConfig: RenderUiConfig = {
       menuItems,
 
-      menus: !editor.settings.menu ? {} : Obj.map(editor.settings.menu, (menu) => ({ ...menu, items: menu.items })),
-      menubar: editor.settings.menubar,
-      toolbar: toolbarOpt.getOrThunk(() => editor.getParam('toolbar', true)),
+      menus: Settings.getMenus(editor),
+      menubar: Settings.getMenubar(editor),
+      toolbar: toolbarOpt.getOrThunk(() => Settings.getToolbar(editor)),
       allowToolbarGroups: toolbarMode === Settings.ToolbarMode.floating,
       buttons,
 

--- a/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
@@ -5,17 +5,21 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj, Option, Type } from '@ephox/katamari';
+import { Arr, Option, Obj, Type } from '@ephox/katamari';
 import { Body, Element, SelectorFind } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import { AllowedFormat } from 'tinymce/core/api/fmt/StyleFormat';
 
+export interface ToolbarGroupSetting {
+  name?: string;
+  items: string[];
+}
+
 const getSkinUrl = function (editor: Editor): string {
-  const settings = editor.settings;
-  const skin = settings.skin;
-  let skinUrl = settings.skin_url;
+  const skin = editor.getParam('skin');
+  let skinUrl = editor.getParam('skin_url');
 
   if (skin !== false) {
     const skinName = skin ? skin : 'oxide';
@@ -35,8 +39,8 @@ const isSkinDisabled = (editor: Editor) => editor.getParam('skin') === false;
 
 const getHeightSetting = (editor: Editor): string | number => editor.getParam('height', Math.max(editor.getElement().offsetHeight, 200));
 const getWidthSetting = (editor: Editor): string | number => editor.getParam('width', DOMUtils.DOM.getStyle(editor.getElement(), 'width'));
-const getMinWidthSetting = (editor: Editor): Option<number> => Option.from(editor.settings.min_width).filter(Type.isNumber);
-const getMinHeightSetting = (editor: Editor): Option<number> => Option.from(editor.settings.min_height).filter(Type.isNumber);
+const getMinWidthSetting = (editor: Editor): Option<number> => Option.from(editor.getParam('min_width')).filter(Type.isNumber);
+const getMinHeightSetting = (editor: Editor): Option<number> => Option.from(editor.getParam('min_height')).filter(Type.isNumber);
 const getMaxWidthSetting = (editor: Editor): Option<number> => Option.from(editor.getParam('max_width')).filter(Type.isNumber);
 const getMaxHeightSetting = (editor: Editor): Option<number> => Option.from(editor.getParam('max_height')).filter(Type.isNumber);
 
@@ -57,9 +61,7 @@ const isToolbarEnabled = (editor: Editor): boolean => {
 
 // Convert toolbar<n> into toolbars array
 const getMultipleToolbarsSetting = (editor: Editor): Option<string[]> => {
-  const keys = Obj.keys(editor.settings);
-  const toolbarKeys = Arr.filter(keys, (key) => /^toolbar([1-9])$/.test(key));
-  const toolbars = Arr.map(toolbarKeys, (key) => editor.getParam(key, false, 'string'));
+  const toolbars = Arr.range(9, (num) => editor.getParam('toolbar' + (num + 1), false, 'string'));
   const toolbarArray = Arr.filter(toolbars, (toolbar) => typeof toolbar === 'string');
   return toolbarArray.length > 0 ? Option.some(toolbarArray) : Option.none();
 };
@@ -118,6 +120,42 @@ const isStickyToolbar = (editor: Editor) => {
 
 const isDraggableModal = (editor: Editor): boolean => editor.getParam('draggable_modal', false, 'boolean');
 
+const getMenus = (editor: Editor) => {
+  const menu = editor.getParam('menu');
+
+  if (menu) {
+    return Obj.map(menu, (menu) => ({ ...menu, items: menu.items }));
+  } else {
+    return {};
+  }
+};
+
+const getMenubar = (editor: Editor) => editor.getParam('menubar');
+
+const getToolbar = (editor: Editor): Array<string | ToolbarGroupSetting> | string | boolean => editor.getParam('toolbar', true);
+
+const getFilePickerCallback = (editor: Editor) => editor.getParam('file_picker_callback');
+
+const getFilePickerTypes = (editor: Editor) => editor.getParam('file_picker_types');
+
+const getFileBrowserCallbackTypes = (editor: Editor) => editor.getParam('file_browser_callback_types');
+
+const noTypeaheadUrls = (editor: Editor) => editor.getParam('typeahead_urls') === false;
+
+const getAnchorTop = (editor: Editor): string => editor.getParam('anchor_top', '#top', 'string');
+
+const getAnchorBottom = (editor: Editor): string => editor.getParam('anchor_bottom', '#bottom', 'string');
+
+const getFilePickerValidatorHandler = (editor: Editor) => {
+  const handler = editor.getParam('file_picker_validator_handler', undefined, 'function');
+  if (handler === undefined) {
+    // Fallback to legacy/deprecated setting
+    return editor.getParam('filepicker_validator_handler', undefined, 'function');
+  } else {
+    return handler;
+  }
+};
+
 export {
   getSkinUrl,
   isReadOnly,
@@ -143,5 +181,15 @@ export {
   isStickyToolbar,
   getToolbarLocation,
   isToolbarLocationBottom,
-  getToolbarGroups
+  getToolbarGroups,
+  getMenus,
+  getMenubar,
+  getToolbar,
+  getFilePickerCallback,
+  getFilePickerTypes,
+  getFileBrowserCallbackTypes,
+  noTypeaheadUrls,
+  getAnchorTop,
+  getAnchorBottom,
+  getFilePickerValidatorHandler
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj } from '@ephox/katamari';
+import { Arr } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { SelectData } from './BespokeSelect';
 
@@ -53,8 +53,8 @@ const split = (rawFormats: string, delimiter: Delimiter): string[] => {
   }
 };
 
-const buildBasicSettingsDataset = (editor: Editor, settingName, defaults, delimiter: Delimiter): BasicSelectDataset => {
-  const rawFormats = Obj.get(editor.settings, settingName).getOr(defaults);
+const buildBasicSettingsDataset = (editor: Editor, settingName: string, defaults: string, delimiter: Delimiter): BasicSelectDataset => {
+  const rawFormats = editor.getParam(settingName, defaults, 'string');
   const data = process(split(rawFormats, delimiter));
   return {
     type: 'basic',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Settings.ts
@@ -6,17 +6,22 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
-import { Obj, Arr } from '@ephox/katamari';
+import { Obj, Arr, Option } from '@ephox/katamari';
 
 const patchPipeConfig = (config: string[] | string) => typeof config === 'string' ? config.split(/[ ,]/) : config;
 
 const shouldNeverUseNative = function (editor: Editor): boolean {
-  return editor.settings.contextmenu_never_use_native || false;
+  return editor.getParam('contextmenu_never_use_native', false, 'boolean');
 };
 
-const getMenuItems = (editor: Editor, name: string, defaultItems: string) => {
+const getMenuItems = (editor: Editor, name: string, defaultItems: string): string[] => {
   const contextMenus = editor.ui.registry.getAll().contextMenus;
-  return Obj.get(editor.settings, name).map(patchPipeConfig).getOrThunk(() => Arr.filter(patchPipeConfig(defaultItems), (item) => Obj.has(contextMenus, item)));
+
+  return Option.from(editor.getParam(name)).map(patchPipeConfig).getOrThunk(() =>
+    Arr.filter(patchPipeConfig(defaultItems), (item) =>
+      Obj.has(contextMenus, item)
+    )
+  );
 };
 
 const isContextMenuDisabled = (editor: Editor): boolean => editor.getParam('contextmenu') === false;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
@@ -52,7 +52,7 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
 
   const getResizeType = (editor): ResizeTypes => {
     // If autoresize is enabled, disable resize
-    const fallback = !Strings.contains(editor.settings.plugins, 'autoresize');
+    const fallback = !Strings.contains(editor.getParam('plugins', '', 'string'), 'autoresize');
     const resize = editor.getParam('resize', fallback);
     if (resize === false) {
       return ResizeTypes.None;
@@ -70,7 +70,7 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
       components.push(ElementPath.renderElementPath(editor, { }, providersBackstage));
     }
 
-    if (Strings.contains(editor.settings.plugins, 'wordcount')) {
+    if (Strings.contains(editor.getParam('plugins', '', 'string'), 'wordcount')) {
       components.push(renderWordCount(editor, providersBackstage));
     }
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -11,10 +11,10 @@ import { Toolbar } from '@ephox/bridge';
 import { console } from '@ephox/dom-globals';
 import { Arr, Obj, Option, Result, Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
-import { getToolbarMode, ToolbarMode } from '../../api/Settings';
+import { getToolbarMode, ToolbarMode, ToolbarGroupSetting } from '../../api/Settings';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
-import { RenderToolbarConfig, ToolbarGroupSetting } from '../../Render';
+import { RenderToolbarConfig } from '../../Render';
 import { renderMenuButton } from '../button/MenuButton';
 import { createAlignSelect } from '../core/complex/AlignSelect';
 import { createFontSelect } from '../core/complex/FontSelect';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -17,7 +17,6 @@ import { Attr, SelectorFind } from '@ephox/sugar';
 import I18n from 'tinymce/core/api/util/I18n';
 import { UiFactoryBackstage, UiFactoryBackstageProviders, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import * as ReadOnly from '../../../ReadOnly';
-import { ToolbarGroupSetting } from '../../../Render';
 import { DisablingConfigs } from '../../alien/DisablingConfigs';
 import { detectSize } from '../../alien/FlatgridAutodetect';
 import { SimpleBehaviours } from '../../alien/SimpleBehaviours';
@@ -34,6 +33,7 @@ import { createTieredDataFrom } from '../../menus/menu/SingleMenu';
 import { ToolbarButtonClasses } from '../button/ButtonClasses';
 import { onToolbarButtonExecute, toolbarButtonEventOrder } from '../button/ButtonEvents';
 import { renderToolbarGroup, ToolbarGroup } from '../CommonToolbar';
+import { ToolbarGroupSetting } from 'tinymce/themes/silver/api/Settings';
 
 interface Specialisation<T> {
   toolbarButtonBehaviours: Array<Behaviour.NamedConfiguredBehaviour<Behaviour.BehaviourConfigSpec, Behaviour.BehaviourConfigDetail>>;


### PR DESCRIPTION
Related Ticket: TINY-2711

Description of Changes:
Changed editor.settings.[something] calls to editor.getParam s and moved all such calls to the settings-file, where applicable.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved