### PR TITLE
TINY-6051: Fixed an issue where responsive tables weren't converted to relative tables when resizing

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Tinymce.ts
+++ b/modules/tinymce/src/core/main/ts/api/Tinymce.ts
@@ -130,7 +130,7 @@ export interface TinyMCE extends EditorManager {
 
   // Global instances
   DOM: DOMUtils;
-  ScriptLoader: ScriptLoaderConstructor;
+  ScriptLoader: ScriptLoader;
   PluginManager: AddOnManager<void | Plugin>;
   ThemeManager: AddOnManager<Theme>;
   IconManager: IconManager;

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -94,10 +94,9 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
     if (isTable(targetElm)) {
       const table = Element.fromDom(targetElm);
 
-      const tableHasPercentage = Sizes.isPercentSizing(table);
-      if (tableHasPercentage && isPixelsForced(editor)) {
+      if (!Sizes.isPixelSizing(table) && isPixelsForced(editor)) {
         enforcePixels(editor, table);
-      } else if (!tableHasPercentage && (isPercentagesForced(editor) || isResponsiveForced(editor))) {
+      } else if (!Sizes.isPercentSizing(table) && isPercentagesForced(editor)) {
         enforcePercentage(editor, table);
       }
 
@@ -111,7 +110,11 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
     if (isTable(targetElm)) {
       const table = Element.fromDom(targetElm);
 
-      if (Util.isPercentage(startRawW)) {
+      if (startRawW === '' || (!Util.isPercentage(startRawW) && isResponsiveForced(editor))) {
+        // Responsive tables don't have a width so we need to convert it to a relative/percent
+        // table instead, as that's closer to responsive sizing than fixed sizing
+        enforcePercentage(editor, table);
+      } else if (Util.isPercentage(startRawW)) {
         const percentW = parseFloat(startRawW.replace('%', ''));
         const targetPercentW = e.width * percentW / startW;
         Css.set(table, 'width', targetPercentW + '%');


### PR DESCRIPTION
Related Ticket: TINY-6051

Description of Changes:
* This fixes an issue I noticed overnight whereby if you didn't have a fixed sizing mode on and then resized a table without widths it'd resize incorrectly. This also moves the responsive -> relative conversion until after the initial resize, which makes it behave more like it previously did.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable) (pressed on time, will add a test later)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
