### PR TITLE
TINY-6190: Added changelog and bump versions for 5.4.0 release

### DIFF
--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@ephox/acid",
   "description": "Color library including Alloy UI component for a color picker",
-  "version": "1.0.76",
+  "version": "1.0.77",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
   },
   "dependencies": {
-    "@ephox/alloy": "^7.0.2",
-    "@ephox/boulder": "^4.0.5",
+    "@ephox/alloy": "^7.0.3",
+    "@ephox/boulder": "^4.0.6",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/sugar": "^6.0.1",
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/sugar": "^6.1.0",
     "tslib": "^1.9.3"
   },
   "author": "Ephox Corporation",

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/agar",
-  "version": "4.15.5",
+  "version": "4.16.0",
   "description": "Testing infrastructure",
   "repository": {
     "type": "git",
@@ -25,14 +25,14 @@
   "dependencies": {
     "@ephox/bedrock-client": "^9.3.2",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/jax": "^4.1.33",
-    "@ephox/sand": "^3.1.8",
-    "@ephox/sugar": "^6.0.1",
+    "@ephox/jax": "^4.1.34",
+    "@ephox/sand": "^3.1.9",
+    "@ephox/sugar": "^6.1.0",
     "@ephox/wrap-jsverify": "^2.0.1",
     "@ephox/wrap-sizzle": "^4.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.6"
+    "@ephox/katamari-assertions": "^1.0.7"
   },
   "files": [
     "lib/main",

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ephox/alloy",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "Ui Framework",
   "dependencies": {
-    "@ephox/agar": "^4.15.5",
-    "@ephox/boulder": "^4.0.5",
+    "@ephox/agar": "^4.16.0",
+    "@ephox/boulder": "^4.0.6",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/sand": "^3.1.8",
-    "@ephox/sugar": "^6.0.1"
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/sand": "^3.1.9",
+    "@ephox/sugar": "^6.1.0"
   },
   "files": [
     "lib/main",

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/boss",
   "description": "Generic wrapper to document models - DomUniverse vs TestUniverse",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -19,12 +19,12 @@
   ],
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/sugar": "^6.0.1",
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/sugar": "^6.1.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.6"
+    "@ephox/katamari-assertions": "^1.0.7"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/boulder/package.json
+++ b/modules/boulder/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ephox/boulder",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Basic javascript object validation",
   "dependencies": {
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/sand": "^3.1.8"
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/sand": "^3.1.9"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.6"
+    "@ephox/katamari-assertions": "^1.0.7"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test/ts",

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/bridge",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Ui API for TinyMCE 5",
   "repository": {
     "type": "git",
@@ -12,9 +12,9 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
   "dependencies": {
-    "@ephox/boulder": "^4.0.5",
+    "@ephox/boulder": "^4.0.6",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1"
+    "@ephox/katamari": "^6.1.0"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/darwin",
   "description": "This project's purpose is to handle selection and cursor navigation.",
-  "version": "4.0.16",
+  "version": "4.0.17",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -19,12 +19,12 @@
   ],
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/phoenix": "^5.1.6",
-    "@ephox/robin": "^7.0.53",
-    "@ephox/sand": "^3.1.8",
-    "@ephox/snooker": "^5.1.14",
-    "@ephox/sugar": "^6.0.1"
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/phoenix": "^5.1.7",
+    "@ephox/robin": "^7.0.54",
+    "@ephox/sand": "^3.1.9",
+    "@ephox/snooker": "^6.0.0",
+    "@ephox/sugar": "^6.1.0"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/dragster",
   "description": "This project handles dragging.",
-  "version": "4.0.48",
+  "version": "4.0.49",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -19,9 +19,9 @@
   ],
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/porkbun": "^4.0.35",
-    "@ephox/sugar": "^6.0.1"
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/porkbun": "^4.0.36",
+    "@ephox/sugar": "^6.1.0"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test",

--- a/modules/imagetools/package.json
+++ b/modules/imagetools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/imagetools",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Image tools for tinymce and textbox.io",
   "keywords": [
     "image",

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/jax",
-  "version": "4.1.33",
+  "version": "4.1.34",
   "description": "AJAX library",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
+    "@ephox/katamari": "^6.1.0",
     "tslib": "^1.9.3"
   },
   "files": [

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari-assertions",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Bedrock test assertions for Katamari",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "@ephox/bedrock-client": "^9.3.2",
     "@ephox/dispute": "^1.0.3",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
+    "@ephox/katamari": "^6.1.0",
     "@ephox/wrap-promise-polyfill": "^2.2.0",
     "tslib": "^1.9.3"
   },

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Basic data type library",
   "repository": {
     "type": "git",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/mcagar",
-  "version": "4.1.6",
+  "version": "4.2.0",
   "description": "Tinymce agar wrapper",
   "repository": {
     "type": "git",
@@ -23,11 +23,11 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/agar": "^4.15.5",
+    "@ephox/agar": "^4.16.0",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/sand": "^3.1.8",
-    "@ephox/sugar": "^6.0.1",
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/sand": "^3.1.9",
+    "@ephox/sugar": "^6.1.0",
     "@ephox/wrap-jsverify": "^2.0.1"
   },
   "main": "./lib/main/ts/ephox/mcagar/api/Main.js",

--- a/modules/oxide-icons-default/package.json
+++ b/modules/oxide-icons-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide-icons-default",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "The default icon pack for TinyMCE",
   "main": "dist/js/icons.js",
   "scripts": {

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "TinyMCE 5 Oxide skin",
   "scripts": {
     "test": "echo 'No tests'",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/phoenix",
   "description": "DOM node text gathering library, rose from the ashes of some other projects we can't remember the names of now (edit: seek, sherlock, gift)",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,14 +18,14 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^3.1.5",
+    "@ephox/boss": "^3.1.6",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/polaris": "^3.0.50",
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/polaris": "^3.0.51",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.6"
+    "@ephox/katamari-assertions": "^1.0.7"
   },
   "scripts": {
     "test-manual": "bedrock -d src/test",

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/polaris",
   "description": "This project does data manipulation on arrays and strings.",
-  "version": "3.0.50",
+  "version": "3.0.51",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -19,11 +19,11 @@
   ],
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
+    "@ephox/katamari": "^6.1.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.6"
+    "@ephox/katamari-assertions": "^1.0.7"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/porkbun",
   "description": "Event framework for JavaScript",
-  "version": "4.0.35",
+  "version": "4.0.36",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,7 +18,7 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^6.0.1"
+    "@ephox/katamari": "^6.1.0"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test/ts",

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/robin",
   "description": "This project is for grouping sibling DOM nodes together by boundary points, for example the list of elements and nodes representing a word.",
-  "version": "7.0.53",
+  "version": "7.0.54",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,14 +18,14 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^3.1.5",
+    "@ephox/boss": "^3.1.6",
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/phoenix": "^5.1.6",
-    "@ephox/polaris": "^3.0.50"
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/phoenix": "^5.1.7",
+    "@ephox/polaris": "^3.0.51"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.6"
+    "@ephox/katamari-assertions": "^1.0.7"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sand",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Platform detection library",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1"
+    "@ephox/katamari": "^6.1.0"
   },
   "main": "./lib/main/ts/ephox/sand/api/Main.js",
   "module": "./lib/main/ts/ephox/sand/api/Main.js",

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/snooker",
   "description": "This project implements the table model.",
-  "version": "5.1.14",
+  "version": "6.0.0",
   "files": [
     "lib/main",
     "lib/demo",
@@ -19,11 +19,11 @@
   },
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/dragster": "^4.0.48",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/porkbun": "^4.0.35",
-    "@ephox/robin": "^7.0.53",
-    "@ephox/sugar": "^6.0.1"
+    "@ephox/dragster": "^4.0.49",
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/porkbun": "^4.0.36",
+    "@ephox/robin": "^7.0.54",
+    "@ephox/sugar": "^6.1.0"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sugar",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Basic DOM manipulation",
   "repository": {
     "type": "git",
@@ -22,11 +22,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ephox/dom-globals": "^1.1.2",
-    "@ephox/katamari": "^6.0.1",
-    "@ephox/sand": "^3.1.8"
+    "@ephox/katamari": "^6.1.0",
+    "@ephox/sand": "^3.1.9"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.6"
+    "@ephox/katamari-assertions": "^1.0.7"
   },
   "files": [
     "lib/main",

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,4 @@
-Version 5.4.0 (TBD)
+Version 5.4.0 (2020-06-30)
     Added keyboard navigation support to menus and toolbars when the editor is in a ShadowRoot #TINY-6152
     Added the ability for menus to be clicked when the editor is in an open shadow root #TINY-6091
     Added the `Editor.ui.styleSheetLoader` API for loading stylesheets within the Document or ShadowRoot containing the editor UI #TINY-6089


### PR DESCRIPTION
Related Ticket: TINY-6190

Description of Changes:
```
Changes:
 - @ephox/acid: 1.0.76 => 1.0.77
 - @ephox/agar: 4.15.5 => 4.16.0
 - @ephox/alloy: 7.0.2 => 7.0.3
 - @ephox/boss: 3.1.5 => 3.1.6
 - @ephox/boulder: 4.0.5 => 4.0.6
 - @ephox/bridge: 1.2.1 => 1.2.2
 - @ephox/darwin: 4.0.16 => 4.0.17
 - @ephox/dragster: 4.0.48 => 4.0.49
 - @ephox/imagetools: 3.3.1 => 3.3.2
 - @ephox/jax: 4.1.33 => 4.1.34
 - @ephox/katamari-assertions: 1.0.6 => 1.0.7
 - @ephox/katamari: 6.0.1 => 6.1.0
 - @ephox/mcagar: 4.1.6 => 4.2.0
 - @tinymce/oxide-icons-default: 1.3.3 => 1.4.0
 - @tinymce/oxide: 1.3.3 => 1.4.0
 - @ephox/phoenix: 5.1.6 => 5.1.7
 - @ephox/polaris: 3.0.50 => 3.0.51
 - @ephox/porkbun: 4.0.35 => 4.0.36
 - @ephox/robin: 7.0.53 => 7.0.54
 - @ephox/sand: 3.1.8 => 3.1.9
 - @ephox/snooker: 5.1.14 => 6.0.0
 - @ephox/sugar: 6.0.1 => 6.1.0
```

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
