### PR TITLE
GH_DOCS_1539: API docs typo

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -18,7 +18,7 @@ import Tools from './util/Tools';
  * editor.shortcuts.add('ctrl+a', "description of the shortcut", function() {});
  * editor.shortcuts.add('meta+a', "description of the shortcut", function() {}); // "meta" maps to Command on Mac and Ctrl on PC
  * editor.shortcuts.add('ctrl+alt+a', "description of the shortcut", function() {});
- * editor.shortcuts.add('access+a', "description of the shortcut", function() {}); // "access" maps to ctrl+option on Mac and shift+alt on PC
+ * editor.shortcuts.add('access+a', "description of the shortcut", function() {}); // "access" maps to Control+Option on Mac and shift+alt on PC
  */
 
 const each = Tools.each, explode = Tools.explode;

--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -18,7 +18,7 @@ import Tools from './util/Tools';
  * editor.shortcuts.add('ctrl+a', "description of the shortcut", function() {});
  * editor.shortcuts.add('meta+a', "description of the shortcut", function() {}); // "meta" maps to Command on Mac and Ctrl on PC
  * editor.shortcuts.add('ctrl+alt+a', "description of the shortcut", function() {});
- * editor.shortcuts.add('access+a', "description of the shortcut", function() {}); // "access" maps to ctrl+alt on Mac and shift+alt on PC
+ * editor.shortcuts.add('access+a', "description of the shortcut", function() {}); // "access" maps to command+alt on Mac and shift+alt on PC
  */
 
 const each = Tools.each, explode = Tools.explode;

--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -18,7 +18,7 @@ import Tools from './util/Tools';
  * editor.shortcuts.add('ctrl+a', "description of the shortcut", function() {});
  * editor.shortcuts.add('meta+a', "description of the shortcut", function() {}); // "meta" maps to Command on Mac and Ctrl on PC
  * editor.shortcuts.add('ctrl+alt+a', "description of the shortcut", function() {});
- * editor.shortcuts.add('access+a', "description of the shortcut", function() {}); // "access" maps to command+alt on Mac and shift+alt on PC
+ * editor.shortcuts.add('access+a', "description of the shortcut", function() {}); // "access" maps to ctrl+option on Mac and shift+alt on PC
  */
 
 const each = Tools.each, explode = Tools.explode;


### PR DESCRIPTION
Related Ticket: https://github.com/tinymce/tinymce-docs/issues/1539

Description of Changes:
* Fixing minor typo in shortcut API docs

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): https://github.com/tinymce/tinymce-docs/issues/1539
