### PR TITLE
DOC-571: API docs - fix queryCommandState return

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -502,7 +502,7 @@ class Editor implements EditorObservable {
    * @param {addQueryStateHandlerCallback} callback Function to execute when the command state retrieval occurs.
    * @param {Object} scope Optional scope to execute the function in.
    */
-  public addQueryStateHandler(name: string, callback: () => void, scope?: {}) {
+  public addQueryStateHandler(name: string, callback: () => boolean, scope?: {}) {
     /**
      * Callback function that gets called when a queryCommandState is executed.
      *

--- a/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
@@ -125,7 +125,7 @@ class EditorCommands {
    *
    * @method queryCommandState
    * @param {String} command Command to check the state of.
-   * @return {Boolean/Number} true/false if the selected contents is bold or not, -1 if it's not found.
+   * @return {Boolean} true/false if the selected contents is bold or not.
    */
   public queryCommandState(command: string): boolean {
     let func;

--- a/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
@@ -33,6 +33,12 @@ const map = Tools.map, inArray = Tools.inArray;
 export type EditorCommandCallback = (ui: boolean, value: any, args: any) => void;
 export type EditorCommandsCallback = (command: string, ui: boolean, value: any, args: any) => void;
 
+interface Commands {
+  state: Record<string, (command: string) => boolean>;
+  exec: Record<string, EditorCommandsCallback>;
+  value: Record<string, (command: string) => string>;
+}
+
 export interface EditorCommandsConstructor {
   readonly prototype: EditorCommands;
 
@@ -42,7 +48,7 @@ export interface EditorCommandsConstructor {
 class EditorCommands {
   private readonly editor: Editor;
   private selectionBookmark: Bookmark;
-  private commands = { state: {}, exec: {}, value: {}};
+  private commands: Commands = { state: {}, exec: {}, value: {}};
 
   public constructor(editor: Editor) {
     this.editor = editor;
@@ -183,9 +189,10 @@ class EditorCommands {
    * @param {Object} commandList Name/value collection with commands to add, the names can also be comma separated.
    * @param {String} type Optional type to add, defaults to exec. Can be value or state as well.
    */
-  public addCommands(commandList: Record<string, EditorCommandsCallback>, type?: 'exec' | 'state' | 'value') {
+  public addCommands<K extends keyof Commands>(commandList: Commands[K], type: K): void;
+  public addCommands(commandList: Record<string, EditorCommandsCallback>): void;
+  public addCommands(commandList: Commands[keyof Commands], type: 'exec' | 'state' | 'query' = 'exec') {
     const self = this;
-    type = type || 'exec';
 
     each(commandList, function (callback, command) {
       each(command.toLowerCase().split(','), function (command) {
@@ -223,7 +230,7 @@ class EditorCommands {
     return false;
   }
 
-  public addQueryStateHandler(command: string, callback: () => void, scope?: {}) {
+  public addQueryStateHandler(command: string, callback: () => boolean, scope?: {}) {
     command = command.toLowerCase();
     this.commands.state[command] = () => callback.call(scope || this.editor);
   }


### PR DESCRIPTION
Related Ticket: DOC-571

Description of Changes:
* Remove the incorrect `queryCommandState` return type in the API docs.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
