### PR TITLE
TINY-6115: Fixed template previews missing styles and other content

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -5,6 +5,7 @@ Version 5.5.0 (TBD)
     Changed `imagetools` context menu icon for accessing the `image` settings to use the same icon #TINY-4141
     Deprecated the `Env.experimentalShadowDom` flag #TINY-6128
     Fixed the `event.getComposedPath()` function on events fired from TinyMCE. This was throwing an exception, but now works as expected. #TINY-6128
+    Fixed the `template` plugin previews missing some content styles #TINY-6115
     Fixed the `media` plugin not saving the alternative source url in some situations #TINY-4113
     Fixed an issue where dragging and dropping within a table would select table cells #TINY-5950
     Fixed up and down keyboard navigation not working for inline `contenteditable="false"` elements #TINY-6226

--- a/modules/tinymce/src/plugins/preview/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/api/Settings.ts
@@ -10,7 +10,7 @@ const getPreviewDialogWidth = (editor: Editor): number => parseInt(editor.getPar
 
 const getPreviewDialogHeight = (editor: Editor): number => parseInt(editor.getParam('plugin_preview_height', '500'), 10);
 
-const getContentStyle = (editor: Editor): string => editor.getParam('content_style', '');
+const getContentStyle = (editor: Editor): string => editor.getParam('content_style', '', 'string');
 
 const shouldUseContentCssCors = (editor: Editor): boolean => editor.getParam('content_css_cors', false, 'boolean');
 

--- a/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
@@ -10,7 +10,7 @@ import Env from 'tinymce/core/api/Env';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 
-const getPreviewHtml = function (editor: Editor) {
+const getPreviewHtml = (editor: Editor) => {
   let headHtml = '';
   const encode = editor.dom.encode;
   const contentStyle = Settings.getContentStyle(editor);
@@ -22,7 +22,7 @@ const getPreviewHtml = function (editor: Editor) {
   }
 
   const cors = Settings.shouldUseContentCssCors(editor) ? ' crossorigin="anonymous"' : '';
-  Tools.each(editor.contentCSS, function (url) {
+  Tools.each(editor.contentCSS, (url) => {
     headHtml += '<link type="text/css" rel="stylesheet" href="' + encode(editor.documentBaseURI.toAbsolute(url)) + '"' + cors + '>';
   });
 

--- a/modules/tinymce/src/plugins/template/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/api/Settings.ts
@@ -15,6 +15,10 @@ const getSelectedContentClasses = (editor: Editor) => editor.getParam('template_
 
 const getPreviewReplaceValues = (editor: Editor) => editor.getParam('template_preview_replace_values');
 
+const getContentStyle = (editor: Editor): string => editor.getParam('content_style', '', 'string');
+
+const shouldUseContentCssCors = (editor: Editor): boolean => editor.getParam('content_css_cors', false, 'boolean');
+
 const getTemplateReplaceValues = (editor: Editor) => editor.getParam('template_replace_values');
 
 const getTemplates = (editor: Editor) => editor.getParam('templates');
@@ -47,5 +51,7 @@ export {
   getTemplates,
   getCdateFormat,
   getMdateFormat,
-  getBodyClass
+  getBodyClass,
+  getContentStyle,
+  shouldUseContentCssCors
 };

--- a/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
@@ -1,0 +1,113 @@
+import { Log, Pipeline, Step } from '@ephox/agar';
+import { UnitTest, Assert } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import TemplatePlugin from 'tinymce/plugins/template/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+import { getPreviewContent } from 'tinymce/plugins/template/ui/Dialog';
+import Env from 'tinymce/core/api/Env';
+
+const metaKey = Env.mac ? 'e.metaKey' : 'e.ctrlKey && !e.altKey';
+
+const noCorsNoStyle = '<!DOCTYPE html><html><head>' +
+  '<base href="http://localhost:8000/">' +
+  '<link type="text/css" rel="stylesheet" href="http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css">' +
+  '<link type="text/css" rel="stylesheet" href="http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css">' +
+  '<script>document.addEventListener && document.addEventListener("click", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === "A" && !(' +
+  metaKey +
+  ')) {e.preventDefault();}}}, false);</script> ' +
+  '</head><body class=""></body></html>';
+
+const corsNoStyle = '<!DOCTYPE html><html><head>' +
+  '<base href=\"http://localhost:8000/\">' +
+  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css\" crossorigin=\"anonymous\">' +
+  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css\" crossorigin=\"anonymous\">' +
+  '<script>document.addEventListener && document.addEventListener(\"click\", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === \"A\" && !(' +
+  metaKey +
+  ')) {e.preventDefault();}}}, false);</script> </head><body class=\"\"></body></html>';
+
+const noCorsStyle = '<!DOCTYPE html><html><head>' +
+  '<base href=\"http://localhost:8000/\">' +
+  '<style type=\"text/css\">This is the style inserted into the document</style>' +
+  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css\">' +
+  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css\">' +
+  '<script>document.addEventListener && document.addEventListener(\"click\", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === \"A\" && !(' +
+  metaKey +
+  ')) {e.preventDefault();}}}, false);</script> ' +
+  '</head><body class=\"\"></body></html>';
+
+const corsStyle = '<!DOCTYPE html><html><head>' +
+  '<base href=\"http://localhost:8000/\">' +
+  '<style type=\"text/css\">This is the style inserted into the document</style>' +
+  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css\" crossorigin=\"anonymous\">' +
+  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css\" crossorigin=\"anonymous\">' +
+  '<script>document.addEventListener && document.addEventListener(\"click\", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === \"A\" && !(' +
+  metaKey +
+  ')) {e.preventDefault();}}}, false);</script> ' +
+  '</head><body class=\"\"></body></html>';
+
+const corsStyleAndContent = '<!DOCTYPE html><html><head>' +
+  '<base href=\"http://localhost:8000/\">' +
+  '<style type=\"text/css\">This is the style inserted into the document</style>' +
+  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css\" crossorigin=\"anonymous\">' +
+  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css\" crossorigin=\"anonymous\">' +
+  '<script>document.addEventListener && document.addEventListener(\"click\", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === \"A\" && !(' +
+  metaKey +
+  ')) {e.preventDefault();}}}, false);</script> ' +
+  '</head>' +
+  '<body class=\"\">Custom content which was provided</body></html>';
+
+UnitTest.asynctest('browser.tinymce.plugins.template.Dialog.getPreviewContent', (success, failure) => {
+  TemplatePlugin();
+  SilverTheme();
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+
+    const sCheckPreview = (expected: string, html?: string) =>
+      Step.sync(() =>
+        Assert.eq('', expected, getPreviewContent(editor, html ? html : '')));
+
+    Pipeline.async({}, [
+      Log.stepsAsStep('TINY-6115', 'Dialog.getPreviewcontent: No CORS or content style, no previous HTML', [
+        sCheckPreview(noCorsNoStyle)
+      ]),
+      Log.stepsAsStep('TINY-6115', 'Dialog.getPreviewcontent: CORS but no content style, no previous HTML', [
+        tinyApis.sSetSetting('content_css_cors', true),
+        sCheckPreview(corsNoStyle),
+        tinyApis.sDeleteSetting('content_css_cors')
+      ]),
+      Log.stepsAsStep('TINY-6115', 'Dialog.getPreviewcontent: No CORS but content style, no previous HTML', [
+        tinyApis.sSetSetting('content_style', 'This is the style inserted into the document'),
+        sCheckPreview(noCorsStyle),
+        tinyApis.sDeleteSetting('content_style')
+      ]),
+      Log.stepsAsStep('TINY-6115', 'Dialog.getPreviewcontent: CORS and content style, no previous HTML', [
+        tinyApis.sSetSetting('content_style', 'This is the style inserted into the document'),
+        tinyApis.sSetSetting('content_css_cors', true),
+        sCheckPreview(corsStyle),
+        tinyApis.sDeleteSetting('content_style'),
+        tinyApis.sDeleteSetting('content_css_cors')
+      ]),
+      Log.stepsAsStep('TINY-6115', 'Dialog.getPreviewcontent: with provided content', [
+        tinyApis.sSetSetting('content_style', 'This is the style inserted into the document'),
+        tinyApis.sSetSetting('content_css_cors', true),
+        sCheckPreview(corsStyleAndContent, 'Custom content which was provided'),
+        tinyApis.sDeleteSetting('content_style'),
+        tinyApis.sDeleteSetting('content_css_cors')
+      ]),
+      Log.stepsAsStep('TINY-6115', 'Dialog.getPreviewcontent: with provided html', [
+        tinyApis.sSetSetting('content_style', 'This is the style inserted into the document'),
+        tinyApis.sSetSetting('content_css_cors', true),
+        sCheckPreview('<html>Custom content here', '<html>Custom content here'),
+        tinyApis.sDeleteSetting('content_style'),
+        tinyApis.sDeleteSetting('content_css_cors')
+      ])
+    ], onSuccess, onFailure);
+  }, {
+    theme: 'silver',
+    plugins: 'template',
+    toolbar: 'template',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, success, failure);
+});


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Allowed template to also apply CORS and content style, similar to preview.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
