### PR TITLE
Ensure aux div is in ShadowRoot if editor is in ShadowRoot

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -10,6 +10,7 @@ Version 5.4.0 (TBD)
     Changed `advlist` toolbar buttons to only show a dropdown list if there's more than one option #TINY-3194
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Changed stylesheet loading, so that UI skin stylesheets now to load in a ShadowRoot, if the editor is in a ShadowRoot. #TINY-6089
+    Changed the DOM location of menus so that they display correctly when the editor is in a ShadowRoot. #TINY-6093
     Fixed table `Paste row after` and `Paste row before` menu items not disabled when nothing was available to paste #TINY-6006
     Fixed a selection performance issue with large tables on Microsoft Internet Explorer and Edge #TINY-6057
     Fixed filters for screening commands from the undo stack to be properly case-insensitive #TINY-5946

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -8,7 +8,7 @@
 import { Attachment } from '@ephox/alloy';
 import { Cell, Throttler } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Body, Css, DomEvent, Element, Position } from '@ephox/sugar';
+import { Css, DomEvent, Element, Position, ShadowDom } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import * as Events from '../api/Events';
@@ -74,8 +74,11 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
 
   loadIframeSkin(editor);
 
-  Attachment.attachSystemAfter(Element.fromDom(args.targetNode), uiComponents.mothership);
-  Attachment.attachSystem(Body.body(), uiComponents.uiMothership);
+  const eTargetNode = Element.fromDom(args.targetNode);
+  const uiRoot = ShadowDom.getContentContainer(ShadowDom.getRootNode(eTargetNode));
+
+  Attachment.attachSystemAfter(eTargetNode, uiComponents.mothership);
+  Attachment.attachSystem(uiRoot, uiComponents.uiMothership);
 
   editor.on('PostRender', () => {
     setToolbar(editor, uiComponents, rawUiConfig, backstage);


### PR DESCRIPTION
Related Ticket: TINY-6093

Description of Changes:
* TinyMCE's Silver theme uses a div as a container for menus. This div is known as the "aux" or "sink" div. This change moves its location to within the ShadowRoot if the editor is within a ShadowRoot. Without this, menus do not display correctly.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
