### PR TITLE
Tiny 5950: Prevent dragging and dropping inside a table from creating selections

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
@@ -1,71 +1,133 @@
 import { Element, Focus } from '@ephox/sugar';
+import { Fun } from '@ephox/katamari';
 
 import * as Clicks from '../mouse/Clicks';
 import { Chain } from './Chain';
 import * as UiFinder from './UiFinder';
 
-const cTrigger = (selector: string, action: (ele: Element) => void) => Chain.async<Element, Element>((container, next, die) => {
-  UiFinder.findIn(container, selector).fold(
-    () => die('Could not find element: ' + selector),
-    (ele) => {
-      action(ele);
-      next(container);
-    }
-  );
-});
+// Custom event creation
+const cClickWith = Fun.compose(Chain.op, Clicks.click);
+const cContextMenuWith = Fun.compose(Chain.op, Clicks.contextMenu);
+const cMouseOverWith = Fun.compose(Chain.op, Clicks.mouseOver);
+const cMouseDownWith = Fun.compose(Chain.op, Clicks.mouseDown);
+const cMouseUpWith = Fun.compose(Chain.op, Clicks.mouseUp);
+const cMouseMoveWith = Fun.compose(Chain.op, Clicks.mouseMove);
+const cMouseOutWith = Fun.compose(Chain.op, Clicks.mouseOut);
 
-const sTriggerWith = <T>(container: Element, selector: string, action: (ele: Element) => void) => Chain.asStep<T, Element>(container, [ cTrigger(selector, action) ]);
+// With delta position (shifted relative to top-left of component)
+/**
+ * @deprecated use cMouseUpWith({ dx, dy }) instead */
+const cMouseUpTo = (dx: number, dy: number) => cMouseUpWith({ dx, dy });
+/**
+ * @deprecated use cMouseMoveWith({ dx, dy }) instead */
+const cMouseMoveTo = (dx: number, dy: number) => cMouseMoveWith({ dx, dy });
 
-const trueClick = function (elem: Element) {
+// No extra settings
+/**
+ * @deprecated use cClickWith({ }) instead*/
+const cClick = cClickWith({ });
+/**
+ * @deprecated use cContextMenuWith({ }) instead */
+const cContextMenu = cContextMenuWith({ });
+/**
+ * @deprecated use cMouseOverWith({ }) instead */
+const cMouseOver = cMouseOverWith({ });
+/**
+ * @deprecated use cMouseDownWith({ }) instead */
+const cMouseDown = cMouseDownWith({ });
+/**
+ * @deprecated use cMouseUpWith({ }) instead */
+const cMouseUp = cMouseUpWith({ });
+/**
+ * @deprecated use cMouseMoveWith({ }) instead */
+const cMouseMove = cMouseMoveWith({ });
+/**
+ * @deprecated use cMouseOutWith({ }) instead */
+const cMouseOut = cMouseOutWith({ });
+
+// Work with selectors
+const sTriggerOn = <T>(container: Element, selector: string, action: (ele: Element) => void) =>
+  Chain.asStep<T, Element>(container, [ Chain.async<Element, Element>((container, next, die) => {
+    UiFinder.findIn(container, selector).fold(
+      () => die('Could not find element: ' + selector),
+      (ele) => {
+        action(ele);
+        next(container);
+      }
+    );
+  }) ]);
+
+const sClickOn = <T>(container: Element, selector: string) => sTriggerOn<T>(container, selector, Clicks.trigger);
+
+const sHoverOn = <T>(container: Element, selector: string) =>
+  sTriggerOn<T>(container, selector, Clicks.mouseOver({ }));
+
+const sContextMenuOn = <T>(container: Element, selector: string) =>
+  sTriggerOn<T>(container, selector, Clicks.contextMenu({ }));
+
+const cClickOn = (selector: string): Chain<Element, Element> => Chain.fromIsolatedChains([
+  UiFinder.cFindIn(selector),
+  cClick
+]);
+
+// True click utilities: mouse down / mouse up / click events all in one
+const trueClick = (elem: Element) => {
   // The closest event queue to a true Click
   Focus.focus(elem);
-  Clicks.mousedown(elem);
-  Clicks.mouseup(elem);
+  Clicks.mouseDown({ })(elem);
+  Clicks.mouseUp({ })(elem);
   Clicks.trigger(elem);
 };
-
-const sClickOn = <T>(container: Element, selector: string) => sTriggerWith<T>(container, selector, Clicks.trigger);
-
-const sHoverOn = <T>(container: Element, selector: string) => sTriggerWith<T>(container, selector, Clicks.mouseover);
-
-const sTrueClickOn = <T>(container: Element, selector: string) => sTriggerWith<T>(container, selector, trueClick);
-
-const sContextMenuOn = <T>(container: Element, selector: string) => sTriggerWith<T>(container, selector, Clicks.contextmenu);
-
-const cClickOn = (selector: string): Chain<Element, Element> => cTrigger(selector, Clicks.trigger);
-
-const cMouseUpTo = (dx: number, dy: number) => Chain.op(Clicks.mouseupTo(dx, dy));
-
-const cMouseMoveTo = (dx: number, dy: number) => Chain.op(Clicks.mousemoveTo(dx, dy));
-
-const point = Clicks.point;
-
-const cClick = Chain.op(Clicks.trigger);
 const cTrueClick = Chain.op(trueClick);
-const cContextMenu = Chain.op(Clicks.contextmenu);
-const cMouseOver = Chain.op(Clicks.mouseover);
-const cMouseDown = Chain.op(Clicks.mousedown);
-const cMouseUp = Chain.op(Clicks.mouseup);
-const cMouseMove = Chain.op(Clicks.mousemove);
-const cMouseOut = Chain.op(Clicks.mouseout);
+const sTrueClickOn = <T>(container: Element, selector: string) => sTriggerOn<T>(container, selector, trueClick);
+
+// Low level exports
+const leftClickButton = Clicks.leftClickButton ;
+const middleClickButton = Clicks.middleClickButton ;
+const rightClickButton = Clicks.rightClickButton ;
+const leftClickButtons = Clicks.leftClickButtons ;
+const rightClickButtons = Clicks.rightClickButtons ;
+const middleClickButtons = Clicks.middleClickButtons ;
+/**
+ * @deprecated Use event instead */
+const point = Clicks.point;
+const event = Clicks.event;
 
 export {
-  point,
-
-  sClickOn,
-  sTrueClickOn,
-  sHoverOn,
-  sContextMenuOn,
+  cClickWith,
+  cContextMenuWith,
+  cMouseOverWith,
+  cMouseDownWith,
+  cMouseUpWith,
+  cMouseMoveWith,
+  cMouseOutWith,
 
   cClick,
-  cClickOn,
-  cTrueClick,
   cContextMenu,
   cMouseOver,
   cMouseDown,
   cMouseUp,
-  cMouseUpTo,
   cMouseMove,
+  cMouseOut,
+
+  cMouseUpTo,
   cMouseMoveTo,
-  cMouseOut
+
+  sClickOn,
+  sHoverOn,
+  sContextMenuOn,
+  cClickOn,
+
+  cTrueClick,
+  sTrueClickOn,
+
+  leftClickButton,
+  middleClickButton,
+  rightClickButton,
+  leftClickButtons,
+  rightClickButtons,
+  middleClickButtons,
+
+  point,
+  event
 };

--- a/modules/agar/src/main/ts/ephox/agar/mouse/Clicks.ts
+++ b/modules/agar/src/main/ts/ephox/agar/mouse/Clicks.ts
@@ -1,8 +1,82 @@
-import { Document, HTMLElement, MouseEvent, window } from '@ephox/dom-globals';
-import { Element, Location } from '@ephox/sugar';
+import { Node as DomNode, Document, HTMLElement, MouseEvent, window } from '@ephox/dom-globals';
+import { Element, Location, Node, Position } from '@ephox/sugar';
+import { Fun, Obj } from '@ephox/katamari';
 
-const LEFT_CLICK = 0;
-const RIGHT_CLICK = 2;
+// The 'button' field of the mouse event - which button was pressed to create the event. Pick only one value. Not defined for mouseenter,
+// mouseleave, mouseover, mouseout or mousemove.
+const leftClickButton = 0;
+const middleClickButton = 1;
+const rightClickButton = 2;
+
+// The 'buttons' field of the mouse event - which buttons *were already pressed* at the time the event fired. Forms a bitfield.
+const leftClickButtons = 1;
+const rightClickButtons = 2;
+const middleClickButtons = 4;
+
+// Settings for mouse events
+interface Settings {
+  // used to tweak the location before firing the event
+  dx?: number;
+  dy?: number;
+  // settings for the event itself
+  button?: number;
+  buttons?: number;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+  bubbles?: boolean;
+  cancelable?: boolean;
+}
+
+// Types of events
+type EventType = 'click' | 'mousedown' | 'mouseup' | 'mousemove' | 'mouseover' | 'mouseout' | 'contextmenu';
+
+// Fire an event
+const event = (type: EventType, { dx, dy, ...settings }: Settings) => (element: Element<DomNode>) => {
+  const location = (Node.isElement(element) ? Location.absolute(element) : Position(0, 0)).translate(dx || 0, dy || 0);
+  // IE doesn't support MouseEvent constructor
+  if (typeof MouseEvent === 'function') {
+    const event = new MouseEvent(type, {
+      screenX: location.left(),
+      screenY: location.top(),
+      clientX: location.left(),
+      clientY: location.top(),
+      bubbles: true,
+      cancelable: true,
+      ...settings
+    });
+    element.dom().dispatchEvent(event);
+  } else {
+    // Adapted from: http://stackoverflow.com/questions/17468611/triggering-click-event-phantomjs
+    const event: MouseEvent = (<Document> element.dom().ownerDocument).createEvent('MouseEvents');
+    event.initMouseEvent(
+      type,
+      true, /* bubble */ true, /* cancelable */
+      window, null,
+      location.left(), location.top(), /* screen coordinates */
+      location.left(), location.top(), /* client coordinates, hope they're the same */
+      Obj.get(settings, 'ctrlKey').getOr(false), /* meta key */
+      Obj.get(settings, 'shiftKey').getOr(false),
+      Obj.get(settings, 'altKey').getOr(false),
+      Obj.get(settings, 'metaKey').getOr(false),
+      Obj.get(settings, 'button').getOr(0), /* button */
+      null
+    );
+    element.dom().dispatchEvent(event);
+  }
+};
+
+const click = (settings: Settings) => (element: Element<DomNode>) => {
+  const dom = element.dom();
+  Obj.get(dom as any, 'click').fold(() => event('click', settings)(element), Fun.call);
+};
+const mouseDown = Fun.curry(event, 'mousedown');
+const mouseUp = Fun.curry(event, 'mouseup');
+const mouseMove = Fun.curry(event, 'mousemove');
+const mouseOver = Fun.curry(event, 'mouseover');
+const mouseOut = Fun.curry(event, 'mouseout');
+const contextMenu = (settings: Settings) => event('contextmenu', { button: rightClickButton, ...settings });
 
 // Note: This can be used for phantomjs.
 const trigger = function (element: Element<any>): any {
@@ -11,7 +85,7 @@ const trigger = function (element: Element<any>): any {
     return ele.click();
   }
   // Adapted from: http://stackoverflow.com/questions/17468611/triggering-click-event-phantomjs
-  point('click', LEFT_CLICK, element, 0, 0);
+  point('click', leftClickButton, element, 0, 0);
   return undefined;
 };
 
@@ -29,34 +103,24 @@ const point = (type: string, button: number, element: Element<any>, x: number, y
   element.dom().dispatchEvent(ev);
 };
 
-const click = (eventType: string, button: number) => (element: Element<any>): void => {
-  const position = Location.absolute(element);
-  point(eventType, button, element, position.left(), position.top());
-};
-
-const clickAt = (eventType: string, button: number) => (dx: number, dy: number) => (element: Element<any>): void => {
-  const position = Location.absolute(element);
-  point(eventType, button, element, position.left() + dx, position.top() + dy);
-};
-
-const mousedown = click('mousedown', LEFT_CLICK);
-const mouseup = click('mouseup', LEFT_CLICK);
-const mouseupTo = clickAt('mouseup', LEFT_CLICK);
-const mousemove = click('mousemove', LEFT_CLICK);
-const mousemoveTo = clickAt('mousemove', LEFT_CLICK);
-const mouseover = click('mouseover', LEFT_CLICK);
-const mouseout = click('mouseout', LEFT_CLICK);
-const contextmenu = click('contextmenu', RIGHT_CLICK);
-
 export {
-  trigger,
-  mousedown,
-  mouseup,
-  mouseupTo,
-  mousemove,
-  mousemoveTo,
-  mouseover,
-  mouseout,
-  contextmenu,
-  point
+  event,
+  Settings,
+  EventType,
+  leftClickButton,
+  middleClickButton,
+  rightClickButton,
+  leftClickButtons,
+  rightClickButtons,
+  middleClickButtons,
+  click,
+  mouseDown,
+  mouseUp,
+  mouseMove,
+  mouseOver,
+  mouseOut,
+  contextMenu,
+  // deprecate these
+  point,
+  trigger
 };

--- a/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
@@ -24,6 +24,7 @@ const mouse = function (win: Window, container: Element, isRoot: (e: Element) =>
   const handlers = MouseSelection(bridge, container, isRoot, annotations);
 
   return {
+    clearstate: handlers.clearstate,
     mousedown: handlers.mousedown,
     mouseover: handlers.mouseover,
     mouseup: handlers.mouseup

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Singleton.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Singleton.ts
@@ -1,25 +1,37 @@
 import { Option } from './Option';
 import { Cell } from './Cell';
 
-const revocable = function <T> (doRevoke: (data: T) => void) {
+interface Singleton<T> {
+  clear: () => void;
+  isSet: () => boolean;
+  set: (value: T) => void;
+}
+
+export interface Revocable<T> extends Singleton<T> { };
+
+export interface Api<T> extends Singleton<T> {
+  run: (fn: (data: T) => void) => void;
+}
+
+export interface Value<T> extends Singleton<T> {
+  on: (fn: (data: T) => void) => void;
+}
+
+const revocable = <T> (doRevoke: (data: T) => void): Singleton<T> => {
   const subject = Cell(Option.none<T>());
 
-  const revoke = function () {
-    subject.get().each(doRevoke);
-  };
+  const revoke = (): void => subject.get().each(doRevoke);
 
-  const clear = function () {
+  const clear = () => {
     revoke();
     subject.set(Option.none());
   };
 
-  const set = function (s: T) {
+  const isSet = () => subject.get().isSome();
+
+  const set = (s: T) => {
     revoke();
     subject.set(Option.some(s));
-  };
-
-  const isSet = function () {
-    return subject.get().isSome();
   };
 
   return {
@@ -29,44 +41,28 @@ const revocable = function <T> (doRevoke: (data: T) => void) {
   };
 };
 
-export const destroyable = function <T extends { destroy: () => void }> () {
-  return revocable<T>(function (s) {
-    s.destroy();
-  });
-};
+export const destroyable = <T extends { destroy: () => void }> (): Revocable<T> => revocable<T>((s) => s.destroy());
 
-export const unbindable = function <T extends { unbind: () => void }> () {
-  return revocable<T>(function (s) {
-    s.unbind();
-  });
-};
+export const unbindable = <T extends { unbind: () => void }> (): Revocable<T> => revocable<T>((s) => s.unbind());
 
-export const api = function <T extends { destroy: () => void }> () {
+export const api = <T extends { destroy: () => void }> (): Api<T> => {
   const subject = Cell(Option.none<T>());
 
-  const revoke = function () {
-    subject.get().each(function (s) {
-      s.destroy();
-    });
-  };
+  const revoke = () => subject.get().each((s) => s.destroy());
 
-  const clear = function () {
+  const clear = () => {
     revoke();
     subject.set(Option.none());
   };
 
-  const set = function (s: T) {
+  const set = (s: T) => {
     revoke();
     subject.set(Option.some(s));
   };
 
-  const run = function (f: (data: T) => void) {
-    subject.get().each(f);
-  };
+  const run = (f: (data: T) => void) => subject.get().each(f);
 
-  const isSet = function () {
-    return subject.get().isSome();
-  };
+  const isSet = () => subject.get().isSome();
 
   return {
     clear,
@@ -76,24 +72,16 @@ export const api = function <T extends { destroy: () => void }> () {
   };
 };
 
-export const value = function <T> () {
+export const value = <T> (): Value<T> => {
   const subject = Cell(Option.none<T>());
 
-  const clear = function () {
-    subject.set(Option.none());
-  };
+  const clear = () => subject.set(Option.none());
 
-  const set = function (s: T) {
-    subject.set(Option.some(s));
-  };
+  const set = (s: T) => subject.set(Option.some(s));
 
-  const on = function (f: (data: T) => void) {
-    subject.get().each(f);
-  };
+  const isSet = () => subject.get().isSome();
 
-  const isSet = function () {
-    return subject.get().isSome();
-  };
+  const on = (f: (data: T) => void) => subject.get().each(f);
 
   return {
     clear,

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.5.0 (TBD)
     Fixed the `media` plugin not saving the alternative source url in some situations #TINY-4113
+    Fixed an issue where dragging and dropping within a table would select table cells #TINY-5950
 Version 5.4.1 (TBD)
     Fixed zero-width caret characters included in the Search and Replace plugin results #TINY-4599
     Fixed content in an iframe element parsing as dom elements instead of text content #TINY-5943

--- a/modules/tinymce/src/core/main/ts/dom/MousePosition.ts
+++ b/modules/tinymce/src/core/main/ts/dom/MousePosition.ts
@@ -5,7 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { HTMLElement, MouseEvent } from '@ephox/dom-globals';
 import Editor from '../api/Editor';
+import { EditorEvent } from '../api/util/EventDispatcher';
 
 /**
  * This module calculates an absolute coordinate inside the editor body for both local and global mouse events.
@@ -14,7 +16,17 @@ import Editor from '../api/Editor';
  * @class tinymce.dom.MousePosition
  */
 
-const getAbsolutePosition = function (elm) {
+export interface PagePosition {
+  pageX: number;
+  pageY: number;
+};
+
+interface Position {
+  top: number;
+  left: number;
+};
+
+const getAbsolutePosition = (elm: HTMLElement) => {
   const clientRect = elm.getBoundingClientRect();
   const doc = elm.ownerDocument;
   const docElem = doc.documentElement;
@@ -26,16 +38,14 @@ const getAbsolutePosition = function (elm) {
   };
 };
 
-const getBodyPosition = function (editor: Editor) {
-  return editor.inline ? getAbsolutePosition(editor.getBody()) : { left: 0, top: 0 };
-};
+const getBodyPosition = (editor: Editor): Position => editor.inline ? getAbsolutePosition(editor.getBody()) : { left: 0, top: 0 };
 
-const getScrollPosition = function (editor: Editor) {
+const getScrollPosition = (editor: Editor): Position => {
   const body = editor.getBody();
   return editor.inline ? { left: body.scrollLeft, top: body.scrollTop } : { left: 0, top: 0 };
 };
 
-const getBodyScroll = function (editor: Editor) {
+const getBodyScroll = (editor: Editor): Position => {
   const body = editor.getBody(), docElm = editor.getDoc().documentElement;
   const inlineScroll = { left: body.scrollLeft, top: body.scrollTop };
   const iframeScroll = { left: body.scrollLeft || docElm.scrollLeft, top: body.scrollTop || docElm.scrollTop };
@@ -43,7 +53,7 @@ const getBodyScroll = function (editor: Editor) {
   return editor.inline ? inlineScroll : iframeScroll;
 };
 
-const getMousePosition = function (editor: Editor, event) {
+const getMousePosition = (editor: Editor, event: EditorEvent<MouseEvent>): Position => {
   if (event.target.ownerDocument !== editor.getDoc()) {
     const iframePosition = getAbsolutePosition(editor.getContentAreaContainer());
     const scrollPosition = getBodyScroll(editor);
@@ -60,16 +70,13 @@ const getMousePosition = function (editor: Editor, event) {
   };
 };
 
-const calculatePosition = function (bodyPosition, scrollPosition, mousePosition) {
-  return {
-    pageX: (mousePosition.left - bodyPosition.left) + scrollPosition.left,
-    pageY: (mousePosition.top - bodyPosition.top) + scrollPosition.top
-  };
-};
+const calculatePosition = (bodyPosition: Position, scrollPosition: Position, mousePosition: Position): PagePosition => ({
+  pageX: (mousePosition.left - bodyPosition.left) + scrollPosition.left,
+  pageY: (mousePosition.top - bodyPosition.top) + scrollPosition.top
+});
 
-const calc = function (editor: Editor, event) {
-  return calculatePosition(getBodyPosition(editor), getScrollPosition(editor), getMousePosition(editor, event));
-};
+const calc = (editor: Editor, event: EditorEvent<MouseEvent>): PagePosition =>
+  calculatePosition(getBodyPosition(editor), getScrollPosition(editor), getMousePosition(editor, event));
 
 export {
   calc

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -37,7 +37,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
           FileInput.sRunOnPatchedFileInput([ Files.createFile('logo.png', 0, blob) ], Chain.asStep({}, [
             // cPopupToDialog('div[role="dialog"]'),
             ui.cWaitForPopup('Locate popup', 'div[role="dialog"]'),
-            UiFinder.cFindIn('input[type="file"]'),
+            UiFinder.cFindIn('button:contains("Browse for an image")'),
             Mouse.cClick
           ]))
         ], next, die);

--- a/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
@@ -14,6 +14,7 @@ import { Class, Compare, DomEvent, Element, Node, Selection, SelectionDirection 
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as Events from '../api/Events';
 import { getCloneElements } from '../api/Settings';
 import * as Util from '../core/Util';
@@ -132,17 +133,21 @@ export default function (editor: Editor, lazyResize: () => Option<TableResize>, 
       return (raw.buttons & 1) !== 0;
     };
 
-    const mouseDown = (e: MouseEvent) => {
+    const dragStart = (_e: EditorEvent<DragEvent>) => {
+      mouseHandlers.clearstate();
+    };
+
+    const mouseDown = (e: EditorEvent<MouseEvent>) => {
       if (isLeftMouse(e) && hasInternalTarget(e)) {
         mouseHandlers.mousedown(DomEvent.fromRawEvent(e));
       }
     };
-    const mouseOver = (e: MouseEvent) => {
+    const mouseOver = (e: EditorEvent<MouseEvent>) => {
       if (isLeftButtonPressed(e) && hasInternalTarget(e)) {
         mouseHandlers.mouseover(DomEvent.fromRawEvent(e));
       }
     };
-    const mouseUp = (e: MouseEvent) => {
+    const mouseUp = (e: EditorEvent<MouseEvent>) => {
       if (isLeftMouse(e) && hasInternalTarget(e)) {
         mouseHandlers.mouseup(DomEvent.fromRawEvent(e));
       }
@@ -172,6 +177,7 @@ export default function (editor: Editor, lazyResize: () => Option<TableResize>, 
 
     const doubleTap = getDoubleTap();
 
+    editor.on('dragstart', dragStart);
     editor.on('mousedown', mouseDown);
     editor.on('mouseover', mouseOver);
     editor.on('mouseup', mouseUp);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/DragSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/DragSelectionTest.ts
@@ -1,0 +1,59 @@
+import { Chain, Log, Mouse, Pipeline, UiFinder } from '@ephox/agar';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Element } from '@ephox/sugar';
+
+import Theme from 'tinymce/themes/silver/Theme';
+import Plugin from 'tinymce/plugins/table/Plugin';
+
+UnitTest.asynctest('browser.tinymce.plugins.table.DragSelectionTest', (success, failure) => {
+  Theme();
+  Plugin();
+
+  TinyLoader.setupLight((editor, success, failure) => {
+    const tinyApis = TinyApis(editor);
+
+    Pipeline.async({}, [
+      tinyApis.sSetContent(`<div>
+        <table style="border-collapse: collapse; width: 100%;" border="1">
+          <tbody>
+            <tr>
+              <td style="width: 33.333%;">1</td>
+              <td style="width: 33.334%;">2</td>
+              <td id="dragto" style="width: 33.333%;">3</td>
+            </tr>
+            <tr>
+              <td style="width: 66.667%;" colspan="2" rowspan="2">4</td>
+              <td style="width: 33.333%;"><span id="dragfrom" contenteditable="false">55</span></td>
+            </tr>
+            <tr>
+              <td style="width: 33.333%;">6</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>`),
+
+      Log.chainsAsStep('TINY-5950', 'Drag and drop should not select', [
+        Chain.mapper(() => Element.fromDom(editor.getBody())),
+        Chain.fromIsolatedChains([
+          UiFinder.cFindIn('#dragfrom'),
+          Mouse.cMouseDownWith({ }),
+          // realistically the browser would probably put more than 2 mousemove events in here
+          // but as long as there aren't zero mouse move events along the way to the mouse over
+          // event then it's okay
+          Mouse.cMouseMoveWith({ dx: 0, dy: -10, buttons: Mouse.leftClickButtons }),
+          Mouse.cMouseMoveWith({ dx: 0, dy: -20, buttons: Mouse.leftClickButtons })
+        ]),
+        Chain.fromIsolatedChains([
+          UiFinder.cFindIn('#dragto'),
+          Mouse.cMouseOverWith({ buttons: Mouse.leftClickButtons })
+        ]),
+        UiFinder.cNotExists('td[data-mce-selected]')
+      ])
+    ], success, failure);
+  }, {
+    base_url: '/project/tinymce/js/tinymce',
+    plugins: 'table',
+    height: 300
+  }, success, failure);
+});

--- a/versions.txt
+++ b/versions.txt
@@ -1,3 +1,4 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 snooker@6.0.0
+darwin@4.1.0


### PR DESCRIPTION
Related Ticket: TINY-5950

Description of Changes:
* Deprecated a lot of the methods in agar's Mouse module, replacing them with more customisable alternatives
* Added more types to DragDropOverrides.ts in core
* Fixed the issue where dragging and dropping inside a table could lead to selections in the table

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes a bug brought up during #3075