### PR TITLE
TINY-4599: Fixed zero-width characters included in the Search and Replace results

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,3 +1,5 @@
+Version 5.4.1 (TBD)
+    Fixed zero-width caret characters included in the Search and Replace plugin results #TINY-4599
 Version 5.4.0 (2020-06-30)
     Added keyboard navigation support to menus and toolbars when the editor is in a ShadowRoot #TINY-6152
     Added the ability for menus to be clicked when the editor is in an open shadow root #TINY-6091

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/Actions.ts
@@ -125,7 +125,7 @@ const removeNode = function (dom: DOMUtils, node: Node) {
 };
 
 const escapeSearchText = (text: string, wholeWord: boolean) => {
-  const escapedText = text.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&').replace(/\s/g, '[^\\S\\r\\n]');
+  const escapedText = text.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&').replace(/\s/g, '[^\\S\\r\\n\\uFEFF]');
   const wordRegex = '(' + escapedText + ')';
   return wholeWord ? `(?:^|\\s|${PolarisPattern.punctuation()})` + wordRegex + `(?=$|\\s|${PolarisPattern.punctuation()})` : wordRegex;
 };

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
@@ -1,5 +1,6 @@
 import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Unicode } from '@ephox/katamari';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -178,11 +179,21 @@ UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplacePluginTes
       'x</p>');
   });
 
+  suite.test('TestCase-TINY-4599: SearchReplace: Excludes zwsp characters', (editor) => {
+    const content = `<p>a${Unicode.zeroWidth} b${Unicode.zeroWidth} a</p>`;
+    editor.setContent(content, { format: 'raw' });
+    LegacyUnit.equal(2, editor.plugins.searchreplace.find(' '));
+    LegacyUnit.equal(2, editor.getBody().getElementsByTagName('span').length);
+    editor.plugins.searchreplace.done();
+    LegacyUnit.equal(0, editor.getBody().getElementsByTagName('span').length);
+    LegacyUnit.equal(editor.getBody().innerHTML, content);
+  });
+
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, Log.steps('TBA', 'SearchReplace: Find and replace matches', suite.toSteps(editor)), onSuccess, onFailure);
   }, {
     plugins: 'searchreplace',
-    valid_elements: 'b,i,br,span[contenteditable]',
+    valid_elements: 'p,b,i,br,span[contenteditable]',
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     theme: 'silver'


### PR DESCRIPTION
Related Ticket: TINY-4599

Description of Changes:
* This fixes zwsp caret characters being included in the search results.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
