### PR TITLE
Remove failing condition in ShadowDomEditorTest

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
@@ -26,11 +26,7 @@ UnitTest.asynctest('Skin stylesheets should be loaded in ShadowRoot when editor 
   TinyLoader.setupFromElement((editor: Editor, onSuccess, onFailure) => {
     Pipeline.async({}, [
       Step.sync(() => {
-        Assert.eq(
-          'There should not be any skin stylesheets in the document',
-          false,
-          Arr.exists(document.styleSheets, isSkin)
-        );
+        // TODO: Test that there are no skin stylesheets in the head. We will need to clean up existing stylesheets first, which may require a StyleSheetLoader.removeAll() function
         Assert.eq(
           'There should be a skin stylesheet in the ShadowRoot',
           true,

--- a/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
@@ -26,7 +26,7 @@ UnitTest.asynctest('Skin stylesheets should be loaded in ShadowRoot when editor 
   TinyLoader.setupFromElement((editor: Editor, onSuccess, onFailure) => {
     Pipeline.async({}, [
       Step.sync(() => {
-        // TODO: Test that there are no skin stylesheets in the head. We will need to clean up existing stylesheets first, which may require a StyleSheetLoader.removeAll() function
+        // TODO TINY-6144: Test that there are no skin stylesheets in the head. We will need to clean up existing stylesheets first, which may require a StyleSheetLoader.removeAll() function
         Assert.eq(
           'There should be a skin stylesheet in the ShadowRoot',
           true,


### PR DESCRIPTION
Related Ticket: TINY-6143

Description of Changes:
* This test was testing that there are no skin stylesheets in the body. However, previous tests may have added a skin stylesheet. For now, we're just removing this test condition. In future, we probably need a `StyleSheetLoader.removeAll()` method.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
