### PR TITLE
TINY-6086: Fixed a regression introduced in 5.3.0 whereby the `images_dataimg_filter` wouldn't ever be called

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,3 +1,5 @@
+Version 5.3.2 (2020-06-10)
+    Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -5,14 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { HTMLImageElement } from '@ephox/dom-globals';
 import * as LegacyFilter from '../../html/LegacyFilter';
 import * as ParserFilters from '../../html/ParserFilters';
 import { hasOnlyChild, isEmpty, isLineBreakNode, isPaddedWithNbsp, paddEmptyNode } from '../../html/ParserUtils';
+import { BlobCache } from '../file/BlobCache';
 import Tools from '../util/Tools';
 import Node from './Node';
 import SaxParser from './SaxParser';
 import Schema from './Schema';
-import { BlobCache } from '../file/BlobCache';
 
 /**
  * This class parses HTML code into a DOM like structure of nodes it will remove redundant whitespace and make
@@ -64,6 +65,7 @@ export interface DomParserSettings {
   validate?: boolean;
   inline_styles?: boolean;
   blob_cache?: BlobCache;
+  images_dataimg_filter?: (img: HTMLImageElement) => boolean;
 }
 
 interface DomParser {

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -6,6 +6,7 @@
  */
 
 import { document, window } from '@ephox/dom-globals';
+import { Obj, Type } from '@ephox/katamari';
 import { Attr, Element, Insert } from '@ephox/sugar';
 import Annotator from '../api/Annotator';
 import DOMUtils from '../api/dom/DOMUtils';
@@ -31,14 +32,13 @@ import * as TouchEvents from '../events/TouchEvents';
 import * as ForceBlocks from '../ForceBlocks';
 import * as KeyboardOverrides from '../keyboard/KeyboardOverrides';
 import { NodeChange } from '../NodeChange';
+import * as Rtc from '../Rtc';
 import * as DetailsElement from '../selection/DetailsElement';
 import * as MultiClickSelection from '../selection/MultiClickSelection';
 import * as SelectionBookmark from '../selection/SelectionBookmark';
 import { hasAnyRanges } from '../selection/SelectionUtils';
 import SelectionOverrides from '../SelectionOverrides';
 import Quirks from '../util/Quirks';
-import { Obj, Type } from '@ephox/katamari';
-import * as Rtc from '../Rtc';
 
 declare const escape: any;
 
@@ -76,7 +76,10 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     inline_styles: settings.inline_styles,
     root_name: getRootName(editor),
     validate: true,
-    blob_cache: blobCache
+    blob_cache: blobCache,
+
+    // Deprecated
+    images_dataimg_filter: settings.images_dataimg_filter
   });
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -760,16 +760,22 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
     blobCache.destroy();
   });
 
-  suite.test('do not extract base64 uris for transparent images used by for example the page break plugin', () => {
+  suite.test('do not extract base64 uris for transparent or placeholder images used by for example the page break plugin', () => {
     const blobCache = BlobCache();
+    const placeholderImg = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mNk+P//PwMRgHFUIX0VAgAE3B3t0SaZ0AAAAABJRU5ErkJggg==';
     const parser = DomParser({ blob_cache: blobCache });
-    const html = `<p><img src="${Env.transparentSrc}" /></p>`;
+    const html = `<p><img src="${Env.transparentSrc}" /><img src="${placeholderImg}" data-mce-placeholder="1"></p>`;
     const root = parser.parse(html);
 
     Assertions.assertEq(
       'Should be the unchanged transparent image source',
       Env.transparentSrc,
       root.getAll('img')[0].attr('src')
+    );
+    Assertions.assertEq(
+      'Should be the unchanged placeholder image source',
+      placeholderImg,
+      root.getAll('img')[1].attr('src')
     );
 
     blobCache.destroy();


### PR DESCRIPTION
Description of Changes:
This adds a fix to the new parser filter introduced in 5.3.0 that converts base64 images to blobs while parsing. With this change, if the `images_dataimg_filter` is configured an image element will be constructed and then passed to the callback to see if the image should be converted to a blob. If it returns false, then it'll leave it as base64 content.

This also fixes the `EditorUploadTest`, as it was very broken and wasn't failing when assertions failed previously.

**Note:** This is only a temporary fix to unblock the 5.3 enterprise release. We'll need to come back to this in a later release, as moving forward for RTC we need to avoid having base64 images in the editor (which is why this the new filter was introduced).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
* Fixes #5756
