### PR TITLE
TINY-5956

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
@@ -258,7 +258,6 @@ class EditorCommands {
 
   private toggleFormat(name: string, value?) {
     this.editor.formatter.toggle(name, value ? { value } : undefined);
-    this.editor.nodeChanged();
   }
 
   private storeSelection(type?: number) {

--- a/modules/tinymce/src/core/main/ts/fmt/ToggleFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ToggleFormat.ts
@@ -20,6 +20,7 @@ const toggle = (editor: Editor, name: string, vars: FormatVars, node: Node) => {
   } else {
     ApplyFormat.applyFormat(editor, name, vars, node);
   }
+  editor.nodeChanged();
 };
 
 export {


### PR DESCRIPTION
Related Ticket: TINY-5956

Description of Changes:
This moves a `toggleFormat` call to `nodeChanged()` out of `EditorCommands` and into the `editor.formatter.toggle()` implementation. In between these two functions is the check to call the RTC implementation instead of the editor one.

RTC toggle format doesn't update the DOM synchronously, so the change isn't applied before the existing `nodeChanged()` call. RTC triggers one to make sure the toolbar updates at the right time, it's a waste to have two when the fix is this easy.

Pre-checks:
* ~[ ] Changelog entry added~ I assume this isn't necessary as there's no customer impact, and RTC is an unreleased feature
* ~[ ] Tests have been added (if applicable)~
* ~[ ] Branch prefixed with `feature/` for new features (if applicable)~
* ~[ ] License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [ ] Review comments resolved
