### PR TITLE
TINY-6057: Fixed a selection performance issue when using large tables on IE and Edge

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -9,6 +9,7 @@ Version 5.4.0 (TBD)
     Changed `advlist` toolbar buttons to only show a dropdown list if there's more than one option #TINY-3194
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Fixed table `Paste row after` and `Paste row before` menu items not disabled when nothing was available to paste #TINY-6006
+    Fixed a selection performance issue with large tables on Microsoft Internet Explorer and Edge #TINY-6057
     Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946
     Fixed `fullscreen` plugin now removes all classes when the editor is closed #TINY-4048
     Fixed handling of mixed-case icon names by having the silver theme downcase them before icon retrieval #TINY-3854

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -223,11 +223,11 @@ const SelectionOverrides = function (editor: Editor): SelectionOverrides {
         removeContentEditableSelection();
         hideFakeCaret();
 
-        const caretInfo = LineUtils.closestCaret(rootNode, e.clientX, e.clientY);
-        if (caretInfo) {
-          if (!hasBetterMouseTarget(e.target, caretInfo.node)) {
+        const fakeCaretInfo = LineUtils.closestFakeCaret(rootNode, e.clientX, e.clientY);
+        if (fakeCaretInfo) {
+          if (!hasBetterMouseTarget(e.target, fakeCaretInfo.node)) {
             e.preventDefault();
-            const range = showCaret(1, caretInfo.node as HTMLElement, caretInfo.before, false);
+            const range = showCaret(1, fakeCaretInfo.node as HTMLElement, fakeCaretInfo.before, false);
             editor.getBody().focus();
             setRange(range);
           }

--- a/modules/tinymce/src/core/main/ts/caret/LineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/caret/LineUtils.ts
@@ -5,16 +5,16 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Node, ClientRect, HTMLElement } from '@ephox/dom-globals';
-import { Fun, Arr } from '@ephox/katamari';
-import * as ArrUtils from '../util/ArrUtils';
+import { ClientRect, HTMLElement, Node } from '@ephox/dom-globals';
+import { Arr, Fun } from '@ephox/katamari';
+import { getClientRects, NodeClientRect } from '../dom/Dimensions';
 import * as NodeType from '../dom/NodeType';
-import { NodeClientRect, getClientRects } from '../dom/Dimensions';
 import * as GeomClientRect from '../geom/ClientRect';
-import * as CaretUtils from './CaretUtils';
+import * as ArrUtils from '../util/ArrUtils';
 import * as CaretCandidate from './CaretCandidate';
-import { ClientRectLine, VDirection } from './LineWalker';
+import * as CaretUtils from './CaretUtils';
 import { isFakeCaretTarget } from './FakeCaret';
+import { ClientRectLine, VDirection } from './LineWalker';
 
 export interface CaretInfo {
   node: Node;
@@ -25,7 +25,8 @@ const isContentEditableFalse = NodeType.isContentEditableFalse;
 const findNode = CaretUtils.findNode;
 const distanceToRectLeft = (clientRect: NodeClientRect, clientX: number) => Math.abs(clientRect.left - clientX);
 const distanceToRectRight = (clientRect: NodeClientRect, clientX: number) => Math.abs(clientRect.right - clientX);
-const isInside = (clientX: number, clientRect: ClientRect): boolean => clientX >= clientRect.left && clientX <= clientRect.right;
+const isInsideX = (clientX: number, clientRect: ClientRect): boolean => clientX >= clientRect.left && clientX <= clientRect.right;
+const isInsideY = (clientY: number, clientRect: ClientRect): boolean => clientY >= clientRect.top && clientY <= clientRect.bottom;
 
 const findClosestClientRect = (clientRects: ClientRect[], clientX: number): NodeClientRect => ArrUtils.reduce(clientRects, (oldClientRect, clientRect) => {
   let oldDistance, newDistance;
@@ -33,11 +34,11 @@ const findClosestClientRect = (clientRects: ClientRect[], clientX: number): Node
   oldDistance = Math.min(distanceToRectLeft(oldClientRect, clientX), distanceToRectRight(oldClientRect, clientX));
   newDistance = Math.min(distanceToRectLeft(clientRect, clientX), distanceToRectRight(clientRect, clientX));
 
-  if (isInside(clientX, clientRect)) {
+  if (isInsideX(clientX, clientRect)) {
     return clientRect;
   }
 
-  if (isInside(clientX, oldClientRect)) {
+  if (isInsideX(clientX, oldClientRect)) {
     return oldClientRect;
   }
 
@@ -53,15 +54,16 @@ const findClosestClientRect = (clientRects: ClientRect[], clientX: number): Node
   return oldClientRect;
 });
 
-const walkUntil = (direction: VDirection, root: Node, predicateFn: (node: Node) => boolean, node: Node): void => {
-  while ((node = findNode(node, direction, CaretCandidate.isEditableCaretCandidate, root))) {
-    if (predicateFn(node)) {
+const walkUntil = (direction: VDirection, root: Node, predicateFn: (node: Node) => boolean, startNode: Node, includeChildren: boolean): void => {
+  let node = findNode(startNode, direction, CaretCandidate.isEditableCaretCandidate, root, !includeChildren);
+  do {
+    if (!node || predicateFn(node)) {
       return;
     }
-  }
+  } while ((node = findNode(node, direction, CaretCandidate.isEditableCaretCandidate, root)));
 };
 
-const findLineNodeRects = (root: Node, targetNodeRect: NodeClientRect): ClientRectLine[] => {
+const findLineNodeRects = (root: Node, targetNodeRect: NodeClientRect, includeChildren: boolean = true): ClientRectLine[] => {
   let clientRects = [];
 
   const collect = (checkPosFn, node) => {
@@ -77,8 +79,8 @@ const findLineNodeRects = (root: Node, targetNodeRect: NodeClientRect): ClientRe
   };
 
   clientRects.push(targetNodeRect);
-  walkUntil(VDirection.Up, root, Fun.curry(collect, GeomClientRect.isAbove), targetNodeRect.node);
-  walkUntil(VDirection.Down, root, Fun.curry(collect, GeomClientRect.isBelow), targetNodeRect.node);
+  walkUntil(VDirection.Up, root, Fun.curry(collect, GeomClientRect.isAbove), targetNodeRect.node, includeChildren);
+  walkUntil(VDirection.Down, root, Fun.curry(collect, GeomClientRect.isBelow), targetNodeRect.node, includeChildren);
 
   return clientRects;
 };
@@ -90,15 +92,17 @@ const caretInfo = (clientRect: NodeClientRect, clientX: number): CaretInfo => ({
   before: distanceToRectLeft(clientRect, clientX) < distanceToRectRight(clientRect, clientX)
 });
 
-const closestCaret = (root: HTMLElement, clientX: number, clientY: number): CaretInfo => {
-  let closestNodeRect;
+const closestFakeCaret = (root: HTMLElement, clientX: number, clientY: number): CaretInfo => {
+  const fakeTargetNodeRects = getClientRects(getFakeCaretTargets(root));
+  const targetNodeRects = Arr.filter(fakeTargetNodeRects, Fun.curry(isInsideY, clientY));
 
-  const contentEditableFalseNodeRects = getClientRects(getFakeCaretTargets(root));
-  const targetNodeRects = Arr.filter(contentEditableFalseNodeRects, (rect) => clientY >= rect.top && clientY <= rect.bottom);
-
-  closestNodeRect = findClosestClientRect(targetNodeRects, clientX);
+  let closestNodeRect = findClosestClientRect(targetNodeRects, clientX);
   if (closestNodeRect) {
-    closestNodeRect = findClosestClientRect(findLineNodeRects(root, closestNodeRect), clientX);
+    // TINY-6057: Don't include children nodes within a table when finding the line
+    // rects, as that will never be a valid position for a table fake caret and can
+    // lead to performance issues with large tables.
+    const includeChildren = !NodeType.isTable(closestNodeRect.node);
+    closestNodeRect = findClosestClientRect(findLineNodeRects(root, closestNodeRect, includeChildren), clientX);
     if (closestNodeRect && isFakeCaretTarget(closestNodeRect.node)) {
       return caretInfo(closestNodeRect, clientX);
     }
@@ -110,5 +114,5 @@ const closestCaret = (root: HTMLElement, clientX: number, clientY: number): Care
 export {
   findClosestClientRect,
   findLineNodeRects,
-  closestCaret
+  closestFakeCaret
 };

--- a/modules/tinymce/src/core/main/ts/dom/Dimensions.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Dimensions.ts
@@ -5,10 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import * as NodeType from './NodeType';
-import * as ClientRect from '../geom/ClientRect';
 import { HTMLElement, Node } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
+import * as ClientRect from '../geom/ClientRect';
+import * as NodeType from './NodeType';
 
 export interface NodeClientRect extends ClientRect.ClientRect {
   node: HTMLElement;
@@ -38,9 +38,7 @@ const getNodeClientRects = (node: Node): NodeClientRect[] => {
   }
 };
 
-const getClientRects = (node: Node[]): NodeClientRect[] => Arr.foldl(node, function (result, node) {
-  return result.concat(getNodeClientRects(node));
-}, []);
+const getClientRects = (nodes: Node[]): NodeClientRect[] => Arr.bind(nodes, getNodeClientRects);
 
 export {
   getClientRects

--- a/modules/tinymce/src/core/test/ts/browser/caret/LineUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/LineUtilsTest.ts
@@ -1,35 +1,45 @@
-import { LegacyUnit } from '@ephox/mcagar';
-import { Pipeline } from '@ephox/agar';
-import Env from 'tinymce/core/api/Env';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Body, Element, Insert, InsertAll, Remove, SelectorFind } from '@ephox/sugar';
 import * as LineUtils from 'tinymce/core/caret/LineUtils';
-import { UnitTest } from '@ephox/bedrock-client';
+import { getClientRects } from 'tinymce/core/dom/Dimensions';
 
-UnitTest.asynctest('browser.tinymce.core.LineUtilsTest', function (success, failure) {
-  const suite = LegacyUnit.createSuite();
+const rect = (x: number, y: number, w: number, h: number) => ({
+  left: x,
+  top: y,
+  bottom: y + h,
+  right: x + w,
+  width: w,
+  height: h
+});
 
-  if (!Env.ceFalse) {
-    return;
-  }
+UnitTest.test('browser.tinymce.core.LineUtilsTest - findClosestClientRect', () => {
+  Assert.eq('', LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(30, 10, 10, 10) ], 15), rect(10, 10, 10, 10));
+  Assert.eq('', LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(30, 10, 10, 10) ], 27), rect(30, 10, 10, 10));
+  Assert.eq('', LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(30, 10, 10, 10) ], 23), rect(10, 10, 10, 10));
+  Assert.eq('', LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(20, 10, 10, 10) ], 13), rect(10, 10, 10, 10));
+});
 
-  const rect = function (x, y, w, h) {
-    return {
-      left: x,
-      top: y,
-      bottom: y + h,
-      right: x + w,
-      width: w,
-      height: h
-    };
-  };
+UnitTest.test('browser.tinymce.core.LineUtilsTest - findLineNodeRects', () => {
+  const container = Element.fromTag('div');
+  const para = Element.fromHtml('<p>Paragraph with content</p>');
+  const multiLinePara = Element.fromHtml('<p>Multiple line <br>paragraph with content</p>');
+  const table = Element.fromHtml('<table border="1"><tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody></table>');
+  const paraWithCef = Element.fromHtml('<p>Before <span contenteditable="false">Noneditable</span> After</p>');
+  const cef = SelectorFind.descendant(paraWithCef, 'span').getOrDie();
+  InsertAll.append(container, [ para, multiLinePara, table, paraWithCef ]);
+  Insert.append(Body.body(), container);
 
-  suite.test('findClosestClientRect', function () {
-    LegacyUnit.deepEqual(LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(30, 10, 10, 10) ], 15), rect(10, 10, 10, 10));
-    LegacyUnit.deepEqual(LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(30, 10, 10, 10) ], 27), rect(30, 10, 10, 10));
-    LegacyUnit.deepEqual(LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(30, 10, 10, 10) ], 23), rect(10, 10, 10, 10));
-    LegacyUnit.deepEqual(LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(20, 10, 10, 10) ], 13), rect(10, 10, 10, 10));
-  });
+  const paraLines = LineUtils.findLineNodeRects(container.dom(), getClientRects([ para.dom().firstChild ])[0]);
+  const multiParaLines = LineUtils.findLineNodeRects(container.dom(), getClientRects([ multiLinePara.dom().lastChild ])[0]);
+  const tableLines = LineUtils.findLineNodeRects(container.dom(), getClientRects([ table.dom() ])[0], false);
+  const tableLinesWithChildren = LineUtils.findLineNodeRects(container.dom(), getClientRects([ table.dom() ])[0]);
+  const cefLines = LineUtils.findLineNodeRects(container.dom(), getClientRects([ cef.dom() ])[0]);
 
-  Pipeline.async({}, suite.toSteps({}), function () {
-    success();
-  }, failure);
+  Assert.eq('Should only find one line rect for a para', 1, paraLines.length);
+  Assert.eq('Should only find one line rect for a multiline para', 1, multiParaLines.length);
+  Assert.eq('Should only find one line rect for a table', 1, tableLines.length);
+  Assert.eq('Should find multiple line rects for a table plus children', 5, tableLinesWithChildren.length);
+  Assert.eq('Should find multiple line rects for a cef element', 3, cefLines.length);
+
+  Remove.remove(container);
 });


### PR DESCRIPTION
Related Ticket: TINY-6057

Description of Changes:
This fixes a performance issue on IE and Edge (Firefox was also partially impacted, but it's much faster so wasn't noticeable). The cause was that when clicking, TinyMCE would attempt to find a suitable fake caret position to place the cursor at. The problem however, was that it would attempt to find all client rects on the same "line", but since a table is a single "line" it would get the client rects of every cell and the nodes inside each cell.

This was slow on IE and Edge, as they are somewhat slow at computing the client rect. This really wasn't needed, as for a table the fake caret will never be inside the table. So this just updates the logic to skip checking the children of a table when computing the line rects for the potential fake caret placement.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
