### PR TITLE
Add explicit return types

### DIFF
--- a/modules/sugar/src/main/ts/ephox/sugar/alien/Recurse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/alien/Recurse.ts
@@ -7,7 +7,7 @@ import { Option } from '@ephox/katamari';
  *
  * This is what recursion looks like when manually unravelled :)
  */
-const toArray = <T = any> (target: T, f: (t: T) => Option<T>) => {
+const toArray = <T = any> (target: T, f: (t: T) => Option<T>): T[] => {
   const r: T[] = [];
 
   const recurse = (e: T) => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Compare.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Compare.ts
@@ -4,14 +4,17 @@ import { Node, PlatformDetection } from '@ephox/sand';
 import Element from '../node/Element';
 import * as Selectors from '../search/Selectors';
 
-const eq = (e1: Element<unknown>, e2: Element<unknown>) => e1.dom() === e2.dom();
+const eq = (e1: Element<unknown>, e2: Element<unknown>): boolean =>
+  e1.dom() === e2.dom();
 
-const isEqualNode = (e1: Element<DomNode>, e2: Element<DomNode>) => e1.dom().isEqualNode(e2.dom());
+const isEqualNode = (e1: Element<DomNode>, e2: Element<DomNode>): boolean =>
+  e1.dom().isEqualNode(e2.dom());
 
-const member = (element: Element, elements: Element[]) => Arr.exists(elements, Fun.curry(eq, element));
+const member = (element: Element, elements: Element[]): boolean =>
+  Arr.exists(elements, Fun.curry(eq, element));
 
 // DOM contains() method returns true if e1===e2, we define our contains() to return false (a node does not contain itself).
-const regularContains = (e1: Element<DomNode>, e2: Element<DomNode>) => {
+const regularContains = (e1: Element<DomNode>, e2: Element<DomNode>): boolean => {
   const d1 = e1.dom();
   const d2 = e2.dom();
   return d1 === d2 ? false : d1.contains(d2);
@@ -22,11 +25,12 @@ const regularContains = (e1: Element<DomNode>, e2: Element<DomNode>) => {
 // https://connect.microsoft.com/IE/feedback/details/780874/node-contains-is-incorrect
 // Note that compareDocumentPosition returns CONTAINED_BY if 'e2 *is_contained_by* e1':
 // Also, compareDocumentPosition defines a node containing itself as false.
-const ieContains = (e1: Element<DomNode>, e2: Element<DomNode>) => Node.documentPositionContainedBy(e1.dom(), e2.dom());
+const ieContains = (e1: Element<DomNode>, e2: Element<DomNode>): boolean =>
+  Node.documentPositionContainedBy(e1.dom(), e2.dom());
 
 // Returns: true if node e1 contains e2, otherwise false.
 // (returns false if e1===e2: A node does not contain itself).
-const contains = (e1: Element<DomNode>, e2: Element<DomNode>) =>
+const contains = (e1: Element<DomNode>, e2: Element<DomNode>): boolean =>
   PlatformDetection.detect().browser.isIE() ? ieContains(e1, e2) : regularContains(e1, e2);
 
 const is = Selectors.is;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/DocumentPosition.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/DocumentPosition.ts
@@ -1,9 +1,9 @@
-import { Node as DomNode } from '@ephox/dom-globals';
+import { Node as DomNode, Range } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as Traverse from '../search/Traverse';
 import * as Compare from './Compare';
 
-const makeRange = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => {
+const makeRange = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): Range => {
   const doc = Traverse.owner(start);
 
   // TODO: We need to think about a better place to put native range creation code. Does it even belong in sugar?
@@ -16,12 +16,12 @@ const makeRange = (start: Element<DomNode>, soffset: number, finish: Element<Dom
 
 // Return the deepest - or furthest down the document tree - Node that contains both boundary points
 // of the range (start:soffset, finish:foffset).
-const commonAncestorContainer = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => {
+const commonAncestorContainer = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): Element<DomNode> => {
   const r = makeRange(start, soffset, finish, foffset);
   return Element.fromDom(r.commonAncestorContainer);
 };
 
-const after = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number) => {
+const after = (start: Element<DomNode>, soffset: number, finish: Element<DomNode>, foffset: number): boolean => {
   const r = makeRange(start, soffset, finish, foffset);
 
   const same = Compare.eq(start, finish) && soffset === foffset;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Hierarchy.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Hierarchy.ts
@@ -19,7 +19,7 @@ const up = (descendant: Element<DomNode>, stopper: (e: Element<DomNode>) => bool
   }
 };
 
-const path = (ancestor: Element<DomNode>, descendant: Element<DomNode>) => {
+const path = (ancestor: Element<DomNode>, descendant: Element<DomNode>): Option<number[]> => {
   const stopper = Fun.curry(Compare.eq, ancestor);
   return Compare.eq(ancestor, descendant) ? Option.some<number[]>([]) : up(descendant, stopper);
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Insert.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Insert.ts
@@ -2,14 +2,14 @@ import { Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as Traverse from '../search/Traverse';
 
-const before = (marker: Element<DomNode>, element: Element<DomNode>) => {
+const before = (marker: Element<DomNode>, element: Element<DomNode>): void => {
   const parent = Traverse.parent(marker);
   parent.each((v) => {
     v.dom().insertBefore(element.dom(), marker.dom());
   });
 };
 
-const after = (marker: Element<DomNode>, element: Element<DomNode>) => {
+const after = (marker: Element<DomNode>, element: Element<DomNode>): void => {
   const sibling = Traverse.nextSibling(marker);
   sibling.fold(() => {
     const parent = Traverse.parent(marker);
@@ -21,7 +21,7 @@ const after = (marker: Element<DomNode>, element: Element<DomNode>) => {
   });
 };
 
-const prepend = (parent: Element<DomNode>, element: Element<DomNode>) => {
+const prepend = (parent: Element<DomNode>, element: Element<DomNode>): void => {
   const firstChild = Traverse.firstChild(parent);
   firstChild.fold(() => {
     append(parent, element);
@@ -30,11 +30,11 @@ const prepend = (parent: Element<DomNode>, element: Element<DomNode>) => {
   });
 };
 
-const append = (parent: Element<DomNode>, element: Element<DomNode>) => {
+const append = (parent: Element<DomNode>, element: Element<DomNode>): void => {
   parent.dom().appendChild(element.dom());
 };
 
-const appendAt = (parent: Element<DomNode>, element: Element<DomNode>, index: number) => {
+const appendAt = (parent: Element<DomNode>, element: Element<DomNode>, index: number): void => {
   Traverse.child(parent, index).fold(() => {
     append(parent, element);
   }, (v) => {
@@ -42,7 +42,7 @@ const appendAt = (parent: Element<DomNode>, element: Element<DomNode>, index: nu
   });
 };
 
-const wrap = (element: Element<DomNode>, wrapper: Element<DomNode>) => {
+const wrap = (element: Element<DomNode>, wrapper: Element<DomNode>): void => {
   before(element, wrapper);
   append(wrapper, element);
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/InsertAll.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/InsertAll.ts
@@ -3,26 +3,26 @@ import { Arr } from '@ephox/katamari';
 import Element from '../node/Element';
 import * as Insert from './Insert';
 
-const before = (marker: Element<DomNode>, elements: Element<DomNode>[]) => {
+const before = (marker: Element<DomNode>, elements: Element<DomNode>[]): void => {
   Arr.each(elements, (x) => {
     Insert.before(marker, x);
   });
 };
 
-const after = (marker: Element<DomNode>, elements: Element<DomNode>[]) => {
+const after = (marker: Element<DomNode>, elements: Element<DomNode>[]): void => {
   Arr.each(elements, (x, i) => {
     const e = i === 0 ? marker : elements[i - 1];
     Insert.after(e, x);
   });
 };
 
-const prepend = (parent: Element<DomNode>, elements: Element<DomNode>[]) => {
+const prepend = (parent: Element<DomNode>, elements: Element<DomNode>[]): void => {
   Arr.each(elements.slice().reverse(), (x) => {
     Insert.prepend(parent, x);
   });
 };
 
-const append = (parent: Element<DomNode>, elements: Element<DomNode>[]) => {
+const append = (parent: Element<DomNode>, elements: Element<DomNode>[]): void => {
   Arr.each(elements, (x) => {
     Insert.append(parent, x);
   });

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Link.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Link.ts
@@ -1,9 +1,9 @@
-import { document, Document, Node as DomNode } from '@ephox/dom-globals';
+import { document, Document, HTMLLinkElement, Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as Attr from '../properties/Attr';
 import * as Insert from './Insert';
 
-const addToHead = (doc: Element<Document>, tag: Element<DomNode>) => {
+const addToHead = (doc: Element<Document>, tag: Element<DomNode>): void => {
   /*
    * IE9 and above per
    * https://developer.mozilla.org/en-US/docs/Web/API/Document/head
@@ -12,7 +12,7 @@ const addToHead = (doc: Element<Document>, tag: Element<DomNode>) => {
   Insert.append(head, tag);
 };
 
-const addStylesheet = (url: string, scope?: Element<Document>) => {
+const addStylesheet = (url: string, scope?: Element<Document>): Element<HTMLLinkElement> => {
   const doc = scope || Element.fromDom(document);
 
   const link = Element.fromTag('link', doc.dom()); // We really need to fix that Element API

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Remove.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Remove.ts
@@ -4,7 +4,7 @@ import Element from '../node/Element';
 import * as Traverse from '../search/Traverse';
 import * as InsertAll from './InsertAll';
 
-const empty = (element: Element<DomNode>) => {
+const empty = (element: Element<DomNode>): void => {
   // shortcut "empty node" trick. Requires IE 9.
   element.dom().textContent = '';
 
@@ -17,14 +17,14 @@ const empty = (element: Element<DomNode>) => {
   });
 };
 
-const remove = (element: Element<DomNode>) => {
+const remove = (element: Element<DomNode>): void => {
   const dom = element.dom();
   if (dom.parentNode !== null) {
     dom.parentNode.removeChild(dom);
   }
 };
 
-const unwrap = (wrapper: Element<DomNode>) => {
+const unwrap = (wrapper: Element<DomNode>): void => {
   const children = Traverse.children(wrapper);
   if (children.length > 0) {
     InsertAll.before(wrapper, children);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
@@ -6,13 +6,16 @@ import * as Insert from './Insert';
 import * as InsertAll from './InsertAll';
 import * as Remove from './Remove';
 
-const clone = <E extends DomNode> (original: Element<E>, isDeep: boolean) => Element.fromDom(original.dom().cloneNode(isDeep) as E);
+const clone = <E extends DomNode> (original: Element<E>, isDeep: boolean): Element<E> =>
+  Element.fromDom(original.dom().cloneNode(isDeep) as E);
 
 /** Shallow clone - just the tag, no children */
-const shallow = <E extends DomNode> (original: Element<E>) => clone(original, false);
+const shallow = <E extends DomNode> (original: Element<E>): Element<E> =>
+  clone(original, false);
 
 /** Deep clone - everything copied including children */
-const deep = <E extends DomNode> (original: Element<E>) => clone(original, true);
+const deep = <E extends DomNode> (original: Element<E>): Element<E> =>
+  clone(original, true);
 
 /** Shallow clone, with a new tag */
 const shallowAs = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K): Element<HTMLElementTagNameMap[K]> => {
@@ -25,7 +28,7 @@ const shallowAs = <K extends keyof HTMLElementTagNameMap> (original: Element<Dom
 };
 
 /** Deep clone, with a new tag */
-const copy = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K) => {
+const copy = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K): Element<HTMLElementTagNameMap[K]> => {
   const nu = shallowAs(original, tag);
 
   // NOTE
@@ -41,7 +44,7 @@ const copy = <K extends keyof HTMLElementTagNameMap> (original: Element<DomEleme
 };
 
 /** Change the tag name, but keep all children */
-const mutate = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K) => {
+const mutate = <K extends keyof HTMLElementTagNameMap> (original: Element<DomElement>, tag: K): Element<HTMLElementTagNameMap[K]> => {
   const nu = shallowAs(original, tag);
 
   Insert.before(original, nu);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvent.ts
@@ -20,7 +20,7 @@ const isLeftButtonPressed = (raw: MouseEvent) => {
 };
 
 // Not 100% sure whether this works, so use with caution
-const isRealClick = (raw: any) =>
+const isRealClick = (raw: any): boolean =>
   // Firefox non-standard property
   // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent#mozInputSource
   (raw.mozInputSource === 6 || raw.mozInputSource === 0) ? false

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Ready.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Ready.ts
@@ -2,7 +2,7 @@ import { document } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as DomEvent from './DomEvent';
 
-const execute = (f: () => void) => {
+const execute = (f: () => void): void => {
   /*
    * We only use this in one place, so creating one listener per ready request is more optimal than managing
    * a single event with a queue of functions.

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Resize.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Resize.ts
@@ -27,7 +27,7 @@ const elems: Monitored[] = [];
 
 const findElem = (element: Element<DomNode>) => Arr.findIndex(elems, (el) => Compare.eq(el.element, element)).getOr(-1);
 
-const bind = (element: Element<HTMLElement>, handler: () => void) => {
+const bind = (element: Element<HTMLElement>, handler: () => void): void => {
   const el = Arr.find(elems, (elm) => Compare.eq(elm.element, element)).getOrThunk(() => {
     const newEl = elem(element);
     elems.push(newEl);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/ScrollChange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/ScrollChange.ts
@@ -3,12 +3,13 @@ import Element from '../node/Element';
 import { Position } from '../view/Position';
 import * as Scroll from '../view/Scroll';
 import * as DomEvent from './DomEvent';
+import { EventUnbinder } from './Types';
 
 /* Some browsers (Firefox) fire a scroll event even if the values for scroll don't
  * change. This acts as an intermediary between the scroll event, and the value for scroll
  * changing
  */
-const bind = (doc: Element<Document>, handler: (pos: Position) => void) => {
+const bind = (doc: Element<Document>, handler: (pos: Position) => void): EventUnbinder => {
   let lastScroll = Scroll.get(doc);
   const scrollBinder = DomEvent.bind(doc, 'scroll', (_event) => {
     const scroll = Scroll.get(doc);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
@@ -14,13 +14,13 @@ declare const window: any;
  * It's a bit harder to manage, though, because visibility is a one-shot listener.
  */
 
-const poll = (element: Element<HTMLElement>, f: () => void) => {
+const poll = (element: Element<HTMLElement>, f: () => void): () => void => {
   const poller = setInterval(f, 500);
 
   return () => clearInterval(poller);
 };
 
-const mutate = (element: Element<HTMLElement>, f: () => void) => {
+const mutate = (element: Element<HTMLElement>, f: () => void): () => void => {
   const observer: MutationObserver = new window.MutationObserver(f);
 
   const unbindMutate = () => observer.disconnect();

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Body.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Body.ts
@@ -23,7 +23,8 @@ const inBody = (element: Element<DomNode>): boolean => {
   );
 };
 
-const body = () => getBody(Element.fromDom(document));
+const body = (): Element<HTMLElement> =>
+  getBody(Element.fromDom(document));
 
 const getBody = (doc: Element<Document>): Element<HTMLElement> => {
   const b = doc.dom().body;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Comment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Comment.ts
@@ -6,11 +6,14 @@ import * as Node from './Node';
 
 const api = NodeValue(Node.isComment, 'comment');
 
-const get = (element: Element<Comment>) => api.get(element);
+const get = (element: Element<Comment>): string =>
+  api.get(element);
 
-const getOption = (element: Element<DomNode>): Option<string> => api.getOption(element);
+const getOption = (element: Element<DomNode>): Option<string> =>
+  api.getOption(element);
 
-const set = (element: Element<Comment>, value: string) => api.set(element, value);
+const set = (element: Element<Comment>, value: string): void =>
+  api.set(element, value);
 
 export {
   get,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Elements.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Elements.ts
@@ -1,4 +1,4 @@
-import { document, Document, Node, Window } from '@ephox/dom-globals';
+import { document, Document, HTMLElement, Node, Text, Window } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import * as Traverse from '../search/Traverse';
 import Element from './Element';
@@ -12,10 +12,13 @@ const fromHtml = <T extends Node[]> (html: string, scope?: Document | null): Ele
   return Traverse.children(Element.fromDom(div)) as unknown as ElementTuple<T>;
 };
 
-const fromTags = (tags: string[], scope?: Document | null) => Arr.map(tags, (x) => Element.fromTag(x, scope));
+const fromTags = (tags: string[], scope?: Document | null): Element<HTMLElement>[] =>
+  Arr.map(tags, (x) => Element.fromTag(x, scope));
 
-const fromText = (texts: string[], scope?: Document | null) => Arr.map(texts, (x) => Element.fromText(x, scope));
+const fromText = (texts: string[], scope?: Document | null): Element<Text>[] =>
+  Arr.map(texts, (x) => Element.fromText(x, scope));
 
-const fromDom = <T extends (Node | Window)>(nodes: ArrayLike<T>): Element<T>[] => Arr.map(nodes, Element.fromDom);
+const fromDom = <T extends (Node | Window)>(nodes: ArrayLike<T>): Element<T>[] =>
+  Arr.map(nodes, Element.fromDom);
 
 export { fromHtml, fromTags, fromText, fromDom };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Fragment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Fragment.ts
@@ -1,8 +1,8 @@
-import { document, Document, Node as DomNode } from '@ephox/dom-globals';
+import { document, Document, DocumentFragment, Node as DomNode } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import Element from './Element';
 
-const fromElements = (elements: Element<DomNode>[], scope?: Document | null) => {
+const fromElements = (elements: Element<DomNode>[], scope?: Document | null): Element<DocumentFragment> => {
   const doc = scope || document;
   const fragment = doc.createDocumentFragment();
   Arr.each(elements, (element) => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Node.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Node.ts
@@ -12,27 +12,33 @@ import { HTMLElement } from '@ephox/sand';
 import Element from './Element';
 import * as NodeTypes from './NodeTypes';
 
-const name = (element: Element<DomNode>) => {
+const name = (element: Element<DomNode>): string => {
   const r = element.dom().nodeName;
   return r.toLowerCase();
 };
 
-const type = (element: Element<DomNode>) => element.dom().nodeType;
+const type = (element: Element<DomNode>): number =>
+  element.dom().nodeType;
 
-const value = (element: Element<DomNode>) => element.dom().nodeValue;
+const value = (element: Element<DomNode>): string | null =>
+  element.dom().nodeValue;
 
-const isType = <E> (t: number) => (element: Element): element is Element<E> => type(element) === t;
+const isType = <E> (t: number) => (element: Element): element is Element<E> =>
+  type(element) === t;
 
-const isComment = (element: Element): element is Element<Comment> => type(element) === NodeTypes.COMMENT || name(element) === '#comment';
+const isComment = (element: Element): element is Element<Comment> =>
+  type(element) === NodeTypes.COMMENT || name(element) === '#comment';
 
-const isHTMLElement = (element: Element<any>): element is Element<DomHTMLElement> => HTMLElement.isPrototypeOf(element.dom());
+const isHTMLElement = (element: Element<any>): element is Element<DomHTMLElement> =>
+  HTMLElement.isPrototypeOf(element.dom());
 
 const isElement = isType<DomElement>(NodeTypes.ELEMENT);
 const isText = isType<Text>(NodeTypes.TEXT);
 const isDocument = isType<Document>(NodeTypes.DOCUMENT);
 const isDocumentFragment = isType<DocumentFragment>(NodeTypes.DOCUMENT_FRAGMENT);
 
-const isTag = <K extends keyof HTMLElementTagNameMap>(tag: K) => (e: Element<any>): e is Element<HTMLElementTagNameMap[K]> => isElement(e) && name(e) === tag;
+const isTag = <K extends keyof HTMLElementTagNameMap>(tag: K) => (e: Element<any>): e is Element<HTMLElementTagNameMap[K]> =>
+  isElement(e) && name(e) === tag;
 
 export {
   name,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/Text.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/Text.ts
@@ -6,11 +6,14 @@ import * as Node from './Node';
 
 const api = NodeValue(Node.isText, 'text');
 
-const get = (element: Element<Text>) => api.get(element);
+const get = (element: Element<Text>): string =>
+  api.get(element);
 
-const getOption = (element: Element<DomNode>): Option<string> => api.getOption(element);
+const getOption = (element: Element<DomNode>): Option<string> =>
+  api.getOption(element);
 
-const set = (element: Element<Text>, value: string) => api.set(element, value);
+const set = (element: Element<Text>, value: string): void =>
+  api.set(element, value);
 
 export {
   get,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Alignment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Alignment.ts
@@ -7,7 +7,8 @@ import * as Direction from './Direction';
 
 type Alignment = 'left' | 'right' | 'justify' | 'center' | 'match-parent';
 
-const normal = (value: Alignment) => (_element: Element<DomElement>) => value;
+const normal = (value: Alignment) => (_element: Element<DomElement>): Alignment =>
+  value;
 
 const lookups: Record<string, (element: Element<DomElement>) => string> = {
   'start': Direction.onDirection<Alignment>('left', 'right'),
@@ -24,7 +25,7 @@ const getAlignment = (element: Element<DomElement>, property: string): string =>
     .getOr(raw);
 };
 
-const hasAlignment = (element: Element<DomElement> | Element<Text>, property: string, value: string) =>
+const hasAlignment = (element: Element<DomElement> | Element<Text>, property: string, value: string): boolean =>
   Node.isText(element) ? false : getAlignment(element, property) === value;
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attr.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attr.ts
@@ -3,7 +3,7 @@ import { Arr, Obj, Option, Type } from '@ephox/katamari';
 import Element from '../node/Element';
 import * as Node from '../node/Node';
 
-const rawSet = (dom: DomElement, key: string, value: string | boolean | number) => {
+const rawSet = (dom: DomElement, key: string, value: string | boolean | number): void => {
   /*
    * JQuery coerced everything to a string, and silently did nothing on text node/null/undefined.
    *
@@ -18,18 +18,18 @@ const rawSet = (dom: DomElement, key: string, value: string | boolean | number) 
   }
 };
 
-const set = (element: Element<DomElement>, key: string, value: string | boolean | number) => {
+const set = (element: Element<DomElement>, key: string, value: string | boolean | number): void => {
   rawSet(element.dom(), key, value);
 };
 
-const setAll = (element: Element<DomElement>, attrs: Record<string, string | boolean | number>) => {
+const setAll = (element: Element<DomElement>, attrs: Record<string, string | boolean | number>): void => {
   const dom = element.dom();
   Obj.each(attrs, (v, k) => {
     rawSet(dom, k, v);
   });
 };
 
-const get = (element: Element<DomElement>, key: string) => {
+const get = (element: Element<DomElement>, key: string): undefined | string => {
   const v = element.dom().getAttribute(key);
 
   // undefined is the more appropriate value for JS, and this matches JQuery
@@ -39,28 +39,29 @@ const get = (element: Element<DomElement>, key: string) => {
 const getOpt = (element: Element<DomElement>, key: string): Option<string> =>
   Option.from(get(element, key));
 
-const has = (element: Element<DomNode>, key: string) => {
+const has = (element: Element<DomNode>, key: string): boolean => {
   const dom = element.dom();
 
   // return false for non-element nodes, no point in throwing an error
   return dom && (dom as DomElement).hasAttribute ? (dom as DomElement).hasAttribute(key) : false;
 };
 
-const remove = (element: Element<DomElement>, key: string) => {
+const remove = (element: Element<DomElement>, key: string): void => {
   element.dom().removeAttribute(key);
 };
 
-const hasNone = (element: Element<DomNode>) => {
+const hasNone = (element: Element<DomNode>): boolean => {
   const attrs = (element.dom() as DomElement).attributes;
   return attrs === undefined || attrs === null || attrs.length === 0;
 };
 
-const clone = (element: Element<DomElement>) => Arr.foldl(element.dom().attributes, (acc, attr) => {
-  acc[attr.name] = attr.value;
-  return acc;
-}, {} as Record<string, string>);
+const clone = (element: Element<DomElement>): Record<string, string> =>
+  Arr.foldl(element.dom().attributes, (acc, attr) => {
+    acc[attr.name] = attr.value;
+    return acc;
+  }, {} as Record<string, string>);
 
-const transferOne = (source: Element<DomElement>, destination: Element<DomElement>, attr: string) => {
+const transferOne = (source: Element<DomElement>, destination: Element<DomElement>, attr: string): void => {
   // NOTE: We don't want to clobber any existing attributes
   if (!has(destination, attr)) {
     getOpt(source, attr).each((srcValue) => set(destination, attr, srcValue));
@@ -68,7 +69,7 @@ const transferOne = (source: Element<DomElement>, destination: Element<DomElemen
 };
 
 // Transfer attributes(attrs) from source to destination, unless they are already present
-const transfer = (source: Element<DomElement>, destination: Element<DomElement>, attrs: string[]) => {
+const transfer = (source: Element<DomElement>, destination: Element<DomElement>, attrs: string[]): void => {
   if (!Node.isElement(source) || !Node.isElement(destination)) { return; }
   Arr.each(attrs, (attr) => {
     transferOne(source, destination, attr);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttributeProperty.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttributeProperty.ts
@@ -3,11 +3,14 @@ import Element from '../node/Element';
 import * as Attr from './Attr';
 
 export default (attribute: string, value: string) => {
-  const is = (element: Element<DomElement>) => Attr.get(element, attribute) === value;
+  const is = (element: Element<DomElement>): boolean =>
+    Attr.get(element, attribute) === value;
 
-  const remove = (element: Element<DomElement>) => Attr.remove(element, attribute);
+  const remove = (element: Element<DomElement>): void =>
+    Attr.remove(element, attribute);
 
-  const set = (element: Element<DomElement>) => Attr.set(element, attribute, value);
+  const set = (element: Element<DomElement>): void =>
+    Attr.set(element, attribute, value);
 
   return {
     is,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Checked.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Checked.ts
@@ -1,14 +1,16 @@
 import { HTMLInputElement, Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as SelectorFind from '../search/SelectorFind';
+import { Option } from '@ephox/katamari';
 
-const set = (element: Element<HTMLInputElement>, status: boolean) => {
+const set = (element: Element<HTMLInputElement>, status: boolean): void => {
   element.dom().checked = status;
 };
 
 // :checked selector requires IE9
 // http://www.quirksmode.org/css/selectors/#t60
-const find = (parent: Element<DomNode>) => SelectorFind.descendant<HTMLInputElement>(parent, 'input:checked');
+const find = (parent: Element<DomNode>): Option<Element<HTMLInputElement>> =>
+  SelectorFind.descendant<HTMLInputElement>(parent, 'input:checked');
 
 export {
   set,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Class.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Class.ts
@@ -12,7 +12,7 @@ import Toggler from './Toggler';
  * If it did, the toggler could be better.
  */
 
-const add = (element: Element<DomElement>, clazz: string) => {
+const add = (element: Element<DomElement>, clazz: string): void => {
   if (ClassList.supports(element)) {
     element.dom().classList.add(clazz);
   } else {
@@ -20,7 +20,7 @@ const add = (element: Element<DomElement>, clazz: string) => {
   }
 };
 
-const cleanClass = (element: Element<DomElement>) => {
+const cleanClass = (element: Element<DomElement>): void => {
   const classList = ClassList.supports(element) ? element.dom().classList : ClassList.get(element);
   // classList is a "live list", so this is up to date already
   if (classList.length === 0) {
@@ -29,7 +29,7 @@ const cleanClass = (element: Element<DomElement>) => {
   }
 };
 
-const remove = (element: Element<DomElement>, clazz: string) => {
+const remove = (element: Element<DomElement>, clazz: string): void => {
   if (ClassList.supports(element)) {
     const classList = element.dom().classList;
     classList.remove(clazz);
@@ -40,7 +40,7 @@ const remove = (element: Element<DomElement>, clazz: string) => {
   cleanClass(element);
 };
 
-const toggle = (element: Element<DomElement>, clazz: string) =>
+const toggle = (element: Element<DomElement>, clazz: string): boolean =>
   ClassList.supports(element) ? element.dom().classList.toggle(clazz) : ClassList.toggle(element, clazz);
 
 const toggler = (element: Element<DomElement>, clazz: string) => {
@@ -63,7 +63,7 @@ const toggler = (element: Element<DomElement>, clazz: string) => {
   return Toggler(off, on, has(element, clazz));
 };
 
-const has = (element: Element<Node>, clazz: string) =>
+const has = (element: Element<Node>, clazz: string): boolean =>
   ClassList.supports(element) && element.dom().classList.contains(clazz);
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Classes.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Classes.ts
@@ -8,29 +8,31 @@ import * as Class from './Class';
  * ClassList is IE10 minimum:
  * https://developer.mozilla.org/en-US/docs/Web/API/Element.classList
  */
-const add = (element: Element<DomElement>, classes: string[]) => {
+const add = (element: Element<DomElement>, classes: string[]): void => {
   Arr.each(classes, (x) => {
     Class.add(element, x);
   });
 };
 
-const remove = (element: Element<DomElement>, classes: string[]) => {
+const remove = (element: Element<DomElement>, classes: string[]): void => {
   Arr.each(classes, (x) => {
     Class.remove(element, x);
   });
 };
 
-const toggle = (element: Element<DomElement>, classes: string[]) => {
+const toggle = (element: Element<DomElement>, classes: string[]): void => {
   Arr.each(classes, (x) => {
     Class.toggle(element, x);
   });
 };
 
-const hasAll = (element: Element<DomNode>, classes: string[]) => Arr.forall(classes, (clazz) => Class.has(element, clazz));
+const hasAll = (element: Element<DomNode>, classes: string[]): boolean =>
+  Arr.forall(classes, (clazz) => Class.has(element, clazz));
 
-const hasAny = (element: Element<DomNode>, classes: string[]) => Arr.exists(classes, (clazz) => Class.has(element, clazz));
+const hasAny = (element: Element<DomNode>, classes: string[]): boolean =>
+  Arr.exists(classes, (clazz) => Class.has(element, clazz));
 
-const getNative = (element: Element<DomElement>) => {
+const getNative = (element: Element<DomElement>): string[] => {
   const classList = element.dom().classList;
   const r: Array<string> = new Array(classList.length);
   for (let i = 0; i < classList.length; i++) {
@@ -42,7 +44,8 @@ const getNative = (element: Element<DomElement>) => {
   return r;
 };
 
-const get = (element: Element<DomElement>) => ClassList.supports(element) ? getNative(element) : ClassList.get(element);
+const get = (element: Element<DomElement>): string[] =>
+  ClassList.supports(element) ? getNative(element) : ClassList.get(element);
 
 export {
   add,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
@@ -6,7 +6,7 @@ import Element from '../node/Element';
 import * as Node from '../node/Node';
 import * as Attr from './Attr';
 
-const internalSet = (dom: DomNode, property: string, value: string) => {
+const internalSet = (dom: DomNode, property: string, value: string): void => {
   // This is going to hurt. Apologies.
   // JQuery coerces numbers to pixels for certain property names, and other times lets numbers through.
   // we're going to be explicit; strings only.
@@ -22,7 +22,7 @@ const internalSet = (dom: DomNode, property: string, value: string) => {
   }
 };
 
-const internalRemove = (dom: DomNode, property: string) => {
+const internalRemove = (dom: DomNode, property: string): void => {
   /*
    * IE9 and above - MDN doesn't have details, but here's a couple of random internet claims
    *
@@ -86,7 +86,8 @@ const get = (element: Element<DomElement>, property: string): string => {
 
 // removed: support for dom().style[property] where prop is camel case instead of normal property name
 // empty string is what the browsers (IE11 and Chrome) return when the propertyValue doesn't exists.
-const getUnsafeProperty = (dom: DomNode, property: string) => Style.isSupported(dom) ? dom.style.getPropertyValue(property) : '';
+const getUnsafeProperty = (dom: DomNode, property: string): string =>
+  Style.isSupported(dom) ? dom.style.getPropertyValue(property) : '';
 
 /*
  * Gets the raw value from the style attribute. Useful for retrieving "used values" from the DOM:
@@ -94,14 +95,15 @@ const getUnsafeProperty = (dom: DomNode, property: string) => Style.isSupported(
  *
  * Returns NONE if the property isn't set, or the value is an empty string.
  */
-const getRaw = (element: Element<DomNode>, property: string) => {
+const getRaw = (element: Element<DomNode>, property: string): Option<string> => {
   const dom = element.dom();
   const raw = getUnsafeProperty(dom, property);
 
   return Option.from(raw).filter((r) => r.length > 0);
 };
 
-const getAllRaw = (element: Element<DomNode>) => {
+// TODO: TINY-3312: when we update dom-globals, this return type will need to change
+const getAllRaw = (element: Element<DomNode>): Record<string, string> => {
   const css: Record<string, string> = {};
   const dom = element.dom();
 
@@ -114,14 +116,14 @@ const getAllRaw = (element: Element<DomNode>) => {
   return css;
 };
 
-const isValidValue = (tag: string, property: string, value: string) => {
+const isValidValue = (tag: string, property: string, value: string): boolean => {
   const element = Element.fromTag(tag);
   set(element, property, value);
   const style = getRaw(element, property);
   return style.isSome();
 };
 
-const remove = (element: Element<DomNode>, property: string) => {
+const remove = (element: Element<DomNode>, property: string): void => {
   const dom = element.dom();
 
   internalRemove(dom, property);
@@ -132,7 +134,7 @@ const remove = (element: Element<DomNode>, property: string) => {
   }
 };
 
-const preserve = <E extends DomElement, T> (element: Element<E>, f: (e: Element<E>) => T) => {
+const preserve = <E extends DomElement, T> (element: Element<E>, f: (e: Element<E>) => T): T => {
   const oldStyles = Attr.get(element, 'style');
   const result = f(element);
   if (oldStyles === undefined) {
@@ -143,7 +145,7 @@ const preserve = <E extends DomElement, T> (element: Element<E>, f: (e: Element<
   return result;
 };
 
-const copy = (source: Element<DomNode>, target: Element<HTMLElement>) => {
+const copy = (source: Element<DomNode>, target: Element<HTMLElement>): void => {
   const sourceDom = source.dom();
   const targetDom = target.dom();
   if (Style.isSupported(sourceDom) && Style.isSupported(targetDom)) {
@@ -155,9 +157,10 @@ const copy = (source: Element<DomNode>, target: Element<HTMLElement>) => {
  * do not rely on this return value.
  * It's here so the closure compiler doesn't optimise the property access away.
  */
-const reflow = (e: Element<HTMLElement>) => e.dom().offsetWidth;
+const reflow = (e: Element<HTMLElement>): number =>
+  e.dom().offsetWidth;
 
-const transferOne = (source: Element<DomNode>, destination: Element<DomNode>, style: string) => {
+const transferOne = (source: Element<DomNode>, destination: Element<DomNode>, style: string): void => {
   getRaw(source, style).each((value) => {
     // NOTE: We don't want to clobber any existing inline styles.
     if (getRaw(destination, style).isNone()) {
@@ -166,7 +169,7 @@ const transferOne = (source: Element<DomNode>, destination: Element<DomNode>, st
   });
 };
 
-const transfer = (source: Element<DomNode>, destination: Element<DomNode>, styles: string[]) => {
+const transfer = (source: Element<DomNode>, destination: Element<DomNode>, styles: string[]): void => {
   if (!Node.isElement(source) || !Node.isElement(destination)) {
     return;
   }

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
@@ -153,12 +153,12 @@ const copy = (source: Element<DomNode>, target: Element<HTMLElement>): void => {
   }
 };
 
-/* NOTE:
- * do not rely on this return value.
- * It's here so the closure compiler doesn't optimise the property access away.
+/* NOTE: This function is here for the side effect it triggers.
+The value itself is not used.
+Be sure to not use the return value, and that it is not removed by a minifier.
  */
-const reflow = (e: Element<HTMLElement>): number =>
-  e.dom().offsetWidth;
+const reflow = (e: Element<HTMLElement>): void =>
+  e.dom().offsetWidth as unknown as void;
 
 const transferOne = (source: Element<DomNode>, destination: Element<DomNode>, style: string): void => {
   getRaw(source, style).each((value) => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/CssProperty.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/CssProperty.ts
@@ -3,11 +3,14 @@ import Element from '../node/Element';
 import * as Css from './Css';
 
 export default (property: string, value: string) => {
-  const is = (element: Element<DomElement>) => Css.get(element, property) === value;
+  const is = (element: Element<DomElement>): boolean =>
+    Css.get(element, property) === value;
 
-  const remove = (element: Element<DomNode>) => Css.remove(element, property);
+  const remove = (element: Element<DomNode>): void =>
+    Css.remove(element, property);
 
-  const set = (element: Element<DomNode>) => Css.set(element, property, value);
+  const set = (element: Element<DomNode>): void =>
+    Css.set(element, property, value);
 
   return {
     is,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Direction.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Direction.ts
@@ -2,9 +2,11 @@ import { Element as DomElement } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as Css from './Css';
 
-const onDirection = <T = any> (isLtr: T, isRtl: T) => (element: Element<DomElement>) => getDirection(element) === 'rtl' ? isRtl : isLtr;
+const onDirection = <T = any> (isLtr: T, isRtl: T) => (element: Element<DomElement>): T =>
+  getDirection(element) === 'rtl' ? isRtl : isLtr;
 
-const getDirection = (element: Element<DomElement>): 'rtl' | 'ltr' => Css.get(element, 'direction') === 'rtl' ? 'rtl' : 'ltr';
+const getDirection = (element: Element<DomElement>): 'rtl' | 'ltr' =>
+  Css.get(element, 'direction') === 'rtl' ? 'rtl' : 'ltr';
 
 export {
   onDirection,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Float.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Float.ts
@@ -4,7 +4,7 @@ import * as Style from '../../impl/Style';
 import Element from '../node/Element';
 import * as Css from './Css';
 
-const isCentered = (element: Element<DomNode>) => {
+const isCentered = (element: Element<DomNode>): boolean => {
   const dom = element.dom();
   if (Style.isSupported(dom)) {
     const marginLeft = dom.style.marginRight;
@@ -15,7 +15,7 @@ const isCentered = (element: Element<DomNode>) => {
   }
 };
 
-const divine = (element: Element<DomElement>) => {
+const divine = (element: Element<DomElement>): Option<string> => {
   if (isCentered(element)) {
     return Option.some('center');
   } else {
@@ -24,9 +24,10 @@ const divine = (element: Element<DomElement>) => {
   }
 };
 
-const getRaw = (element: Element<DomNode>) => Css.getRaw(element, 'float').getOrNull();
+const getRaw = (element: Element<DomNode>): string | null =>
+  Css.getRaw(element, 'float').getOrNull();
 
-const setCentered = (element: Element<DomNode>) => {
+const setCentered = (element: Element<DomNode>): void => {
   Css.setAll(element, {
     'margin-left': 'auto',
     'margin-right': 'auto'

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Html.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Html.ts
@@ -6,9 +6,10 @@ import Element from '../node/Element';
 import * as Elements from '../node/Elements';
 import * as Traverse from '../search/Traverse';
 
-const get = (element: Element<HTMLElement>) => element.dom().innerHTML;
+const get = (element: Element<HTMLElement>): string =>
+  element.dom().innerHTML;
 
-const set = (element: Element<DomNode>, content: string) => {
+const set = (element: Element<DomNode>, content: string): void => {
   const owner = Traverse.owner(element);
   const docDom = owner.dom();
 
@@ -21,7 +22,7 @@ const set = (element: Element<DomNode>, content: string) => {
   Insert.append(element, fragment);
 };
 
-const getOuter = (element: Element<DomNode>) => {
+const getOuter = (element: Element<DomNode>): string => {
   const container = Element.fromTag('div');
   const clone = Element.fromDom(element.dom().cloneNode(true));
   Insert.append(container, clone);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/OnNode.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/OnNode.ts
@@ -3,19 +3,20 @@ import Element from '../node/Element';
 import * as Class from './Class';
 import * as Classes from './Classes';
 
-const addClass = (clazz: string) => (element: Element<DomElement>) => {
+const addClass = (clazz: string) => (element: Element<DomElement>): void => {
   Class.add(element, clazz);
 };
 
-const removeClass = (clazz: string) => (element: Element<DomElement>) => {
+const removeClass = (clazz: string) => (element: Element<DomElement>): void => {
   Class.remove(element, clazz);
 };
 
-const removeClasses = (classes: string[]) => (element: Element<DomElement>) => {
+const removeClasses = (classes: string[]) => (element: Element<DomElement>): void => {
   Classes.remove(element, classes);
 };
 
-const hasClass = (clazz: string) => (element: Element<DomNode>) => Class.has(element, clazz);
+const hasClass = (clazz: string) => (element: Element<DomNode>): boolean =>
+  Class.has(element, clazz);
 
 export {
   addClass,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/TextContent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/TextContent.ts
@@ -1,10 +1,12 @@
 import { Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 
-// REQUIRES IE9
-const get = (element: Element<DomNode>) => element.dom().textContent;
+const get = (element: Element<DomNode>): string | null =>
+  element.dom().textContent;
 
-const set = (element: Element<DomNode>, value: string) => element.dom().textContent = value;
+const set = (element: Element<DomNode>, value: string): void => {
+  element.dom().textContent = value;
+};
 
 export {
   get,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Value.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Value.ts
@@ -3,9 +3,10 @@ import Element from '../node/Element';
 
 type TogglableElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | HTMLOptionElement | HTMLButtonElement;
 
-const get = (element: Element<TogglableElement>) => element.dom().value;
+const get = (element: Element<TogglableElement>): string =>
+  element.dom().value;
 
-const set = (element: Element<TogglableElement>, value: string) => {
+const set = (element: Element<TogglableElement>, value: string): void => {
   if (value === undefined) {
     throw new Error('Value.set was undefined');
   }

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Has.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Has.ts
@@ -4,19 +4,19 @@ import * as Compare from '../dom/Compare';
 import Element from '../node/Element';
 import * as PredicateExists from './PredicateExists';
 
-const ancestor = (element: Element<DomNode>, target: Element<DomNode>) =>
+const ancestor = (element: Element<DomNode>, target: Element<DomNode>): boolean =>
   PredicateExists.ancestor(element, Fun.curry(Compare.eq, target));
 
-const anyAncestor = (element: Element<DomNode>, targets: Element<DomNode>[]) =>
+const anyAncestor = (element: Element<DomNode>, targets: Element<DomNode>[]): boolean =>
   Arr.exists(targets, (target) => ancestor(element, target));
 
-const sibling = (element: Element<DomNode>, targets: Element<DomNode>[]) =>
+const sibling = (element: Element<DomNode>, targets: Element<DomNode>[]): boolean =>
   PredicateExists.sibling(element, (elem) => Arr.exists(targets, Fun.curry(Compare.eq, elem)));
 
-const child = (element: Element<DomNode>, target: Element<DomNode>) =>
+const child = (element: Element<DomNode>, target: Element<DomNode>): boolean =>
   PredicateExists.child(element, Fun.curry(Compare.eq, target));
 
-const descendant = (element: Element<DomNode>, target: Element<DomNode>) =>
+const descendant = (element: Element<DomNode>, target: Element<DomNode>): boolean =>
   PredicateExists.descendant(element, Fun.curry(Compare.eq, target));
 
 export { ancestor, anyAncestor, sibling, child, descendant };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateExists.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateExists.ts
@@ -2,22 +2,22 @@ import { Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as PredicateFind from './PredicateFind';
 
-const any = (predicate: (e: Element<DomNode>) => boolean) =>
+const any = (predicate: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.first(predicate).isSome();
 
-const ancestor = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean, isRoot?: (e: Element<DomNode>) => boolean) =>
+const ancestor = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean, isRoot?: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.ancestor(scope, predicate, isRoot).isSome();
 
-const closest = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean, isRoot?: (e: Element<DomNode>) => boolean) =>
+const closest = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean, isRoot?: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.closest(scope, predicate, isRoot).isSome();
 
-const sibling = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean) =>
+const sibling = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.sibling(scope, predicate).isSome();
 
-const child = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean) =>
+const child = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.child(scope, predicate).isSome();
 
-const descendant = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean) =>
+const descendant = (scope: Element<DomNode>, predicate: (e: Element<DomNode>) => boolean): boolean =>
   PredicateFind.descendant(scope, predicate).isSome();
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorExists.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorExists.ts
@@ -2,22 +2,22 @@ import { Node as DomNode } from '@ephox/dom-globals';
 import Element from '../node/Element';
 import * as SelectorFind from './SelectorFind';
 
-const any = (selector: string) =>
+const any = (selector: string): boolean =>
   SelectorFind.first(selector).isSome();
 
-const ancestor = (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean) =>
+const ancestor = (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean): boolean =>
   SelectorFind.ancestor(scope, selector, isRoot).isSome();
 
-const sibling = (scope: Element<DomNode>, selector: string) =>
+const sibling = (scope: Element<DomNode>, selector: string): boolean =>
   SelectorFind.sibling(scope, selector).isSome();
 
-const child = (scope: Element<DomNode>, selector: string) =>
+const child = (scope: Element<DomNode>, selector: string): boolean =>
   SelectorFind.child(scope, selector).isSome();
 
-const descendant = (scope: Element<DomNode>, selector: string) =>
+const descendant = (scope: Element<DomNode>, selector: string): boolean =>
   SelectorFind.descendant(scope, selector).isSome();
 
-const closest = (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean) =>
+const closest = (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean): boolean =>
   SelectorFind.closest(scope, selector, isRoot).isSome();
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFilter.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFilter.ts
@@ -3,7 +3,8 @@ import Element from '../node/Element';
 import * as PredicateFilter from './PredicateFilter';
 import * as Selectors from './Selectors';
 
-const all = <T extends DomElement = DomElement> (selector: string) => Selectors.all<T>(selector);
+const all = <T extends DomElement = DomElement> (selector: string): Element<T>[] =>
+  Selectors.all<T>(selector);
 
 // For all of the following:
 //
@@ -11,22 +12,23 @@ const all = <T extends DomElement = DomElement> (selector: string) => Selectors.
 // Traverse should also do this (but probably not by default).
 //
 
-const ancestors = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean) =>
+const ancestors = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string, isRoot?: (e: Element<DomNode>) => boolean): Element<T>[] =>
   // It may surprise you to learn this is exactly what JQuery does
   // TODO: Avoid all this wrapping and unwrapping
   PredicateFilter.ancestors(scope, (e): e is Element<T> => Selectors.is<T>(e, selector), isRoot);
 
-const siblings = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) =>
+const siblings = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Element<T>[] =>
   // It may surprise you to learn this is exactly what JQuery does
   // TODO: Avoid all the wrapping and unwrapping
   PredicateFilter.siblings(scope, (e): e is Element<T> => Selectors.is<T>(e, selector));
 
-const children = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) =>
+const children = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Element<T>[] =>
   // It may surprise you to learn this is exactly what JQuery does
   // TODO: Avoid all the wrapping and unwrapping
   PredicateFilter.children(scope, (e): e is Element<T> => Selectors.is<T>(e, selector));
 
-const descendants = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string) => Selectors.all<T>(selector, scope);
+const descendants = <T extends DomElement = DomElement> (scope: Element<DomNode>, selector: string): Element<T>[] =>
+  Selectors.all<T>(selector, scope);
 
 export {
   all,

--- a/modules/tinymce/src/core/demo/ts/demo/InlineDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/InlineDemo.ts
@@ -26,7 +26,7 @@ export default function () {
     plugins: [
       'autosave advlist autolink link image lists charmap print preview hr anchor pagebreak spellchecker toc',
       'searchreplace wordcount visualblocks visualchars code fullscreen fullpage insertdatetime media nonbreaking',
-      'save table directionality emoticons template paste importcss textpattern',
+      'save table directionality emoticons template paste textpattern',
       'codesample help noneditable print'
     ]
   };


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Add explicit return types to functions in sugar, in preparation for upgrading dom-globals. Replaces a previous PR, which went a bit too far and broke tests. This one is just adding return types - I've looked for any quick wins.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
