### PR TITLE
Bumped total test timeout as it was failing on IE 11 due to additional tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,7 @@ const bedrockBrowser = (tests, browserName, osName, bucket, buckets, auto) => {
     return {
       browser: {
         ...bedrockDefaults,
-        overallTimeout: 1020000,
+        overallTimeout: 1200000,
         name: `${browserName}-${osName}`,
         browser: browserName,
         testfiles: testFolders(tests, auto),


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Bumps the total test timeout from 17mins to 20mins, as with the addition of new tests we're now running over 17mins on IE 11.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] ~Milestone set~
* [x] Review comments resolved

GitHub issues (if applicable):
