### PR TITLE
TINY-4001: Cleanup attributes created on target element

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -18,6 +18,7 @@ Version 5.4.0 (TBD)
     Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
     Fixed an issue where the `allow_html_data_urls` setting was not correctly applied #TINY-5951
     Fixed the `autolink` feature so that it no longer treats a string with multiple "@" characters as an email address #TINY-4773
+    Fixed an issue where removing the editor would leave unexpected attributes on the target element #TINY-4001
 Version 5.3.2 (2020-06-10)
     Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { BeforeUnloadEvent, document, Element, HTMLFormElement, Window } from '@ephox/dom-globals';
+import { BeforeUnloadEvent, document, HTMLElement, HTMLFormElement, Window } from '@ephox/dom-globals';
 import { Arr, Obj, Type } from '@ephox/katamari';
 import * as ErrorReporter from '../ErrorReporter';
 import * as FocusController from '../focus/FocusController';
@@ -363,7 +363,7 @@ const EditorManager: EditorManager = {
    *    ...
    * });
    */
-  init(settings) {
+  init(settings: RawEditorSettings) {
     const self: EditorManager = this;
     let result;
 
@@ -373,19 +373,19 @@ const EditorManager: EditorManager = {
       ' '
     );
 
-    const isInvalidInlineTarget = function (settings, elm) {
+    const isInvalidInlineTarget = (settings: RawEditorSettings, elm: HTMLElement) => {
       return settings.inline && elm.tagName.toLowerCase() in invalidInlineTargets;
     };
 
-    const createId = function (elm) {
+    const createId = function (elm: HTMLElement) {
       let id = elm.id;
 
       // Use element id, or unique name or generate a unique id
       if (!id) {
-        id = elm.name;
+        id = (elm as unknown as HTMLTextAreaElement).name as string | undefined;
 
         if (id && !DOM.get(id)) {
-          id = elm.name;
+          // Keep current name
         } else {
           // Generate unique name
           id = DOM.uniqueId();
@@ -411,8 +411,8 @@ const EditorManager: EditorManager = {
       return className.constructor === RegExp ? className.test(elm.className) : DOM.hasClass(elm, className);
     };
 
-    const findTargets = function (settings): Element[] {
-      let l, targets = [];
+    const findTargets = (settings: RawEditorSettings): HTMLElement[] => {
+      let targets: HTMLElement[] = [];
 
       if (Env.browser.isIE() && Env.browser.version.major < 11) {
         ErrorReporter.initError(
@@ -443,13 +443,13 @@ const EditorManager: EditorManager = {
       // Fallback to old setting
       switch (settings.mode) {
         case 'exact':
-          l = settings.elements || '';
+          const l = settings.elements || '';
 
           if (l.length > 0) {
             each(explode(l), function (id) {
-              let elm;
+              const elm = DOM.get(id);
 
-              if ((elm = DOM.get(id))) {
+              if (elm) {
                 targets.push(elm);
               } else {
                 each(document.forms, function (f: HTMLFormElement) {
@@ -490,9 +490,9 @@ const EditorManager: EditorManager = {
     const initEditors = function () {
       let initCount = 0;
       const editors = [];
-      let targets: Element[];
+      let targets: HTMLElement[];
 
-      const createEditor = function (id, settings, targetElm) {
+      const createEditor = function (id: string, settings: RawEditorSettings, targetElm: HTMLElement) {
         const editor: Editor = new Editor(id, settings, self);
 
         editors.push(editor);
@@ -515,7 +515,7 @@ const EditorManager: EditorManager = {
       // TODO: Deprecate this one
       if (settings.types) {
         each(settings.types, function (type) {
-          Tools.each(targets, function (elm) {
+          Tools.each(targets, function (elm: HTMLElement) {
             if (DOM.is(elm, type.selector)) {
               createEditor(createId(elm), extend({}, settings, type), elm);
               return false;

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -7,6 +7,7 @@
 
 import { BeforeUnloadEvent, document, HTMLElement, HTMLFormElement, Window } from '@ephox/dom-globals';
 import { Arr, Obj, Type } from '@ephox/katamari';
+import { Attr, Element as SugarElement } from '@ephox/sugar';
 import * as ErrorReporter from '../ErrorReporter';
 import * as FocusController from '../focus/FocusController';
 import AddOnManager from './AddOnManager';
@@ -373,9 +374,8 @@ const EditorManager: EditorManager = {
       ' '
     );
 
-    const isInvalidInlineTarget = (settings: RawEditorSettings, elm: HTMLElement) => {
-      return settings.inline && elm.tagName.toLowerCase() in invalidInlineTargets;
-    };
+    const isInvalidInlineTarget = (settings: RawEditorSettings, elm: HTMLElement) =>
+      settings.inline && elm.tagName.toLowerCase() in invalidInlineTargets;
 
     const createId = function (elm: HTMLElement) {
       let id = elm.id;
@@ -493,7 +493,16 @@ const EditorManager: EditorManager = {
       let targets: HTMLElement[];
 
       const createEditor = function (id: string, settings: RawEditorSettings, targetElm: HTMLElement) {
+        const targetElmWrap = SugarElement.fromDom(targetElm);
+        const tagSnapshot = Attr.clone(targetElmWrap);
+
         const editor: Editor = new Editor(id, settings, self);
+        editor.on('remove', () => {
+          Arr.each(Arr.map(targetElm.attributes, (attr) => attr.name), (name: string) => {
+            Attr.remove(targetElmWrap, name);
+          });
+          Attr.setAll(targetElmWrap, tagSnapshot);
+        });
 
         editors.push(editor);
 

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Element, HTMLElement, HTMLImageElement, Node, ReferrerPolicy as DomReferrerPolicy } from '@ephox/dom-globals';
+import { HTMLElement, HTMLImageElement, Node, ReferrerPolicy as DomReferrerPolicy } from '@ephox/dom-globals';
 import { UploadHandler } from '../file/Uploader';
 import Editor from './Editor';
 import { Formats } from './fmt/Format';
@@ -162,7 +162,7 @@ interface BaseEditorSettings {
   style_formats_merge?: boolean;
   submit_patch?: boolean;
   suffix?: string;
-  target?: Element;
+  target?: HTMLElement;
   theme?: string | ThemeInitFunc;
   theme_url?: string;
   toolbar?: boolean | string | string[] | Array<ToolbarGroup>;

--- a/modules/tinymce/src/core/main/ts/content/Placeholder.ts
+++ b/modules/tinymce/src/core/main/ts/content/Placeholder.ts
@@ -118,13 +118,6 @@ const setup = (editor: Editor) => {
       // TINY-4828: Update the placeholder after pasting content. This needs to use a timeout as
       // the browser doesn't update the dom until after the paste event has fired
       editor.on('paste', (e) => Delay.setEditorTimeout(editor, () => updatePlaceholder(e)));
-
-      // Remove the placeholder attributes on remove
-      editor.on('remove', () => {
-        const body = editor.getBody();
-        dom.setAttrib(body, placeholderAttr, null);
-        dom.setAttrib(body, 'aria-placeholder', null);
-      });
     });
   }
 };

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -349,14 +349,6 @@ const initContentBody = function (editor: Editor, skipWrite?: boolean) {
   }
 
   if (editor.inline) {
-    editor.on('remove', function () {
-      const bodyEl = this.getBody();
-
-      DOM.removeClass(bodyEl, 'mce-content-body');
-      DOM.removeClass(bodyEl, 'mce-edit-focus');
-      DOM.setAttrib(bodyEl, 'contentEditable', null);
-    });
-
     DOM.addClass(targetElm, 'mce-content-body');
     editor.contentDocument = doc = document;
     editor.contentWindow = window;

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -168,11 +168,11 @@ const createParser = function (editor: Editor): DomParser {
 
   // Keep scripts from executing
   parser.addNodeFilter('script', function (nodes: Node[]) {
-    let i = nodes.length, node, type;
+    let i = nodes.length;
 
     while (i--) {
-      node = nodes[i];
-      type = node.attr('type') || 'no/type';
+      const node = nodes[i];
+      const type = node.attr('type') || 'no/type';
       if (type.indexOf('mce-') !== 0) {
         node.attr('type', 'mce-' + type);
       }
@@ -181,10 +181,10 @@ const createParser = function (editor: Editor): DomParser {
 
   if (editor.settings.preserve_cdata) {
     parser.addNodeFilter('#cdata', function (nodes: Node[]) {
-      let i = nodes.length, node;
+      let i = nodes.length;
 
       while (i--) {
-        node = nodes[i];
+        const node = nodes[i];
         node.type = 8;
         node.name = '#comment';
         node.value = '[CDATA[' + editor.dom.encode(node.value) + ']]';
@@ -193,11 +193,11 @@ const createParser = function (editor: Editor): DomParser {
   }
 
   parser.addNodeFilter('p,h1,h2,h3,h4,h5,h6,div', function (nodes: Node[]) {
-    let i = nodes.length, node;
+    let i = nodes.length;
     const nonEmptyElements = editor.schema.getNonEmptyElements();
 
     while (i--) {
-      node = nodes[i];
+      const node = nodes[i];
 
       if (node.isEmpty(nonEmptyElements) && node.getAll('br').length === 0) {
         node.append(new Node('br', 1)).shortEnded = true;

--- a/modules/tinymce/src/core/main/ts/init/Render.ts
+++ b/modules/tinymce/src/core/main/ts/init/Render.ts
@@ -7,6 +7,7 @@
 
 import { HTMLFormElement, window } from '@ephox/dom-globals';
 import { Arr, Fun, Option, Options, Type } from '@ephox/katamari';
+import { Attr, Element } from '@ephox/sugar';
 import { UrlObject } from '../api/AddOnManager';
 import DOMUtils from '../api/dom/DOMUtils';
 import EventUtils from '../api/dom/EventUtils';
@@ -192,6 +193,16 @@ const render = function (editor: Editor) {
     return;
   }
 
+  // snapshot the element we're going to render to
+  const element = Element.fromDom(editor.getElement());
+  const snapshot = Attr.clone(element);
+  editor.on('remove', () => {
+    Arr.eachr(element.dom().attributes, (attr) =>
+      Attr.remove(element, attr.name)
+    );
+    Attr.setAll(element, snapshot);
+  });
+
   // Hide target element early to prevent content flashing
   if (!settings.inline) {
     editor.orgVisibility = editor.getElement().style.visibility;
@@ -200,6 +211,7 @@ const render = function (editor: Editor) {
     editor.inline = true;
   }
 
+  // TODO: Investigate the types here
   const form = (editor.getElement() as HTMLFormElement).form || DOM.getParent(id, 'form');
   if (form) {
     editor.formElement = form;

--- a/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
@@ -1,0 +1,47 @@
+import { Assertions, Chain, Log, NamedChain, Pipeline } from '@ephox/agar';
+import { Editor as McEditor } from '@ephox/mcagar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Attr, Element, Truncate } from '@ephox/sugar';
+import { HTMLDivElement } from '@ephox/dom-globals';
+
+import Editor from 'tinymce/core/api/Editor';
+import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
+import Theme from 'tinymce/themes/silver/Theme';
+import VisualBlocksPlugin from 'tinymce/plugins/visualblocks/Plugin';
+
+UnitTest.asynctest('browser.tinymce.core.EditorCleanupTest', (success, failure) => {
+  Theme();
+  VisualBlocksPlugin();
+
+  const base_url = '/project/tinymce/js/tinymce';
+
+  const cTestCleanup = (settings: RawEditorSettings, html: string = '<div></div>') => NamedChain.asChain([
+    NamedChain.direct(NamedChain.inputName(), McEditor.cFromHtml(html, settings), 'editor'),
+    NamedChain.direct('editor', Chain.mapper((editor: Editor) => Element.fromDom(editor.getElement())), 'element'),
+    NamedChain.read('editor', Chain.op((editor: Editor) => editor.remove())),
+    // first, remove the id of the element, as that's inserted from McEditor.cFromHtml and is out of our control
+    NamedChain.read('element', Chain.op((element: Element<HTMLDivElement>) => Attr.remove(element, 'id'))),
+    NamedChain.direct('element', Chain.mapper(Truncate.getHtml), 'raw-html'),
+    NamedChain.read('raw-html', Assertions.cAssertHtml('all properties on the element should be cleaned up', html)),
+    NamedChain.read('editor', McEditor.cRemove)
+  ]);
+
+  Pipeline.async({}, [
+    Log.chainsAsStep('TINY-4001', 'Inline editor should clean up attributes', [
+      cTestCleanup({ base_url, inline: true })
+    ]),
+
+    Log.chainsAsStep('TINY-4001', 'Iframe editor should clean up attributes', [
+      cTestCleanup({ base_url })
+    ]),
+
+    Log.chainsAsStep('TINY-4001', 'Editor should clean up placeholder', [
+      cTestCleanup({ base_url, placeholder: 'Some text' }),
+      cTestCleanup({ base_url, placeholder: 'Some text' }, '<div placeholder="Testing"></div>')
+    ]),
+
+    Log.chainsAsStep('TINY-4001', 'Visual blocks plugin should not leave classes on target', [
+      cTestCleanup({ base_url, plugins: 'visualblocks' })
+    ])
+  ], success, failure);
+});

--- a/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
@@ -38,7 +38,7 @@ UnitTest.asynctest('browser.tinymce.core.EditorCleanupTest', (success, failure) 
 
     Log.chainsAsStep('TINY-4001', 'Editor should replace existing attributes on teardown', [
       cTestCleanup({ }, '<div classname="these are some classes"></div>'),
-      cTestCleanup({ }, '<div style="position: absolute"></div>'),
+      cTestCleanup({ }, '<div style="position: absolute;"></div>'),
       cTestCleanup({ }, '<div data-someattribute="7"></div>'),
       cTestCleanup({ }, '<textarea name="foo"></textarea>')
     ]),

--- a/modules/tinymce/src/core/test/ts/browser/init/EditorInitializationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/EditorInitializationTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { console, document, window } from '@ephox/dom-globals';
+import { HTMLElement, console, document, window } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import { LegacyUnit } from '@ephox/mcagar';
 import { Attr, Element, SelectorFilter } from '@ephox/sugar';
@@ -35,7 +35,7 @@ UnitTest.asynctest('browser.tinymce.core.init.EditorInitializationTest', functio
   };
 
   suite.asyncTest('target (initialised properly)', function (_, done) {
-    const elm1 = viewBlock.get().querySelector('#elm-1');
+    const elm1 = viewBlock.get().querySelector<HTMLElement>('#elm-1');
 
     EditorManager.init({
       target: elm1,

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/core/Bindings.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/core/Bindings.ts
@@ -23,10 +23,6 @@ const setup = function (editor: Editor, pluginUrl: string, enabledState: Cell<bo
       VisualBlocks.toggleVisualBlocks(editor, pluginUrl, enabledState);
     }
   });
-
-  editor.on('remove', function () {
-    editor.dom.removeClass(editor.getBody(), 'mce-visualblocks');
-  });
 };
 
 export {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Cleans up attributes on the target element when the editor is removed. Takes a snapshot of the attribute state when creating the editor, and restores it later. Also centralises a bit of code that was scattered around the codebase aiming to do the same thing for individual attributes / classes.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #5117 