### PR TITLE
Add keyboard navigation to editors in shadow roots, by adding shadow dom support to focus code

### DIFF
--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Focus.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Focus.ts
@@ -15,8 +15,8 @@ const blur = (element: Element<HTMLElement>): void =>
   element.dom().blur();
 
 const hasFocus = (element: Element<DomNode>): boolean => {
-  const doc = ShadowDom.getRootNode(element).dom();
-  return element.dom() === doc.activeElement;
+  const root = ShadowDom.getRootNode(element).dom();
+  return element.dom() === root.activeElement;
 };
 
 const active = (root: RootNode = Document.getDocument()): Option<Element<HTMLElement>> => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Focus.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Focus.ts
@@ -17,10 +17,9 @@ const hasFocus = (element: Element<DomNode>): boolean => {
   return element.dom() === root.activeElement;
 };
 
-const active = (root: RootNode = Document.getDocument()): Option<Element<HTMLElement>> => {
-  // Note: assuming that activeElement will always be a HTMLElement (maybe we should add a runtime check?)
-  return Option.from(root.dom().activeElement as HTMLElement).map(Element.fromDom);
-};
+// Note: assuming that activeElement will always be a HTMLElement (maybe we should add a runtime check?)
+const active = (root: RootNode = Document.getDocument()): Option<Element<HTMLElement>> =>
+  Option.from(root.dom().activeElement as HTMLElement).map(Element.fromDom);
 
 /** Focus the specified element, unless one of its descendents already has focus. */
 const focusInside = (element: Element<HTMLElement>): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Focus.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Focus.ts
@@ -1,28 +1,28 @@
-import { document, Document, HTMLElement, Node as DomNode } from '@ephox/dom-globals';
+import { document, Document, HTMLElement, Node as DomNode, ShadowRoot } from '@ephox/dom-globals';
 import { Fun, Option } from '@ephox/katamari';
 import Element from '../node/Element';
 import * as PredicateExists from '../search/PredicateExists';
-import * as Traverse from '../search/Traverse';
 import * as Compare from './Compare';
+import { ShadowDom } from '@ephox/sugar';
 
 const focus = (element: Element<HTMLElement>) => element.dom().focus();
 
 const blur = (element: Element<HTMLElement>) => element.dom().blur();
 
-const hasFocus = (element: Element<DomNode>) => {
-  const doc = Traverse.owner(element).dom();
+const hasFocus = (element: Element<DomNode>): boolean => {
+  const doc = ShadowDom.getRootNode(element).dom();
   return element.dom() === doc.activeElement;
 };
 
-const active = (_doc?: Element<Document>) => {
-  const doc = _doc !== undefined ? _doc.dom() : document;
+const active = (_dos?: Element<Document | ShadowRoot>): Option<Element<HTMLElement>> => {
+  const dos = _dos !== undefined ? _dos.dom() : document;
   // Note: assuming that activeElement will always be a HTMLElement (maybe we should add a runtime check?)
-  return Option.from(doc.activeElement as HTMLElement).map(Element.fromDom);
+  return Option.from(dos.activeElement as HTMLElement).map(Element.fromDom);
 };
 
 const focusInside = (element: Element<HTMLElement>) => {
   // Only call focus if the focus is not already inside it.
-  const doc = Traverse.owner(element);
+  const doc = ShadowDom.getRootNode(element);
   const inside = active(doc).filter((a) => PredicateExists.closest(a, Fun.curry(Compare.eq, element)));
 
   inside.fold(() => {
@@ -35,7 +35,8 @@ const focusInside = (element: Element<HTMLElement>) => {
  * Use instead of SelectorFind.descendant(container, ':focus')
  *  because the :focus selector relies on keyboard focus.
  */
-const search = (element: Element<DomNode>) => active(Traverse.owner(element))
-  .filter((e) => element.dom().contains(e.dom()));
+const search = (element: Element<DomNode>): Option<Element<HTMLElement>> =>
+  active(ShadowDom.getRootNode(element))
+    .filter((e) => element.dom().contains(e.dom()));
 
 export { hasFocus, focus, blur, active, search, focusInside };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Focus.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Focus.ts
@@ -1,8 +1,6 @@
 import { HTMLElement, Node as DomNode } from '@ephox/dom-globals';
-import { Fun, Option } from '@ephox/katamari';
+import { Option } from '@ephox/katamari';
 import Element from '../node/Element';
-import * as PredicateExists from '../search/PredicateExists';
-import * as Compare from './Compare';
 import * as ShadowDom from '../node/ShadowDom';
 import * as Document from '../node/Document';
 
@@ -26,8 +24,7 @@ const active = (root: RootNode = Document.getDocument()): Option<Element<HTMLEle
 
 /** Focus the specified element, unless one of its descendents already has focus. */
 const focusInside = (element: Element<HTMLElement>): void => {
-  const root = ShadowDom.getRootNode(element);
-  const alreadyFocusedInside = active(root).exists((a) => PredicateExists.closest(a, Fun.curry(Compare.eq, element)));
+  const alreadyFocusedInside = search(element).isSome();
   if (!alreadyFocusedInside) {
     focus(element);
   }

--- a/modules/sugar/src/test/ts/browser/ElementInstancesTest.ts
+++ b/modules/sugar/src/test/ts/browser/ElementInstancesTest.ts
@@ -2,8 +2,9 @@ import { UnitTest, Assert } from '@ephox/bedrock-client';
 import Element from 'ephox/sugar/api/node/Element';
 import { tElement, eqElement } from 'ephox/sugar/test/ElementInstances';
 import { Option, OptionInstances } from '@ephox/katamari';
-import tOption = OptionInstances.tOption;
 import { HTMLDivElement, Element as DomElement } from '@ephox/dom-globals';
+
+const tOption = OptionInstances.tOption;
 
 UnitTest.test('Element testable/eq', () => {
   const span1: Element<DomElement> = Element.fromTag('span');

--- a/modules/sugar/src/test/ts/browser/FocusTest.ts
+++ b/modules/sugar/src/test/ts/browser/FocusTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, assert, UnitTest } from '@ephox/bedrock-client';
 import * as Compare from 'ephox/sugar/api/dom/Compare';
 import * as Focus from 'ephox/sugar/api/dom/Focus';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
@@ -6,6 +6,11 @@ import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as Body from 'ephox/sugar/api/node/Body';
 import Element from 'ephox/sugar/api/node/Element';
 import * as Attr from 'ephox/sugar/api/properties/Attr';
+import { withShadowElement } from 'ephox/sugar/test/WithHelpers';
+import { Option, OptionInstances } from '@ephox/katamari';
+import tOption = OptionInstances.tOption;
+import { tElement } from 'ephox/sugar/test/ElementInstances';
+import { HTMLElement } from '@ephox/dom-globals';
 
 UnitTest.test('FocusTest', () => {
   const div = Element.fromTag('div');
@@ -30,4 +35,94 @@ UnitTest.test('FocusTest', () => {
   assert.eq(true, Compare.eq(Focus.active().getOrDie(), div));
 
   Remove.remove(div);
+});
+
+UnitTest.test('Focus.active in ShadowRoot', () => {
+  withShadowElement((sr, id, sh) => {
+    const innerInput: Element<HTMLElement> = Element.fromTag('input');
+    Insert.append(sr, innerInput);
+
+    const outerInput: Element<HTMLElement> = Element.fromTag('input');
+    Insert.append(Body.body(), outerInput);
+
+    Focus.focus(innerInput);
+    Assert.eq('ShadowRoot\'s active element is the inner input box', Focus.active(sr), Option.some(innerInput), tOption(tElement()));
+    Assert.eq('Document\'s active element is the shadow host', Focus.active(), Option.some(sh), tOption(tElement()));
+
+    Focus.focus(outerInput);
+    Assert.eq('ShadowRoot\'s active element should be none', Focus.active(sr), Option.none(), tOption(tElement()));
+    Assert.eq('Document\'s active element is the outer input box', Focus.active(), Option.some(outerInput), tOption(tElement()));
+
+    Remove.remove(outerInput);
+  });
+});
+
+UnitTest.test('Focus.search in ShadowRoot', () => {
+  withShadowElement((sr, id, sh) => {
+    const innerInput: Element<HTMLElement> = Element.fromTag('input');
+    Insert.append(id, innerInput);
+
+    const outerInput: Element<HTMLElement> = Element.fromTag('input');
+    Insert.append(Body.body(), outerInput);
+
+    Focus.focus(innerInput);
+    Assert.eq('Searching from div inside shadow root should yield focused input box', Focus.search(id), Option.some(innerInput), tOption(tElement()));
+    Assert.eq('Searching from shadow root should yield focused input box', Focus.search(sr), Option.some(innerInput), tOption(tElement()));
+    Assert.eq('Searching from shadow host should yield shadow host', Focus.search(sh), Option.some(sh), tOption(tElement()));
+    Assert.eq('Searching from body should yield shadow host', Focus.search(Body.body()), Option.some(sh), tOption(tElement()));
+
+    Focus.focus(outerInput);
+    Assert.eq('Searching from div inside shadow root should yield none', Focus.search(id), Option.none(), tOption(tElement()));
+    Assert.eq('Searching from shadow root should yield none', Focus.search(sr), Option.none(), tOption(tElement()));
+    Assert.eq('Searching from shadow host should yield none', Focus.search(sh), Option.none(), tOption(tElement()));
+    Assert.eq('Searching from body should yield outer input box', Focus.search(Body.body()), Option.some(outerInput), tOption(tElement()));
+
+    Remove.remove(outerInput);
+  });
+});
+
+UnitTest.test('Focus.hasFocus in ShadowRoot', () => {
+  withShadowElement((shadowRoot, innerDiv, shadowHost) => {
+    const innerInput: Element<HTMLElement> = Element.fromTag('input');
+    Insert.append(innerDiv, innerInput);
+
+    const outerInput: Element<HTMLElement> = Element.fromTag('input');
+    Insert.append(Body.body(), outerInput);
+
+    Focus.focus(innerInput);
+    Assert.eq('innerInput should have focus', true, Focus.hasFocus(innerInput));
+    Assert.eq('shadowHost should have focus', true, Focus.hasFocus(shadowHost));
+    Assert.eq('innerDiv should not have focus', false, Focus.hasFocus(innerDiv));
+    Assert.eq('outerInput should not have focus', false, Focus.hasFocus(outerInput));
+    Assert.eq('shadowRoot should not have focus', false, Focus.hasFocus(shadowRoot));
+
+    Focus.focus(outerInput);
+    Assert.eq('innerInput should not have focus', false, Focus.hasFocus(innerInput));
+    Assert.eq('shadowHost should not have focus', false, Focus.hasFocus(shadowHost));
+    Assert.eq('innerDiv should not have focus', false, Focus.hasFocus(innerDiv));
+    Assert.eq('outerInput should have focus', true, Focus.hasFocus(outerInput));
+    Assert.eq('shadowRoot should not have focus', false, Focus.hasFocus(shadowRoot));
+  });
+});
+
+UnitTest.test('Focus.focusInside in ShadowRoot', () => {
+  withShadowElement((shadowRoot, innerDiv, shadowHost) => {
+    const innerInput: Element<HTMLElement> = Element.fromTag('input');
+    Insert.append(innerDiv, innerInput);
+
+    Attr.set(innerDiv, 'tabindex', '-1');
+
+    Focus.focus(innerInput);
+    Assert.eq('innerInput should have focus', true, Focus.hasFocus(innerInput));
+    Assert.eq('innerDiv should not have focus', false, Focus.hasFocus(innerDiv));
+
+    Focus.focusInside(innerDiv);
+    Assert.eq('innerInput should have focus', true, Focus.hasFocus(innerInput));
+    Assert.eq('innerDiv should not have focus', false, Focus.hasFocus(innerDiv));
+
+    Focus.focus(innerDiv);
+    Assert.eq('innerInput should not have focus', false, Focus.hasFocus(innerInput));
+    Assert.eq('innerDiv should have focus', true, Focus.hasFocus(innerDiv));
+
+  });
 });

--- a/modules/sugar/src/test/ts/browser/FocusTest.ts
+++ b/modules/sugar/src/test/ts/browser/FocusTest.ts
@@ -8,9 +8,10 @@ import Element from 'ephox/sugar/api/node/Element';
 import * as Attr from 'ephox/sugar/api/properties/Attr';
 import { withShadowElement } from 'ephox/sugar/test/WithHelpers';
 import { Option, OptionInstances } from '@ephox/katamari';
-import tOption = OptionInstances.tOption;
 import { tElement } from 'ephox/sugar/test/ElementInstances';
 import { HTMLElement } from '@ephox/dom-globals';
+
+const tOption = OptionInstances.tOption;
 
 UnitTest.test('FocusTest', () => {
   const div = Element.fromTag('div');

--- a/modules/sugar/src/test/ts/browser/FocusTest.ts
+++ b/modules/sugar/src/test/ts/browser/FocusTest.ts
@@ -115,14 +115,17 @@ UnitTest.test('Focus.focusInside in ShadowRoot', () => {
     Focus.focus(innerInput);
     Assert.eq('innerInput should have focus', true, Focus.hasFocus(innerInput));
     Assert.eq('innerDiv should not have focus', false, Focus.hasFocus(innerDiv));
+    Assert.eq('shadowHost should have focus', true, Focus.hasFocus(shadowHost));
 
     Focus.focusInside(innerDiv);
     Assert.eq('innerInput should have focus', true, Focus.hasFocus(innerInput));
     Assert.eq('innerDiv should not have focus', false, Focus.hasFocus(innerDiv));
+    Assert.eq('shadowHost should have focus', true, Focus.hasFocus(shadowHost));
 
     Focus.focus(innerDiv);
     Assert.eq('innerInput should not have focus', false, Focus.hasFocus(innerInput));
     Assert.eq('innerDiv should have focus', true, Focus.hasFocus(innerDiv));
+    Assert.eq('shadowHost should have focus', true, Focus.hasFocus(shadowHost));
 
   });
 });

--- a/modules/sugar/src/test/ts/browser/FocusTest.ts
+++ b/modules/sugar/src/test/ts/browser/FocusTest.ts
@@ -103,6 +103,8 @@ UnitTest.test('Focus.hasFocus in ShadowRoot', () => {
     Assert.eq('innerDiv should not have focus', false, Focus.hasFocus(innerDiv));
     Assert.eq('outerInput should have focus', true, Focus.hasFocus(outerInput));
     Assert.eq('shadowRoot should not have focus', false, Focus.hasFocus(shadowRoot));
+
+    Remove.remove(outerInput);
   });
 });
 

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -1,5 +1,12 @@
 import Element from 'ephox/sugar/api/node/Element';
-import { document, Element as DomElement, HTMLIFrameElement, ShadowRoot, Window } from '@ephox/dom-globals';
+import {
+  document,
+  Element as DomElement,
+  HTMLElement,
+  HTMLIFrameElement,
+  ShadowRoot,
+  Window
+} from '@ephox/dom-globals';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Body from 'ephox/sugar/api/node/Body';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -12,7 +19,7 @@ export const withNormalElement = (f: (d: Element<DomElement>) => void): void => 
   Remove.remove(div);
 };
 
-const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>, shadowHost: Element<DomElement>) => void) => {
+const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<HTMLElement>, shadowHost: Element<HTMLElement>) => void) => {
   const shadowHost = Element.fromTag('div', document);
   Insert.append(Body.body(), shadowHost);
   const sr = Element.fromDom(shadowHost.dom().attachShadow({ mode }));
@@ -23,13 +30,13 @@ const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<Shadow
   Remove.remove(shadowHost);
 };
 
-export const withShadowElement = (f: (shadowRoot: Element<ShadowRoot>, innerDiv: Element<DomElement>, shadowHost: Element<DomElement>) => void): void => {
+export const withShadowElement = (f: (shadowRoot: Element<ShadowRoot>, innerDiv: Element<HTMLElement>, shadowHost: Element<HTMLElement>) => void): void => {
   withShadowElementInMode('open', f);
   withShadowElementInMode('closed', f);
 };
 
 
-export const withIframe = (f: (div: Element<DomElement>, iframe: Element<HTMLIFrameElement>, cw: Window) => void): void => {
+export const withIframe = (f: (div: Element<HTMLElement>, iframe: Element<HTMLIFrameElement>, cw: Window) => void): void => {
   const iframe = Element.fromTag('iframe');
   Insert.append(Body.body(), iframe);
 

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -10,6 +10,7 @@ import {
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Body from 'ephox/sugar/api/node/Body';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
+import * as ShadowDom from 'ephox/sugar/api/node/ShadowDom';
 
 export const withNormalElement = (f: (d: Element<DomElement>) => void): void => {
   const div = Element.fromTag('div');
@@ -20,14 +21,16 @@ export const withNormalElement = (f: (d: Element<DomElement>) => void): void => 
 };
 
 const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<HTMLElement>, shadowHost: Element<HTMLElement>) => void) => {
-  const shadowHost = Element.fromTag('div', document);
-  Insert.append(Body.body(), shadowHost);
-  const sr = Element.fromDom(shadowHost.dom().attachShadow({ mode }));
-  const innerDiv = Element.fromTag('div', document);
+  if (ShadowDom.isSupported()) {
+    const shadowHost = Element.fromTag('div', document);
+    Insert.append(Body.body(), shadowHost);
+    const sr = Element.fromDom(shadowHost.dom().attachShadow({ mode }));
+    const innerDiv = Element.fromTag('div', document);
 
-  Insert.append(sr, innerDiv);
-  f(sr, innerDiv, shadowHost);
-  Remove.remove(shadowHost);
+    Insert.append(sr, innerDiv);
+    f(sr, innerDiv, shadowHost);
+    Remove.remove(shadowHost);
+  }
 };
 
 export const withShadowElement = (f: (shadowRoot: Element<ShadowRoot>, innerDiv: Element<HTMLElement>, shadowHost: Element<HTMLElement>) => void): void => {

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.4.0 (TBD)
+    Added keyboard navigation support to menus and toolbars when the editor is in a ShadowRoot. #TINY-6152
     Added `Editor.ui.styleSheetLoader` API field, which allows loading of stylesheets within the Document or ShadowRoot that the editor UI is in. #TINY-6089
     Added `StyleSheetLoader` module to public API, as it was already part of `DOMUtils` #TINY-6100
     Added Oxide variables for styling the select element and headings in dialog content #TINY-6070


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Add keyboard navigation to editors in shadow roots, by adding shadow dom support to focus code
* Minor refactors

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
