### PR TITLE
TINY-6000: Fixed legacy width attribute not being removed when switching sizing modes

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableConversions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableConversions.ts
@@ -1,24 +1,36 @@
+import { HTMLElement, HTMLTableElement } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
-import { Css, Element } from '@ephox/sugar';
+import { Attr, Css, Element } from '@ephox/sugar';
 import { BarPositions, ColInfo } from '../resize/BarPositions';
 import * as Sizes from '../resize/Sizes';
 import { redistribute } from './Sizes';
 import * as TableLookup from './TableLookup';
 import { TableSize } from './TableSize';
 
-const convertToPercentSize = (table: Element, direction: BarPositions<ColInfo>, tableSize: TableSize) => {
+// Remove legacy sizing attributes such as "width"
+const cleanupLegacyAttributes = (element: Element<HTMLElement>) => {
+  Attr.remove(element, 'width');
+};
+
+const convertToPercentSize = (table: Element<HTMLTableElement>, direction: BarPositions<ColInfo>, tableSize: TableSize) => {
   const newWidth = Sizes.getPercentTableWidth(table);
   redistribute(table, Option.some(newWidth), Option.none(), direction, tableSize);
+  cleanupLegacyAttributes(table);
 };
 
-const convertToPixelSize = (table: Element, direction: BarPositions<ColInfo>, tableSize: TableSize) => {
+const convertToPixelSize = (table: Element<HTMLTableElement>, direction: BarPositions<ColInfo>, tableSize: TableSize) => {
   const newWidth = Sizes.getPixelTableWidth(table);
   redistribute(table, Option.some(newWidth), Option.none(), direction, tableSize);
+  cleanupLegacyAttributes(table);
 };
 
-const convertToNoneSize = (table: Element) => {
+const convertToNoneSize = (table: Element<HTMLTableElement>) => {
   Css.remove(table, 'width');
-  Arr.each(TableLookup.cells(table), (cell) => Css.remove(cell, 'width'));
+  Arr.each(TableLookup.cells(table), (cell) => {
+    Css.remove(cell, 'width');
+    cleanupLegacyAttributes(cell);
+  });
+  cleanupLegacyAttributes(table);
 };
 
 export {


### PR DESCRIPTION
Related Ticket: TINY-6000

Description of Changes:
* Fixes an issue @trevorjay found that prevented swapping back to responsive sizing mode since we don't clean up the legacy width attributes.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
