### PR TITLE
Turn the ElementInstances values into polymorphic functions.

### DIFF
--- a/modules/sugar/src/test/ts/browser/ElementInstancesTest.ts
+++ b/modules/sugar/src/test/ts/browser/ElementInstancesTest.ts
@@ -1,0 +1,25 @@
+import { UnitTest, Assert } from '@ephox/bedrock-client';
+import Element from 'ephox/sugar/api/node/Element';
+import { tElement, eqElement } from 'ephox/sugar/test/ElementInstances';
+import { Option, OptionInstances } from '@ephox/katamari';
+import tOption = OptionInstances.tOption;
+import { HTMLDivElement, Element as DomElement } from '@ephox/dom-globals';
+
+UnitTest.test('Element testable/eq', () => {
+  const span1: Element<DomElement> = Element.fromTag('span');
+  Assert.eq('span === span', span1, span1, tElement<DomElement>());
+
+  const span2 = Element.fromDom(span1.dom());
+  Assert.eq('spans should be equal when they refer to the same underlying element', span1, span2, tElement<DomElement>());
+
+  const span3 = Element.fromTag('span');
+  Assert.eq('different spans should be inequal', false, tElement<DomElement>().eq(span1, span3));
+  Assert.eq('different spans should be inequal', false, eqElement<DomElement>().eq(span1, span3));
+});
+
+UnitTest.test('TINY-6151: Element testable/eq - options', () => {
+  const el1: Option<Element<HTMLDivElement>> = Option.some(Element.fromTag('div'));
+  // Before TINY-6151, tElement was a value - a Testable<DomElement> - and statements like below wouldn't compile.
+  // We changed it to be a polymorphic function.
+  Assert.eq('same', el1, el1, tOption(tElement()));
+});

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -48,13 +48,13 @@ const shouldBeDocument = (n: RootNode) => {
 
 UnitTest.test('getRootNode === document on normal element in dom', () => {
   withNormalElement((div) => {
-    Assert.eq('should be document', Document.getDocument(), ShadowDom.getRootNode(div), tElement);
+    Assert.eq('should be document', Document.getDocument(), ShadowDom.getRootNode(div), tElement());
   });
 });
 
 UnitTest.test('getRootNode(document) === document on normal element in dom', () => {
   withNormalElement(() => {
-    Assert.eq('should be document', Document.getDocument(), ShadowDom.getRootNode(Document.getDocument()), tElement);
+    Assert.eq('should be document', Document.getDocument(), ShadowDom.getRootNode(Document.getDocument()), tElement());
   });
 });
 
@@ -71,13 +71,13 @@ UnitTest.test('document is document', () => {
 if (ShadowDom.isSupported()) {
   UnitTest.test('getRootNode === shadowroot on element in shadow root', () => {
     withShadowElement((sr, innerDiv) => {
-      Assert.eq('should be shadowroot', sr, ShadowDom.getRootNode(innerDiv), tElement);
+      Assert.eq('should be shadowroot', sr, ShadowDom.getRootNode(innerDiv), tElement());
     });
   });
 
   UnitTest.test('getRootNode(shadowroot) === shadowroot', () => {
     withShadowElement((sr) => {
-      Assert.eq('should be shadowroot', sr, sr, tElement);
+      Assert.eq('should be shadowroot', sr, sr, tElement());
     });
   });
 
@@ -121,31 +121,31 @@ UnitTest.test('isSupported platform test', () => {
 if (ShadowDom.isSupported()) {
   UnitTest.test('stylecontainer is shadow root for shadow root', () => {
     withShadowElement((sr) => {
-      Assert.eq('Should be shadow root', sr, ShadowDom.getStyleContainer(sr), tElement);
+      Assert.eq('Should be shadow root', sr, ShadowDom.getStyleContainer(sr), tElement());
     });
   });
 }
 
 UnitTest.test('stylecontainer is head for document', () => {
-  Assert.eq('Should be head', Head.getHead(Document.getDocument()), ShadowDom.getStyleContainer(Document.getDocument()), tElement);
+  Assert.eq('Should be head', Head.getHead(Document.getDocument()), ShadowDom.getStyleContainer(Document.getDocument()), tElement());
 });
 
 if (ShadowDom.isSupported()) {
   UnitTest.test('contentcontainer is shadow root for shadow root', () => {
     withShadowElement((sr) => {
-      Assert.eq('Should be shadow root', sr, ShadowDom.getContentContainer(sr), tElement);
+      Assert.eq('Should be shadow root', sr, ShadowDom.getContentContainer(sr), tElement());
     });
   });
 }
 
 UnitTest.test('stylecontainer is body for document', () => {
-  Assert.eq('Should be head', Body.getBody(Document.getDocument()), ShadowDom.getContentContainer(Document.getDocument()), tElement);
+  Assert.eq('Should be head', Body.getBody(Document.getDocument()), ShadowDom.getContentContainer(Document.getDocument()), tElement());
 });
 
 if (ShadowDom.isSupported()) {
   UnitTest.test('getShadowHost', () => {
     withShadowElement((sr, inner, sh) => {
-      Assert.eq('Should be shadow host', sh, ShadowDom.getShadowHost(sr), tElement);
+      Assert.eq('Should be shadow host', sh, ShadowDom.getShadowHost(sr), tElement());
     });
   });
 }

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/Checkers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/Checkers.ts
@@ -10,11 +10,11 @@ import { tElement } from './ElementInstances';
 const { tArray } = Testable;
 
 const checkOpt = <T extends DomNode>(expected: Option<Element<T>>, actual: Option<Element<T>>) => {
-  KAssert.eqOption('eq', expected, actual, tElement);
+  KAssert.eqOption('eq', expected, actual, tElement());
 };
 
 const checkList = <T extends DomNode>(expected: ArrayLike<Element<T>>, actual: ArrayLike<Element<T>>) => {
-  Assert.eq('eq', expected, actual, tArray(tElement));
+  Assert.eq('eq', expected, actual, tArray(tElement()));
 };
 
 const isName = <K extends keyof HTMLElementTagNameMap>(name: K) => (x: Element<DomNode>): x is Element<HTMLElementTagNameMap[K]> => Node.name(x) === name;

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/ElementInstances.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/ElementInstances.ts
@@ -7,8 +7,11 @@ type Eq<A> = Eq.Eq<A>;
 type Pprint<A> = Pprint.Pprint<A>;
 type Testable<A> = Testable.Testable<A>;
 
-export const eqElement: Eq<Element<DomNode>> = Eq.contramap(Eq.tripleEq, (e) => e.dom());
+export const eqElement = <T extends DomNode> (): Eq<Element<T>> =>
+  Eq.contramap(Eq.tripleEq, (e) => e.dom());
 
-export const pprintElement: Pprint<Element<DomNode>> = Pprint.pprint<Element<DomNode>>((e) => Pnode.single(Html.getOuter(e)));
+export const pprintElement = <T extends DomNode> (): Pprint<Element<T>> =>
+  Pprint.pprint<Element<T>>((e) => Pnode.single(Html.getOuter(e)));
 
-export const tElement: Testable<Element<DomNode>> = Testable.testable(eqElement, pprintElement);
+export const tElement = <T extends DomNode> (): Testable<Element<T>> =>
+  Testable.testable(eqElement(), pprintElement());


### PR DESCRIPTION
Related Ticket: TINY-6151

Description of Changes:
* The Eq, Pprint and Testable instances are all parameterized on `Element<DomNode>` - e.g. `Testable<Element<DomNode>>>`. However, I’ve hit issues where I need to make a `Testable<Option<Element<HTMLElement>>>` and it won’t compile. Making them polymorphic functions fixes this.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
