### PR TITLE
Results.unite

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Results.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Results.ts
@@ -1,5 +1,6 @@
 import { Adt } from './Adt';
 import * as Arr from './Arr';
+import * as Fun from './Fun';
 import { Result } from './Result';
 
 const comparison = Adt.generate([
@@ -39,3 +40,6 @@ export const compare = function<A, B> (result1: Result<A, B>, result2: Result<A,
     });
   });
 };
+
+export const unite: <T>(result: Result<T, T>) => T = <T>(result: Result<T, T>): T =>
+  result.fold(Fun.identity, Fun.identity);

--- a/modules/katamari/src/test/ts/atomic/api/data/ResultsTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/data/ResultsTest.ts
@@ -126,3 +126,10 @@ UnitTest.test('Check that value, value always equal comparison.bothValues', () =
     }
   ));
 });
+
+UnitTest.test('Results.unite', () => {
+  fc.assert(fc.property(fc.integer(), (a) => {
+    Assert.eq('should be error', a, Results.unite(Result.error<number, number>(a)));
+    Assert.eq('should be value', a, Results.unite(Result.value<number, number>(a)));
+  }));
+});

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -6,7 +6,7 @@
  */
 
 import { navigator } from '@ephox/dom-globals';
-import { Arr, Fun, Future, Futures, Result } from '@ephox/katamari';
+import { Arr, Fun, Future, Futures, Result, Results } from '@ephox/katamari';
 import { Attr, Element } from '@ephox/sugar';
 import { ReferrerPolicy } from '../SettingsTypes';
 import Delay from '../util/Delay';
@@ -231,10 +231,6 @@ export function StyleSheetLoader(document, settings: Partial<StyleSheetLoaderSet
     });
   };
 
-  const unbox = function (result) {
-    return result.fold(Fun.identity, Fun.identity);
-  };
-
   const loadAll = function (urls: string[], success: Function, failure: Function) {
     Futures.par(Arr.map(urls, loadF)).get(function (result) {
       const parts = Arr.partition(result, function (r) {
@@ -242,9 +238,9 @@ export function StyleSheetLoader(document, settings: Partial<StyleSheetLoaderSet
       });
 
       if (parts.fail.length > 0) {
-        failure(parts.fail.map(unbox));
+        failure(parts.fail.map(Results.unite));
       } else {
-        success(parts.pass.map(unbox));
+        success(parts.pass.map(Results.unite));
       }
     });
   };


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* `Result<T, T> -> T`. Similar function exists on the `\/` (Either) type in Scalaz (they call it "merge"). Replaces `unbox` function in `StyleSheetLoader`. 

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
