### PR TITLE
Add functions for interacting with Shadow DOM

### DIFF
--- a/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
@@ -23,6 +23,7 @@ import * as Elements from './node/Elements';
 import * as Fragment from './node/Fragment';
 import * as Node from './node/Node';
 import * as NodeTypes from './node/NodeTypes';
+import * as ShadowDom from './node/ShadowDom';
 import * as Text from './node/Text';
 import * as Alignment from './properties/Alignment';
 import * as Attr from './properties/Attr';
@@ -101,6 +102,7 @@ export {
   Fragment,
   Node,
   NodeTypes,
+  ShadowDom,
   Text,
   Alignment,
   Attr,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
@@ -19,6 +19,8 @@ import * as Body from './node/Body';
 import * as Comment from './node/Comment';
 import * as Comments from './node/Comments';
 import Element from './node/Element';
+import * as Document from './node/Document';
+import * as Head from './node/Head';
 import * as Elements from './node/Elements';
 import * as Fragment from './node/Fragment';
 import * as Node from './node/Node';
@@ -97,9 +99,11 @@ export {
   Body,
   Comment,
   Comments,
+  Document,
   Element,
   Elements,
   Fragment,
+  Head,
   Node,
   NodeTypes,
   ShadowDom,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Document.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Document.ts
@@ -1,0 +1,5 @@
+import Element from './Element';
+import { document, Document as DomDocument } from '@ephox/dom-globals';
+
+export const getDocument = (): Element<DomDocument> =>
+  Element.fromDom(document);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Head.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Head.ts
@@ -1,0 +1,10 @@
+import Element from './Element';
+import { Document, HTMLHeadElement } from '@ephox/dom-globals';
+
+export const getHead = (doc: Element<Document>): Element<HTMLHeadElement> => {
+  const b = doc.dom().getElementsByTagName('head')[0];
+  if (b === null || b === undefined) {
+    throw new Error('Head is not available yet');
+  }
+  return Element.fromDom(b);
+};

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Head.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Head.ts
@@ -2,7 +2,7 @@ import Element from './Element';
 import { Document, HTMLHeadElement } from '@ephox/dom-globals';
 
 export const getHead = (doc: Element<Document>): Element<HTMLHeadElement> => {
-  const b = doc.dom().getElementsByTagName('head')[0];
+  const b = doc.dom().head;
   if (b === null || b === undefined) {
     throw new Error('Head is not available yet');
   }

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Node.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Node.ts
@@ -1,4 +1,13 @@
-import { Comment, Document, Element as DomElement, HTMLElement as DomHTMLElement, HTMLElementTagNameMap, Node as DomNode, Text } from '@ephox/dom-globals';
+import {
+  Comment,
+  Document,
+  DocumentFragment,
+  Element as DomElement,
+  HTMLElement as DomHTMLElement,
+  HTMLElementTagNameMap,
+  Node as DomNode,
+  Text
+} from '@ephox/dom-globals';
 import { HTMLElement } from '@ephox/sand';
 import Element from './Element';
 import * as NodeTypes from './NodeTypes';
@@ -21,6 +30,7 @@ const isHTMLElement = (element: Element<any>): element is Element<DomHTMLElement
 const isElement = isType<DomElement>(NodeTypes.ELEMENT);
 const isText = isType<Text>(NodeTypes.TEXT);
 const isDocument = isType<Document>(NodeTypes.DOCUMENT);
+const isDocumentFragment = isType<DocumentFragment>(NodeTypes.DOCUMENT_FRAGMENT);
 
 const isTag = <K extends keyof HTMLElementTagNameMap>(tag: K) => (e: Element<any>): e is Element<HTMLElementTagNameMap[K]> => isElement(e) && name(e) === tag;
 
@@ -32,6 +42,7 @@ export {
   isHTMLElement,
   isText,
   isDocument,
+  isDocumentFragment,
   isComment,
   isTag
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -62,7 +62,7 @@ export const getContentContainer = (dos: RootNode): Element<DomNode> =>
 
 /** Is this element either a ShadowRoot or a descendent of a ShadowRoot. */
 export const isInShadowRoot = (e: Element<DomNode>): boolean =>
-  isShadowRoot(getRootNode(e));
+  getShadowRoot(e).isSome();
 
 /** If this element is in a ShadowRoot, return it. */
 export const getShadowRoot = (e: Element<DomNode>): Option<Element<ShadowRoot>> => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -21,7 +21,7 @@ export const isDocument = (dos: RootNode): dos is Element<Document> =>
 /**
  * Does the browser support shadow DOM?
  *
- * NOTE: Node.getRootNode() and Element.attachShadow doesn't exist on IE11 and pre-Chromium Edge.
+ * NOTE: Node.getRootNode() and Element.attachShadow don't exist on IE11 and pre-Chromium Edge.
  */
 export const isSupported = (): boolean =>
   Type.isFunction((DomElement.prototype as any).attachShadow) &&

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -31,7 +31,7 @@ export const getRootNode = (e: Element<DomNode>): RootNode => {
   } else {
     // ownerDocument returns null for a document, and Element.fromDom requires non-null,
     // so we have to check if the element is a document.
-    return Node.isDocument(e) ? e : Element.fromDom(e.dom().ownerDocument);
+    return Node.isDocument(e) ? e : Traverse.owner(e);
   }
 };
 
@@ -39,7 +39,7 @@ export const getRootNode = (e: Element<DomNode>): RootNode => {
  * If this is a Document, return it.
  * If this is a ShadowRoot, return its parent document.
  */
-export const actualDocument = (dos: RootNode): Element<Document> =>
+export const getDocument = (dos: RootNode): Element<Document> =>
   Node.isDocument(dos) ? dos : Traverse.owner(dos);
 
 /** Create an element, using the actual document. */
@@ -47,15 +47,15 @@ export const createElement: {
   <K extends keyof HTMLElementTagNameMap>(dos: RootNode, tag: K): Element<HTMLElementTagNameMap[K]>;
   (dos: RootNode, tag: string): Element<HTMLElement>;
 } = (dos: RootNode, tag: string) =>
-  Element.fromTag(tag, actualDocument(dos).dom());
+  Element.fromTag(tag, getDocument(dos).dom());
 
 /** Where style tags need to go. ShadowRoot or document head */
 export const getStyleContainer = (dos: RootNode): Element<DomNode> =>
-  isShadowRoot(dos) ? dos : Head.getHead(actualDocument(dos));
+  isShadowRoot(dos) ? dos : Head.getHead(getDocument(dos));
 
 /** Where content needs to go. ShadowRoot or document body */
 export const getContentContainer = (dos: RootNode): Element<DomNode> =>
-  isShadowRoot(dos) ? dos : Body.getBody(actualDocument(dos));
+  isShadowRoot(dos) ? dos : Body.getBody(getDocument(dos));
 
 /** Is this element either a ShadowRoot or a descendent of a ShadowRoot. */
 export const isInShadowRoot = (e: Element<DomNode>): boolean =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -39,12 +39,6 @@ export const getRootNode = (e: Element<DomNode>): RootNode => {
   }
 };
 
-/**
- * If this is a Document, return it.
- * If this is a ShadowRoot, return its parent document.
- */
-
-
 /** Create an element, using the actual document. */
 export const createElement: {
   <K extends keyof HTMLElementTagNameMap>(dos: RootNode, tag: K): Element<HTMLElementTagNameMap[K]>;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -37,9 +37,14 @@ export const getRootNode = (e: Element<DomNode>): RootNode => {
   }
 };
 
+/**
+ * If this is a Document, return it.
+ * If this is a ShadowRoot, return its parent document.
+ */
 export const actualDocument = (dos: RootNode): Element<Document> =>
   isDocument(dos) ? dos : Element.fromDom(dos.dom().ownerDocument);
 
+/** Create an element, using the actual document. */
 export const createElement: {
   <K extends keyof HTMLElementTagNameMap>(dos: RootNode, tag: K): Element<HTMLElementTagNameMap[K]>;
   (dos: RootNode, tag: string): Element<HTMLElement>;
@@ -54,13 +59,20 @@ export const getStyleContainer = (dos: RootNode): Element<DomNode> =>
 export const getContentContainer = (dos: RootNode): Element<DomNode> =>
   isShadowRoot(dos) ? dos : Body.getBody(actualDocument(dos));
 
+/** Is this element either a ShadowRoot or a descendent of a ShadowRoot. */
 export const isInShadowRoot = (e: Element<DomNode>): boolean =>
   isShadowRoot(getRootNode(e));
 
+/** If this element is in a ShadowRoot, return it. */
 export const getShadowRoot = (e: Element<DomNode>): Option<Element<ShadowRoot>> => {
   const r = getRootNode(e);
   return isShadowRoot(r) ? Option.some(r) : Option.none();
 };
 
+/** Return the host of a ShadowRoot.
+ *
+ * This function will throw if Shadow DOM is unsupported in the browser, or if the host is null.
+ * If you actually have a ShadowRoot, this shouldn't happen.
+ */
 export const getShadowHost = (e: Element<ShadowRoot>): Element<DomElement> =>
   Element.fromDom(e.dom().host);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -1,0 +1,37 @@
+import {
+  Document,
+  Element as DomElement,
+  ElementCreationOptions,
+  Node as DomNode,
+  ShadowRoot
+} from '@ephox/dom-globals';
+import * as NodeTypes from './NodeTypes';
+import { Type } from '@ephox/katamari';
+
+export type RootNode = Document | ShadowRoot;
+
+export const isShadowRoot = (dos: RootNode): dos is ShadowRoot =>
+  dos.nodeType === NodeTypes.DOCUMENT_FRAGMENT;
+
+export const isDocument = (dos: RootNode): dos is Document =>
+  dos.nodeType === NodeTypes.DOCUMENT;
+
+export const isSupported = (): boolean =>
+  Type.isFunction((DomNode.prototype as any).getRootNode);
+
+// NOTE: Node.getRootNode() doesn't exist on IE11 and pre-Chromium Edge
+export const getRootNode = (e: DomElement): RootNode =>
+  isSupported() ? (e as any).getRootNode() : e.ownerDocument;
+
+export const actualDocument = (dos: RootNode): Document =>
+  isDocument(dos) ? dos : dos.ownerDocument;
+
+export const createElement = (dos: RootNode, tagName: string, options?: ElementCreationOptions): DomElement =>
+  actualDocument(dos).createElement(tagName, options);
+
+export const getStyleContainer = (dos: RootNode): DomNode =>
+  isShadowRoot(dos) ? dos : dos.getElementsByTagName('head')[0];
+
+export const getContentContainer = (dos: RootNode): DomNode =>
+  isShadowRoot(dos) ? dos : dos.body;
+

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -22,15 +22,15 @@ export type RootNode = Element<Document | ShadowRoot>;
 export const isShadowRoot = (dos: RootNode): dos is Element<ShadowRoot> =>
   Node.isDocumentFragment(dos);
 
+const supported: boolean =
+  Type.isFunction((DomElement.prototype as any).attachShadow) &&
+  Type.isFunction((DomNode.prototype as any).getRootNode);
+
 /**
  * Does the browser support shadow DOM?
  *
  * NOTE: Node.getRootNode() and Element.attachShadow don't exist on IE11 and pre-Chromium Edge.
  */
-const supported: boolean =
-  Type.isFunction((DomElement.prototype as any).attachShadow) &&
-  Type.isFunction((DomNode.prototype as any).getRootNode);
-
 export const isSupported = Fun.constant(supported);
 
 export const getRootNode: (e: Element<DomNode>) => RootNode =

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -1,37 +1,47 @@
 import {
-  Document,
-  Element as DomElement,
-  ElementCreationOptions,
+  Document, Element as DomElement,
+  HTMLElement, HTMLElementTagNameMap,
   Node as DomNode,
   ShadowRoot
 } from '@ephox/dom-globals';
-import * as NodeTypes from './NodeTypes';
+import * as Node from './Node';
+import * as Head from './Head';
+import * as Body from './Body';
 import { Type } from '@ephox/katamari';
+import Element from './Element';
 
-export type RootNode = Document | ShadowRoot;
+export type RootNode = Element<Document | ShadowRoot>;
 
-export const isShadowRoot = (dos: RootNode): dos is ShadowRoot =>
-  dos.nodeType === NodeTypes.DOCUMENT_FRAGMENT;
+export const isShadowRoot = (dos: RootNode): dos is Element<ShadowRoot> =>
+  Node.isDocumentFragment(dos);
 
-export const isDocument = (dos: RootNode): dos is Document =>
-  dos.nodeType === NodeTypes.DOCUMENT;
+export const isDocument = (dos: RootNode): dos is Element<Document> =>
+  Node.isDocument(dos);
 
 export const isSupported = (): boolean =>
+  Type.isFunction((DomElement.prototype as any).attachShadow) &&
   Type.isFunction((DomNode.prototype as any).getRootNode);
 
 // NOTE: Node.getRootNode() doesn't exist on IE11 and pre-Chromium Edge
-export const getRootNode = (e: DomElement): RootNode =>
-  isSupported() ? (e as any).getRootNode() : e.ownerDocument;
+export const getRootNode = (e: Element<DomNode>): RootNode =>
+  Element.fromDom(isSupported() ? (e.dom() as any).getRootNode() : e.dom().ownerDocument);
 
-export const actualDocument = (dos: RootNode): Document =>
-  isDocument(dos) ? dos : dos.ownerDocument;
+export const actualDocument = (dos: RootNode): Element<Document> =>
+  isDocument(dos) ? dos : Element.fromDom(dos.dom().ownerDocument);
 
-export const createElement = (dos: RootNode, tagName: string, options?: ElementCreationOptions): DomElement =>
-  actualDocument(dos).createElement(tagName, options);
+export const createElement: {
+  <K extends keyof HTMLElementTagNameMap>(dos: RootNode, tag: K): Element<HTMLElementTagNameMap[K]>;
+  (dos: RootNode, tag: string): Element<HTMLElement>;
+} = (dos: RootNode, tag: string) =>
+  Element.fromTag(tag, actualDocument(dos).dom());
 
-export const getStyleContainer = (dos: RootNode): DomNode =>
-  isShadowRoot(dos) ? dos : dos.getElementsByTagName('head')[0];
+/** Where style tags need to go. ShadowRoot or document head */
+export const getStyleContainer = (dos: RootNode): Element<DomNode> =>
+  isShadowRoot(dos) ? dos : Head.getHead(actualDocument(dos));
 
-export const getContentContainer = (dos: RootNode): DomNode =>
-  isShadowRoot(dos) ? dos : dos.body;
+/** Where content needs to go. ShadowRoot or document body */
+export const getContentContainer = (dos: RootNode): Element<DomNode> =>
+  isShadowRoot(dos) ? dos : Body.getBody(actualDocument(dos));
 
+export const isInShadowRoot = (e: Element<DomNode>): boolean =>
+  isShadowRoot(getRootNode(e));

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -9,6 +9,7 @@ import * as Head from './Head';
 import * as Body from './Body';
 import { Option, Type } from '@ephox/katamari';
 import Element from './Element';
+import * as Traverse from '../search/Traverse';
 
 export type RootNode = Element<Document | ShadowRoot>;
 
@@ -42,7 +43,7 @@ export const getRootNode = (e: Element<DomNode>): RootNode => {
  * If this is a ShadowRoot, return its parent document.
  */
 export const actualDocument = (dos: RootNode): Element<Document> =>
-  isDocument(dos) ? dos : Element.fromDom(dos.dom().ownerDocument);
+  isDocument(dos) ? dos : Traverse.owner(dos);
 
 /** Create an element, using the actual document. */
 export const createElement: {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -7,7 +7,7 @@ import {
 import * as Node from './Node';
 import * as Head from './Head';
 import * as Body from './Body';
-import { Option, Type } from '@ephox/katamari';
+import { Fun, Option, Type } from '@ephox/katamari';
 import Element from './Element';
 import * as Traverse from '../search/Traverse';
 
@@ -27,17 +27,17 @@ export const isShadowRoot = (dos: RootNode): dos is Element<ShadowRoot> =>
  *
  * NOTE: Node.getRootNode() and Element.attachShadow don't exist on IE11 and pre-Chromium Edge.
  */
-export const isSupported = (): boolean =>
+const supported: boolean =
   Type.isFunction((DomElement.prototype as any).attachShadow) &&
   Type.isFunction((DomNode.prototype as any).getRootNode);
 
-export const getRootNode = (e: Element<DomNode>): RootNode => {
-  if (isSupported()) {
-    return Element.fromDom((e.dom() as any).getRootNode());
-  } else {
-    return Traverse.documentOrOwner(e);
-  }
-};
+export const isSupported = Fun.constant(supported);
+
+export const getRootNode: (e: Element<DomNode>) => RootNode =
+  supported
+    ? (e) => Element.fromDom((e.dom() as any).getRootNode())
+    : Traverse.documentOrOwner;
+
 
 /** Create an element, using the actual document. */
 export const createElement: {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -16,9 +16,6 @@ export type RootNode = Element<Document | ShadowRoot>;
 export const isShadowRoot = (dos: RootNode): dos is Element<ShadowRoot> =>
   Node.isDocumentFragment(dos);
 
-export const isDocument = (dos: RootNode): dos is Element<Document> =>
-  Node.isDocument(dos);
-
 /**
  * Does the browser support shadow DOM?
  *
@@ -43,7 +40,7 @@ export const getRootNode = (e: Element<DomNode>): RootNode => {
  * If this is a ShadowRoot, return its parent document.
  */
 export const actualDocument = (dos: RootNode): Element<Document> =>
-  isDocument(dos) ? dos : Traverse.owner(dos);
+  Node.isDocument(dos) ? dos : Traverse.owner(dos);
 
 /** Create an element, using the actual document. */
 export const createElement: {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -61,3 +61,6 @@ export const getShadowRoot = (e: Element<DomNode>): Option<Element<ShadowRoot>> 
   const r = getRootNode(e);
   return isShadowRoot(r) ? Option.some(r) : Option.none();
 };
+
+export const getShadowHost = (e: Element<ShadowRoot>): Element<DomElement> =>
+  Element.fromDom(e.dom().host);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
@@ -1,11 +1,22 @@
-import { HTMLElement, Node as DomNode } from '@ephox/dom-globals';
+import { Document, HTMLElement, Node as DomNode } from '@ephox/dom-globals';
 import { Arr, Fun, Option, Type } from '@ephox/katamari';
 import * as Recurse from '../../alien/Recurse';
 import * as Compare from '../dom/Compare';
 import Element from '../node/Element';
+import * as Node from '../node/Node';
 
-// The document associated with the current element
+/**
+ * The document associated with the current element
+ * NOTE: this will throw if the owner is null.
+ */
 const owner = (element: Element<DomNode>) => Element.fromDom(element.dom().ownerDocument);
+
+/**
+ * If the element is a document, return it. Otherwise, return its ownerDocument.
+ * @param dos
+ */
+const documentOrOwner = (dos: Element<DomNode>): Element<Document> =>
+  Node.isDocument(dos) ? dos : owner(dos);
 
 const documentElement = (element: Element<DomNode>) => Element.fromDom(element.dom().ownerDocument.documentElement);
 
@@ -91,6 +102,7 @@ const leaf = (element: Element<DomNode>, offset: number): ElementAndOffset<DomNo
 
 export {
   owner,
+  documentOrOwner,
   defaultView,
   documentElement,
   parent,

--- a/modules/sugar/src/test/ts/browser/HeadTest.ts
+++ b/modules/sugar/src/test/ts/browser/HeadTest.ts
@@ -1,0 +1,16 @@
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import * as Head from 'ephox/sugar/api/node/Head';
+import Element from 'ephox/sugar/api/node/Element';
+import { Testable } from '@ephox/dispute';
+import { document } from '@ephox/dom-globals';
+import { withIframe } from 'ephox/sugar/test/WithHelpers';
+
+UnitTest.test('head in normal document', () => {
+  Assert.eq('head should be head', document.head, Head.getHead(Element.fromDom(document)).dom(), Testable.tStrict);
+});
+
+UnitTest.test('head in iframe', () => {
+  withIframe((div, iframe, cw) => {
+    Assert.eq('head should be iframe head', cw.document.head, Head.getHead(Element.fromDom(cw.document)).dom(), Testable.tStrict);
+  });
+});

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -140,3 +140,11 @@ if (ShadowDom.isSupported()) {
 UnitTest.test('stylecontainer is body for document', () => {
   Assert.eq('Should be head', Body.getBody(Document.getDocument()), ShadowDom.getContentContainer(Document.getDocument()), tElement);
 });
+
+if (ShadowDom.isSupported()) {
+  UnitTest.test('getShadowHost', () => {
+    withShadowElement((sr, inner, sh) => {
+      Assert.eq('Should be shadow host', sh, ShadowDom.getShadowHost(sr), tElement);
+    });
+  });
+}

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -75,7 +75,7 @@ if (ShadowDom.isSupported()) {
   });
 
   UnitTest.test('getRootNode(shadowroot) === shadowroot', () => {
-    withShadowElement((sr, innerDiv) => {
+    withShadowElement((sr) => {
       Assert.eq('should be shadowroot', sr, sr, tElement);
     });
   });

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -13,6 +13,7 @@ import { tElement } from 'ephox/sugar/test/ElementInstances';
 import * as Document from 'ephox/sugar/api/node/Document';
 import * as Head from 'ephox/sugar/api/node/Head';
 import * as Body from 'ephox/sugar/api/node/Body';
+import * as Node from 'ephox/sugar/api/node/Node';
 
 type RootNode = ShadowDom.RootNode;
 
@@ -37,12 +38,12 @@ shadowDomTest('ShadowDom - SelectorFind.descendant', () => {
 
 const shouldBeShadowRoot = (n: RootNode) => {
   Assert.eq('should be shadow root', true, ShadowDom.isShadowRoot(n));
-  Assert.eq('should not be document', false, ShadowDom.isDocument(n));
+  Assert.eq('should not be document', false, Node.isDocument(n));
 };
 
 const shouldBeDocument = (n: RootNode) => {
   Assert.eq('should not be shadow root', false, ShadowDom.isShadowRoot(n));
-  Assert.eq('should be document', true, ShadowDom.isDocument(n));
+  Assert.eq('should be document', true, Node.isDocument(n));
 };
 
 UnitTest.test('getRootNode === document on normal element in dom', () => {

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -2,10 +2,15 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import Element from 'ephox/sugar/api/node/Element';
 import * as Body from 'ephox/sugar/api/node/Body';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
-import { Element as DomElement, ShadowRoot } from '@ephox/dom-globals';
+import { document, Element as DomElement, HTMLIFrameElement, navigator, ShadowRoot, Window } from '@ephox/dom-globals';
 import * as SelectorFind from 'ephox/sugar/api/search/SelectorFind';
 import fc, { Arbitrary } from 'fast-check';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
+import { PlatformDetection } from '@ephox/sand';
+import * as ShadowDom from 'ephox/sugar/api/node/ShadowDom';
+import { Testable } from '@ephox/dispute';
+
+type RootNode = ShadowDom.RootNode;
 
 const shadowDomTest = (name: string, fn: () => void) => {
   if (DomElement.prototype.hasOwnProperty('attachShadow')) {
@@ -47,4 +52,126 @@ shadowDomTest('ShadowDom - SelectorFind.descendant', () => {
       Assert.eq('textcontent', text, frog.dom().textContent);
     });
   }));
+});
+
+
+const withNormalElement = (f: (d: DomElement) => void): void => {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+
+  try {
+    f(div);
+  } finally {
+    document.body.removeChild(div);
+  }
+};
+
+const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: ShadowRoot, innerDiv: DomElement) => void) => {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  const sr = div.attachShadow({ mode });
+  const innerDiv = document.createElement('div');
+  sr.appendChild(innerDiv);
+
+  try {
+    f(sr, innerDiv);
+  } finally {
+    document.body.removeChild(div);
+  }
+};
+
+const withShadowElement = (f: (sr: ShadowRoot, innerDiv: DomElement) => void): void => {
+  withShadowElementInMode('open', f);
+  withShadowElementInMode('closed', f);
+};
+
+
+const withIframe = (f: (div: DomElement, iframe: HTMLIFrameElement, cw: Window) => void): void => {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+
+  const cw = iframe.contentWindow;
+  if (cw === null) {
+    throw new Error('contentWindow was null');
+  }
+
+  cw.document.open();
+  cw.document.write('<html><head></head><body></body><html></html>');
+  const div = cw.document.createElement('div');
+  cw.document.body.appendChild(div);
+  try {
+    f(div, iframe, cw);
+  } finally {
+    document.body.removeChild(iframe);
+  }
+};
+
+const shouldBeShadowRoot = (n: RootNode) => {
+  Assert.eq('should be shadow root', true, ShadowDom.isShadowRoot(n));
+  Assert.eq('should not be document', false, ShadowDom.isDocument(n));
+};
+
+const shouldBeDocument = (n: RootNode) => {
+  Assert.eq('should not be shadow root', false, ShadowDom.isShadowRoot(n));
+  Assert.eq('should be document', true, ShadowDom.isDocument(n));
+};
+
+UnitTest.test('getRootNode === document on normal element in dom', () => {
+  withNormalElement((div) => {
+    Assert.eq('should be document', document, ShadowDom.getRootNode(div), Testable.tStrict);
+  });
+});
+
+UnitTest.test('isDocument(getRootNode) === true on normal element in dom', () => {
+  withNormalElement((div) => {
+    shouldBeDocument(ShadowDom.getRootNode(div));
+  });
+});
+
+UnitTest.test('document is document', () => {
+  shouldBeDocument(document);
+});
+
+if (ShadowDom.isSupported()) {
+  UnitTest.test('getRootNode === shadowroot on element in shadow root', () => {
+    withShadowElement((sr, innerDiv) => {
+      Assert.eq('should be shadowroot', sr, ShadowDom.getRootNode(innerDiv), Testable.tStrict);
+    });
+  });
+
+  UnitTest.test('shadow root is shadow root', () => {
+    withShadowElement((sr, innerDiv) => {
+      shouldBeShadowRoot(ShadowDom.getRootNode(innerDiv));
+      shouldBeShadowRoot(sr);
+    });
+  });
+}
+
+UnitTest.test('getRootNode in iframe', () => {
+  withIframe((div: DomElement, iframe: HTMLIFrameElement, cw: Window) => {
+    Assert.eq('should be inner doc', cw.document, ShadowDom.getRootNode(div), Testable.tStrict);
+  });
+});
+
+UnitTest.test('isDocument in iframe', () => {
+  withIframe((div: DomElement, iframe: HTMLIFrameElement, cw: Window) => {
+    shouldBeDocument(cw.document);
+  });
+});
+
+// TODO: this should be in sand
+const isPhantomJs = (): boolean =>
+  navigator.userAgent.indexOf('PhantomJS') > -1;
+
+UnitTest.test('isSupported platform test', () => {
+  const browser = PlatformDetection.detect().browser;
+  if (browser.isIE()) {
+    Assert.eq('IE does not support root node', false, ShadowDom.isSupported());
+  } else if (browser.isEdge()) {
+    // could be yes or no
+  } else if (isPhantomJs()) {
+    Assert.eq('PhantomJS does not support root node', false, ShadowDom.isSupported());
+  } else {
+    Assert.eq('This browser should support root node', true, ShadowDom.isSupported());
+  }
 });

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -1,11 +1,7 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import Element from 'ephox/sugar/api/node/Element';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
-import {
-  document,
-  Element as DomElement,
-  navigator,
-} from '@ephox/dom-globals';
+import { Element as DomElement, navigator } from '@ephox/dom-globals';
 import * as SelectorFind from 'ephox/sugar/api/search/SelectorFind';
 import fc from 'fast-check';
 import { PlatformDetection } from '@ephox/sand';
@@ -51,7 +47,13 @@ const shouldBeDocument = (n: RootNode) => {
 
 UnitTest.test('getRootNode === document on normal element in dom', () => {
   withNormalElement((div) => {
-    Assert.eq('should be document', document, ShadowDom.getRootNode(div).dom(), Testable.tStrict);
+    Assert.eq('should be document', Document.getDocument(), ShadowDom.getRootNode(div), tElement);
+  });
+});
+
+UnitTest.test('getRootNode(document) === document on normal element in dom', () => {
+  withNormalElement(() => {
+    Assert.eq('should be document', Document.getDocument(), ShadowDom.getRootNode(Document.getDocument()), tElement);
   });
 });
 
@@ -62,13 +64,19 @@ UnitTest.test('isDocument(getRootNode) === true on normal element in dom', () =>
 });
 
 UnitTest.test('document is document', () => {
-  shouldBeDocument(Element.fromDom(document));
+  shouldBeDocument(Document.getDocument());
 });
 
 if (ShadowDom.isSupported()) {
   UnitTest.test('getRootNode === shadowroot on element in shadow root', () => {
     withShadowElement((sr, innerDiv) => {
-      Assert.eq('should be shadowroot', sr.dom(), ShadowDom.getRootNode(innerDiv).dom(), Testable.tStrict);
+      Assert.eq('should be shadowroot', sr, ShadowDom.getRootNode(innerDiv), tElement);
+    });
+  });
+
+  UnitTest.test('getRootNode(shadowroot) === shadowroot', () => {
+    withShadowElement((sr, innerDiv) => {
+      Assert.eq('should be shadowroot', sr, sr, tElement);
     });
   });
 
@@ -112,23 +120,23 @@ UnitTest.test('isSupported platform test', () => {
 if (ShadowDom.isSupported()) {
   UnitTest.test('stylecontainer is shadow root for shadow root', () => {
     withShadowElement((sr) => {
-      Assert.eq('Should be shadow root', sr, ShadowDom.getStyleContainer(sr), tElement)
+      Assert.eq('Should be shadow root', sr, ShadowDom.getStyleContainer(sr), tElement);
     });
   });
 }
 
 UnitTest.test('stylecontainer is head for document', () => {
-  Assert.eq('Should be head', Head.getHead(Document.getDocument()), ShadowDom.getStyleContainer(Document.getDocument()), tElement)
+  Assert.eq('Should be head', Head.getHead(Document.getDocument()), ShadowDom.getStyleContainer(Document.getDocument()), tElement);
 });
 
 if (ShadowDom.isSupported()) {
   UnitTest.test('contentcontainer is shadow root for shadow root', () => {
     withShadowElement((sr) => {
-      Assert.eq('Should be shadow root', sr, ShadowDom.getContentContainer(sr), tElement)
+      Assert.eq('Should be shadow root', sr, ShadowDom.getContentContainer(sr), tElement);
     });
   });
 }
 
 UnitTest.test('stylecontainer is body for document', () => {
-  Assert.eq('Should be head', Body.getBody(Document.getDocument()), ShadowDom.getContentContainer(Document.getDocument()), tElement)
+  Assert.eq('Should be head', Body.getBody(Document.getDocument()), ShadowDom.getContentContainer(Document.getDocument()), tElement);
 });

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -101,7 +101,7 @@ UnitTest.test('isDocument in iframe', () => {
   });
 });
 
-// TODO: this should be in sand
+// TODO: this should be somewhere else (maybe Agar?)
 const isPhantomJs = (): boolean =>
   navigator.userAgent.indexOf('PhantomJS') > -1;
 

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/Arbitrary.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/Arbitrary.ts
@@ -1,0 +1,9 @@
+import fc, { Arbitrary } from 'fast-check';
+
+export const htmlBlockTagName = (): Arbitrary<string> =>
+  // note: list is incomplete
+  fc.constantFrom('div', 'article', 'section', 'main', 'h1', 'h2', 'h3', 'aside', 'nav');
+
+export const htmlInlineTagName = (): Arbitrary<string> =>
+  // note: list is incomplete
+  fc.constantFrom('span', 'b', 'i', 'u', 'strong', 'em');

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/Doc.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/Doc.ts
@@ -1,5 +1,0 @@
-import Element from 'ephox/sugar/api/node/Element';
-import { document, Document } from '@ephox/dom-globals';
-
-export const getDoc = (): Element<Document> =>
-  Element.fromDom(document);

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/Doc.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/Doc.ts
@@ -1,0 +1,5 @@
+import Element from 'ephox/sugar/api/node/Element';
+import { document, Document } from '@ephox/dom-globals';
+
+export const getDoc = (): Element<Document> =>
+  Element.fromDom(document);

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -5,16 +5,15 @@ import * as Body from 'ephox/sugar/api/node/Body';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 
 export const withNormalElement = (f: (d: Element<DomElement>) => void): void => {
-  const div = document.createElement('div');
-  document.body.appendChild(div);
+  const div = Element.fromTag('div');
+  Insert.append(Body.body(), div);
 
   try {
-    f(Element.fromDom(div));
+    f(div);
   } finally {
-    document.body.removeChild(div);
+    Remove.remove(div);
   }
 };
-
 
 const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>, shadowHost: Element<DomElement>) => void) => {
   const shadowHost = Element.fromTag('div', document);

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -16,22 +16,22 @@ export const withNormalElement = (f: (d: Element<DomElement>) => void): void => 
 };
 
 
-const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>) => void) => {
-  const div = Element.fromTag('div', document);
-  Insert.append(Body.body(), div);
-  const sr = Element.fromDom(div.dom().attachShadow({ mode }));
+const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>, shadowHost: Element<DomElement>) => void) => {
+  const shadowHost = Element.fromTag('div', document);
+  Insert.append(Body.body(), shadowHost);
+  const sr = Element.fromDom(shadowHost.dom().attachShadow({ mode }));
   const innerDiv = Element.fromTag('div', document);
 
   Insert.append(sr, innerDiv);
 
   try {
-    f(sr, innerDiv);
+    f(sr, innerDiv, shadowHost);
   } finally {
-    Remove.remove(div);
+    Remove.remove(shadowHost);
   }
 };
 
-export const withShadowElement = (f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>) => void): void => {
+export const withShadowElement = (f: (shadowRoot: Element<ShadowRoot>, innerDiv: Element<DomElement>, shadowHost: Element<DomElement>) => void): void => {
   withShadowElementInMode('open', f);
   withShadowElementInMode('closed', f);
 };

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -1,0 +1,60 @@
+import Element from 'ephox/sugar/api/node/Element';
+import { document, Element as DomElement, HTMLIFrameElement, ShadowRoot, Window } from '@ephox/dom-globals';
+import * as Insert from 'ephox/sugar/api/dom/Insert';
+import * as Body from 'ephox/sugar/api/node/Body';
+import * as Remove from 'ephox/sugar/api/dom/Remove';
+import { getDoc } from './Doc';
+
+export const withNormalElement = (f: (d: Element<DomElement>) => void): void => {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+
+  try {
+    f(Element.fromDom(div));
+  } finally {
+    document.body.removeChild(div);
+  }
+};
+
+
+const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>) => void) => {
+  const div = Element.fromTag('div', document);
+  Insert.append(Body.getBody(getDoc()), div);
+  const sr = Element.fromDom(div.dom().attachShadow({ mode }));
+  const innerDiv = Element.fromTag('div', document);
+
+  Insert.append(sr, innerDiv);
+
+  try {
+    f(sr, innerDiv);
+  } finally {
+    Remove.remove(div);
+  }
+};
+
+export const withShadowElement = (f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>) => void): void => {
+  withShadowElementInMode('open', f);
+  withShadowElementInMode('closed', f);
+};
+
+
+export const withIframe = (f: (div: Element<DomElement>, iframe: Element<HTMLIFrameElement>, cw: Window) => void): void => {
+  const iframe = Element.fromTag('iframe');
+  Insert.append(Body.body(), iframe);
+
+  const cw = iframe.dom().contentWindow;
+  if (cw === null) {
+    throw new Error('contentWindow was null');
+  }
+
+  cw.document.open();
+  cw.document.write('<html><head></head><body></body><html></html>');
+  const div = Element.fromTag('div', cw.document);
+  Insert.append(Body.getBody(Element.fromDom(cw.document)), div);
+  cw.document.close();
+  try {
+    f(div, iframe, cw);
+  } finally {
+    Remove.remove(iframe);
+  }
+};

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -3,7 +3,6 @@ import { document, Element as DomElement, HTMLIFrameElement, ShadowRoot, Window 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Body from 'ephox/sugar/api/node/Body';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
-import { getDoc } from './Doc';
 
 export const withNormalElement = (f: (d: Element<DomElement>) => void): void => {
   const div = document.createElement('div');
@@ -19,7 +18,7 @@ export const withNormalElement = (f: (d: Element<DomElement>) => void): void => 
 
 const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>) => void) => {
   const div = Element.fromTag('div', document);
-  Insert.append(Body.getBody(getDoc()), div);
+  Insert.append(Body.body(), div);
   const sr = Element.fromDom(div.dom().attachShadow({ mode }));
   const innerDiv = Element.fromTag('div', document);
 


### PR DESCRIPTION
Related Ticket: TINY-6075

Description of Changes:
* Add functions for interacting with Shadow DOM
* Add Head and Document functions in sugar (equivalents of Body)
* Add Node.isDocumentFragment

Pre-checks:
* [ ] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
