### PR TITLE
DOC-464: add examples to shortcut api docs

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -543,10 +543,10 @@ class Editor implements EditorObservable {
    * @example
    * editor.addShortcut('ctrl+a', "description of the shortcut", function() {});
    * editor.addShortcut('ctrl+alt+a', "description of the shortcut", function() {});
-   * editor.addShortcut('meta+a', "description of the shortcut", function() {});
    * // "meta" maps to Command on Mac and Ctrl on PC
-   * editor.addShortcut('access+a', "description of the shortcut", function() {});
+   * editor.addShortcut('meta+a', "description of the shortcut", function() {});
    * // "access" maps to Control+Option on Mac and shift+alt on PC
+   * editor.addShortcut('access+a', "description of the shortcut", function() {});
    *
    * editor.addShortcut(
    *  'meta+access+c', 'Opens the code editor dialog.', function () {

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -540,6 +540,23 @@ class Editor implements EditorObservable {
    * @param {String/Function} cmdFunc Command name string or function to execute when the key is pressed.
    * @param {Object} scope Optional scope to execute the function in.
    * @return {Boolean} true/false state if the shortcut was added or not.
+   * @example
+   * editor.addShortcut('ctrl+a', "description of the shortcut", function() {});
+   * editor.addShortcut('ctrl+alt+a', "description of the shortcut", function() {});
+   * editor.addShortcut('meta+a', "description of the shortcut", function() {}); 
+   * // "meta" maps to Command on Mac and Ctrl on PC
+   * editor.addShortcut('access+a', "description of the shortcut", function() {}); 
+   * // "access" maps to Control+Option on Mac and shift+alt on PC
+   * 
+   * editor.addShortcut(
+   *  'meta+access+c', 'Opens the code editor dialog.', function () {
+   *    editor.execCommand('mceCodeEditor');
+   * });
+   * 
+   * editor.addShortcut(
+   *  'meta+shift+32', 'Inserts "Hello, World!" for meta+shift+space', function () {
+   *    editor.execCommand('mceInsertContent', false, 'Hello, World!');
+   * });
    */
   public addShortcut(pattern: string, desc: string, cmdFunc: string | any[] | Function, scope?: {}) {
     this.shortcuts.add(pattern, desc, cmdFunc, scope);

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -543,16 +543,16 @@ class Editor implements EditorObservable {
    * @example
    * editor.addShortcut('ctrl+a', "description of the shortcut", function() {});
    * editor.addShortcut('ctrl+alt+a', "description of the shortcut", function() {});
-   * editor.addShortcut('meta+a', "description of the shortcut", function() {}); 
+   * editor.addShortcut('meta+a', "description of the shortcut", function() {});
    * // "meta" maps to Command on Mac and Ctrl on PC
-   * editor.addShortcut('access+a', "description of the shortcut", function() {}); 
+   * editor.addShortcut('access+a', "description of the shortcut", function() {});
    * // "access" maps to Control+Option on Mac and shift+alt on PC
-   * 
+   *
    * editor.addShortcut(
    *  'meta+access+c', 'Opens the code editor dialog.', function () {
    *    editor.execCommand('mceCodeEditor');
    * });
-   * 
+   *
    * editor.addShortcut(
    *  'meta+shift+32', 'Inserts "Hello, World!" for meta+shift+space', function () {
    *    editor.execCommand('mceInsertContent', false, 'Hello, World!');

--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -17,16 +17,16 @@ import Tools from './util/Tools';
  * @example
  * editor.shortcuts.add('ctrl+a', "description of the shortcut", function() {});
  * editor.shortcuts.add('ctrl+alt+a', "description of the shortcut", function() {});
- * editor.shortcuts.add('meta+a', "description of the shortcut", function() {}); 
+ * editor.shortcuts.add('meta+a', "description of the shortcut", function() {});
  * // "meta" maps to Command on Mac and Ctrl on PC
- * editor.shortcuts.add('access+a', "description of the shortcut", function() {}); 
+ * editor.shortcuts.add('access+a', "description of the shortcut", function() {});
  * // "access" maps to Control+Option on Mac and shift+alt on PC
- * 
+ *
  * editor.shortcuts.add(
  *  'meta+access+c', 'Opens the code editor dialog.', function () {
  *    editor.execCommand('mceCodeEditor');
  * });
- * 
+ *
  * editor.shortcuts.add(
  *  'meta+shift+32', 'Inserts "Hello, World!" for meta+shift+space', function () {
  *    editor.execCommand('mceInsertContent', false, 'Hello, World!');

--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -17,10 +17,10 @@ import Tools from './util/Tools';
  * @example
  * editor.shortcuts.add('ctrl+a', "description of the shortcut", function() {});
  * editor.shortcuts.add('ctrl+alt+a', "description of the shortcut", function() {});
- * editor.shortcuts.add('meta+a', "description of the shortcut", function() {});
  * // "meta" maps to Command on Mac and Ctrl on PC
- * editor.shortcuts.add('access+a', "description of the shortcut", function() {});
+ * editor.shortcuts.add('meta+a', "description of the shortcut", function() {});
  * // "access" maps to Control+Option on Mac and shift+alt on PC
+ * editor.shortcuts.add('access+a', "description of the shortcut", function() {});
  *
  * editor.shortcuts.add(
  *  'meta+access+c', 'Opens the code editor dialog.', function () {

--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -16,9 +16,21 @@ import Tools from './util/Tools';
  * @class tinymce.Shortcuts
  * @example
  * editor.shortcuts.add('ctrl+a', "description of the shortcut", function() {});
- * editor.shortcuts.add('meta+a', "description of the shortcut", function() {}); // "meta" maps to Command on Mac and Ctrl on PC
  * editor.shortcuts.add('ctrl+alt+a', "description of the shortcut", function() {});
- * editor.shortcuts.add('access+a', "description of the shortcut", function() {}); // "access" maps to Control+Option on Mac and shift+alt on PC
+ * editor.shortcuts.add('meta+a', "description of the shortcut", function() {}); 
+ * // "meta" maps to Command on Mac and Ctrl on PC
+ * editor.shortcuts.add('access+a', "description of the shortcut", function() {}); 
+ * // "access" maps to Control+Option on Mac and shift+alt on PC
+ * 
+ * editor.shortcuts.add(
+ *  'meta+access+c', 'Opens the code editor dialog.', function () {
+ *    editor.execCommand('mceCodeEditor');
+ * });
+ * 
+ * editor.shortcuts.add(
+ *  'meta+shift+32', 'Inserts "Hello, World!" for meta+shift+space', function () {
+ *    editor.execCommand('mceInsertContent', false, 'Hello, World!');
+ * });
  */
 
 const each = Tools.each, explode = Tools.explode;


### PR DESCRIPTION
Related Ticket: DOC-464

Description of Changes:
* Add useful examples to `editor.shortcuts.add` and `editor.addshortcut`API docs

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
