### PR TITLE
TinyLoader should fail (instead of timeout) when exception is thrown …

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,6 @@
 // Tests either run in PhantomJs or real browsers
 const runsInPhantom = [
   '@ephox/alloy',
-  '@ephox/mcagar',
   '@ephox/katamari',
   '@ephox/katamari-test',
   '@ephox/imagetools',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 // Tests either run in PhantomJs or real browsers
 const runsInPhantom = [
   '@ephox/alloy',
+  '@ephox/mcagar',
   '@ephox/katamari',
   '@ephox/katamari-test',
   '@ephox/imagetools',

--- a/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
@@ -79,7 +79,11 @@ const setup = (callbacks: Callbacks, settings: Record<string, any>, elementOpt: 
 
         editor.on('SkinLoaded', () => {
           setTimeout(function () {
-            callbacks.run(editor, onSuccess, onFailure);
+            try {
+              callbacks.run(editor, onSuccess, onFailure);
+            } catch (e) {
+              onFailure(e);
+            }
           }, 0);
         });
 

--- a/modules/mcagar/src/test/ts/browser/api/TinyLoaderErrorTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinyLoaderErrorTest.ts
@@ -1,10 +1,7 @@
 import { UnitTest } from '@ephox/bedrock-client';
 import * as TinyLoader from 'ephox/mcagar/api/TinyLoader';
-import Theme from 'tinymce/lib/themes/silver/main/ts/Theme';
 
 UnitTest.asynctest('TinyLoader should fail (instead of timeout) when exception is thrown in callback function', (success, failure) => {
-  Theme();
-
   TinyLoader.setup(() => {
     throw new Error('boo!');
   }, { base_url: '/project/tinymce/js/tinymce' }, failure, success);

--- a/modules/mcagar/src/test/ts/browser/api/TinyLoaderErrorTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinyLoaderErrorTest.ts
@@ -1,0 +1,11 @@
+import { UnitTest } from '@ephox/bedrock-client';
+import * as TinyLoader from 'ephox/mcagar/api/TinyLoader';
+import Theme from 'tinymce/lib/themes/silver/main/ts/Theme';
+
+UnitTest.asynctest('TinyLoader should fail (instead of timeout) when exception is thrown in callback function', (success, failure) => {
+  Theme();
+
+  TinyLoader.setup(() => {
+    throw new Error('boo!');
+  }, { base_url: '/project/tinymce/js/tinymce' }, failure, success);
+});


### PR DESCRIPTION
…in callback function.

Related Ticket: TINY-6137

Description of Changes:
* This change makes mcagar's TinyLoader fail if the callback function throws. Not only is the timeout annoying, but it prevents us doing synchronous assertions.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
