### PR TITLE
LazyValue should only use the value from the first callback

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/LazyValue.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/LazyValue.ts
@@ -3,25 +3,23 @@ import { Option } from './Option';
 import { setTimeout } from '@ephox/dom-globals';
 
 export interface LazyValue<T> {
-  get: (callback: (value: T) => void) => void;
-  map: <U> (mapper: (value: T) => U) => LazyValue<U>;
-  isReady: () => boolean;
+  readonly get: (callback: (value: T) => void) => void;
+  readonly map: <U> (mapper: (value: T) => U) => LazyValue<U>;
+  readonly isReady: () => boolean;
 }
 
-const nu = function <T> (baseFn: (completer: (value: T) => void) => void): LazyValue<T> {
+const nu = <T>(baseFn: (completer: (value: T) => void) => void): LazyValue<T> => {
   let data = Option.none<T>();
   let callbacks: ((value: T) => void)[] = [];
 
   /** map :: this LazyValue a -> (a -> b) -> LazyValue b */
-  const map = function <U> (f: (value: T) => U) {
-    return nu(function (nCallback: (value: U) => void) {
-      get(function (data) {
-        nCallback(f(data));
-      });
+  const map = <U>(f: (value: T) => U) => nu((nCallback: (value: U) => void) => {
+    get((data) => {
+      nCallback(f(data));
     });
-  };
+  });
 
-  const get = function (nCallback: (value: T) => void) {
+  const get = (nCallback: (value: T) => void) => {
     if (isReady()) {
       call(nCallback);
     } else {
@@ -29,7 +27,7 @@ const nu = function <T> (baseFn: (completer: (value: T) => void) => void): LazyV
     }
   };
 
-  const set = function (x: T) {
+  const set = (x: T) => {
     if (!isReady()) {
       data = Option.some(x);
       run(callbacks);
@@ -37,17 +35,15 @@ const nu = function <T> (baseFn: (completer: (value: T) => void) => void): LazyV
     }
   };
 
-  const isReady = function () {
-    return data.isSome();
-  };
+  const isReady = () => data.isSome();
 
-  const run = function (cbs: ((value: T) => void)[]) {
+  const run = (cbs: ((value: T) => void)[]) => {
     Arr.each(cbs, call);
   };
 
-  const call = function (cb: (value: T) => void) {
-    data.each(function (x) {
-      setTimeout(function () {
+  const call = (cb: (value: T) => void) => {
+    data.each((x) => {
+      setTimeout(() => {
         cb(x);
       }, 0);
     });
@@ -63,11 +59,10 @@ const nu = function <T> (baseFn: (completer: (value: T) => void) => void): LazyV
   };
 };
 
-const pure = function <T> (a: T) {
-  return nu(function (callback: (value: T) => void) {
+const pure = <T>(a: T) =>
+  nu((callback: (value: T) => void) => {
     callback(a);
   });
-};
 
 export const LazyValue = {
   nu,

--- a/modules/katamari/src/main/ts/ephox/katamari/api/LazyValue.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/LazyValue.ts
@@ -30,9 +30,11 @@ const nu = function <T> (baseFn: (completer: (value: T) => void) => void): LazyV
   };
 
   const set = function (x: T) {
-    data = Option.some(x);
-    run(callbacks);
-    callbacks = [];
+    if (!isReady()) {
+      data = Option.some(x);
+      run(callbacks);
+      callbacks = [];
+    }
   };
 
   const isReady = function () {

--- a/modules/katamari/src/test/ts/atomic/api/async/LazyValueTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/async/LazyValueTest.ts
@@ -110,3 +110,15 @@ promiseTest('LazyValue: parallel spec', () => fc.assert(fc.asyncProperty(fc.arra
     resolve();
   });
 }))));
+
+promiseTest('LazyValue: TINY-6106: LazyValue should only use the value from the first time the callback is called', () => new Promise((resolve, reject) => {
+  LazyValue.nu((completer) => {
+    // Since lazyvalue kicks off the computation straight away, both completer calls happen before the callback is fired.
+    // If the bug is present, the value will be 3. If the bug is fixed, the value will be 2.
+    completer(2);
+    completer(3);
+  }).get((actual) => {
+    eqAsync('should be 2', 2, actual, reject);
+    resolve();
+  });
+}));


### PR DESCRIPTION
Related Ticket: TINY-6106

Description of Changes:
* A Katamari LazyValue wraps an asynchronous function, similar to a Future. The async function has to call a callback to complete. If the callback is called multiple times, then the LazyValue's value is set to the last of these. Basically, the LazyValue becomes mutable, which isn't what's intended. Instead, LazyValue should only consider the value from the first callback, and should ignore subsequent values.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
