### PR TITLE
TINY-6000: Added the ability to switch via between none, percentage and pixel based table sizing

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/assertions/ApproxComparisons.ts
+++ b/modules/agar/src/main/ts/ephox/agar/assertions/ApproxComparisons.ts
@@ -1,5 +1,5 @@
-import { Arr, Fun, Id, Strings } from '@ephox/katamari';
 import { Assert, TestLabel } from '@ephox/bedrock-client';
+import { Arr, Fun, Id, Strings } from '@ephox/katamari';
 import { ArrayAssert, StringAssert } from './ApproxStructures';
 
 const missingValuePlaceholder: string = Id.generate('missing');
@@ -22,7 +22,7 @@ const is = (target: string): CombinedAssert => {
 
   const strAssert = (label: TestLabel, actual: string) => {
     const c = compare(actual);
-    assertOnBool(c, TestLabel.concat(label, '\nExpected value: ' + target), actual);
+    assertOnBool(c, TestLabel.concat(label, '\nExpected value: ' + JSON.stringify(target)), actual);
   };
 
   return {

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/OffsetOrigin.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/OffsetOrigin.ts
@@ -1,14 +1,14 @@
-import { Element as DomElement } from '@ephox/dom-globals';
+import { HTMLElement } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 import { Css, Element, Insert, Location, Position, Remove, Traverse } from '@ephox/sugar';
 
-const getOffsetParent = (element: Element): Option<Element<DomElement>> => {
+const getOffsetParent = (element: Element): Option<Element<HTMLElement>> => {
   // Firefox sets the offsetParent to the body when fixed instead of null like
   // all other browsers. So we need to check if the element is fixed and if so then
   // disregard the elements offsetParent.
   const isFixed = Css.getRaw(element, 'position').is('fixed');
-  const offsetParent = isFixed ? Option.none<Element<DomElement>>() : Traverse.offsetParent(element);
-  return offsetParent.orThunk((): Option<Element<DomElement>> => {
+  const offsetParent = isFixed ? Option.none<Element<HTMLElement>>() : Traverse.offsetParent(element);
+  return offsetParent.orThunk(() => {
     const marker = Element.fromTag('span');
     // PERFORMANCE: Append the marker to the parent element, as adding it before the current element will
     // trigger the styles to be recalculated which is a little costly (particularly in scroll/resize events)

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Main.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Main.ts
@@ -13,6 +13,7 @@ import { ResizeWire } from './ResizeWire';
 import * as Sizes from './Sizes';
 import * as Structs from './Structs';
 import * as TableContent from './TableContent';
+import * as TableConversions from './TableConversions';
 import { TableDirection } from './TableDirection';
 import * as TableFill from './TableFill';
 import * as TableGridSize from './TableGridSize';
@@ -37,6 +38,7 @@ export {
   Sizes,
   Structs,
   TableContent,
+  TableConversions,
   TableDirection,
   TableFill,
   TableGridSize,

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
@@ -4,6 +4,7 @@ import { Warehouse } from '../model/Warehouse';
 import * as BarPositions from '../resize/BarPositions';
 import * as ColumnSizes from '../resize/ColumnSizes';
 import * as Redistribution from '../resize/Redistribution';
+import * as Sizes from '../resize/Sizes';
 import * as CellUtils from '../util/CellUtils';
 import { DetailExt, RowData } from './Structs';
 import { TableSize } from './TableSize';
@@ -62,6 +63,18 @@ const redistribute = function (table: Element, optWidth: Option<string>, optHeig
 
 };
 
+const isPercentSizing = Sizes.isPercentSizing;
+const isPixelSizing = Sizes.isPixelSizing;
+const isNoneSizing = Sizes.isNoneSizing;
+
+const getPercentTableWidth = Sizes.getPercentTableWidth;
+const getPercentTableHeight = Sizes.getPercentTableHeight;
+
 export {
+  getPercentTableWidth,
+  getPercentTableHeight,
+  isPercentSizing,
+  isPixelSizing,
+  isNoneSizing,
   redistribute
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableConversions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableConversions.ts
@@ -1,0 +1,28 @@
+import { Arr, Option } from '@ephox/katamari';
+import { Css, Element } from '@ephox/sugar';
+import { BarPositions, ColInfo } from '../resize/BarPositions';
+import * as Sizes from '../resize/Sizes';
+import { redistribute } from './Sizes';
+import * as TableLookup from './TableLookup';
+import { TableSize } from './TableSize';
+
+const convertToPercentSize = (table: Element, direction: BarPositions<ColInfo>, tableSize: TableSize) => {
+  const newWidth = Sizes.getPercentTableWidth(table);
+  redistribute(table, Option.some(newWidth), Option.none(), direction, tableSize);
+};
+
+const convertToPixelSize = (table: Element, direction: BarPositions<ColInfo>, tableSize: TableSize) => {
+  const newWidth = Sizes.getPixelTableWidth(table);
+  redistribute(table, Option.some(newWidth), Option.none(), direction, tableSize);
+};
+
+const convertToNoneSize = (table: Element) => {
+  Css.remove(table, 'width');
+  Arr.each(TableLookup.cells(table), (cell) => Css.remove(cell, 'width'));
+};
+
+export {
+  convertToPixelSize,
+  convertToPercentSize,
+  convertToNoneSize
+};

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/Render.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/Render.ts
@@ -3,7 +3,6 @@ import { Attr, Css, Element, Insert, InsertAll } from '@ephox/sugar';
 export interface RenderOptions {
   styles: Record<string, string>;
   attributes: Record<string, string>;
-  percentages: boolean;
 }
 
 const DefaultRenderOptions: RenderOptions = {
@@ -13,8 +12,7 @@ const DefaultRenderOptions: RenderOptions = {
   },
   attributes: {
     border: '1'
-  },
-  percentages: true
+  }
 };
 
 const makeTable = function () {
@@ -58,9 +56,6 @@ const render = (rows: number, columns: number, rowHeaders: number, columnHeaders
 
       // Note, this is a placeholder so that the cells have height. The unicode character didn't work in IE10.
       Insert.append(td, Element.fromTag('br'));
-      if (renderOpts.percentages) {
-        Css.set(td, 'width', (100 / columns) + '%');
-      }
       Insert.append(tr, td);
     }
     trs.push(tr);

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
@@ -35,7 +35,7 @@ const adjustWidth = function (table: Element, delta: number, index: number, dire
 
   // Set the overall width of the table.
   if (index === warehouse.grid.columns() - 1) {
-    tableSize.setTableWidth(table, newWidths, step);
+    tableSize.adjustTableWidth(step);
   }
 };
 
@@ -72,13 +72,6 @@ const adjustWidthTo = function <T extends Detail> (table: Element, list: RowData
   Arr.each(newSizes, function (cell) {
     tableSize.setElementWidth(cell.element, cell.width);
   });
-
-  // const total = Arr.foldr(widths, function (b, a) { return a + b; }, 0);
-  if (newSizes.length > 0) {
-    // tableSize.setTableWidth(table, total);
-    // WARNING, this may be incorrect, the commented out code above was the original
-    tableSize.setTableWidth(table, widths, tableSize.getCellDelta(0));
-  }
 };
 
 export {

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Redistribution.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Redistribution.ts
@@ -60,7 +60,7 @@ const redistributeValues = function (newWidthType: Size, widths: string[], total
 const redistribute = function (widths: string[], totalWidth: number, newWidth: string) {
   const newType = Size.from(newWidth);
   const floats = Arr.forall(widths, function (s) { return s === '0px'; }) ? redistributeEmpty(newType, widths.length) : redistributeValues(newType, widths, totalWidth);
-  return toIntegers(floats);
+  return normalize(floats);
 };
 
 const sum = function (values: string[], fallback: number) {
@@ -85,21 +85,15 @@ const add = function (value: string, amount: number) {
   });
 };
 
-const toIntegers = function (values: string[]) {
+const normalize = function (values: string[]) {
   if (values.length === 0) {
     return values;
   }
-  const scan = Arr.foldr(values, function (rest, value) {
+  const scan = Arr.foldr(values, (rest, value) => {
     const info = Size.from(value).fold(
-      function () {
-        return { value, remainder: 0 };
-      },
-      function (num) {
-        return roundDown(num, 'px');
-      },
-      function (num) {
-        return roundDown(num, '%');
-      }
+      () => ({ value, remainder: 0 }),
+      (num) => roundDown(num, 'px'),
+      (num) => ({ value: num + '%', remainder: 0 })
     );
 
     return {
@@ -114,5 +108,5 @@ const toIntegers = function (values: string[]) {
 
 const validate = Size.from;
 
-export { validate, redistribute, sum, toIntegers };
+export { validate, redistribute, sum, normalize };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/RuntimeSize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/RuntimeSize.ts
@@ -1,37 +1,56 @@
 import { HTMLElement } from '@ephox/dom-globals';
 import { PlatformDetection } from '@ephox/sand';
-import { Css, Element, Height } from '@ephox/sugar';
+import { Css, Element, Height, Width } from '@ephox/sugar';
 
-const needManualCalc = function () {
-  const platform = PlatformDetection.detect();
-  return platform.browser.isIE() || platform.browser.isEdge();
+const needManualCalc = () => {
+  const browser = PlatformDetection.detect().browser;
+  return browser.isIE() || browser.isEdge();
 };
 
-const toNumber = function (px: string, fallback: number) {
+const toNumber = (px: string, fallback: number) => {
   const num = parseFloat(px); // parseFloat removes suffixes like px
   return isNaN(num) ? fallback : num;
 };
 
-const getProp = function (elm: Element, name: string, fallback: number) {
-  return toNumber(Css.get(elm, name), fallback);
-};
+const getProp = (elm: Element, name: string, fallback: number) => toNumber(Css.get(elm, name), fallback);
 
-const getCalculatedHeight = function (cell: Element) {
-  const paddingTop = getProp(cell, 'padding-top', 0);
-  const paddingBottom = getProp(cell, 'padding-bottom', 0);
-  const borderTop = getProp(cell, 'border-top-width', 0);
-  const borderBottom = getProp(cell, 'border-bottom-width', 0);
-  const height = (cell.dom() as HTMLElement).getBoundingClientRect().height;
+const getCalculatedHeight = (cell: Element<HTMLElement>) => {
+  const height = cell.dom().getBoundingClientRect().height;
   const boxSizing = Css.get(cell, 'box-sizing');
-  const borders = borderTop + borderBottom;
+  if (boxSizing === 'border-box') {
+    return height;
+  } else {
+    const paddingTop = getProp(cell, 'padding-top', 0);
+    const paddingBottom = getProp(cell, 'padding-bottom', 0);
+    const borderTop = getProp(cell, 'border-top-width', 0);
+    const borderBottom = getProp(cell, 'border-bottom-width', 0);
+    const borders = borderTop + borderBottom;
 
-  return boxSizing === 'border-box' ? height : height - paddingTop - paddingBottom - borders;
+    return height - paddingTop - paddingBottom - borders;
+  }
 };
 
-const getHeight = function (cell: Element) {
-  return needManualCalc() ? getCalculatedHeight(cell) : getProp(cell, 'height', Height.get(cell));
+const getCalculatedWidth = (cell: Element<HTMLElement>) => {
+  const width = cell.dom().getBoundingClientRect().width;
+  const boxSizing = Css.get(cell, 'box-sizing');
+  if (boxSizing === 'border-box') {
+    return width;
+  } else {
+    const paddingLeft = getProp(cell, 'padding-left', 0);
+    const paddingRight = getProp(cell, 'padding-right', 0);
+    const borderLeft = getProp(cell, 'border-left-width', 0);
+    const borderRight = getProp(cell, 'border-right-width', 0);
+    const borders = borderLeft + borderRight;
+
+    return width - paddingLeft - paddingRight - borders;
+  }
 };
+
+const getHeight = (cell: Element<HTMLElement>) => needManualCalc() ? getCalculatedHeight(cell) : getProp(cell, 'height', Height.get(cell));
+
+const getWidth = (cell: Element<HTMLElement>) => needManualCalc() ? getCalculatedWidth(cell) : getProp(cell, 'width', Width.get(cell));
 
 export {
-  getHeight
+  getHeight,
+  getWidth
 };

--- a/modules/snooker/src/test/ts/atomic/resize/RedistributeTest.ts
+++ b/modules/snooker/src/test/ts/atomic/resize/RedistributeTest.ts
@@ -1,5 +1,5 @@
+import { assert, UnitTest } from '@ephox/bedrock-client';
 import * as Redistribution from 'ephox/snooker/resize/Redistribution';
-import { UnitTest, assert } from '@ephox/bedrock-client';
 import { Size } from '../../../../main/ts/ephox/snooker/resize/Size';
 
 UnitTest.test('RedistributeTest', function () {
@@ -43,7 +43,9 @@ UnitTest.test('RedistributeTest', function () {
   check([ '', '', '20px' ], [ '', '', '20px' ], 60, '60px');
   check([ '', '', '' ], [ '', '', '' ], 60, '60px');
 
-  assert.eq([ '10px', '10px', '11px' ], Redistribution.toIntegers([ '10.3px', '10.3px', '10.3px' ]));
+  assert.eq([ '10px', '10px', '11px' ], Redistribution.normalize([ '10.3px', '10.3px', '10.3px' ]));
+  assert.eq([ '10px', '11px', '10px' ], Redistribution.normalize([ '10px', '11px', '10px' ]));
+  assert.eq([ '33.33%', '33.33%', '33.33%' ], Redistribution.normalize([ '33.33%', '33.33%', '33.33%' ]));
 
   assert.eq(100, Redistribution.sum([ '100px' ], 10));
   assert.eq(50, Redistribution.sum([ '50%' ], 10));

--- a/modules/snooker/src/test/ts/browser/RenderTest.ts
+++ b/modules/snooker/src/test/ts/browser/RenderTest.ts
@@ -18,53 +18,11 @@ UnitTest.asynctest('RenderTest', (success, failure) => {
               s.element('tr', {
                 children: [
                   s.element('td', {
-                    styles: {
-                      width: str.is('50%')
-                    },
                     children: [
                       s.element('br', {})
                     ]
                   }),
                   s.element('td', {
-                    styles: {
-                      width: str.is('50%')
-                    },
-                    children: [
-                      s.element('br', {})
-                    ]
-                  })
-                ]
-              })
-            ]
-          })
-        ]
-      })), table);
-    })),
-    Logger.t('Render table with percentages', Step.sync(() => {
-      const table = Render.render(1, 2, 0, 0, { styles: {}, attributes: {}, percentages: true });
-
-      Assertions.assertStructure('Should be a table with percentages', ApproxStructure.build((s, str, _arr) => s.element('table', {
-        styles: {
-          'width': str.none('Should not have width'),
-          'border-collapse': str.none('Should not have border-collapse')
-        },
-        children: [
-          s.element('tbody', {
-            children: [
-              s.element('tr', {
-                children: [
-                  s.element('td', {
-                    styles: {
-                      width: str.is('50%')
-                    },
-                    children: [
-                      s.element('br', {})
-                    ]
-                  }),
-                  s.element('td', {
-                    styles: {
-                      width: str.is('50%')
-                    },
                     children: [
                       s.element('br', {})
                     ]
@@ -77,7 +35,7 @@ UnitTest.asynctest('RenderTest', (success, failure) => {
       })), table);
     })),
     Logger.t('Render table with everything disabled', Step.sync(() => {
-      const table = Render.render(1, 2, 0, 0, { styles: { width: '50%', height: '100px' }, attributes: {}, percentages: false });
+      const table = Render.render(1, 2, 0, 0, { styles: { width: '50%', height: '100px' }, attributes: {}});
 
       Assertions.assertStructure('Should be a table with styles', ApproxStructure.build((s, str, _arr) => s.element('table', {
         styles: {
@@ -113,7 +71,7 @@ UnitTest.asynctest('RenderTest', (success, failure) => {
       })), table);
     })),
     Logger.t('Render table with attributes', Step.sync(() => {
-      const table = Render.render(1, 2, 0, 0, { styles: {}, attributes: { border: '1', class: 'myclass' }, percentages: false });
+      const table = Render.render(1, 2, 0, 0, { styles: {}, attributes: { border: '1', class: 'myclass' }});
 
       Assertions.assertStructure('Should be a table with styles', ApproxStructure.build((s, str, _arr) => s.element('table', {
         styles: {
@@ -153,7 +111,7 @@ UnitTest.asynctest('RenderTest', (success, failure) => {
       })), table);
     })),
     Logger.t('Render table with everything disabled', Step.sync(() => {
-      const table = Render.render(1, 2, 0, 0, { styles: {}, attributes: {}, percentages: false });
+      const table = Render.render(1, 2, 0, 0, { styles: {}, attributes: {}});
 
       Assertions.assertStructure('Should be a table with default styles/attributes', ApproxStructure.build((s, str, _arr) => s.element('table', {
         styles: {

--- a/modules/snooker/src/test/ts/browser/ResizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/ResizeTest.ts
@@ -57,7 +57,7 @@ UnitTest.test('ResizeTest', function () {
     assert.eq([ 25, -25 ], deltas);
 
     // Set new width
-    tableSize.setTableWidth(table, [], step);
+    tableSize.adjustTableWidth(step);
     assert.eq(Css.getRaw(table, 'width').getOrDie(), '125%');
 
     Remove.remove(table);
@@ -115,7 +115,7 @@ UnitTest.test('ResizeTest', function () {
     assert.eq([ 25, -25 ], deltas);
 
     // Set new width
-    tableSize.setTableWidth(table, [], step);
+    tableSize.adjustTableWidth(step);
     assert.eq(Css.getRaw(table, 'width').getOrDie(), '125%');
 
     Remove.remove(table);

--- a/modules/snooker/src/test/ts/browser/RuntimeSizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/RuntimeSizeTest.ts
@@ -1,75 +1,74 @@
-import { assert, UnitTest, TestLabel } from '@ephox/bedrock-client';
+import { assert, TestLabel, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Attr, Body, Css, Element, Html, Insert, Remove, SelectorFilter } from '@ephox/sugar';
+import { Attr, Body, Css, Element, Html, Insert, InsertAll, Remove, SelectorFilter } from '@ephox/sugar';
 import * as RuntimeSize from 'ephox/snooker/resize/RuntimeSize';
 
-UnitTest.test('Runtime Size Test', function () {
+interface TableModel {
+  total: number;
+  rows: number;
+  cols: number;
+  cells: number[];
+}
+
+UnitTest.test('Runtime Size Test', () => {
   const platform = PlatformDetection.detect();
 
-  const random = function (min: number, max: number) {
-    return Math.round(Math.random() * (max - min) + min);
-  };
+  const random = (min: number, max: number) => Math.round(Math.random() * (max - min) + min);
 
-  const getOuterHeight = function (elm: Element) {
-    return Math.round(elm.dom().getBoundingClientRect().height);
-  };
+  const getOuterHeight = (elm: Element) => Math.round(elm.dom().getBoundingClientRect().height);
+  const getOuterWidth = (elm: Element) => Math.round(elm.dom().getBoundingClientRect().width);
 
-  const measureCells = function (getSize: (e: Element) => number, table: Element) {
-    return Arr.map(SelectorFilter.descendants(table, 'td'), getSize);
-  };
+  const measureCells = (getSize: (e: Element) => number, table: Element) => Arr.map(SelectorFilter.descendants(table, 'td'), getSize);
 
-  const measureTable = function (table: Element, getSize: (e: Element) => number) {
-    return {
-      total: getSize(table),
-      cells: measureCells(getSize, table)
-    };
-  };
+  const measureTable = (table: Element, getSize: (e: Element) => number) => ({
+    total: getSize(table),
+    cells: measureCells(getSize, table)
+  });
 
-  const setHeight = function (table: Element, value: string) {
-    Css.set(table, 'height', value);
-  };
+  const setHeight = (table: Element, value: string) => Css.set(table, 'height', value);
+  const setWidth = (table: Element, value: string) => Css.set(table, 'width', value);
 
-  const resizeTableBy = function (table: Element, setSize: (e: Element, v: string) => void, tableInfo: { total: number; cells: number[] }, delta: number) {
+  const resizeTableBy = (table: Element, setSize: (e: Element, v: string) => void, tableInfo: { total: number; cells: number[] }, delta: number) => {
     setSize(table, '');
-    Arr.map(SelectorFilter.descendants(table, 'td'), function (cell, i) {
+    Arr.map(SelectorFilter.descendants(table, 'td'), (cell, i) => {
       setSize(cell, (tableInfo.cells[i] + delta) + 'px');
     });
   };
 
-  const fuzzyAssertEq = function (a: number, b: number, msg: TestLabel) {
+  const fuzzyAssertEq = (a: number, b: number, msg: TestLabel) => {
     // Sometimes the widths of the cells are 1 px off due to rounding but the total table width is never off
     assert.eq(true, Math.abs(a - b) <= 1, msg);
   };
 
-  const assertSize = function (s1: { total: number; cells: number[] }, table: Element, getOuterSize: (e: Element) => number, message: string) {
+  const assertSize = (s1: { total: number; cells: number[] }, table: Element, getOuterSize: (e: Element) => number, message: string) => {
     const s2 = measureTable(table, getOuterSize);
     const cellAssertEq = platform.browser.isIE() || platform.browser.isEdge() ? fuzzyAssertEq : assert.eq;
 
     assert.eq(s1.total, s2.total, () => message + ', expected table size: ' + s1.total + ', actual: ' + s2.total + ', table: ' + Html.getOuter(table));
 
-    Arr.each(s1.cells, function (cz1, i) {
+    Arr.each(s1.cells, (cz1, i) => {
       const cz2 = s2.cells[i];
       cellAssertEq(cz1, cz2, () => message + ', expected cell size: ' + cz1 + ', actual: ' + cz2 + ', table: ' + Html.getOuter(table));
     });
   };
 
-  const randomValue = function <T> (values: T[]) {
+  const randomValue = <T>(values: T[]) => {
     const idx = random(0, values.length - 1);
     return values[idx];
   };
 
-  const randomSize = function (min: number, max: number) {
+  const randomSize = (min: number, max: number) => {
     const n = random(min, max);
     return n > 0 ? n + 'px' : '0';
   };
 
-  const randomBorder = function (min: number, max: number, color: string) {
+  const randomBorder = (min: number, max: number, color: string) => {
     const n = random(min, max);
     return n > 0 ? n + 'px solid ' + color : '0';
   };
 
-  const createTableV = function () {
+  const createTable = (rows: number, cols: number) => {
     const table = Element.fromTag('table');
     const tbody = Element.fromTag('tbody');
 
@@ -80,78 +79,90 @@ UnitTest.test('Runtime Size Test', function () {
     Css.setAll(table, {
       'border-collapse': randomValue([ 'collapse', 'separate' ]),
       'border-top': randomBorder(0, 5, 'red'),
+      'border-left': randomBorder(0, 5, 'red'),
       'border-bottom': randomBorder(0, 5, 'red'),
-      'height': randomSize(100, 1000)
+      'border-right': randomBorder(0, 5, 'red'),
+      'height': randomSize(100, 1000),
+      'width': randomSize(100, 1000)
     });
 
-    const rows = Arr.range(random(1, 5), function (_) {
+    const rowElms = Arr.range(rows, () => {
       const row = Element.fromTag('tr');
-      const cell = Element.fromTag('td');
 
-      Css.setAll(cell, {
-        'width': '10px',
-        'height': randomSize(1, 100),
-        'box-sizing': randomValue([ 'content-box', 'border-box' ]),
-        'padding-top': randomSize(0, 5),
-        'padding-bottom': randomSize(0, 5),
-        'border-top': randomBorder(0, 5, 'green'),
-        'border-bottom': randomBorder(0, 5, 'green')
+      Arr.range(cols, () => {
+        const cell = Element.fromTag('td');
+
+        Css.setAll(cell, {
+          'width': randomSize(1, 100),
+          'height': randomSize(1, 100),
+          'box-sizing': randomValue([ 'content-box', 'border-box' ]),
+          'padding-top': randomSize(0, 5),
+          'padding-left': randomSize(0, 5),
+          'padding-bottom': randomSize(0, 5),
+          'padding-right': randomSize(0, 5),
+          'border-top': randomBorder(0, 5, 'green'),
+          'border-left': randomBorder(0, 5, 'green'),
+          'border-bottom': randomBorder(0, 5, 'green'),
+          'border-right': randomBorder(0, 5, 'green')
+        });
+
+        const content = Element.fromTag('div');
+
+        Css.setAll(content, {
+          width: '10px',
+          height: randomSize(1, 200)
+        });
+
+        Insert.append(cell, content);
+        Insert.append(row, cell);
       });
-
-      const content = Element.fromTag('div');
-
-      Css.setAll(content, {
-        width: '10px',
-        height: randomSize(1, 200)
-      });
-
-      Insert.append(cell, content);
-      Insert.append(row, cell);
 
       return row;
     });
 
     Insert.append(table, tbody);
-
-    Arr.each(rows, function (row) {
-      Insert.append(tbody, row);
-    });
-
+    InsertAll.append(tbody, rowElms);
     Insert.append(Body.body(), table);
 
     return table;
   };
 
-  const resizeModel = function (size: { total: number; cells: number[] }, delta: number) {
-    const deltaTotal = delta * size.cells.length;
-    const cells = Arr.map(size.cells, function (cz) {
-      return cz + delta;
-    });
+  const resizeModel = (model: TableModel, delta: number, getTotalDelta: (model: TableModel, delta: number) => number) => {
+    const deltaTotal = getTotalDelta(model, delta);
+    const cells = Arr.map(model.cells, (cz) => cz + delta);
 
     return {
-      total: size.total + deltaTotal,
+      total: model.total + deltaTotal,
       cells
     };
   };
 
-  const testTableSize = function (createTable: () => Element, getOuterSize: (e: Element) => number, getSize: (e: Element) => number, setSize: (e: Element, v: string) => void) {
-    return function (_n: any) {
-      const table = createTable();
-      const beforeSize = measureTable(table, getOuterSize);
+  const getHeightDelta = (model: TableModel, delta: number) => model.rows * delta;
+  const getWidthDelta = (model: TableModel, delta: number) => model.cols * delta;
 
-      resizeTableBy(table, setSize, measureTable(table, getSize), 0);
-      assertSize(beforeSize, table, getOuterSize, 'Should be unchanged in size');
+  const testTableSize = (createTable: (rows: number, cols: number) => Element, getOuterSize: (e: Element) => number, getSize: (e: Element) => number,
+                         setSize: (e: Element, v: string) => void, getTotalDelta: (model: TableModel, delta: number) => number) => () => {
+    const rows = random(1, 5);
+    const cols = random(1, 5);
 
-      resizeTableBy(table, setSize, measureTable(table, getSize), 10);
-      assertSize(resizeModel(beforeSize, 10), table, getOuterSize, 'Should be changed by 10 size');
-
-      Remove.remove(table);
+    const table = createTable(rows, cols);
+    const beforeSize = {
+      ...measureTable(table, getOuterSize),
+      rows,
+      cols
     };
+
+    resizeTableBy(table, setSize, measureTable(table, getSize), 0);
+    assertSize(beforeSize, table, getOuterSize, 'Should be unchanged in size');
+
+    resizeTableBy(table, setSize, measureTable(table, getSize), 10);
+    assertSize(resizeModel(beforeSize, 10, getTotalDelta), table, getOuterSize, 'Should be changed by 10 size');
+
+    Remove.remove(table);
   };
 
-  const generateTest = function (generator: (n: number) => void, n: number) {
-    Arr.each(Arr.range(n, Fun.identity), generator);
-  };
+  const generateTest = (generator: (n: number) => void, n: number) => Arr.each(Arr.range(n, Fun.identity), generator);
 
-  generateTest(testTableSize(createTableV, getOuterHeight, RuntimeSize.getHeight, setHeight), 50);
+  generateTest(testTableSize(createTable, getOuterHeight, RuntimeSize.getHeight, setHeight, getHeightDelta), 50);
+  generateTest(testTableSize(createTable, getOuterWidth, RuntimeSize.getWidth, setWidth, getWidthDelta), 50);
 });

--- a/modules/snooker/src/test/ts/browser/TableConversionsTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableConversionsTest.ts
@@ -1,0 +1,177 @@
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { HTMLDivElement, HTMLTableElement } from '@ephox/dom-globals';
+import { Option, OptionInstances } from '@ephox/katamari';
+import { Body, Css, Element, Insert, Remove, Width } from '@ephox/sugar';
+import { ResizeDirection } from 'ephox/snooker/api/ResizeDirection';
+import * as TableConversions from 'ephox/snooker/api/TableConversions';
+import { TableSize } from 'ephox/snooker/api/TableSize';
+import { addStyles, assertApproxCellSizes, readWidth } from 'ephox/snooker/test/SizeUtils';
+
+const tOption = OptionInstances.tOption;
+
+const percentTable =
+  '<table style="width: 100%;">' +
+  '<tbody>' +
+  '<tr><td style="width: 10%;">A0</td><td style="width: 30%;">B0</td>' +
+  '<td style="width: 20%;">C0</td><td style="width: 25%;">D0</td>' +
+  '<td style="width: 15%;">E0</td></tr>' +
+  '<tr><td style="width: 60%;" colspan="3">A1</td>' +
+  '<td style="width: 25%;">D1</td><td style="width: 15%;">E1</td></tr>' +
+  '<tr><td style="width: 40%;" colspan="2">A2</td>' +
+  '<td style="width: 60%;" colspan="3">C2</td></tr>' +
+  '<tr><td style="width: 100%;" colspan="5">A0</td></tr>' +
+  '</tbody>' +
+  '</table>';
+
+const pixelTable =
+  '<table style="width: 500px;">' +
+  '<tbody>' +
+  '<tr><td style="width: 50px;">A0</td><td style="width: 150px;">B0</td>' +
+  '<td style="width: 100px;">C0</td><td style="width: 125px;">D0</td>' +
+  '<td style="width: 75px;">E0</td></tr>' +
+  '<tr><td style="width: 300px;" colspan="3">A1</td>' +
+  '<td style="width: 125px;">D1</td><td style="width: 75px;">E1</td></tr>' +
+  '<tr><td style="width: 200px;" colspan="2">A2</td>' +
+  '<td style="width: 300px;" colspan="3">C2</td></tr>' +
+  '<tr><td style="width: 500px;" colspan="5">A0</td></tr>' +
+  '</tbody>' +
+  '</table>';
+
+const noneTable =
+  '<table>' +
+  '<tbody>' +
+  '<tr><td>A0</td><td>B0</td><td>C0</td><td>D0</td><td>E0</td></tr>' +
+  '<tr><td colspan="3">A1</td><td>D1</td><td>E1</td></tr>' +
+  '<tr><td colspan="2">A2</td><td colspan="3">C2</td></tr>' +
+  '<tr><td colspan="5">A0</td></tr>' +
+  '</tbody>' +
+  '</table>';
+
+
+UnitTest.test('TableConversions.convertToPixelSize', () => {
+  const container = Element.fromHtml<HTMLDivElement>('<div style="width: 500px; position: relative;"></div>');
+  Insert.append(Body.body(), container);
+
+  const check = (expectedTableWidth: string, expected: string[][], table: Element<HTMLTableElement>, approx: boolean) => {
+    Insert.append(container, table);
+    TableConversions.convertToPixelSize(table, ResizeDirection.ltr, TableSize.getTableSize(table));
+    if (approx) {
+      Assert.eq('Assert table width', true, Math.abs(parseFloat(expectedTableWidth) - Width.get(table)) <= 2);
+      assertApproxCellSizes(expected, readWidth(table), 2);
+    } else {
+      Assert.eq('Assert table width', expectedTableWidth, Width.get(table) + 'px');
+      Assert.eq('Assert cell widths', expected, readWidth(table));
+    }
+    Remove.remove(table);
+  };
+
+  const styles = addStyles();
+
+  check('500px', [
+    [ '50px', '150px', '100px', '125px', '75px' ],
+    [ '300px', '125px', '75px' ],
+    [ '200px', '300px' ],
+    [ '500px' ]
+  ], Element.fromHtml(pixelTable), false);
+
+  check('500px', [
+    [ '50px', '150px', '100px', '125px', '75px' ],
+    [ '300px', '125px', '75px' ],
+    [ '200px', '300px' ],
+    [ '500px' ]
+  ], Element.fromHtml(percentTable), false);
+
+  check('141px', [
+    [ '25px', '25px', '25px', '25px', '25px' ],
+    [ '75px', '25px', '25px' ],
+    [ '50px', '75px' ],
+    [ '125px' ]
+  ], Element.fromHtml(noneTable), true);
+
+  styles.remove();
+  Remove.remove(container);
+});
+
+UnitTest.test('TableConversions.convertToPercentSize', () => {
+  const container = Element.fromHtml<HTMLDivElement>('<div style="width: 500px; position: relative;"></div>');
+  Insert.append(Body.body(), container);
+
+  const check = (expectedTableWidth: string, expected: string[][], table: Element<HTMLTableElement>, approx: boolean) => {
+    Insert.append(container, table);
+    TableConversions.convertToPercentSize(table, ResizeDirection.ltr, TableSize.getTableSize(table));
+    if (approx) {
+      const delta = parseFloat(expectedTableWidth) - parseFloat(Css.getRaw(table, 'width').getOrDie());
+      Assert.eq('Assert table width', true, Math.abs(delta) <= 2);
+      assertApproxCellSizes(expected, readWidth(table), 2);
+    } else {
+      Assert.eq('Assert table width', Option.some(expectedTableWidth), Css.getRaw(table, 'width'), tOption());
+      Assert.eq('Assert cell widths', expected, readWidth(table));
+    }
+    Remove.remove(table);
+  };
+
+  const styles = addStyles();
+
+  check('100%', [
+    [ '10%', '30%', '20%', '25%', '15%' ],
+    [ '60%', '25%', '15%' ],
+    [ '40%', '60%' ],
+    [ '100%' ]
+  ], Element.fromHtml(percentTable), false);
+
+  check('100%', [
+    [ '10%', '30%', '20%', '25%', '15%' ],
+    [ '60%', '25%', '15%' ],
+    [ '40%', '60%' ],
+    [ '100%' ]
+  ], Element.fromHtml(pixelTable), false);
+
+  check('28%', [
+    [ '18%', '18%', '18%', '18%', '18%' ],
+    [ '54%', '18%', '18%' ],
+    [ '36%', '54%' ],
+    [ '90%' ]
+  ], Element.fromHtml(noneTable), true);
+
+  styles.remove();
+  Remove.remove(container);
+});
+
+UnitTest.test('TableConversions.convertToNoneSize', () => {
+  const container = Element.fromHtml<HTMLDivElement>('<div style="width: 500px; position: relative;"></div>');
+  Insert.append(Body.body(), container);
+
+  const check = (expected: (string | null)[][], table: Element<HTMLTableElement>) => {
+    Insert.append(container, table);
+    TableConversions.convertToNoneSize(table);
+    Assert.eq('Assert no table width', Option.none<string>(), Css.getRaw(table, 'width'), tOption());
+    Assert.eq('Assert no cell widths', expected, readWidth(table));
+    Remove.remove(table);
+  };
+
+  const styles = addStyles();
+
+  check([
+    [ null, null, null, null, null ],
+    [ null, null, null ],
+    [ null, null ],
+    [ null ]
+  ], Element.fromHtml(noneTable));
+
+  check([
+    [ null, null, null, null, null ],
+    [ null, null, null ],
+    [ null, null ],
+    [ null ]
+  ], Element.fromHtml(percentTable));
+
+  check([
+    [ null, null, null, null, null ],
+    [ null, null, null ],
+    [ null, null ],
+    [ null ]
+  ], Element.fromHtml(pixelTable));
+
+  styles.remove();
+  Remove.remove(container);
+});

--- a/modules/snooker/src/test/ts/browser/TableSizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableSizeTest.ts
@@ -47,8 +47,10 @@ UnitTest.test('TableSize.pixelSizing', () => {
     Assert.eq('Single column delta width should be the delta', [ delta ], sizing.singleColumnWidth(colWidth, delta));
   }));
 
-  sizing.setTableWidth(table, [ 100, 100 ], -200);
-  Assert.eq('Table width after resizing is 200px', Option.some('200px'), Css.getRaw(table, 'width'), tOption());
+  sizing.adjustTableWidth(-200);
+  Assert.eq('Table raw width after resizing is 200px', Option.some('200px'), Css.getRaw(table, 'width'), tOption());
+  Assert.eq('Table width after resizing is 200px', 200, sizing.width());
+  Assert.eq('Table pixel width after resizing is 200px', 200, sizing.pixelWidth());
 
   const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
   sizing.setElementWidth(cell, 50);
@@ -77,8 +79,10 @@ UnitTest.test('TableSize.percentageSizing', () => {
     Assert.eq('Single column delta width should be 100% - percentage width', [ 100 - colWidth ], sizing.singleColumnWidth(colWidth, delta));
   }));
 
-  sizing.setTableWidth(table, [ 50, 50 ], -25);
-  Assert.eq('Table width after resizing is 25% less of the original 80%', Option.some('60%'), Css.getRaw(table, 'width'), tOption());
+  sizing.adjustTableWidth(-25);
+  Assert.eq('Table raw width after resizing is 25% less of the original 80%', Option.some('60%'), Css.getRaw(table, 'width'), tOption());
+  Assert.eq('Table width after resizing is 60%', 60, sizing.width());
+  Assert.eq('Table pixel width after resizing is 300px', 300, sizing.pixelWidth());
 
   const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
   sizing.setElementWidth(cell, 25);
@@ -94,7 +98,9 @@ UnitTest.test('TableSize.noneSizing', () => {
   const sizing = TableSize.getTableSize(table);
   const warehouse = Warehouse.fromTable(table);
   const width = Width.get(table);
-  const cellWidth = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').map(Width.get).getOrDie();
+  const cellWidth = SelectorFind.descendant<HTMLTableCellElement>(table, 'td')
+    .map((cell) => parseInt(Css.get(cell, 'width'), 10))
+    .getOrDie();
 
   Assert.eq('Width should be the computed size of the table', width, sizing.width());
   Assert.eq('Pixel width should be the computed size of the table', width, sizing.pixelWidth());
@@ -106,8 +112,10 @@ UnitTest.test('TableSize.noneSizing', () => {
     Assert.eq('Single column delta width should be 0', [ 0 ], sizing.singleColumnWidth(colWidth, delta));
   }));
 
-  sizing.setTableWidth(table, [ cellWidth - 10, cellWidth - 10 ], -20);
-  Assert.eq('Table width after resizing is unchanged', Option.none<string>(), Css.getRaw(table, 'width'), tOption());
+  sizing.adjustTableWidth(-20);
+  Assert.eq('Table raw width after resizing is unchanged', Option.none<string>(), Css.getRaw(table, 'width'), tOption());
+  Assert.eq('Table width after resizing is unchanged', width, sizing.width());
+  Assert.eq('Table pixel width after resizing is unchanged', width, sizing.pixelWidth());
 
   const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
   sizing.setElementWidth(cell, 20);

--- a/modules/snooker/src/test/ts/browser/TableSizesTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableSizesTest.ts
@@ -1,10 +1,10 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
-import { document } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
-import { TableSize } from '@ephox/snooker';
-import { Body, Css, Element, Html, Insert, InsertAll, Remove, SelectorFilter } from '@ephox/sugar';
+import { Body, Css, Element, Html, Insert, InsertAll, Remove } from '@ephox/sugar';
 import { ResizeDirection } from 'ephox/snooker/api/ResizeDirection';
 import * as Sizes from 'ephox/snooker/api/Sizes';
+import { TableSize } from 'ephox/snooker/api/TableSize';
+import { addStyles, readHeight, readWidth } from '../module/ephox/snooker/test/SizeUtils';
 
 UnitTest.test('Table Sizes Test (fusebox)', function () {
   const percentTable =
@@ -52,9 +52,6 @@ UnitTest.test('Table Sizes Test (fusebox)', function () {
   '</tbody> ' +
   '</table';
 
-  const style = Element.fromHtml('<style>table { border-collapse: collapse; } td { border: 1px solid #333; }</style>');
-  Insert.append(Element.fromDom(document.head), style);
-
   const generateW = function (info: string[][], totalWidth: string) {
     const table = Element.fromTag('table');
     Css.set(table, 'width', totalWidth);
@@ -95,26 +92,6 @@ UnitTest.test('Table Sizes Test (fusebox)', function () {
     return table;
   };
 
-  const readWidth = function (element: Element) {
-    const rows = SelectorFilter.descendants(element, 'tr');
-    return Arr.map(rows, function (row) {
-      const cells = SelectorFilter.descendants(row, 'td,th');
-      return Arr.map(cells, function (cell) {
-        return Css.getRaw(cell, 'width').getOrDie('Did not contain width information.');
-      });
-    });
-  };
-
-  const readHeight = function (element: Element) {
-    const rows = SelectorFilter.descendants(element, 'tr');
-    return Arr.map(rows, function (row) {
-      const cells = SelectorFilter.descendants(row, 'td,th');
-      return Arr.map(cells, function (cell) {
-        return Css.getRaw(cell, 'height').getOrDie('Did not contain height information.');
-      });
-    });
-  };
-
   assert.eq(
     '<table style="width: 25px;"><tbody>' +
       '<tr><td style="width: 20px;">A0</td><td style="width: 30%;">B0</td></tr>' +
@@ -152,6 +129,8 @@ UnitTest.test('Table Sizes Test (fusebox)', function () {
     checkHeight(expected, table, newHeight);
   };
 
+  const styles = addStyles();
+
   checkBasicHeight([[ '5px' ]], [[ '10px' ]], '100px', '50px');
   checkBasicHeight([[ '10%' ]], [[ '10px' ]], '100px', '100%');
   checkBasicHeight([[ '20px' ]], [[ '10px' ]], '25px', '50px');
@@ -178,15 +157,15 @@ UnitTest.test('Table Sizes Test (fusebox)', function () {
   ], Element.fromHtml(pixelTableHeight), '150px');
 
   checkHeight([
-    [ '46%', '13%', '13%', '46%' ],
-    [ '84%', '33%', '33%' ],
-    [ '51%', '51%', '51%', '51%' ]
+    [ '46.7%', '13.3%', '13.3%', '46.7%' ],
+    [ '83.3%', '33.3%', '33.3%' ],
+    [ '50%', '50%', '50%', '50%' ]
   ], Element.fromHtml(pixelTableHeight), '100%');
 
   checkHeight([
-    [ '46%', '13%', '13%', '46%' ],
-    [ '84%', '33%', '33%' ],
-    [ '51%', '51%', '51%', '51%' ]
+    [ '46.7%', '13.3%', '13.3%', '46.7%' ],
+    [ '83.3%', '33.3%', '33.3%' ],
+    [ '50%', '50%', '50%', '50%' ]
   ], Element.fromHtml(pixelTableHeight), '150%');
 
   checkWidth([
@@ -245,5 +224,5 @@ UnitTest.test('Table Sizes Test (fusebox)', function () {
     [ '300px' ]
   ], Element.fromHtml(percentTable), '300px');
 
-  Remove.remove(style);
+  styles.remove();
 });

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/SizeUtils.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/SizeUtils.ts
@@ -1,0 +1,61 @@
+import { Assert } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Css, Element, Head, Insert, Remove, SelectorFilter } from '@ephox/sugar';
+
+const addStyles = () => {
+  const style = Element.fromHtml('<style>table { border-collapse: collapse; } td { border: 1px solid #333; min-width: 25px; }</style>');
+  Insert.append(Head.head(), style);
+
+  return {
+    remove: () => Remove.remove(style)
+  };
+};
+
+const reducePrecision = (value: string, precision: number = 1) => {
+  const floatValue = parseFloat(value);
+  if (!floatValue) {
+    return value;
+  } else {
+    const match = /^\d+(\.\d+)?(px|%)$/.exec(value);
+    const unit = match ? match[2] : '';
+    const p = Math.pow(10, precision);
+    return (Math.round(floatValue * p ) / p) + unit;
+  }
+};
+
+const readWidth = (element: Element) => {
+  const rows = SelectorFilter.descendants(element, 'tr');
+  return Arr.map(rows, (row) => {
+    const cells = SelectorFilter.descendants(row, 'td,th');
+    return Arr.map(cells, (cell) =>
+      Css.getRaw(cell, 'width').map(reducePrecision).getOrNull()
+    );
+  });
+};
+
+const readHeight = (element: Element) => {
+  const rows = SelectorFilter.descendants(element, 'tr');
+  return Arr.map(rows, (row) => {
+    const cells = SelectorFilter.descendants(row, 'td,th');
+    return Arr.map(cells, (cell) =>
+      Css.getRaw(cell, 'height').map(reducePrecision).getOrNull()
+    );
+  });
+};
+
+const assertApproxCellSizes = (expectedSizes: (string | null)[][], actualSizes: (string | null)[][], diff: number = 2) => {
+  Arr.each(expectedSizes, (row, rowIdx) => {
+    Arr.each(row, (expectedSize, colIdx) => {
+      const actualSize = actualSizes[rowIdx][colIdx];
+      const delta = parseFloat(expectedSize || '0') - parseFloat(actualSize || '0');
+      Assert.eq(`Assert cell size [${rowIdx}][${colIdx}] should be ${expectedSize}`, true, Math.abs(delta) <= diff);
+    });
+  });
+};
+
+export {
+  addStyles,
+  assertApproxCellSizes,
+  readHeight,
+  readWidth
+};

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Head.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Head.ts
@@ -1,5 +1,7 @@
+import { document, Document, HTMLHeadElement } from '@ephox/dom-globals';
 import Element from './Element';
-import { Document, HTMLHeadElement } from '@ephox/dom-globals';
+
+export const head = (): Element<HTMLHeadElement> => getHead(Element.fromDom(document));
 
 export const getHead = (doc: Element<Document>): Element<HTMLHeadElement> => {
   const b = doc.dom().head;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
@@ -59,7 +59,7 @@ const siblings = (element: Element<DomNode>) => {
   return parent(element).map(children).map(filterSelf).getOr([]);
 };
 
-const offsetParent = (element: Element<HTMLElement>) => Option.from(element.dom().offsetParent).map(Element.fromDom);
+const offsetParent = (element: Element<HTMLElement>) => Option.from(element.dom().offsetParent as HTMLElement).map(Element.fromDom);
 
 const prevSibling = (element: Element<DomNode>) => Option.from(element.dom().previousSibling).map(Element.fromDom);
 

--- a/modules/sugar/src/test/ts/browser/HeadTest.ts
+++ b/modules/sugar/src/test/ts/browser/HeadTest.ts
@@ -1,12 +1,13 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import * as Head from 'ephox/sugar/api/node/Head';
-import Element from 'ephox/sugar/api/node/Element';
 import { Testable } from '@ephox/dispute';
 import { document } from '@ephox/dom-globals';
+import Element from 'ephox/sugar/api/node/Element';
+import * as Head from 'ephox/sugar/api/node/Head';
 import { withIframe } from 'ephox/sugar/test/WithHelpers';
 
 UnitTest.test('head in normal document', () => {
   Assert.eq('head should be head', document.head, Head.getHead(Element.fromDom(document)).dom(), Testable.tStrict);
+  Assert.eq('head should be head', document.head, Head.head().dom(), Testable.tStrict);
 });
 
 UnitTest.test('head in iframe', () => {

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -9,7 +9,7 @@ Version 5.4.0 (TBD)
     Added additional font related Oxide variables for secondary buttons allowing more specific styling. #TINY-6061
     Added new `table_header_type` setting to control how table header rows are structured #TINY-6007
     Added new `table_sizing_mode` setting to replace the `table_responsive_width` setting, which has now been deprecated #TINY-6051
-    Added new `mceTableSizingMode` command to change a tables sizing mode #TINY-6000
+    Added new `mceTableSizingMode` command for changing the sizing mode of a table #TINY-6000
     Changed `advlist` toolbar buttons to only show a dropdown list if there's more than one option #TINY-3194
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Changed stylesheet loading, so that UI skin stylesheets now to load in a ShadowRoot, if the editor is in a ShadowRoot. #TINY-6089

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -9,6 +9,7 @@ Version 5.4.0 (TBD)
     Added additional font related Oxide variables for secondary buttons allowing more specific styling. #TINY-6061
     Added new `table_header_type` setting to control how table header rows are structured #TINY-6007
     Added new `table_sizing_mode` setting to replace the `table_responsive_width` setting, which has now been deprecated #TINY-6051
+    Added new `mceTableSizingMode` command to change a tables sizing mode #TINY-6000
     Changed `advlist` toolbar buttons to only show a dropdown list if there's more than one option #TINY-3194
     Changed `mceInsertTable` command and `insertTable` API method to take optional header rows and columns arguments #TINY-6012
     Changed stylesheet loading, so that UI skin stylesheets now to load in a ShadowRoot, if the editor is in a ShadowRoot. #TINY-6089

--- a/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
@@ -40,8 +40,7 @@ const insert = (editor: Editor, columns: number, rows: number, colHeaders: numbe
   const defaultStyles = getDefaultStyles(editor);
   const options: TableRender.RenderOptions = {
     styles: defaultStyles,
-    attributes: getDefaultAttributes(editor),
-    percentages: isPercentage(defaultStyles.width)
+    attributes: getDefaultAttributes(editor)
   };
 
   const table = TableRender.render(rows, columns, rowHeaders, colHeaders, options);
@@ -51,13 +50,12 @@ const insert = (editor: Editor, columns: number, rows: number, colHeaders: numbe
   editor.insertContent(html);
 
   return SelectorFind.descendant<HTMLTableElement>(Util.getBody(editor), 'table[data-mce-id="__mce"]').map((table) => {
-    const rawTable = table.dom();
     if (isPixelsForced(editor)) {
-      enforcePixels(rawTable);
-    } else if (isPercentagesForced(editor)) {
-      enforcePercentage(rawTable);
+      enforcePixels(editor, table);
     } else if (isResponsiveForced(editor)) {
-      enforceNone(rawTable);
+      enforceNone(table);
+    } else if (isPercentagesForced(editor) || isPercentage(defaultStyles.width)) {
+      enforcePercentage(editor, table);
     }
     Util.removeDataStyle(table);
     Attr.remove(table, 'data-mce-id');

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -5,18 +5,17 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { HTMLTableCellElement, HTMLTableElement, HTMLTableRowElement, Node, Range } from '@ephox/dom-globals';
+import { HTMLTableElement, Node, Range } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
-import { ResizeWire, TableDirection, TableResize } from '@ephox/snooker';
-import { Element as SugarElement } from '@ephox/sugar';
+import { ResizeWire, Sizes, TableDirection, TableResize } from '@ephox/snooker';
+import { Css, Element, Element as SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
-import Tools from 'tinymce/core/api/util/Tools';
 import * as Events from '../api/Events';
 import { hasObjectResizing, hasTableResizeBars, isPercentagesForced, isPixelsForced, isResponsiveForced } from '../api/Settings';
 import * as Util from '../core/Util';
 import * as Direction from '../queries/Direction';
 import * as TableSize from '../queries/TableSize';
-import { enforcePercentage, enforcePixels } from './EnforceUnit';
+import { enforcePercentage, enforcePixels, syncPixels } from './EnforceUnit';
 import * as TableWire from './TableWire';
 
 export interface ResizeHandler {
@@ -93,13 +92,13 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
   editor.on('ObjectResizeStart', function (e) {
     const targetElm = e.target;
     if (isTable(targetElm)) {
+      const table = Element.fromDom(targetElm);
 
-      const tableHasPercentage = Util.getRawWidth(editor, targetElm).exists(Util.isPercentage);
-
+      const tableHasPercentage = Sizes.isPercentSizing(table);
       if (tableHasPercentage && isPixelsForced(editor)) {
-        enforcePixels(targetElm);
+        enforcePixels(editor,table);
       } else if (!tableHasPercentage && (isPercentagesForced(editor) || isResponsiveForced(editor))) {
-        enforcePercentage(targetElm);
+        enforcePercentage(editor, table);
       }
 
       startW = e.width;
@@ -107,34 +106,19 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
     }
   });
 
-  interface CellSize { cell: HTMLTableCellElement; width: string }
-
   editor.on('ObjectResized', function (e) {
     const targetElm = e.target;
     if (isTable(targetElm)) {
-      const table = targetElm;
+      const table = Element.fromDom(targetElm);
 
       if (Util.isPercentage(startRawW)) {
         const percentW = parseFloat(startRawW.replace('%', ''));
         const targetPercentW = e.width * percentW / startW;
-        editor.dom.setStyle(table, 'width', targetPercentW + '%');
+        Css.set(table, 'width', targetPercentW + '%');
       } else {
-        const newCellSizes: CellSize[] = [];
-        Tools.each(table.rows, function (row: HTMLTableRowElement) {
-          Tools.each(row.cells, function (cell: HTMLTableCellElement) {
-            const width = editor.dom.getStyle(cell, 'width', true);
-            newCellSizes.push({
-              cell,
-              width
-            });
-          });
-        });
-
-        Tools.each(newCellSizes, function (newCellSize: CellSize) {
-          editor.dom.setStyle(newCellSize.cell, 'width', newCellSize.width);
-          editor.dom.setAttrib(newCellSize.cell, 'width', null);
-        });
+        syncPixels(table);
       }
+      Util.removeDataStyle(table);
     }
   });
 

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -96,7 +96,7 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
 
       const tableHasPercentage = Sizes.isPercentSizing(table);
       if (tableHasPercentage && isPixelsForced(editor)) {
-        enforcePixels(editor,table);
+        enforcePixels(editor, table);
       } else if (!tableHasPercentage && (isPercentagesForced(editor) || isResponsiveForced(editor))) {
         enforcePercentage(editor, table);
       }

--- a/modules/tinymce/src/plugins/table/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Util.ts
@@ -7,7 +7,8 @@
 
 import { HTMLElement, Node } from '@ephox/dom-globals';
 import { Arr, Option, Strings } from '@ephox/katamari';
-import { Attr, Compare, Element, SelectorFilter } from '@ephox/sugar';
+import { TableLookup } from '@ephox/snooker';
+import { Attr, Compare, Element } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
 const getNodeName = (elm: Node) => elm.nodeName.toLowerCase();
@@ -25,9 +26,8 @@ const removePxSuffix = (size: string) => size ? size.replace(/px$/, '') : '';
 const addPxSuffix = (size: string): string => /^\d+(\.\d+)?$/.test(size) ? size + 'px' : size;
 
 const removeDataStyle = (table: Element<HTMLElement>): void => {
-  const dataStyleCells = SelectorFilter.descendants(table, 'td[data-mce-style],th[data-mce-style]');
   Attr.remove(table, 'data-mce-style');
-  Arr.each(dataStyleCells, (cell) => Attr.remove(cell, 'data-mce-style'));
+  Arr.each(TableLookup.cells(table), (cell) => Attr.remove(cell, 'data-mce-style'));
 };
 
 const getRawWidth = (editor: Editor, elm: HTMLElement): Option<string> => {

--- a/modules/tinymce/src/plugins/table/main/ts/queries/TableSize.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/TableSize.ts
@@ -6,10 +6,9 @@
  */
 
 import { HTMLTableElement } from '@ephox/dom-globals';
-import { TableSize } from '@ephox/snooker';
-import { Element, Traverse, Width } from '@ephox/sugar';
+import { Sizes, TableSize } from '@ephox/snooker';
+import { Element, Width } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
-import { calculatePercentageWidth } from '../actions/EnforceUnit';
 import { isPercentagesForced, isPixelsForced } from '../api/Settings';
 import * as Util from '../core/Util';
 
@@ -17,16 +16,12 @@ export const get = (editor: Editor, table: Element<HTMLTableElement>) => {
   // Note: We can't enforce none (responsive), as if someone manually resizes a table
   // then it must switch to either pixel (fixed) or percentage (relative) sizing
   if (isPercentagesForced(editor)) {
-    return Util.getRawWidth(editor, table.dom())
+    const width = Util.getRawWidth(editor, table.dom())
       .filter(Util.isPercentage)
-      .orThunk(() => Traverse.offsetParent(table).map((parent) => calculatePercentageWidth(table, parent)))
-      .fold(
-        // If the table isn't attached then we can't do relative sizing, so fallback to the current sizing mode
-        () => TableSize.getTableSize(table),
-        (width) => TableSize.percentageSize(width, table)
-      );
+      .getOrThunk(() => Sizes.getPercentTableWidth(table));
+    return TableSize.percentageSize(width, table);
   } else if (isPixelsForced(editor)) {
-    return TableSize.pixelSize(Width.get(table));
+    return TableSize.pixelSize(Width.get(table), table);
   } else {
     // Detect based on the table width
     return TableSize.getTableSize(table);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableTest.ts
@@ -1,19 +1,19 @@
-import { Logger, Pipeline, Step, Log } from '@ephox/agar';
+import { Log, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
+import { sAssertTableStructureWithSizes } from '../module/test/TableTestUtils';
 
 UnitTest.asynctest('browser.tinymce.plugins.table.InsertTableTest', (success, failure) => {
   Plugin();
   SilverTheme();
 
-  const sInsertTable = function (editor, cols, rows) {
-    return Logger.t('Insert table ' + cols + 'x' + rows, Step.sync(function () {
-      editor.plugins.table.insertTable(cols, rows);
-    }));
-  };
+  const sInsertTable = (editor: Editor, cols: number, rows: number) => Logger.t('Insert table ' + cols + 'x' + rows, Step.sync(() => {
+    editor.plugins.table.insertTable(cols, rows);
+  }));
 
   TinyLoader.setup(function (editor, onSuccess, onFailure) {
     const tinyApis = TinyApis(editor);
@@ -22,43 +22,27 @@ UnitTest.asynctest('browser.tinymce.plugins.table.InsertTableTest', (success, fa
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2', [
         tinyApis.sSetContent(''),
         sInsertTable(editor, 2, 2),
-        tinyApis.sAssertContent(
-          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
-          '<tbody><tr>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '</tr><tr>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '</tr></tbody>' +
-          '</table>'
-        ),
+        sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
+          [ 50, 50 ],
+          [ 50, 50 ]
+        ]),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 1x2', [
         tinyApis.sSetContent(''),
         sInsertTable(editor, 1, 2),
-        tinyApis.sAssertContent(
-          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
-          '<tbody><tr>' +
-          '<td style="width: 100%;">&nbsp;</td>' +
-          '</tr><tr>' +
-          '<td style="width: 100%;">&nbsp;</td>' +
-          '</tr></tbody>' +
-          '</table>'
-        ),
+        sAssertTableStructureWithSizes(editor, 1, 2, '%', 100, [
+          [ 100 ],
+          [ 100 ]
+        ]),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x1', [
         tinyApis.sSetContent(''),
         sInsertTable(editor, 2, 1),
-        tinyApis.sAssertContent(
-          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
-          '<tbody><tr>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '</tr></tbody></table>'
-        ),
+        sAssertTableStructureWithSizes(editor, 2, 1, '%', 100, [
+          [ 50, 50 ]
+        ]),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ])
     ], onSuccess, onFailure);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSizingModeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSizingModeTest.ts
@@ -4,7 +4,7 @@ import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.table.TableSizingTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.table.TableSizingModeTest', (success, failure) => {
   Plugin();
   SilverTheme();
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/ApplyCellStyleCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/ApplyCellStyleCommandTest.ts
@@ -5,9 +5,9 @@ import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
-import * as TableTestUtils from '../module/test/TableTestUtils';
+import * as TableTestUtils from '../../module/test/TableTestUtils';
 
-UnitTest.asynctest('browser.tinymce.plugins.table.ApplyCellStyleCommandTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.table.command.ApplyCellStyleCommandTest', (success, failure) => {
   Plugin();
   SilverTheme();
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertCommandsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertCommandsTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.table.InsertCommandsTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.table.command.InsertCommandsTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandTest.ts
@@ -4,8 +4,9 @@ import { TinyApis, TinyLoader } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
+import { sAssertTableStructureWithSizes } from '../../module/test/TableTestUtils';
 
-UnitTest.asynctest('browser.tinymce.plugins.table.InsertTableCommandTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.table.command.InsertTableCommandTest', (success, failure) => {
   Plugin();
   SilverTheme();
 
@@ -28,97 +29,55 @@ UnitTest.asynctest('browser.tinymce.plugins.table.InsertTableCommandTest', (succ
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2', [
         tinyApis.sSetContent(''),
         sInsertTable(editor, { rows: 2, columns: 2 }),
-        tinyApis.sAssertContent(
-          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
-          '<tbody><tr>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '</tr><tr>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '</tr></tbody>' +
-          '</table>'
-        ),
+        sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
+          [ 50, 50 ],
+          [ 50, 50 ]
+        ]),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 1 header row', [
         tinyApis.sSetContent(''),
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 1 }}),
-        tinyApis.sAssertContent(
-          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
-          '<tbody><tr>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '</tr><tr>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '</tr></tbody>' +
-          '</table>'
-        ),
+        sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
+          [ 50, 50 ],
+          [ 50, 50 ]
+        ], { headerRows: 1, headerCols: 0 }),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 1 header column', [
         tinyApis.sSetContent(''),
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerColumns: 1 }}),
-        tinyApis.sAssertContent(
-          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
-          '<tbody><tr>' +
-          '<th style="width: 50%;" scope="row">&nbsp;</th>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '</tr><tr>' +
-          '<th style="width: 50%;" scope="row">&nbsp;</th>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '</tr></tbody>' +
-          '</table>'
-        ),
+        sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
+          [ 50, 50 ],
+          [ 50, 50 ]
+        ], { headerRows: 0, headerCols: 1 }),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 1 header row and 1 header column', [
         tinyApis.sSetContent(''),
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 1, headerColumns: 1 }}),
-        tinyApis.sAssertContent(
-          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
-          '<tbody><tr>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '</tr><tr>' +
-          '<th style="width: 50%;" scope="row">&nbsp;</th>' +
-          '<td style="width: 50%;">&nbsp;</td>' +
-          '</tr></tbody>' +
-          '</table>'
-        ),
+        sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
+          [ 50, 50 ],
+          [ 50, 50 ]
+        ], { headerRows: 1, headerCols: 1 }),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 2 header rows and 2 header columns', [
         tinyApis.sSetContent(''),
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 2, headerColumns: 2 }}),
-        tinyApis.sAssertContent(
-          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
-          '<tbody><tr>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '</tr><tr>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '</tr></tbody>' +
-          '</table>'
-        ),
+        sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
+          [ 50, 50 ],
+          [ 50, 50 ]
+        ], { headerRows: 2, headerCols: 2 }),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 3 header rows and 3 header columns - should only get 2', [
         tinyApis.sSetContent(''),
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 3, headerColumns: 3 }}),
-        tinyApis.sAssertContent(
-          '<table style="width: 100%; border-collapse: collapse;" border="1">' +
-          '<tbody><tr>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '</tr><tr>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '<th style="width: 50%;" scope="col">&nbsp;</th>' +
-          '</tr></tbody>' +
-          '</table>'
-        ),
+        sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
+          [ 50, 50 ],
+          [ 50, 50 ]
+        ], { headerRows: 2, headerCols: 2 }),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ])
     ], onSuccess, onFailure);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.table.MergeCellCommandTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.table.command.MergeCellCommandTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandTest.ts
@@ -1,0 +1,148 @@
+import { GeneralSteps, Log, Pipeline } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import Plugin from 'tinymce/plugins/table/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+import { sAssertTableStructureWithSizes } from '../../module/test/TableTestUtils';
+
+type SizingMode = 'relative' | 'fixed' | 'responsive';
+
+interface Scenario {
+  mode: SizingMode;
+  tableWidth: number;
+  cols: number;
+  rows: number;
+  expectedTableWidth: number;
+  expectedWidths: number[][];
+  newMode: SizingMode;
+}
+
+UnitTest.asynctest('browser.tinymce.plugins.table.command.TableSizingModeCommandTest', (success, failure) => {
+  Plugin();
+  SilverTheme();
+
+  const getUnit = (mode: SizingMode) => {
+    switch (mode) {
+      case 'fixed':
+        return 'px';
+      case 'relative':
+        return '%';
+      case 'responsive':
+        return null;
+    }
+  };
+
+  const generateWidth = (mode: SizingMode, tableWidth: number, cols: number) => {
+    if (mode === 'responsive') {
+      return '';
+    } else {
+      return `width: ${tableWidth / cols}${getUnit(mode)}`;
+    }
+  };
+
+  const generateTable = (mode: SizingMode, width: number, rows: number, cols: number) => {
+    const tableWidth = generateWidth(mode, width,1);
+    const renderedRows = Arr.range(rows, (row) => '<tr>' + Arr.range(cols, (col) => {
+      const cellWidth = generateWidth(mode, width, cols);
+      const cellNum = (row * cols) + col + 1;
+      return `<td style="${cellWidth}">Cell ${cellNum}</td>`;
+    }).join('') + '</tr>').join('');
+    return `<table border="1" style="border-collapse: collapse;${tableWidth}"><tbody>${renderedRows}</tbody></table>`;
+  };
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+
+    const sTest = (scenario: Scenario) => GeneralSteps.sequence([
+      tinyApis.sSetContent(generateTable(scenario.mode, scenario.tableWidth, scenario.rows, scenario.cols)),
+      tinyApis.sSetSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0),
+      tinyApis.sExecCommand('mceTableSizingMode', scenario.newMode),
+      sAssertTableStructureWithSizes(editor, scenario.cols, scenario.rows, getUnit(scenario.newMode), scenario.expectedTableWidth, scenario.expectedWidths)
+    ]);
+
+    Pipeline.async({}, [
+      Log.step('TINY-6000', 'Percent (relative) to pixel (fixed) sizing', sTest({
+        mode: 'relative',
+        tableWidth: 100,
+        rows: 3,
+        cols: 2,
+        newMode: 'fixed',
+        expectedTableWidth: 800,
+        expectedWidths: [
+          [ 400, 400 ],
+          [ 400, 400 ],
+          [ 400, 400 ]
+        ]
+      })),
+      Log.step('TINY-6000', 'Percent (relative) to none (responsive) sizing', sTest({
+        mode: 'relative',
+        tableWidth: 100,
+        rows: 3,
+        cols: 2,
+        newMode: 'responsive',
+        expectedTableWidth: null,
+        expectedWidths: [
+          [ null, null ],
+          [ null, null ],
+          [ null, null ]
+        ]
+      })),
+      Log.step('TINY-6000', 'Pixel (fixed) to percent (relative) sizing', sTest({
+        mode: 'fixed',
+        tableWidth: 600,
+        rows: 2,
+        cols: 2,
+        newMode: 'relative',
+        expectedTableWidth: 75,
+        expectedWidths: [
+          [ 50, 50 ],
+          [ 50, 50 ]
+        ]
+      })),
+      Log.step('TINY-6000', 'Pixel (fixed) to none (responsive) sizing', sTest({
+        mode: 'fixed',
+        tableWidth: 600,
+        rows: 2,
+        cols: 2,
+        newMode: 'responsive',
+        expectedTableWidth: null,
+        expectedWidths: [
+          [ null, null ],
+          [ null, null ]
+        ]
+      })),
+      Log.step('TINY-6000', 'None (responsive) to percent (relative) sizing', sTest({
+        mode: 'responsive',
+        tableWidth: null,
+        rows: 2,
+        cols: 3,
+        newMode: 'relative',
+        expectedTableWidth: 16,
+        expectedWidths: [
+          [ 31, 31, 31 ],
+          [ 31, 31, 31 ]
+        ]
+      })),
+      Log.step('TINY-6000', 'None (responsive) to pixel (fixed) sizing', sTest({
+        mode: 'responsive',
+        tableWidth: null,
+        rows: 2,
+        cols: 3,
+        newMode: 'fixed',
+        expectedTableWidth: 133,
+        expectedWidths: [
+          [ 41, 41, 41 ],
+          [ 41, 41, 41 ]
+        ]
+      }))
+    ], onSuccess, onFailure);
+  }, {
+    plugins: 'table',
+    indent: false,
+    width: 850,
+    content_css: false,
+    content_style: 'body { margin: 10px; max-width: 800px }',
+    base_url: '/project/tinymce/js/tinymce'
+  }, success, failure);
+});

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandTest.ts
@@ -42,7 +42,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.command.TableSizingModeCommand
   };
 
   const generateTable = (mode: SizingMode, width: number, rows: number, cols: number) => {
-    const tableWidth = generateWidth(mode, width,1);
+    const tableWidth = generateWidth(mode, width, 1);
     const renderedRows = Arr.range(rows, (row) => '<tr>' + Arr.range(cols, (col) => {
       const cellWidth = generateWidth(mode, width, cols);
       const cellNum = (row * cols) + col + 1;

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesTest.ts
@@ -1,4 +1,4 @@
-import { GeneralSteps, Logger, Pipeline, ApproxStructure, Waiter } from '@ephox/agar';
+import { ApproxStructure, GeneralSteps, Logger, Pipeline, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
@@ -14,13 +14,13 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableDefaultAttributesTest', (
     const tinyApis = TinyApis(editor);
     const tinyUi = TinyUi(editor);
 
-    const tableBody2By2 = (s, str, _arr) => s.element('tbody', {
+    const tableBody2By2 = (s, str: ApproxStructure.StringApi, _arr) => s.element('tbody', {
       children: [
         s.element('tr', {
           children: [
             s.element('td', {
               styles: {
-                width: str.is('50%')
+                width: str.contains('%')
               },
               children: [
                 s.element('br', {})
@@ -28,7 +28,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableDefaultAttributesTest', (
             }),
             s.element('td', {
               styles: {
-                width: str.is('50%')
+                width: str.contains('%')
               },
               children: [
                 s.element('br', {})
@@ -40,7 +40,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableDefaultAttributesTest', (
           children: [
             s.element('td', {
               styles: {
-                width: str.is('50%')
+                width: str.contains('%')
               },
               children: [
                 s.element('br', {})
@@ -48,7 +48,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableDefaultAttributesTest', (
             }),
             s.element('td', {
               styles: {
-                width: str.is('50%')
+                width: str.contains('%')
               },
               children: [
                 s.element('br', {})

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultStylesTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultStylesTest.ts
@@ -1,4 +1,4 @@
-import { GeneralSteps, Logger, Pipeline, ApproxStructure, Waiter } from '@ephox/agar';
+import { ApproxStructure, GeneralSteps, Logger, Pipeline, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
@@ -35,7 +35,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableDefaultStylesTest', (succ
                   children: [
                     s.element('td', {
                       styles: {
-                        width: str.is('100%')
+                        width: str.contains('%')
                       },
                       children: [
                         s.element('br', {})

--- a/versions.txt
+++ b/versions.txt
@@ -1,3 +1,3 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
-snooker@5.2.0
+snooker@6.0.0


### PR DESCRIPTION
Related Ticket: TINY-6000

Description of Changes:
This adds the new `mceTableSizingMode` command that will change the currently selected tables sizing mode between `fixed`, `relative` and `responsive`. This command will do nothing if a sizing mode is forced via the `table_sizing_mode` setting.

This also fixes the following issues I found that impacted swapping sizes:
- `TableSize.setTableWidth` was relying on adding up the cell widths to get the table width for pixels. This won't work as it's missing the row borders, cell-padding and cell padding/borders when using `content-box` sizing. So it now uses the delta instead, which is the same as percent sizing.
- `Render` would generate incorrect percent sizes, as it again didn't account for borders/padding/box-sizing. The table needs to be attached to calculate the correct cell widths, so this is now done in the insert logic instead of the render logic.
- `Redistribute` would convert percent to an integer which lost a lot of precision. It will now only covert pixels to integers.
- `Sizes.getPixelWidth` would use the offset width to set the CSS width style. This value was incorrect as it didn't account for the `box-sizing` of the cell, so it now uses the computed width where possible like it was for calculating the cell height (see `RuntimeSize).
- `Adjustments.adjustWidthTo` would attempt to change the table size if a width was adjusted. This was incorrect, as its purpose is to adjust the cell widths to the current table width. Also worth mentioning this only impacted pixel tables, as percent tables used a 0 delta so it'd always end up being the same size anyways.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
