### PR TITLE
TINY-6073: Backported parsing fix to 4.5.x

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
-Version 4.5.12 (2020-07-01)
+Version 4.5.12 (2020-07-03)
   Fixed so links with xlink:href attributes are filtered correctly to prevent XSS. #TINY-1626
+  Fixed the `visualchars` plugin converting HTML-like text to DOM elements in certain cases #TINY-4507
   Fixed HTML comments incorrectly being parsed in certain cases #TINY-4511
   Fixed a security issue related to CDATA sanitization during parsing #TINY-4669
 Version 4.5.11 (2019-05-16)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 4.5.12 (2020-07-01)
+  Fixed so links with xlink:href attributes are filtered correctly to prevent XSS. #TINY-6073
 Version 4.5.11 (2019-05-16)
   Fixed bug where the editor would scroll to the top of the editable area if a dialog was closed in inline mode. #TINY-1073
 Version 4.5.10 (2018-10-19)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 Version 4.5.12 (2020-07-01)
-  Fixed so links with xlink:href attributes are filtered correctly to prevent XSS. #TINY-6073
+  Fixed so links with xlink:href attributes are filtered correctly to prevent XSS. #TINY-1626
+  Fixed HTML comments incorrectly being parsed in certain cases #TINY-4511
+  Fixed a security issue related to CDATA sanitization during parsing #TINY-4669
 Version 4.5.11 (2019-05-16)
   Fixed bug where the editor would scroll to the top of the editable area if a dialog was closed in inline mode. #TINY-1073
 Version 4.5.10 (2018-10-19)

--- a/js/tinymce/classes/html/SaxParser.js
+++ b/js/tinymce/classes/html/SaxParser.js
@@ -137,7 +137,8 @@ define("tinymce/html/SaxParser", [
 			var validate, elementRule, isValidElement, attr, attribsValue, validAttributesMap, validAttributePatterns;
 			var attributesRequired, attributesDefault, attributesForced;
 			var anyAttributesRequired, selfClosing, tokenRegExp, attrRegExp, specialElements, attrValue, idCount = 0;
-			var decode = Entities.decode, fixSelfClosing, filteredUrlAttrs = Tools.makeMap('src,href,data,background,formaction,poster');
+			var decode = Entities.decode, fixSelfClosing;
+			var filteredUrlAttrs = Tools.makeMap('src,href,data,background,formaction,poster,xlink:href');
 			var scriptUriRegExp = /((java|vb)script|mhtml):/i, dataUriRegExp = /^data:/i;
 
 			function processEndTag(name) {

--- a/js/tinymce/classes/html/SaxParser.js
+++ b/js/tinymce/classes/html/SaxParser.js
@@ -57,6 +57,14 @@ define("tinymce/html/SaxParser", [
 ], function(Schema, Entities, Tools) {
 	var each = Tools.each;
 
+	function trimComments(text) {
+		var sanitizedText = text;
+		while (/<!--|--!?>/g.test(sanitizedText)) {
+			sanitizedText = sanitizedText.replace(/<!--|--!?>/g, '');
+		}
+		return sanitizedText;
+	}
+
 	/**
 	 * Returns the index of the end tag for a specific start tag. This can be
 	 * used to skip all children of a parent element from being processed.
@@ -236,7 +244,7 @@ define("tinymce/html/SaxParser", [
 
 			// Precompile RegExps and map objects
 			tokenRegExp = new RegExp('<(?:' +
-				'(?:!--([\\w\\W]*?)-->)|' + // Comment
+				'(?:!--([\\w\\W]*?)--!?>)|' + // Comment
 				'(?:!\\[CDATA\\[([\\w\\W]*?)\\]\\]>)|' + // CDATA
 				'(?:!DOCTYPE([\\w\\W]*?)>)|' + // DOCTYPE
 				'(?:\\?([^\\s\\/<>]+) ?([\\w\\W]*?)[?/]>)|' + // PI
@@ -443,7 +451,7 @@ define("tinymce/html/SaxParser", [
 
 					self.comment(value);
 				} else if ((value = matches[2])) { // CDATA
-					self.cdata(value);
+					self.cdata(trimComments(value));
 				} else if ((value = matches[3])) { // DOCTYPE
 					self.doctype(value);
 				} else if ((value = matches[4])) { // PI

--- a/js/tinymce/plugins/visualchars/plugin.js
+++ b/js/tinymce/plugins/visualchars/plugin.js
@@ -68,7 +68,7 @@ tinymce.PluginManager.add('visualchars', function(editor) {
 			}, 'childNodes');
 
 			for (i = 0; i < nodeList.length; i++) {
-				nodeValue = nodeList[i].nodeValue;
+				nodeValue = editor.dom.encode(nodeList[i].nodeValue);
 				nodeValue = nodeValue.replace(visualCharsRegExp, wrapCharWithSpan);
 
 				div = editor.dom.create('div', null, nodeValue);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "4.5.11",
+  "version": "4.5.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git"

--- a/tests/plugins/visualchars.js
+++ b/tests/plugins/visualchars.js
@@ -29,3 +29,13 @@ test('Visualchar toggle on/off', function() {
 	editor.execCommand('mceVisualChars');
 	equal(0, editor.dom.select('span').length);
 });
+
+test('Visualchar toggle on/off with HTML like content ', function() {
+	editor.setContent('<p>&lt;img src="image.png"&gt;&nbsp;</p>');
+	equal(0, editor.dom.select('span').length);
+	editor.execCommand('mceVisualChars');
+	equal('<p>&lt;img src="image.png"&gt;&nbsp;</p>', editor.getContent());
+	equal(1, editor.dom.select('span').length);
+	editor.execCommand('mceVisualChars');
+	equal(0, editor.dom.select('span').length);
+});

--- a/tests/tinymce/html/SaxParser.js
+++ b/tests/tinymce/html/SaxParser.js
@@ -367,7 +367,7 @@
 	test('Parsing comments', function() {
 		var counter, parser;
 
-		expect(8);
+		expect(10);
 
 		counter = createCounter(writer);
 		parser = new tinymce.html.SaxParser(counter, schema);
@@ -396,6 +396,13 @@
 		parser.parse('<b>a<!-- value -->b</b>');
 		equal(writer.getContent(), '<b>a<!-- value -->b</b>', 'Parse comment with tags around it.');
 		deepEqual(counter.counts, {comment:1, text:2, start:1, end:1}, 'Parse comment with tags around it counts.');
+
+		counter = createCounter(writer);
+		parser = new tinymce.html.SaxParser(counter, schema);
+		writer.reset();
+		parser.parse('<!-- value --!>');
+		equal(writer.getContent(), '<!-- value -->', 'Parse comment with exclamation in end value.');
+		deepEqual(counter.counts, {comment: 1}, 'Parse comment with exclamation in end value counts.');
 	});
 
 	test('Parsing cdata', function() {
@@ -739,5 +746,25 @@
 			'<?xml &gt;&lt;iframe SRC=&amp;#106&amp;#97&amp;#118&amp;#97&amp;#115&amp;#99&amp;#114&amp;#105&amp;#112&amp;' +
 			'#116&amp;#58&amp;#97&amp;#108&amp;#101&amp;#114&amp;#116&amp;#40&amp;#39&amp;#88&amp;#83&amp;#83&amp;#39&amp;#41&gt;?>'
 		);
+	});
+
+	test('Parse cdata with comments and trim those comments away', function () {
+		var testCDataSaxParse = function (inputHtml, outputHtml, counters) {
+			var counter, parser;
+
+			counter = createCounter(writer);
+			counter.validate = true;
+			parser = new tinymce.html.SaxParser(counter, schema);
+			writer.reset();
+			parser.parse(inputHtml);
+			equal(writer.getContent(), outputHtml);
+			deepEqual(counter.counts, counters);
+		};
+
+		expect(6);
+
+		testCDataSaxParse('<![CDATA[<!--x--><!--y--!>--><!--]]>', '<![CDATA[xy]]>', {cdata: 1});
+		testCDataSaxParse('<![CDATA[------>>>xy]]>', '<![CDATA[xy]]>', {cdata: 1});
+		testCDataSaxParse('<![CDATA[------!>>!>xy]]>', '<![CDATA[xy]]>', {cdata: 1});
 	});
 })();

--- a/tests/tinymce/html/SaxParser.js
+++ b/tests/tinymce/html/SaxParser.js
@@ -671,6 +671,7 @@
 			'<button formaction="javascript:alert(11)">11</button>' +
 			'<table background="javascript:alert(12)"><tr><tr>12</tr></tr></table>' +
 			'<a href="mhtml:13">13</a>' +
+			'<a xlink:href="jAvaScript:alert(1)">14</a>' +
 			'<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
 			'<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>'
 		);
@@ -678,7 +679,7 @@
 		equal(
 			writer.getContent(),
 			'<a>1</a><a>2</a><a>3</a><a>4</a><a>5</a><a>6</a><a>7</a><a>8</a><a>9</a>' +
-			'<object>10</object><button>11</button><table><tr></tr><tr>12</tr></table><a>13</a>' +
+			'<object>10</object><button>11</button><table><tr></tr><tr>12</tr></table><a>13</a><a>14</a>' +
 			'<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />' +
 			'<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>'
 		);


### PR DESCRIPTION
Related Ticket: TINY-6073

Description of Changes:
* This backports the following parsing/serialization fixes for 4.5.x:
  * xlink:href fix done in 4.7.12 (see https://github.com/tinymce/tinymce/commit/15ff5b81c2a1e44efbc7fdba92b65d2bdcbc4c38)
  * comments fix done in 4.9.7 (see https://github.com/tinymce/tinymce/commit/cb6bbf495356a6fbd333ab8c0ce17a32fca81cc5)
  * cdata fix done in 4.9.10 (see https://github.com/tinymce/tinymce/commit/aa516c52d4f2104c36af3d640b2adb22e379f9a4)
  * visual chars plugin fix done in 4.9.7 (see https://github.com/tinymce/tinymce/commit/84156be76c0ed398b1a3f806cd353ae0eb3f1473)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):