### PR TITLE
Add explicit return types throughout sugar

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Options.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Options.ts
@@ -66,3 +66,7 @@ export const flatten = <T> (oot: Option<Option<T>>): Option<T> => oot.bind(Fun.i
 // This can help with type inference, by specifying the type param on the none case, so the caller doesn't have to.
 export const someIf = <A> (b: boolean, a: A): Option<A> =>
   b ? Option.some(a) : Option.none<A>();
+
+/** covariant upcast */
+export const vary: <A, B extends A> (oab: Option<B>) => Option<A> =
+  Fun.identity;

--- a/modules/robin/src/test/ts/module/ephox/robin/test/BrowserCheck.ts
+++ b/modules/robin/src/test/ts/module/ephox/robin/test/BrowserCheck.ts
@@ -1,16 +1,15 @@
-import { Option } from '@ephox/katamari';
 import { Element, Insert, Remove, SelectorFind, Traverse } from '@ephox/sugar';
 import { Node as DomNode } from '@ephox/dom-globals';
+import { Option, Options } from '@ephox/katamari';
 
-const getNode = function (container: Element) {
-  return SelectorFind.descendant(container, '.me').fold(function () {
-    return SelectorFind.descendant(container, '.child').bind(Traverse.firstChild);
-  }, function (v: Element<DomNode>) {
-    return Option.some(v);
-  }).getOrDie('Could not find the descendant ".me" or the first child of the descendant ".child"');
+const getNode = (container: Element): Element<DomNode> => {
+  const dotme: Option<Element<DomNode>> = Options.vary(SelectorFind.descendant(container, '.me'));
+  return dotme
+    .orThunk(() => Options.vary(SelectorFind.descendant(container, '.child').bind(Traverse.firstChild)))
+    .getOrDie('Could not find the descendant ".me" or the first child of the descendant ".child"');
 };
 
-const run = function (input: string, f: (e: Element) => void) {
+const run = (input: string, f: (e: Element) => void): void => {
   const body = SelectorFind.first('body').getOrDie();
   const container = Element.fromTag('div');
   Insert.append(body, container);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Compare.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Compare.ts
@@ -4,14 +4,17 @@ import { Node, PlatformDetection } from '@ephox/sand';
 import Element from '../node/Element';
 import * as Selectors from '../search/Selectors';
 
-const eq = (e1: Element<unknown>, e2: Element<unknown>) => e1.dom() === e2.dom();
+const eq = (e1: Element<unknown>, e2: Element<unknown>): boolean =>
+  e1.dom() === e2.dom();
 
-const isEqualNode = (e1: Element<DomNode>, e2: Element<DomNode>) => e1.dom().isEqualNode(e2.dom());
+const isEqualNode = (e1: Element<DomNode>, e2: Element<DomNode>): boolean =>
+  e1.dom().isEqualNode(e2.dom());
 
-const member = (element: Element, elements: Element[]) => Arr.exists(elements, Fun.curry(eq, element));
+const member = (element: Element, elements: Element[]): boolean =>
+  Arr.exists(elements, Fun.curry(eq, element));
 
 // DOM contains() method returns true if e1===e2, we define our contains() to return false (a node does not contain itself).
-const regularContains = (e1: Element<DomNode>, e2: Element<DomNode>) => {
+const regularContains = (e1: Element<DomNode>, e2: Element<DomNode>): boolean => {
   const d1 = e1.dom();
   const d2 = e2.dom();
   return d1 === d2 ? false : d1.contains(d2);
@@ -22,11 +25,12 @@ const regularContains = (e1: Element<DomNode>, e2: Element<DomNode>) => {
 // https://connect.microsoft.com/IE/feedback/details/780874/node-contains-is-incorrect
 // Note that compareDocumentPosition returns CONTAINED_BY if 'e2 *is_contained_by* e1':
 // Also, compareDocumentPosition defines a node containing itself as false.
-const ieContains = (e1: Element<DomNode>, e2: Element<DomNode>) => Node.documentPositionContainedBy(e1.dom(), e2.dom());
+const ieContains = (e1: Element<DomNode>, e2: Element<DomNode>): boolean =>
+  Node.documentPositionContainedBy(e1.dom(), e2.dom());
 
 // Returns: true if node e1 contains e2, otherwise false.
 // (returns false if e1===e2: A node does not contain itself).
-const contains = (e1: Element<DomNode>, e2: Element<DomNode>) =>
+const contains = (e1: Element<DomNode>, e2: Element<DomNode>): boolean =>
   PlatformDetection.detect().browser.isIE() ? ieContains(e1, e2) : regularContains(e1, e2);
 
 const is = Selectors.is;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/DocumentPosition.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/DocumentPosition.ts
@@ -1,9 +1,9 @@
-import { Node as DomNode } from '@ephox/dom-globals';
+import { Node as DomNode, Range } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as Traverse from '../search/Traverse';
 import * as Compare from './Compare';
 
-const makeRange = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => {
+const makeRange = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): Range => {
   const doc = Traverse.owner(start);
 
   // TODO: We need to think about a better place to put native range creation code. Does it even belong in sugar?
@@ -16,12 +16,12 @@ const makeRange = (start: Element<DomNode>, soffset: number, finish: Element<Dom
 
 // Return the deepest - or furthest down the document tree - Node that contains both boundary points
 // of the range (start:soffset, finish:foffset).
-const commonAncestorContainer = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => {
+const commonAncestorContainer = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): Element<DomNode> => {
   const r = makeRange(start, soffset, finish, foffset);
   return Element.fromDom(r.commonAncestorContainer);
 };
 
-const after = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => {
+const after = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): boolean => {
   const r = makeRange(start, soffset, finish, foffset);
 
   const same = Compare.eq(start, finish) && soffset === foffset;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Hierarchy.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Hierarchy.ts
@@ -19,7 +19,7 @@ const up = (descendant: Element<DomNode>, stopper: (e: Element<DomNode>) => bool
   }
 };
 
-const path = (ancestor: Element<DomNode>, descendant: Element<DomNode>) => {
+const path = (ancestor: Element<DomNode>, descendant: Element<DomNode>): Option<number[]> => {
   const stopper = Fun.curry(Compare.eq, ancestor);
   return Compare.eq(ancestor, descendant) ? Option.some<number[]>([]) : up(descendant, stopper);
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Insert.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Insert.ts
@@ -2,14 +2,14 @@ import { Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as Traverse from '../search/Traverse';
 
-const before = (marker: Element<DomNode>, element: Element<DomNode>) => {
+const before = (marker: Element<DomNode>, element: Element<DomNode>): void => {
   const parent = Traverse.parent(marker);
   parent.each((v) => {
     v.dom().insertBefore(element.dom(), marker.dom());
   });
 };
 
-const after = (marker: Element<DomNode>, element: Element<DomNode>) => {
+const after = (marker: Element<DomNode>, element: Element<DomNode>): void => {
   const sibling = Traverse.nextSibling(marker);
   sibling.fold(() => {
     const parent = Traverse.parent(marker);
@@ -21,7 +21,7 @@ const after = (marker: Element<DomNode>, element: Element<DomNode>) => {
   });
 };
 
-const prepend = (parent: Element<DomNode>, element: Element<DomNode>) => {
+const prepend = (parent: Element<DomNode>, element: Element<DomNode>): void => {
   const firstChild = Traverse.firstChild(parent);
   firstChild.fold(() => {
     append(parent, element);
@@ -30,11 +30,11 @@ const prepend = (parent: Element<DomNode>, element: Element<DomNode>) => {
   });
 };
 
-const append = (parent: Element<DomNode>, element: Element<DomNode>) => {
+const append = (parent: Element<DomNode>, element: Element<DomNode>): void => {
   parent.dom().appendChild(element.dom());
 };
 
-const appendAt = (parent: Element<DomNode>, element: Element<DomNode>, index: number) => {
+const appendAt = (parent: Element<DomNode>, element: Element<DomNode>, index: number): void => {
   Traverse.child(parent, index).fold(() => {
     append(parent, element);
   }, (v) => {
@@ -42,7 +42,7 @@ const appendAt = (parent: Element<DomNode>, element: Element<DomNode>, index: nu
   });
 };
 
-const wrap = (element: Element<DomNode>, wrapper: Element<DomNode>) => {
+const wrap = (element: Element<DomNode>, wrapper: Element<DomNode>): void => {
   before(element, wrapper);
   append(wrapper, element);
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/InsertAll.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/InsertAll.ts
@@ -3,26 +3,26 @@ import { Arr } from '@ephox/katamari';
 import Element from '../node/Element';
 import * as Insert from './Insert';
 
-const before = (marker: Element<DomNode>, elements: Element<DomNode>[]) => {
+const before = (marker: Element<DomNode>, elements: Element<DomNode>[]): void => {
   Arr.each(elements, (x) => {
     Insert.before(marker, x);
   });
 };
 
-const after = (marker: Element<DomNode>, elements: Element<DomNode>[]) => {
+const after = (marker: Element<DomNode>, elements: Element<DomNode>[]): void => {
   Arr.each(elements, (x, i) => {
     const e = i === 0 ? marker : elements[i - 1];
     Insert.after(e, x);
   });
 };
 
-const prepend = (parent: Element<DomNode>, elements: Element<DomNode>[]) => {
+const prepend = (parent: Element<DomNode>, elements: Element<DomNode>[]): void => {
   Arr.each(elements.slice().reverse(), (x) => {
     Insert.prepend(parent, x);
   });
 };
 
-const append = (parent: Element<DomNode>, elements: Element<DomNode>[]) => {
+const append = (parent: Element<DomNode>, elements: Element<DomNode>[]): void => {
   Arr.each(elements, (x) => {
     Insert.append(parent, x);
   });

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Link.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Link.ts
@@ -1,19 +1,20 @@
-import { document, Document, Node as DomNode } from '@ephox/dom-globals';
+import { Document as DomDocument, HTMLLinkElement, Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as Attr from '../properties/Attr';
 import * as Insert from './Insert';
+import * as Head from '../node/Head';
+import * as Document from '../node/Document';
 
-const addToHead = (doc: Element<Document>, tag: Element<DomNode>) => {
+const addToHead = (doc: Element<DomDocument>, tag: Element<DomNode>): void => {
   /*
    * IE9 and above per
    * https://developer.mozilla.org/en-US/docs/Web/API/Document/head
    */
-  const head = Element.fromDom(doc.dom().head);
+  const head = Head.getHead(doc);
   Insert.append(head, tag);
 };
 
-const addStylesheet = (url: string, scope?: Element<Document>) => {
-  const doc = scope || Element.fromDom(document);
+const addStylesheet = (url: string, doc: Element<DomDocument> = Document.getDocument()): Element<HTMLLinkElement> => {
 
   const link = Element.fromTag('link', doc.dom()); // We really need to fix that Element API
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Remove.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Remove.ts
@@ -4,7 +4,7 @@ import Element from '../node/Element';
 import * as Traverse from '../search/Traverse';
 import * as InsertAll from './InsertAll';
 
-const empty = (element: Element<DomNode>) => {
+const empty = (element: Element<DomNode>): void => {
   // shortcut "empty node" trick. Requires IE 9.
   element.dom().textContent = '';
 
@@ -17,14 +17,14 @@ const empty = (element: Element<DomNode>) => {
   });
 };
 
-const remove = (element: Element<DomNode>) => {
+const remove = (element: Element<DomNode>): void => {
   const dom = element.dom();
   if (dom.parentNode !== null) {
     dom.parentNode.removeChild(dom);
   }
 };
 
-const unwrap = (wrapper: Element<DomNode>) => {
+const unwrap = (wrapper: Element<DomNode>): void => {
   const children = Traverse.children(wrapper);
   if (children.length > 0) {
     InsertAll.before(wrapper, children);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
@@ -6,13 +6,16 @@ import * as Insert from './Insert';
 import * as InsertAll from './InsertAll';
 import * as Remove from './Remove';
 
-const clone = <E extends DomNode> (original: Element<E>, isDeep: boolean) => Element.fromDom(original.dom().cloneNode(isDeep) as E);
+const clone = <E extends DomNode> (original: Element<E>, isDeep: boolean): Element<E> =>
+  Element.fromDom(original.dom().cloneNode(isDeep) as E);
 
 /** Shallow clone - just the tag, no children */
-const shallow = <E extends DomNode> (original: Element<E>) => clone(original, false);
+const shallow = <E extends DomNode> (original: Element<E>): Element<E> =>
+  clone(original, false);
 
 /** Deep clone - everything copied including children */
-const deep = <E extends DomNode> (original: Element<E>) => clone(original, true);
+const deep = <E extends DomNode> (original: Element<E>): Element<E> =>
+  clone(original, true);
 
 /** Shallow clone, with a new tag */
 const shallowAs = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K): Element<HTMLElementTagNameMap[K]> => {
@@ -25,7 +28,7 @@ const shallowAs = <K extends keyof HTMLElementTagNameMap> (original: Element<Dom
 };
 
 /** Deep clone, with a new tag */
-const copy = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K) => {
+const copy = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K): Element<HTMLElementTagNameMap[K]> => {
   const nu = shallowAs(original, tag);
 
   // NOTE
@@ -41,7 +44,7 @@ const copy = <K extends keyof HTMLElementTagNameMap> (original: Element<DomEleme
 };
 
 /** Change the tag name, but keep all children */
-const mutate = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K) => {
+const mutate = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K): Element<HTMLElementTagNameMap[K]> => {
   const nu = shallowAs(original, tag);
 
   Insert.before(original, nu);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvent.ts
@@ -1,13 +1,14 @@
-import { MouseEvent } from '@ephox/dom-globals';
+import { Event, MouseEvent } from '@ephox/dom-globals';
 import * as FilteredEvent from '../../impl/FilteredEvent';
 import Element from '../node/Element';
-import { EventFilter, EventHandler } from './Types';
+import { EventFilter, EventHandler, EventUnbinder } from './Types';
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
-const isLeftClick = (raw: MouseEvent) => raw.button === 0;
+const isLeftClick = (raw: MouseEvent): boolean =>
+  raw.button === 0;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
-const isLeftButtonPressed = (raw: MouseEvent) => {
+const isLeftButtonPressed = (raw: MouseEvent): boolean => {
   // Only added by Chrome/Firefox in June 2015.
   // This is only to fix a 1px bug (TBIO-2836) so return true if we're on an older browser
   if (raw.buttons === undefined) {
@@ -20,7 +21,7 @@ const isLeftButtonPressed = (raw: MouseEvent) => {
 };
 
 // Not 100% sure whether this works, so use with caution
-const isRealClick = (raw: any) =>
+const isRealClick = (raw: any): boolean =>
   // Firefox non-standard property
   // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent#mozInputSource
   (raw.mozInputSource === 6 || raw.mozInputSource === 0) ? false
@@ -30,16 +31,20 @@ const isRealClick = (raw: any) =>
       // fallback to yes because there's no other way to really know
       : true;
 
-const filtered = (event: string, filter: EventFilter<MouseEvent>) => ({
+interface Binder <T extends Event> {
+  readonly bind: (element: Element, f: EventHandler<MouseEvent>) => EventUnbinder;
+}
+
+const filtered = (event: string, filter: EventFilter<MouseEvent>): Binder<MouseEvent> => ({
   bind(element: Element, f: EventHandler<MouseEvent>) {
     return FilteredEvent.bind(element, event, filter, f);
   }
 });
 
-const realClick = filtered('click', isRealClick);
-const leftDown = filtered('mousedown', isLeftClick);
-const leftPressedOver = filtered('mouseover', isLeftButtonPressed);
-const leftUp = filtered('mouseup', isLeftClick);
+const realClick: Binder<MouseEvent> = filtered('click', isRealClick);
+const leftDown: Binder<MouseEvent> = filtered('mousedown', isLeftClick);
+const leftPressedOver: Binder<MouseEvent> = filtered('mouseover', isLeftButtonPressed);
+const leftUp: Binder<MouseEvent> = filtered('mouseup', isLeftClick);
 
 export {
   realClick,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Ready.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Ready.ts
@@ -2,7 +2,7 @@ import { document } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as DomEvent from './DomEvent';
 
-const execute = (f: () => void) => {
+const execute = (f: () => void): void => {
   /*
    * We only use this in one place, so creating one listener per ready request is more optimal than managing
    * a single event with a queue of functions.

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/ScrollChange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/ScrollChange.ts
@@ -3,12 +3,13 @@ import Element from '../node/Element';
 import { Position } from '../view/Position';
 import * as Scroll from '../view/Scroll';
 import * as DomEvent from './DomEvent';
+import { EventUnbinder } from './Types';
 
 /* Some browsers (Firefox) fire a scroll event even if the values for scroll don't
  * change. This acts as an intermediary between the scroll event, and the value for scroll
  * changing
  */
-const bind = (doc: Element<Document>, handler: (pos: Position) => void) => {
+const bind = (doc: Element<Document>, handler: (pos: Position) => void): EventUnbinder => {
   let lastScroll = Scroll.get(doc);
   const scrollBinder = DomEvent.bind(doc, 'scroll', (_event) => {
     const scroll = Scroll.get(doc);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Types.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Types.ts
@@ -2,17 +2,17 @@ import { Event } from '@ephox/dom-globals';
 import Element from '../node/Element';
 
 export interface EventArgs<T = Event> {
-  target: () => Element;
-  x: () => number;
-  y: () => number;
-  stop: () => void;
-  prevent: () => void;
-  kill: () => void;
-  raw: () => T;
+  readonly target: () => Element;
+  readonly x: () => number;
+  readonly y: () => number;
+  readonly stop: () => void;
+  readonly prevent: () => void;
+  readonly kill: () => void;
+  readonly raw: () => T;
 }
 
 export interface EventUnbinder {
-  unbind: () => void;
+  readonly unbind: () => void;
 }
 
 export type EventHandler<T = Event> = (evt: EventArgs<T>) => void;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
@@ -14,13 +14,13 @@ declare const window: any;
  * It's a bit harder to manage, though, because visibility is a one-shot listener.
  */
 
-const poll = (element: Element<HTMLElement>, f: () => void) => {
+const poll = (element: Element<HTMLElement>, f: () => void): () => void => {
   const poller = setInterval(f, 500);
 
   return () => clearInterval(poller);
 };
 
-const mutate = (element: Element<HTMLElement>, f: () => void) => {
+const mutate = (element: Element<HTMLElement>, f: () => void): () => void => {
   const observer: MutationObserver = new window.MutationObserver(f);
 
   const unbindMutate = () => observer.disconnect();

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Body.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Body.ts
@@ -23,7 +23,8 @@ const inBody = (element: Element<DomNode>): boolean => {
   );
 };
 
-const body = () => getBody(Element.fromDom(document));
+const body = (): Element<HTMLElement> =>
+  getBody(Element.fromDom(document));
 
 const getBody = (doc: Element<Document>): Element<HTMLElement> => {
   const b = doc.dom().body;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Comment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Comment.ts
@@ -6,11 +6,14 @@ import * as Node from './Node';
 
 const api = NodeValue(Node.isComment, 'comment');
 
-const get = (element: Element<Comment>) => api.get(element);
+const get = (element: Element<Comment>): string =>
+  api.get(element);
 
-const getOption = (element: Element<DomNode>): Option<string> => api.getOption(element);
+const getOption = (element: Element<DomNode>): Option<string> =>
+  api.getOption(element);
 
-const set = (element: Element<Comment>, value: string) => api.set(element, value);
+const set = (element: Element<Comment>, value: string): void =>
+  api.set(element, value);
 
 export {
   get,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Comments.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Comments.ts
@@ -28,9 +28,9 @@ const getNodes = <T extends DomNode> (texas: TreeWalker): Element<T>[] => {
 };
 
 // Weird, but oh well
-const noFilter = Fun.constant(Fun.constant(true));
+const noFilter = Fun.constant(Fun.never);
 
-const find = (node: Element<DomNode>, filterOpt: Option<(n: string | null) => boolean>) => {
+const find = (node: Element<DomNode>, filterOpt: Option<(n: string | null) => boolean>): Element<Comment>[] => {
 
   const vmlFilter: any = filterOpt.fold(noFilter, (filter) => (comment: DomNode) => filter(comment.nodeValue));
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Elements.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Elements.ts
@@ -1,21 +1,23 @@
-import { document, Document, Node, Window } from '@ephox/dom-globals';
+import { document, Document, Node, Text, Window } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import * as Traverse from '../search/Traverse';
 import Element from './Element';
 
 type ElementTuple<T> = { [K in keyof T]: Element<T[K]> };
 
-const fromHtml = <T extends Node[]> (html: string, scope?: Document | null): ElementTuple<T> => {
-  const doc: Document = scope || document;
+const fromHtml = <T extends Node[]> (html: string, doc: Document = document): ElementTuple<T> => {
   const div = doc.createElement('div');
   div.innerHTML = html;
   return Traverse.children(Element.fromDom(div)) as unknown as ElementTuple<T>;
 };
 
-const fromTags = (tags: string[], scope?: Document | null) => Arr.map(tags, (x) => Element.fromTag(x, scope));
+const fromTags = (tags: string[], scope?: Document | null): Array<Element<unknown>> =>
+  Arr.map(tags, (x) => Element.fromTag(x, scope));
 
-const fromText = (texts: string[], scope?: Document | null) => Arr.map(texts, (x) => Element.fromText(x, scope));
+const fromText = (texts: string[], scope?: Document | null): Element<Text>[] =>
+  Arr.map(texts, (x) => Element.fromText(x, scope));
 
-const fromDom = <T extends (Node | Window)>(nodes: ArrayLike<T>): Element<T>[] => Arr.map(nodes, Element.fromDom);
+const fromDom = <T extends (Node | Window)>(nodes: ArrayLike<T>): Element<T>[] =>
+  Arr.map(nodes, Element.fromDom);
 
 export { fromHtml, fromTags, fromText, fromDom };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Fragment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Fragment.ts
@@ -1,9 +1,8 @@
-import { document, Document, Node as DomNode } from '@ephox/dom-globals';
+import { document, Document, DocumentFragment, Node as DomNode } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import Element from './Element';
 
-const fromElements = (elements: Element<DomNode>[], scope?: Document | null) => {
-  const doc = scope || document;
+const fromElements = (elements: Element<DomNode>[], doc: Document = document): Element<DocumentFragment> => {
   const fragment = doc.createDocumentFragment();
   Arr.each(elements, (element) => {
     fragment.appendChild(element.dom());

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Node.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Node.ts
@@ -12,27 +12,40 @@ import { HTMLElement } from '@ephox/sand';
 import Element from './Element';
 import * as NodeTypes from './NodeTypes';
 
-const name = (element: Element<DomNode>) => {
+const name = (element: Element<DomNode>): string => {
   const r = element.dom().nodeName;
   return r.toLowerCase();
 };
 
-const type = (element: Element<DomNode>) => element.dom().nodeType;
+const type = (element: Element<DomNode>): number =>
+  element.dom().nodeType;
 
-const value = (element: Element<DomNode>) => element.dom().nodeValue;
+const value = (element: Element<DomNode>): string | null =>
+  element.dom().nodeValue;
 
-const isType = <E> (t: number) => (element: Element): element is Element<E> => type(element) === t;
+const isType = <E extends DomNode> (t: number) => (element: Element<DomNode>): element is Element<E> =>
+  type(element) === t;
 
-const isComment = (element: Element): element is Element<Comment> => type(element) === NodeTypes.COMMENT || name(element) === '#comment';
+const isComment = (element: Element): element is Element<Comment> =>
+  type(element) === NodeTypes.COMMENT || name(element) === '#comment';
 
-const isHTMLElement = (element: Element<any>): element is Element<DomHTMLElement> => HTMLElement.isPrototypeOf(element.dom());
+const isHTMLElement = (element: Element<any>): element is Element<DomHTMLElement> =>
+  HTMLElement.isPrototypeOf(element.dom());
 
-const isElement = isType<DomElement>(NodeTypes.ELEMENT);
-const isText = isType<Text>(NodeTypes.TEXT);
-const isDocument = isType<Document>(NodeTypes.DOCUMENT);
-const isDocumentFragment = isType<DocumentFragment>(NodeTypes.DOCUMENT_FRAGMENT);
+const isElement: (element: Element<DomNode>) => element is Element<DomElement> =
+  isType<DomElement>(NodeTypes.ELEMENT);
 
-const isTag = <K extends keyof HTMLElementTagNameMap>(tag: K) => (e: Element<any>): e is Element<HTMLElementTagNameMap[K]> => isElement(e) && name(e) === tag;
+const isText: (element: Element<DomNode>) =>
+  element is Element<Text> = isType<Text>(NodeTypes.TEXT);
+
+const isDocument: (element: Element<DomNode>) => element is Element<Document> =
+  isType<Document>(NodeTypes.DOCUMENT);
+
+const isDocumentFragment: (element: Element<DomNode>) => element is Element<DocumentFragment> =
+  isType<DocumentFragment>(NodeTypes.DOCUMENT_FRAGMENT);
+
+const isTag = <K extends keyof HTMLElementTagNameMap>(tag: K) => (e: Element<DomNode>): e is Element<HTMLElementTagNameMap[K]> =>
+  isElement(e) && name(e) === tag;
 
 export {
   name,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/ShadowDom.ts
@@ -30,7 +30,8 @@ const supported: boolean =
  *
  * NOTE: Node.getRootNode() and Element.attachShadow don't exist on IE11 and pre-Chromium Edge.
  */
-export const isSupported = Fun.constant(supported);
+export const isSupported: () => boolean =
+  Fun.constant(supported);
 
 export const getRootNode: (e: Element<DomNode>) => RootNode =
   supported

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Text.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Text.ts
@@ -6,11 +6,14 @@ import * as Node from './Node';
 
 const api = NodeValue(Node.isText, 'text');
 
-const get = (element: Element<Text>) => api.get(element);
+const get = (element: Element<Text>): string =>
+  api.get(element);
 
-const getOption = (element: Element<DomNode>): Option<string> => api.getOption(element);
+const getOption = (element: Element<DomNode>): Option<string> =>
+  api.getOption(element);
 
-const set = (element: Element<Text>, value: string) => api.set(element, value);
+const set = (element: Element<Text>, value: string): void =>
+  api.set(element, value);
 
 export {
   get,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Alignment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Alignment.ts
@@ -1,5 +1,5 @@
 import { Element as DomElement, Text } from '@ephox/dom-globals';
-import { Obj } from '@ephox/katamari';
+import { Fun, Obj } from '@ephox/katamari';
 import Element from '../node/Element';
 import * as Node from '../node/Node';
 import * as Css from './Css';
@@ -7,7 +7,8 @@ import * as Direction from './Direction';
 
 type Alignment = 'left' | 'right' | 'justify' | 'center' | 'match-parent';
 
-const normal = (value: Alignment) => (_element: Element<DomElement>) => value;
+const normal = (value: Alignment): (_element: Element<DomElement>) => Alignment =>
+  Fun.constant(value);
 
 const lookups: Record<string, (element: Element<DomElement>) => string> = {
   'start': Direction.onDirection<Alignment>('left', 'right'),
@@ -24,7 +25,7 @@ const getAlignment = (element: Element<DomElement>, property: string): string =>
     .getOr(raw);
 };
 
-const hasAlignment = (element: Element<DomElement> | Element<Text>, property: string, value: string) =>
+const hasAlignment = (element: Element<DomElement> | Element<Text>, property: string, value: string): boolean =>
   Node.isText(element) ? false : getAlignment(element, property) === value;
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attr.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attr.ts
@@ -1,4 +1,4 @@
-import { console, Element as DomElement, Node as DomNode } from '@ephox/dom-globals';
+import { console, Element as DomElement, Node as DomNode, Attr as DomAttr } from '@ephox/dom-globals';
 import { Arr, Obj, Option, Type } from '@ephox/katamari';
 import Element from '../node/Element';
 import * as Node from '../node/Node';
@@ -18,18 +18,18 @@ const rawSet = (dom: DomElement, key: string, value: string | boolean | number) 
   }
 };
 
-const set = (element: Element<DomElement>, key: string, value: string | boolean | number) => {
+const set = (element: Element<DomElement>, key: string, value: string | boolean | number): void => {
   rawSet(element.dom(), key, value);
 };
 
-const setAll = (element: Element<DomElement>, attrs: Record<string, string | boolean | number>) => {
+const setAll = (element: Element<DomElement>, attrs: Record<string, string | boolean | number>): void => {
   const dom = element.dom();
   Obj.each(attrs, (v, k) => {
     rawSet(dom, k, v);
   });
 };
 
-const get = (element: Element<DomElement>, key: string) => {
+const get = (element: Element<DomElement>, key: string): undefined | string => {
   const v = element.dom().getAttribute(key);
 
   // undefined is the more appropriate value for JS, and this matches JQuery
@@ -39,28 +39,29 @@ const get = (element: Element<DomElement>, key: string) => {
 const getOpt = (element: Element<DomElement>, key: string): Option<string> =>
   Option.from(get(element, key));
 
-const has = (element: Element<DomNode>, key: string) => {
+const has = (element: Element<DomNode>, key: string): boolean => {
   const dom = element.dom();
 
   // return false for non-element nodes, no point in throwing an error
   return dom && (dom as DomElement).hasAttribute ? (dom as DomElement).hasAttribute(key) : false;
 };
 
-const remove = (element: Element<DomElement>, key: string) => {
+const remove = (element: Element<DomElement>, key: string): void => {
   element.dom().removeAttribute(key);
 };
 
-const hasNone = (element: Element<DomNode>) => {
+const hasNone = (element: Element<DomNode>): boolean => {
   const attrs = (element.dom() as DomElement).attributes;
   return attrs === undefined || attrs === null || attrs.length === 0;
 };
 
-const clone = (element: Element<DomElement>) => Arr.foldl(element.dom().attributes, (acc, attr) => {
-  acc[attr.name] = attr.value;
-  return acc;
-}, {} as Record<string, string>);
+const clone = (element: Element<DomElement>): Record<string, string> =>
+  Arr.foldl<DomAttr, Record<string, string>>(element.dom().attributes, (acc, attr) => {
+    acc[attr.name] = attr.value;
+    return acc;
+  }, {});
 
-const transferOne = (source: Element<DomElement>, destination: Element<DomElement>, attr: string) => {
+const transferOne = (source: Element<DomElement>, destination: Element<DomElement>, attr: string): void => {
   // NOTE: We don't want to clobber any existing attributes
   if (!has(destination, attr)) {
     getOpt(source, attr).each((srcValue) => set(destination, attr, srcValue));
@@ -68,7 +69,7 @@ const transferOne = (source: Element<DomElement>, destination: Element<DomElemen
 };
 
 // Transfer attributes(attrs) from source to destination, unless they are already present
-const transfer = (source: Element<DomElement>, destination: Element<DomElement>, attrs: string[]) => {
+const transfer = (source: Element<DomElement>, destination: Element<DomElement>, attrs: string[]): void => {
   if (!Node.isElement(source) || !Node.isElement(destination)) { return; }
   Arr.each(attrs, (attr) => {
     transferOne(source, destination, attr);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttributeProperty.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttributeProperty.ts
@@ -3,11 +3,14 @@ import Element from '../node/Element';
 import * as Attr from './Attr';
 
 export default (attribute: string, value: string) => {
-  const is = (element: Element<DomElement>) => Attr.get(element, attribute) === value;
+  const is = (element: Element<DomElement>): boolean =>
+    Attr.get(element, attribute) === value;
 
-  const remove = (element: Element<DomElement>) => Attr.remove(element, attribute);
+  const remove = (element: Element<DomElement>): void =>
+    Attr.remove(element, attribute);
 
-  const set = (element: Element<DomElement>) => Attr.set(element, attribute, value);
+  const set = (element: Element<DomElement>): void =>
+    Attr.set(element, attribute, value);
 
   return {
     is,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Checked.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Checked.ts
@@ -1,14 +1,16 @@
 import { HTMLInputElement, Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as SelectorFind from '../search/SelectorFind';
+import { Option } from '@ephox/katamari';
 
-const set = (element: Element<HTMLInputElement>, status: boolean) => {
+const set = (element: Element<HTMLInputElement>, status: boolean): void => {
   element.dom().checked = status;
 };
 
 // :checked selector requires IE9
 // http://www.quirksmode.org/css/selectors/#t60
-const find = (parent: Element<DomNode>) => SelectorFind.descendant<HTMLInputElement>(parent, 'input:checked');
+const find = (parent: Element<DomNode>): Option<Element<HTMLInputElement>> =>
+  SelectorFind.descendant<HTMLInputElement>(parent, 'input:checked');
 
 export {
   set,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Class.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Class.ts
@@ -12,7 +12,7 @@ import Toggler from './Toggler';
  * If it did, the toggler could be better.
  */
 
-const add = (element: Element<DomElement>, clazz: string) => {
+const add = (element: Element<DomElement>, clazz: string): void => {
   if (ClassList.supports(element)) {
     element.dom().classList.add(clazz);
   } else {
@@ -20,7 +20,7 @@ const add = (element: Element<DomElement>, clazz: string) => {
   }
 };
 
-const cleanClass = (element: Element<DomElement>) => {
+const cleanClass = (element: Element<DomElement>): void => {
   const classList = ClassList.supports(element) ? element.dom().classList : ClassList.get(element);
   // classList is a "live list", so this is up to date already
   if (classList.length === 0) {
@@ -29,7 +29,7 @@ const cleanClass = (element: Element<DomElement>) => {
   }
 };
 
-const remove = (element: Element<DomElement>, clazz: string) => {
+const remove = (element: Element<DomElement>, clazz: string): void => {
   if (ClassList.supports(element)) {
     const classList = element.dom().classList;
     classList.remove(clazz);
@@ -40,7 +40,7 @@ const remove = (element: Element<DomElement>, clazz: string) => {
   cleanClass(element);
 };
 
-const toggle = (element: Element<DomElement>, clazz: string) =>
+const toggle = (element: Element<DomElement>, clazz: string): boolean =>
   ClassList.supports(element) ? element.dom().classList.toggle(clazz) : ClassList.toggle(element, clazz);
 
 const toggler = (element: Element<DomElement>, clazz: string) => {
@@ -53,7 +53,7 @@ const toggler = (element: Element<DomElement>, clazz: string) => {
       ClassList.remove(element, clazz);
     }
   };
-  const on = () => {
+  const on = (): void => {
     if (hasClasslist) {
       classList.add(clazz);
     } else {
@@ -63,7 +63,7 @@ const toggler = (element: Element<DomElement>, clazz: string) => {
   return Toggler(off, on, has(element, clazz));
 };
 
-const has = (element: Element<Node>, clazz: string) =>
+const has = (element: Element<Node>, clazz: string): boolean =>
   ClassList.supports(element) && element.dom().classList.contains(clazz);
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Classes.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Classes.ts
@@ -8,29 +8,31 @@ import * as Class from './Class';
  * ClassList is IE10 minimum:
  * https://developer.mozilla.org/en-US/docs/Web/API/Element.classList
  */
-const add = (element: Element<DomElement>, classes: string[]) => {
+const add = (element: Element<DomElement>, classes: string[]): void => {
   Arr.each(classes, (x) => {
     Class.add(element, x);
   });
 };
 
-const remove = (element: Element<DomElement>, classes: string[]) => {
+const remove = (element: Element<DomElement>, classes: string[]): void => {
   Arr.each(classes, (x) => {
     Class.remove(element, x);
   });
 };
 
-const toggle = (element: Element<DomElement>, classes: string[]) => {
+const toggle = (element: Element<DomElement>, classes: string[]): void => {
   Arr.each(classes, (x) => {
     Class.toggle(element, x);
   });
 };
 
-const hasAll = (element: Element<DomNode>, classes: string[]) => Arr.forall(classes, (clazz) => Class.has(element, clazz));
+const hasAll = (element: Element<DomNode>, classes: string[]): boolean =>
+  Arr.forall(classes, (clazz) => Class.has(element, clazz));
 
-const hasAny = (element: Element<DomNode>, classes: string[]) => Arr.exists(classes, (clazz) => Class.has(element, clazz));
+const hasAny = (element: Element<DomNode>, classes: string[]): boolean =>
+  Arr.exists(classes, (clazz) => Class.has(element, clazz));
 
-const getNative = (element: Element<DomElement>) => {
+const getNative = (element: Element<DomElement>): Array<string> => {
   const classList = element.dom().classList;
   const r: Array<string> = new Array(classList.length);
   for (let i = 0; i < classList.length; i++) {
@@ -42,7 +44,8 @@ const getNative = (element: Element<DomElement>) => {
   return r;
 };
 
-const get = (element: Element<DomElement>) => ClassList.supports(element) ? getNative(element) : ClassList.get(element);
+const get = (element: Element<DomElement>): Array<string> =>
+  ClassList.supports(element) ? getNative(element) : ClassList.get(element);
 
 export {
   add,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
@@ -6,7 +6,7 @@ import Element from '../node/Element';
 import * as Node from '../node/Node';
 import * as Attr from './Attr';
 
-const internalSet = (dom: DomNode, property: string, value: string) => {
+const internalSet = (dom: DomNode, property: string, value: string): void => {
   // This is going to hurt. Apologies.
   // JQuery coerces numbers to pixels for certain property names, and other times lets numbers through.
   // we're going to be explicit; strings only.
@@ -22,7 +22,7 @@ const internalSet = (dom: DomNode, property: string, value: string) => {
   }
 };
 
-const internalRemove = (dom: DomNode, property: string) => {
+const internalRemove = (dom: DomNode, property: string): void => {
   /*
    * IE9 and above - MDN doesn't have details, but here's a couple of random internet claims
    *
@@ -94,14 +94,15 @@ const getUnsafeProperty = (dom: DomNode, property: string) => Style.isSupported(
  *
  * Returns NONE if the property isn't set, or the value is an empty string.
  */
-const getRaw = (element: Element<DomNode>, property: string) => {
+const getRaw = (element: Element<DomNode>, property: string): Option<string> => {
   const dom = element.dom();
   const raw = getUnsafeProperty(dom, property);
 
   return Option.from(raw).filter((r) => r.length > 0);
 };
 
-const getAllRaw = (element: Element<DomNode>) => {
+// TODO: When dom-globals is updated, this will need to return Record<string, CrazyCssUnionType>
+const getAllRaw = (element: Element<DomNode>): Record<string, string> => {
   const css: Record<string, string> = {};
   const dom = element.dom();
 
@@ -114,7 +115,7 @@ const getAllRaw = (element: Element<DomNode>) => {
   return css;
 };
 
-const isValidValue = (tag: string, property: string, value: string) => {
+const isValidValue = (tag: string, property: string, value: string): boolean => {
   const element = Element.fromTag(tag);
   set(element, property, value);
   const style = getRaw(element, property);
@@ -132,7 +133,7 @@ const remove = (element: Element<DomNode>, property: string) => {
   }
 };
 
-const preserve = <E extends DomElement, T> (element: Element<E>, f: (e: Element<E>) => T) => {
+const preserve = <E extends DomElement, T> (element: Element<E>, f: (e: Element<E>) => T): T => {
   const oldStyles = Attr.get(element, 'style');
   const result = f(element);
   if (oldStyles === undefined) {
@@ -143,7 +144,7 @@ const preserve = <E extends DomElement, T> (element: Element<E>, f: (e: Element<
   return result;
 };
 
-const copy = (source: Element<DomNode>, target: Element<HTMLElement>) => {
+const copy = (source: Element<DomNode>, target: Element<HTMLElement>): void => {
   const sourceDom = source.dom();
   const targetDom = target.dom();
   if (Style.isSupported(sourceDom) && Style.isSupported(targetDom)) {
@@ -155,9 +156,10 @@ const copy = (source: Element<DomNode>, target: Element<HTMLElement>) => {
  * do not rely on this return value.
  * It's here so the closure compiler doesn't optimise the property access away.
  */
-const reflow = (e: Element<HTMLElement>) => e.dom().offsetWidth;
+const reflow = (e: Element<HTMLElement>): number =>
+  e.dom().offsetWidth;
 
-const transferOne = (source: Element<DomNode>, destination: Element<DomNode>, style: string) => {
+const transferOne = (source: Element<DomNode>, destination: Element<DomNode>, style: string): void => {
   getRaw(source, style).each((value) => {
     // NOTE: We don't want to clobber any existing inline styles.
     if (getRaw(destination, style).isNone()) {
@@ -166,7 +168,7 @@ const transferOne = (source: Element<DomNode>, destination: Element<DomNode>, st
   });
 };
 
-const transfer = (source: Element<DomNode>, destination: Element<DomNode>, styles: string[]) => {
+const transfer = (source: Element<DomNode>, destination: Element<DomNode>, styles: string[]): void => {
   if (!Node.isElement(source) || !Node.isElement(destination)) {
     return;
   }

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/CssProperty.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/CssProperty.ts
@@ -3,11 +3,14 @@ import Element from '../node/Element';
 import * as Css from './Css';
 
 export default (property: string, value: string) => {
-  const is = (element: Element<DomElement>) => Css.get(element, property) === value;
+  const is = (element: Element<DomElement>): boolean =>
+    Css.get(element, property) === value;
 
-  const remove = (element: Element<DomNode>) => Css.remove(element, property);
+  const remove = (element: Element<DomNode>): void =>
+    Css.remove(element, property);
 
-  const set = (element: Element<DomNode>) => Css.set(element, property, value);
+  const set = (element: Element<DomNode>): void =>
+    Css.set(element, property, value);
 
   return {
     is,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Direction.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Direction.ts
@@ -2,9 +2,11 @@ import { Element as DomElement } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as Css from './Css';
 
-const onDirection = <T = any> (isLtr: T, isRtl: T) => (element: Element<DomElement>) => getDirection(element) === 'rtl' ? isRtl : isLtr;
+const onDirection = <T = any> (isLtr: T, isRtl: T) => (element: Element<DomElement>): T =>
+  getDirection(element) === 'rtl' ? isRtl : isLtr;
 
-const getDirection = (element: Element<DomElement>): 'rtl' | 'ltr' => Css.get(element, 'direction') === 'rtl' ? 'rtl' : 'ltr';
+const getDirection = (element: Element<DomElement>): 'rtl' | 'ltr' =>
+  Css.get(element, 'direction') === 'rtl' ? 'rtl' : 'ltr';
 
 export {
   onDirection,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Float.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Float.ts
@@ -4,7 +4,7 @@ import * as Style from '../../impl/Style';
 import Element from '../node/Element';
 import * as Css from './Css';
 
-const isCentered = (element: Element<DomNode>) => {
+const isCentered = (element: Element<DomNode>): boolean => {
   const dom = element.dom();
   if (Style.isSupported(dom)) {
     const marginLeft = dom.style.marginRight;
@@ -15,7 +15,7 @@ const isCentered = (element: Element<DomNode>) => {
   }
 };
 
-const divine = (element: Element<DomElement>) => {
+const divine = (element: Element<DomElement>): Option<string> => {
   if (isCentered(element)) {
     return Option.some('center');
   } else {
@@ -24,9 +24,10 @@ const divine = (element: Element<DomElement>) => {
   }
 };
 
-const getRaw = (element: Element<DomNode>) => Css.getRaw(element, 'float').getOrNull();
+const getRaw = (element: Element<DomNode>): string | null =>
+  Css.getRaw(element, 'float').getOrNull();
 
-const setCentered = (element: Element<DomNode>) => {
+const setCentered = (element: Element<DomNode>): void => {
   Css.setAll(element, {
     'margin-left': 'auto',
     'margin-right': 'auto'

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Html.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Html.ts
@@ -6,9 +6,10 @@ import Element from '../node/Element';
 import * as Elements from '../node/Elements';
 import * as Traverse from '../search/Traverse';
 
-const get = (element: Element<HTMLElement>) => element.dom().innerHTML;
+const get = (element: Element<HTMLElement>): string =>
+  element.dom().innerHTML;
 
-const set = (element: Element<DomNode>, content: string) => {
+const set = (element: Element<DomNode>, content: string): void => {
   const owner = Traverse.owner(element);
   const docDom = owner.dom();
 
@@ -21,7 +22,7 @@ const set = (element: Element<DomNode>, content: string) => {
   Insert.append(element, fragment);
 };
 
-const getOuter = (element: Element<DomNode>) => {
+const getOuter = (element: Element<DomNode>): string => {
   const container = Element.fromTag('div');
   const clone = Element.fromDom(element.dom().cloneNode(true));
   Insert.append(container, clone);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/OnNode.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/OnNode.ts
@@ -3,19 +3,20 @@ import Element from '../node/Element';
 import * as Class from './Class';
 import * as Classes from './Classes';
 
-const addClass = (clazz: string) => (element: Element<DomElement>) => {
+const addClass = (clazz: string) => (element: Element<DomElement>): void => {
   Class.add(element, clazz);
 };
 
-const removeClass = (clazz: string) => (element: Element<DomElement>) => {
+const removeClass = (clazz: string) => (element: Element<DomElement>): void => {
   Class.remove(element, clazz);
 };
 
-const removeClasses = (classes: string[]) => (element: Element<DomElement>) => {
+const removeClasses = (classes: string[]) => (element: Element<DomElement>): void => {
   Classes.remove(element, classes);
 };
 
-const hasClass = (clazz: string) => (element: Element<DomNode>) => Class.has(element, clazz);
+const hasClass = (clazz: string) => (element: Element<DomNode>): boolean =>
+  Class.has(element, clazz);
 
 export {
   addClass,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/TextContent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/TextContent.ts
@@ -2,9 +2,11 @@ import { Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 
 // REQUIRES IE9
-const get = (element: Element<DomNode>) => element.dom().textContent;
+const get = (element: Element<DomNode>): string | null =>
+  element.dom().textContent;
 
-const set = (element: Element<DomNode>, value: string) => element.dom().textContent = value;
+const set = (element: Element<DomNode>, value: string): string =>
+  element.dom().textContent = value;
 
 export {
   get,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Toggler.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Toggler.ts
@@ -1,22 +1,23 @@
 export default (turnOff: () => void, turnOn: () => void, initial: boolean) => {
   let active = initial || false;
 
-  const on = () => {
+  const on = (): void => {
     turnOn();
     active = true;
   };
 
-  const off = () => {
+  const off = (): void => {
     turnOff();
     active = false;
   };
 
-  const toggle = () => {
+  const toggle = (): void => {
     const f = active ? off : on;
     f();
   };
 
-  const isOn = () => active;
+  const isOn = (): boolean =>
+    active;
 
   return {
     on,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Value.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Value.ts
@@ -3,9 +3,10 @@ import Element from '../node/Element';
 
 type TogglableElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | HTMLOptionElement | HTMLButtonElement;
 
-const get = (element: Element<TogglableElement>) => element.dom().value;
+const get = (element: Element<TogglableElement>): string =>
+  element.dom().value;
 
-const set = (element: Element<TogglableElement>, value: string) => {
+const set = (element: Element<TogglableElement>, value: string): void => {
   if (value === undefined) {
     throw new Error('Value.set was undefined');
   }

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Has.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Has.ts
@@ -4,19 +4,19 @@ import * as Compare from '../dom/Compare';
 import Element from '../node/Element';
 import * as PredicateExists from './PredicateExists';
 
-const ancestor = (element: Element<DomNode>, target: Element<DomNode>) =>
+const ancestor = (element: Element<DomNode>, target: Element<DomNode>): boolean =>
   PredicateExists.ancestor(element, Fun.curry(Compare.eq, target));
 
-const anyAncestor = (element: Element<DomNode>, targets: Element<DomNode>[]) =>
+const anyAncestor = (element: Element<DomNode>, targets: Element<DomNode>[]): boolean =>
   Arr.exists(targets, (target) => ancestor(element, target));
 
-const sibling = (element: Element<DomNode>, targets: Element<DomNode>[]) =>
+const sibling = (element: Element<DomNode>, targets: Element<DomNode>[]): boolean =>
   PredicateExists.sibling(element, (elem) => Arr.exists(targets, Fun.curry(Compare.eq, elem)));
 
-const child = (element: Element<DomNode>, target: Element<DomNode>) =>
+const child = (element: Element<DomNode>, target: Element<DomNode>): boolean =>
   PredicateExists.child(element, Fun.curry(Compare.eq, target));
 
-const descendant = (element: Element<DomNode>, target: Element<DomNode>) =>
+const descendant = (element: Element<DomNode>, target: Element<DomNode>): boolean =>
   PredicateExists.descendant(element, Fun.curry(Compare.eq, target));
 
 export { ancestor, anyAncestor, sibling, child, descendant };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateExists.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateExists.ts
@@ -2,22 +2,22 @@ import { Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as PredicateFind from './PredicateFind';
 
-const any = (predicate: (e: Element<DomNode>) => boolean) =>
+const any = (predicate: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.first(predicate).isSome();
 
-const ancestor = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean, isRoot?: (e: Element<DomNode>) => boolean) =>
+const ancestor = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean, isRoot?: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.ancestor(scope, predicate, isRoot).isSome();
 
-const closest = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean, isRoot?: (e: Element<DomNode>) => boolean) =>
+const closest = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean, isRoot?: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.closest(scope, predicate, isRoot).isSome();
 
-const sibling = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean) =>
+const sibling = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.sibling(scope, predicate).isSome();
 
-const child = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean) =>
+const child = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.child(scope, predicate).isSome();
 
-const descendant = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean) =>
+const descendant = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.descendant(scope, predicate).isSome();
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorExists.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorExists.ts
@@ -5,19 +5,19 @@ import * as SelectorFind from './SelectorFind';
 const any = (selector: string) =>
   SelectorFind.first(selector).isSome();
 
-const ancestor = (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean) =>
+const ancestor = (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean): boolean =>
   SelectorFind.ancestor(scope, selector, isRoot).isSome();
 
-const sibling = (scope: Element<DomNode>, selector: string) =>
+const sibling = (scope: Element<DomNode>, selector: string): boolean =>
   SelectorFind.sibling(scope, selector).isSome();
 
-const child = (scope: Element<DomNode>, selector: string) =>
+const child = (scope: Element<DomNode>, selector: string): boolean =>
   SelectorFind.child(scope, selector).isSome();
 
-const descendant = (scope: Element<DomNode>, selector: string) =>
+const descendant = (scope: Element<DomNode>, selector: string): boolean =>
   SelectorFind.descendant(scope, selector).isSome();
 
-const closest = (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean) =>
+const closest = (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean): boolean =>
   SelectorFind.closest(scope, selector, isRoot).isSome();
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFilter.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFilter.ts
@@ -3,7 +3,8 @@ import Element from '../node/Element';
 import * as PredicateFilter from './PredicateFilter';
 import * as Selectors from './Selectors';
 
-const all = <T extends DomElement = DomElement> (selector: string) => Selectors.all<T>(selector);
+const all = <T extends DomElement = DomElement> (selector: string): Element<T>[] =>
+  Selectors.all<T>(selector);
 
 // For all of the following:
 //
@@ -11,22 +12,23 @@ const all = <T extends DomElement = DomElement> (selector: string) => Selectors.
 // Traverse should also do this (but probably not by default).
 //
 
-const ancestors = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean) =>
+const ancestors = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean): Element<T>[] =>
   // It may surprise you to learn this is exactly what JQuery does
   // TODO: Avoid all this wrapping and unwrapping
   PredicateFilter.ancestors(scope, (e): e is Element<T> => Selectors.is<T>(e, selector), isRoot);
 
-const siblings = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) =>
+const siblings = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Element<T>[] =>
   // It may surprise you to learn this is exactly what JQuery does
   // TODO: Avoid all the wrapping and unwrapping
   PredicateFilter.siblings(scope, (e): e is Element<T> => Selectors.is<T>(e, selector));
 
-const children = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) =>
+const children = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Element<T>[] =>
   // It may surprise you to learn this is exactly what JQuery does
   // TODO: Avoid all the wrapping and unwrapping
   PredicateFilter.children(scope, (e): e is Element<T> => Selectors.is<T>(e, selector));
 
-const descendants = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) => Selectors.all<T>(selector, scope);
+const descendants = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Element<T>[] =>
+  Selectors.all<T>(selector, scope);
 
 export {
   all,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFind.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFind.ts
@@ -19,7 +19,7 @@ const sibling = <T extends DomElement = DomElement> (scope: Element<DomNode>, se
 const child = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) =>
   PredicateFind.child(scope, (e): e is Element<T> => Selectors.is<T>(e, selector));
 
-const descendant = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) =>
+const descendant = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Option<Element<T>> =>
   Selectors.one<T>(selector, scope);
 
 // Returns Some(closest ancestor element (sugared)) matching 'selector' up to isRoot, or None() otherwise

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFind.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFind.ts
@@ -1,4 +1,4 @@
-import { Element as DomElement, Node as DomNode } from '@ephox/dom-globals';
+import { ChildNode, Element as DomElement, Node as DomNode } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 import ClosestOrAncestor from '../../impl/ClosestOrAncestor';
 import Element from '../node/Element';
@@ -7,16 +7,16 @@ import * as Selectors from './Selectors';
 
 // TODO: An internal SelectorFilter module that doesn't Element.fromDom() everything
 
-const first = <T extends DomElement = DomElement> (selector: string) =>
+const first = <T extends DomElement = DomElement> (selector: string): Option<Element<T>> =>
   Selectors.one<T>(selector);
 
-const ancestor = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean) =>
+const ancestor = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean): Option<Element<T>> =>
   PredicateFind.ancestor(scope, (e): e is Element<T> => Selectors.is<T>(e, selector), isRoot);
 
-const sibling = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) =>
+const sibling = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Option<Element<T & ChildNode>> =>
   PredicateFind.sibling(scope, (e): e is Element<T> => Selectors.is<T>(e, selector));
 
-const child = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) =>
+const child = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Option<Element<T & ChildNode>> =>
   PredicateFind.child(scope, (e): e is Element<T> => Selectors.is<T>(e, selector));
 
 const descendant = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Option<Element<T>> =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Selectors.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Selectors.ts
@@ -24,7 +24,7 @@ const is = <T extends DomElement = DomElement> (element: Element<DomNode>, selec
   }
 };
 
-const bypassSelector = (dom: DomNode) =>
+const bypassSelector = (dom: DomNode): boolean =>
   // Only elements, documents and shadow roots support querySelector
   // shadow root element type is DOCUMENT_FRAGMENT
   dom.nodeType !== ELEMENT && dom.nodeType !== DOCUMENT && dom.nodeType !== DOCUMENT_FRAGMENT ||

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Selectors.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Selectors.ts
@@ -36,7 +36,7 @@ const all = <T extends DomElement = DomElement> (selector: string, scope?: Eleme
   return bypassSelector(base) ? [] : Arr.map((base as DomElement | Document).querySelectorAll<T>(selector), Element.fromDom);
 };
 
-const one = <T extends DomElement = DomElement> (selector: string, scope?: Element<DomNode>) => {
+const one = <T extends DomElement = DomElement> (selector: string, scope?: Element<DomNode>): Option<Element<T>> => {
   const base = scope === undefined ? document : scope.dom();
   return bypassSelector(base) ? Option.none<Element<T>>() : Option.from((base as DomElement | Document).querySelector<T>(selector)).map(Element.fromDom);
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/TransformFind.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/TransformFind.ts
@@ -2,7 +2,8 @@ import { Node as DomNode } from '@ephox/dom-globals';
 import { Fun, Option, Type } from '@ephox/katamari';
 import Element from '../node/Element';
 
-const ensureIsRoot = (isRoot?: (e: Element<DomNode>) => boolean) => Type.isFunction(isRoot) ? isRoot : Fun.constant(false);
+const ensureIsRoot = (isRoot?: (e: Element<DomNode>) => boolean): (e: Element<DomNode>) => boolean =>
+  Type.isFunction(isRoot) ? isRoot : Fun.constant(false);
 
 const ancestor = <A> (scope: Element<DomNode>, transform: (e: Element<DomNode>) => Option<A>, isRoot?: (e: Element<DomNode>) => boolean): Option<A> => {
   let element = scope.dom();

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
@@ -1,4 +1,4 @@
-import { Document, HTMLElement, Node as DomNode } from '@ephox/dom-globals';
+import { Document, HTMLElement, Node as DomNode, Window, Element as DomElement, ChildNode } from '@ephox/dom-globals';
 import { Arr, Fun, Option, Type } from '@ephox/katamari';
 import * as Recurse from '../../alien/Recurse';
 import * as Compare from '../dom/Compare';
@@ -9,7 +9,8 @@ import * as Node from '../node/Node';
  * The document associated with the current element
  * NOTE: this will throw if the owner is null.
  */
-const owner = (element: Element<DomNode>) => Element.fromDom(element.dom().ownerDocument);
+const owner = (element: Element<DomNode>): Element<Document> =>
+  Element.fromDom(element.dom().ownerDocument);
 
 /**
  * If the element is a document, return it. Otherwise, return its ownerDocument.
@@ -18,20 +19,24 @@ const owner = (element: Element<DomNode>) => Element.fromDom(element.dom().owner
 const documentOrOwner = (dos: Element<DomNode>): Element<Document> =>
   Node.isDocument(dos) ? dos : owner(dos);
 
-const documentElement = (element: Element<DomNode>) => Element.fromDom(element.dom().ownerDocument.documentElement);
+const documentElement = (element: Element<DomNode>): Element<HTMLElement> =>
+  Element.fromDom(element.dom().ownerDocument.documentElement);
 
 // The window element associated with the element
-const defaultView = (element: Element<DomNode>) => Element.fromDom(element.dom().ownerDocument.defaultView);
+const defaultView = (element: Element<DomNode>): Element<Window> =>
+  Element.fromDom(element.dom().ownerDocument.defaultView);
 
-const parent = (element: Element<DomNode>) => Option.from(element.dom().parentNode).map(Element.fromDom);
+const parent = (element: Element<DomNode>): Option<Element<DomNode>> =>
+  Option.from(element.dom().parentNode).map(Element.fromDom);
 
-const findIndex = (element: Element<DomNode>) => parent(element).bind((p) => {
-  // TODO: Refactor out children so we can avoid the constant unwrapping
-  const kin = children(p);
-  return Arr.findIndex(kin, (elem) => Compare.eq(element, elem));
-});
+const findIndex = (element: Element<DomNode>): Option<number> =>
+  parent(element).bind((p) => {
+    // TODO: Refactor out children so we can avoid the constant unwrapping
+    const kin = children(p);
+    return Arr.findIndex(kin, (elem) => Compare.eq(element, elem));
+  });
 
-const parents = (element: Element<DomNode>, isRoot?: (e: Element<DomNode>) => boolean) => {
+const parents = (element: Element<DomNode>, isRoot?: (e: Element<DomNode>) => boolean): Element<DomNode>[] => {
   const stop = Type.isFunction(isRoot) ? isRoot : Fun.never;
 
   // This is used a *lot* so it needs to be performant, not recursive
@@ -43,7 +48,7 @@ const parents = (element: Element<DomNode>, isRoot?: (e: Element<DomNode>) => bo
     const p = Element.fromDom(rawParent);
     ret.push(p);
 
-    if (stop(p) === true) {
+    if (stop(p)) {
       break;
     } else {
       dom = rawParent;
@@ -52,38 +57,48 @@ const parents = (element: Element<DomNode>, isRoot?: (e: Element<DomNode>) => bo
   return ret;
 };
 
-const siblings = (element: Element<DomNode>) => {
+const siblings = (element: Element<DomNode>): Element<DomNode>[] => {
   // TODO: Refactor out children so we can just not add self instead of filtering afterwards
   const filterSelf = <E> (elements: Element<E>[]) => Arr.filter(elements, (x) => !Compare.eq(element, x));
 
   return parent(element).map(children).map(filterSelf).getOr([]);
 };
 
-const offsetParent = (element: Element<HTMLElement>) => Option.from(element.dom().offsetParent).map(Element.fromDom);
+const offsetParent = (element: Element<HTMLElement>): Option<Element<DomElement>> =>
+  Option.from(element.dom().offsetParent).map(Element.fromDom);
 
-const prevSibling = (element: Element<DomNode>) => Option.from(element.dom().previousSibling).map(Element.fromDom);
+const prevSibling = (element: Element<DomNode>): Option<Element<DomNode>> =>
+  Option.from(element.dom().previousSibling).map(Element.fromDom);
 
-const nextSibling = (element: Element<DomNode>) => Option.from(element.dom().nextSibling).map(Element.fromDom);
+const nextSibling = (element: Element<DomNode>): Option<Element<DomNode>> =>
+  Option.from(element.dom().nextSibling).map(Element.fromDom);
 
 // This one needs to be reversed, so they're still in DOM order
-const prevSiblings = (element: Element<DomNode>) => Arr.reverse(Recurse.toArray(element, prevSibling));
+const prevSiblings = (element: Element<DomNode>): Element<DomNode>[] =>
+  Arr.reverse(Recurse.toArray(element, prevSibling));
 
-const nextSiblings = (element: Element<DomNode>) => Recurse.toArray(element, nextSibling);
+const nextSiblings = (element: Element<DomNode>): Element<DomNode>[] =>
+  Recurse.toArray(element, nextSibling);
 
-const children = (element: Element<DomNode>) => Arr.map(element.dom().childNodes, Element.fromDom);
+const children = (element: Element<DomNode>): Element<DomNode & ChildNode>[] =>
+  Arr.map(element.dom().childNodes, Element.fromDom);
 
-const child = (element: Element<DomNode>, index: number) => {
+const child = (element: Element<DomNode>, index: number): Option<Element<DomNode & ChildNode>> => {
   const cs = element.dom().childNodes;
-  return Option.from(cs[index] as DomNode).map(Element.fromDom);
+  return Option.from(cs[index]).map(Element.fromDom);
 };
 
-const firstChild = (element: Element<DomNode>) => child(element, 0);
+const firstChild = (element: Element<DomNode>): Option<Element<DomNode & ChildNode>> =>
+  child(element, 0);
 
-const lastChild = (element: Element<DomNode>) => child(element, element.dom().childNodes.length - 1);
+const lastChild = (element: Element<DomNode>): Option<Element<DomNode & ChildNode>> =>
+  child(element, element.dom().childNodes.length - 1);
 
-const childNodesCount = (element: Element<DomNode>) => element.dom().childNodes.length;
+const childNodesCount = (element: Element<DomNode>): number =>
+  element.dom().childNodes.length;
 
-const hasChildNodes = (element: Element<DomNode>) => element.dom().hasChildNodes();
+const hasChildNodes = (element: Element<DomNode>): boolean =>
+  element.dom().hasChildNodes();
 
 export interface ElementAndOffset<E> {
   readonly element: () => Element<E>;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
@@ -5,24 +5,27 @@ import * as Node from '../node/Node';
 import * as Text from '../node/Text';
 import * as Traverse from '../search/Traverse';
 
-const getEnd = (element: Element<DomNode>) =>
+const getEnd = (element: Element<DomNode>): number =>
   Node.name(element) === 'img' ? 1 : Text.getOption(element).fold(
     () => Traverse.children(element).length,
     (v) => v.length
   );
 
-const isEnd = (element: Element<DomNode>, offset: number) => getEnd(element) === offset;
+const isEnd = (element: Element<DomNode>, offset: number): boolean =>
+  getEnd(element) === offset;
 
-const isStart = (element: Element<DomNode>, offset: number) => offset === 0;
+const isStart = (element: Element<DomNode>, offset: number): boolean =>
+  offset === 0;
 
-const isTextNodeWithCursorPosition = (el: Element<DomNode>) => Text.getOption(el).filter((text) =>
+const isTextNodeWithCursorPosition = (el: Element<DomNode>): boolean =>
+  Text.getOption(el).filter((text) =>
   // For the purposes of finding cursor positions only allow text nodes with content,
   // but trim removes &nbsp; and that's allowed
-  text.trim().length !== 0 || text.indexOf(Unicode.nbsp) > -1
-).isSome();
+    text.trim().length !== 0 || text.indexOf(Unicode.nbsp) > -1
+  ).isSome();
 
 const elementsWithCursorPosition = [ 'img', 'br' ];
-const isCursorPosition = (elem: Element<DomNode>) => {
+const isCursorPosition = (elem: Element<DomNode>): boolean => {
   const hasCursorPosition = isTextNodeWithCursorPosition(elem);
   return hasCursorPosition || Arr.contains(elementsWithCursorPosition, Node.name(elem));
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/CursorPosition.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/CursorPosition.ts
@@ -5,9 +5,11 @@ import * as PredicateFind from '../search/PredicateFind';
 import * as Traverse from '../search/Traverse';
 import * as Awareness from './Awareness';
 
-const first = (element: Element<DomNode>) => PredicateFind.descendant(element, Awareness.isCursorPosition);
+const first = (element: Element<DomNode>): Option<Element<DomNode & ChildNode>> =>
+  PredicateFind.descendant(element, Awareness.isCursorPosition);
 
-const last = (element: Element<DomNode>) => descendantRtl(element, Awareness.isCursorPosition);
+const last = (element: Element<DomNode>): Option<Element<DomNode & ChildNode>> =>
+  descendantRtl(element, Awareness.isCursorPosition);
 
 // Note, sugar probably needs some RTL traversals.
 const descendantRtl: {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Edge.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Edge.ts
@@ -7,33 +7,33 @@ import * as CursorPosition from './CursorPosition';
 
 // not sure where the "correct" interface is declared, doesn't seem to be in Sugar
 interface SelectionStart {
-  startContainer: () => Element<DomNode>;
-  startOffset: () => number;
+  readonly startContainer: () => Element<DomNode>;
+  readonly startOffset: () => number;
 }
 
 type DescentFn = (element: Element<DomNode>) => Option<Element<DomNode & ChildNode>>;
 type AwarenessFn = (element: Element<DomNode>, offset: number) => boolean;
 
-const isAtEdge = (parent: Element<DomNode>, current: Element<DomNode>, currentOffset: number, descent: DescentFn, awareness: AwarenessFn) =>
+const isAtEdge = (parent: Element<DomNode>, current: Element<DomNode>, currentOffset: number, descent: DescentFn, awareness: AwarenessFn): boolean =>
   descent(parent).fold(
     () => true,
     (element) => Compare.eq(current, element) && awareness(current, currentOffset)
   );
 
-const isLeft = (parent: Element<DomNode>, selection: SelectionStart) =>
+const isLeft = (parent: Element<DomNode>, selection: SelectionStart): boolean =>
   isAtEdge(parent, selection.startContainer(), selection.startOffset(), CursorPosition.first, Awareness.isStart);
 
 // This is doing exactly the same thing as the above isLeft method, checking to see if an element/offset selection endpoint is at the left edge of its parent
 // after ascending up to that parent except we explicitly provide the element and its offset instead of just using the selection object.
-const isAtLeftEdge = (parent: Element<DomNode>, element: Element<DomNode>, offset: number) =>
+const isAtLeftEdge = (parent: Element<DomNode>, element: Element<DomNode>, offset: number): boolean =>
   isAtEdge(parent, element, offset, CursorPosition.first, Awareness.isStart);
 
-const isRight = (parent: Element<DomNode>, selection: SelectionStart) =>
+const isRight = (parent: Element<DomNode>, selection: SelectionStart): boolean =>
   isAtEdge(parent, selection.startContainer(), selection.startOffset(), CursorPosition.last, Awareness.isEnd);
 
 // This is doing exactly the same thing as the above isRight method, checking to see if an element/offset selection endpoint is at the right edge of its parent
 // after ascending up to that parent except we explicitly provide the element and its offset instead of just using the selection object.
-const isAtRightEdge = (parent: Element<DomNode>, element: Element<DomNode>, offset: number) =>
+const isAtRightEdge = (parent: Element<DomNode>, element: Element<DomNode>, offset: number): boolean =>
   isAtEdge(parent, element, offset, CursorPosition.last, Awareness.isEnd);
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Rect.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Rect.ts
@@ -2,21 +2,21 @@
  * @deprecated Use RawRect instead
  */
 export interface StructRect {
-  left: () => number;
-  top: () => number;
-  right: () => number;
-  bottom: () => number;
-  width: () => number;
-  height: () => number;
+  readonly left: () => number;
+  readonly top: () => number;
+  readonly right: () => number;
+  readonly bottom: () => number;
+  readonly width: () => number;
+  readonly height: () => number;
 }
 
 export interface RawRect {
-  left: number;
-  top: number;
-  right: number;
-  bottom: number;
-  width: number;
-  height: number;
+  readonly left: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly width: number;
+  readonly height: number;
 }
 
 const toRaw = (sr: StructRect): RawRect => ({

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/SimRange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/SimRange.ts
@@ -3,10 +3,10 @@ import { Fun } from '@ephox/katamari';
 import Element from '../node/Element';
 
 export interface SimRange {
-  start: () => Element<DomNode>;
-  soffset: () => number;
-  finish: () => Element<DomNode>;
-  foffset: () => number;
+  readonly start: () => Element<DomNode>;
+  readonly soffset: () => number;
+  readonly finish: () => Element<DomNode>;
+  readonly foffset: () => number;
 }
 
 const create = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): SimRange => ({

--- a/modules/sugar/src/main/ts/ephox/sugar/api/tag/OptionTag.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/tag/OptionTag.ts
@@ -1,7 +1,7 @@
 import { HTMLOptionElement } from '@ephox/dom-globals';
 import Element from '../node/Element';
 
-const setValue = (option: Element<HTMLOptionElement>, value: string, text: string) => {
+const setValue = (option: Element<HTMLOptionElement>, value: string, text: string): void => {
   const optionDom = option.dom();
   optionDom.value = value;
   optionDom.text = text;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/tag/SelectTag.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/tag/SelectTag.ts
@@ -2,27 +2,27 @@ import { HTMLOptionElement, HTMLOptionsCollection, HTMLSelectElement } from '@ep
 import { Arr, Option } from '@ephox/katamari';
 import Element from '../node/Element';
 
-const getValueFromIndex = (options: HTMLOptionsCollection, index: number) => {
+const getValueFromIndex = (options: HTMLOptionsCollection, index: number): Option<string> => {
   const optionVal = options[index];
   return optionVal === undefined || index === -1 ? Option.none<string>() : Option.from(optionVal.value);
 };
 
-const getValue = (select: Element<HTMLSelectElement>) => {
+const getValue = (select: Element<HTMLSelectElement>): Option<string> => {
   const selectDom = select.dom();
   return getValueFromIndex(selectDom.options, selectDom.selectedIndex);
 };
 
-const add = (select: Element<HTMLSelectElement>, option: Element<HTMLOptionElement>) => {
+const add = (select: Element<HTMLSelectElement>, option: Element<HTMLOptionElement>): void => {
   select.dom().add(option.dom());
 };
 
-const addAll = (select: Element<HTMLSelectElement>, options: Element<HTMLOptionElement>[]) => {
+const addAll = (select: Element<HTMLSelectElement>, options: Element<HTMLOptionElement>[]): void => {
   Arr.each(options, (option) => {
     add(select, option);
   });
 };
 
-const setSelected = (select: Element<HTMLSelectElement>, index: number) => {
+const setSelected = (select: Element<HTMLSelectElement>, index: number): void => {
   select.dom().selectedIndex = index;
 };
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Height.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Height.ts
@@ -4,19 +4,22 @@ import * as Body from '../node/Body';
 import Element from '../node/Element';
 import * as Css from '../properties/Css';
 
-const api = Dimension('height', (element: Element<HTMLElement>) => {
+const api = Dimension('height', (element: Element<HTMLElement>): number => {
   // getBoundingClientRect gives better results than offsetHeight for tables with captions on Firefox
   const dom = element.dom();
   return Body.inBody(element) ? dom.getBoundingClientRect().height : dom.offsetHeight;
 });
 
-const set = (element: Element<DomNode>, h: number | string) => api.set(element, h);
+const set = (element: Element<DomNode>, h: number | string): void =>
+  api.set(element, h);
 
-const get = (element: Element<HTMLElement>) => api.get(element);
+const get = (element: Element<HTMLElement>): number =>
+  api.get(element);
 
-const getOuter = (element: Element<HTMLElement>) => api.getOuter(element);
+const getOuter = (element: Element<HTMLElement>): number =>
+  api.getOuter(element);
 
-const setMax = (element: Element<DomElement>, value: number) => {
+const setMax = (element: Element<DomElement>, value: number): void => {
   // These properties affect the absolute max-height, they are not counted natively, we want to include these properties.
   const inclusions = [ 'margin-top', 'border-top-width', 'padding-top', 'padding-bottom', 'border-bottom-width', 'margin-bottom' ];
   const absMax = api.max(element, value, inclusions);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Location.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Location.ts
@@ -3,13 +3,13 @@ import { inBody } from '../node/Body';
 import Element from '../node/Element';
 import { Position } from './Position';
 
-const boxPosition = (dom: DomElement) => {
+const boxPosition = (dom: DomElement): Position => {
   const box = dom.getBoundingClientRect();
   return Position(box.left, box.top);
 };
 
 // Avoids falsy false fallthrough
-const firstDefinedOrZero = (a: number, b: number) => {
+const firstDefinedOrZero = (a: number, b: number): number => {
   if (a !== undefined) {
     return a;
   } else {
@@ -17,7 +17,7 @@ const firstDefinedOrZero = (a: number, b: number) => {
   }
 };
 
-const absolute = (element: Element<DomElement>) => {
+const absolute = (element: Element<DomElement>): Position => {
   const doc = element.dom().ownerDocument;
   const body = doc.body;
   const win = doc.defaultView;
@@ -41,14 +41,14 @@ const absolute = (element: Element<DomElement>) => {
 // This is the old $.position(), but JQuery does nonsense calculations.
 // We're only 1 <-> 1 with the old value in the single place we use this function
 // (ego.api.Dragging) so the rest can bite me.
-const relative = (element: Element<HTMLElement>) => {
+const relative = (element: Element<HTMLElement>): Position => {
   const dom = element.dom();
   // jquery-ism: when style="position: fixed", this === boxPosition()
   // but tests reveal it returns the same thing anyway
   return Position(dom.offsetLeft, dom.offsetTop);
 };
 
-const viewport = (element: Element<DomElement>) => {
+const viewport = (element: Element<DomElement>): Position => {
   const dom = element.dom();
 
   const doc = dom.ownerDocument;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Platform.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Platform.ts
@@ -3,8 +3,8 @@ import { Arr, Option } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
 interface ChoiceOption<T> {
-  predicate: () => boolean;
-  value: () => T;
+  readonly predicate: () => boolean;
+  readonly value: () => T;
 }
 
 const platform = PlatformDetection.detect();
@@ -18,7 +18,8 @@ const MINIMUM_LARGE_HEIGHT = 700;
 // window.screen.width and window.screen.height do not change with the orientation,
 // however window.screen.availableWidth and window.screen.availableHeight,
 // do change according to the orientation.
-const isOfSize = (width: number, height: number) => window.screen.width >= width && window.screen.height >= height;
+const isOfSize = (width: number, height: number): boolean =>
+  window.screen.width >= width && window.screen.height >= height;
 
 const choice = <T> (options: ChoiceOption<T>[], fallback: T): T => {
   const target = Arr.foldl(options, (b, option) => b.orThunk(() =>
@@ -28,14 +29,19 @@ const choice = <T> (options: ChoiceOption<T>[], fallback: T): T => {
   return target.getOr(fallback);
 };
 
-const isLargeTouch = () => isOfSize(MINIMUM_LARGE_WIDTH, MINIMUM_LARGE_HEIGHT) && isTouch();
+const isLargeTouch = (): boolean =>
+  isOfSize(MINIMUM_LARGE_WIDTH, MINIMUM_LARGE_HEIGHT) && isTouch();
 
-const isLargeDesktop = () => isOfSize(MINIMUM_LARGE_WIDTH, MINIMUM_LARGE_HEIGHT) && !isTouch();
+const isLargeDesktop = (): boolean =>
+  isOfSize(MINIMUM_LARGE_WIDTH, MINIMUM_LARGE_HEIGHT) && !isTouch();
 
-const isSmallTouch = () => !isOfSize(MINIMUM_LARGE_WIDTH, MINIMUM_LARGE_HEIGHT) && isTouch();
+const isSmallTouch = (): boolean =>
+  !isOfSize(MINIMUM_LARGE_WIDTH, MINIMUM_LARGE_HEIGHT) && isTouch();
 
-const isLarge = () => isOfSize(MINIMUM_LARGE_WIDTH, MINIMUM_LARGE_HEIGHT);
+const isLarge = (): boolean =>
+  isOfSize(MINIMUM_LARGE_WIDTH, MINIMUM_LARGE_HEIGHT);
 
-const isSmallAndroid = () => isSmallTouch() && isAndroid();
+const isSmallAndroid = (): boolean =>
+  isSmallTouch() && isAndroid();
 
 export { isTouch, choice, isLarge, isLargeTouch, isSmallTouch, isLargeDesktop, isSmallAndroid };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Scroll.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Scroll.ts
@@ -9,7 +9,7 @@ import * as Location from './Location';
 import { Position } from './Position';
 
 // get scroll position (x,y) relative to document _doc (or global if not supplied)
-const get = (_DOC?: Element<Document>) => {
+const get = (_DOC?: Element<Document>): Position => {
   const doc = _DOC !== undefined ? _DOC.dom() : document;
 
   // ASSUMPTION: This is for cross-browser support, body works for Safari & EDGE, and when we have an iframe body scroller
@@ -19,28 +19,28 @@ const get = (_DOC?: Element<Document>) => {
 };
 
 // Scroll content to (x,y) relative to document _doc (or global if not supplied)
-const to = (x: number, y: number, _DOC?: Element<Document>) => {
+const to = (x: number, y: number, _DOC?: Element<Document>): void => {
   const doc = _DOC !== undefined ? _DOC.dom() : document;
   const win = doc.defaultView;
   win.scrollTo(x, y);
 };
 
 // Scroll content by (x,y) relative to document _doc (or global if not supplied)
-const by = (x: number, y: number, _DOC?: Element<Document>) => {
+const by = (x: number, y: number, _DOC?: Element<Document>): void => {
   const doc = _DOC !== undefined ? _DOC.dom() : document;
   const win = doc.defaultView;
   win.scrollBy(x, y);
 };
 
 // Set the window scroll position to the element
-const setToElement = (win: Window, element: Element<DomElement>) => {
+const setToElement = (win: Window, element: Element<DomElement>): void => {
   const pos = Location.absolute(element);
   const doc = Element.fromDom(win.document);
   to(pos.left(), pos.top(), doc);
 };
 
 // call f() preserving the original scroll position relative to document doc
-const preserve = (doc: Element<Document>, f: () => void) => {
+const preserve = (doc: Element<Document>, f: () => void): void => {
   const before = get(doc);
   f();
   const after = get(doc);
@@ -53,12 +53,12 @@ const preserve = (doc: Element<Document>, f: () => void) => {
 const capture = (doc: Element<Document>) => {
   let previous = Option.none<Position>();
 
-  const save = () => {
+  const save = (): void => {
     previous = Option.some(get(doc));
   };
 
   // TODO: this is quite similar to the code in nomad.
-  const restore = () => {
+  const restore = (): void => {
     previous.each((p) => {
       to(p.left(), p.top(), doc);
     });
@@ -72,7 +72,7 @@ const capture = (doc: Element<Document>) => {
 };
 
 // TBIO-4472 Safari 10 - Scrolling typeahead with keyboard scrolls page
-const intoView = (element: Element<DomElement>, alignToTop: boolean) => {
+const intoView = (element: Element<DomElement>, alignToTop: boolean): void => {
   const isSafari = PlatformDetection.detect().browser.isSafari();
   // this method isn't in TypeScript
   if (isSafari && Type.isFunction((element.dom() as any).scrollIntoViewIfNeeded)) {
@@ -83,7 +83,7 @@ const intoView = (element: Element<DomElement>, alignToTop: boolean) => {
 };
 
 // If the element is above the container, or below the container, then scroll to the top or bottom
-const intoViewIfNeeded = (element: Element<DomElement>, container: Element<DomElement>) => {
+const intoViewIfNeeded = (element: Element<DomElement>, container: Element<DomElement>): void => {
   const containerBox = container.dom().getBoundingClientRect();
   const elementBox = element.dom().getBoundingClientRect();
   if (elementBox.top < containerBox.top) {
@@ -96,7 +96,7 @@ const intoViewIfNeeded = (element: Element<DomElement>, container: Element<DomEl
 };
 
 // Return the scroll bar width (calculated by temporarily inserting an element into the dom)
-const scrollBarWidth = () => {
+const scrollBarWidth = (): number => {
   // From https://davidwalsh.name/detect-scrollbar-width
   const scrollDiv = Element.fromHtml<HTMLDivElement>('<div style="width: 100px; height: 100px; overflow: scroll; position: absolute; top: -9999px;"></div>');
   Insert.after(Body.body(), scrollDiv);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Visibility.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Visibility.ts
@@ -19,7 +19,8 @@ const visibilityToggler = (element: Element<DomElement>, property: string, hidde
   return Toggler(off, on, false);
 };
 
-const toggler = (element: Element<DomElement>) => visibilityToggler(element, 'visibility', 'hidden', 'visible');
+const toggler = (element: Element<DomElement>) =>
+  visibilityToggler(element, 'visibility', 'hidden', 'visible');
 
 const displayToggler = (element: Element<DomElement>, value: string) => visibilityToggler(element, 'display', 'none', value);
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/VisualViewport.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/VisualViewport.ts
@@ -63,16 +63,17 @@ const getBounds = (_win?: Window): Bounds => {
   );
 };
 
-const bind = (name: string, callback: EventHandler, _win?: Window) => get(_win).map((visualViewport) => {
-  const handler = (e: Event) => fromRawEvent(e);
-  visualViewport.addEventListener(name, handler);
+const bind = (name: string, callback: EventHandler, _win?: Window): { unbind: (...args: any[]) => void } =>
+  get(_win).map((visualViewport) => {
+    const handler = (e: Event) => fromRawEvent(e);
+    visualViewport.addEventListener(name, handler);
 
-  return {
-    unbind: () => visualViewport.removeEventListener(name, handler)
-  };
-}).getOrThunk(() => ({
-  unbind: Fun.noop
-}));
+    return {
+      unbind: () => visualViewport.removeEventListener(name, handler)
+    };
+  }).getOrThunk(() => ({
+    unbind: Fun.noop
+  }));
 
 export {
   bind,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
@@ -3,18 +3,21 @@ import Dimension from '../../impl/Dimension';
 import Element from '../node/Element';
 import * as Css from '../properties/Css';
 
-const api = Dimension('width', (element: Element<HTMLElement>) =>
+const api = Dimension('width', (element: Element<HTMLElement>): number =>
   // IMO passing this function is better than using dom['offset' + 'width']
   element.dom().offsetWidth
 );
 
-const set = (element: Element<DomNode>, h: string | number) => api.set(element, h);
+const set = (element: Element<DomNode>, h: string | number): void =>
+  api.set(element, h);
 
-const get = (element: Element<HTMLElement>) => api.get(element);
+const get = (element: Element<HTMLElement>): number =>
+  api.get(element);
 
-const getOuter = (element: Element<HTMLElement>) => api.getOuter(element);
+const getOuter = (element: Element<HTMLElement>): number =>
+  api.getOuter(element);
 
-const setMax = (element: Element<DomElement>, value: number) => {
+const setMax = (element: Element<DomElement>, value: number): void => {
   // These properties affect the absolute max-height, they are not counted natively, we want to include these properties.
   const inclusions = [ 'margin-left', 'border-left-width', 'padding-left', 'padding-right', 'border-right-width', 'margin-right' ];
   const absMax = api.max(element, value, inclusions);

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/ClassList.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/ClassList.ts
@@ -4,15 +4,19 @@ import Element from '../api/node/Element';
 import * as AttrList from '../api/properties/AttrList';
 
 // IE11 Can return undefined for a classList on elements such as math, so we make sure it's not undefined before attempting to use it.
-const supports = (element: Element<DomNode>): element is Element<DomElement> => (element.dom() as DomElement).classList !== undefined;
+const supports = (element: Element<DomNode>): element is Element<DomElement> =>
+  (element.dom() as DomElement).classList !== undefined;
 
-const get = (element: Element<DomElement>) => AttrList.read(element, 'class');
+const get = (element: Element<DomElement>): string[] =>
+  AttrList.read(element, 'class');
 
-const add = (element: Element<DomElement>, clazz: string) => AttrList.add(element, 'class', clazz);
+const add = (element: Element<DomElement>, clazz: string): boolean =>
+  AttrList.add(element, 'class', clazz);
 
-const remove = (element: Element<DomElement>, clazz: string) => AttrList.remove(element, 'class', clazz);
+const remove = (element: Element<DomElement>, clazz: string): boolean =>
+  AttrList.remove(element, 'class', clazz);
 
-const toggle = (element: Element<DomElement>, clazz: string) => {
+const toggle = (element: Element<DomElement>, clazz: string): boolean => {
   if (Arr.contains(get(element), clazz)) {
     return remove(element, clazz);
   } else {

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/Dimension.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/Dimension.ts
@@ -45,7 +45,7 @@ export default (name: string, getOffset: (e: Element<HTMLElement>) => number) =>
   };
 */
 
-  const get = (element: Element<HTMLElement>) => {
+  const get = (element: Element<HTMLElement>): number => {
     const r = getOffset(element);
 
     // zero or null means non-standard or disconnected, fall back to CSS
@@ -61,13 +61,14 @@ export default (name: string, getOffset: (e: Element<HTMLElement>) => number) =>
   // although these calculations only seem relevant for quirks mode, and edge cases TBIO doesn't rely on
   const getOuter = get;
 
-  const aggregate = (element: Element<DomElement>, properties: string[]) => Arr.foldl(properties, (acc, property) => {
-    const val = Css.get(element, property);
-    const value = val === undefined ? 0 : parseInt(val, 10);
-    return isNaN(value) ? acc : acc + value;
-  }, 0);
+  const aggregate = (element: Element<DomElement>, properties: string[]): number =>
+    Arr.foldl(properties, (acc, property) => {
+      const val = Css.get(element, property);
+      const value = val === undefined ? 0 : parseInt(val, 10);
+      return isNaN(value) ? acc : acc + value;
+    }, 0);
 
-  const max = (element: Element<DomElement>, value: number, properties: string[]) => {
+  const max = (element: Element<DomElement>, value: number, properties: string[]): number => {
     const cumulativeInclusions = aggregate(element, properties);
     // if max-height is 100px and your cumulativeInclusions is 150px, there is no way max-height can be 100px, so we return 0.
     const absoluteMax = value > cumulativeInclusions ? value - cumulativeInclusions : 0;

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/FilteredEvent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/FilteredEvent.ts
@@ -1,8 +1,12 @@
-import { Event, Node } from '@ephox/dom-globals';
+import { Event, EventListener, Node as DomNode } from '@ephox/dom-globals';
 import { Fun } from '@ephox/katamari';
 import { EventArgs, EventFilter, EventHandler, EventUnbinder } from '../api/events/Types';
 import Element from '../api/node/Element';
 import * as ShadowDom from '../api/node/ShadowDom';
+
+// Note: Some of the `T extends Event` type parameters used in this file are unsound.
+// Nothing in `addEventListener` tells us what type of event is being handled, nor are any run-time type checks performed.
+// We're essentially casting.
 
 type WrappedHandler<T> = (rawEvent: T) => void;
 
@@ -22,8 +26,8 @@ const mkEvent = <T extends Event>(target: Element, x: number, y: number, stop: (
  * The returned EventArgs structure has its target set to the "original" target if possible.
  * See ShadowDom.getOriginalEventTarget
  */
-const fromRawEvent = <T extends Event>(rawEvent: T) => {
-  const target = Element.fromDom(ShadowDom.getOriginalEventTarget(rawEvent).getOr(rawEvent.target) as Node);
+const fromRawEvent = <T extends Event>(rawEvent: T): EventArgs<T> => {
+  const target = Element.fromDom(ShadowDom.getOriginalEventTarget(rawEvent).getOr(rawEvent.target) as DomNode);
 
   const stop = () => rawEvent.stopPropagation();
 
@@ -35,31 +39,31 @@ const fromRawEvent = <T extends Event>(rawEvent: T) => {
   return mkEvent(target, (rawEvent as any).clientX, (rawEvent as any).clientY, stop, prevent, kill, rawEvent);
 };
 
-const handle = <T extends Event>(filter: EventFilter<T>, handler: EventHandler<T>): WrappedHandler<T> => (rawEvent: T) => {
+const handle = <T extends Event>(filter: EventFilter<T>, handler: EventHandler<T>): WrappedHandler<T> => (rawEvent: T): void => {
   if (filter(rawEvent)) {
     handler(fromRawEvent<T>(rawEvent));
   }
 };
 
-const binder = <T extends Event>(element: Element, event: string, filter: EventFilter<T>, handler: EventHandler<T>, useCapture: boolean): EventUnbinder => {
+const binder = <T extends Event>(element: Element<DomNode>, event: string, filter: EventFilter<T>, handler: EventHandler<T>, useCapture: boolean): EventUnbinder => {
   const wrapped = handle(filter, handler);
   // IE9 minimum
-  element.dom().addEventListener(event, wrapped, useCapture);
+  element.dom().addEventListener(event, wrapped as EventListener, useCapture);
 
   return {
     unbind: Fun.curry(unbind, element, event, wrapped, useCapture)
   };
 };
 
-const bind = <T extends Event>(element: Element, event: string, filter: EventFilter<T>, handler: EventHandler<T>) =>
+const bind = <T extends Event>(element: Element<DomNode>, event: string, filter: EventFilter<T>, handler: EventHandler<T>): EventUnbinder =>
   binder<T>(element, event, filter, handler, false);
 
-const capture = <T extends Event>(element: Element, event: string, filter: EventFilter<T>, handler: EventHandler<T>) =>
+const capture = <T extends Event>(element: Element<DomNode>, event: string, filter: EventFilter<T>, handler: EventHandler<T>): EventUnbinder =>
   binder<T>(element, event, filter, handler, true);
 
-const unbind = <T extends Event>(element: Element, event: string, handler: WrappedHandler<T>, useCapture: boolean) => {
+const unbind = <T extends Event>(element: Element<DomNode>, event: string, handler: WrappedHandler<T>, useCapture: boolean): void => {
   // IE9 minimum
-  element.dom().removeEventListener(event, handler, useCapture);
+  element.dom().removeEventListener(event, handler as EventListener, useCapture);
 };
 
 export { bind, capture, fromRawEvent };

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/Monitors.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/Monitors.ts
@@ -16,11 +16,13 @@ export interface Polling {
  */
 const polls: Polling[] = [];
 
-const poll = (element: Element<DomNode>, unbind: () => void): Polling => ({ element, unbind });
+const poll = (element: Element<DomNode>, unbind: () => void): Polling =>
+  ({ element, unbind });
 
-const findPoller = (element: Element<DomNode>) => Arr.findIndex(polls, (p) => Compare.eq(p.element, element)).getOr(-1);
+const findPoller = (element: Element<DomNode>): number =>
+  Arr.findIndex(polls, (p) => Compare.eq(p.element, element)).getOr(-1);
 
-const begin = (element: Element<DomNode>, f: () => (() => void)) => {
+const begin = (element: Element<DomNode>, f: () => (() => void)): void => {
   const index = findPoller(element);
   if (index === -1) {
     const unbind = f();
@@ -28,13 +30,13 @@ const begin = (element: Element<DomNode>, f: () => (() => void)) => {
   }
 };
 
-const query = (element: Element<DomNode>) => {
+const query = (element: Element<DomNode>): Option<Polling> => {
   // Used in tests to determine whether an element is still being monitored
   const index = findPoller(element);
   return index === -1 ? Option.none<Polling>() : Option.some(polls[index]);
 };
 
-const end = (element: Element<DomNode>) => {
+const end = (element: Element<DomNode>): void => {
   const index = findPoller(element);
 
   // This function is called speculatively, so just do nothing if there is no monitor for the element

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/alien/Geometry.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/alien/Geometry.ts
@@ -1,6 +1,6 @@
 import { ClientRect, DOMRect } from '@ephox/dom-globals';
 
-const searchForPoint = (rectForOffset: (number: number) => (ClientRect | DOMRect), x: number, y: number, maxX: number, length: number) => {
+const searchForPoint = (rectForOffset: (number: number) => (ClientRect | DOMRect), x: number, y: number, maxX: number, length: number): number => {
   // easy cases
   if (length === 0) {
     return 0;
@@ -31,7 +31,7 @@ const searchForPoint = (rectForOffset: (number: number) => (ClientRect | DOMRect
   return 0; // always return something, even if it's not the exact offset it'll be better than nothing
 };
 
-const inRect = (rect: ClientRect | DOMRect, x: number, y: number) =>
+const inRect = (rect: ClientRect | DOMRect, x: number, y: number): boolean =>
   x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/core/NativeRange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/core/NativeRange.ts
@@ -1,25 +1,26 @@
-import { ClientRect, DOMRect, Node as DomNode, Range, Window } from '@ephox/dom-globals';
+import { ClientRect, DocumentFragment, DOMRect, Node as DomNode, Range, Window } from '@ephox/dom-globals';
 import { Fun, Option } from '@ephox/katamari';
 import Element from '../../api/node/Element';
 import { StructRect } from '../../api/selection/Rect';
 import { Situ } from '../../api/selection/Situ';
 
-const selectNodeContents = (win: Window, element: Element<DomNode>) => {
+const selectNodeContents = (win: Window, element: Element<DomNode>): Range => {
   const rng = win.document.createRange();
   selectNodeContentsUsing(rng, element);
   return rng;
 };
 
-const selectNodeContentsUsing = (rng: Range, element: Element<DomNode>) => rng.selectNodeContents(element.dom());
+const selectNodeContentsUsing = (rng: Range, element: Element<DomNode>): void =>
+  rng.selectNodeContents(element.dom());
 
-const isWithin = (outerRange: Range, innerRange: Range) =>
+const isWithin = (outerRange: Range, innerRange: Range): boolean =>
   // Adapted from: http://stackoverflow.com/questions/5605401/insert-link-in-contenteditable-element
   innerRange.compareBoundaryPoints(outerRange.END_TO_START, outerRange) < 1 && innerRange.compareBoundaryPoints(outerRange.START_TO_END, outerRange) > -1;
 
 const create = (win: Window) => win.document.createRange();
 
 // NOTE: Mutates the range.
-const setStart = (rng: Range, situ: Situ) => {
+const setStart = (rng: Range, situ: Situ): void => {
   situ.fold((e) => {
     rng.setStartBefore(e.dom());
   }, (e, o) => {
@@ -29,7 +30,7 @@ const setStart = (rng: Range, situ: Situ) => {
   });
 };
 
-const setFinish = (rng: Range, situ: Situ) => {
+const setFinish = (rng: Range, situ: Situ): void => {
   situ.fold((e) => {
     rng.setEndBefore(e.dom());
   }, (e, o) => {
@@ -39,31 +40,31 @@ const setFinish = (rng: Range, situ: Situ) => {
   });
 };
 
-const replaceWith = (rng: Range, fragment: Element<DomNode>) => {
+const replaceWith = (rng: Range, fragment: Element<DomNode>): void => {
   // Note: this document fragment approach may not work on IE9.
   deleteContents(rng);
   rng.insertNode(fragment.dom());
 };
 
-const relativeToNative = (win: Window, startSitu: Situ, finishSitu: Situ) => {
+const relativeToNative = (win: Window, startSitu: Situ, finishSitu: Situ): Range => {
   const range = win.document.createRange();
   setStart(range, startSitu);
   setFinish(range, finishSitu);
   return range;
 };
 
-const exactToNative = (win: Window, start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => {
+const exactToNative = (win: Window, start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): Range => {
   const rng = win.document.createRange();
   rng.setStart(start.dom(), soffset);
   rng.setEnd(finish.dom(), foffset);
   return rng;
 };
 
-const deleteContents = (rng: Range) => {
+const deleteContents = (rng: Range): void => {
   rng.deleteContents();
 };
 
-const cloneFragment = (rng: Range) => {
+const cloneFragment = (rng: Range): Element<DocumentFragment> => {
   const fragment = rng.cloneContents();
   return Element.fromDom(fragment);
 };
@@ -77,18 +78,19 @@ const toRect = (rect: ClientRect | DOMRect): StructRect => ({
   height: Fun.constant(rect.height)
 });
 
-const getFirstRect = (rng: Range) => {
+const getFirstRect = (rng: Range): Option<StructRect> => {
   const rects = rng.getClientRects();
   // ASSUMPTION: The first rectangle is the start of the selection
   const rect = rects.length > 0 ? rects[0] : rng.getBoundingClientRect();
   return rect.width > 0 || rect.height > 0 ? Option.some(rect).map(toRect) : Option.none<StructRect>();
 };
 
-const getBounds = (rng: Range) => {
+const getBounds = (rng: Range): Option<StructRect> => {
   const rect = rng.getBoundingClientRect();
   return rect.width > 0 || rect.height > 0 ? Option.some(rect).map(toRect) : Option.none<StructRect>();
 };
 
-const toString = (rng: Range) => rng.toString();
+const toString = (rng: Range): string =>
+  rng.toString();
 
 export { create, replaceWith, selectNodeContents, selectNodeContentsUsing, relativeToNative, exactToNative, deleteContents, cloneFragment, getFirstRect, getBounds, isWithin, toString };

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/CaretRange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/CaretRange.ts
@@ -8,21 +8,24 @@ import * as EdgePoint from './EdgePoint';
 
 declare const document: any;
 
-const caretPositionFromPoint = (doc: Element<Document>, x: number, y: number) => Option.from((doc.dom() as any).caretPositionFromPoint(x, y))
-  .bind((pos) => {
-    // It turns out that Firefox can return null for pos.offsetNode
-    if (pos.offsetNode === null) {
-      return Option.none<Range>();
-    }
-    const r = doc.dom().createRange();
-    r.setStart(pos.offsetNode, pos.offset);
-    r.collapse();
-    return Option.some(r);
-  });
+const caretPositionFromPoint = (doc: Element<Document>, x: number, y: number): Option<Range> =>
+  Option.from((doc.dom() as any)
+    .caretPositionFromPoint(x, y))
+    .bind((pos) => {
+      // It turns out that Firefox can return null for pos.offsetNode
+      if (pos.offsetNode === null) {
+        return Option.none<Range>();
+      }
+      const r = doc.dom().createRange();
+      r.setStart(pos.offsetNode, pos.offset);
+      r.collapse();
+      return Option.some(r);
+    });
 
-const caretRangeFromPoint = (doc: Element<Document>, x: number, y: number) => Option.from(doc.dom().caretRangeFromPoint(x, y));
+const caretRangeFromPoint = (doc: Element<Document>, x: number, y: number): Option<Range> =>
+  Option.from(doc.dom().caretRangeFromPoint(x, y));
 
-const searchTextNodes = (doc: Element<Document>, node: Element<DomNode>, x: number, y: number) => {
+const searchTextNodes = (doc: Element<Document>, node: Element<DomNode>, x: number, y: number): Option<Range> => {
   const r = doc.dom().createRange();
   r.selectNode(node.dom());
   const rect = r.getBoundingClientRect();
@@ -49,7 +52,7 @@ const availableSearch = document.caretPositionFromPoint ? caretPositionFromPoint
   document.caretRangeFromPoint ? caretRangeFromPoint :        // webkit implementation
     searchFromPoint;                                            // fallback
 
-const fromPoint = (win: Window, x: number, y: number) => {
+const fromPoint = (win: Window, x: number, y: number): Option<SimRange> => {
   const doc = Element.fromDom(win.document);
   return availableSearch(doc, x, y).map((rng) => SimRange.create(
     Element.fromDom(rng.startContainer),

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/ContainerPoint.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/ContainerPoint.ts
@@ -29,10 +29,10 @@ const searchInChildren = (doc: Element<Document>, node: Element<DomNode>, x: num
   });
 };
 
-const locateNode = (doc: Element<Document>, node: Element<DomNode>, x: number, y: number) =>
+const locateNode = (doc: Element<Document>, node: Element<DomNode>, x: number, y: number): Option<Range> =>
   Node.isText(node) ? TextPoint.locate(doc, node, x, y) : searchInChildren(doc, node, x, y);
 
-const locate = (doc: Element<Document>, node: Element<DomNode>, x: number, y: number) => {
+const locate = (doc: Element<Document>, node: Element<DomNode>, x: number, y: number): Option<Range> => {
   const r = doc.dom().createRange();
   r.selectNode(node.dom());
   const rect = r.getBoundingClientRect();

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/EdgePoint.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/EdgePoint.ts
@@ -1,4 +1,4 @@
-import { ClientRect, Document, DOMRect, Element as DomElement, Node as DomNode } from '@ephox/dom-globals';
+import { ClientRect, Document, DOMRect, Element as DomElement, Node as DomNode, Range } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 import Element from '../../api/node/Element';
 import * as Traverse from '../../api/search/Traverse';
@@ -16,17 +16,17 @@ import * as CursorPosition from '../../api/selection/CursorPosition';
 const COLLAPSE_TO_LEFT = true;
 const COLLAPSE_TO_RIGHT = false;
 
-const getCollapseDirection = (rect: ClientRect | DOMRect, x: number) =>
+const getCollapseDirection = (rect: ClientRect | DOMRect, x: number): boolean =>
   x - rect.left < rect.right - x ? COLLAPSE_TO_LEFT : COLLAPSE_TO_RIGHT;
 
-const createCollapsedNode = (doc: Element<Document>, target: Element<DomNode>, collapseDirection: boolean) => {
+const createCollapsedNode = (doc: Element<Document>, target: Element<DomNode>, collapseDirection: boolean): Range => {
   const r = doc.dom().createRange();
   r.selectNode(target.dom());
   r.collapse(collapseDirection);
   return r;
 };
 
-const locateInElement = (doc: Element<Document>, node: Element<DomElement>, x: number) => {
+const locateInElement = (doc: Element<Document>, node: Element<DomElement>, x: number): Option<Range> => {
   const cursorRange = doc.dom().createRange();
   cursorRange.selectNode(node.dom());
   const rect = cursorRange.getBoundingClientRect();
@@ -36,13 +36,13 @@ const locateInElement = (doc: Element<Document>, node: Element<DomElement>, x: n
   return f(node).map((target) => createCollapsedNode(doc, target, collapseDirection));
 };
 
-const locateInEmpty = (doc: Element<Document>, node: Element<DomElement>, x: number) => {
+const locateInEmpty = (doc: Element<Document>, node: Element<DomElement>, x: number): Option<Range> => {
   const rect = node.dom().getBoundingClientRect();
   const collapseDirection = getCollapseDirection(rect, x);
   return Option.some(createCollapsedNode(doc, node, collapseDirection));
 };
 
-const search = (doc: Element<Document>, node: Element<DomElement>, x: number) => {
+const search = (doc: Element<Document>, node: Element<DomElement>, x: number): Option<Range> => {
   const f = Traverse.children(node).length === 0 ? locateInEmpty : locateInElement;
   return f(doc, node, x);
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/TextPoint.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/TextPoint.ts
@@ -1,10 +1,10 @@
-import { ClientRect, Document, DOMRect, Text as DomText } from '@ephox/dom-globals';
+import { ClientRect, Document, DOMRect, Range, Text as DomText } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
 import Element from '../../api/node/Element';
 import * as Text from '../../api/node/Text';
 import * as Geometry from '../alien/Geometry';
 
-const locateOffset = (doc: Element<Document>, textnode: Element<DomText>, x: number, y: number, rect: ClientRect | DOMRect) => {
+const locateOffset = (doc: Element<Document>, textnode: Element<DomText>, x: number, y: number, rect: ClientRect | DOMRect): Range => {
   const rangeForOffset = (o: number) => {
     const r = doc.dom().createRange();
     r.setStart(textnode.dom(), o);
@@ -22,7 +22,7 @@ const locateOffset = (doc: Element<Document>, textnode: Element<DomText>, x: num
   return rangeForOffset(offset);
 };
 
-const locate = (doc: Element<Document>, node: Element<DomText>, x: number, y: number) => {
+const locate = (doc: Element<Document>, node: Element<DomText>, x: number, y: number): Option<Range> => {
   const r = doc.dom().createRange();
   r.selectNode(node.dom());
   const rects = r.getClientRects();

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/Within.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/Within.ts
@@ -8,7 +8,7 @@ import { Selection } from '../../api/selection/Selection';
 import * as NativeRange from '../core/NativeRange';
 import * as SelectionDirection from '../core/SelectionDirection';
 
-const withinContainer = (win: Window, ancestor: Element<DomElement>, outerRange: Range, selector: string) => {
+const withinContainer = (win: Window, ancestor: Element<DomElement>, outerRange: Range, selector: string): Element<DomElement>[] => {
   const innerRange = NativeRange.create(win);
   const self = Selectors.is(ancestor, selector) ? [ ancestor ] : [];
   const elements = self.concat(SelectorFilter.descendants(ancestor, selector));
@@ -19,7 +19,7 @@ const withinContainer = (win: Window, ancestor: Element<DomElement>, outerRange:
   });
 };
 
-const find = (win: Window, selection: Selection, selector: string) => {
+const find = (win: Window, selection: Selection, selector: string): Element<DomElement>[] => {
   // Reverse the selection if it is RTL when doing the comparison
   const outerRange = SelectionDirection.asLtrRange(win, selection);
   const ancestor = Element.fromDom(outerRange.commonAncestorContainer);

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/quirks/Prefilter.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/quirks/Prefilter.ts
@@ -5,7 +5,7 @@ import * as Node from '../../api/node/Node';
 import { Selection } from '../../api/selection/Selection';
 import { Situ } from '../../api/selection/Situ';
 
-const beforeSpecial = (element: Element<DomNode>, offset: number) => {
+const beforeSpecial = (element: Element<DomNode>, offset: number): Situ => {
   // From memory, we don't want to use <br> directly on Firefox because it locks the keyboard input.
   // It turns out that <img> directly on IE locks the keyboard as well.
   // If the offset is 0, use before. If the offset is 1, use after.
@@ -20,27 +20,28 @@ const beforeSpecial = (element: Element<DomNode>, offset: number) => {
   }
 };
 
-const preprocessRelative = (startSitu: Situ, finishSitu: Situ) => {
+const preprocessRelative = (startSitu: Situ, finishSitu: Situ): Selection => {
   const start = startSitu.fold(Situ.before, beforeSpecial, Situ.after);
   const finish = finishSitu.fold(Situ.before, beforeSpecial, Situ.after);
   return Selection.relative(start, finish);
 };
 
-const preprocessExact = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => {
+const preprocessExact = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): Selection => {
   const startSitu = beforeSpecial(start, soffset);
   const finishSitu = beforeSpecial(finish, foffset);
   return Selection.relative(startSitu, finishSitu);
 };
 
-const preprocess = (selection: Selection) => selection.match({
-  domRange(rng) {
-    const start = Element.fromDom(rng.startContainer);
-    const finish = Element.fromDom(rng.endContainer);
-    return preprocessExact(start, rng.startOffset, finish, rng.endOffset);
-  },
-  relative: preprocessRelative,
-  exact: preprocessExact
-});
+const preprocess = (selection: Selection): Selection =>
+  selection.match({
+    domRange(rng) {
+      const start = Element.fromDom(rng.startContainer);
+      const finish = Element.fromDom(rng.endContainer);
+      return preprocessExact(start, rng.startOffset, finish, rng.endOffset);
+    },
+    relative: preprocessRelative,
+    exact: preprocessExact
+  });
 
 export {
   beforeSpecial,

--- a/modules/tinymce/src/core/main/ts/dom/Position.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Position.ts
@@ -8,6 +8,7 @@
 import { Arr } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Element, Node, Css, Traverse } from '@ephox/sugar';
+import { HTMLElement } from '@ephox/dom-globals';
 
 const browser = PlatformDetection.detect().browser;
 
@@ -19,16 +20,16 @@ const firstElement = function (nodes) {
 // this tries to compensate for that by detecting if that offsets are incorrect and then remove the height
 const getTableCaptionDeltaY = function (elm) {
   if (browser.isFirefox() && Node.name(elm) === 'table') {
-    return firstElement(Traverse.children(elm)).filter(function (elm) {
-      return Node.name(elm) === 'caption';
-    }).bind(function (caption) {
-      return firstElement(Traverse.nextSiblings(caption)).map(function (body) {
-        const bodyTop = body.dom().offsetTop;
-        const captionTop = caption.dom().offsetTop;
-        const captionHeight = caption.dom().offsetHeight;
-        return bodyTop <= captionTop ? -captionHeight : 0;
-      });
-    }).getOr(0);
+    return firstElement(Traverse.children(elm))
+      .filter(Node.isTag('caption'))
+      .bind((caption) =>
+        firstElement(Traverse.nextSiblings(caption))
+          .map((body) => {
+            const bodyTop = (body as Element<HTMLElement>).dom().offsetTop;
+            const captionTop = caption.dom().offsetTop;
+            const captionHeight = caption.dom().offsetHeight;
+            return bodyTop <= captionTop ? -captionHeight : 0;
+          })).getOr(0);
   } else {
     return 0;
   }


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Add explicit return types throughout sugar. This has been done in preparation for updating dom-globals. The dom-globals update changes many types, so having the explicit return types will help us know where the update affects the code.
* A few minor refactors.
* Some readonly on interfaces.
* Sorry it's so big.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
