### PR TITLE
TINY-6189: Fixed broken help detection for Tiny Drive and Tiny Comments

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -52,7 +52,7 @@ const urls = [
   { key: 'advcode', name: 'Advanced Code Editor*' },
   { key: 'formatpainter', name: 'Format Painter*' },
   { key: 'powerpaste', name: 'PowerPaste*' },
-  { key: 'drive', name: 'Tiny Drive*' },
+  { key: 'tinydrive', name: 'Tiny Drive*', slug: 'drive' },
   { key: 'tinymcespellchecker', name: 'Spell Checker Pro*' },
   { key: 'a11ychecker', name: 'Accessibility Checker*' },
   { key: 'linkchecker', name: 'Link Checker*' },
@@ -62,7 +62,7 @@ const urls = [
   { key: 'casechange', name: 'Case Change*' },
   { key: 'permanentpen', name: 'Permanent Pen*' },
   { key: 'pageembed', name: 'Page Embed*' },
-  { key: 'comments', name: 'Tiny Comments*' },
+  { key: 'tinycomments', name: 'Tiny Comments*', slug: 'comments' },
   { key: 'advtable', name: 'Advanced Tables*' },
   { key: 'autocorrect', name: 'Autocorrect*' }
 ];

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -15,6 +15,7 @@ import * as Settings from '../api/Settings';
 export interface PluginUrlType {
   key: string;
   name: string;
+  slug?: string;
 }
 
 const tab = (editor: Editor): Types.Dialog.TabApi => {
@@ -60,7 +61,8 @@ const tab = (editor: Editor): Types.Dialog.TabApi => {
     const getMetadata = editor.plugins[key].getMetadata;
     return typeof getMetadata === 'function' ? makeLink(getMetadata()) : key;
   }, function (x) {
-    return makeLink({ name: x.name, url: 'https://www.tiny.cloud/docs/plugins/' + x.key });
+    const urlSlug = x.slug || x.key;
+    return makeLink({ name: x.name, url: 'https://www.tiny.cloud/docs/plugins/' + urlSlug });
   });
 
   const getPluginKeys = (editor: Editor) => {


### PR DESCRIPTION
Related Ticket: TINY-6189

Description of Changes:
* Fixes the help plugin that was broken in 5.4.0 while attempting to fix the broken URLs for comments and drive.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
