### PR TITLE
Feature/TINY-6007 (part of) Table header detection and section switching + new setting

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,7 +7,7 @@ Version 5.4.0 (TBD)
     Added new `mceTableApplyCellStyle` command to the `table` plugin #TINY-6004
     Added new `table` cut, copy and paste column editor commands and menu items #TINY-6006
     Added additional font related Oxide variables for secondary buttons allowing more specific styling. #TINY-6061
-    Added new `table_header_row_type` setting to control how table header rows are structured #TINY-6007
+    Added new `table_header_type` setting to control how table header rows are structured #TINY-6007
     Changed `advlist` toolbar buttons to only show a dropdown list if there's more than one option #TINY-3194
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Changed stylesheet loading, so that UI skin stylesheets now to load in a ShadowRoot, if the editor is in a ShadowRoot. #TINY-6089

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,10 +7,12 @@ Version 5.4.0 (TBD)
     Added new `mceTableApplyCellStyle` command to the `table` plugin #TINY-6004
     Added new `table` cut, copy and paste column editor commands and menu items #TINY-6006
     Added additional font related Oxide variables for secondary buttons allowing more specific styling. #TINY-6061
+    Added new `table_header_row_type` setting to control how table header rows are structured #TINY-6007
     Changed `advlist` toolbar buttons to only show a dropdown list if there's more than one option #TINY-3194
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Changed stylesheet loading, so that UI skin stylesheets now to load in a ShadowRoot, if the editor is in a ShadowRoot. #TINY-6089
     Changed the DOM location of menus so that they display correctly when the editor is in a ShadowRoot. #TINY-6093
+    Changed the table plugin to correctly detect all valid header row structures #TINY-6007
     Fixed the `autosave` isEmpty API incorrectly detecting non-empty content as empty #TINY-5953
     Fixed table `Paste row after` and `Paste row before` menu items not disabled when nothing was available to paste #TINY-6006
     Fixed a selection performance issue with large tables on Microsoft Internet Explorer and Edge #TINY-6057

--- a/modules/tinymce/src/plugins/table/main/ts/alien/Util.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/alien/Util.ts
@@ -8,7 +8,9 @@
 import { Compare, Element, Attr, SelectorFilter } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import { Arr } from '@ephox/katamari';
-import { HTMLElement } from '@ephox/dom-globals';
+import { HTMLElement, Node } from '@ephox/dom-globals';
+
+const getNodeName = (elm: Node) => elm.nodeName.toLowerCase();
 
 const getBody = function (editor: Editor) {
   return Element.fromDom(editor.getBody());
@@ -44,6 +46,7 @@ const removeDataStyle = (table) => {
 };
 
 export {
+  getNodeName,
   getBody,
   getIsRoot,
   addSizeSuffix,

--- a/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
@@ -46,10 +46,11 @@ const getToolbar = (editor: Editor): string => editor.getParam('table_toolbar', 
 
 
 const getTableHeaderType = (editor: Editor): string => {
-  const value = editor.getParam('table_header_type', 'auto', 'string');
-  const validValues = [ 'thead', 'ths', 'both', 'auto' ];
+  const defaultValue = 'section';
+  const value = editor.getParam('table_header_type', defaultValue, 'string');
+  const validValues = [ 'section', 'cells', 'sectionCells', 'auto' ];
   if (!Arr.contains(validValues, value)) {
-    return 'auto';
+    return defaultValue;
   } else {
     return value;
   }

--- a/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
@@ -6,7 +6,7 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
-import { Type, Option } from '@ephox/katamari';
+import { Type, Option, Arr } from '@ephox/katamari';
 
 export interface StringMap {
   [key: string]: string;
@@ -44,6 +44,17 @@ const isPercentagesForced = (editor: Editor): boolean => editor.getParam('table_
 const isPixelsForced = (editor: Editor): boolean => editor.getParam('table_responsive_width') === false;
 const getToolbar = (editor: Editor): string => editor.getParam('table_toolbar', defaultTableToolbar);
 
+
+const getTableHeaderRowType = (editor: Editor): string => {
+  const value = editor.getParam('table_header_row_type', 'auto', 'string');
+  const validValues = [ 'thead', 'ths', 'both', 'auto' ];
+  if (!Arr.contains(validValues, value)) {
+    return 'auto';
+  } else {
+    return value;
+  }
+};
+
 const getCloneElements = (editor: Editor): Option<string[]> => {
   const cloneElements = editor.getParam('table_clone_elements');
 
@@ -80,5 +91,6 @@ export {
   hasObjectResizing,
   isPercentagesForced,
   isPixelsForced,
-  getToolbar
+  getToolbar,
+  getTableHeaderRowType
 };

--- a/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
@@ -45,8 +45,8 @@ const isPixelsForced = (editor: Editor): boolean => editor.getParam('table_respo
 const getToolbar = (editor: Editor): string => editor.getParam('table_toolbar', defaultTableToolbar);
 
 
-const getTableHeaderRowType = (editor: Editor): string => {
-  const value = editor.getParam('table_header_row_type', 'auto', 'string');
+const getTableHeaderType = (editor: Editor): string => {
+  const value = editor.getParam('table_header_type', 'auto', 'string');
   const validValues = [ 'thead', 'ths', 'both', 'auto' ];
   if (!Arr.contains(validValues, value)) {
     return 'auto';
@@ -92,5 +92,5 @@ export {
   isPercentagesForced,
   isPixelsForced,
   getToolbar,
-  getTableHeaderRowType
+  getTableHeaderType
 };

--- a/modules/tinymce/src/plugins/table/main/ts/core/TableRowSectionTypes.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/TableRowSectionTypes.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { HTMLElement, HTMLTableRowElement } from '@ephox/dom-globals';
+import { Arr, Option } from '@ephox/katamari';
+import { TableLookup } from '@ephox/snooker';
+import { Element } from '@ephox/sugar';
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import Editor from 'tinymce/core/api/Editor';
+import { getTableHeaderRowType } from '../api/Settings';
+import * as Util from '../alien/Util';
+
+export interface HeaderRowConfiguration {
+  thead: boolean;
+  ths: boolean;
+}
+
+const getSection = (elm: HTMLTableRowElement) => Util.getNodeName(elm.parentNode);
+
+const detectHeaderRow = (editor: Editor, elm: HTMLTableRowElement): Option<HeaderRowConfiguration> => {
+  // Header rows can use a combination of theads and ths - want to detect the 3 combinations
+  const isThead = getSection(elm) === 'thead';
+  const areAllCellsThs = !Arr.exists(elm.cells, (c) => Util.getNodeName(c) !== 'th');
+
+  if (isThead || areAllCellsThs) {
+    return Option.some({ thead: isThead, ths: areAllCellsThs });
+  }
+  return Option.none();
+};
+
+const getRowType = (editor: Editor, elm: HTMLTableRowElement) => detectHeaderRow(editor, elm).fold(
+  () => getSection(elm),
+  (_rowConfig) => 'thead'
+);
+
+const switchRowSection = (dom: DOMUtils, rowElm: HTMLElement, newSectionName: string) => {
+  const tableElm = dom.getParent(rowElm, 'table');
+  const oldParentElm = rowElm.parentNode;
+  let parentElm = dom.select(newSectionName, tableElm)[0];
+
+  if (!parentElm) {
+    parentElm = dom.create(newSectionName);
+    const firstTableChild = tableElm.firstChild;
+    if (firstTableChild) {
+      // caption tag should be the first descendant of the table tag (see TINY-1167)
+      if (Util.getNodeName(firstTableChild) === 'CAPTION') {
+        dom.insertAfter(parentElm, firstTableChild);
+      } else {
+        tableElm.insertBefore(parentElm, firstTableChild);
+      }
+    } else {
+      tableElm.appendChild(parentElm);
+    }
+  }
+
+  // If moving from the head to the body, add to the top of the body
+  if (newSectionName === 'tbody' && Util.getNodeName(oldParentElm) === 'THEAD' && parentElm.firstChild) {
+    parentElm.insertBefore(rowElm, parentElm.firstChild);
+  } else {
+    parentElm.appendChild(rowElm);
+  }
+
+  if (!oldParentElm.hasChildNodes()) {
+    dom.remove(oldParentElm);
+  }
+};
+
+const switchRowCellType = (dom: DOMUtils, rowElm: HTMLTableRowElement, newCellType: string) => {
+  Arr.each(rowElm.cells, (c) => Util.getNodeName(c) !== newCellType ? dom.rename(c, newCellType): c);
+};
+
+const switchRowType = (editor: Editor, rowElm: HTMLTableRowElement, newType: string) => {
+  const determineHeaderRowType = () => {
+    // default if all else fails is thead > tr > tds aka 'thead' mode
+    const allTableRows = TableLookup.table(Element.fromDom(rowElm.cells[0]))
+      .map((table) => TableLookup.rows(table)).getOr([]);
+    return Arr.find(allTableRows, (row: Element<HTMLTableRowElement>) => detectHeaderRow(editor, row.dom()).isSome()).map((detectedType) => {
+      if (detectedType.thead && detectedType.ths) {
+        return 'both';
+      } else {
+        return detectedType.thead ? 'thead' : 'ths';
+      }
+    }).getOr('thead');
+  };
+
+  const dom = editor.dom;
+
+  if (newType === 'thead') {
+    const headerRowTypeSetting = getTableHeaderRowType(editor);
+    const headerRowType = headerRowTypeSetting === 'auto' ? determineHeaderRowType() : headerRowTypeSetting;
+    if (headerRowType === 'ths') {
+      switchRowCellType(dom, rowElm, 'th');
+    } else if (headerRowType === 'both') {
+      switchRowCellType(dom, rowElm, 'th');
+      switchRowSection(dom, rowElm, 'thead');
+    } else { // technically headerRowType === 'thead' case but also default behaviour
+      switchRowSection(dom, rowElm, 'thead');
+    }
+  } else {
+    switchRowCellType(dom, rowElm, 'td'); // if switching from header to other, may need to switch th to td
+    switchRowSection(dom, rowElm, newType);
+  }
+};
+
+export { getRowType, detectHeaderRow, switchRowType };
+

--- a/modules/tinymce/src/plugins/table/main/ts/core/TableSections.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/TableSections.ts
@@ -11,7 +11,7 @@ import { TableLookup } from '@ephox/snooker';
 import { Element } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
-import { getTableHeaderRowType } from '../api/Settings';
+import { getTableHeaderType } from '../api/Settings';
 import * as Util from '../alien/Util';
 
 export interface HeaderRowConfiguration {
@@ -47,7 +47,7 @@ const switchRowSection = (dom: DOMUtils, rowElm: HTMLElement, newSectionName: st
     const firstTableChild = tableElm.firstChild;
     if (firstTableChild) {
       // caption tag should be the first descendant of the table tag (see TINY-1167)
-      if (Util.getNodeName(firstTableChild) === 'CAPTION') {
+      if (Util.getNodeName(firstTableChild) === 'caption') {
         dom.insertAfter(parentElm, firstTableChild);
       } else {
         tableElm.insertBefore(parentElm, firstTableChild);
@@ -58,7 +58,7 @@ const switchRowSection = (dom: DOMUtils, rowElm: HTMLElement, newSectionName: st
   }
 
   // If moving from the head to the body, add to the top of the body
-  if (newSectionName === 'tbody' && Util.getNodeName(oldParentElm) === 'THEAD' && parentElm.firstChild) {
+  if (newSectionName === 'tbody' && Util.getNodeName(oldParentElm) === 'thead' && parentElm.firstChild) {
     parentElm.insertBefore(rowElm, parentElm.firstChild);
   } else {
     parentElm.appendChild(rowElm);
@@ -90,7 +90,7 @@ const switchRowType = (editor: Editor, rowElm: HTMLTableRowElement, newType: str
   const dom = editor.dom;
 
   if (newType === 'thead') {
-    const headerRowTypeSetting = getTableHeaderRowType(editor);
+    const headerRowTypeSetting = getTableHeaderType(editor);
     const headerRowType = headerRowTypeSetting === 'auto' ? determineHeaderRowType() : headerRowTypeSetting;
     if (headerRowType === 'ths') {
       switchRowCellType(dom, rowElm, 'th');

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -51,7 +51,7 @@ const applyCellData = (editor: Editor, cells: HTMLTableCellElement[], data: Cell
 
   Arr.each(cells, (cell) => {
     // Switch cell type if applicable
-    const cellElm = data.celltype && cell.nodeName.toLowerCase() !== data.celltype ? (dom.rename(cell, data.celltype) as HTMLTableCellElement) : cell;
+    const cellElm = data.celltype && Util.getNodeName(cell).toLowerCase() !== data.celltype ? (dom.rename(cell, data.celltype) as HTMLTableCellElement) : cell;
     const modifier = isSingleCell ? DomModifier.normal(editor, cellElm) : DomModifier.ifTruthy(editor, cellElm);
 
     updateSimpleProps(modifier, data);

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -51,7 +51,7 @@ const applyCellData = (editor: Editor, cells: HTMLTableCellElement[], data: Cell
 
   Arr.each(cells, (cell) => {
     // Switch cell type if applicable
-    const cellElm = data.celltype && Util.getNodeName(cell).toLowerCase() !== data.celltype ? (dom.rename(cell, data.celltype) as HTMLTableCellElement) : cell;
+    const cellElm = data.celltype && Util.getNodeName(cell) !== data.celltype ? (dom.rename(cell, data.celltype) as HTMLTableCellElement) : cell;
     const modifier = isSingleCell ? DomModifier.normal(editor, cellElm) : DomModifier.ifTruthy(editor, cellElm);
 
     updateSimpleProps(modifier, data);

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -7,12 +7,14 @@
 
 import { Types } from '@ephox/bridge';
 import { Element as DomElement, HTMLElement, HTMLTableRowElement, Node } from '@ephox/dom-globals';
-import { Arr, Fun, Obj, Strings, Option } from '@ephox/katamari';
+import { Arr, Fun, Obj, Strings } from '@ephox/katamari';
 import { Css, Element } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import * as Styles from '../actions/Styles';
 import { getDefaultAttributes, getDefaultStyles, shouldStyleWithCss } from '../api/Settings';
+import { getRowType } from '../core/TableRowSectionTypes';
+import * as Util from '../alien/Util';
 
 /**
  * @class tinymce.table.ui.Helpers
@@ -229,29 +231,6 @@ const extractDataFromTableElement = (editor: Editor, elm: DomElement, hasAdvTabl
   };
 };
 
-export interface HeaderRowConfiguration {
-  thead: boolean;
-  ths: boolean;
-}
-
-const getSection = (elm: HTMLTableRowElement) => elm.parentNode.nodeName.toLowerCase();
-
-const detectHeaderRow = (editor: Editor, elm: HTMLTableRowElement): Option<HeaderRowConfiguration> => {
-  // Header rows can use a combination of theads and ths - want to detect the 3 combinations
-  const isThead = getSection(elm) === 'thead';
-  const areAllCellsThs = !Arr.exists(elm.cells, (c) => c.nodeName.toLowerCase() !== 'th');
-
-  if (isThead || areAllCellsThs) {
-    return Option.some({ thead: isThead, ths: areAllCellsThs });
-  }
-  return Option.none();
-};
-
-const getRowType = (editor: Editor, elm: HTMLTableRowElement) => detectHeaderRow(editor, elm).fold(
-  () => getSection(elm),
-  (_rowConfig) => 'thead'
-);
-
 export interface RowData {
   height: string;
   scope: string;
@@ -295,7 +274,7 @@ const extractDataFromCellElement = (editor: Editor, elm: HTMLElement, hasAdvance
     width: dom.getStyle(elm, 'width') || dom.getAttrib(elm, 'width'),
     height: dom.getStyle(elm, 'height') || dom.getAttrib(elm, 'height'),
     scope: dom.getAttrib(elm, 'scope'),
-    celltype: elm.nodeName.toLowerCase(),
+    celltype: Util.getNodeName(elm),
     class: dom.getAttrib(elm, 'class', ''),
     halign: getHAlignment(editor, elm),
     valign: getVAlignment(editor, elm),
@@ -303,4 +282,5 @@ const extractDataFromCellElement = (editor: Editor, elm: HTMLElement, hasAdvance
   };
 };
 
-export { buildListItems, extractAdvancedStyles, getSharedValues, getAdvancedTab, extractDataFromTableElement, extractDataFromRowElement, extractDataFromCellElement, extractDataFromSettings, getRowType, detectHeaderRow };
+export { buildListItems, extractAdvancedStyles, getSharedValues, getAdvancedTab, extractDataFromTableElement, extractDataFromRowElement, extractDataFromCellElement, extractDataFromSettings };
+

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -13,7 +13,7 @@ import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import * as Styles from '../actions/Styles';
 import { getDefaultAttributes, getDefaultStyles, shouldStyleWithCss } from '../api/Settings';
-import { getRowType } from '../core/TableRowSectionTypes';
+import { getRowType } from '../core/TableSections';
 import * as Util from '../alien/Util';
 
 /**

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -16,7 +16,7 @@ import * as TableSelection from '../selection/TableSelection';
 import { DomModifier } from './DomModifier';
 import * as Helpers from './Helpers';
 import * as RowDialogGeneralTab from './RowDialogGeneralTab';
-import { switchRowType } from '../core/TableSections';
+import { switchSectionType } from '../core/TableSections';
 
 type RowData = Helpers.RowData;
 
@@ -38,7 +38,7 @@ const applyRowData = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowD
   Arr.each(rows, (rowElm) => {
     // Switch row type
     if (data.type !== Util.getNodeName(rowElm.parentNode)) {
-      switchRowType(editor, rowElm, data.type);
+      switchSectionType(editor, rowElm, data.type);
     }
 
     const modifier = isSingleRow ? DomModifier.normal(editor, rowElm) : DomModifier.ifTruthy(editor, rowElm);

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -16,7 +16,7 @@ import * as TableSelection from '../selection/TableSelection';
 import { DomModifier } from './DomModifier';
 import * as Helpers from './Helpers';
 import * as RowDialogGeneralTab from './RowDialogGeneralTab';
-import { switchRowType } from '../core/TableRowSectionTypes';
+import { switchRowType } from '../core/TableSections';
 
 type RowData = Helpers.RowData;
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -6,50 +6,19 @@
  */
 
 import { Types } from '@ephox/bridge';
-import { HTMLElement } from '@ephox/dom-globals';
+import { HTMLTableRowElement } from '@ephox/dom-globals';
 import { Arr, Fun } from '@ephox/katamari';
-import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import * as Styles from '../actions/Styles';
 import * as Util from '../alien/Util';
 import { hasAdvancedRowTab } from '../api/Settings';
+import * as TableSelection from '../selection/TableSelection';
 import { DomModifier } from './DomModifier';
 import * as Helpers from './Helpers';
 import * as RowDialogGeneralTab from './RowDialogGeneralTab';
-import * as TableSelection from '../selection/TableSelection';
+import { switchRowType } from '../core/TableRowSectionTypes';
 
 type RowData = Helpers.RowData;
-
-const switchRowType = (dom: DOMUtils, rowElm: HTMLElement, toType: string) => {
-  const tableElm = dom.getParent(rowElm, 'table');
-  const oldParentElm = rowElm.parentNode;
-  let parentElm = dom.select(toType, tableElm)[0];
-
-  if (!parentElm) {
-    parentElm = dom.create(toType);
-    if (tableElm.firstChild) {
-      // caption tag should be the first descendant of the table tag (see TINY-1167)
-      if (tableElm.firstChild.nodeName === 'CAPTION') {
-        dom.insertAfter(parentElm, tableElm.firstChild);
-      } else {
-        tableElm.insertBefore(parentElm, tableElm.firstChild);
-      }
-    } else {
-      tableElm.appendChild(parentElm);
-    }
-  }
-
-  // If moving from the head to the body, add to the top of the body
-  if (toType === 'tbody' && oldParentElm.nodeName === 'THEAD' && parentElm.firstChild) {
-    parentElm.insertBefore(rowElm, parentElm.firstChild);
-  } else {
-    parentElm.appendChild(rowElm);
-  }
-
-  if (!oldParentElm.hasChildNodes()) {
-    dom.remove(oldParentElm);
-  }
-};
 
 const updateSimpleProps = (modifier: DomModifier, data: RowData) => {
   modifier.setAttrib('scope', data.scope);
@@ -63,13 +32,13 @@ const updateAdvancedProps = (modifier: DomModifier, data: RowData) => {
   modifier.setStyle('border-style', data.borderstyle);
 };
 
-const applyRowData = (editor: Editor, rows: HTMLElement[], oldData: RowData, data: RowData) => {
+const applyRowData = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowData, data: RowData) => {
   const isSingleRow = rows.length === 1;
 
   Arr.each(rows, (rowElm) => {
     // Switch row type
-    if (data.type !== rowElm.parentNode.nodeName.toLowerCase()) {
-      switchRowType(editor.dom, rowElm, data.type);
+    if (data.type !== Util.getNodeName(rowElm.parentNode)) {
+      switchRowType(editor, rowElm, data.type);
     }
 
     const modifier = isSingleRow ? DomModifier.normal(editor, rowElm) : DomModifier.ifTruthy(editor, rowElm);
@@ -87,7 +56,7 @@ const applyRowData = (editor: Editor, rows: HTMLElement[], oldData: RowData, dat
   });
 };
 
-const onSubmitRowForm = (editor: Editor, rows: HTMLElement[], oldData: RowData, api) => {
+const onSubmitRowForm = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowData, api) => {
   const data: RowData = api.getData();
   api.close();
 
@@ -153,6 +122,5 @@ const open = (editor: Editor) => {
   });
 };
 
-export {
-  open
-};
+export { open };
+

--- a/modules/tinymce/src/plugins/table/test/ts/browser/DetectHeaderRowTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/DetectHeaderRowTest.ts
@@ -6,6 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { detectHeaderRow, getRowType } from 'tinymce/plugins/table/core/TableSections';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
+import { HTMLTableRowElement } from '@ephox/dom-globals';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success, failure) => {
   Plugin();
@@ -14,8 +15,14 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
   TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
 
+    const sAssertRow = (selector: string, assertions: (row: Element<HTMLTableRowElement>) => void) =>
+      Chain.asStep(Element.fromDom(editor.getBody()), [
+        UiFinder.cFindIn(selector),
+        Chain.op(assertions)
+      ]);
+
     Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'No header rows', [
+      Log.stepsAsStep('TINY-6007', 'No header rows', [
         tinyApis.sSetContent(
           '<table>' +
           '<tbody><tr>' +
@@ -23,15 +30,12 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
           '</tr></tbody>' +
           '</table>'
         ),
-        Chain.asStep(Element.fromDom(editor.getBody()), [
-          UiFinder.cFindIn('tr'),
-          Chain.op((tr) => {
-            const rowData = getRowType(editor, tr.dom());
-            Assertions.assertEq('Detect as part of the tbody', 'tbody', rowData);
-          })
-        ])
+        sAssertRow('tr', (tr) => {
+          const rowData = getRowType(editor, tr.dom());
+          Assertions.assertEq('Detect as part of the tbody', 'tbody', rowData);
+        })
       ]),
-      Log.stepsAsStep('TBA', 'Tbody > tr > th is detected correctly as a header row', [
+      Log.stepsAsStep('TINY-6007', 'Tbody > tr > th is detected correctly as a header row', [
         tinyApis.sSetContent(
           '<table>' +
           '<tbody><tr>' +
@@ -39,20 +43,17 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
           '</tr></tbody>' +
           '</table>'
         ),
-        Chain.asStep(Element.fromDom(editor.getBody()), [
-          UiFinder.cFindIn('tr'),
-          Chain.op((tr) => {
-            detectHeaderRow(editor, tr.dom()).fold(
-              () => Assertions.assertEq('Row incorrectly detected as not a header row', true, false), // would call failure() but want logs
-              (rowData) => {
-                Assertions.assertEq('Detect as part of the tbody', false, rowData.thead);
-                Assertions.assertEq('Detect as ths', true, rowData.ths);
-              }
-            );
-          })
-        ])
+        sAssertRow('tr', (tr) => {
+          detectHeaderRow(editor, tr.dom()).fold(
+            () => Assertions.assertEq('Row incorrectly detected as not a header row', true, false), // would call failure() but want logs
+            (rowData) => {
+              Assertions.assertEq('Detect as part of the tbody', false, rowData.thead);
+              Assertions.assertEq('Detect as ths', true, rowData.ths);
+            }
+          );
+        })
       ]),
-      Log.stepsAsStep('TBA', 'Tbody > tr > ths is detected correctly as a header row', [
+      Log.stepsAsStep('TINY-6007', 'Tbody > tr > ths is detected correctly as a header row', [
         tinyApis.sSetContent(
           '<table>' +
           '<tbody><tr>' +
@@ -61,16 +62,13 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
           '</tr></tbody>' +
           '</table>'
         ),
-        Chain.asStep(Element.fromDom(editor.getBody()), [
-          UiFinder.cFindIn('tr'),
-          Chain.op((tr) => {
-            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
-            Assertions.assertEq('Detect as part of the tbody', false, rowData.thead);
-            Assertions.assertEq('Detect as all ths', true, rowData.ths);
-          })
-        ])
+        sAssertRow('tr', (tr) => {
+          const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
+          Assertions.assertEq('Detect as part of the tbody', false, rowData.thead);
+          Assertions.assertEq('Detect as all ths', true, rowData.ths);
+        })
       ]),
-      Log.stepsAsStep('TBA', 'Tbody > tr > td+th is detected correctly as NOT a header row', [
+      Log.stepsAsStep('TINY-6007', 'Tbody > tr > td+th is detected correctly as NOT a header row', [
         tinyApis.sSetContent(
           '<table>' +
           '<tbody><tr>' +
@@ -79,15 +77,12 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
           '</tr></tbody>' +
           '</table>'
         ),
-        Chain.asStep(Element.fromDom(editor.getBody()), [
-          UiFinder.cFindIn('tr'),
-          Chain.op((tr) => {
-            const rowData = getRowType(editor, tr.dom());
-            Assertions.assertEq('Detect as part of the tbody', 'tbody', rowData);
-          })
-        ])
+        sAssertRow('tr', (tr) => {
+          const rowData = getRowType(editor, tr.dom());
+          Assertions.assertEq('Detect as part of the tbody', 'tbody', rowData);
+        })
       ]),
-      Log.stepsAsStep('TBA', 'Thead > tr > td is detected correctly as a header row', [
+      Log.stepsAsStep('TINY-6007', 'Thead > tr > td is detected correctly as a header row', [
         tinyApis.sSetContent(
           '<table>' +
           '<thead><tr class="foo">' +
@@ -98,16 +93,13 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
           '</tr></tbody>' +
           '</table>'
         ),
-        Chain.asStep(Element.fromDom(editor.getBody()), [
-          UiFinder.cFindIn('tr.foo'),
-          Chain.op((tr) => {
-            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
-            Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
-            Assertions.assertEq('Detect as td', false, rowData.ths);
-          })
-        ])
+        sAssertRow('tr.foo', (tr) => {
+          const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
+          Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
+          Assertions.assertEq('Detect as td', false, rowData.ths);
+        })
       ]),
-      Log.stepsAsStep('TBA', 'Thead > tr > th is detected correctly as a header row', [
+      Log.stepsAsStep('TINY-6007', 'Thead > tr > th is detected correctly as a header row', [
         tinyApis.sSetContent(
           '<table>' +
           '<thead><tr class="foo">' +
@@ -118,16 +110,13 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
           '</tr></tbody>' +
           '</table>'
         ),
-        Chain.asStep(Element.fromDom(editor.getBody()), [
-          UiFinder.cFindIn('tr.foo'),
-          Chain.op((tr) => {
-            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
-            Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
-            Assertions.assertEq('Detect as all th', true, rowData.ths);
-          })
-        ])
+        sAssertRow('tr.foo', (tr) => {
+          const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
+          Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
+          Assertions.assertEq('Detect as all th', true, rowData.ths);
+        })
       ]),
-      Log.stepsAsStep('TBA', 'Thead > tr > ths is detected correctly as a header row', [
+      Log.stepsAsStep('TINY-6007', 'Thead > tr > ths is detected correctly as a header row', [
         tinyApis.sSetContent(
           '<table>' +
           '<thead><tr class="foo">' +
@@ -139,16 +128,13 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
           '</tr></tbody>' +
           '</table>'
         ),
-        Chain.asStep(Element.fromDom(editor.getBody()), [
-          UiFinder.cFindIn('tr.foo'),
-          Chain.op((tr) => {
-            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
-            Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
-            Assertions.assertEq('Detect as all th', true, rowData.ths);
-          })
-        ])
+        sAssertRow('tr.foo', (tr) => {
+          const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
+          Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
+          Assertions.assertEq('Detect as all th', true, rowData.ths);
+        })
       ]),
-      Log.stepsAsStep('TBA', 'Thead > tr > td+th is detected correctly as a header row', [
+      Log.stepsAsStep('TINY-6007', 'Thead > tr > td+th is detected correctly as a header row', [
         tinyApis.sSetContent(
           '<table>' +
           '<thead><tr class="foo">' +
@@ -160,14 +146,11 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
           '</tr></tbody>' +
           '</table>'
         ),
-        Chain.asStep(Element.fromDom(editor.getBody()), [
-          UiFinder.cFindIn('tr.foo'),
-          Chain.op((tr) => {
-            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
-            Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
-            Assertions.assertEq('Detect as not all th', false, rowData.ths);
-          })
-        ])
+        sAssertRow('tr.foo', (tr) => {
+          const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
+          Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
+          Assertions.assertEq('Detect as not all th', false, rowData.ths);
+        })
       ])
     ], onSuccess, onFailure);
   }, {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/DetectHeaderRowTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/DetectHeaderRowTest.ts
@@ -1,10 +1,10 @@
-import { Assertions, Chain, Pipeline, UiFinder, Log } from '@ephox/agar';
+import { Assertions, Chain, Log, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Element } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
+import { detectHeaderRow, getRowType } from 'tinymce/plugins/table/core/TableRowSectionTypes';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import * as Helpers from 'tinymce/plugins/table/ui/Helpers';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success, failure) => {
@@ -26,7 +26,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
         Chain.asStep(Element.fromDom(editor.getBody()), [
           UiFinder.cFindIn('tr'),
           Chain.op((tr) => {
-            const rowData = Helpers.getRowType(editor, tr.dom());
+            const rowData = getRowType(editor, tr.dom());
             Assertions.assertEq('Detect as part of the tbody', 'tbody', rowData);
           })
         ])
@@ -42,7 +42,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
         Chain.asStep(Element.fromDom(editor.getBody()), [
           UiFinder.cFindIn('tr'),
           Chain.op((tr) => {
-            Helpers.detectHeaderRow(editor, tr.dom()).fold(
+            detectHeaderRow(editor, tr.dom()).fold(
               () => Assertions.assertEq('Row incorrectly detected as not a header row', true, false), // would call failure() but want logs
               (rowData) => {
                 Assertions.assertEq('Detect as part of the tbody', false, rowData.thead);
@@ -64,7 +64,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
         Chain.asStep(Element.fromDom(editor.getBody()), [
           UiFinder.cFindIn('tr'),
           Chain.op((tr) => {
-            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
             Assertions.assertEq('Detect as part of the tbody', false, rowData.thead);
             Assertions.assertEq('Detect as all ths', true, rowData.ths);
           })
@@ -82,7 +82,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
         Chain.asStep(Element.fromDom(editor.getBody()), [
           UiFinder.cFindIn('tr'),
           Chain.op((tr) => {
-            const rowData = Helpers.getRowType(editor, tr.dom());
+            const rowData = getRowType(editor, tr.dom());
             Assertions.assertEq('Detect as part of the tbody', 'tbody', rowData);
           })
         ])
@@ -101,7 +101,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
         Chain.asStep(Element.fromDom(editor.getBody()), [
           UiFinder.cFindIn('tr.foo'),
           Chain.op((tr) => {
-            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
             Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
             Assertions.assertEq('Detect as td', false, rowData.ths);
           })
@@ -121,7 +121,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
         Chain.asStep(Element.fromDom(editor.getBody()), [
           UiFinder.cFindIn('tr.foo'),
           Chain.op((tr) => {
-            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
             Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
             Assertions.assertEq('Detect as all th', true, rowData.ths);
           })
@@ -142,7 +142,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
         Chain.asStep(Element.fromDom(editor.getBody()), [
           UiFinder.cFindIn('tr.foo'),
           Chain.op((tr) => {
-            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
             Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
             Assertions.assertEq('Detect as all th', true, rowData.ths);
           })
@@ -163,7 +163,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success
         Chain.asStep(Element.fromDom(editor.getBody()), [
           UiFinder.cFindIn('tr.foo'),
           Chain.op((tr) => {
-            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            const rowData = detectHeaderRow(editor, tr.dom()).getOrDie();
             Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
             Assertions.assertEq('Detect as not all th', false, rowData.ths);
           })

--- a/modules/tinymce/src/plugins/table/test/ts/browser/DetectHeaderRowTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/DetectHeaderRowTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Element } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
-import { detectHeaderRow, getRowType } from 'tinymce/plugins/table/core/TableRowSectionTypes';
+import { detectHeaderRow, getRowType } from 'tinymce/plugins/table/core/TableSections';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/DetectHeaderRowTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/DetectHeaderRowTest.ts
@@ -1,0 +1,179 @@
+import { Assertions, Chain, Pipeline, UiFinder, Log } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { Element } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/table/Plugin';
+import * as Helpers from 'tinymce/plugins/table/ui/Helpers';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.plugins.table.DetectHeaderRowTest', (success, failure) => {
+  Plugin();
+  SilverTheme();
+
+  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+
+    Pipeline.async({}, [
+      Log.stepsAsStep('TBA', 'No header rows', [
+        tinyApis.sSetContent(
+          '<table>' +
+          '<tbody><tr>' +
+          '<td>text</td>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        Chain.asStep(Element.fromDom(editor.getBody()), [
+          UiFinder.cFindIn('tr'),
+          Chain.op((tr) => {
+            const rowData = Helpers.getRowType(editor, tr.dom());
+            Assertions.assertEq('Detect as part of the tbody', 'tbody', rowData);
+          })
+        ])
+      ]),
+      Log.stepsAsStep('TBA', 'Tbody > tr > th is detected correctly as a header row', [
+        tinyApis.sSetContent(
+          '<table>' +
+          '<tbody><tr>' +
+          '<th>text</th>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        Chain.asStep(Element.fromDom(editor.getBody()), [
+          UiFinder.cFindIn('tr'),
+          Chain.op((tr) => {
+            Helpers.detectHeaderRow(editor, tr.dom()).fold(
+              () => Assertions.assertEq('Row incorrectly detected as not a header row', true, false), // would call failure() but want logs
+              (rowData) => {
+                Assertions.assertEq('Detect as part of the tbody', false, rowData.thead);
+                Assertions.assertEq('Detect as ths', true, rowData.ths);
+              }
+            );
+          })
+        ])
+      ]),
+      Log.stepsAsStep('TBA', 'Tbody > tr > ths is detected correctly as a header row', [
+        tinyApis.sSetContent(
+          '<table>' +
+          '<tbody><tr>' +
+          '<th>text</th>' +
+          '<th>more text</th>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        Chain.asStep(Element.fromDom(editor.getBody()), [
+          UiFinder.cFindIn('tr'),
+          Chain.op((tr) => {
+            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            Assertions.assertEq('Detect as part of the tbody', false, rowData.thead);
+            Assertions.assertEq('Detect as all ths', true, rowData.ths);
+          })
+        ])
+      ]),
+      Log.stepsAsStep('TBA', 'Tbody > tr > td+th is detected correctly as NOT a header row', [
+        tinyApis.sSetContent(
+          '<table>' +
+          '<tbody><tr>' +
+          '<td>text</td>' +
+          '<th>more text</th>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        Chain.asStep(Element.fromDom(editor.getBody()), [
+          UiFinder.cFindIn('tr'),
+          Chain.op((tr) => {
+            const rowData = Helpers.getRowType(editor, tr.dom());
+            Assertions.assertEq('Detect as part of the tbody', 'tbody', rowData);
+          })
+        ])
+      ]),
+      Log.stepsAsStep('TBA', 'Thead > tr > td is detected correctly as a header row', [
+        tinyApis.sSetContent(
+          '<table>' +
+          '<thead><tr class="foo">' +
+          '<td>text</td>' +
+          '</tr></thead>' +
+          '<tbody><tr>' +
+          '<td>text</td>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        Chain.asStep(Element.fromDom(editor.getBody()), [
+          UiFinder.cFindIn('tr.foo'),
+          Chain.op((tr) => {
+            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
+            Assertions.assertEq('Detect as td', false, rowData.ths);
+          })
+        ])
+      ]),
+      Log.stepsAsStep('TBA', 'Thead > tr > th is detected correctly as a header row', [
+        tinyApis.sSetContent(
+          '<table>' +
+          '<thead><tr class="foo">' +
+          '<th>text</th>' +
+          '</tr></thead>' +
+          '<tbody><tr>' +
+          '<td>text</td>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        Chain.asStep(Element.fromDom(editor.getBody()), [
+          UiFinder.cFindIn('tr.foo'),
+          Chain.op((tr) => {
+            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
+            Assertions.assertEq('Detect as all th', true, rowData.ths);
+          })
+        ])
+      ]),
+      Log.stepsAsStep('TBA', 'Thead > tr > ths is detected correctly as a header row', [
+        tinyApis.sSetContent(
+          '<table>' +
+          '<thead><tr class="foo">' +
+          '<th>text</th>' +
+          '<th>more text</th>' +
+          '</tr></thead>' +
+          '<tbody><tr>' +
+          '<td>text</td>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        Chain.asStep(Element.fromDom(editor.getBody()), [
+          UiFinder.cFindIn('tr.foo'),
+          Chain.op((tr) => {
+            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
+            Assertions.assertEq('Detect as all th', true, rowData.ths);
+          })
+        ])
+      ]),
+      Log.stepsAsStep('TBA', 'Thead > tr > td+th is detected correctly as a header row', [
+        tinyApis.sSetContent(
+          '<table>' +
+          '<thead><tr class="foo">' +
+          '<td>text</td>' +
+          '<th>more text</th>' +
+          '</tr></thead>' +
+          '<tbody><tr>' +
+          '<td>text</td>' +
+          '</tr></tbody>' +
+          '</table>'
+        ),
+        Chain.asStep(Element.fromDom(editor.getBody()), [
+          UiFinder.cFindIn('tr.foo'),
+          Chain.op((tr) => {
+            const rowData = Helpers.detectHeaderRow(editor, tr.dom()).getOrDie();
+            Assertions.assertEq('Detect as part of the thead', true, rowData.thead);
+            Assertions.assertEq('Detect as not all th', false, rowData.ths);
+          })
+        ])
+      ])
+    ], onSuccess, onFailure);
+  }, {
+    plugins: 'table',
+    indent : false,
+    theme : 'silver',
+    base_url: '/project/tinymce/js/tinymce'
+  }, success, failure );
+});

--- a/modules/tinymce/src/plugins/table/test/ts/browser/SwitchTableSectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/SwitchTableSectionTest.ts
@@ -1,0 +1,271 @@
+import { Chain, Log, Pipeline, UiFinder } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { ApiChains, Editor as McEditor } from '@ephox/mcagar';
+import { Element } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import * as TableSections from 'tinymce/plugins/table/core/TableSections';
+import Plugin from 'tinymce/plugins/table/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.plugins.table.SwitchTableSectionTest', (success, failure) => {
+  Plugin();
+  SilverTheme();
+
+  const cSwitchSection = (rowSelector: string, newSectionType: string) => Chain.op((editor: Editor) => {
+    const row = UiFinder.findIn(Element.fromDom(editor.getBody()), rowSelector).getOrDie();
+    TableSections.switchSectionType(editor, row.dom(), newSectionType);
+  });
+
+  const basicContent = `<table>
+<tbody>
+<tr id="one">
+<td>text</td>
+</tr>
+<tr id="two">
+<td>text</td>
+</tr>
+</tbody>
+</table>`;
+
+  const theadExpected = `<table>
+<thead>
+<tr id="one">
+<td>text</td>
+</tr>
+</thead>
+<tbody>
+<tr id="two">
+<td>text</td>
+</tr>
+</tbody>
+</table>`;
+
+  const thsExpected = `<table>
+<tbody>
+<tr id="one">
+<th>text</th>
+</tr>
+<tr id="two">
+<td>text</td>
+</tr>
+</tbody>
+</table>`;
+
+  const reversedThsExpected = `<table>
+<tbody>
+<tr id="two">
+<td>text</td>
+</tr>
+<tr id="one">
+<th>text</th>
+</tr>
+</tbody>
+</table>`;
+
+  const bothExpected = `<table>
+<thead>
+<tr id="one">
+<th>text</th>
+</tr>
+</thead>
+<tbody>
+<tr id="two">
+<td>text</td>
+</tr>
+</tbody>
+</table>`;
+
+  const sNewHeaderSwitchTest = (tableHeaderType: string, startContent: string, expected: string) =>
+    Log.chainsAsStep('TINY-6007', `Switch new header, table_header_type = ${tableHeaderType}`, [
+      McEditor.cFromSettings({
+        plugins: 'table',
+        theme: 'silver',
+        base_url: '/project/tinymce/js/tinymce',
+        table_header_type: tableHeaderType
+      }),
+      Chain.fromParent(Chain.identity, [
+        ApiChains.cSetContent(startContent),
+        cSwitchSection('tr#one', 'thead'),
+        ApiChains.cAssertContent(expected)
+      ]),
+      McEditor.cRemove
+    ]);
+
+  const existingTheadExpected = `<table>
+<thead>
+<tr id="one">
+<td>text</td>
+</tr>
+<tr id="two">
+<td>text</td>
+</tr>
+</thead>
+</table>`;
+
+  const existingThsExpected = `<table>
+<tbody>
+<tr id="one">
+<th>text</th>
+</tr>
+<tr id="two">
+<th>text</th>
+</tr>
+</tbody>
+</table>`;
+
+  const existingBothExpected = `<table>
+<thead>
+<tr id="one">
+<th>text</th>
+</tr>
+<tr id="two">
+<th>text</th>
+</tr>
+</thead>
+</table>`;
+
+  const thsAndTheadExpected = `<table>
+<thead>
+<tr id="two">
+<td>text</td>
+</tr>
+</thead>
+<tbody>
+<tr id="one">
+<th>text</th>
+</tr>
+</tbody>
+</table>`;
+
+  const theadAndThsExpected = `<table>
+<thead>
+<tr id="one">
+<td>text</td>
+</tr>
+</thead>
+<tbody>
+<tr id="two">
+<th>text</th>
+</tr>
+</tbody>
+</table>`;
+
+  const thsAndBothExpected = `<table>
+<thead>
+<tr id="two">
+<th>text</th>
+</tr>
+</thead>
+<tbody>
+<tr id="one">
+<th>text</th>
+</tr>
+</tbody>
+</table>`;
+
+  const theadAndBothExpected = `<table>
+<thead>
+<tr id="one">
+<td>text</td>
+</tr>
+<tr id="two">
+<th>text</th>
+</tr>
+</thead>
+</table>`;
+
+  const sExistingHeaderSwitchTest = (extraLabel: string, tableHeaderType: string, startContent: string, expected: string) =>
+    Log.chainsAsStep('TINY-6007', `Switch tbody to existing header, table_header_type = ${tableHeaderType}, ${extraLabel}`, [
+      McEditor.cFromSettings({
+        plugins: 'table',
+        theme: 'silver',
+        base_url: '/project/tinymce/js/tinymce',
+        table_header_type: tableHeaderType
+      }),
+      Chain.fromParent(Chain.identity, [
+        ApiChains.cSetContent(startContent),
+        cSwitchSection('tr#two', 'thead'),
+        ApiChains.cAssertContent(expected)
+      ]),
+      McEditor.cRemove
+    ]);
+
+  const tfootContent = `<table>
+<tbody>
+<tr id="two">
+<td>text</td>
+</tr>
+</tbody>
+<tfoot>
+<tr id="one">
+<td>text</td>
+</tr>
+</tfoot>
+</table>`;
+
+  const reversedBasicContent = `<table>
+<tbody>
+<tr id="two">
+<td>text</td>
+</tr>
+<tr id="one">
+<td>text</td>
+</tr>
+</tbody>
+</table>`;
+
+  const sSectionSwitchTest = (newSectionType: string, tableHeaderType: string, startContent: string, expected: string) =>
+    Log.chainsAsStep('TINY-6007', `Switch section to ${newSectionType}, table_header_type = ${tableHeaderType}`, [
+      McEditor.cFromSettings({
+        plugins: 'table',
+        theme: 'silver',
+        base_url: '/project/tinymce/js/tinymce',
+        table_header_type: tableHeaderType
+      }),
+      Chain.fromParent(Chain.identity, [
+        ApiChains.cSetContent(startContent),
+        cSwitchSection('tr#one', newSectionType),
+        ApiChains.cAssertContent(expected)
+      ]),
+      McEditor.cRemove
+    ]);
+
+  Pipeline.async({}, [
+    // Basic tests to switch to header when none exist
+    sNewHeaderSwitchTest('section', basicContent, theadExpected),
+    sNewHeaderSwitchTest('cells', basicContent, thsExpected),
+    sNewHeaderSwitchTest('sectionCells', basicContent, bothExpected),
+    sNewHeaderSwitchTest('section', tfootContent, theadExpected),
+    sNewHeaderSwitchTest('cells', tfootContent, reversedThsExpected),
+    sNewHeaderSwitchTest('sectionCells', tfootContent, bothExpected),
+    sNewHeaderSwitchTest('foo', basicContent, theadExpected), // setting value is invalid so default to section
+    // Switch to a header when one already exists - type is specified and matches
+    sExistingHeaderSwitchTest('type matches existing', 'section', theadExpected, existingTheadExpected),
+    sExistingHeaderSwitchTest('type matches existing', 'cells', thsExpected, existingThsExpected),
+    sExistingHeaderSwitchTest('type matches existing', 'sectionCells', bothExpected, existingBothExpected),
+    // Switch to a header when one already exists - type is specified but doesn't match existing
+    sExistingHeaderSwitchTest('type does not match existing', 'section', thsExpected, thsAndTheadExpected),
+    sExistingHeaderSwitchTest('type does not match existing', 'cells', theadExpected, theadAndThsExpected),
+    sExistingHeaderSwitchTest('type does not match existing', 'sectionCells', thsExpected, thsAndBothExpected),
+    sExistingHeaderSwitchTest('type does not match existing', 'sectionCells', theadExpected, theadAndBothExpected),
+    // Switch to a header when one already exists - type is NOT specified so should match by detection
+    sExistingHeaderSwitchTest('type auto so should detect type from existing', 'auto', theadExpected, existingTheadExpected),
+    sExistingHeaderSwitchTest('type auto so should detect type from existing', 'auto', thsExpected, existingThsExpected),
+    sExistingHeaderSwitchTest('type auto so should detect type from existing', 'auto', bothExpected, existingBothExpected),
+    // General tests for switching between various sections
+    sSectionSwitchTest('tfoot', 'auto', basicContent, tfootContent), // tbody to tfoot
+    sSectionSwitchTest('tbody', 'auto', tfootContent, reversedBasicContent), // tfoot to tbody
+    sSectionSwitchTest('tbody', 'section', theadExpected, basicContent), // thead to tbody
+    sSectionSwitchTest('tbody', 'cells', thsExpected, basicContent), // cells to tbody
+    sSectionSwitchTest('tbody', 'sectionCells', bothExpected, basicContent), // sectionCells to tbody
+    sSectionSwitchTest('tfoot', 'section', theadExpected, tfootContent), // thead to tfoot
+    sSectionSwitchTest('tfoot', 'cells', thsExpected, tfootContent), // ths to tfoot
+    sSectionSwitchTest('tfoot', 'sectionCells', bothExpected, tfootContent), // sectionCells to tfoot
+    // Test that trying to switch to the same section does nothing
+    sSectionSwitchTest('tbody', 'auto', basicContent, basicContent),
+    sSectionSwitchTest('thead', 'section', theadExpected, theadExpected),
+    sSectionSwitchTest('thead', 'cells', thsExpected, thsExpected),
+    sSectionSwitchTest('thead', 'sectionCells', bothExpected, bothExpected),
+    sSectionSwitchTest('tfoot', 'auto', tfootContent, tfootContent)
+  ], success, failure);
+});


### PR DESCRIPTION
Related Ticket: TINY-6007

Description of Changes:
* Correctly detect the 3 kinds of table header row structures
* Add new `table_header_type` setting to control which structure is used for table plugin's output
* Make the row dialog switch row/section types based on the setting/determine the type of a header row by detection
* Unit test for header row type detection
* Unit test for row/section switching

There will be more parts:
- API methods for switching table row/section types
- Updating the table creation API I did the other week to respect this setting, etc.

At some point would like to move this into Snooker too, but that requires fixing Snooker's problem with losing `tr` attributes first, so shelving that for now.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #3941 