### PR TITLE
TINY-6226: Backported up and down keyboard navigation not working for inline contenteditable false elements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 4.9.11 (TBD)
     Fixed the `selection.setContent()` API not running parser filters #TINY-4002
-    Fixed content in an iframe element parsing as dom elements instead of text content #TINY-5943
+    Fixed content in an iframe element parsing as DOM elements instead of text content #TINY-5943
+    Fixed up and down keyboard navigation not working for inline `contenteditable="false"` elements #TINY-6226
 Version 4.9.10 (2020-04-23)
     Fixed an issue where the editor selection could end up inside a short ended element (eg br) #TINY-3999
     Fixed a security issue related to CDATA sanitization during parsing #TINY-4669

--- a/src/core/main/ts/geom/ClientRect.ts
+++ b/src/core/main/ts/geom/ClientRect.ts
@@ -60,7 +60,8 @@ const isValidOverflow = (overflowY: number, rect1: ClientRect, rect2: ClientRect
 };
 
 const isAbove = (rect1: ClientRect, rect2: ClientRect): boolean => {
-  if ((rect1.bottom - rect1.height / 2) < rect2.top) {
+  const halfHeight = Math.min(rect2.height / 2, rect1.height / 2);
+  if ((rect1.bottom - halfHeight) < rect2.top) {
     return true;
   }
 

--- a/src/core/main/ts/keyboard/CefNavigation.ts
+++ b/src/core/main/ts/keyboard/CefNavigation.ts
@@ -214,7 +214,7 @@ const moveH = (editor: Editor, forward: boolean) => {
     const newRng = getHorizontalRange(editor, forward);
 
     if (newRng) {
-      editor.selection.setRng(newRng);
+      CefUtils.moveToRange(editor, newRng);
       return true;
     } else {
       return false;
@@ -227,7 +227,7 @@ const moveV = (editor: Editor, down: boolean) => {
     const newRng = getVerticalRange(editor, down);
 
     if (newRng) {
-      editor.selection.setRng(newRng);
+      CefUtils.moveToRange(editor, newRng);
       return true;
     } else {
       return false;

--- a/src/core/main/ts/keyboard/CefUtils.ts
+++ b/src/core/main/ts/keyboard/CefUtils.ts
@@ -5,11 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Element, Range } from '@ephox/dom-globals';
+import { Editor } from 'tinymce/core/api/Editor';
 import CaretPosition from '../caret/CaretPosition';
 import * as CaretUtils from '../caret/CaretUtils';
 import NodeType from '../dom/NodeType';
-import { Editor } from 'tinymce/core/api/Editor';
-import { Element, Range } from '@ephox/dom-globals';
+import ScrollIntoView from '../dom/ScrollIntoView';
 
 const isContentEditableTrue = NodeType.isContentEditableTrue;
 const isContentEditableFalse = NodeType.isContentEditableFalse;
@@ -72,9 +73,16 @@ const renderRangeCaret = (editor: Editor, range: Range, scrollIntoView: boolean)
   return range;
 };
 
+const moveToRange = (editor: Editor, rng: Range) => {
+  editor.selection.setRng(rng);
+  // Don't reuse the original range as TinyMCE will adjust it
+  ScrollIntoView.scrollRangeIntoView(editor, editor.selection.getRng());
+};
+
 export {
   showCaret,
   selectNode,
   renderCaretAtRange,
-  renderRangeCaret
+  renderRangeCaret,
+  moveToRange
 };

--- a/src/core/main/ts/keyboard/TableNavigation.ts
+++ b/src/core/main/ts/keyboard/TableNavigation.ts
@@ -11,18 +11,12 @@ import * as CefUtils from '../keyboard/CefUtils';
 import { Arr, Option, Fun } from '@ephox/katamari';
 import { getPositionsAbove, findClosestHorizontalPositionFromPoint, getPositionsBelow, getPositionsUntilPreviousLine, getPositionsUntilNextLine, BreakType, LineInfo } from 'tinymce/core/caret/LineReader';
 import { findClosestPositionInAboveCell, findClosestPositionInBelowCell } from 'tinymce/core/caret/TableCells';
-import ScrollIntoView from 'tinymce/core/dom/ScrollIntoView';
 import { Editor } from 'tinymce/core/api/Editor';
 import NodeType from 'tinymce/core/dom/NodeType';
 import Settings from 'tinymce/core/api/Settings';
 import { Element as SugarElement, Attr, Insert } from '@ephox/sugar';
 import { HTMLElement, Range, Element } from '@ephox/dom-globals';
 import { isFakeCaretTableBrowser } from '../caret/FakeCaret';
-
-const moveToRange = (editor: Editor, rng: Range) => {
-  editor.selection.setRng(rng);
-  ScrollIntoView.scrollRangeIntoView(editor, rng);
-};
 
 const hasNextBreak = (getPositionsUntil, scope: HTMLElement, lineInfo: LineInfo): boolean => {
   return lineInfo.breakAt.map((breakPos) => getPositionsUntil(scope, breakPos).breakAt.isSome()).getOr(false);
@@ -59,7 +53,7 @@ const navigateHorizontally = (editor, forward: boolean, table: HTMLElement, td: 
 
   if (isFakeCaretTableBrowser() && isCaretAtStartOrEndOfTable(forward, rng, table)) {
     const newRng = CefUtils.showCaret(direction, editor, table, !forward, true);
-    moveToRange(editor, newRng);
+    CefUtils.moveToRange(editor, newRng);
     return true;
   }
 
@@ -109,10 +103,10 @@ const renderBlock = (down: boolean, editor: Editor, table: HTMLElement, pos: Car
       const rng = editor.dom.createRng();
       rng.setStart(element.dom(), 0);
       rng.setEnd(element.dom(), 0);
-      moveToRange(editor, rng);
+      CefUtils.moveToRange(editor, rng);
     });
   } else {
-    moveToRange(editor, pos.toRange());
+    CefUtils.moveToRange(editor, pos.toRange());
   }
 };
 
@@ -121,10 +115,10 @@ const moveCaret = (editor: Editor, down: boolean, pos: CaretPosition) => {
   const last = down === false;
 
   table.fold(
-    () => moveToRange(editor, pos.toRange()),
+    () => CefUtils.moveToRange(editor, pos.toRange()),
     (table) => {
       return CaretFinder.positionIn(last, editor.getBody()).filter((lastPos) => lastPos.isEqual(pos)).fold(
-        () => moveToRange(editor, pos.toRange()),
+        () => CefUtils.moveToRange(editor, pos.toRange()),
         (_) => renderBlock(down, editor, table, pos)
       );
     }

--- a/src/core/test/ts/browser/geom/ClientRectTest.ts
+++ b/src/core/test/ts/browser/geom/ClientRectTest.ts
@@ -40,6 +40,7 @@ UnitTest.asynctest('browser.tinymce.core.geom.ClientRectTest', function () {
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 20, 10, 10), rect(20, 20, 10, 40)), false);
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 10, 10, 10), rect(20, 15, 10, 10)), false);
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 15, 10, 10), rect(20, 20, 10, 10)), false);
+    LegacyUnit.equal(ClientRect.isAbove(rect(10, 10, 10, 40), rect(20, 40, 10, 10)), false);
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 10, 10, 10), rect(20, 20, 10, 10)), true);
     LegacyUnit.equal(ClientRect.isAbove(rect(10, 10, 10, 10), rect(20, 16, 10, 10)), true);
   });

--- a/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
+++ b/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
@@ -1,0 +1,50 @@
+import { Keys, Log, Pipeline, Step } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
+import Theme from 'tinymce/themes/modern/Theme';
+
+UnitTest.asynctest('browser.tinymce.core.keyboard.ArrowKeysCefTest', (success, failure) => {
+  Theme();
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+    const tinyActions = TinyActions(editor);
+    let scrollIntoViewCount = 0;
+    editor.on('ScrollIntoView', () => scrollIntoViewCount++);
+
+    const sScrollTo = (x: number, y: number) => Step.sync(() => editor.getWin().scrollTo(x, y));
+    const sResetScrollCount = Step.sync(() => scrollIntoViewCount = 0);
+    const sAssertScrollCount = (expected: number) => Step.sync(() => {
+      Assert.eq('ScrollIntoView count', expected, scrollIntoViewCount);
+    });
+
+    Pipeline.async({}, [
+      tinyApis.sFocus,
+      Log.stepsAsStep('TINY-6226', 'Should move to line above when large cef element is inline', [
+        tinyApis.sSetContent('<p>Line 1</p><p><video height="400" width="200" src="video.mp4" contenteditable="false"></video> Line 2</p><p>Line 3 with some more text</p>'),
+        sScrollTo(0, 400),
+        tinyApis.sSetCursor([ 2, 0 ], 26),
+        sResetScrollCount,
+        tinyActions.sContentKeystroke(Keys.up()),
+        sAssertScrollCount(1),
+        tinyApis.sAssertSelection([ 1, 1 ], 1, [ 1, 1 ], 1),
+        tinyActions.sContentKeystroke(Keys.up()),
+        tinyApis.sAssertSelection([ 0, 0 ], 6, [ 0, 0 ], 6)
+      ]),
+      Log.stepsAsStep('TINY-6226', 'Should move to line below when large cef element is on next line', [
+        tinyApis.sSetContent('<p>Line 1</p><p><video height="400" width="200" src="video.mp4" contenteditable="false"></video> Line 2</p><p>Line 3</p>'),
+        sScrollTo(0, 0),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        sResetScrollCount,
+        tinyActions.sContentKeystroke(Keys.down()),
+        sAssertScrollCount(1),
+        tinyApis.sAssertSelection([ 1, 0 ], 0, [ 1, 0 ], 0),
+        tinyActions.sContentKeystroke(Keys.down()),
+        tinyApis.sAssertSelection([ 2, 0 ], 0, [ 2, 0 ], 0)
+      ])
+    ], onSuccess, onFailure);
+  }, {
+    height: 200,
+    base_url: '/project/tinymce/js/tinymce'
+  }, success, failure);
+});


### PR DESCRIPTION
Related Ticket: TINY-6226

Description of Changes:
* Backports the fix done for TinyMCE 5.5.0 (Note: Some changes are different due to the differences in v4 and v5).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
