### PR TITLE
Move StyleSheetLoader into public api folder.

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.4.0 (TBD)
+    Added `StyleSheetLoader` module to public API, as it was already part of `DOMUtils` #TINY-6100
     Added Oxide variables for styling the select element and headings in dialog content #TINY-6070
     Added all `table` menu items to the UI registry, so they can be used by name in other menus #TINY-4866
     Added new `table` cut, copy and paste column editor commands and menu items #TINY-6006
@@ -10,7 +11,6 @@ Version 5.4.0 (TBD)
     Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval #TINY-3854
     Fixed leading and trailing spaces lost when using `editor.selection.getContent({ format: 'text' })` #TINY-5986
     Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
-    Added `StyleSheetLoader` module to public API, as it was already part of `DOMUtils` #TINY-6100
 Version 5.3.2 (2020-06-10)
     Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -10,6 +10,7 @@ Version 5.4.0 (TBD)
     Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval #TINY-3854
     Fixed leading and trailing spaces lost when using `editor.selection.getContent({ format: 'text' })` #TINY-5986
     Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
+    Added `StyleSheetLoader` module to public API, as it was already part of `DOMUtils` #TINY-6100
 Version 5.3.2 (2020-06-10)
     Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)

--- a/modules/tinymce/src/core/main/ts/api/Tinymce.ts
+++ b/modules/tinymce/src/core/main/ts/api/Tinymce.ts
@@ -60,6 +60,7 @@ import URI, { URIConstructor } from './util/URI';
 import VK from './util/VK';
 import XHR from './util/XHR';
 import { UndoManager as UndoManagerType } from '../undo/UndoManagerTypes';
+import { StyleSheetLoader } from './dom/StyleSheetLoader';
 
 export interface TinyMCE extends EditorManager {
 
@@ -123,6 +124,7 @@ export interface TinyMCE extends EditorManager {
   Formatter: (editor: Editor) => Formatter;
   NotificationManager: (editor: Editor) => NotificationManager;
   Shortcuts: ShortcutsConstructor;
+  StyleSheetLoader: StyleSheetLoader;
   UndoManager: (editor: Editor) => UndoManagerType;
   WindowManager: (editor: Editor) => WindowManager;
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -10,7 +10,7 @@ import { Type } from '@ephox/katamari';
 import { VisualViewport } from '@ephox/sugar';
 import * as NodeType from '../../dom/NodeType';
 import * as Position from '../../dom/Position';
-import { StyleSheetLoader } from '../../dom/StyleSheetLoader';
+import { StyleSheetLoader } from './StyleSheetLoader';
 import * as TrimNode from '../../dom/TrimNode';
 import Env from '../Env';
 import { GeomRect } from '../geom/Rect';

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -8,9 +8,9 @@
 import { navigator } from '@ephox/dom-globals';
 import { Arr, Fun, Future, Futures, Result } from '@ephox/katamari';
 import { Attr, Element } from '@ephox/sugar';
-import { ReferrerPolicy } from '../api/SettingsTypes';
-import Delay from '../api/util/Delay';
-import Tools from '../api/util/Tools';
+import { ReferrerPolicy } from '../SettingsTypes';
+import Delay from '../util/Delay';
+import Tools from '../util/Tools';
 
 /**
  * This class handles loading of external stylesheets and fires events when these are loaded.


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Move StyleSheetLoader into public api folder. It was already part of DOMUtils. This change will allow StyleSheetLoaders to be created by the silver theme, which may be useful for Shadow DOM support. 

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
