### PR TITLE
TINY-4113: Now saves both sources if only one previously existed.

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.5.0 (TBD)
-
+    Fixed the `media` plugin not saving the alternative source url in some situations #TINY-4113
 Version 5.4.0 (2020-06-30)
     Added keyboard navigation support to menus and toolbars when the editor is in a ShadowRoot #TINY-6152
     Added the ability for menus to be clicked when the editor is in an open shadow root #TINY-6091

--- a/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
@@ -161,7 +161,7 @@ const updateHtml = (html: string, data: Partial<MediaData>, updateAll?: boolean)
               const attrs: any = [];
               attrs.map = {};
 
-              if (sourceCount < index) {
+              if (sourceCount <= index) {
                 setAttributes(attrs, {
                   src: data[sources[index]],
                   type: data[sources[index] + 'mime']

--- a/modules/tinymce/src/plugins/media/test/ts/atomic/UpdateHtmlTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/atomic/UpdateHtmlTest.ts
@@ -1,0 +1,37 @@
+import * as UpdateHtml from 'tinymce/plugins/media/core/UpdateHtml';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { MediaData } from 'tinymce/plugins/media/core/Types';
+
+UnitTest.test('atomic.plugins.media.UpdateHtmlTest', () => {
+  const testHtmlUpdate = (description: string, html: string, newData: Partial<MediaData>, updateAll: boolean, expected: string) => {
+    const actual = UpdateHtml.updateHtml(html, newData, updateAll);
+    Assert.eq(description, expected, actual);
+  };
+  testHtmlUpdate(
+    'If not updating all, nothing new is added',
+    '<video><source src="oldValue"/></video>',
+    {
+      source: 'source1',
+      sourcemime: 'source1mime',
+      altsource: 'source2',
+      altsourcemime: 'source2mime',
+      poster: 'poster'
+    },
+    false,
+    '<video><source src="oldValue" /></video>'
+  );
+
+  testHtmlUpdate(
+    'If updating all, add missing sources and attributes',
+    '<video><source src="oldValue"/></video>',
+    {
+      source: 'source1',
+      sourcemime: 'source1mime',
+      altsource: 'source2',
+      altsourcemime: 'source2mime',
+      poster: 'poster'
+    },
+    true,
+    '<video poster="poster"><source src="source1" type="source1mime" /><source src="source2" type="source2mime" /></video>'
+  );
+});


### PR DESCRIPTION
Related Ticket: TINY-4113

Description of Changes:
* Placeholder text

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
