### PR TITLE
TINY-6226: Fixed up and down keyboard navigation not working for inline contenteditable false elements

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,6 +2,7 @@ Version 5.5.0 (TBD)
     Added `hasPlugin` function to the editor API to determine if a plugin exists or not #TINY-766
     Fixed the `media` plugin not saving the alternative source url in some situations #TINY-4113
     Fixed an issue where dragging and dropping within a table would select table cells #TINY-5950
+    Fixed up and down keyboard navigation not working for inline `contenteditable="false"` elements #TINY-6226
 Version 5.4.1 (2020-07-08)
     Fixed the Search and Replace plugin incorrectly including zero-width caret characters in search results #TINY-4599
     Fixed dragging and dropping unsupported files navigating the browser away from the editor #TINY-6027

--- a/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
@@ -5,16 +5,17 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from '../api/Editor';
 import * as BlockBoundaryDelete from './BlockBoundaryDelete';
 import * as BlockRangeDelete from './BlockRangeDelete';
+import * as CefBoundaryDelete from './CefBoundaryDelete';
 import * as CefDelete from './CefDelete';
 import * as DeleteUtils from './DeleteUtils';
+import * as ImageBlockDelete from './ImageBlockDelete';
 import * as BoundaryDelete from './InlineBoundaryDelete';
-import * as TableDelete from './TableDelete';
 import * as InlineFormatDelete from './InlineFormatDelete';
-import * as CefBoundaryDelete from './CefBoundaryDelete';
-import Editor from '../api/Editor';
 import * as Outdent from './Outdent';
+import * as TableDelete from './TableDelete';
 
 const nativeCommand = function (editor: Editor, command: string) {
   editor.getDoc().execCommand(command, false, null);
@@ -32,6 +33,8 @@ const deleteCommand = function (editor: Editor) {
   } else if (BlockBoundaryDelete.backspaceDelete(editor, false)) {
     return;
   } else if (TableDelete.backspaceDelete(editor)) {
+    return;
+  } else if (ImageBlockDelete.backspaceDelete(editor, false)) {
     return;
   } else if (BlockRangeDelete.backspaceDelete(editor, false)) {
     return;
@@ -53,6 +56,8 @@ const forwardDeleteCommand = function (editor: Editor) {
   } else if (BlockBoundaryDelete.backspaceDelete(editor, true)) {
     return;
   } else if (TableDelete.backspaceDelete(editor)) {
+    return;
+  } else if (ImageBlockDelete.backspaceDelete(editor, true)) {
     return;
   } else if (BlockRangeDelete.backspaceDelete(editor, true)) {
     return;

--- a/modules/tinymce/src/core/main/ts/geom/ClientRect.ts
+++ b/modules/tinymce/src/core/main/ts/geom/ClientRect.ts
@@ -56,7 +56,8 @@ const isEqual = (rect1: ClientRect, rect2: ClientRect): boolean => (
 const isValidOverflow = (overflowY: number, rect1: ClientRect, rect2: ClientRect): boolean => overflowY >= 0 && overflowY <= Math.min(rect1.height, rect2.height) / 2;
 
 const isAbove = (rect1: ClientRect, rect2: ClientRect): boolean => {
-  if ((rect1.bottom - rect1.height / 2) < rect2.top) {
+  const halfHeight = Math.min(rect2.height / 2, rect1.height / 2);
+  if ((rect1.bottom - halfHeight) < rect2.top) {
     return true;
   }
 

--- a/modules/tinymce/src/core/main/ts/keyboard/CefNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/CefNavigation.ts
@@ -34,7 +34,7 @@ const moveToCeFalseHorizontally = (direction: HDirection, editor: Editor, getNex
   if (!range.collapsed) {
     const node = getSelectedNode(range);
     if (isContentEditableFalse(node)) {
-      return CefUtils.showCaret(direction, editor, node, direction === HDirection.Backwards, true);
+      return CefUtils.showCaret(direction, editor, node, direction === HDirection.Backwards, false);
     }
   }
 
@@ -55,19 +55,19 @@ const moveToCeFalseHorizontally = (direction: HDirection, editor: Editor, getNex
   }
 
   if (isBeforeContentEditableFalseFn(nextCaretPosition)) {
-    return CefUtils.showCaret(direction, editor, nextCaretPosition.getNode(!forwards) as Element, forwards, true);
+    return CefUtils.showCaret(direction, editor, nextCaretPosition.getNode(!forwards) as Element, forwards, false);
   }
 
   // Peek ahead for handling of ab|c<span cE=false> -> abc|<span cE=false>
   const peekCaretPosition = getNextPosFn(nextCaretPosition);
   if (peekCaretPosition && isBeforeContentEditableFalseFn(peekCaretPosition)) {
     if (CaretUtils.isMoveInsideSameBlock(nextCaretPosition, peekCaretPosition)) {
-      return CefUtils.showCaret(direction, editor, peekCaretPosition.getNode(!forwards) as Element, forwards, true);
+      return CefUtils.showCaret(direction, editor, peekCaretPosition.getNode(!forwards) as Element, forwards, false);
     }
   }
 
   if (rangeIsInContainerBlock) {
-    return CefUtils.renderRangeCaret(editor, nextCaretPosition.toRange(), true);
+    return CefUtils.renderRangeCaret(editor, nextCaretPosition.toRange(), false);
   }
 
   return null;
@@ -104,7 +104,7 @@ const moveToCeFalseVertically = (direction: LineWalker.VDirection, editor: Edito
       dist1 = Math.abs(clientX - closestNextLineRect.left);
       dist2 = Math.abs(clientX - closestNextLineRect.right);
 
-      return CefUtils.showCaret(direction, editor, closestNextLineRect.node, dist1 < dist2, true);
+      return CefUtils.showCaret(direction, editor, closestNextLineRect.node, dist1 < dist2, false);
     }
   }
 
@@ -113,12 +113,12 @@ const moveToCeFalseVertically = (direction: LineWalker.VDirection, editor: Edito
 
     closestNextLineRect = LineUtils.findClosestClientRect(Arr.filter(caretPositions, LineWalker.isLine(1)), clientX);
     if (closestNextLineRect) {
-      return CefUtils.renderRangeCaret(editor, closestNextLineRect.position.toRange(), true);
+      return CefUtils.renderRangeCaret(editor, closestNextLineRect.position.toRange(), false);
     }
 
     closestNextLineRect = ArrUtils.last(Arr.filter(caretPositions, LineWalker.isLine(0)));
     if (closestNextLineRect) {
-      return CefUtils.renderRangeCaret(editor, closestNextLineRect.position.toRange(), true);
+      return CefUtils.renderRangeCaret(editor, closestNextLineRect.position.toRange(), false);
     }
   }
 };
@@ -211,7 +211,7 @@ const moveH = (editor: Editor, forward: boolean) => () => {
   const newRng = getHorizontalRange(editor, forward);
 
   if (newRng) {
-    editor.selection.setRng(newRng);
+    CefUtils.moveToRange(editor, newRng);
     return true;
   } else {
     return false;
@@ -222,7 +222,7 @@ const moveV = (editor: Editor, down: boolean) => () => {
   const newRng = getVerticalRange(editor, down);
 
   if (newRng) {
-    editor.selection.setRng(newRng);
+    CefUtils.moveToRange(editor, newRng);
     return true;
   } else {
     return false;

--- a/modules/tinymce/src/core/main/ts/keyboard/CefUtils.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/CefUtils.ts
@@ -6,10 +6,11 @@
  */
 
 import { Element, Range } from '@ephox/dom-globals';
+import Editor from '../api/Editor';
 import CaretPosition from '../caret/CaretPosition';
 import * as CaretUtils from '../caret/CaretUtils';
 import * as NodeType from '../dom/NodeType';
-import Editor from '../api/Editor';
+import * as ScrollIntoView from '../dom/ScrollIntoView';
 
 const isContentEditableTrue = NodeType.isContentEditableTrue;
 const isContentEditableFalse = NodeType.isContentEditableFalse;
@@ -71,9 +72,16 @@ const renderRangeCaret = (editor: Editor, range: Range, scrollIntoView: boolean)
   return range;
 };
 
+const moveToRange = (editor: Editor, rng: Range) => {
+  editor.selection.setRng(rng);
+  // Don't reuse the original range as TinyMCE will adjust it
+  ScrollIntoView.scrollRangeIntoView(editor, editor.selection.getRng());
+};
+
 export {
   showCaret,
   selectNode,
   renderCaretAtRange,
-  renderRangeCaret
+  renderRangeCaret,
+  moveToRange
 };

--- a/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
@@ -5,21 +5,21 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Text, KeyboardEvent } from '@ephox/dom-globals';
+import { KeyboardEvent, Text } from '@ephox/dom-globals';
 import { Cell } from '@ephox/katamari';
+import Editor from '../api/Editor';
+import { EditorEvent } from '../api/util/EventDispatcher';
+import VK from '../api/util/VK';
 import * as BlockBoundaryDelete from '../delete/BlockBoundaryDelete';
 import * as BlockRangeDelete from '../delete/BlockRangeDelete';
-import * as CefDelete from '../delete/CefDelete';
 import * as CefBoundaryDelete from '../delete/CefBoundaryDelete';
+import * as CefDelete from '../delete/CefDelete';
+import * as ImageBlockDelete from '../delete/ImageBlockDelete';
 import * as InlineBoundaryDelete from '../delete/InlineBoundaryDelete';
 import * as InlineFormatDelete from '../delete/InlineFormatDelete';
+import * as Outdent from '../delete/Outdent';
 import * as TableDelete from '../delete/TableDelete';
 import * as MatchKeys from './MatchKeys';
-import VK from '../api/util/VK';
-import Editor from '../api/Editor';
-import * as PageBreakDelete from '../delete/ImageBlockDelete';
-import { EditorEvent } from '../api/util/EventDispatcher';
-import * as Outdent from '../delete/Outdent';
 
 const executeKeydownOverride = function (editor: Editor, caret: Cell<Text>, evt: KeyboardEvent) {
   MatchKeys.execute([
@@ -32,8 +32,8 @@ const executeKeydownOverride = function (editor: Editor, caret: Cell<Text>, evt:
     { keyCode: VK.DELETE, action: MatchKeys.action(InlineBoundaryDelete.backspaceDelete, editor, caret, true) },
     { keyCode: VK.BACKSPACE, action: MatchKeys.action(TableDelete.backspaceDelete, editor, false) },
     { keyCode: VK.DELETE, action: MatchKeys.action(TableDelete.backspaceDelete, editor, true) },
-    { keyCode: VK.BACKSPACE, action: MatchKeys.action(PageBreakDelete.backspaceDelete, editor, false) },
-    { keyCode: VK.DELETE, action: MatchKeys.action(PageBreakDelete.backspaceDelete, editor, true) },
+    { keyCode: VK.BACKSPACE, action: MatchKeys.action(ImageBlockDelete.backspaceDelete, editor, false) },
+    { keyCode: VK.DELETE, action: MatchKeys.action(ImageBlockDelete.backspaceDelete, editor, true) },
     { keyCode: VK.BACKSPACE, action: MatchKeys.action(BlockRangeDelete.backspaceDelete, editor, false) },
     { keyCode: VK.DELETE, action: MatchKeys.action(BlockRangeDelete.backspaceDelete, editor, true) },
     { keyCode: VK.BACKSPACE, action: MatchKeys.action(BlockBoundaryDelete.backspaceDelete, editor, false) },

--- a/modules/tinymce/src/core/main/ts/keyboard/TableNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/TableNavigation.ts
@@ -5,24 +5,18 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { HTMLElement, Range, Element } from '@ephox/dom-globals';
+import { Element, HTMLElement, Range } from '@ephox/dom-globals';
 import { Arr, Option, Fun } from '@ephox/katamari';
-import { Element as SugarElement, Attr, Insert } from '@ephox/sugar';
-import * as CaretFinder from '../caret/CaretFinder';
-import CaretPosition from '../caret/CaretPosition';
-import * as CefUtils from './CefUtils';
-import { getPositionsAbove, findClosestHorizontalPositionFromPoint, getPositionsBelow, getPositionsUntilPreviousLine, getPositionsUntilNextLine, BreakType, LineInfo } from '../caret/LineReader';
-import { findClosestPositionInAboveCell, findClosestPositionInBelowCell } from '../caret/TableCells';
-import * as ScrollIntoView from '../dom/ScrollIntoView';
+import { Attr, Element as SugarElement, Insert } from '@ephox/sugar';
 import Editor from '../api/Editor';
-import * as NodeType from '../dom/NodeType';
 import * as Settings from '../api/Settings';
 import { isFakeCaretTableBrowser } from '../caret/FakeCaret';
-
-const moveToRange = (editor: Editor, rng: Range) => {
-  editor.selection.setRng(rng);
-  ScrollIntoView.scrollRangeIntoView(editor, rng);
-};
+import * as CaretFinder from '../caret/CaretFinder';
+import { findClosestHorizontalPositionFromPoint, getPositionsAbove, getPositionsBelow, getPositionsUntilNextLine, getPositionsUntilPreviousLine, BreakType, LineInfo } from '../caret/LineReader';
+import CaretPosition from '../caret/CaretPosition';
+import { findClosestPositionInAboveCell, findClosestPositionInBelowCell } from '../caret/TableCells';
+import * as NodeType from '../dom/NodeType';
+import * as CefUtils from './CefUtils';
 
 const hasNextBreak = (getPositionsUntil, scope: HTMLElement, lineInfo: LineInfo): boolean => lineInfo.breakAt.map((breakPos) => getPositionsUntil(scope, breakPos).breakAt.isSome()).getOr(false);
 
@@ -56,8 +50,8 @@ const navigateHorizontally = (editor, forward: boolean, table: HTMLElement, _td:
   const direction = forward ? 1 : -1;
 
   if (isFakeCaretTableBrowser() && isCaretAtStartOrEndOfTable(forward, rng, table)) {
-    const newRng = CefUtils.showCaret(direction, editor, table, !forward, true);
-    moveToRange(editor, newRng);
+    const newRng = CefUtils.showCaret(direction, editor, table, !forward, false);
+    CefUtils.moveToRange(editor, newRng);
     return true;
   }
 
@@ -95,10 +89,10 @@ const renderBlock = (down: boolean, editor: Editor, table: HTMLElement, pos: Car
       const rng = editor.dom.createRng();
       rng.setStart(element.dom(), 0);
       rng.setEnd(element.dom(), 0);
-      moveToRange(editor, rng);
+      CefUtils.moveToRange(editor, rng);
     });
   } else {
-    moveToRange(editor, pos.toRange());
+    CefUtils.moveToRange(editor, pos.toRange());
   }
 };
 
@@ -107,9 +101,9 @@ const moveCaret = (editor: Editor, down: boolean, pos: CaretPosition) => {
   const last = down === false;
 
   table.fold(
-    () => moveToRange(editor, pos.toRange()),
+    () => CefUtils.moveToRange(editor, pos.toRange()),
     (table) => CaretFinder.positionIn(last, editor.getBody()).filter((lastPos) => lastPos.isEqual(pos)).fold(
-      () => moveToRange(editor, pos.toRange()),
+      () => CefUtils.moveToRange(editor, pos.toRange()),
       (_) => renderBlock(down, editor, table, pos)
     )
   );

--- a/modules/tinymce/src/core/test/ts/browser/geom/ClientRectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/geom/ClientRectTest.ts
@@ -38,6 +38,7 @@ UnitTest.asynctest('browser.tinymce.core.geom.ClientRectTest', function (success
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 20, 10, 10), rect(20, 20, 10, 40)), false);
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 10, 10, 10), rect(20, 15, 10, 10)), false);
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 15, 10, 10), rect(20, 20, 10, 10)), false);
+    LegacyUnit.equal(ClientRect.isAbove(rect(10, 10, 10, 40), rect(20, 40, 10, 10)), false);
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 10, 10, 10), rect(20, 20, 10, 10)), true);
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 10, 10, 10), rect(20, 16, 10, 10)), true);
   });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
@@ -1,0 +1,52 @@
+import { Keys, Log, Pipeline, Step } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.core.keyboard.ArrowKeysCefTest', (success, failure) => {
+  Theme();
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+    const tinyActions = TinyActions(editor);
+    let scrollIntoViewCount = 0;
+    editor.on('ScrollIntoView', () => scrollIntoViewCount++);
+
+    const sScrollTo = (x: number, y: number) => Step.sync(() => editor.getWin().scrollTo(x, y));
+    const sResetScrollCount = Step.sync(() => scrollIntoViewCount = 0);
+    const sAssertScrollCount = (expected: number) => Step.sync(() => {
+      Assert.eq('ScrollIntoView count', expected, scrollIntoViewCount);
+    });
+
+    Pipeline.async({}, [
+      tinyApis.sFocus(),
+      Log.stepsAsStep('TINY-6226', 'Should move to line above when large cef element is inline', [
+        tinyApis.sSetContent('<p>Line 1</p><p><video height="400" width="200" src="video.mp4" contenteditable="false"></video> Line 2</p><p>Line 3 with some more text</p>'),
+        sScrollTo(0, 400),
+        tinyApis.sSetCursor([ 2, 0 ], 26),
+        sResetScrollCount,
+        tinyActions.sContentKeystroke(Keys.up()),
+        sAssertScrollCount(1),
+        tinyApis.sAssertSelection([ 1, 1 ], 1, [ 1, 1 ], 1),
+        tinyActions.sContentKeystroke(Keys.up()),
+        sAssertScrollCount(2),
+        tinyApis.sAssertSelection([ 0, 0 ], 6, [ 0, 0 ], 6)
+      ]),
+      Log.stepsAsStep('TINY-6226', 'Should move to line below when large cef element is on next line', [
+        tinyApis.sSetContent('<p>Line 1</p><p><video height="400" width="200" src="video.mp4" contenteditable="false"></video> Line 2</p><p>Line 3</p>'),
+        sScrollTo(0, 0),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        sResetScrollCount,
+        tinyActions.sContentKeystroke(Keys.down()),
+        sAssertScrollCount(1),
+        tinyApis.sAssertSelection([ 1, 0 ], 0, [ 1, 0 ], 0),
+        tinyActions.sContentKeystroke(Keys.down()),
+        sAssertScrollCount(2),
+        tinyApis.sAssertSelection([ 2, 0 ], 0, [ 2, 0 ], 0)
+      ])
+    ], onSuccess, onFailure);
+  }, {
+    height: 200,
+    base_url: '/project/tinymce/js/tinymce'
+  }, success, failure);
+});


### PR DESCRIPTION
Related Ticket: TINY-6226

Description of Changes:
* Ports contenteditable=false fixes from https://github.com/tinymce/tinymce/pull/5859, as we're not going ahead with the node filters in that now.

> This fixes some various navigation issues I encountered when manually testing this, such as pressing up not working when near a media element or it not scrolling the cursor into view after pressing up/down. The former was actually a bug I tried to fix when I first started (but no one got back to me) and was a regression caused by the fix for TINY-981 (see 73c077b6be41d355ed9ee346710c05fce2e13ec9). I don't believe we even need the bottom adjustments (based on manual testing), however since I couldn't find out for sure why it was added I've instead opted to limit how much it can be adjusted to.
>
> Here's the picture I sent that outlines the issue of why the cursor doesn't move up:
![image](https://user-images.githubusercontent.com/1575550/86563938-a9a81f80-bfa8-11ea-8db0-d6a6efde415f.png)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
