### PR TITLE
TINY-5139: Fixed checklist icons not showing when printing

### DIFF
--- a/modules/oxide/src/less/theme/content/checklist/checklist.less
+++ b/modules/oxide/src/less/theme/content/checklist/checklist.less
@@ -16,15 +16,13 @@
 
     &::before {
       & when (@content-ui-darkmode = true) {
-        background-image: data-uri('image/svg+xml;charset=UTF-8', '../../../../svg/checklist-unchecked-light.svg');
+        content: data-uri('image/svg+xml;charset=UTF-8', '../../../../svg/checklist-unchecked-light.svg');
       }
 
       & when (@content-ui-darkmode = false) {
-        background-image: data-uri('image/svg+xml;charset=UTF-8', '../../../../svg/checklist-unchecked.svg');
+        content: data-uri('image/svg+xml;charset=UTF-8', '../../../../svg/checklist-unchecked.svg');
       }
 
-      background-size: 100%;
-      content: '';
       cursor: pointer;
       height: 1em;
       margin-left: -1.5em;
@@ -36,11 +34,11 @@
 
   li:not(.tox-checklist--hidden).tox-checklist--checked::before {
     & when (@content-ui-darkmode = true) {
-      background-image: data-uri('image/svg+xml;charset=UTF-8', '../../../../svg/checklist-checked-light.svg');
+      content: data-uri('image/svg+xml;charset=UTF-8', '../../../../svg/checklist-checked-light.svg');
     }
 
     & when (@content-ui-darkmode = false) {
-      background-image: data-uri('image/svg+xml;charset=UTF-8', '../../../../svg/checklist-checked.svg');
+      content: data-uri('image/svg+xml;charset=UTF-8', '../../../../svg/checklist-checked.svg');
     }
   }
 }

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.4.1 (TBD)
     Fixed zero-width caret characters included in the Search and Replace plugin results #TINY-4599
     Fixed content in an iframe element parsing as dom elements instead of text content #TINY-5943
+    Fixed Oxide checklist styles not showing when printing #TINY-5139
 Version 5.4.0 (2020-06-30)
     Added keyboard navigation support to menus and toolbars when the editor is in a ShadowRoot #TINY-6152
     Added the ability for menus to be clicked when the editor is in an open shadow root #TINY-6091


### PR DESCRIPTION
Related Ticket: TINY-5139 & TINY-5135

Description of Changes:
* This changes the checklist icons to be content, rather than background images. This ensures they will show when printing (as background images are ignored) and solves the issue where IE 11 wouldn't render the checklist for the first item.
  * Note: URLs can be used for content on all supported browsers, see: https://developer.mozilla.org/en-US/docs/Web/CSS/content#Browser_compatibility I've also manually tested to make sure this works.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
