### PR TITLE
TINY-5943: Fixed an issue where iframes with content aren't getting parsed correctly

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.4.1 (TBD)
     Fixed zero-width caret characters included in the Search and Replace plugin results #TINY-4599
+    Fixed content in an iframe element parsing as dom elements instead of text content #TINY-5943
 Version 5.4.0 (2020-06-30)
     Added keyboard navigation support to menus and toolbars when the editor is in a ShadowRoot #TINY-6152
     Added the ability for menus to be clicked when the editor is in an open shadow root #TINY-6091

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -487,7 +487,7 @@ function Schema(settings?: SchemaSettings): Schema {
   const textInlineElementsMap = createLookupTable('text_inline_elements', 'span strong b em i font strike u var cite ' +
     'dfn code mark q sup sub samp');
 
-  each((settings.special || 'script noscript noframes noembed title style textarea xmp').split(' '), function (name) {
+  each((settings.special || 'script noscript iframe noframes noembed title style textarea xmp').split(' '), function (name) {
     specialElements[name] = new RegExp('<\/' + name + '[^>]*>', 'gi');
   });
 

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -76,7 +76,7 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
       const blockElements = Tools.extend({}, schema.getBlockElements());
       const nonEmptyElements = schema.getNonEmptyElements();
       let parent, lastParent, prev, prevName;
-      const whiteSpaceElements = schema.getNonEmptyElements();
+      const whiteSpaceElements = schema.getWhiteSpaceElements();
       let elementRule, textNode;
 
       // Remove brs from body element as well

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -679,6 +679,17 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
     );
   });
 
+  suite.test('parse iframe XSS', function () {
+    const serializer = Serializer();
+
+    LegacyUnit.equal(
+      serializer.serialize(DomParser().parse(
+        '<iframe><textarea></iframe><img src="a" onerror="alert(document.domain)" />')
+      ),
+      '<iframe><textarea></iframe><img src="a" />'
+    );
+  });
+
   suite.test('getAttributeFilters/getNodeFilters', function () {
     const parser = DomParser();
     const cb1 = (_nodes, _name, _args) => {};

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -909,6 +909,7 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', function (success,
     const specialHtml = (
       '<b>' +
       '<textarea></b></textarea><title></b></title><script></b></script>' +
+      '<iframe><img src="image.png"></iframe>' +
       '<noframes></b></noframes><noscript></b></noscript><style></b></style>' +
       '<xmp></b></xmp>' +
       '<noembed></b></noembed>' +
@@ -920,7 +921,7 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', function (success,
     writer.reset();
     parser.parse(specialHtml);
     LegacyUnit.equal(writer.getContent(), specialHtml);
-    LegacyUnit.deepEqual(counter.counts, { start: 9, text: 8, end: 9 });
+    LegacyUnit.deepEqual(counter.counts, { start: 10, text: 9, end: 10 });
   });
 
   suite.test('Parse malformed elements that start with numbers', function () {

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -1,5 +1,6 @@
 import { Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Arr, Obj } from '@ephox/katamari';
 import { LegacyUnit } from '@ephox/mcagar';
 import Schema from 'tinymce/core/api/html/Schema';
 
@@ -277,6 +278,22 @@ UnitTest.asynctest('browser.tinymce.core.html.SchemaTest', function (success, fa
       b: {}, cite: {}, code: {}, dfn: {}, em: {}, font: {}, i: {}, mark: {}, q: {},
       samp: {}, span: {}, strike: {}, strong: {}, sub: {}, sup: {}, u: {}, var: {}
     });
+  });
+
+  suite.test('getSpecialElements', () => {
+    const schema = Schema();
+    const keys = Arr.sort(Obj.keys(schema.getSpecialElements()));
+    Assert.eq('special elements', keys, Arr.sort([
+      'script',
+      'noscript',
+      'iframe',
+      'noframes',
+      'noembed',
+      'title',
+      'style',
+      'textarea',
+      'xmp'
+    ]));
   });
 
   suite.test('isValidChild', function () {


### PR DESCRIPTION
Related Ticket: TINY-5943

Description of Changes:
As per the HTML parsing spec [1], content within an `<iframe>` element should be parsed as general text, so this just adds iframe to the special elements list. This also fixes an issue I noticed where a parser filter was using the wrong data from the schema (though it was very similar data).

[1] https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
