### PR TITLE
TINY-6011: Can now include the option to remove images on a failed upload.

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.5.0 (TBD)
     Added new `table_column_resizing` setting to control how the table is affected when resizing columns using the resize bars #TINY-6001
     Added ability to load TinyMCE in inline mode within a ShadowRoot #TINY-6128
+    Added the `image` `images_upload_handler` can now chose to have images removed on a failed upload #TINY-6011
     Added `hasPlugin` function to the editor API to determine if a plugin exists or not #TINY-766
     Changed the `target` property on fired events to use the native event target. The original target for an open shadow root can be obtained using `event.getComposedPath()` #TINY-6128
     Changed `imagetools` context menu icon for accessing the `image` settings to use the same icon #TINY-4141

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -135,7 +135,13 @@ const EditorUpload = function (editor: Editor): EditorUpload {
             blobCache.removeByUri(image.src);
             replaceImageUriInView(image, uploadInfo.url);
           } else if (uploadInfo.error) {
-            ErrorReporter.uploadError(editor, uploadInfo.error);
+            if (uploadInfo.error.options.remove) {
+              editor.undoManager.transact(() => {
+                editor.dom.remove(image);
+              });
+            }
+
+            ErrorReporter.uploadError(editor, uploadInfo.error.error);
           }
 
           return {

--- a/modules/tinymce/src/core/main/ts/file/Uploader.ts
+++ b/modules/tinymce/src/core/main/ts/file/Uploader.ts
@@ -31,13 +31,20 @@ import Tools from '../api/util/Tools';
  * });
  */
 
-export type UploadHandler = (blobInfo: BlobInfo, success: (url: string) => void, failure: (err: string) => void, progress?: (percent: number) => void) => void;
+export interface UploadFailureOptions {
+  remove?: boolean;
+}
+
+export type UploadHandler = (blobInfo: BlobInfo, success: (url: string) => void, failure: (err: string, options?: UploadFailureOptions) => void, progress?: (percent: number) => void) => void;
 
 export interface UploadResult {
   url: string;
   blobInfo: BlobInfo;
   status: boolean;
-  error?: string;
+  error?: {
+    options: UploadFailureOptions;
+    error: string;
+  };
 }
 
 export interface Uploader {
@@ -47,7 +54,7 @@ export interface Uploader {
 export function Uploader(uploadStatus, settings): Uploader {
   const pendingPromises = {};
 
-  const pathJoin = function (path1, path2) {
+  const pathJoin = (path1, path2) => {
     if (path1) {
       return path1.replace(/\/$/, '') + '/' + path2.replace(/^\//, '');
     }
@@ -55,20 +62,20 @@ export function Uploader(uploadStatus, settings): Uploader {
     return path2;
   };
 
-  const defaultHandler: UploadHandler = function (blobInfo, success, failure, progress) {
+  const defaultHandler: UploadHandler = (blobInfo, success, failure, progress) => {
     const xhr = new XMLHttpRequest();
     xhr.open('POST', settings.url);
     xhr.withCredentials = settings.credentials;
 
-    xhr.upload.onprogress = function (e) {
+    xhr.upload.onprogress = (e) => {
       progress(e.loaded / e.total * 100);
     };
 
-    xhr.onerror = function () {
+    xhr.onerror = () => {
       failure('Image upload failed due to a XHR Transport error. Code: ' + xhr.status);
     };
 
-    xhr.onload = function () {
+    xhr.onload = () => {
       if (xhr.status < 200 || xhr.status >= 300) {
         failure('HTTP Error: ' + xhr.status);
         return;
@@ -84,75 +91,75 @@ export function Uploader(uploadStatus, settings): Uploader {
       success(pathJoin(settings.basePath, json.location));
     };
 
-    const formData = new FormData(); // TODO: Stick this in sand
+    const formData = new FormData();
     formData.append('file', blobInfo.blob(), blobInfo.filename());
 
     xhr.send(formData);
   };
 
-  const noUpload = function (): Promise<UploadResult[]> {
-    return new Promise(function (resolve) {
+  const noUpload = (): Promise<UploadResult[]> =>
+    new Promise((resolve) => {
       resolve([]);
     });
-  };
 
-  const handlerSuccess = function (blobInfo: BlobInfo, url: string): UploadResult {
-    return {
-      url,
-      blobInfo,
-      status: true
-    };
-  };
+  const handlerSuccess = (blobInfo: BlobInfo, url: string): UploadResult => ({
+    url,
+    blobInfo,
+    status: true
+  });
 
-  const handlerFailure = function (blobInfo: BlobInfo, error): UploadResult {
-    return {
-      url: '',
-      blobInfo,
-      status: false,
-      error
-    };
-  };
+  const handlerFailure = (blobInfo: BlobInfo, error: string, options: UploadFailureOptions): UploadResult => ({
+    url: '',
+    blobInfo,
+    status: false,
+    error: {
+      error,
+      options
+    }
+  });
 
-  const resolvePending = function (blobUri, result) {
-    Tools.each(pendingPromises[blobUri], function (resolve) {
+  const resolvePending = (blobUri, result) => {
+    Tools.each(pendingPromises[blobUri], (resolve) => {
       resolve(result);
     });
 
     delete pendingPromises[blobUri];
   };
 
-  const uploadBlobInfo = function (blobInfo: BlobInfo, handler, openNotification): Promise<UploadResult> {
+  const uploadBlobInfo = (blobInfo: BlobInfo, handler: UploadHandler, openNotification): Promise<UploadResult> => {
     uploadStatus.markPending(blobInfo.blobUri());
 
-    return new Promise(function (resolve) {
+    return new Promise((resolve) => {
       let notification, progress;
 
-      const noop = function () {
+      const noop = () => {
       };
 
       try {
-        const closeNotification = function () {
+        const closeNotification = () => {
           if (notification) {
             notification.close();
             progress = noop; // Once it's closed it's closed
           }
         };
 
-        const success = function (url) {
+        const success = (url) => {
           closeNotification();
           uploadStatus.markUploaded(blobInfo.blobUri(), url);
           resolvePending(blobInfo.blobUri(), handlerSuccess(blobInfo, url));
           resolve(handlerSuccess(blobInfo, url));
         };
 
-        const failure = function (error) {
+        const failure = (error: string, options?: UploadFailureOptions): void => {
+          const failureOptions = options ? options : {};
+
           closeNotification();
           uploadStatus.removeFailed(blobInfo.blobUri());
-          resolvePending(blobInfo.blobUri(), handlerFailure(blobInfo, error));
-          resolve(handlerFailure(blobInfo, error));
+          resolvePending(blobInfo.blobUri(), handlerFailure(blobInfo, error, failureOptions));
+          resolve(handlerFailure(blobInfo, error, failureOptions));
         };
 
-        progress = function (percent) {
+        progress = (percent) => {
           if (percent < 0 || percent > 100) {
             return;
           }
@@ -166,38 +173,36 @@ export function Uploader(uploadStatus, settings): Uploader {
 
         handler(blobInfo, success, failure, progress);
       } catch (ex) {
-        resolve(handlerFailure(blobInfo, ex.message));
+        resolve(handlerFailure(blobInfo, ex.message, {}));
       }
     });
   };
 
-  const isDefaultHandler = function (handler) {
-    return handler === defaultHandler;
-  };
+  const isDefaultHandler = (handler) =>
+    handler === defaultHandler;
 
-  const pendingUploadBlobInfo = function (blobInfo: BlobInfo): Promise<UploadResult> {
+  const pendingUploadBlobInfo = (blobInfo: BlobInfo): Promise<UploadResult> => {
     const blobUri = blobInfo.blobUri();
 
-    return new Promise(function (resolve) {
+    return new Promise((resolve) => {
       pendingPromises[blobUri] = pendingPromises[blobUri] || [];
       pendingPromises[blobUri].push(resolve);
     });
   };
 
-  const uploadBlobs = function (blobInfos: BlobInfo[], openNotification): Promise<UploadResult[]> {
-    blobInfos = Tools.grep(blobInfos, function (blobInfo) {
-      return !uploadStatus.isUploaded(blobInfo.blobUri());
-    });
+  const uploadBlobs = (blobInfos: BlobInfo[], openNotification): Promise<UploadResult[]> => {
+    blobInfos = Tools.grep(blobInfos, (blobInfo) =>
+      !uploadStatus.isUploaded(blobInfo.blobUri())
+    );
 
-    return Promise.all(Tools.map(blobInfos, function (blobInfo: BlobInfo) {
-      return uploadStatus.isPending(blobInfo.blobUri()) ?
-        pendingUploadBlobInfo(blobInfo) : uploadBlobInfo(blobInfo, settings.handler, openNotification);
-    }));
+    return Promise.all(Tools.map(blobInfos, (blobInfo: BlobInfo) =>
+      uploadStatus.isPending(blobInfo.blobUri()) ?
+        pendingUploadBlobInfo(blobInfo) : uploadBlobInfo(blobInfo, settings.handler, openNotification)
+    ));
   };
 
-  const upload = function (blobInfos, openNotification) {
-    return (!settings.url && isDefaultHandler(settings.handler)) ? noUpload() : uploadBlobs(blobInfos, openNotification);
-  };
+  const upload = (blobInfos, openNotification) =>
+    (!settings.url && isDefaultHandler(settings.handler)) ? noUpload() : uploadBlobs(blobInfos, openNotification);
 
   if (Type.isFunction(settings.handler) === false) {
     settings.handler = defaultHandler;


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Added options to the uploader failure function to permit the removal of images that could not be uploaded. Defaults to false.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
