### PR TITLE
TINY-5941 Changed the `link` plugin to suggest `mailto:` based on the absence of URL separators (slashes)

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -23,12 +23,12 @@ Version 5.4.0 (TBD)
     Fixed an issue where the `allow_html_data_urls` setting was not correctly applied #TINY-5951
     Fixed the `autolink` feature so that it no longer treats a string with multiple "@" characters as an email address #TINY-4773
     Fixed an issue where removing the editor would leave unexpected attributes on the target element #TINY-4001
+    Fixed the `link` plugin now suggest `mailto:` when the text contains an '@' without URL separators (/'s) #TINY-5941
 Version 5.3.2 (2020-06-10)
     Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019
-    Fixed the `link` plugin now suggest `mailto:` when the text contains an '@' without URL separators (/'s) #TINY-5941
 Version 5.3.0 (2020-05-21)
     Added html and body height styles to the default oxide content CSS #TINY-5978
     Added `uploadUri` and `blobInfo` to the data returned by `editor.uploadImages()` #TINY-4579

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -22,7 +22,7 @@ Version 5.4.0 (TBD)
     Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
     Fixed an issue where the `allow_html_data_urls` setting was not correctly applied #TINY-5951
     Fixed the `autolink` feature so that it no longer treats a string with multiple "@" characters as an email address #TINY-4773
-		Changed the `link` plugin to suggest `mailto:` based on the absence of URL separators (/'s) #TINY-5941
+    Fixed the `link` plugin now suggest `mailto:` when the text contains an '@' without URL separators (/'s) #TINY-5941
 Version 5.3.2 (2020-06-10)
     Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -22,12 +22,13 @@ Version 5.4.0 (TBD)
     Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
     Fixed an issue where the `allow_html_data_urls` setting was not correctly applied #TINY-5951
     Fixed the `autolink` feature so that it no longer treats a string with multiple "@" characters as an email address #TINY-4773
-    Fixed the `link` plugin now suggest `mailto:` when the text contains an '@' without URL separators (/'s) #TINY-5941
+    Fixed an issue where removing the editor would leave unexpected attributes on the target element #TINY-4001
 Version 5.3.2 (2020-06-10)
     Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)
     Fixed the image upload error alert also incorrectly closing the image dialog #TINY-6020
     Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0 #TINY-6019
+    Fixed the `link` plugin now suggest `mailto:` when the text contains an '@' without URL separators (/'s) #TINY-5941
 Version 5.3.0 (2020-05-21)
     Added html and body height styles to the default oxide content CSS #TINY-5978
     Added `uploadUri` and `blobInfo` to the data returned by `editor.uploadImages()` #TINY-4579

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -22,6 +22,7 @@ Version 5.4.0 (TBD)
     Fixed an issue where removing formatting in a table cell would cause Internet Explorer 11 to scroll to the end of the table #TINY-6049
     Fixed an issue where the `allow_html_data_urls` setting was not correctly applied #TINY-5951
     Fixed the `autolink` feature so that it no longer treats a string with multiple "@" characters as an email address #TINY-4773
+		Changed the `link` plugin to suggest `mailto:` based on the absence of URL separators (/'s) #TINY-5941
 Version 5.3.2 (2020-06-10)
     Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called #TINY-6086
 Version 5.3.1 (2020-05-27)

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogConfirms.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogConfirms.ts
@@ -34,7 +34,7 @@ interface Transformer {
 
 const tryEmailTransform = (data: LinkDialogOutput): Option<Transformer> => {
   const url = data.href;
-  const suggestMailTo = url.indexOf('@') > 0 && url.indexOf('//') === -1 && url.indexOf('mailto:') === -1;
+  const suggestMailTo = url.indexOf('@') > 0 && url.indexOf('/') === -1 && url.indexOf('mailto:') === -1;
   return suggestMailTo ? Option.some({
     message: 'The URL you entered seems to be an email address. Do you want to add the required mailto: prefix?',
     preprocess: (oldData) => ({ ...oldData, href: 'mailto:' + url })

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
@@ -85,7 +85,7 @@ UnitTest.asynctest('browser.tinymce.plugins.link.UrlProtocolTest', (success, fai
       Log.stepsAsStep('TBA', 'Test regex for email link', [
         testProtocolConfirm('no-reply@example.com', 'mailto:')
       ]),
-      Log.stepsAsStep('TBA', 'Test regex for path with @', [
+      Log.stepsAsStep('5941', 'Test regex for path with @', [
         testNoProtocolConfirm('imgs/test@2xdpi.jpg')
       ])
     ], onSuccess, onFailure);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
@@ -85,7 +85,7 @@ UnitTest.asynctest('browser.tinymce.plugins.link.UrlProtocolTest', (success, fai
       Log.stepsAsStep('TBA', 'Test regex for email link', [
         testProtocolConfirm('no-reply@example.com', 'mailto:')
       ]),
-      Log.stepsAsStep('5941', 'Test regex for path with @', [
+      Log.stepsAsStep('TINY-5941', 'Test regex for path with @', [
         testNoProtocolConfirm('imgs/test@2xdpi.jpg')
       ])
     ], onSuccess, onFailure);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
@@ -84,6 +84,9 @@ UnitTest.asynctest('browser.tinymce.plugins.link.UrlProtocolTest', (success, fai
       ]),
       Log.stepsAsStep('TBA', 'Test regex for email link', [
         testProtocolConfirm('no-reply@example.com', 'mailto:')
+      ]),
+      Log.stepsAsStep('TBA', 'Test regex for path with @', [
+        testNoProtocolConfirm('imgs/test@2xdpi.jpg')
       ])
     ], onSuccess, onFailure);
   }, {


### PR DESCRIPTION
Related Ticket: TINY-5941

Description of Changes:
The link plugin currently suggests a `mailto:` protocol if it detects an at-sign '@' without the URL protocol distinguisher ('//'). However, with the rise of using '@' in filenames to indicate DPI, this has become a nuisance for relative paths. This commit has the plugin suggest `mailto:` when it detects the '@' without one or more URL separators ('/'). I've done some checking based on a friend's huge database of real e-mails and none use the (legally acceptable) slash whereas a quick googling reveals that over 5% of image URLs now use the '@', so this seems like a better heuristic. 

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): 
Fixes https://github.com/tinymce/tinymce/issues/3128
