### PR TITLE
DOC-600: Set stylesheetloader docs to public, add loadall docs

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -16,7 +16,6 @@ import Tools from '../util/Tools';
  * This class handles loading of external stylesheets and fires events when these are loaded.
  *
  * @class tinymce.dom.StyleSheetLoader
- * @private
  */
 
 export interface StyleSheetLoader {
@@ -235,6 +234,14 @@ export function StyleSheetLoader(documentOrShadowRoot: DomDocument | ShadowRoot,
     });
   };
 
+   /**
+   * Loads the specified css style sheet files and call the success callback once it's finished loading.
+   *
+   * @method loadAll
+   * @param {Array} urls Urls to be loaded.
+   * @param {Function} success Callback to be executed when the styles sheets have been successfully loaded.
+   * @param {Function} failure Callback to be executed when the style sheets fail to load.
+   */
   const loadAll = function (urls: string[], success: Function, failure: Function) {
     Futures.par(Arr.map(urls, loadF)).get(function (result) {
       const parts = Arr.partition(result, function (r) {

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -48,7 +48,7 @@ export function StyleSheetLoader(documentOrShadowRoot: DomDocument | ShadowRoot,
   };
 
   /**
-   * Loads the specified css style sheet file and call the loadedCallback once it's finished loading.
+   * Loads the specified CSS file and calls the `loadedCallback` once it's finished loading.
    *
    * @method load
    * @param {String} url Url to be loaded.
@@ -235,7 +235,7 @@ export function StyleSheetLoader(documentOrShadowRoot: DomDocument | ShadowRoot,
   };
 
   /**
-   * Loads the specified css style sheets and call the success callback once it's finished loading.
+   * Loads the specified CSS files and calls the `success` callback once it's finished loading.
    *
    * @method loadAll
    * @param {Array} urls Urls to be loaded.

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -234,12 +234,12 @@ export function StyleSheetLoader(documentOrShadowRoot: DomDocument | ShadowRoot,
     });
   };
 
-   /**
-   * Loads the specified css style sheet files and call the success callback once it's finished loading.
+  /**
+   * Loads the specified css style sheets and call the success callback once it's finished loading.
    *
    * @method loadAll
    * @param {Array} urls Urls to be loaded.
-   * @param {Function} success Callback to be executed when the styles sheets have been successfully loaded.
+   * @param {Function} success Callback to be executed when the style sheets have been successfully loaded.
    * @param {Function} failure Callback to be executed when the style sheets fail to load.
    */
   const loadAll = function (urls: string[], success: Function, failure: Function) {

--- a/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
+++ b/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
@@ -10,3 +10,10 @@
  * @property registry
  * @type tinymce.editor.ui.Registry
  */
+
+/**
+ * Editor UI stylesheet loader instance. StyleSheetLoader for styles in the editor UI. For content styles, use editor.dom.styleSheetLoader.
+ *
+ * @property styleSheetLoader
+ * @type tinymce.dom.StyleSheetLoader
+ */

--- a/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
+++ b/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
@@ -13,6 +13,8 @@
 
 /**
  * Editor UI stylesheet loader instance. StyleSheetLoader for styles in the editor UI. For content styles, use editor.dom.styleSheetLoader.
+ * <br>
+ * <em>Added in TinyMCE 5.4</em>
  *
  * @property styleSheetLoader
  * @type tinymce.dom.StyleSheetLoader


### PR DESCRIPTION
Related Ticket: DOC-600

Description of Changes:
* Set Stylesheetloader API docs to public

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
