### PR TITLE
TINY-5951: Pass editor.allow_html_data_urls through to SaxParser

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -12,7 +12,7 @@ Version 5.4.0 (TBD)
     Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval #TINY-3854
     Fixed leading and trailing spaces lost when using `editor.selection.getContent({ format: 'text' })` #TINY-5986
     Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
-    Fixed an issue where editor.allow_html_data_urls was not being correctly applied #TINY-5951
+    Fixed an issue where the `allow_html_data_urls` setting was not correctly applied #TINY-5951
 Version 5.3.2 (2020-06-10)
     Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -12,6 +12,7 @@ Version 5.4.0 (TBD)
     Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval #TINY-3854
     Fixed leading and trailing spaces lost when using `editor.selection.getContent({ format: 'text' })` #TINY-5986
     Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
+    Fixed an issue where editor.allow_html_data_urls was not being correctly applied #TINY-5951
 Version 5.3.2 (2020-06-10)
     Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -44,6 +44,7 @@ interface BaseEditorSettings {
   add_form_submit_trigger?: boolean;
   add_unload_trigger?: boolean;
   allow_conditional_comments?: boolean;
+  allow_html_data_urls?: boolean;
   allow_html_in_named_anchor?: boolean;
   allow_script_urls?: boolean;
   allow_unsafe_link_target?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -49,6 +49,7 @@ export interface ParserFilter {
 }
 
 export interface DomParserSettings {
+  allow_html_data_urls?: boolean;
   allow_conditional_comments?: boolean;
   allow_html_in_named_anchor?: boolean;
   allow_script_urls?: boolean;
@@ -477,6 +478,7 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
 
     parser = SaxParser({
       validate,
+      allow_html_data_urls: settings.allow_html_data_urls,
       allow_script_urls: settings.allow_script_urls,
       allow_conditional_comments: settings.allow_conditional_comments,
       preserve_cdata: settings.preserve_cdata,

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -62,6 +62,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
 
   return removeUndefined<DomParserSettings>({
     allow_conditional_comments: settings.allow_conditional_comments,
+    allow_html_data_urls: settings.allow_html_data_urls,
     allow_html_in_named_anchor: settings.allow_html_in_named_anchor,
     allow_script_urls: settings.allow_script_urls,
     allow_unsafe_link_target: settings.allow_unsafe_link_target,

--- a/modules/tinymce/src/core/test/ts/browser/content/HTMLDataURLsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/HTMLDataURLsTest.ts
@@ -1,0 +1,32 @@
+import { Assertions, Pipeline, Logger, NamedChain, Chain } from '@ephox/agar';
+import Theme from 'tinymce/themes/silver/Theme';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Editor as McEditor, ApiChains } from '@ephox/mcagar';
+
+UnitTest.asynctest('browser.tinymce.core.content.HTMLDataURLsTest', (success, failure) =>  {
+  Theme();
+
+  const content = '<p><a href="data:text/plain;base64,SGVsbG8sIHdvcmxkCg==">Click me</a></p>';
+
+  const getSettings = (hasDataUrls: boolean) => ({
+    base_url: '/project/tinymce/js/tinymce',
+    allow_html_data_urls: hasDataUrls
+  });
+
+  Pipeline.async({}, [
+    Logger.t('Editor should not allow data urls by default', Chain.asStep({}, [ NamedChain.asChain([
+      NamedChain.direct(NamedChain.inputName(), McEditor.cFromSettings(getSettings(false)), 'editor'),
+      NamedChain.read('editor', ApiChains.cSetContent(content)),
+      NamedChain.direct('editor', ApiChains.cGetContent, 'content'),
+      NamedChain.read('content', Assertions.cAssertEq('Href should be removed', '<p><a>Click me</a></p>')),
+      NamedChain.read('editor', McEditor.cRemove),
+    ]) ])),
+    Logger.t('Editor should allow data urls when allow_html_data_urls is true', Chain.asStep({}, [ NamedChain.asChain([
+      NamedChain.direct(NamedChain.inputName(), McEditor.cFromSettings(getSettings(true)), 'editor'),
+      NamedChain.read('editor', ApiChains.cSetContent(content)),
+      NamedChain.direct('editor', ApiChains.cGetContent, 'content'),
+      NamedChain.read('content', Assertions.cAssertEq('Href should not be removed', content)),
+      NamedChain.read('editor', McEditor.cRemove),
+    ]) ])),
+  ], success, failure);
+});

--- a/modules/tinymce/src/core/test/ts/browser/content/HTMLDataURLsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/HTMLDataURLsTest.ts
@@ -1,4 +1,4 @@
-import { Assertions, Pipeline, Logger, NamedChain, Chain } from '@ephox/agar';
+import { Assertions, Pipeline, Log, NamedChain } from '@ephox/agar';
 import Theme from 'tinymce/themes/silver/Theme';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Editor as McEditor, ApiChains } from '@ephox/mcagar';
@@ -14,19 +14,23 @@ UnitTest.asynctest('browser.tinymce.core.content.HTMLDataURLsTest', (success, fa
   });
 
   Pipeline.async({}, [
-    Logger.t('Editor should not allow data urls by default', Chain.asStep({}, [ NamedChain.asChain([
-      NamedChain.direct(NamedChain.inputName(), McEditor.cFromSettings(getSettings(false)), 'editor'),
-      NamedChain.read('editor', ApiChains.cSetContent(content)),
-      NamedChain.direct('editor', ApiChains.cGetContent, 'content'),
-      NamedChain.read('content', Assertions.cAssertEq('Href should be removed', '<p><a>Click me</a></p>')),
-      NamedChain.read('editor', McEditor.cRemove),
-    ]) ])),
-    Logger.t('Editor should allow data urls when allow_html_data_urls is true', Chain.asStep({}, [ NamedChain.asChain([
-      NamedChain.direct(NamedChain.inputName(), McEditor.cFromSettings(getSettings(true)), 'editor'),
-      NamedChain.read('editor', ApiChains.cSetContent(content)),
-      NamedChain.direct('editor', ApiChains.cGetContent, 'content'),
-      NamedChain.read('content', Assertions.cAssertEq('Href should not be removed', content)),
-      NamedChain.read('editor', McEditor.cRemove),
-    ]) ])),
+    Log.chainsAsStep('TINY-5951', 'Editor should not allow data urls by default', [
+      NamedChain.asChain([
+        NamedChain.direct(NamedChain.inputName(), McEditor.cFromSettings(getSettings(false)), 'editor'),
+        NamedChain.read('editor', ApiChains.cSetContent(content)),
+        NamedChain.direct('editor', ApiChains.cGetContent, 'content'),
+        NamedChain.read('content', Assertions.cAssertEq('Href should be removed', '<p><a>Click me</a></p>')),
+        NamedChain.read('editor', McEditor.cRemove)
+      ])
+    ]),
+    Log.chainsAsStep('TINY-5951', 'Editor should allow data urls when allow_html_data_urls is true', [
+      NamedChain.asChain([
+        NamedChain.direct(NamedChain.inputName(), McEditor.cFromSettings(getSettings(true)), 'editor'),
+        NamedChain.read('editor', ApiChains.cSetContent(content)),
+        NamedChain.direct('editor', ApiChains.cGetContent, 'content'),
+        NamedChain.read('content', Assertions.cAssertEq('Href should not be removed', content)),
+        NamedChain.read('editor', McEditor.cRemove)
+      ])
+    ])
   ], success, failure);
 });


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Placeholder text

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #4669 