### PR TITLE
TINY-6230: Fixed pressing escape not focusing the editor when using multiple toolbars

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -5,6 +5,7 @@ Version 5.5.0 (TBD)
     Fixed up and down keyboard navigation not working for inline `contenteditable="false"` elements #TINY-6226
     Fixed the `unlink` toolbar button not working when selecting multiple links #TINY-4867
     Fixed the `link` dialog not showing the "Text to display" field in some valid cases #TINY-5205
+    Fixed pressing escape not focusing the editor when using multiple toolbars #TINY-6230
 Version 5.4.1 (2020-07-08)
     Fixed the Search and Replace plugin incorrectly including zero-width caret characters in search results #TINY-4599
     Fixed dragging and dropping unsupported files navigating the browser away from the editor #TINY-6027

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -172,7 +172,9 @@ const setup = (editor: Editor): RenderInfo => {
       classes: [ 'tox-toolbar-overlord' ]
     },
     providers: backstage.shared.providers,
-    onEscape: () => { },
+    onEscape: () => {
+      editor.focus();
+    },
     type: toolbarMode
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -179,7 +179,10 @@ const partMultipleToolbar = Composite.partType.optional<OuterContainerSketchDeta
         cyclicKeying: false,
         initGroups: [ ],
         providers: spec.providers,
-        onEscape: () => Option.none()
+        onEscape: () => {
+          spec.onEscape();
+          return Option.some(true);
+        }
       }),
       setupItem: (_mToolbar, tc, data, _index) => {
         Toolbar.setGroups(tc, data);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarFocusTest.ts
@@ -1,0 +1,45 @@
+import { Chain, FocusTools, Keyboard, Keys, Log, Pipeline } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { ApiChains, Editor as McEditor } from '@ephox/mcagar';
+import { Document, Element } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.themes.silver.editor.toolbar.ToolbarFocusTest', (success, failure) => {
+  SilverTheme();
+
+  const cTestFocus = (label: string, settings: RawEditorSettings) => Chain.label(label, Chain.fromChains([
+    McEditor.cFromSettings({
+      toolbar: 'undo redo | bold italic',
+      menubar: false,
+      statusbar: false,
+      ...settings,
+      base_url: '/project/tinymce/js/tinymce'
+    }),
+    ApiChains.cFocus,
+    Chain.runStepsOnValue((editor: Editor) => {
+      const editorDoc = Element.fromDom(editor.getDoc());
+      const doc = Document.getDocument();
+
+      return [
+        // Press the Alt+F10 key
+        Keyboard.sKeystroke(editorDoc, 121, { alt: true }),
+        FocusTools.sTryOnSelector('Assert toolbar is focused', doc, 'div[role=toolbar] .tox-tbtn'),
+        Keyboard.sKeystroke(doc, Keys.escape(), { }),
+        FocusTools.sTryOnSelector('Assert editor is focused', doc, 'iframe'),
+        FocusTools.sTryOnSelector('Assert editor is focused', editorDoc, 'body')
+      ];
+    }),
+    McEditor.cRemove
+  ]));
+
+  Pipeline.async({}, [
+    Log.chainsAsStep('TINY-6230', 'Pressing Alt+F10 focuses the toolbar and escape from the toolbar will focus the editor', [
+      cTestFocus('Floating toolbar', { toolbar_mode: 'floating' }),
+      cTestFocus('Sliding toolbar', { toolbar_mode: 'sliding' }),
+      cTestFocus('Wrap toolbar', { toolbar_mode: 'wrap' }),
+      cTestFocus('Multiple toolbars', { toolbar: [ 'undo redo', 'bold italic' ] })
+    ])
+  ], success, failure);
+});


### PR DESCRIPTION
Related Ticket: TINY-6230

Description of Changes:
* Fixes pressing the escape key when a multiple toolbar was focused not returning focus to the editor. This appears to have been something that was missed when multiple toolbars was originally implemented.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #5876