### PR TITLE
TINY-6073: Backported additional security fixes to 4.5.x

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version 4.5.12 (2020-07-03)
   Fixed the `visualchars` plugin converting HTML-like text to DOM elements in certain cases #TINY-4507
   Fixed HTML comments incorrectly being parsed in certain cases #TINY-4511
   Fixed a security issue related to CDATA sanitization during parsing #TINY-4669
+  Fixed content in an iframe element parsing as dom elements instead of text content #TINY-5943
 Version 4.5.11 (2019-05-16)
   Fixed bug where the editor would scroll to the top of the editable area if a dialog was closed in inline mode. #TINY-1073
 Version 4.5.10 (2018-10-19)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 4.5.12 (2020-07-03)
   Fixed so links with xlink:href attributes are filtered correctly to prevent XSS. #TINY-1626
+  Fixed the `selection.setContent()` API not running parser filters #TINY-4002
   Fixed the `visualchars` plugin converting HTML-like text to DOM elements in certain cases #TINY-4507
   Fixed HTML comments incorrectly being parsed in certain cases #TINY-4511
   Fixed a security issue related to CDATA sanitization during parsing #TINY-4669

--- a/js/tinymce/classes/dom/Selection.js
+++ b/js/tinymce/classes/dom/Selection.js
@@ -24,11 +24,12 @@ define("tinymce/dom/Selection", [
 	"tinymce/dom/RangeUtils",
 	"tinymce/dom/BookmarkManager",
 	"tinymce/dom/NodeType",
+	"tinymce/html/Serializer",
 	"tinymce/Env",
 	"tinymce/util/Tools",
 	"tinymce/caret/CaretPosition"
-], function(TreeWalker, TridentSelection, ControlSelection, RangeUtils, BookmarkManager, NodeType, Env, Tools, CaretPosition) {
-	var each = Tools.each, trim = Tools.trim;
+], function(TreeWalker, TridentSelection, ControlSelection, RangeUtils, BookmarkManager, NodeType, Serializer, Env, Tools, CaretPosition) {
+	var each = Tools.each, trim = Tools.trim, extend = Tools.extend;
 	var isIE = Env.ie;
 
 	/**
@@ -166,7 +167,12 @@ define("tinymce/dom/Selection", [
 				self.editor.fire('BeforeSetContent', args);
 			}
 
-			content = args.content;
+			if (args.format !== 'raw') {
+				var node = self.editor.parser.parse(args.content, extend({isRootContent: true, forced_root_block: false}, args));
+				content = new Serializer({validate: self.editor.settings.validate}, self.editor.schema).serialize(node);
+			} else {
+				content = args.content;
+			}
 
 			if (rng.insertNode) {
 				// Make caret marker since insertNode places the caret in the beginning of text after insert

--- a/js/tinymce/classes/html/Schema.js
+++ b/js/tinymce/classes/html/Schema.js
@@ -402,7 +402,7 @@ define("tinymce/html/Schema", [
 		textInlineElementsMap = createLookupTable('text_inline_elements', 'span strong b em i font strike u var cite ' +
 		'dfn code mark q sup sub samp');
 
-		each((settings.special || 'script noscript style textarea').split(' '), function(name) {
+		each((settings.special || 'script noscript iframe noframes noembed title style textarea xmp').split(' '), function(name) {
 			specialElements[name] = new RegExp('<\/' + name + '[^>]*>', 'gi');
 		});
 

--- a/tests/tinymce/dom/Selection.js
+++ b/tests/tinymce/dom/Selection.js
@@ -75,6 +75,15 @@ ModuleLoader.require([
 		editor.selection.setContent('<div>test</div>');
 		equal(editor.getContent(), '<div>test</div>', 'Set contents at selection');
 
+		// Insert XSS at selection
+		editor.setContent('<p>text</p>');
+		rng = editor.dom.createRng();
+		rng.setStart(editor.getBody(), 0);
+		rng.setEnd(editor.getBody(), 1);
+		editor.selection.setRng(rng);
+		editor.selection.setContent('<img src="a" onerror="alert(1)" />');
+		equal(editor.getContent(), '<img src="a" />', 'Set XSS at selection');
+
 		// Set contents at selection (collapsed)
 		editor.setContent('<p>text</p>');
 		rng = editor.dom.createRng();

--- a/tests/tinymce/html/DomParser.js
+++ b/tests/tinymce/html/DomParser.js
@@ -576,4 +576,16 @@
 			'<div>1 2<div>3</div></div>'
 		);
 	});
+
+	test('parse iframe XSS', function () {
+		var serializer = new tinymce.html.Serializer();
+
+		equal(
+			serializer.serialize(new tinymce.html.DomParser().parse(
+				'<iframe><textarea></iframe><img src="a" onerror="alert(document.domain)" />')
+			),
+			'<iframe><textarea></iframe><img src="a" />'
+		);
+	});
+
 })();

--- a/tests/tinymce/html/SaxParser.js
+++ b/tests/tinymce/html/SaxParser.js
@@ -767,4 +767,25 @@
 		testCDataSaxParse('<![CDATA[------>>>xy]]>', '<![CDATA[xy]]>', {cdata: 1});
 		testCDataSaxParse('<![CDATA[------!>>!>xy]]>', '<![CDATA[xy]]>', {cdata: 1});
 	});
+
+	test('Parse special elements', function () {
+		var counter, parser;
+
+		var specialHtml = (
+			'<b>' +
+			'<textarea></b></textarea><title></b></title><script></b></script>' +
+			'<iframe><img src="image.png"></iframe>' +
+			'<noframes></b></noframes><noscript></b></noscript><style></b></style>' +
+			'<xmp></b></xmp>' +
+			'<noembed></b></noembed>' +
+			'</b>'
+		);
+
+		counter = createCounter(writer);
+		parser = new tinymce.html.SaxParser(counter, schema);
+		writer.reset();
+		parser.parse(specialHtml);
+		equal(writer.getContent(), specialHtml);
+		deepEqual(counter.counts, {start: 10, text: 9, end: 10});
+	});
 })();


### PR DESCRIPTION
Related Ticket: TINY-6073

Description of Changes:
* This backports the additional security fixes to 4.5.x:
  * `selection.setContent()` API not running parser filters (see https://github.com/tinymce/tinymce/pull/5845/commits/b3d0f6352aeb5b65eb7633c91477930dfbbfeda7)
  * iframe content not being parsed correctly (see https://github.com/tinymce/tinymce/pull/5844/commits/2b71c922214d388838d930806207a66c14e80f63)

Note: I also found 4.5.x was missing a number of additional special elements, which caused similar issues to the iframe. So I've included all of them as special elements.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
