### PR TITLE
TINY-5943: Backported iframe with content not getting parsed correctly

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 4.9.11 (TBD)
+    Fixed content in an iframe element parsing as dom elements instead of text content #TINY-5943
 Version 4.9.10 (2020-04-23)
     Fixed an issue where the editor selection could end up inside a short ended element (eg br) #TINY-3999
     Fixed a security issue related to CDATA sanitization during parsing #TINY-4669

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "4.9.10",
+  "version": "4.9.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git"

--- a/src/core/main/ts/api/html/Schema.ts
+++ b/src/core/main/ts/api/html/Schema.ts
@@ -446,7 +446,7 @@ function Schema(settings?) {
   textInlineElementsMap = createLookupTable('text_inline_elements', 'span strong b em i font strike u var cite ' +
     'dfn code mark q sup sub samp');
 
-  each((settings.special || 'script noscript noframes noembed title style textarea xmp').split(' '), function (name) {
+  each((settings.special || 'script noscript iframe noframes noembed title style textarea xmp').split(' '), function (name) {
     specialElements[name] = new RegExp('<\/' + name + '[^>]*>', 'gi');
   });
 

--- a/src/core/main/ts/html/ParserFilters.ts
+++ b/src/core/main/ts/html/ParserFilters.ts
@@ -23,7 +23,7 @@ const register = (parser, settings: any): void => {
       const blockElements = Tools.extend({}, schema.getBlockElements());
       const nonEmptyElements = schema.getNonEmptyElements();
       let parent, lastParent, prev, prevName;
-      const whiteSpaceElements = schema.getNonEmptyElements();
+      const whiteSpaceElements = schema.getWhiteSpaceElements();
       let elementRule, textNode;
 
       // Remove brs from body element as well

--- a/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/src/core/test/ts/browser/html/DomParserTest.ts
@@ -694,6 +694,17 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function () {
     );
   });
 
+  suite.test('parse iframe XSS', function () {
+    const serializer = Serializer();
+
+    LegacyUnit.equal(
+      serializer.serialize(DomParser().parse(
+        '<iframe><textarea></iframe><img src="a" onerror="alert(document.domain)" />')
+      ),
+      '<iframe><textarea></iframe><img src="a" />'
+    );
+  });
+
   suite.test('getAttributeFilters/getNodeFilters', function () {
     const parser = DomParser();
     const cb1 = (nodes, name, args) => {};

--- a/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -871,6 +871,7 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', function () {
     const specialHtml = (
       '<b>' +
       '<textarea></b></textarea><title></b></title><script></b></script>' +
+      '<iframe><img src="image.png"></iframe>' +
       '<noframes></b></noframes><noscript></b></noscript><style></b></style>' +
       '<xmp></b></xmp>' +
       '<noembed></b></noembed>' +
@@ -882,7 +883,7 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', function () {
     writer.reset();
     parser.parse(specialHtml);
     LegacyUnit.equal(writer.getContent(), specialHtml);
-    LegacyUnit.deepEqual(counter.counts, { start: 9, text: 8, end: 9 });
+    LegacyUnit.deepEqual(counter.counts, { start: 10, text: 9, end: 10 });
   });
 
   suite.test('Parse malformed elements that start with numbers', function () {

--- a/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/src/core/test/ts/browser/html/SchemaTest.ts
@@ -1,3 +1,4 @@
+import { Arr, Obj } from '@ephox/katamari';
 import { LegacyUnit } from '@ephox/mcagar';
 import { Pipeline } from '@ephox/agar';
 import Schema from 'tinymce/core/api/html/Schema';
@@ -311,6 +312,22 @@ UnitTest.asynctest('browser.tinymce.core.html.SchemaTest', function () {
       b: {}, cite: {}, code: {}, dfn: {}, em: {}, font: {}, i: {}, mark: {}, q: {},
       samp: {}, span: {}, strike: {}, strong: {}, sub: {}, sup: {}, u: {}, var: {}
     });
+  });
+
+  suite.test('getSpecialElements', () => {
+    const schema = Schema();
+    const keys = Arr.sort(Obj.keys(schema.getSpecialElements()));
+    LegacyUnit.equal(keys, Arr.sort([
+      'script',
+      'noscript',
+      'iframe',
+      'noframes',
+      'noembed',
+      'title',
+      'style',
+      'textarea',
+      'xmp'
+    ]));
   });
 
   suite.test('isValidChild', function () {


### PR DESCRIPTION
Related Ticket: TINY-5943

Description of Changes:
Backports the fix done for 5.4.1 to the 4.x release stream. See https://github.com/tinymce/tinymce/pull/5843

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
