### PR TITLE
Updated codeowners to reflect team changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
-* @spocke @TheSpyder @metricjs @lnewson @ltrouton @HAFRMO @trevorjay
+* @spocke @TheSpyder @metricjs @lnewson @ltrouton @HAFRMO @trevorjay @ashfordneil
+
+# Oxide changes should include the design team as well
+/modules/oxide/ @lostkeys @spocke @TheSpyder @metricjs @lnewson @ltrouton @HAFRMO @trevorjay @ashfordneil
+/modules/oxide-icons-default/ @lostkeys @spocke @TheSpyder @metricjs @lnewson @ltrouton @HAFRMO @trevorjay @ashfordneil


### PR DESCRIPTION
This adds Neil to the codeowners and also ensures Fredrik gets included for oxide related changes.

Also yes, GitHub is annoying in that a more specific rule excludes the global owners list :disappointed: 
