### PR TITLE
TINY-6027: Added notification banner when blocking an unsupported file drop

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/DragnDrop.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/DragnDrop.ts
@@ -12,9 +12,14 @@ import {
   isDefaultPrevented,
   getWindowFromElement
 } from '../dragndrop/DndEvents';
-import { File, DragEvent } from '@ephox/dom-globals';
+import { File, DragEvent, DataTransfer } from '@ephox/dom-globals';
 import { createDataTransfer, getDragImage } from '../datatransfer/DataTransfer';
 import { Step } from './Step';
+
+interface Item {
+  data: string;
+  type: string;
+}
 
 const isDraggable = (element: Element<any>): boolean => {
   const name = Node.name(element);
@@ -31,7 +36,13 @@ const checkDefaultPrevented = (evt: DragEvent): void => {
   }
 };
 
-const dragnDrop = (from: Element<any>, to: Element<any>): void => {
+const checkNotDefaultPrevented = (evt: DragEvent): void => {
+  if (isDefaultPrevented(evt) === true) {
+    throw new Error(`preventDefault was called on drag event: ${evt.type}`);
+  }
+};
+
+const dragnDrop = (from: Element<any>, to: Element<any>, prevented: boolean = true): void => {
   const fromWin = getWindowFromElement(from);
   const toWin = getWindowFromElement(to);
   const fromRect = from.dom().getBoundingClientRect();
@@ -42,55 +53,86 @@ const dragnDrop = (from: Element<any>, to: Element<any>): void => {
     throw new Error('Can not drag a non draggable element.');
   }
 
+  const check = prevented ? checkDefaultPrevented : checkNotDefaultPrevented;
+
   dispatchDndEvent(createDragstartEvent(fromWin, fromRect.left, fromRect.top, transfer), from);
   dispatchDndEvent(createDragEvent(fromWin, fromRect.left, fromRect.top, transfer), from);
-  checkDefaultPrevented(dispatchDndEvent(createDragenterEvent(toWin, toRect.left, toRect.top, transfer), to));
-  checkDefaultPrevented(dispatchDndEvent(createDragoverEvent(toWin, toRect.left, toRect.top, transfer), to));
-  checkDefaultPrevented(dispatchDndEvent(createDropEvent(toWin, toRect.left, toRect.top, transfer), to));
+  check(dispatchDndEvent(createDragenterEvent(toWin, toRect.left, toRect.top, transfer), to));
+  check(dispatchDndEvent(createDragoverEvent(toWin, toRect.left, toRect.top, transfer), to));
+  check(dispatchDndEvent(createDropEvent(toWin, toRect.left, toRect.top, transfer), to));
   dispatchDndEvent(createDragendEvent(fromWin, fromRect.left, fromRect.top, transfer), from);
 };
 
-const dropFiles = (files: File[], to: Element<any>): void => {
+const drop = (to: Element<any>, prevented: boolean, addItems: (transfer: DataTransfer) => void): void => {
   const toWin = getWindowFromElement(to);
   const toRect = to.dom().getBoundingClientRect();
   const transfer = createDataTransfer();
 
-  Arr.each(files, (file) => {
-    transfer.items.add(file);
-  });
+  addItems(transfer);
+
+  const check = prevented ? checkDefaultPrevented : checkNotDefaultPrevented;
 
   dispatchDndEvent(createDragenterEvent(toWin, toRect.left, toRect.top, transfer), to);
   dispatchDndEvent(createDragoverEvent(toWin, toRect.left, toRect.top, transfer), to);
-  checkDefaultPrevented(dispatchDndEvent(createDropEvent(toWin, toRect.left, toRect.top, transfer), to));
+  check(dispatchDndEvent(createDropEvent(toWin, toRect.left, toRect.top, transfer), to));
 };
 
-const cDragnDrop = <T> (fromSelector: string, toSelector: string): Chain<Element<T>, Element<T>> => NamedChain.asChain([
+const dropFiles = (files: File[], to: Element<any>, prevented: boolean = true): void => {
+  drop(to, prevented, (transfer) => {
+    Arr.each(files, (file) => {
+      transfer.items.add(file);
+    });
+  });
+};
+
+const dropItems = (items: Item[], to: Element<any>, prevented: boolean = true): void => {
+  drop(to, prevented, (transfer) => {
+    Arr.each(items, (item) => {
+      transfer.items.add(item.data, item.type);
+    });
+  });
+};
+
+const cDragnDrop = <T> (fromSelector: string, toSelector: string, prevented?: boolean): Chain<Element<T>, Element<T>> => NamedChain.asChain([
   NamedChain.direct(NamedChain.inputName(), UiFinder.cFindIn(fromSelector), 'from'),
   NamedChain.direct(NamedChain.inputName(), UiFinder.cFindIn(toSelector), 'to'),
-  Chain.op((obj) => dragnDrop(obj.from, obj.to)),
+  Chain.op((obj) => dragnDrop(obj.from, obj.to, prevented)),
   NamedChain.output(NamedChain.inputName())
 ]);
 
-const sDragnDrop = <T>(fromSelector: string, toSelector: string): Step<T, T> =>
-  Chain.asStep(Body.body(), [ cDragnDrop(fromSelector, toSelector) ]);
+const sDragnDrop = <T>(fromSelector: string, toSelector: string, prevented?: boolean): Step<T, T> =>
+  Chain.asStep(Body.body(), [ cDragnDrop(fromSelector, toSelector, prevented) ]);
 
-const sDropFiles = <T>(files: File[], toSelector: string): Step<T, T> => Chain.asStep(Body.body(), [
+const sDropFiles = <T>(files: File[], toSelector: string, prevented?: boolean): Step<T, T> => Chain.asStep(Body.body(), [
   UiFinder.cFindIn(toSelector),
-  cDropFiles(files)
+  cDropFiles(files, prevented)
 ]);
 
-const cDropFiles = <T> (files: File[]): Chain<Element<T>, Element<T>> =>
+const cDropFiles = <T> (files: File[], prevented?: boolean): Chain<Element<T>, Element<T>> =>
   Chain.op((elm) => {
-    dropFiles(files, elm);
+    dropFiles(files, elm, prevented);
+  });
+
+const sDropItems = <T> (items: Item[], toSelector: string, prevented?: boolean): Step<T, T> => Chain.asStep(Body.body(), [
+  UiFinder.cFindIn(toSelector),
+  cDropItems(items, prevented)
+]);
+
+const cDropItems = <T> (items: Item[], prevented?: boolean): Chain<Element<T>, Element<T>> =>
+  Chain.op((elm) => {
+    dropItems(items, elm, prevented);
   });
 
 export {
   isDraggable,
   dragnDrop,
   dropFiles,
+  dropItems,
   cDragnDrop,
   sDragnDrop,
   sDropFiles,
   cDropFiles,
+  sDropItems,
+  cDropItems,
   getDragImage
 };

--- a/modules/agar/src/test/ts/browser/api/DragnDropTest.ts
+++ b/modules/agar/src/test/ts/browser/api/DragnDropTest.ts
@@ -1,11 +1,11 @@
 import { Assert, assert, UnitTest } from '@ephox/bedrock-client';
-import { Body, DomEvent, Element, Insert, Remove, SelectorFind } from '@ephox/sugar';
-import { Pipeline } from 'ephox/agar/api/Pipeline';
-import { dragnDrop, dropFiles, isDraggable, sDragnDrop, sDropFiles } from 'ephox/agar/api/DragnDrop';
-import { Step } from 'ephox/agar/api/Step';
-import { GeneralSteps, Logger } from 'ephox/agar/api/Main';
-import { createFile } from 'ephox/agar/api/Files';
 import { Blob } from '@ephox/dom-globals';
+import { Body, DomEvent, Element, Insert, Remove, SelectorFind } from '@ephox/sugar';
+import { dragnDrop, dropFiles, isDraggable, sDragnDrop, sDropItems, sDropFiles } from 'ephox/agar/api/DragnDrop';
+import { createFile } from 'ephox/agar/api/Files';
+import { GeneralSteps, Logger } from 'ephox/agar/api/Main';
+import { Pipeline } from 'ephox/agar/api/Pipeline';
+import { Step } from 'ephox/agar/api/Step';
 
 UnitTest.test('DragDrop.isDraggable', () => {
   const check = (expected: boolean, html: string) => {
@@ -111,6 +111,15 @@ UnitTest.asynctest('DragnDropTest', (success, failure) => {
         ], to);
       }),
       sAssertStoreItems([ 'dragenter', 'dragover', 'drop files: 2' ])
+    ])),
+
+    Logger.t('Drop items using selector', GeneralSteps.sequence([
+      sClearStore,
+      sDropItems([
+        { data: 'hello', type: 'text/plain' },
+        { data: '<p>hello</p>', type: 'text/html' }
+      ], '.dropzone'),
+      sAssertStoreItems([ 'dragenter', 'dragover', 'drop text: hello' ])
     ]))
   ], () => {
     Remove.remove(dropzone);

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -3,6 +3,8 @@ Version 5.5.0 (TBD)
     Fixed an issue where dragging and dropping within a table would select table cells #TINY-5950
 Version 5.4.1 (TBD)
     Fixed zero-width caret characters included in the Search and Replace plugin results #TINY-4599
+    Fixed dragging and dropping unsupported files navigating the browser away from the editor #TINY-6027
+    Fixed undo levels not created on browser handled drop or paste events #TINY-6027
     Fixed content in an iframe element parsing as dom elements instead of text content #TINY-5943
     Fixed Oxide checklist styles not showing when printing #TINY-5139
 Version 5.4.0 (2020-06-30)

--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -17,6 +17,7 @@ import * as MousePosition from './dom/MousePosition';
 import * as NodeType from './dom/NodeType';
 import { isUIElement } from './focus/FocusController';
 import * as Predicate from './util/Predicate';
+import * as ErrorReporter from './ErrorReporter';
 
 /**
  * This module contains logic overriding the drag/drop logic of the editor.
@@ -289,8 +290,10 @@ const blockUnsupportedFileDrop = (editor: Editor) => {
       // Prevent file drop events within the editor, as they'll cause the browser to navigate away
       const dataTransfer = e.dataTransfer;
       if (dataTransfer && (Arr.contains(dataTransfer.types, 'Files') || dataTransfer.files.length > 0)) {
-        // TODO: Add an error notification in 5.5
         e.preventDefault();
+        if (e.type === 'drop') {
+          ErrorReporter.displayError(editor, 'Dropped file type is not supported');
+        }
       }
     }
   };

--- a/modules/tinymce/src/core/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/core/main/ts/api/Settings.ts
@@ -183,6 +183,8 @@ const getPlugins = (editor: Editor) => editor.getParam('plugins');
 
 const getExternalPlugins = (editor: Editor) => editor.getParam('external_plugins');
 
+const shouldBlockUnsupportedDrop = (editor: Editor) => editor.getParam('block_unsupported_drop', true, 'boolean');
+
 export {
   getIframeAttrs,
   getDocType,
@@ -242,5 +244,6 @@ export {
   isReadOnly,
   hasContentCssCors,
   getPlugins,
-  getExternalPlugins
+  getExternalPlugins,
+  shouldBlockUnsupportedDrop
 };

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -54,6 +54,7 @@ interface BaseEditorSettings {
   automatic_uploads?: boolean;
   base_url?: string;
   block_formats?: string;
+  block_unsupported_drop?: boolean;
   body_id?: string;
   body_class?: string;
   br_in_pre?: boolean;

--- a/modules/tinymce/src/core/main/ts/undo/Setup.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Setup.ts
@@ -7,6 +7,7 @@
 
 import { Cell } from '@ephox/katamari';
 import Editor from '../api/Editor';
+import { EditorEvent, InputEvent } from '../api/util/EventDispatcher';
 import * as Levels from './Levels';
 import { UndoManager, Locks, UndoLevel } from './UndoManagerTypes';
 import { endTyping, setTyping } from './TypingState';
@@ -116,13 +117,14 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
   });
 
   // Special inputType, currently only Chrome implements this: https://www.w3.org/TR/input-events-2/#x5.1.2-attributes
-  const isInsertReplacementText = (event) => event.inputType === 'insertReplacementText';
+  const isInsertReplacementText = (event: EditorEvent<InputEvent>) => event.inputType === 'insertReplacementText';
   // Safari just shows inputType `insertText` but with data set to null so we can use that
-  const isInsertTextDataNull = (event) => event.inputType === 'insertText' && event.data === null;
+  const isInsertTextDataNull = (event: EditorEvent<InputEvent>) => event.inputType === 'insertText' && event.data === null;
+  const isInsertFromPasteOrDrop = (event: EditorEvent<InputEvent>) => event.inputType === 'insertFromPaste' || event.inputType === 'insertFromDrop';
 
-  // For detecting when user has replaced text using the browser built-in spell checker
+  // For detecting when user has replaced text using the browser built-in spell checker or paste/drop events
   editor.on('input', (e) => {
-    if (e.inputType && (isInsertReplacementText(e) || isInsertTextDataNull(e))) {
+    if (e.inputType && (isInsertReplacementText(e) || isInsertTextDataNull(e) || isInsertFromPasteOrDrop(e))) {
       addNonTypingUndoLevel(e);
     }
   });

--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -1,19 +1,28 @@
-import { Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
+import { Assertions, Chain, DragnDrop, GeneralSteps, Log, Logger, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { document } from '@ephox/dom-globals';
+import { Blob, document, File } from '@ephox/dom-globals';
 import { Cell } from '@ephox/katamari';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { Element, Hierarchy, Node } from '@ephox/sugar';
+import { ApiChains, TinyApis, TinyLoader } from '@ephox/mcagar';
+import { Body, Element, Hierarchy, Node } from '@ephox/sugar';
 import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.core.DragDropOverridesTest', (success, failure) => {
   Theme();
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  const createFile = (name: string, lastModified: number, blob: Blob): File => {
+    const newBlob: any = new Blob([ blob ], { type: blob.type });
+
+    newBlob.name = name;
+    newBlob.lastModified = lastModified;
+
+    return Object.freeze(newBlob);
+  };
+
+  TinyLoader.setup((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
     const fired = Cell(false);
 
-    editor.on('dragend', function () {
+    editor.on('dragend', () => {
       fired.set(true);
     });
 
@@ -31,10 +40,29 @@ UnitTest.asynctest('browser.tinymce.core.DragDropOverridesTest', (success, failu
 
           Assertions.assertEq('Should fire dragend event', true, fired.get());
         })
-      ]))
+      ])),
+      Log.chainsAsStep('TINY-6027', 'Drag unsupported file into the editor/UI is prevented', [
+        Chain.inject(editor),
+        ApiChains.cSetContent('<p>Content</p>'),
+        Chain.fromIsolatedChainsWith(Element.fromDom(editor.getBody()), [
+          DragnDrop.cDropFiles([
+            createFile('test.txt', 123, new Blob([ 'content' ], { type: 'text/plain' }))
+          ]),
+          DragnDrop.cDropItems([
+            { data: 'Some content', type: 'text/plain' }
+          ], false)
+        ]),
+        Chain.fromIsolatedChainsWith(Body.body(), [
+          UiFinder.cFindIn('.tox-toolbar__primary'),
+          DragnDrop.cDropFiles([
+            createFile('test.js', 123, new Blob([ 'var a = "content";' ], { type: 'application/javascript' }))
+          ])
+        ])
+      ])
     ], onSuccess, onFailure);
   }, {
     indent: false,
+    menubar: false,
     base_url: '/project/tinymce/js/tinymce'
   }, success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -1,4 +1,4 @@
-import { Assertions, Chain, DragnDrop, GeneralSteps, Log, Logger, Pipeline, Step, UiFinder } from '@ephox/agar';
+import { Assertions, Chain, DragnDrop, GeneralSteps, Log, Logger, Mouse, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Blob, document, File } from '@ephox/dom-globals';
 import { Cell } from '@ephox/katamari';
@@ -17,6 +17,14 @@ UnitTest.asynctest('browser.tinymce.core.DragDropOverridesTest', (success, failu
 
     return Object.freeze(newBlob);
   };
+
+  const cAssertNotification = (message: string) => Chain.fromIsolatedChainsWith(Body.body(), [
+    UiFinder.cWaitForVisible('Wait for notification to appear', '.tox-notification'),
+    Assertions.cAssertPresence('Verify message content', {
+      ['.tox-notification__body:contains(' + message + ')']: 1
+    }),
+    Mouse.cClickOn('.tox-notification__dismiss')
+  ]);
 
   TinyLoader.setup((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
@@ -48,6 +56,7 @@ UnitTest.asynctest('browser.tinymce.core.DragDropOverridesTest', (success, failu
           DragnDrop.cDropFiles([
             createFile('test.txt', 123, new Blob([ 'content' ], { type: 'text/plain' }))
           ]),
+          cAssertNotification('Dropped file type is not supported'),
           DragnDrop.cDropItems([
             { data: 'Some content', type: 'text/plain' }
           ], false)


### PR DESCRIPTION
Related Ticket: TINY-6027

Description of Changes:
* This adds the notification banner and merges the changes from master to develop. See 26d6976e8eab52e8891b7281ae6349e148504ea7 for the additional changes.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
