### PR TITLE
DOC-581: Add back deprecated setMode API documentation

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -185,7 +185,12 @@ class Editor implements EditorObservable {
   public mode: Mode;
 
   /**
+   * Sets the editor mode. For example: "design", "code" or "readonly".
+   * <br>
+   * <em>Deprecated in TinyMCE 5.0.4</em> - Use <code>editor.mode.set(mode)</code> instead.
    *
+   * @method setMode
+   * @param {String} mode Mode to set the editor in.
    * @deprecated now an alias for editor.mode.set()
    */
   public setMode: (mode: string) => void;


### PR DESCRIPTION
Related Ticket: DOC-581

Description of Changes:
* Adds back some documentation that accidentally got deleted in 5.0.4, as moxiedoc doesn't handle the `@deprecated` marker.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
