### PR TITLE
Set event targets to the "original" target, by inspecting composedPath

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -42,7 +42,7 @@ export const isNullable = (a: any): boolean =>
   a === null || a === undefined;
 
 export const isNonNullable = <A> (a: A | null | undefined): a is NonNullable<A> =>
-  a !== null && a !== undefined;
+  !isNullable(a);
 
 export const isFunction: (value: any) => value is Function =
   isSimpleType<Function>('function');

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -38,6 +38,12 @@ export const isBoolean: (value: any) => value is boolean =
 export const isUndefined: (a: any) => a is undefined =
   eq(undefined);
 
+export const isNullable = (a: any): boolean =>
+  a === null || a === undefined;
+
+export const isNonNullable = <A> (a: A | null | undefined): a is NonNullable<A> =>
+  a !== null && a !== undefined;
+
 export const isFunction: (value: any) => value is Function =
   isSimpleType<Function>('function');
 

--- a/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
@@ -148,7 +148,7 @@ UnitTest.test('Type.isNullable', () => {
   Assert.eq('null should be nullable', true, Type.isNullable(null));
   Assert.eq('undefined should be nullable', true, Type.isNullable(undefined));
   fc.assert(fc.property(fc.string(), (s) => {
-    Assert.eq('string should not is nullable', false, Type.isNullable(s));
+    Assert.eq('string should not be nullable', false, Type.isNullable(s));
   }));
   fc.assert(fc.property(fc.integer(), (i) => {
     Assert.eq('integer should not is nullable', false, Type.isNullable(i));
@@ -159,10 +159,10 @@ UnitTest.test('Type.isNonNullable', () => {
   Assert.eq('null should be nullable', false, Type.isNonNullable(null));
   Assert.eq('undefined should be nullable', false, Type.isNonNullable(undefined));
   fc.assert(fc.property(fc.string(), (s) => {
-    Assert.eq('string should not is nullable', false, Type.isNonNullable(s));
+    Assert.eq('string should not be nullable', true, Type.isNonNullable(s));
   }));
   fc.assert(fc.property(fc.integer(), (i) => {
-    Assert.eq('integer should not is nullable', false, Type.isNullable(i));
+    Assert.eq('integer should not be nullable', true, Type.isNonNullable(i));
   }));
 
   // this is testing a compile-time check of the type guard

--- a/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
@@ -151,7 +151,7 @@ UnitTest.test('Type.isNullable', () => {
     Assert.eq('string should not be nullable', false, Type.isNullable(s));
   }));
   fc.assert(fc.property(fc.integer(), (i) => {
-    Assert.eq('integer should not is nullable', false, Type.isNullable(i));
+    Assert.eq('integer should not be nullable', false, Type.isNullable(i));
   }));
 });
 

--- a/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
@@ -143,3 +143,33 @@ UnitTest.test('Type.is*: only one should match for every value', () => {
     Assert.eq('number of matching types', 1, matches.length, tNumber);
   }));
 });
+
+UnitTest.test('Type.isNullable', () => {
+  Assert.eq('null should be nullable', true, Type.isNullable(null));
+  Assert.eq('undefined should be nullable', true, Type.isNullable(undefined));
+  fc.assert(fc.property(fc.string(), (s) => {
+    Assert.eq('string should not is nullable', false, Type.isNullable(s));
+  }));
+  fc.assert(fc.property(fc.integer(), (i) => {
+    Assert.eq('integer should not is nullable', false, Type.isNullable(i));
+  }));
+});
+
+UnitTest.test('Type.isNonNullable', () => {
+  Assert.eq('null should be nullable', false, Type.isNonNullable(null));
+  Assert.eq('undefined should be nullable', false, Type.isNonNullable(undefined));
+  fc.assert(fc.property(fc.string(), (s) => {
+    Assert.eq('string should not is nullable', false, Type.isNonNullable(s));
+  }));
+  fc.assert(fc.property(fc.integer(), (i) => {
+    Assert.eq('integer should not is nullable', false, Type.isNullable(i));
+  }));
+
+  // this is testing a compile-time check of the type guard
+  const os: string | null | undefined = 'hello';
+  if (Type.isNonNullable(os)) {
+    const s: string = os;
+    Assert.eq('s', s, os);
+  }
+});
+

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -72,7 +72,9 @@ export const getShadowHost = (e: Element<ShadowRoot>): Element<DomElement> =>
   Element.fromDom(e.dom().host);
 
 /**
- * Gets the event target based on shadow dom properties. Only works if the shadow tree is open.
+ * When Events bubble up through a ShadowRoot, the browser changes the target to be the shadow host.
+ * This function gets the "original" event target if possible.
+ * This only works if the shadow tree is open - if the shadow tree is closed, event.target is returned.
  * See: https://developers.google.com/web/fundamentals/web-components/shadowdom#events
  */
 export const getOriginalEventTarget = (event: Event): Option<EventTarget> => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -94,9 +94,15 @@ export const getOriginalEventTarget = (event: Event): Option<EventTarget> => {
 };
 
 // TODO: TINY-3312 Upgrade to latest dom-globals which includes the missing 'mode' property
-export const isOpen = (sr: Element<ShadowRoot>): boolean =>
+export const isOpenShadowRoot = (sr: Element<ShadowRoot>): boolean =>
   (sr.dom() as any).mode === 'open';
 
 // TODO: TINY-3312 Upgrade to latest dom-globals which includes the missing 'mode' property
-export const isClosed = (sr: Element<ShadowRoot>): boolean =>
+export const isClosedShadowRoot = (sr: Element<ShadowRoot>): boolean =>
   (sr.dom() as any).mode === 'closed';
+
+/** Return true if the element is a host of an open shadow root.
+ *  Return false if the element is a host of a closed shadow root, or if the element is not a host.
+ */
+export const isOpenShadowHost = (element: Element<DomElement>): boolean =>
+  Type.isNonNullable(element.dom().shadowRoot);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -9,7 +9,6 @@ import * as Head from './Head';
 import { Fun, Option, Type } from '@ephox/katamari';
 import Element from './Element';
 import * as Traverse from '../search/Traverse';
-import { EventArgs } from '../events/Types';
 
 export type RootNode = Element<Document | ShadowRoot>;
 
@@ -90,19 +89,6 @@ export const getOriginalEventTarget = (event: Event): Option<EventTarget> => {
     }
   }
   return Option.from(event.target);
-};
-
-export const setEventTargetToOriginalTarget = <T extends Event> (event: EventArgs<T>): EventArgs<T> => {
-
-  const doOverride = (target: EventTarget) => ({
-    ...event,
-    target: Fun.constant(Element.fromDom(target as DomNode))
-  });
-
-  return getOriginalEventTarget(event.raw()).fold(
-    () => event,
-    (target) => target === event.raw().target ? event : doOverride(target)
-  );
 };
 
 export const isOpen = (sr: Element<ShadowRoot>): boolean =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -82,7 +82,7 @@ export const getOriginalEventTarget = (event: Event): Option<EventTarget> => {
     // otherwise we'll get Shadow Root parent, not actual target element.
     // TODO: update @ephox/dom-globals to include Event.composedPath
     const eventAny = event as any;
-    if (eventAny.composedPath) {
+    if (eventAny.composed && eventAny.composedPath) {
       const composedPath = eventAny.composedPath();
       if (composedPath && composedPath.length > 0) {
         return Option.from(composedPath[0]);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -78,15 +78,18 @@ export const getShadowHost = (e: Element<ShadowRoot>): Element<DomElement> =>
  * See: https://developers.google.com/web/fundamentals/web-components/shadowdom#events
  */
 export const getOriginalEventTarget = (event: Event): Option<EventTarget> => {
-  if (isSupported()) {
-    // When target element is inside Shadow DOM we need to take first element from composedPath
-    // otherwise we'll get Shadow Root parent, not actual target element.
-    // TODO: TINY-3312 Upgrade to latest dom-globals which includes the missing Event.composedPath property
-    const eventAny = event as any;
-    if (eventAny.composed && eventAny.composedPath) {
-      const composedPath = eventAny.composedPath();
-      if (composedPath) {
-        return Arr.head(composedPath);
+  if (isSupported() && Type.isNonNullable(event.target)) {
+    const el = Element.fromDom(event.target as DomNode);
+    if (Node.isElement(el) && isOpenShadowHost(Element.fromDom(event.target as DomElement))) {
+      // When target element is inside Shadow DOM we need to take first element from composedPath
+      // otherwise we'll get Shadow Root parent, not actual target element.
+      // TODO: TINY-3312 Upgrade to latest dom-globals which includes the missing Event.composedPath property
+      const eventAny = event as any;
+      if (eventAny.composed && eventAny.composedPath) {
+        const composedPath = eventAny.composedPath();
+        if (composedPath) {
+          return Arr.head(composedPath);
+        }
       }
     }
   }

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -93,8 +93,10 @@ export const getOriginalEventTarget = (event: Event): Option<EventTarget> => {
   return Option.from(event.target);
 };
 
+// TODO: TINY-3312 Upgrade to latest dom-globals which includes the missing 'mode' property
 export const isOpen = (sr: Element<ShadowRoot>): boolean =>
   (sr.dom() as any).mode === 'open';
 
+// TODO: TINY-3312 Upgrade to latest dom-globals which includes the missing 'mode' property
 export const isClosed = (sr: Element<ShadowRoot>): boolean =>
   (sr.dom() as any).mode === 'closed';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -81,7 +81,7 @@ export const getOriginalEventTarget = (event: Event): Option<EventTarget> => {
   if (isSupported()) {
     // When target element is inside Shadow DOM we need to take first element from composedPath
     // otherwise we'll get Shadow Root parent, not actual target element.
-    // TODO: update @ephox/dom-globals to include Event.composedPath
+    // TODO: TINY-3312 Upgrade to latest dom-globals which includes the missing Event.composedPath property
     const eventAny = event as any;
     if (eventAny.composed && eventAny.composedPath) {
       const composedPath = eventAny.composedPath();

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -6,7 +6,7 @@ import {
 } from '@ephox/dom-globals';
 import * as Node from './Node';
 import * as Head from './Head';
-import { Fun, Option, Type } from '@ephox/katamari';
+import { Arr, Fun, Option, Type } from '@ephox/katamari';
 import Element from './Element';
 import * as Traverse from '../search/Traverse';
 
@@ -85,8 +85,8 @@ export const getOriginalEventTarget = (event: Event): Option<EventTarget> => {
     const eventAny = event as any;
     if (eventAny.composed && eventAny.composedPath) {
       const composedPath = eventAny.composedPath();
-      if (composedPath && composedPath.length > 0) {
-        return Option.from(composedPath[0]);
+      if (composedPath) {
+        return Arr.head(composedPath);
       }
     }
   }

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/FilteredEvent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/FilteredEvent.ts
@@ -2,6 +2,7 @@ import { Event, Node } from '@ephox/dom-globals';
 import { Fun } from '@ephox/katamari';
 import { EventArgs, EventFilter, EventHandler, EventUnbinder } from '../api/events/Types';
 import Element from '../api/node/Element';
+import * as ShadowDom from '../api/node/ShadowDom';
 
 type WrappedHandler<T> = (rawEvent: T) => void;
 
@@ -18,7 +19,7 @@ const mkEvent = <T extends Event>(target: Element, x: number, y: number, stop: (
   });
 
 const fromRawEvent = <T extends Event>(rawEvent: T) => {
-  const target = Element.fromDom(rawEvent.target as Node);
+  const target = Element.fromDom(ShadowDom.getOriginalEventTarget(rawEvent).getOr(rawEvent.target) as Node);
 
   const stop = () => rawEvent.stopPropagation();
 

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/FilteredEvent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/FilteredEvent.ts
@@ -18,6 +18,10 @@ const mkEvent = <T extends Event>(target: Element, x: number, y: number, stop: (
     raw:     Fun.constant(raw)
   });
 
+/** Wraps an Event in an EventArgs structure.
+ * The returned EventArgs structure has its target set to the "original" target if possible.
+ * See ShadowDom.getOriginalEventTarget
+ */
 const fromRawEvent = <T extends Event>(rawEvent: T) => {
   const target = Element.fromDom(ShadowDom.getOriginalEventTarget(rawEvent).getOr(rawEvent.target) as Node);
 

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -138,10 +138,3 @@ UnitTest.test('getShadowHost', () => {
   });
 });
 
-if (ShadowDom.isSupported()) {
-  UnitTest.test('get', () => {
-    withShadowElement((sr, inner, sh) => {
-      Assert.eq('Should be shadow host', sh, ShadowDom.getShadowHost(sr), tElement);
-    });
-  });
-}

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -147,14 +147,14 @@ UnitTest.test('getShadowHost', () => {
   });
 });
 
-UnitTest.test('isOpen / isClosed', () => {
+UnitTest.test('isOpenShadowRoot / isClosedShadowRoot', () => {
   withShadowElementInMode('open', (sr) => {
-    Assert.eq('open shadow root is open', true, ShadowDom.isOpen(sr));
-    Assert.eq('open shadow root is not closed', false, ShadowDom.isClosed(sr));
+    Assert.eq('open shadow root is open', true, ShadowDom.isOpenShadowRoot(sr));
+    Assert.eq('open shadow root is not closed', false, ShadowDom.isClosedShadowRoot(sr));
   });
   withShadowElementInMode('closed', (sr) => {
-    Assert.eq('closed shadow root is not open', false, ShadowDom.isOpen(sr));
-    Assert.eq('closed shadow root is closed', true, ShadowDom.isClosed(sr));
+    Assert.eq('closed shadow root is not open', false, ShadowDom.isOpenShadowRoot(sr));
+    Assert.eq('closed shadow root is closed', true, ShadowDom.isClosedShadowRoot(sr));
   });
 });
 
@@ -201,4 +201,18 @@ UnitTest.asynctest('getOriginalEventTarget on an open shadow root', (success, fa
     return success();
   }
   checkOriginalEventTarget('open', success, failure);
+});
+
+UnitTest.test('isOpenShadowHost on open shadow host', () => {
+  withShadowElementInMode('open', (shadowRoot, innerDiv, shadowHost) => () => {
+    Assert.eq('The open shadow host is an open shadow host', true, ShadowDom.isOpenShadowHost(shadowHost));
+    Assert.eq('The innerDiv is not an open shadow host', false, ShadowDom.isOpenShadowHost(innerDiv));
+  });
+});
+
+UnitTest.test('isOpenShadowHost on closed shadow host', () => {
+  withShadowElementInMode('closed', (shadowRoot, innerDiv, shadowHost) => () => {
+    Assert.eq('The closed shadow host is an open shadow host', false, ShadowDom.isOpenShadowHost(shadowHost));
+    Assert.eq('The innerDiv is not an open shadow host', false, ShadowDom.isOpenShadowHost(innerDiv));
+  });
 });

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -81,7 +81,7 @@ UnitTest.test('getRootNode === shadowroot on element in shadow root', () => {
 
 UnitTest.test('getRootNode(shadowroot) === shadowroot', () => {
   withShadowElement((sr) => {
-    Assert.eq('should be shadowroot', sr, sr, tElement);
+    Assert.eq('should be shadowroot', sr, sr, tElement());
   });
 });
 
@@ -137,7 +137,7 @@ UnitTest.test('contentcontainer is shadow root for shadow root', () => {
   });
 });
 
-UnitTest.test('stylecontainer is body for document', () => {
+UnitTest.test('contentcontainer is body for document', () => {
   Assert.eq('Should be head', Body.getBody(Document.getDocument()), ShadowDom.getContentContainer(Document.getDocument()), tElement());
 });
 
@@ -176,7 +176,7 @@ const checkOriginalEventTarget = (mode: 'open' | 'closed', success: UnitTest.Suc
   const unbinder = DomEvent.bind(Body.body(), 'click', (evt) => {
     try {
       const expected = mode === 'open' ? i2 : shadowHost;
-      Assert.eq('Check event target', expected, evt.target(), tElement);
+      Assert.eq('Check event target', expected, evt.target(), tElement());
       unbinder.unbind();
       Remove.remove(i1);
       Remove.remove(shadowHost);

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -21,7 +21,7 @@ import * as Head from 'ephox/sugar/api/node/Head';
 import * as Body from 'ephox/sugar/api/node/Body';
 import * as Node from 'ephox/sugar/api/node/Node';
 import * as DomEvent from 'ephox/sugar/api/events/DomEvent';
-import { Remove } from '@ephox/sugar';
+import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as Attr from 'ephox/sugar/api/properties/Attr';
 
 type RootNode = ShadowDom.RootNode;

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -158,7 +158,7 @@ UnitTest.test('isOpen / isClosed', () => {
   });
 });
 
-function checkOriginalEventTarget(mode: 'open' | 'closed', success: UnitTest.SuccessCallback, failure: UnitTest.FailureCallback) {
+const checkOriginalEventTarget = (mode: 'open' | 'closed', success: UnitTest.SuccessCallback, failure: UnitTest.FailureCallback): void => {
   const { innerDiv, shadowHost } = setupShadowRoot(mode);
 
   const input = (desc: string, parent: Element<DomElement>) => {
@@ -186,7 +186,7 @@ function checkOriginalEventTarget(mode: 'open' | 'closed', success: UnitTest.Suc
     }
   });
   i2.dom().click();
-}
+};
 
 UnitTest.asynctest('getOriginalEventTarget on a closed shadow root', (success, failure) => {
   if (!ShadowDom.isSupported()) {

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -17,23 +17,19 @@ import * as Node from 'ephox/sugar/api/node/Node';
 
 type RootNode = ShadowDom.RootNode;
 
-const shadowDomTest = (name: string, fn: () => void) => {
-  if (DomElement.prototype.hasOwnProperty('attachShadow')) {
-    UnitTest.test(name, fn);
+UnitTest.test('ShadowDom - SelectorFind.descendant', () => {
+  if (ShadowDom.isSupported()) {
+    fc.assert(fc.property(htmlBlockTagName(), htmlInlineTagName(), fc.hexaString(), (block, inline, text) => {
+      withShadowElement((ss) => {
+        const id = 'theid';
+        const inner = Element.fromHtml(`<${block}><p>hello<${inline} id="${id}">${text}</${inline}></p></${block}>`);
+        Insert.append(ss, inner);
+
+        const frog: Element<DomElement> = SelectorFind.descendant(ss, `#${id}`).getOrDie('Element not found');
+        Assert.eq('textcontent', text, frog.dom().textContent);
+      });
+    }));
   }
-};
-
-shadowDomTest('ShadowDom - SelectorFind.descendant', () => {
-  fc.assert(fc.property(htmlBlockTagName(), htmlInlineTagName(), fc.hexaString(), (block, inline, text) => {
-    withShadowElement((ss) => {
-      const id = 'theid';
-      const inner = Element.fromHtml(`<${block}><p>hello<${inline} id="${id}">${text}</${inline}></p></${block}>`);
-      Insert.append(ss, inner);
-
-      const frog: Element<DomElement> = SelectorFind.descendant(ss, `#${id}`).getOrDie('Element not found');
-      Assert.eq('textcontent', text, frog.dom().textContent);
-    });
-  }));
 });
 
 const shouldBeShadowRoot = (n: RootNode) => {
@@ -68,26 +64,24 @@ UnitTest.test('document is document', () => {
   shouldBeDocument(Document.getDocument());
 });
 
-if (ShadowDom.isSupported()) {
-  UnitTest.test('getRootNode === shadowroot on element in shadow root', () => {
-    withShadowElement((sr, innerDiv) => {
-      Assert.eq('should be shadowroot', sr, ShadowDom.getRootNode(innerDiv), tElement);
-    });
+UnitTest.test('getRootNode === shadowroot on element in shadow root', () => {
+  withShadowElement((sr, innerDiv) => {
+    Assert.eq('should be shadowroot', sr, ShadowDom.getRootNode(innerDiv), tElement);
   });
+});
 
-  UnitTest.test('getRootNode(shadowroot) === shadowroot', () => {
-    withShadowElement((sr) => {
-      Assert.eq('should be shadowroot', sr, sr, tElement);
-    });
+UnitTest.test('getRootNode(shadowroot) === shadowroot', () => {
+  withShadowElement((sr) => {
+    Assert.eq('should be shadowroot', sr, sr, tElement);
   });
+});
 
-  UnitTest.test('shadow root is shadow root', () => {
-    withShadowElement((sr, innerDiv) => {
-      shouldBeShadowRoot(ShadowDom.getRootNode(innerDiv));
-      shouldBeShadowRoot(sr);
-    });
+UnitTest.test('shadow root is shadow root', () => {
+  withShadowElement((sr, innerDiv) => {
+    shouldBeShadowRoot(ShadowDom.getRootNode(innerDiv));
+    shouldBeShadowRoot(sr);
   });
-}
+});
 
 UnitTest.test('getRootNode in iframe', () => {
   withIframe((div, iframe, cw) => {
@@ -118,32 +112,34 @@ UnitTest.test('isSupported platform test', () => {
   }
 });
 
-if (ShadowDom.isSupported()) {
-  UnitTest.test('stylecontainer is shadow root for shadow root', () => {
-    withShadowElement((sr) => {
-      Assert.eq('Should be shadow root', sr, ShadowDom.getStyleContainer(sr), tElement);
-    });
+UnitTest.test('stylecontainer is shadow root for shadow root', () => {
+  withShadowElement((sr) => {
+    Assert.eq('Should be shadow root', sr, ShadowDom.getStyleContainer(sr), tElement);
   });
-}
+});
 
 UnitTest.test('stylecontainer is head for document', () => {
   Assert.eq('Should be head', Head.getHead(Document.getDocument()), ShadowDom.getStyleContainer(Document.getDocument()), tElement);
 });
 
-if (ShadowDom.isSupported()) {
-  UnitTest.test('contentcontainer is shadow root for shadow root', () => {
-    withShadowElement((sr) => {
-      Assert.eq('Should be shadow root', sr, ShadowDom.getContentContainer(sr), tElement);
-    });
+UnitTest.test('contentcontainer is shadow root for shadow root', () => {
+  withShadowElement((sr) => {
+    Assert.eq('Should be shadow root', sr, ShadowDom.getContentContainer(sr), tElement);
   });
-}
+});
 
 UnitTest.test('stylecontainer is body for document', () => {
   Assert.eq('Should be head', Body.getBody(Document.getDocument()), ShadowDom.getContentContainer(Document.getDocument()), tElement);
 });
 
+UnitTest.test('getShadowHost', () => {
+  withShadowElement((sr, inner, sh) => {
+    Assert.eq('Should be shadow host', sh, ShadowDom.getShadowHost(sr), tElement);
+  });
+});
+
 if (ShadowDom.isSupported()) {
-  UnitTest.test('getShadowHost', () => {
+  UnitTest.test('get', () => {
     withShadowElement((sr, inner, sh) => {
       Assert.eq('Should be shadow host', sh, ShadowDom.getShadowHost(sr), tElement);
     });

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -8,7 +8,12 @@ import { PlatformDetection } from '@ephox/sand';
 import * as ShadowDom from 'ephox/sugar/api/node/ShadowDom';
 import { Testable } from '@ephox/dispute';
 import { htmlBlockTagName, htmlInlineTagName } from 'ephox/sugar/test/Arbitrary';
-import { withIframe, withNormalElement, withShadowElement } from 'ephox/sugar/test/WithHelpers';
+import {
+  withIframe,
+  withNormalElement,
+  withShadowElement,
+  withShadowElementInMode
+} from 'ephox/sugar/test/WithHelpers';
 import { tElement } from 'ephox/sugar/test/ElementInstances';
 import * as Document from 'ephox/sugar/api/node/Document';
 import * as Head from 'ephox/sugar/api/node/Head';
@@ -138,3 +143,13 @@ UnitTest.test('getShadowHost', () => {
   });
 });
 
+UnitTest.test('isOpen / isClosed', () => {
+  withShadowElementInMode('open', (sr) => {
+    Assert.eq('open shadow root is open', true, ShadowDom.isOpen(sr));
+    Assert.eq('open shadow root is not closed', false, ShadowDom.isClosed(sr));
+  });
+  withShadowElementInMode('closed', (sr) => {
+    Assert.eq('closed shadow root is not open', false, ShadowDom.isOpen(sr));
+    Assert.eq('closed shadow root is closed', true, ShadowDom.isClosed(sr));
+  });
+});

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -13,7 +13,7 @@ export const withNormalElement = (f: (d: Element<DomElement>) => void): void => 
   Remove.remove(div);
 };
 
-const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>, shadowHost: Element<DomElement>) => void) => {
+export const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>, shadowHost: Element<DomElement>) => void) => {
   if (ShadowDom.isSupported()) {
     const shadowHost = Element.fromTag('div', document);
     Insert.append(Body.body(), shadowHost);

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -4,7 +4,7 @@ import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Body from 'ephox/sugar/api/node/Body';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as ShadowDom from 'ephox/sugar/api/node/ShadowDom';
-import { Attr } from '@ephox/sugar';
+import * as Attr from 'ephox/sugar/api/properties/Attr';
 
 export const withNormalElement = (f: (d: Element<DomElement>) => void): void => {
   const div = Element.fromTag('div');

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -3,6 +3,7 @@ import { document, Element as DomElement, HTMLIFrameElement, ShadowRoot, Window 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Body from 'ephox/sugar/api/node/Body';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
+import * as ShadowDom from 'ephox/sugar/api/node/ShadowDom';
 
 export const withNormalElement = (f: (d: Element<DomElement>) => void): void => {
   const div = Element.fromTag('div');
@@ -13,14 +14,16 @@ export const withNormalElement = (f: (d: Element<DomElement>) => void): void => 
 };
 
 const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: Element<ShadowRoot>, innerDiv: Element<DomElement>, shadowHost: Element<DomElement>) => void) => {
-  const shadowHost = Element.fromTag('div', document);
-  Insert.append(Body.body(), shadowHost);
-  const sr = Element.fromDom(shadowHost.dom().attachShadow({ mode }));
-  const innerDiv = Element.fromTag('div', document);
+  if (ShadowDom.isSupported()) {
+    const shadowHost = Element.fromTag('div', document);
+    Insert.append(Body.body(), shadowHost);
+    const sr = Element.fromDom(shadowHost.dom().attachShadow({ mode }));
+    const innerDiv = Element.fromTag('div', document);
 
-  Insert.append(sr, innerDiv);
-  f(sr, innerDiv, shadowHost);
-  Remove.remove(shadowHost);
+    Insert.append(sr, innerDiv);
+    f(sr, innerDiv, shadowHost);
+    Remove.remove(shadowHost);
+  }
 };
 
 export const withShadowElement = (f: (shadowRoot: Element<ShadowRoot>, innerDiv: Element<DomElement>, shadowHost: Element<DomElement>) => void): void => {

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.4.0 (TBD)
+    Added ability for menus to be clicked when the editor is in an open shadow root. #TINY-6091
     Added `Editor.ui.styleSheetLoader` API field, which allows loading of stylesheets within the Document or ShadowRoot that the editor UI is in. #TINY-6089
     Added `StyleSheetLoader` module to public API, as it was already part of `DOMUtils` #TINY-6100
     Added Oxide variables for styling the select element and headings in dialog content #TINY-6070


### PR DESCRIPTION
Related Ticket: TINY-6091

Description of Changes:
* Set event targets to the "original" target, by inspecting composedPath. See the comments in the code for more details.
* This fixes clicking on menus when the editor is in a shadow root.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
