### PR TITLE
TINY-5992: Backported `selection.setContent()` API not running parser filters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 Version 4.9.11 (TBD)
+    Fixed the `selection.setContent()` API not running parser filters #TINY-4002
     Fixed content in an iframe element parsing as dom elements instead of text content #TINY-5943
 Version 4.9.10 (2020-04-23)
     Fixed an issue where the editor selection could end up inside a short ended element (eg br) #TINY-3999

--- a/src/core/main/ts/content/GetContent.ts
+++ b/src/core/main/ts/content/GetContent.ts
@@ -26,6 +26,7 @@ export interface GetContentArgs {
   content?: string;
   getInner?: boolean;
   no_events?: boolean;
+  [key: string]: any;
 }
 
 const trimEmptyContents = (editor: Editor, html: string): string => {

--- a/src/core/main/ts/selection/GetSelectionContent.ts
+++ b/src/core/main/ts/selection/GetSelectionContent.ts
@@ -7,11 +7,17 @@
 
 import { Option } from '@ephox/katamari';
 import { Element } from '@ephox/sugar';
+import { GetContentArgs } from '../content/GetContent';
 import EventProcessRanges from './EventProcessRanges';
 import FragmentReader from './FragmentReader';
 import MultiRange from './MultiRange';
 import Zwsp from '../text/Zwsp';
 import { Editor } from '../api/Editor';
+
+export interface GetSelectionContentArgs extends GetContentArgs {
+  selection?: boolean;
+  contextual?: boolean;
+}
 
 const getTextContent = (editor: Editor): string => {
   return Option.from(editor.selection.getRng()).map((rng) => {
@@ -26,7 +32,7 @@ const getTextContent = (editor: Editor): string => {
   }).getOr('');
 };
 
-const getHtmlContent = (editor: Editor, args: any): string => {
+const getHtmlContent = (editor: Editor, args: GetSelectionContentArgs): string => {
   const rng = editor.selection.getRng(), tmpElm = editor.dom.create('body');
   const sel = editor.selection.getSel();
   let fragment;
@@ -40,7 +46,7 @@ const getHtmlContent = (editor: Editor, args: any): string => {
   return editor.selection.serializer.serialize(tmpElm, args);
 };
 
-const getContent = (editor: Editor, args: any = {}): string => {
+const getContent = (editor: Editor, args: GetSelectionContentArgs = {}): string => {
   args.get = true;
   args.format = args.format || 'html';
   args.selection = true;

--- a/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -85,6 +85,15 @@ UnitTest.asynctest('browser.tinymce.core.dom.SelectionTest', function () {
     editor.selection.setContent('<div>test</div>');
     LegacyUnit.equal(editor.getContent(), '<div>test</div>', 'Set contents at selection');
 
+    // Insert XSS at selection
+    editor.setContent('<p>text</p>');
+    rng = editor.dom.createRng();
+    rng.setStart(editor.getBody(), 0);
+    rng.setEnd(editor.getBody(), 1);
+    editor.selection.setRng(rng);
+    editor.selection.setContent('<img src="a" onerror="alert(1)" />');
+    LegacyUnit.equal(editor.getContent(), '<img src="a" />', 'Set XSS at selection');
+
     // Set contents at selection (collapsed)
     editor.setContent('<p>text</p>');
     rng = editor.dom.createRng();


### PR DESCRIPTION
Related Ticket: TINY-5992 & TINY-4002

Description of Changes:
* Backports the fix for the `editor.selection.setContent()` API not running parser filters, etc... to the 4.9.x release stream. See: https://github.com/tinymce/tinymce/pull/5598

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
