### PR TITLE
TINY-6189: Fix broken help urls

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -52,7 +52,7 @@ const urls = [
   { key: 'advcode', name: 'Advanced Code Editor*' },
   { key: 'formatpainter', name: 'Format Painter*' },
   { key: 'powerpaste', name: 'PowerPaste*' },
-  { key: '../tinydrive', name: 'Tiny Drive*' },
+  { key: 'drive', name: 'Tiny Drive*' },
   { key: 'tinymcespellchecker', name: 'Spell Checker Pro*' },
   { key: 'a11ychecker', name: 'Accessibility Checker*' },
   { key: 'linkchecker', name: 'Link Checker*' },

--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -52,7 +52,7 @@ const urls = [
   { key: 'advcode', name: 'Advanced Code Editor*' },
   { key: 'formatpainter', name: 'Format Painter*' },
   { key: 'powerpaste', name: 'PowerPaste*' },
-  { key: 'tinydrive', name: 'Tiny Drive*' },
+  { key: '../tinydrive', name: 'Tiny Drive*' },
   { key: 'tinymcespellchecker', name: 'Spell Checker Pro*' },
   { key: 'a11ychecker', name: 'Accessibility Checker*' },
   { key: 'linkchecker', name: 'Link Checker*' },
@@ -62,7 +62,7 @@ const urls = [
   { key: 'casechange', name: 'Case Change*' },
   { key: 'permanentpen', name: 'Permanent Pen*' },
   { key: 'pageembed', name: 'Page Embed*' },
-  { key: 'tinycomments', name: 'Tiny Comments*' },
+  { key: 'comments', name: 'Tiny Comments*' },
   { key: 'advtable', name: 'Advanced Tables*' },
   { key: 'autocorrect', name: 'Autocorrect*' }
 ];


### PR DESCRIPTION
Related Ticket: TINY-6189

Description of Changes:
* Fix broken plugin URLs in the help plugin

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
