### PR TITLE
TINY-5205: Fixed the `link` dialog not showing the "Text to display" field in some valid cases

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -4,6 +4,7 @@ Version 5.5.0 (TBD)
     Fixed an issue where dragging and dropping within a table would select table cells #TINY-5950
     Fixed up and down keyboard navigation not working for inline `contenteditable="false"` elements #TINY-6226
     Fixed the `unlink` toolbar button not working when selecting multiple links #TINY-4867
+    Fixed the `link` dialog not showing the "Text to display" field in some valid cases #TINY-5205
 Version 5.4.1 (2020-07-08)
     Fixed the Search and Replace plugin incorrectly including zero-width caret characters in search results #TINY-4599
     Fixed dragging and dropping unsupported files navigating the browser away from the editor #TINY-6027

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -80,13 +80,14 @@ const hasLinks = (elements: Node[]) => Tools.grep(elements, isLink).length > 0;
 
 const hasLinksInSelection = (rng: Range) => collectNodesInRange(rng, isLink).length > 0;
 
-const isOnlyTextSelected = (html: string) => {
-  // Partial html and not a fully selected anchor element
-  if (/</.test(html) && (!/^<a [^>]+>[^<]+<\/a>$/.test(html) || html.indexOf('href=') === -1)) {
-    return false;
-  }
+const isOnlyTextSelected = (editor: Editor) => {
+  // Allow anchor and inline text elements to be in the selection but nothing else
+  const inlineTextElements = editor.schema.getTextInlineElements();
+  const isElement = (elm: Node): elm is Element => elm.nodeType === 1 && !isAnchor(elm) && !Obj.has(inlineTextElements, elm.nodeName.toLowerCase());
 
-  return true;
+  // Collect all non inline text elements in the range and make sure no elements were found
+  const elements = collectNodesInRange(editor.selection.getRng(), isElement);
+  return elements.length === 0;
 };
 
 const isImageFigure = (elm: Element) => elm && elm.nodeName === 'FIGURE' && /\bimage\b/i.test(elm.className);

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -109,7 +109,7 @@ const setupContextToolbars = function (editor: Editor) {
           const value = formApi.getValue();
           if (!anchor) {
             const attachState = { href: value, attach: () => { } };
-            const onlyText = Utils.isOnlyTextSelected(editor.selection.getContent());
+            const onlyText = Utils.isOnlyTextSelected(editor);
             const text: Option<string> = onlyText ? Option.some(Utils.getAnchorText(editor.selection, anchor)).filter((t) => t.length > 0).or(Option.from(value)) : Option.none();
             Utils.link(editor, attachState, {
               href: value,

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
@@ -26,7 +26,7 @@ const nonEmptyAttr = (dom: DOMUtils, elem: string | Element, name: string): Opti
 
 const extractFromAnchor = (editor: Editor, anchor: HTMLAnchorElement) => {
   const dom = editor.dom;
-  const onlyText = Utils.isOnlyTextSelected(editor.selection.getContent());
+  const onlyText = Utils.isOnlyTextSelected(editor);
   const text: Option<string> = onlyText ? Option.some(Utils.getAnchorText(editor.selection, anchor)) : Option.none();
   const url: Option<string> = anchor ? Option.some(dom.getAttrib(anchor, 'href')) : Option.none();
   const target: Option<string> = anchor ? Option.from(dom.getAttrib(anchor, 'target')) : Option.none();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -1,7 +1,8 @@
-import { FocusTools, Keyboard, Keys, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
+import { FocusTools, GeneralSteps, Keyboard, Keys, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
 import { TinyApis, TinyDom, TinyLoader } from '@ephox/mcagar';
+import { Body } from '@ephox/sugar';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 import { TestLinkUi } from '../module/TestLinkUi';
@@ -11,17 +12,40 @@ UnitTest.asynctest('browser.tinymce.plugins.link.SelectedTextTest', (success, fa
   LinkPlugin();
   SilverTheme();
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
     const doc = TinyDom.fromDom(document);
 
-    Pipeline.async({},
-      Log.steps('TBA', 'Link: complex selections should preserve the text', [
-        TestLinkUi.sClearHistory,
+    const sTextToDisplayShown = UiFinder.sExists(Body.body(), '.tox-label:contains("Text to display")');
+    const sTextToDisplayHidden = UiFinder.sNotExists(Body.body(), '.tox-label:contains("Text to display")');
+
+    const sOpenDialog = (textToDisplayVisible: boolean = true) => GeneralSteps.sequence([
+      tinyApis.sExecCommand('mcelink'),
+      UiFinder.sWaitForVisible('wait for link dialog', TinyDom.fromDom(document.body), '[role="dialog"]'),
+      textToDisplayVisible ? sTextToDisplayShown : sTextToDisplayHidden
+    ]);
+
+    Pipeline.async({}, [
+      TestLinkUi.sClearHistory,
+      Log.stepsAsStep('TINY-5205', 'Link: basic text selection with existing link should preserve the text when changing URL', [
+        tinyApis.sSetContent('<p><a href="http://oldlink/">word</a></p>'),
+        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
+        sOpenDialog(),
+        FocusTools.sSetActiveValue(doc, 'http://something'),
+        TestLinkUi.sClickSave,
+        Waiter.sTryUntil(
+          'Wait until link is inserted',
+          tinyApis.sAssertContentPresence({
+            'a[href="http://something"]': 1,
+            'p:contains(word)': 1,
+            'p': 1
+          })
+        )
+      ]),
+      Log.stepsAsStep('TBA', 'Link: complex selections across paragraphs should preserve the text', [
         tinyApis.sSetContent('<p><strong>word</strong></p><p><strong>other</strong></p>'),
         tinyApis.sSetSelection([ 0 ], 0, [ 1 ], 1),
-        tinyApis.sExecCommand('mcelink'),
-        UiFinder.sWaitForVisible('wait for link dialog', TinyDom.fromDom(document.body), '[role="dialog"]'),
+        sOpenDialog(false),
         FocusTools.sSetActiveValue(doc, 'http://something'),
         Keyboard.sKeydown(doc, Keys.enter(), { }),
         Waiter.sTryUntil(
@@ -32,14 +56,104 @@ UnitTest.asynctest('browser.tinymce.plugins.link.SelectedTextTest', (success, fa
             'p:contains(other)': 1,
             'p': 2
           })
-        ),
-        TestLinkUi.sClearHistory
-      ])
-      , onSuccess, onFailure);
+        )
+      ]),
+      Log.stepsAsStep('TINY-5205', 'Link: complex selections with existing link should preserve the text when changing URL', [
+        tinyApis.sSetContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>'),
+        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
+        sOpenDialog(),
+        FocusTools.sSetActiveValue(doc, 'http://something'),
+        TestLinkUi.sClickSave,
+        Waiter.sTryUntil(
+          'Wait until link is inserted',
+          tinyApis.sAssertContentPresence({
+            'a[href="http://something"]': 1,
+            'strong:contains(word)': 1,
+            'em:contains(other)': 1,
+            'p': 1
+          })
+        )
+      ]),
+      Log.stepsAsStep('TINY-5205', 'Link: complex selections with existing link should replace the text when changing text', [
+        tinyApis.sSetContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>'),
+        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
+        sOpenDialog(),
+        FocusTools.sSetActiveValue(doc, 'http://something'),
+        Keyboard.sKeydown(doc, Keys.tab(), { }),
+        FocusTools.sSetActiveValue(doc, 'new text'),
+        TestLinkUi.sClickSave,
+        Waiter.sTryUntil(
+          'Wait until link is inserted',
+          tinyApis.sAssertContentPresence({
+            'a[href="http://something"]': 1,
+            'a:contains(new text)': 1,
+            'strong': 0,
+            'em': 0,
+            'p': 1
+          })
+        )
+      ]),
+      Log.stepsAsStep('TINY-5205', 'Link: collapsed selection in complex structure should preserve the text when changing URL', [
+        tinyApis.sSetContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>'),
+        tinyApis.sSetSelection([ 0, 0, 0, 0 ], 2, [ 0, 0, 0, 0 ], 2),
+        sOpenDialog(),
+        FocusTools.sSetActiveValue(doc, 'http://something'),
+        TestLinkUi.sClickSave,
+        Waiter.sTryUntil(
+          'Wait until link is inserted',
+          tinyApis.sAssertContentPresence({
+            'a[href="http://something"]': 1,
+            'strong:contains(word)': 1,
+            'em:contains(other)': 1,
+            'p': 1
+          })
+        )
+      ]),
+      Log.stepsAsStep('TINY-5205', 'Link: Selection with link inside should replace link', [
+        tinyApis.sSetContent('<p>a <a href="http://www.google.com/">b</a> c</p>'),
+        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 2 ], 2),
+        sOpenDialog(),
+        FocusTools.sSetActiveValue(doc, 'http://something'),
+        TestLinkUi.sClickSave,
+        Waiter.sTryUntil(
+          'Wait until link is updated',
+          tinyApis.sAssertContentPresence({
+            'a[href="http://something"]': 1,
+            'a': 1,
+            'p': 1
+          })
+        )
+      ]),
+      Log.stepsAsStep('TINY-5205', 'Link: Selection across partial link should split and replace link', [
+        tinyApis.sSetContent('<p><a href="http://www.google.com/">a b</a> c</p>'),
+        tinyApis.sSetSelection([ 0, 0, 0 ], 2, [ 0, 1 ], 2),
+        sOpenDialog(),
+        FocusTools.sSetActiveValue(doc, 'http://something'),
+        TestLinkUi.sClickSave,
+        Waiter.sTryUntil(
+          'Wait until link is updated',
+          tinyApis.sAssertContentPresence({
+            'a[href="http://www.google.com/"]': 1,
+            'a[href="http://something"]': 1,
+            'a': 2,
+            'p': 1
+          })
+        )
+      ]),
+      TestLinkUi.sClearHistory
+    ], onSuccess, onFailure);
   }, {
     plugins: 'link',
     toolbar: '',
     theme: 'silver',
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (editor) => {
+      // Simulate comments being enabled
+      editor.on('GetContent', (e) => {
+        if (e.selection) {
+          e.content += '<!-- TinyComments -->';
+        }
+      });
+    }
   }, success, failure);
 });


### PR DESCRIPTION
Related Ticket: TINY-5205

Description of Changes:
* The way the "Text to display" field was being determined was rather hacky, as it just used a regex on the selected content. This caused problems when coupled with Comments for example, as Comments would add a HTML comment that would cause this to no longer match. This updates it to actually walk the dom and determine when it shouldn't be shown based on the elements found.
* This also fixes an inconsistency with how it handled "inline text elements" inside an anchor, as if you used a collapsed selection for something like `<a href="URL"><strong>word</strong> more</a>`, then the "Text to display" would be shown. However, if you did a range selection then the field would disappear.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
