### PR TITLE
TINY-3194: Changed advlist to only show split button if there's more than one options.

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,5 @@
 Version 5.4.0 (TBD)
     Added all table menu items to the UI registry, so they can be used by name in other menus #TINY-4866
-    Added additional font related variables for secondary buttons allowing more specific styling. #TINY-6061
     Changed `advlist` toolbar buttons to only show a dropdown list if there's more than one option #TINY-3194
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.4.0 (TBD)
     Added all table menu items to the UI registry, so they can be used by name in other menus #TINY-4866
     Added additional font related variables for secondary buttons allowing more specific styling. #TINY-6061
+    Changed `advlist` toolbar buttons to only show a dropdown list if there's more than one option #TINY-3194
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946
     Fixed `fullscreen` plugin now removes all classes when the editor is closed #TINY-4048

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -100,7 +100,7 @@ const addButton = function (editor: Editor, id, tooltip, cmd, nodeName, _styles)
 };
 
 const addControl = function (editor, id, tooltip, cmd, nodeName, styles) {
-  if (styles.length > 0) {
+  if (styles.length > 1) {
     addSplitButton(editor, id, tooltip, cmd, nodeName, styles);
   } else {
     addButton(editor, id, tooltip, cmd, nodeName, styles);

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/ToolbarButtonStructureTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/ToolbarButtonStructureTest.ts
@@ -1,0 +1,77 @@
+import { UnitTest } from '@ephox/bedrock-client';
+import { Pipeline, Log, NamedChain, Waiter, Assertions, ApproxStructure, UiFinder } from '@ephox/agar';
+import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
+import ListsPlugin from 'tinymce/plugins/lists/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { Editor } from '@ephox/mcagar';
+import { Body } from '@ephox/sugar';
+
+UnitTest.asynctest('browser.tinymce.plugins.advlist.ToolbarButtonStructureTest', (success, failure) => {
+  AdvListPlugin();
+  ListsPlugin();
+  Theme();
+
+  Pipeline.async({}, [
+    Log.chainsAsStep('TBA', 'Test that one list type = toolbar button NOT splitbutton', [
+      Editor.cFromSettings({
+        theme: 'silver',
+        plugins: 'lists advlist',
+        toolbar: 'numlist',
+        advlist_number_styles: 'default',
+        menubar: false,
+        statusbar: false,
+        base_url: '/project/tinymce/js/tinymce'
+      }),
+      NamedChain.asChain([
+        NamedChain.writeValue('body', Body.body()),
+        NamedChain.direct('body', UiFinder.cFindIn('.tox-editor-header .tox-toolbar .tox-toolbar__group'), 'toolbarGroup'),
+        NamedChain.read('toolbarGroup', Waiter.cTryUntil('', Assertions.cAssertStructure(
+          'Check lists toolbar button structure',
+          ApproxStructure.build((s, str, arr) => s.element('div', {
+            classes: [ arr.has('tox-toolbar__group') ],
+            children: [
+              s.element('button', {
+                classes: [ arr.has('tox-tbtn'), arr.not('tox-split-button') ],
+                attrs: {
+                  title: str.is('Numbered list')
+                }
+              })
+            ]
+          }))
+        ))),
+        NamedChain.outputInput
+      ]),
+      Editor.cRemove
+    ]),
+    Log.chainsAsStep('TBA', 'Test that one list type = toolbar button IS splitbutton', [
+      Editor.cFromSettings({
+        theme: 'silver',
+        plugins: 'lists advlist',
+        toolbar: 'numlist',
+        menubar: false,
+        statusbar: false,
+        base_url: '/project/tinymce/js/tinymce'
+      }),
+      NamedChain.asChain([
+        NamedChain.writeValue('body', Body.body()),
+        NamedChain.direct('body', UiFinder.cFindIn('.tox-editor-header .tox-toolbar .tox-toolbar__group'), 'toolbarGroup'),
+        NamedChain.read('toolbarGroup', Waiter.cTryUntil('', Assertions.cAssertStructure(
+          'Check lists toolbar button structure',
+          ApproxStructure.build((s, str, arr) => s.element('div', {
+            classes: [ arr.has('tox-toolbar__group') ],
+            children: [
+              s.element('div', {
+                classes: [ arr.not('tox-tbtn'), arr.has('tox-split-button') ],
+                attrs: {
+                  title: str.is('Numbered list')
+                }
+              })
+            ]
+          }))
+        ))),
+        NamedChain.outputInput
+      ]),
+      Editor.cRemove
+    ])
+  ], success, failure);
+});


### PR DESCRIPTION
Recreating pull request with the right issue.

Fixes #4776