### PR TITLE
TINY-3785: Rename TinyMCE core modules that conflict with TS dom names

### DIFF
--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -5,19 +5,19 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { document, DragEvent, Element, Node, HTMLElement, MouseEvent } from '@ephox/dom-globals';
+import { document, DragEvent, Element, HTMLElement, MouseEvent, Node } from '@ephox/dom-globals';
 import { Arr, Singleton } from '@ephox/katamari';
 import DOMUtils from './api/dom/DOMUtils';
-import Selection from './api/dom/Selection';
+import EditorSelection from './api/dom/Selection';
 import Editor from './api/Editor';
 import * as Settings from './api/Settings';
 import Delay from './api/util/Delay';
 import { EditorEvent } from './api/util/EventDispatcher';
 import * as MousePosition from './dom/MousePosition';
 import * as NodeType from './dom/NodeType';
+import * as ErrorReporter from './ErrorReporter';
 import { isUIElement } from './focus/FocusController';
 import * as Predicate from './util/Predicate';
-import * as ErrorReporter from './ErrorReporter';
 
 /**
  * This module contains logic overriding the drag/drop logic of the editor.
@@ -197,7 +197,7 @@ const move = (state: Singleton.Value<State>, editor: Editor) => {
 };
 
 // Returns the raw element instead of the fake cE=false element
-const getRawTarget = (selection: Selection) => {
+const getRawTarget = (selection: EditorSelection) => {
   const rng = selection.getSel().getRangeAt(0);
   const startContainer = rng.startContainer;
   return startContainer.nodeType === 3 ? startContainer.parentNode : startContainer;

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -5,12 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Event, Node as DomNode, Range } from '@ephox/dom-globals';
+import { Event, Node, Range } from '@ephox/dom-globals';
 import { Fun, Obj, Option, Type } from '@ephox/katamari';
 import Editor from './api/Editor';
 import Formatter from './api/Formatter';
-import Node from './api/html/Node';
-import Serializer from './api/html/Serializer';
+import AstNode from './api/html/Node';
+import HtmlSerializer from './api/html/Serializer';
 import { Content, ContentFormat, GetContentArgs, SetContentArgs } from './content/ContentTypes';
 import { getContentInternal } from './content/GetContentImpl';
 import { insertHtmlAtCaret } from './content/InsertContentImpl';
@@ -24,9 +24,9 @@ import { RangeLikeObject } from './selection/RangeTypes';
 import * as Operations from './undo/Operations';
 import { Index, Locks, UndoBookmark, UndoLevel, UndoLevelType, UndoManager } from './undo/UndoManagerTypes';
 
-const isTreeNode = (content: any): content is Node => content instanceof Node;
+const isTreeNode = (content: any): content is AstNode => content instanceof AstNode;
 
-const runSerializerFiltersOnFragment = (editor: Editor, fragment: Node) => {
+const runSerializerFiltersOnFragment = (editor: Editor, fragment: AstNode) => {
   FilterNode.filter(editor.serializer.getNodeFilters(), editor.serializer.getAttributeFilters(), fragment);
 };
 
@@ -40,10 +40,10 @@ interface RtcRuntimeApi {
   applyFormat: (format: string, vars: Record<string, string>) => void;
   removeFormat: (format: string, vars: Record<string, string>) => void;
   toggleFormat: (format: string, vars: Record<string, string>) => void;
-  getContent: () => Node | null;
-  setContent: (node: Node) => void;
-  insertContent: (node: Node) => void;
-  getSelectedContent: () => Node | null;
+  getContent: () => AstNode | null;
+  setContent: (node: AstNode) => void;
+  insertContent: (node: AstNode) => void;
+  getSelectedContent: () => AstNode | null;
   getRawModel: () => any;
   isRemote: boolean;
 }
@@ -175,7 +175,7 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
       getContent: (args, format) => {
         if (format === 'html' || format === 'tree') {
           const fragment = rtcEditor.getContent();
-          const serializer = Serializer({ inner: true });
+          const serializer = HtmlSerializer({ inner: true });
 
           runSerializerFiltersOnFragment(tinymceEditor, fragment);
 
@@ -200,7 +200,7 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
       getContent: (format, args) => {
         if (format === 'html' || format === 'tree') {
           const fragment = rtcEditor.getSelectedContent();
-          const serializer = Serializer({});
+          const serializer = HtmlSerializer({});
 
           runSerializerFiltersOnFragment(tinymceEditor, fragment);
 
@@ -304,16 +304,16 @@ export const applyFormat = (
   editor: Editor,
   name: string,
   vars?: Record<string, string>,
-  node?: DomNode | RangeLikeObject
+  node?: Node | RangeLikeObject
 ): void => {
   getRtcInstanceWithError(editor).formatter.apply(name, vars, node);
 };
 
-export const removeFormat = (editor: Editor, name: string, vars?: Record<string, string>, node?: DomNode | Range, similar?: boolean) => {
+export const removeFormat = (editor: Editor, name: string, vars?: Record<string, string>, node?: Node | Range, similar?: boolean) => {
   getRtcInstanceWithError(editor).formatter.remove(name, vars, node, similar);
 };
 
-export const toggleFormat = (editor: Editor, name: string, vars: Record<string, string>, node: DomNode): void => {
+export const toggleFormat = (editor: Editor, name: string, vars: Record<string, string>, node: Node): void => {
   getRtcInstanceWithError(editor).formatter.toggle(name, vars, node);
 };
 

--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationFilter.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationFilter.ts
@@ -5,15 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Option, Arr } from '@ephox/katamari';
+import { Arr, Option } from '@ephox/katamari';
 
+import Editor from '../api/Editor';
+import AstNode from '../api/html/Node';
 import { AnnotationsRegistry, AnnotatorSettings } from './AnnotationsRegistry';
 import * as Markings from './Markings';
-import Editor from '../api/Editor';
-import Node from '../api/html/Node';
 
 const setup = (editor: Editor, registry: AnnotationsRegistry): void => {
-  const identifyParserNode = (span: Node): Option<AnnotatorSettings> => Option.from(span.attr(Markings.dataAnnotation())).bind(registry.lookup);
+  const identifyParserNode = (span: AstNode): Option<AnnotatorSettings> => Option.from(span.attr(Markings.dataAnnotation())).bind(registry.lookup);
 
   editor.on('init', () => {
     editor.serializer.addNodeFilter('span', (spans) => {

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -7,7 +7,7 @@
 
 import { Registry } from '@ephox/bridge';
 import { Document, Element, Event, HTMLElement, HTMLIFrameElement, Window } from '@ephox/dom-globals';
-import { Option, Arr } from '@ephox/katamari';
+import { Arr, Option } from '@ephox/katamari';
 import * as EditorContent from '../content/EditorContent';
 import * as NodeType from '../dom/NodeType';
 import * as EditorRemove from '../EditorRemove';
@@ -24,8 +24,9 @@ import Annotator from './Annotator';
 import DomQuery, { DomQueryConstructor } from './dom/DomQuery';
 import DOMUtils from './dom/DOMUtils';
 import ScriptLoader from './dom/ScriptLoader';
-import Selection from './dom/Selection';
+import EditorSelection from './dom/Selection';
 import DomSerializer from './dom/Serializer';
+import { StyleSheetLoader } from './dom/StyleSheetLoader';
 import EditorCommands, { EditorCommandCallback } from './EditorCommands';
 import EditorManager from './EditorManager';
 import EditorObservable from './EditorObservable';
@@ -33,11 +34,12 @@ import EditorUpload, { UploadCallback, UploadResult } from './EditorUpload';
 import Env from './Env';
 import Formatter from './Formatter';
 import DomParser from './html/DomParser';
-import Node from './html/Node';
+import AstNode from './html/Node';
 import Schema from './html/Schema';
 import { create, Mode } from './Mode';
 import NotificationManager from './NotificationManager';
 import PluginManager, { Plugin } from './PluginManager';
+import * as Settings from './Settings';
 import { EditorSettings, RawEditorSettings } from './SettingsTypes';
 import Shortcuts from './Shortcuts';
 import { Theme } from './ThemeManager';
@@ -47,8 +49,6 @@ import I18n, { TranslatedString, Untranslated } from './util/I18n';
 import Tools from './util/Tools';
 import URI from './util/URI';
 import WindowManager from './WindowManager';
-import { StyleSheetLoader } from './dom/StyleSheetLoader';
-import * as Settings from './Settings';
 
 /**
  * This class contains the core logic for a TinyMCE editor.
@@ -255,7 +255,7 @@ class Editor implements EditorObservable {
   public readonly: boolean;
   public removed: boolean;
   public schema: Schema;
-  public selection: Selection;
+  public selection: EditorSelection;
   public serializer: DomSerializer;
   public startContent: string;
   public targetElm: HTMLElement;
@@ -841,7 +841,7 @@ class Editor implements EditorObservable {
    * tinymce.activeEditor.setContent('<p>Some html</p>', {format: 'html'});
    */
   public setContent (content: string, args?: EditorContent.SetContentArgs): string;
-  public setContent (content: Node, args?: EditorContent.SetContentArgs): Node;
+  public setContent (content: AstNode, args?: EditorContent.SetContentArgs): AstNode;
   public setContent(content: EditorContent.Content, args?: EditorContent.SetContentArgs): EditorContent.Content {
     return EditorContent.setContent(this, content, args);
   }
@@ -863,7 +863,7 @@ class Editor implements EditorObservable {
    * // Get content of a specific editor:
    * tinymce.get('content id').getContent()
    */
-  public getContent (args: { format: 'tree' } & EditorContent.GetContentArgs): Node;
+  public getContent (args: { format: 'tree' } & EditorContent.GetContentArgs): AstNode;
   public getContent (args?: EditorContent.GetContentArgs): string;
   public getContent(args?: EditorContent.GetContentArgs): EditorContent.Content {
     return EditorContent.getContent(this, args);

--- a/modules/tinymce/src/core/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/core/main/ts/api/Settings.ts
@@ -11,7 +11,7 @@ import { UploadHandler } from '../file/Uploader';
 import DOMUtils from './dom/DOMUtils';
 import Editor from './Editor';
 import Env from './Env';
-import { ReferrerPolicy } from './SettingsTypes';
+import { UpdatedReferrerPolicy } from './SettingsTypes';
 import I18n from './util/I18n';
 import Tools from './util/Tools';
 
@@ -96,7 +96,7 @@ const getImagesUploadHandler = (editor: Editor): UploadHandler => editor.getPara
 
 const shouldUseContentCssCors = (editor: Editor): boolean => editor.getParam('content_css_cors', false, 'boolean');
 
-const getReferrerPolicy = (editor: Editor): ReferrerPolicy => editor.getParam('referrer_policy', '', 'string') as ReferrerPolicy;
+const getReferrerPolicy = (editor: Editor): UpdatedReferrerPolicy => editor.getParam('referrer_policy', '', 'string') as UpdatedReferrerPolicy;
 
 const getLanguageCode = (editor: Editor): string => editor.getParam('language', 'en', 'string');
 

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { HTMLElement, HTMLImageElement, Node, ReferrerPolicy as DomReferrerPolicy } from '@ephox/dom-globals';
+import { HTMLElement, HTMLImageElement, Node, ReferrerPolicy } from '@ephox/dom-globals';
 import { UploadHandler } from '../file/Uploader';
 import Editor from './Editor';
 import { Formats } from './fmt/Format';
@@ -28,7 +28,7 @@ export type FilePickerValidationStatus = 'valid' | 'unknown' | 'invalid' | 'none
 export type FilePickerValidationCallback = (info: { type: string; url: string }, callback: (validation: { status: FilePickerValidationStatus; message: string}) => void) => void;
 
 // dom-globals is outdated and missing a number of valid values
-export type ReferrerPolicy = DomReferrerPolicy | 'origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin';
+export type UpdatedReferrerPolicy = ReferrerPolicy | 'origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin';
 
 export type URLConverter = (url: string, name: string, elm?: HTMLElement) => string;
 export type URLConverterCallback = (url: string, node: Node, on_save: boolean, name: string) => void;
@@ -144,7 +144,7 @@ interface BaseEditorSettings {
   preview_styles?: boolean | string;
   protect?: RegExp[];
   readonly?: boolean;
-  referrer_policy?: ReferrerPolicy;
+  referrer_policy?: UpdatedReferrerPolicy;
   relative_urls?: boolean;
   remove_script_host?: boolean;
   remove_trailing_brs?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/Tinymce.ts
+++ b/modules/tinymce/src/core/main/ts/api/Tinymce.ts
@@ -5,45 +5,46 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Storage, Window } from '@ephox/dom-globals';
+import { Node, Storage, Window } from '@ephox/dom-globals';
+import { UndoManager as UndoManagerType } from '../undo/UndoManagerTypes';
 import AddOnManager from './AddOnManager';
-import { Theme } from './ThemeManager';
-import { Plugin } from './PluginManager';
 import Annotator from './Annotator';
+import BookmarkManager from './dom/BookmarkManager';
+import ControlSelection from './dom/ControlSelection';
+import DomQuery, { DomQueryConstructor } from './dom/DomQuery';
+import DOMUtils from './dom/DOMUtils';
+import EventUtils, { EventUtilsConstructor } from './dom/EventUtils';
+import RangeUtils from './dom/RangeUtils';
+import ScriptLoader, { ScriptLoaderConstructor } from './dom/ScriptLoader';
+import EditorSelection from './dom/Selection';
+import DomSerializer, { DomSerializerSettings } from './dom/Serializer';
+import Sizzle from './dom/Sizzle';
+import { StyleSheetLoader } from './dom/StyleSheetLoader';
+import TextSeeker from './dom/TextSeeker';
+import DomTreeWalker, { DomTreeWalkerConstructor } from './dom/TreeWalker';
 import Editor, { EditorConstructor } from './Editor';
 import EditorCommands, { EditorCommandsConstructor } from './EditorCommands';
 import EditorManager from './EditorManager';
 import EditorObservable from './EditorObservable';
 import Env from './Env';
-import Shortcuts, { ShortcutsConstructor } from './Shortcuts';
-import UndoManager from './UndoManager';
 import FocusManager from './FocusManager';
 import Formatter from './Formatter';
-import NotificationManager from './NotificationManager';
-import WindowManager from './WindowManager';
-import IconManager from './IconManager';
-import BookmarkManager from './dom/BookmarkManager';
-import RangeUtils from './dom/RangeUtils';
-import DomSerializer, { SerializerSettings as DomSerializerSettings } from './dom/Serializer';
-import ControlSelection from './dom/ControlSelection';
-import DOMUtils from './dom/DOMUtils';
-import DomQuery, { DomQueryConstructor } from './dom/DomQuery';
-import EventUtils, { EventUtilsConstructor } from './dom/EventUtils';
-import ScriptLoader, { ScriptLoaderConstructor } from './dom/ScriptLoader';
-import Resource from './Resource';
-import Selection from './dom/Selection';
-import Sizzle from './dom/Sizzle';
-import TextSeeker from './dom/TextSeeker';
-import TreeWalker, { TreeWalkerConstructor } from './dom/TreeWalker';
 import Rect from './geom/Rect';
 import DomParser, { DomParserSettings } from './html/DomParser';
 import Entities from './html/Entities';
-import Node from './html/Node';
+import AstNode from './html/Node';
 import SaxParser, { SaxParserSettings } from './html/SaxParser';
 import Schema, { SchemaSettings } from './html/Schema';
-import HtmlSerializer, { SerializerSettings as HtmlSerializerSettings } from './html/Serializer';
+import HtmlSerializer, { HtmlSerializerSettings } from './html/Serializer';
 import Styles from './html/Styles';
 import Writer, { WriterSettings } from './html/Writer';
+import IconManager from './IconManager';
+import NotificationManager from './NotificationManager';
+import { Plugin } from './PluginManager';
+import Resource from './Resource';
+import Shortcuts, { ShortcutsConstructor } from './Shortcuts';
+import { Theme } from './ThemeManager';
+import UndoManager from './UndoManager';
 import Class from './util/Class';
 import Color from './util/Color';
 import Delay from './util/Delay';
@@ -59,8 +60,7 @@ import Tools from './util/Tools';
 import URI, { URIConstructor } from './util/URI';
 import VK from './util/VK';
 import XHR from './util/XHR';
-import { UndoManager as UndoManagerType } from '../undo/UndoManagerTypes';
-import { StyleSheetLoader } from './dom/StyleSheetLoader';
+import WindowManager from './WindowManager';
 
 export interface TinyMCE extends EditorManager {
 
@@ -90,15 +90,15 @@ export interface TinyMCE extends EditorManager {
     EventUtils: EventUtilsConstructor;
     Sizzle: any;
     DomQuery: DomQueryConstructor;
-    TreeWalker: TreeWalkerConstructor;
+    TreeWalker: DomTreeWalkerConstructor;
     TextSeeker: (dom: DOMUtils, isBlockBoundary?: (node: Node) => boolean) => TextSeeker;
     DOMUtils: DOMUtils;
     ScriptLoader: ScriptLoaderConstructor;
     RangeUtils: (dom: DOMUtils) => RangeUtils;
     Serializer: (settings: DomSerializerSettings, editor?: Editor) => DomSerializer;
-    ControlSelection: (selection: Selection, editor: Editor) => ControlSelection;
-    BookmarkManager: (selection: Selection) => BookmarkManager;
-    Selection: (dom: DOMUtils, win: Window, serializer, editor: Editor) => Selection;
+    ControlSelection: (selection: EditorSelection, editor: Editor) => ControlSelection;
+    BookmarkManager: (selection: EditorSelection) => BookmarkManager;
+    Selection: (dom: DOMUtils, win: Window, serializer, editor: Editor) => EditorSelection;
     StyleSheetLoader: StyleSheetLoader;
     Event: EventUtils;
   };
@@ -106,7 +106,7 @@ export interface TinyMCE extends EditorManager {
   html: {
     Styles: Styles;
     Entities: Entities;
-    Node: Node;
+    Node: AstNode;
     Schema: (settings?: SchemaSettings) => Schema;
     SaxParser: (settings?: SaxParserSettings, schema?: Schema) => SaxParser;
     DomParser: (settings?: DomParserSettings, schema?: Schema) => DomParser;
@@ -221,7 +221,7 @@ const publicApi = {
     EventUtils,
     Sizzle,
     DomQuery,
-    TreeWalker,
+    TreeWalker: DomTreeWalker,
     TextSeeker,
     DOMUtils,
     ScriptLoader,
@@ -230,14 +230,14 @@ const publicApi = {
     StyleSheetLoader,
     ControlSelection,
     BookmarkManager,
-    Selection,
+    Selection: EditorSelection,
     Event: EventUtils.Event
   },
 
   html: {
     Styles,
     Entities,
-    Node,
+    Node: AstNode,
     Schema,
     SaxParser,
     DomParser,

--- a/modules/tinymce/src/core/main/ts/api/dom/BookmarkManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/BookmarkManager.ts
@@ -9,7 +9,7 @@ import { Node } from '@ephox/dom-globals';
 import { Fun } from '@ephox/katamari';
 import * as Bookmarks from '../../bookmark/Bookmarks';
 import { Bookmark } from '../../bookmark/BookmarkTypes';
-import Selection from './Selection';
+import EditorSelection from './Selection';
 
 /**
  * This class handles selection bookmarks.
@@ -29,7 +29,7 @@ interface BookmarkManager {
  * @method BookmarkManager
  * @param {tinymce.dom.Selection} selection Selection instance to handle bookmarks for.
  */
-function BookmarkManager(selection: Selection): BookmarkManager {
+function BookmarkManager(selection: EditorSelection): BookmarkManager {
   return {
     /**
      * Returns a bookmark location for the current selection. This bookmark object

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -19,7 +19,7 @@ import Delay from '../util/Delay';
 import { EditorEvent } from '../util/EventDispatcher';
 import Tools from '../util/Tools';
 import VK from '../util/VK';
-import Selection from './Selection';
+import EditorSelection from './Selection';
 
 interface ControlSelection {
   isResizable (elm: Element): boolean;
@@ -40,7 +40,7 @@ interface ControlSelection {
 
 const isContentEditableFalse = NodeType.isContentEditableFalse;
 
-const ControlSelection = (selection: Selection, editor: Editor): ControlSelection => {
+const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSelection => {
   const dom = editor.dom, each = Tools.each;
   let selectedElm, selectedElmGhost, resizeHelper, selectedHandle;
   let startX, startY, selectedElmX, selectedElmY, startW, startH, ratio, resizeStarted;

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -20,13 +20,13 @@ import { GeomRect } from '../geom/Rect';
 import Entities from '../html/Entities';
 import Schema from '../html/Schema';
 import Styles, { StyleMap } from '../html/Styles';
-import { ReferrerPolicy, URLConverter } from '../SettingsTypes';
+import { UpdatedReferrerPolicy, URLConverter } from '../SettingsTypes';
 import Tools from '../util/Tools';
 import DomQuery, { DomQueryConstructor } from './DomQuery';
 import EventUtils, { EventUtilsCallback } from './EventUtils';
 import Sizzle from './Sizzle';
 import { StyleSheetLoader } from './StyleSheetLoader';
-import TreeWalker from './TreeWalker';
+import DomTreeWalker from './TreeWalker';
 
 /**
  * Utility class for various DOM manipulation and retrieval functions.
@@ -167,7 +167,7 @@ export interface DOMUtilsSettings {
   collect: Function;
   onSetAttrib: Function;
   contentCssCors: boolean;
-  referrerPolicy: ReferrerPolicy;
+  referrerPolicy: UpdatedReferrerPolicy;
 }
 
 export type Target = Node | Window | Array<Node | Window>;
@@ -998,7 +998,7 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
 
     node = node.firstChild;
     if (node) {
-      const walker = new TreeWalker(node, node.parentNode);
+      const walker = new DomTreeWalker(node, node.parentNode);
       const whitespace = schema ? schema.getWhiteSpaceElements() : {};
       elements = elements || (schema ? schema.getNonEmptyElements() : null);
 

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -7,7 +7,7 @@
 
 import { console, document } from '@ephox/dom-globals';
 import { Type } from '@ephox/katamari';
-import { ReferrerPolicy } from '../SettingsTypes';
+import { UpdatedReferrerPolicy } from '../SettingsTypes';
 import Tools from '../util/Tools';
 import DOMUtils from './DOMUtils';
 
@@ -41,7 +41,7 @@ const DOM = DOMUtils.DOM;
 const each = Tools.each, grep = Tools.grep;
 
 export interface ScriptLoaderSettings {
-  referrerPolicy?: ReferrerPolicy;
+  referrerPolicy?: UpdatedReferrerPolicy;
 }
 
 export interface ScriptLoaderConstructor {
@@ -60,7 +60,7 @@ interface ScriptLoader {
   load (url: string, success?: () => void, scope?: {}, failure?: () => void): void;
   remove (url: string);
   loadQueue (success?: () => void, scope?: {}, failure?: (urls: string[]) => void): void;
-  _setReferrerPolicy (referrerPolicy: ReferrerPolicy): void;
+  _setReferrerPolicy (referrerPolicy: UpdatedReferrerPolicy): void;
 }
 
 const QUEUED = 0;
@@ -82,7 +82,7 @@ class ScriptLoader {
     this.settings = settings;
   }
 
-  public _setReferrerPolicy(referrerPolicy: ReferrerPolicy) {
+  public _setReferrerPolicy(referrerPolicy: UpdatedReferrerPolicy) {
     this.settings.referrerPolicy = referrerPolicy;
   }
 

--- a/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
@@ -5,16 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { DomSerializer, DomSerializerSettings } from '../../dom/DomSerializer';
+import { DomSerializerImpl, DomSerializerSettings } from '../../dom/DomSerializerImpl';
 import Editor from '../Editor';
 
-// tslint:disable-next-line:no-empty-interface
-export interface SerializerSettings extends DomSerializerSettings {
-}
+export { DomSerializerSettings } from '../../dom/DomSerializerImpl';
 
-// tslint:disable-next-line:no-empty-interface
-interface Serializer extends DomSerializer {
-}
+interface DomSerializer extends DomSerializerImpl { }
 
 /**
  * This class is used to serialize DOM trees into a string. Consult the TinyMCE API Documentation for
@@ -23,8 +19,8 @@ interface Serializer extends DomSerializer {
  * @class tinymce.dom.Serializer
  */
 
-const Serializer = function (settings: SerializerSettings, editor?: Editor): Serializer {
-  const domSerializer = DomSerializer(settings, editor);
+const DomSerializer = function (settings: DomSerializerSettings, editor?: Editor): DomSerializer {
+  const domSerializer = DomSerializerImpl(settings, editor);
 
   // Return public methods
   return {
@@ -120,4 +116,4 @@ const Serializer = function (settings: SerializerSettings, editor?: Editor): Ser
   };
 };
 
-export default Serializer;
+export default DomSerializer;

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -8,7 +8,7 @@
 import { Document, navigator, Node, ShadowRoot } from '@ephox/dom-globals';
 import { Arr, Fun, Future, Futures, Result, Results } from '@ephox/katamari';
 import { Attribute, Insert, SugarElement, SugarShadowDom, Traverse } from '@ephox/sugar';
-import { ReferrerPolicy } from '../SettingsTypes';
+import { UpdatedReferrerPolicy } from '../SettingsTypes';
 import Delay from '../util/Delay';
 import Tools from '../util/Tools';
 
@@ -21,13 +21,13 @@ import Tools from '../util/Tools';
 export interface StyleSheetLoader {
   load: (url: string, loadedCallback: Function, errorCallback?: Function) => void;
   loadAll: (urls: string[], success: Function, failure: Function) => void;
-  _setReferrerPolicy: (referrerPolicy: ReferrerPolicy) => void;
+  _setReferrerPolicy: (referrerPolicy: UpdatedReferrerPolicy) => void;
 }
 
 export interface StyleSheetLoaderSettings {
   maxLoadTime: number;
   contentCssCors: boolean;
-  referrerPolicy: ReferrerPolicy;
+  referrerPolicy: UpdatedReferrerPolicy;
 }
 
 export function StyleSheetLoader(documentOrShadowRoot: Document | ShadowRoot, settings: Partial<StyleSheetLoaderSettings> = {}): StyleSheetLoader {
@@ -39,7 +39,7 @@ export function StyleSheetLoader(documentOrShadowRoot: Document | ShadowRoot, se
 
   const maxLoadTime = settings.maxLoadTime || 5000;
 
-  const _setReferrerPolicy = (referrerPolicy: ReferrerPolicy) => {
+  const _setReferrerPolicy = (referrerPolicy: UpdatedReferrerPolicy) => {
     settings.referrerPolicy = referrerPolicy;
   };
 

--- a/modules/tinymce/src/core/main/ts/api/dom/TextSeeker.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/TextSeeker.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
 import { Node, Text } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 import * as NodeType from '../../dom/NodeType';

--- a/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
@@ -7,10 +7,10 @@
 
 import { Node } from '@ephox/dom-globals';
 
-export interface TreeWalkerConstructor {
-  readonly prototype: TreeWalker;
+export interface DomTreeWalkerConstructor {
+  readonly prototype: DomTreeWalker;
 
-  new (startNode: Node, rootNode: Node): TreeWalker;
+  new (startNode: Node, rootNode: Node): DomTreeWalker;
 }
 
 /**
@@ -25,7 +25,7 @@ export interface TreeWalkerConstructor {
  * } while (walker.next());
  */
 
-class TreeWalker {
+class DomTreeWalker {
   private readonly rootNode: Node;
   private node: Node;
 
@@ -135,4 +135,4 @@ class TreeWalker {
   }
 }
 
-export default TreeWalker;
+export default DomTreeWalker;

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -11,7 +11,7 @@ import * as ParserFilters from '../../html/ParserFilters';
 import { hasOnlyChild, isEmpty, isLineBreakNode, isPaddedWithNbsp, paddEmptyNode } from '../../html/ParserUtils';
 import { BlobCache } from '../file/BlobCache';
 import Tools from '../util/Tools';
-import Node from './Node';
+import AstNode from './Node';
 import SaxParser, { ParserFormat } from './SaxParser';
 import Schema, { SchemaElement } from './Schema';
 
@@ -41,7 +41,7 @@ export interface ParserArgs {
   [key: string]: any;
 }
 
-export type ParserFilterCallback = (nodes: Node[], name: string, args: ParserArgs) => void;
+export type ParserFilterCallback = (nodes: AstNode[], name: string, args: ParserArgs) => void;
 
 export interface ParserFilter {
   name: string;
@@ -71,12 +71,12 @@ export interface DomParserSettings {
 
 interface DomParser {
   schema: Schema;
-  addAttributeFilter (name: string, callback: (nodes: Node[], name: string, args: ParserArgs) => void): void;
+  addAttributeFilter (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void): void;
   getAttributeFilters (): ParserFilter[];
-  addNodeFilter (name: string, callback: (nodes: Node[], name: string, args: ParserArgs) => void): void;
+  addNodeFilter (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void): void;
   getNodeFilters (): ParserFilter[];
-  filterNode (node: Node): Node;
-  parse (html: string, args?: ParserArgs): Node;
+  filterNode (node: AstNode): AstNode;
+  parse (html: string, args?: ParserArgs): AstNode;
 }
 
 const DomParser = function (settings?: DomParserSettings, schema = Schema()): DomParser {
@@ -189,13 +189,13 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
             continue;
           }
 
-          node.wrap(filterNode(new Node('ul', 1)));
+          node.wrap(filterNode(new AstNode('ul', 1)));
           continue;
         }
 
         // Try wrapping the element in a DIV
         if (schema.isValidChild(node.parent.name, 'div') && schema.isValidChild('div', node.name)) {
-          node.wrap(filterNode(new Node('div', 1)));
+          node.wrap(filterNode(new AstNode('div', 1)));
         } else {
           // We failed wrapping it, then remove or unwrap it
           if (specialElements[node.name]) {
@@ -215,7 +215,7 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
    * @param {tinymce.html.Node} node the node to run filters on.
    * @return {tinymce.html.Node} The passed in node.
    */
-  const filterNode = (node: Node): Node => {
+  const filterNode = (node: AstNode): AstNode => {
     let i, name, list;
 
     name = node.name;
@@ -263,7 +263,7 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
    * @method {String} name Comma separated list of nodes to collect.
    * @param {function} callback Callback function to execute once it has collected nodes.
    */
-  const addNodeFilter = (name: string, callback: (nodes: Node[], name: string, args: ParserArgs) => void) => {
+  const addNodeFilter = (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => {
     each(explode(name), function (name) {
       let list = nodeFilters[name];
 
@@ -301,7 +301,7 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
    * @param {String} name Comma separated list of nodes to collect.
    * @param {function} callback Callback function to execute once it has collected nodes.
    */
-  const addAttributeFilter = (name: string, callback: (nodes: Node[], name: string, args: ParserArgs) => void) => {
+  const addAttributeFilter = (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => {
     each(explode(name), function (name) {
       let i;
 
@@ -328,11 +328,11 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
    * @param {Object} args Optional args object that gets passed to all filter functions.
    * @return {tinymce.html.Node} Root node containing the tree.
    */
-  const parse = (html: string, args?: ParserArgs): Node => {
+  const parse = (html: string, args?: ParserArgs): AstNode => {
     let nodes, i, l, fi, fl, list, name;
     const invalidChildren = [];
     let isInWhiteSpacePreservedElement;
-    let node: Node;
+    let node: AstNode;
 
     const getRootBlockName = (name) => {
       if (name === false) {
@@ -411,7 +411,7 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
     };
 
     const createNode = function (name, type) {
-      const node = new Node(name, type);
+      const node = new AstNode(name, type);
       let list;
 
       if (name in nodeFilters) {
@@ -680,7 +680,7 @@ const DomParser = function (settings?: DomParserSettings, schema = Schema()): Do
       }
     }, schema);
 
-    const rootNode = node = new Node(args.context || settings.root_name, 11);
+    const rootNode = node = new AstNode(args.context || settings.root_name, 11);
 
     parser.parse(html, args.format as ParserFormat);
 

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -5,8 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { SchemaMap } from './Schema';
 import { Obj } from '@ephox/katamari';
+import { SchemaMap } from './Schema';
 
 export type Attributes = Array<{ name: string; value: string }> & { map: Record<string, string> };
 
@@ -21,7 +21,7 @@ const typeLookup = {
 };
 
 // Walks the tree left/right
-const walk = function (node: Node, root: Node | null, prev?: boolean): Node {
+const walk = function (node: AstNode, root: AstNode | null, prev?: boolean): AstNode {
   const startName = prev ? 'lastChild' : 'firstChild';
   const siblingName = prev ? 'prev' : 'next';
 
@@ -49,7 +49,7 @@ const walk = function (node: Node, root: Node | null, prev?: boolean): Node {
   }
 };
 
-const isEmptyTextNode = (node: Node) => {
+const isEmptyTextNode = (node: AstNode) => {
   // Non whitespace content
   if (!whiteSpaceRegExp.test(node.value)) {
     return false;
@@ -65,7 +65,7 @@ const isEmptyTextNode = (node: Node) => {
 };
 
 // Check if node contains data-bookmark attribute, name attribute, id attribute or is a named anchor
-const isNonEmptyElement = (node: Node) => {
+const isNonEmptyElement = (node: AstNode) => {
   const isNamedAnchor = node.name === 'a' && !node.attr('href') && node.attr('id');
   return (node.attr('name') || (node.attr('id') && !node.firstChild) || node.attr('data-mce-bookmark') || isNamedAnchor);
 };
@@ -81,7 +81,7 @@ const isNonEmptyElement = (node: Node) => {
  * @version 3.4
  */
 
-class Node {
+class AstNode {
   /**
    * Creates a node of a specific type.
    *
@@ -90,9 +90,9 @@ class Node {
    * @param {String} name Name of the node type to create for example "b" or "#text".
    * @param {Object} attrs Name/value collection of attributes that will be applied to elements.
    */
-  public static create(name: string, attrs?: Record<string, string>): Node {
+  public static create(name: string, attrs?: Record<string, string>): AstNode {
     // Create node
-    const node = new Node(name, typeLookup[name] || 1);
+    const node = new AstNode(name, typeLookup[name] || 1);
 
     // Add attributes if needed
     if (attrs) {
@@ -109,11 +109,11 @@ class Node {
   public attributes?: Attributes;
   public value?: string;
   public shortEnded?: boolean;
-  public parent?: Node;
-  public firstChild?: Node;
-  public lastChild?: Node;
-  public next?: Node;
-  public prev?: Node;
+  public parent?: AstNode;
+  public firstChild?: AstNode;
+  public lastChild?: AstNode;
+  public next?: AstNode;
+  public prev?: AstNode;
 
   /**
    * Constructs a new Node instance.
@@ -143,7 +143,7 @@ class Node {
    * @param {tinymce.html.Node} node Node to replace the current node with.
    * @return {tinymce.html.Node} The old node that got replaced.
    */
-  public replace(node: Node): Node {
+  public replace(node: AstNode): AstNode {
     const self = this;
 
     if (node.parent) {
@@ -169,10 +169,10 @@ class Node {
    * @param {String} value Optional value to set.
    * @return {String/tinymce.html.Node} String or undefined on a get operation or the current node on a set operation.
    */
-  public attr(name: string, value: string): string | Node;
-  public attr(name: Record<string, string>): Node;
+  public attr(name: string, value: string): string | AstNode;
+  public attr(name: Record<string, string>): AstNode;
   public attr(name: string): string;
-  public attr(name: string | Record<string, string>, value?: string): string | Node {
+  public attr(name: string | Record<string, string>, value?: string): string | AstNode {
     const self = this;
     let attrs: Attributes;
 
@@ -238,9 +238,9 @@ class Node {
    * @method clone
    * @return {tinymce.html.Node} New copy of the original node.
    */
-  public clone(): Node {
+  public clone(): AstNode {
     const self = this;
-    const clone = new Node(self.name, self.type);
+    const clone = new AstNode(self.name, self.type);
     let selfAttrs: Attributes;
 
     // Clone element attributes
@@ -275,7 +275,7 @@ class Node {
    *
    * @method wrap
    */
-  public wrap(wrapper: Node): Node {
+  public wrap(wrapper: AstNode): AstNode {
     const self = this;
 
     self.parent.insert(wrapper, self);
@@ -313,7 +313,7 @@ class Node {
    * @method remove
    * @return {tinymce.html.Node} Current node that got removed.
    */
-  public remove(): Node {
+  public remove(): AstNode {
     const self = this, parent = self.parent, next = self.next, prev = self.prev;
 
     if (parent) {
@@ -353,7 +353,7 @@ class Node {
    * @param {tinymce.html.Node} node Node to append as a child of the current one.
    * @return {tinymce.html.Node} The node that got appended.
    */
-  public append(node: Node): Node {
+  public append(node: AstNode): AstNode {
     const self = this;
 
     if (node.parent) {
@@ -386,7 +386,7 @@ class Node {
    * @param {Boolean} before Optional state to insert the node before the reference node.
    * @return {tinymce.html.Node} The node that got inserted.
    */
-  public insert(node: Node, refNode: Node, before?: boolean): Node {
+  public insert(node: AstNode, refNode: AstNode, before?: boolean): AstNode {
 
     if (node.parent) {
       node.remove();
@@ -428,9 +428,9 @@ class Node {
    * @param {String} name Name of the child nodes to collect.
    * @return {Array} Array with child nodes matchin the specified name.
    */
-  public getAll(name: string): Node[] {
+  public getAll(name: string): AstNode[] {
     const self = this;
-    const collection: Node[] = [];
+    const collection: AstNode[] = [];
 
     for (let node = self.firstChild; node; node = walk(node, self)) {
       if (node.name === name) {
@@ -447,7 +447,7 @@ class Node {
    * @method empty
    * @return {tinymce.html.Node} The current node that got cleared.
    */
-  public empty(): Node {
+  public empty(): AstNode {
     const self = this;
 
     // Remove all children
@@ -483,7 +483,7 @@ class Node {
    * @param {function} predicate Optional predicate that gets called after the other rules determine that the node is empty. Should return true if the node is a content node.
    * @return {Boolean} true/false if the node is empty or not.
    */
-  public isEmpty(elements: SchemaMap, whitespace: SchemaMap = {}, predicate?: (node: Node) => boolean) {
+  public isEmpty(elements: SchemaMap, whitespace: SchemaMap = {}, predicate?: (node: AstNode) => boolean) {
     const self = this;
     let node = self.firstChild;
 
@@ -541,9 +541,9 @@ class Node {
    * @param {Boolean} prev Optional previous node state defaults to false.
    * @return {tinymce.html.Node} Node that is next to or previous of the current node.
    */
-  public walk(prev?: boolean): Node {
+  public walk(prev?: boolean): AstNode {
     return walk(this, null, prev);
   }
 }
 
-export default Node;
+export default AstNode;

--- a/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
@@ -5,17 +5,17 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Node from './Node';
+import AstNode from './Node';
 import Schema from './Schema';
 import Writer, { WriterSettings } from './Writer';
 
-export interface SerializerSettings extends WriterSettings {
+export interface HtmlSerializerSettings extends WriterSettings {
   inner?: boolean;
   validate?: boolean;
 }
 
-interface Serializer {
-  serialize (node: Node): string;
+interface HtmlSerializer {
+  serialize (node: AstNode): string;
 }
 
 /**
@@ -28,7 +28,7 @@ interface Serializer {
  * @version 3.4
  */
 
-const Serializer = function (settings?: SerializerSettings, schema = Schema()) {
+const HtmlSerializer = function (settings?: HtmlSerializerSettings, schema = Schema()): HtmlSerializer {
   const writer = Writer(settings);
 
   settings = settings || {};
@@ -43,7 +43,7 @@ const Serializer = function (settings?: SerializerSettings, schema = Schema()) {
    * @param {tinymce.html.Node} node Node instance to serialize.
    * @return {String} String with HTML based on DOM tree.
    */
-  const serialize = (node: Node): string => {
+  const serialize = (node: AstNode): string => {
     const validate = settings.validate;
 
     const handlers = {
@@ -84,7 +84,7 @@ const Serializer = function (settings?: SerializerSettings, schema = Schema()) {
 
     writer.reset();
 
-    const walk = function (node: Node) {
+    const walk = function (node: AstNode) {
       const handler = handlers[node.type];
       let name, isEmpty, attrs, attrName, attrValue, sortedAttrs, i, l, elementRule;
 
@@ -155,4 +155,4 @@ const Serializer = function (settings?: SerializerSettings, schema = Schema()) {
   };
 };
 
-export default Serializer;
+export default HtmlSerializer;

--- a/modules/tinymce/src/core/main/ts/bookmark/Bookmarks.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/Bookmarks.ts
@@ -5,18 +5,18 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import * as GetBookmark from './GetBookmark';
-import * as ResolveBookmark from './ResolveBookmark';
-import Selection from '../api/dom/Selection';
+import { Node } from '@ephox/dom-globals';
+import EditorSelection from '../api/dom/Selection';
 import * as NodeType from '../dom/NodeType';
 import { Bookmark } from './BookmarkTypes';
-import { Node } from '@ephox/dom-globals';
+import * as GetBookmark from './GetBookmark';
+import * as ResolveBookmark from './ResolveBookmark';
 
-const getBookmark = function (selection: Selection, type: number, normalized: boolean): Bookmark {
+const getBookmark = function (selection: EditorSelection, type: number, normalized: boolean): Bookmark {
   return GetBookmark.getBookmark(selection, type, normalized);
 };
 
-const moveToBookmark = function (selection: Selection, bookmark: Bookmark) {
+const moveToBookmark = function (selection: EditorSelection, bookmark: Bookmark) {
   ResolveBookmark.resolve(selection, bookmark).each(function (rng) {
     selection.setRng(rng);
   });

--- a/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
@@ -8,7 +8,7 @@
 import { Element, Node, Range, Text } from '@ephox/dom-globals';
 import { Fun } from '@ephox/katamari';
 import DOMUtils from '../api/dom/DOMUtils';
-import Selection from '../api/dom/Selection';
+import EditorSelection from '../api/dom/Selection';
 import Tools from '../api/util/Tools';
 import * as CaretContainer from '../caret/CaretContainer';
 import CaretPosition from '../caret/CaretPosition';
@@ -61,7 +61,7 @@ const getPoint = function (dom: DOMUtils, trim: TrimFn, normalized: boolean, rng
   return point;
 };
 
-const getLocation = function (trim: TrimFn, selection: Selection, normalized: boolean, rng: Range): PathBookmark {
+const getLocation = function (trim: TrimFn, selection: EditorSelection, normalized: boolean, rng: Range): PathBookmark {
   const dom = selection.dom, bookmark: any = {};
 
   bookmark.start = getPoint(dom, trim, normalized, rng, true);
@@ -146,7 +146,7 @@ const findAdjacentContentEditableFalseElm = function (rng: Range) {
   return findSibling(rng.startContainer, rng.startOffset) || findSibling(rng.endContainer, rng.endOffset);
 };
 
-const getOffsetBookmark = function (trim: TrimFn, normalized: boolean, selection: Selection): IndexBookmark | PathBookmark {
+const getOffsetBookmark = function (trim: TrimFn, normalized: boolean, selection: EditorSelection): IndexBookmark | PathBookmark {
   const element = selection.getNode();
   let name = element ? element.nodeName : null;
   const rng = selection.getRng();
@@ -164,7 +164,7 @@ const getOffsetBookmark = function (trim: TrimFn, normalized: boolean, selection
   return getLocation(trim, selection, normalized, rng);
 };
 
-const getCaretBookmark = function (selection: Selection): StringPathBookmark {
+const getCaretBookmark = function (selection: EditorSelection): StringPathBookmark {
   const rng = selection.getRng();
 
   return {
@@ -173,7 +173,7 @@ const getCaretBookmark = function (selection: Selection): StringPathBookmark {
   };
 };
 
-const getRangeBookmark = function (selection: Selection): RangeBookmark {
+const getRangeBookmark = function (selection: EditorSelection): RangeBookmark {
   return { rng: selection.getRng() };
 };
 
@@ -182,7 +182,7 @@ const createBookmarkSpan = (dom: DOMUtils, id: string, filled: boolean) => {
   return filled ? dom.create('span', args, '&#xFEFF;') : dom.create('span', args);
 };
 
-const getPersistentBookmark = function (selection: Selection, filled: boolean): IdBookmark | IndexBookmark {
+const getPersistentBookmark = function (selection: EditorSelection, filled: boolean): IdBookmark | IndexBookmark {
   const dom = selection.dom;
   let rng = selection.getRng();
   const id = dom.uniqueId();
@@ -214,7 +214,7 @@ const getPersistentBookmark = function (selection: Selection, filled: boolean): 
   return { id };
 };
 
-const getBookmark = function (selection: Selection, type: number, normalized: boolean): Bookmark {
+const getBookmark = function (selection: EditorSelection, type: number, normalized: boolean): Bookmark {
   if (type === 2) {
     return getOffsetBookmark(Zwsp.trim, normalized, selection);
   } else if (type === 3) {
@@ -226,7 +226,7 @@ const getBookmark = function (selection: Selection, type: number, normalized: bo
   }
 };
 
-const getUndoBookmark = Fun.curry(getOffsetBookmark, Fun.identity, true) as (selection: Selection) => IndexBookmark | PathBookmark;
+const getUndoBookmark = Fun.curry(getOffsetBookmark, Fun.identity, true) as (selection: EditorSelection) => IndexBookmark | PathBookmark;
 
 export {
   getBookmark,

--- a/modules/tinymce/src/core/main/ts/bookmark/ResolveBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/ResolveBookmark.ts
@@ -8,7 +8,7 @@
 import { Element, HTMLElement, Node, Range, Text } from '@ephox/dom-globals';
 import { Option, Options } from '@ephox/katamari';
 import DOMUtils from '../api/dom/DOMUtils';
-import Selection from '../api/dom/Selection';
+import EditorSelection from '../api/dom/Selection';
 import Env from '../api/Env';
 import Tools from '../api/util/Tools';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -246,7 +246,7 @@ const resolveIndex = (dom: DOMUtils, bookmark: IndexBookmark): Option<Range> => 
   return rng;
 });
 
-const resolve = (selection: Selection, bookmark: Bookmark): Option<Range> => {
+const resolve = (selection: EditorSelection, bookmark: Bookmark): Option<Range> => {
   const dom = selection.dom;
 
   if (bookmark) {

--- a/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
@@ -8,7 +8,7 @@
 import { HTMLElement, Node, Range } from '@ephox/dom-globals';
 import { Fun, Option } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
-import TreeWalker from '../api/dom/TreeWalker';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import * as NodeType from '../dom/NodeType';
 import * as CaretCandidate from './CaretCandidate';
 import * as CaretContainer from './CaretContainer';
@@ -40,7 +40,7 @@ const skipCaretContainers = function (walk, shallow?: boolean): Node {
 };
 
 const findNode = (node: Node, direction: number, predicateFn: (node: Node) => boolean, rootNode: Node, shallow?: boolean) => {
-  const walker = new TreeWalker(node, rootNode);
+  const walker = new DomTreeWalker(node, rootNode);
 
   if (isBackwards(direction)) {
     if (isContentEditableFalse(node) || isCaretContainerBlock(node)) {

--- a/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
+++ b/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
@@ -5,9 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Node from '../api/html/Node';
+import AstNode from '../api/html/Node';
 
-export type Content = string | Node;
+export type Content = string | AstNode;
 export type ContentFormat = 'raw' | 'text' | 'html' | 'tree';
 
 export interface GetContentArgs {

--- a/modules/tinymce/src/core/main/ts/content/GetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/GetContentImpl.ts
@@ -9,7 +9,7 @@ import { HTMLElement } from '@ephox/dom-globals';
 import { Fun, Option } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import Editor from '../api/Editor';
-import Node from '../api/html/Node';
+import AstNode from '../api/html/Node';
 import * as Settings from '../api/Settings';
 import Tools from '../api/util/Tools';
 import { isWsPreserveElement } from '../dom/ElementType';
@@ -59,6 +59,6 @@ const getContentFromBody = (editor: Editor, args: GetContentArgs, format: Conten
 
 export const getContentInternal = (editor: Editor, args: GetContentArgs, format): Content => Option.from(editor.getBody())
   .fold(
-    Fun.constant(args.format === 'tree' ? new Node('body', 11) : ''),
+    Fun.constant(args.format === 'tree' ? new AstNode('body', 11) : ''),
     (body) => getContentFromBody(editor, args, format, body)
   );

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -10,11 +10,11 @@ import { Option } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import ElementUtils from '../api/dom/ElementUtils';
-import Selection from '../api/dom/Selection';
+import EditorSelection from '../api/dom/Selection';
 import Editor from '../api/Editor';
 import Env from '../api/Env';
-import ParserNode from '../api/html/Node';
-import Serializer from '../api/html/Serializer';
+import AstNode from '../api/html/Node';
+import HtmlSerializer from '../api/html/Serializer';
 import * as Settings from '../api/Settings';
 import Tools from '../api/util/Tools';
 import CaretPosition from '../caret/CaretPosition';
@@ -93,7 +93,7 @@ const reduceInlineTextElements = (editor: Editor, merge: boolean) => {
   }
 };
 
-const markFragmentElements = (fragment: ParserNode) => {
+const markFragmentElements = (fragment: AstNode) => {
   let node = fragment;
 
   while ((node = node.walk())) {
@@ -220,7 +220,7 @@ const deleteSelectedContent = (editor: Editor) => {
 export const insertHtmlAtCaret = function (editor: Editor, value: string, details) {
   let parentNode, rootNode, args;
   let marker, rng, node;
-  const selection: Selection = editor.selection, dom = editor.dom;
+  const selection: EditorSelection = editor.selection, dom = editor.dom;
 
   // Check for whitespace before/after value
   if (/^ | $/.test(value)) {
@@ -231,7 +231,7 @@ export const insertHtmlAtCaret = function (editor: Editor, value: string, detail
   const parser = editor.parser;
   const merge = details.merge;
 
-  const serializer = Serializer({
+  const serializer = HtmlSerializer({
     validate: Settings.shouldValidate(editor)
   }, editor.schema);
   const bookmarkHtml = '<span id="mce_marker" data-mce-type="bookmark">&#xFEFF;&#x200B;</span>';

--- a/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
@@ -9,8 +9,8 @@ import { HTMLElement } from '@ephox/dom-globals';
 import { Fun, Option } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import Editor from '../api/Editor';
-import Node from '../api/html/Node';
-import Serializer from '../api/html/Serializer';
+import AstNode from '../api/html/Node';
+import HtmlSerializer from '../api/html/Serializer';
 import * as Settings from '../api/Settings';
 import Tools from '../api/util/Tools';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -22,7 +22,7 @@ import { Content, SetContentArgs } from './ContentTypes';
 
 const defaultFormat = 'html';
 
-const isTreeNode = (content: any): content is Node => content instanceof Node;
+const isTreeNode = (content: any): content is AstNode => content instanceof AstNode;
 
 const moveSelection = (editor: Editor) => {
   if (EditorFocus.hasFocus(editor)) {
@@ -71,7 +71,7 @@ const setContentString = (editor: Editor, body: HTMLElement, content: string, ar
     editor.fire('SetContent', args);
   } else {
     if (args.format !== 'raw') {
-      content = Serializer({
+      content = HtmlSerializer({
         validate: editor.validate
       }, editor.schema).serialize(
         editor.parser.parse(content, { isRootContent: true, insert: true })
@@ -89,10 +89,10 @@ const setContentString = (editor: Editor, body: HTMLElement, content: string, ar
   return args.content;
 };
 
-const setContentTree = (editor: Editor, body: HTMLElement, content: Node, args: SetContentArgs): Node => {
+const setContentTree = (editor: Editor, body: HTMLElement, content: AstNode, args: SetContentArgs): AstNode => {
   FilterNode.filter(editor.parser.getNodeFilters(), editor.parser.getAttributeFilters(), content);
 
-  const html = Serializer({ validate: editor.validate }, editor.schema).serialize(content);
+  const html = HtmlSerializer({ validate: editor.validate }, editor.schema).serialize(content);
 
   args.content = isWsPreserveElement(SugarElement.fromDom(body)) ? html : Tools.trim(html);
   setEditorHtml(editor, args.content);

--- a/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
@@ -8,7 +8,7 @@
 import { Node, Range } from '@ephox/dom-globals';
 import { Fun, Options } from '@ephox/katamari';
 import { Compare, PredicateFind, SugarElement } from '@ephox/sugar';
-import Selection from '../api/dom/Selection';
+import EditorSelection from '../api/dom/Selection';
 import Editor from '../api/Editor';
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
@@ -16,7 +16,7 @@ import * as ElementType from '../dom/ElementType';
 import * as DeleteUtils from './DeleteUtils';
 import * as MergeBlocks from './MergeBlocks';
 
-const deleteRangeMergeBlocks = (rootNode: SugarElement<Node>, selection: Selection) => {
+const deleteRangeMergeBlocks = (rootNode: SugarElement<Node>, selection: EditorSelection) => {
   const rng = selection.getRng();
 
   return Options.lift2(

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -10,7 +10,7 @@ import DOMUtils from '../api/dom/DOMUtils';
 import DomParser from '../api/html/DomParser';
 import Entities from '../api/html/Entities';
 import * as Zwsp from '../text/Zwsp';
-import { DomSerializerSettings } from './DomSerializer';
+import { DomSerializerSettings } from './DomSerializerImpl';
 
 declare const unescape: any;
 

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerImpl.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerImpl.ts
@@ -12,9 +12,9 @@ import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import * as Events from '../api/Events';
 import DomParser, { DomParserSettings, ParserArgs, ParserFilter } from '../api/html/DomParser';
-import Node from '../api/html/Node';
+import AstNode from '../api/html/Node';
 import Schema, { SchemaSettings } from '../api/html/Schema';
-import Serializer, { SerializerSettings } from '../api/html/Serializer';
+import HtmlSerializer, { HtmlSerializerSettings } from '../api/html/Serializer';
 import { WriterSettings } from '../api/html/Writer';
 import { URLConverter } from '../api/SettingsTypes';
 import Tools from '../api/util/Tools';
@@ -23,23 +23,23 @@ import * as DomSerializerFilters from './DomSerializerFilters';
 import * as DomSerializerPreProcess from './DomSerializerPreProcess';
 import { isWsPreserveElement } from './ElementType';
 
-export interface SerializerArgs extends ParserArgs {
+export interface DomSerializerArgs extends ParserArgs {
   format?: string;
 }
 
-interface DomSerializerSettings extends DomParserSettings, WriterSettings, SchemaSettings, SerializerSettings {
+interface DomSerializerSettings extends DomParserSettings, WriterSettings, SchemaSettings, HtmlSerializerSettings {
   url_converter?: URLConverter;
   url_converter_scope?: {};
 }
 
-interface DomSerializer {
+interface DomSerializerImpl {
   schema: Schema;
-  addNodeFilter (name: string, callback: (nodes: Node[], name: string, args: ParserArgs) => void): void;
-  addAttributeFilter (name: string, callback: (nodes: Node[], name: string, args: ParserArgs) => void): void;
+  addNodeFilter (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void): void;
+  addAttributeFilter (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void): void;
   getNodeFilters (): ParserFilter[];
   getAttributeFilters (): ParserFilter[];
-  serialize (node: Element, parserArgs: { format: 'tree' } & SerializerArgs): Node;
-  serialize (node: Element, parserArgs?: SerializerArgs): string;
+  serialize (node: Element, parserArgs: { format: 'tree' } & DomSerializerArgs): AstNode;
+  serialize (node: Element, parserArgs?: DomSerializerArgs): string;
   addRules (rules: string): void;
   setRules (rules: string): void;
   addTempAttr (name: string): void;
@@ -81,17 +81,17 @@ const parseHtml = function (htmlParser: DomParser, html: string, args: ParserArg
   return rootNode;
 };
 
-const serializeNode = function (settings: SerializerSettings, schema: Schema, node: Node) {
-  const htmlSerializer = Serializer(settings, schema);
+const serializeNode = function (settings: HtmlSerializerSettings, schema: Schema, node: AstNode) {
+  const htmlSerializer = HtmlSerializer(settings, schema);
   return htmlSerializer.serialize(node);
 };
 
-const toHtml = function (editor: Editor, settings: SerializerSettings, schema: Schema, rootNode: Node, args: ParserArgs) {
+const toHtml = function (editor: Editor, settings: HtmlSerializerSettings, schema: Schema, rootNode: AstNode, args: ParserArgs) {
   const content = serializeNode(settings, schema, rootNode);
   return postProcess(editor, args, content);
 };
 
-const DomSerializer = function (settings: DomSerializerSettings, editor: Editor): DomSerializer {
+const DomSerializerImpl = function (settings: DomSerializerSettings, editor: Editor): DomSerializerImpl {
   const tempAttrs = [ 'data-mce-selected' ];
 
   const dom = editor && editor.dom ? editor.dom : DOMUtils.DOM;
@@ -131,6 +131,6 @@ const DomSerializer = function (settings: DomSerializerSettings, editor: Editor)
 };
 
 export {
-  DomSerializer,
+  DomSerializerImpl,
   DomSerializerSettings
 };

--- a/modules/tinymce/src/core/main/ts/dom/Empty.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Empty.ts
@@ -8,7 +8,7 @@
 import { Node } from '@ephox/dom-globals';
 import { Fun } from '@ephox/katamari';
 import { Compare, SelectorExists, SugarElement } from '@ephox/sugar';
-import TreeWalker from '../api/dom/TreeWalker';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import * as CaretCandidate from '../caret/CaretCandidate';
 import * as NodeType from './NodeType';
 
@@ -45,7 +45,7 @@ const isEmptyNode = function (targetNode: Node, skipBogus: boolean) {
       return true;
     }
 
-    const walker = new TreeWalker(node, targetNode);
+    const walker = new DomTreeWalker(node, targetNode);
     do {
       if (skipBogus) {
         if (isBogusAll(node)) {

--- a/modules/tinymce/src/core/main/ts/dom/TextWalker.ts
+++ b/modules/tinymce/src/core/main/ts/dom/TextWalker.ts
@@ -7,8 +7,8 @@
 
 import { Node, Text } from '@ephox/dom-globals';
 import { Fun, Option } from '@ephox/katamari';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import * as NodeType from './NodeType';
-import TreeWalker from '../api/dom/TreeWalker';
 
 interface TextWalker {
   current (): Option<Text>;
@@ -18,7 +18,7 @@ interface TextWalker {
 }
 
 const TextWalker = (startNode: Node, rootNode: Node, isBoundary: (node: Node) => boolean = Fun.never): TextWalker => {
-  const walker = new TreeWalker(startNode, rootNode);
+  const walker = new DomTreeWalker(startNode, rootNode);
 
   const walk = (direction: 'next' | 'prev' | 'prev2'): Option<Text> => {
     let next: Node;

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -7,7 +7,7 @@
 
 import { Node } from '@ephox/dom-globals';
 import DOMUtils from '../api/dom/DOMUtils';
-import Selection from '../api/dom/Selection';
+import EditorSelection from '../api/dom/Selection';
 import Editor from '../api/Editor';
 import { FormatVars } from '../api/fmt/Format';
 import Tools from '../api/util/Tools';
@@ -38,7 +38,7 @@ const applyFormat = function (ed: Editor, name: string, vars?: FormatVars, node?
   const format = formatList[0];
   let rng;
   const isCollapsed = !node && ed.selection.isCollapsed();
-  const dom = ed.dom, selection: Selection = ed.selection;
+  const dom = ed.dom, selection: EditorSelection = ed.selection;
 
   const setElementFormat = function (elm: Node, fmt?) {
     fmt = fmt || format;

--- a/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
@@ -8,7 +8,7 @@
 import { Document, Node, Range } from '@ephox/dom-globals';
 import { Arr, Fun, Obj, Option } from '@ephox/katamari';
 import { Attribute, Insert, Remove, SugarElement, SugarNode } from '@ephox/sugar';
-import TreeWalker from '../api/dom/TreeWalker';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import { FormatVars } from '../api/fmt/Format';
 import CaretPosition from '../caret/CaretPosition';
@@ -53,7 +53,7 @@ const isCaretContainerEmpty = function (node: Node) {
 
 const findFirstTextNode = function (node: Node) {
   if (node) {
-    const walker = new TreeWalker(node, node);
+    const walker = new DomTreeWalker(node, node);
 
     for (node = walker.current(); node; node = walker.next()) {
       if (NodeType.isText(node)) {

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -6,13 +6,13 @@
  */
 
 import { Node, Range } from '@ephox/dom-globals';
-import TreeWalker from '../api/dom/TreeWalker';
-import Selection from '../api/dom/Selection';
+import { Arr, Obj, Type } from '@ephox/katamari';
 import DOMUtils from '../api/dom/DOMUtils';
+import EditorSelection from '../api/dom/Selection';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
+import { Format, FormatAttrOrStyleValue, FormatVars } from '../api/fmt/Format';
 import * as NodeType from '../dom/NodeType';
-import { FormatAttrOrStyleValue, FormatVars, Format } from '../api/fmt/Format';
-import { Obj, Arr, Type } from '@ephox/katamari';
 
 const isNode = (node: any): node is Node => !!(node).nodeType;
 
@@ -20,7 +20,7 @@ const isInlineBlock = function (node: Node): boolean {
   return node && /^(IMG)$/.test(node.nodeName);
 };
 
-const moveStart = function (dom: DOMUtils, selection: Selection, rng: Range) {
+const moveStart = function (dom: DOMUtils, selection: EditorSelection, rng: Range) {
   const offset = rng.startOffset;
   let container = rng.startContainer, walker, node, nodes;
 
@@ -35,10 +35,10 @@ const moveStart = function (dom: DOMUtils, selection: Selection, rng: Range) {
     nodes = container.childNodes;
     if (offset < nodes.length) {
       container = nodes[offset];
-      walker = new TreeWalker(container, dom.getParent(container, dom.isBlock));
+      walker = new DomTreeWalker(container, dom.getParent(container, dom.isBlock));
     } else {
       container = nodes[nodes.length - 1];
-      walker = new TreeWalker(container, dom.getParent(container, dom.isBlock));
+      walker = new DomTreeWalker(container, dom.getParent(container, dom.isBlock));
       walker.next(true);
     }
 

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -9,7 +9,7 @@ import { Element, Node, Range } from '@ephox/dom-globals';
 import { Arr, Option, Type } from '@ephox/katamari';
 import { Insert, InsertAll, SugarElement, Traverse } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
-import TreeWalker from '../api/dom/TreeWalker';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import { FormatAttrOrStyleValue, FormatVars, RemoveFormatPartial } from '../api/fmt/Format';
 import * as Settings from '../api/Settings';
@@ -52,12 +52,12 @@ const getContainer = (ed: Editor, rng: RangeLikeObject, start?: boolean) => {
 
   // If start text node is excluded then walk to the next node
   if (NodeType.isText(container) && start && offset >= container.nodeValue.length) {
-    container = new TreeWalker(container, ed.getBody()).next() || container;
+    container = new DomTreeWalker(container, ed.getBody()).next() || container;
   }
 
   // If end text node is excluded then walk to the previous node
   if (NodeType.isText(container) && !start && offset === 0) {
-    container = new TreeWalker(container, ed.getBody()).prev() || container;
+    container = new DomTreeWalker(container, ed.getBody()).prev() || container;
   }
 
   return container;

--- a/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
+++ b/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
@@ -8,7 +8,7 @@
 import { Element, Node, Range } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 import { Compare, Focus, SugarElement } from '@ephox/sugar';
-import Selection from '../api/dom/Selection';
+import EditorSelection from '../api/dom/Selection';
 import Editor from '../api/Editor';
 import Env from '../api/Env';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -75,7 +75,7 @@ const hasFocus = (editor: Editor): boolean => editor.inline ? hasInlineFocus(edi
 const hasEditorOrUiFocus = (editor: Editor): boolean => hasFocus(editor) || hasUiFocus(editor);
 
 const focusEditor = (editor: Editor) => {
-  const selection: Selection = editor.selection;
+  const selection: EditorSelection = editor.selection;
   const body = editor.getBody();
   let rng = selection.getRng();
 

--- a/modules/tinymce/src/core/main/ts/html/FilterNode.ts
+++ b/modules/tinymce/src/core/main/ts/html/FilterNode.ts
@@ -5,18 +5,18 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Node from '../api/html/Node';
-import { ParserFilter, ParserFilterCallback } from '../api/html/DomParser';
 import { Arr } from '@ephox/katamari';
+import { ParserFilter, ParserFilterCallback } from '../api/html/DomParser';
+import AstNode from '../api/html/Node';
 
 interface FilterMatch {
   filter: ParserFilter;
-  nodes: Node[];
+  nodes: AstNode[];
 }
 
 interface FilterMatchMap { [key: string]: FilterMatch }
 
-const traverse = (node: Node, fn: (node: Node) => void): void => {
+const traverse = (node: AstNode, fn: (node: AstNode) => void): void => {
   fn(node);
 
   if (node.firstChild) {
@@ -28,7 +28,7 @@ const traverse = (node: Node, fn: (node: Node) => void): void => {
   }
 };
 
-const findMatchingNodes = (nodeFilters: ParserFilter[], attributeFilters: ParserFilter[], node: Node): FilterMatch[] => {
+const findMatchingNodes = (nodeFilters: ParserFilter[], attributeFilters: ParserFilter[], node: AstNode): FilterMatch[] => {
   const nodeMatches: FilterMatchMap = {};
   const attrMatches: FilterMatchMap = {};
   const matches: FilterMatch[] = [];
@@ -72,7 +72,7 @@ const findMatchingNodes = (nodeFilters: ParserFilter[], attributeFilters: Parser
   return matches;
 };
 
-const filter = (nodeFilters: ParserFilter[], attributeFilters: ParserFilter[], node: Node): void => {
+const filter = (nodeFilters: ParserFilter[], attributeFilters: ParserFilter[], node: AstNode): void => {
   const matches = findMatchingNodes(nodeFilters, attributeFilters, node);
 
   Arr.each(matches, (match: FilterMatch) => {

--- a/modules/tinymce/src/core/main/ts/html/LegacyFilter.ts
+++ b/modules/tinymce/src/core/main/ts/html/LegacyFilter.ts
@@ -6,12 +6,12 @@
  */
 
 import { Arr } from '@ephox/katamari';
+import DomParser, { DomParserSettings } from '../api/html/DomParser';
+import AstNode from '../api/html/Node';
 import Styles from '../api/html/Styles';
 import Tools from '../api/util/Tools';
-import DomParser, { DomParserSettings } from '../api/html/DomParser';
-import Node from '../api/html/Node';
 
-const removeAttrs = (node: Node, names: string[]) => {
+const removeAttrs = (node: AstNode, names: string[]) => {
   Arr.each(names, (name) => {
     node.attr(name, null);
   });

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -9,17 +9,17 @@ import { Image } from '@ephox/dom-globals';
 import { Arr, Obj, Option, Unicode } from '@ephox/katamari';
 import Env from '../api/Env';
 import DomParser, { DomParserSettings } from '../api/html/DomParser';
-import Node from '../api/html/Node';
+import AstNode from '../api/html/Node';
 import Tools from '../api/util/Tools';
 import * as Conversions from '../file/Conversions';
 import { uniqueId } from '../file/ImageScanner';
 import { parseDataUri } from './Base64Uris';
 import { isEmpty, paddEmptyNode } from './ParserUtils';
 
-const isBogusImage = (img: Node) => img.attr('data-mce-bogus');
-const isInternalImageSource = (img: Node) => img.attr('src') === Env.transparentSrc || img.attr('data-mce-placeholder');
+const isBogusImage = (img: AstNode) => img.attr('data-mce-bogus');
+const isInternalImageSource = (img: AstNode) => img.attr('src') === Env.transparentSrc || img.attr('data-mce-placeholder');
 
-const isValidDataImg = (img: Node, settings: DomParserSettings) => {
+const isValidDataImg = (img: AstNode, settings: DomParserSettings) => {
   if (settings.images_dataimg_filter) {
     // Construct an image element
     const imgElem = new Image();
@@ -37,7 +37,7 @@ const isValidDataImg = (img: Node, settings: DomParserSettings) => {
 
 const registerBase64ImageFilter = (parser: DomParser, settings: DomParserSettings) => {
   const { blob_cache: blobCache } = settings;
-  const processImage = (img: Node): void => {
+  const processImage = (img: AstNode): void => {
     const inputSrc = img.attr('src');
 
     if (isInternalImageSource(img) || isBogusImage(img)) {
@@ -143,7 +143,7 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
           }
 
           if (lastParent === parent && settings.padd_empty_with_br !== true) {
-            textNode = new Node('#text', 3);
+            textNode = new AstNode('#text', 3);
             textNode.value = Unicode.nbsp;
             node.replace(textNode);
           }
@@ -213,7 +213,7 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
           if (node.prev && node.prev.name === 'li') {
             node.prev.append(node);
           } else {
-            const li = new Node('li', 1);
+            const li = new AstNode('li', 1);
             li.attr('style', 'list-style-type: none');
             node.wrap(li);
           }

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -5,33 +5,33 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Node from '../api/html/Node';
 import { Unicode } from '@ephox/katamari';
 import { DomParserSettings, ParserArgs } from '../api/html/DomParser';
+import AstNode from '../api/html/Node';
 import Schema, { SchemaMap } from '../api/html/Schema';
 
-const paddEmptyNode = (settings: DomParserSettings, args: ParserArgs, blockElements: SchemaMap, node: Node) => {
+const paddEmptyNode = (settings: DomParserSettings, args: ParserArgs, blockElements: SchemaMap, node: AstNode) => {
   const brPreferred = settings.padd_empty_with_br || args.insert;
 
   if (brPreferred && blockElements[node.name]) {
-    node.empty().append(new Node('br', 1)).shortEnded = true;
+    node.empty().append(new AstNode('br', 1)).shortEnded = true;
   } else {
-    node.empty().append(new Node('#text', 3)).value = Unicode.nbsp;
+    node.empty().append(new AstNode('#text', 3)).value = Unicode.nbsp;
   }
 };
 
-const isPaddedWithNbsp = (node: Node) => hasOnlyChild(node, '#text') && node.firstChild.value === Unicode.nbsp;
+const isPaddedWithNbsp = (node: AstNode) => hasOnlyChild(node, '#text') && node.firstChild.value === Unicode.nbsp;
 
-const hasOnlyChild = (node: Node, name: string) => node && node.firstChild && node.firstChild === node.lastChild && node.firstChild.name === name;
+const hasOnlyChild = (node: AstNode, name: string) => node && node.firstChild && node.firstChild === node.lastChild && node.firstChild.name === name;
 
-const isPadded = (schema: Schema, node: Node) => {
+const isPadded = (schema: Schema, node: AstNode) => {
   const rule = schema.getElementRule(node.name);
   return rule && rule.paddEmpty;
 };
 
-const isEmpty = (schema: Schema, nonEmptyElements: SchemaMap, whitespaceElements: SchemaMap, node: Node) => node.isEmpty(nonEmptyElements, whitespaceElements, (node) => isPadded(schema, node));
+const isEmpty = (schema: Schema, nonEmptyElements: SchemaMap, whitespaceElements: SchemaMap, node: AstNode) => node.isEmpty(nonEmptyElements, whitespaceElements, (node) => isPadded(schema, node));
 
-const isLineBreakNode = (node: Node, blockElements: SchemaMap) => node && (blockElements[node.name] || node.name === 'br');
+const isLineBreakNode = (node: AstNode, blockElements: SchemaMap) => node && (blockElements[node.name] || node.name === 'br');
 
 export {
   paddEmptyNode,

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -9,7 +9,7 @@ import { DocumentFragment, Element, KeyboardEvent } from '@ephox/dom-globals';
 import { Arr, Obj, Option, Options } from '@ephox/katamari';
 import { Css, PredicateFilter, SugarElement, SugarNode } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
-import TreeWalker from '../api/dom/TreeWalker';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import * as Settings from '../api/Settings';
 import { EditorEvent } from '../api/util/EventDispatcher';
@@ -323,7 +323,7 @@ const insert = function (editor: Editor, evt?: EditorEvent<KeyboardEvent>) {
     }
 
     // Walk the DOM and look for text nodes or non empty elements
-    const walker = new TreeWalker(container, parentBlock);
+    const walker = new DomTreeWalker(container, parentBlock);
 
     // If caret is in beginning or end of a text block then jump to the next/previous node
     if (NodeType.isText(container)) {

--- a/modules/tinymce/src/core/main/ts/newline/InsertBr.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBr.ts
@@ -9,8 +9,8 @@ import { HTMLElement } from '@ephox/dom-globals';
 import { Fun } from '@ephox/katamari';
 import { Insert, SugarElement } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
-import Selection from '../api/dom/Selection';
-import TreeWalker from '../api/dom/TreeWalker';
+import EditorSelection from '../api/dom/Selection';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import Schema from '../api/html/Schema';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -23,7 +23,7 @@ import { rangeInsertNode } from '../selection/RangeInsertNode';
 
 // Walks the parent block to the right and look for BR elements
 const hasRightSideContent = function (schema: Schema, container, parentBlock) {
-  const walker = new TreeWalker(container, parentBlock);
+  const walker = new DomTreeWalker(container, parentBlock);
   let node;
   const nonEmptyElementsMap = schema.getNonEmptyElements();
 
@@ -34,7 +34,7 @@ const hasRightSideContent = function (schema: Schema, container, parentBlock) {
   }
 };
 
-const scrollToBr = function (dom: DOMUtils, selection: Selection, brElm) {
+const scrollToBr = function (dom: DOMUtils, selection: EditorSelection, brElm) {
   // Insert temp marker and scroll to that
   const marker = dom.create('span', {}, '&nbsp;');
   brElm.parentNode.insertBefore(marker, brElm);
@@ -42,7 +42,7 @@ const scrollToBr = function (dom: DOMUtils, selection: Selection, brElm) {
   dom.remove(marker);
 };
 
-const moveSelectionToBr = function (dom: DOMUtils, selection: Selection, brElm, extraBr) {
+const moveSelectionToBr = function (dom: DOMUtils, selection: EditorSelection, brElm, extraBr) {
   const rng = dom.createRng();
 
   if (!extraBr) {

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -7,7 +7,7 @@
 
 import { Fun, Option, Unicode } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
-import TreeWalker from '../api/dom/TreeWalker';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import * as ElementType from '../dom/ElementType';
 import * as NodeType from '../dom/NodeType';
@@ -44,7 +44,7 @@ const moveToCaretPosition = function (editor: Editor, root) {
   root.normalize();
 
   if (root.hasChildNodes()) {
-    const walker = new TreeWalker(root, root);
+    const walker = new DomTreeWalker(root, root);
 
     while ((node = walker.current())) {
       if (NodeType.isText(node)) {

--- a/modules/tinymce/src/core/main/ts/selection/ElementSelection.ts
+++ b/modules/tinymce/src/core/main/ts/selection/ElementSelection.ts
@@ -9,7 +9,7 @@ import { Element, Node, Range, Text } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
-import TreeWalker from '../api/dom/TreeWalker';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import * as NodeType from '../dom/NodeType';
 import { moveEndPoint } from './SelectionUtils';
 
@@ -118,7 +118,7 @@ const getSelectedBlocks = (dom: DOMUtils, rng: Range, startElm?: Element, endElm
   if (startElm && endElm && startElm !== endElm) {
     node = startElm;
 
-    const walker = new TreeWalker(startElm, root);
+    const walker = new DomTreeWalker(startElm, root);
     while ((node = walker.next()) && node !== endElm) {
       if (dom.isBlock(node)) {
         selectedBlocks.push(node);

--- a/modules/tinymce/src/core/main/ts/selection/NormalizeRange.ts
+++ b/modules/tinymce/src/core/main/ts/selection/NormalizeRange.ts
@@ -8,7 +8,7 @@
 import { HTMLElement, Node, Range } from '@ephox/dom-globals';
 import { Option } from '@ephox/katamari';
 import DOMUtils from '../api/dom/DOMUtils';
-import TreeWalker from '../api/dom/TreeWalker';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import * as CaretContainer from '../caret/CaretContainer';
 import { CaretPosition } from '../caret/CaretPosition';
 import * as NodeType from '../dom/NodeType';
@@ -40,7 +40,7 @@ const isTableCell = (node: Node) => node && /^(TD|TH|CAPTION)$/.test(node.nodeNa
 const isCeFalseCaretContainer = (node: Node, rootNode: Node) => CaretContainer.isCaretContainer(node) && hasParent(node, rootNode, isCaretNode) === false;
 
 const hasBrBeforeAfter = (dom: DOMUtils, node: Node, left: boolean) => {
-  const walker = new TreeWalker(node, dom.getParent(node.parentNode, dom.isBlock) || dom.getRoot());
+  const walker = new DomTreeWalker(node, dom.getParent(node.parentNode, dom.isBlock) || dom.getRoot());
 
   while ((node = walker[left ? 'prev' : 'next']())) {
     if (NodeType.isBr(node)) {
@@ -80,7 +80,7 @@ const findTextNodeRelative = (dom: DOMUtils, isAfterNode: boolean, collapsed: bo
   }
 
   // Walk left until we hit a text node we can move to or a block/br/img
-  const walker = new TreeWalker(startNode, parentBlockContainer);
+  const walker = new DomTreeWalker(startNode, parentBlockContainer);
   while ((node = walker[left ? 'prev' : 'next']())) {
     // Break if we hit a non content editable node
     if (dom.getContentEditableParent(node) === 'false' || isCeFalseCaretContainer(node, body)) {
@@ -173,7 +173,7 @@ const normalizeEndPoint = (dom: DOMUtils, collapsed: boolean, start: boolean, rn
       if (container.hasChildNodes() && isTable(container) === false) {
         // Walk the DOM to find a text node to place the caret at or a BR
         node = container;
-        const walker = new TreeWalker(container, body);
+        const walker = new DomTreeWalker(container, body);
 
         do {
           if (NodeType.isContentEditableFalse(node) || CaretContainer.isCaretContainer(node)) {

--- a/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
@@ -9,8 +9,8 @@ import { Range } from '@ephox/dom-globals';
 import { Arr, Fun, Option, Options } from '@ephox/katamari';
 import { Compare, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
-import Selection from '../api/dom/Selection';
-import TreeWalker from '../api/dom/TreeWalker';
+import EditorSelection from '../api/dom/Selection';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import Tools from '../api/util/Tools';
 import { IdBookmark, IndexBookmark } from '../bookmark/BookmarkTypes';
@@ -69,7 +69,7 @@ const hasAllContentsSelected = function (elm, rng) {
 };
 
 const moveEndPoint = (dom: DOMUtils, rng: Range, node, start: boolean): void => {
-  const root = node, walker = new TreeWalker(node, root);
+  const root = node, walker = new DomTreeWalker(node, root);
   const nonEmptyElementsMap = dom.schema.getNonEmptyElements();
 
   do {
@@ -133,7 +133,7 @@ const runOnRanges = (editor: Editor, executor: (rng: Range, fake: boolean) => vo
   }
 };
 
-const preserve = (selection: Selection, fillBookmark: boolean, executor: (bookmark: IdBookmark | IndexBookmark) => void) => {
+const preserve = (selection: EditorSelection, fillBookmark: boolean, executor: (bookmark: IdBookmark | IndexBookmark) => void) => {
   const bookmark = GetBookmark.getPersistentBookmark(selection, fillBookmark);
   executor(bookmark);
   selection.moveToBookmark(bookmark);

--- a/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
@@ -9,7 +9,7 @@ import { DocumentFragment, Range, Text } from '@ephox/dom-globals';
 import { Option, Options } from '@ephox/katamari';
 import { Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import Editor from '../api/Editor';
-import Serializer from '../api/html/Serializer';
+import HtmlSerializer from '../api/html/Serializer';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import { SetContentArgs } from '../content/ContentTypes';
 import * as ScrollIntoView from '../dom/ScrollIntoView';
@@ -68,7 +68,7 @@ const setupArgs = (args: Partial<SelectionSetContentArgs>, content: string): Sel
 const cleanContent = (editor: Editor, args: SelectionSetContentArgs) => {
   if (args.format !== 'raw') {
     const node = editor.parser.parse(args.content, { isRootContent: true, forced_root_block: false, ...args });
-    return Serializer({ validate: editor.validate }, editor.schema).serialize(node);
+    return HtmlSerializer({ validate: editor.validate }, editor.schema).serialize(node);
   } else {
     return args.content;
   }

--- a/modules/tinymce/src/core/main/ts/selection/WordSelection.ts
+++ b/modules/tinymce/src/core/main/ts/selection/WordSelection.ts
@@ -6,16 +6,16 @@
  */
 
 import { Type } from '@ephox/katamari';
+import EditorSelection from '../api/dom/Selection';
+import Editor from '../api/Editor';
 import * as CaretContainer from '../caret/CaretContainer';
 import CaretPosition from '../caret/CaretPosition';
-import Selection from '../api/dom/Selection';
-import Editor from '../api/Editor';
 
 const hasSelectionModifyApi = function (editor: Editor) {
   return Type.isFunction((<any> editor.selection.getSel()).modify);
 };
 
-const moveRel = function (forward: boolean, selection: Selection, pos: CaretPosition) {
+const moveRel = function (forward: boolean, selection: EditorSelection, pos: CaretPosition) {
   const delta = forward ? 1 : -1;
   selection.setRng(CaretPosition(pos.container(), pos.offset() + delta).toRange());
   (<any> selection.getSel()).modify('move', forward ? 'forward' : 'backward', 'word');

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
@@ -4,7 +4,7 @@ import { Editor as McEditor } from '@ephox/mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
-import Node from 'tinymce/core/api/html/Node';
+import AstNode from 'tinymce/core/api/html/Node';
 import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.core.content.EditorContentNotInitializedTest', (success, failure) => {
@@ -61,27 +61,27 @@ UnitTest.asynctest('browser.tinymce.core.content.EditorContentNotInitializedTest
 
     Logger.t('set tree content on editor without initializing it', Chain.asStep({}, [
       cCreateEditor,
-      cSetContentAndAssertReturn(new Node('p', 1)),
+      cSetContentAndAssertReturn(new AstNode('p', 1)),
       McEditor.cRemove
     ])),
 
     Logger.t('set tree content on editor where the body has been removed', Chain.asStep({}, [
       McEditor.cFromHtml('<textarea></textarea>', settings),
       cRemoveBodyElement,
-      cSetContentAndAssertReturn(new Node('p', 1)),
+      cSetContentAndAssertReturn(new AstNode('p', 1)),
       McEditor.cRemove
     ])),
 
     Logger.t('get tree content on editor without initializing it', Chain.asStep({}, [
       cCreateEditor,
-      cGetAndAssertContent(new Node('body', 11), true),
+      cGetAndAssertContent(new AstNode('body', 11), true),
       McEditor.cRemove
     ])),
 
     Logger.t('get tree content on editor where the body has been removed', Chain.asStep({}, [
       McEditor.cFromHtml('<textarea></textarea>', settings),
       cRemoveBodyElement,
-      cGetAndAssertContent(new Node('body', 11), true),
+      cGetAndAssertContent(new AstNode('body', 11), true),
       McEditor.cRemove
     ]))
   ], () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -1,16 +1,16 @@
-import { GeneralSteps, Logger, Pipeline, Step, Assertions } from '@ephox/agar';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import Theme from 'tinymce/themes/silver/Theme';
+import { Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import AstNode from 'tinymce/core/api/html/Node';
+import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 import * as EditorContent from 'tinymce/core/content/EditorContent';
-import Serializer from 'tinymce/core/api/html/Serializer';
-import Node from 'tinymce/core/api/html/Node';
+import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.core.content.EditorContentTest', (success, failure) => {
   const getFontTree = () => {
-    const body = new Node('body', 1);
-    const font = new Node('font', 1);
-    const text = new Node('#text', 3);
+    const body = new AstNode('body', 1);
+    const font = new AstNode('font', 1);
+    const text = new AstNode('#text', 3);
 
     text.value = 'x';
     font.attr('size', '7');
@@ -22,8 +22,8 @@ UnitTest.asynctest('browser.tinymce.core.content.EditorContentTest', (success, f
 
   Theme();
 
-  const toHtml = (node: Node) => {
-    const htmlSerializer = Serializer({});
+  const toHtml = (node: AstNode) => {
+    const htmlSerializer = HtmlSerializer({});
     return htmlSerializer.serialize(node);
   };
 
@@ -41,21 +41,21 @@ UnitTest.asynctest('browser.tinymce.core.content.EditorContentTest', (success, f
       Logger.t('getContent tree', GeneralSteps.sequence([
         tinyApis.sSetContent('<p>tree</p>'),
         Step.sync(() => {
-          const tree = EditorContent.getContent(editor, { format: 'tree' }) as Node;
+          const tree = EditorContent.getContent(editor, { format: 'tree' }) as AstNode;
           Assertions.assertHtml('Should be expected tree html', '<p>tree</p>', toHtml(tree));
         })
       ])),
       Logger.t('getContent tree filtered', GeneralSteps.sequence([
         Step.sync(() => {
           EditorContent.setContent(editor, '<p><font size="7">x</font></p>', { format: 'raw' });
-          const tree = EditorContent.getContent(editor, { format: 'tree' }) as Node;
+          const tree = EditorContent.getContent(editor, { format: 'tree' }) as AstNode;
           Assertions.assertHtml('Should be expected tree filtered html', '<p><span style="font-size: 300%;">x</span></p>', toHtml(tree));
         })
       ])),
       Logger.t('getContent tree using public api', GeneralSteps.sequence([
         tinyApis.sSetContent('<p>html</p>'),
         Step.sync(() => {
-          const tree = editor.getContent({ format: 'tree' }) as Node;
+          const tree = editor.getContent({ format: 'tree' }) as AstNode;
           Assertions.assertHtml('Should be expected filtered html', '<p>html</p>', toHtml(tree));
         })
       ])),
@@ -69,7 +69,7 @@ UnitTest.asynctest('browser.tinymce.core.content.EditorContentTest', (success, f
       Logger.t('setContent tree', GeneralSteps.sequence([
         tinyApis.sSetContent('<p>tree</p>'),
         Step.sync(() => {
-          const tree = EditorContent.getContent(editor, { format: 'tree' }) as Node;
+          const tree = EditorContent.getContent(editor, { format: 'tree' }) as AstNode;
           Assertions.assertHtml('Should be expected tree html', '<p>tree</p>', toHtml(tree));
 
           EditorContent.setContent(editor, '<p>new html</p>');

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTreeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTreeTest.ts
@@ -1,15 +1,15 @@
 import { Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import Node from 'tinymce/core/api/html/Node';
-import Serializer from 'tinymce/core/api/html/Serializer';
+import AstNode from 'tinymce/core/api/html/Node';
+import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.core.content.EditorGetContentTreeTest', (success, failure) => {
   Theme();
 
-  const toHtml = function (node: Node) {
-    const htmlSerializer = Serializer({});
+  const toHtml = function (node: AstNode) {
+    const htmlSerializer = HtmlSerializer({});
     return htmlSerializer.serialize(node);
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/ReferrerPolicyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ReferrerPolicyTest.ts
@@ -2,11 +2,11 @@ import { Chain, Logger, Pipeline, Step } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Editor as McEditor } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
-import Editor from 'tinymce/core/api/Editor';
-import { ReferrerPolicy } from 'tinymce/core/api/SettingsTypes';
-import Theme from 'tinymce/themes/silver/Theme';
-import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
+import Editor from 'tinymce/core/api/Editor';
+import { UpdatedReferrerPolicy } from 'tinymce/core/api/SettingsTypes';
+import Theme from 'tinymce/themes/silver/Theme';
 
 // TODO Find a way to test the referrerpolicy with ScriptLoader, as it removes the dom reference as soon as it's finished loading so we can't check
 // via dom elements. For now we're just loading a script to make sure it doesn't completely die when loading.
@@ -14,7 +14,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.ReferrerPolicyTest', (success, fail
   const platform = PlatformDetection.detect();
   Theme();
 
-  const cAssertReferrerLinkPresence = (referrerPolicy: ReferrerPolicy, expected: boolean) => Chain.op((editor: Editor) => {
+  const cAssertReferrerLinkPresence = (referrerPolicy: UpdatedReferrerPolicy, expected: boolean) => Chain.op((editor: Editor) => {
     const links = editor.getDoc().querySelectorAll(`link[referrerpolicy="${referrerPolicy}"]`);
     Assert.eq(`should have link with referrerpolicy="${referrerPolicy}"`, expected, links.length > 0);
   });

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -4,7 +4,7 @@ import { document } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import { LegacyUnit } from '@ephox/mcagar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
-import Serializer from 'tinymce/core/api/dom/Serializer';
+import DomSerializer from 'tinymce/core/api/dom/Serializer';
 import * as TrimHtml from 'tinymce/core/dom/TrimHtml';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
 import ViewBlock from '../../module/test/ViewBlock';
@@ -27,7 +27,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   };
 
   suite.test('Schema rules', function () {
-    let ser = Serializer({ fix_list_elements : true });
+    let ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('@[id|title|class|style],div,img[src|alt|-style|border],span,hr');
     DOM.setHTML('test', '<img title="test" src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" alt="test" ' +
@@ -63,7 +63,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
       '<img src="tinymce/ui/img/raster.gif" border="0" alt="" /><hr />'
     );
 
-    ser = Serializer({
+    ser = DomSerializer({
       valid_elements : 'img[src|border=0|alt=]',
       extended_valid_elements : 'div[id],img[src|alt=]'
     });
@@ -73,7 +73,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
       '<div id="test"><img src="tinymce/ui/img/raster.gif" alt="" /></div>'
     );
 
-    ser = Serializer({ invalid_elements : 'hr,br' });
+    ser = DomSerializer({ invalid_elements : 'hr,br' });
     DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" /><hr /><br />');
     LegacyUnit.equal(
       ser.serialize(DOM.get('test'), { getInner: true }),
@@ -82,7 +82,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('allow_unsafe_link_target (default)', function () {
-    const ser = Serializer({ });
+    const ser = DomSerializer({ });
 
     DOM.setHTML('test', '<a href="a" target="_blank">a</a><a href="b" target="_blank">b</a>');
     LegacyUnit.equal(
@@ -116,7 +116,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('allow_unsafe_link_target (disabled)', function () {
-    const ser = Serializer({ allow_unsafe_link_target: true });
+    const ser = DomSerializer({ allow_unsafe_link_target: true });
 
     DOM.setHTML('test', '<a href="a" target="_blank">a</a><a href="b" target="_blank">b</a>');
     LegacyUnit.equal(
@@ -126,7 +126,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('format tree', function () {
-    const ser = Serializer({ });
+    const ser = DomSerializer({ });
 
     DOM.setHTML('test', 'a');
     LegacyUnit.equal(
@@ -136,27 +136,27 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Entity encoding', function () {
-    let ser: Serializer;
+    let ser: DomSerializer;
 
-    ser = Serializer({ entity_encoding : 'numeric' });
+    ser = DomSerializer({ entity_encoding : 'numeric' });
     DOM.setHTML('test', '&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
     LegacyUnit.equal(ser.serialize(DOM.get('test'), { getInner : true }), '&lt;&gt;&amp;"&#160;&#229;&#228;&#246;');
 
-    ser = Serializer({ entity_encoding : 'named' });
+    ser = DomSerializer({ entity_encoding : 'named' });
     DOM.setHTML('test', '&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
     LegacyUnit.equal(ser.serialize(DOM.get('test'), { getInner : true }), '&lt;&gt;&amp;"&nbsp;&aring;&auml;&ouml;');
 
-    ser = Serializer({ entity_encoding : 'named+numeric', entities : '160,nbsp,34,quot,38,amp,60,lt,62,gt' });
+    ser = DomSerializer({ entity_encoding : 'named+numeric', entities : '160,nbsp,34,quot,38,amp,60,lt,62,gt' });
     DOM.setHTML('test', '&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
     LegacyUnit.equal(ser.serialize(DOM.get('test'), { getInner : true }), '&lt;&gt;&amp;"&nbsp;&#229;&#228;&#246;');
 
-    ser = Serializer({ entity_encoding : 'raw' });
+    ser = DomSerializer({ entity_encoding : 'raw' });
     DOM.setHTML('test', '&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
     LegacyUnit.equal(ser.serialize(DOM.get('test'), { getInner : true }), '&lt;&gt;&amp;"\u00a0\u00e5\u00e4\u00f6');
   });
 
   suite.test('Form elements (general)', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules(
       'form[method],label[for],input[type|name|value|checked|disabled|readonly|length|maxlength],select[multiple],' +
@@ -185,7 +185,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Form elements (checkbox)', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('form[method],label[for],input[type|name|value|checked|disabled|readonly|length|maxlength],select[multiple],option[value|selected]');
 
@@ -203,7 +203,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Form elements (select)', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('form[method],label[for],input[type|name|value|checked|disabled|readonly|length|maxlength],select[multiple],option[value|selected]');
 
@@ -230,7 +230,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('List elements', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('ul[compact],ol,li');
 
@@ -251,7 +251,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Tables', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('table,tr,td[nowrap]');
 
@@ -269,7 +269,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Styles', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('*[*]');
 
@@ -278,7 +278,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Comments', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('*[*]');
 
@@ -287,7 +287,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Non HTML elements and attributes', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('*[*]');
     ser.schema.addValidChildren('+div[prefix:test]');
@@ -300,7 +300,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Padd empty elements', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('#p');
 
@@ -309,7 +309,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Padd empty elements with BR', function () {
-    const ser = Serializer({ padd_empty_with_br: true });
+    const ser = DomSerializer({ padd_empty_with_br: true });
 
     ser.setRules('#p,table,tr,#td,br');
 
@@ -320,7 +320,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Do not padd empty elements with padded children', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('#p,#span,b');
 
@@ -329,7 +329,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Remove empty elements', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('-p');
 
@@ -338,7 +338,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with non JS type attribute', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<s' + 'cript type="mylanguage"></s' + 'cript>');
@@ -346,7 +346,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with tags inside a comment with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<s' + 'cript>// <img src="test"><a href="#"></a></s' + 'cript>');
@@ -357,7 +357,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with tags inside a comment', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<s' + 'cript>// <img src="test"><a href="#"></a></s' + 'cript>');
@@ -368,7 +368,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with less than with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<s' + 'cript>1 < 2;</s' + 'cript>');
@@ -376,7 +376,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with less than', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<s' + 'cript>1 < 2;</s' + 'cript>');
@@ -384,7 +384,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with type attrib and less than with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<s' + 'cript type="text/javascript">1 < 2;</s' + 'cript>');
@@ -392,7 +392,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with type attrib and less than', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<s' + 'cript type="text/javascript">1 < 2;</s' + 'cript>');
@@ -400,7 +400,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with whitespace in beginning/end with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>\n\t1 < 2;\n\t if (2 < 1)\n\t\talert(1);\n</s' + 'cript>');
@@ -411,7 +411,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with whitespace in beginning/end', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>\n\t1 < 2;\n\t if (2 < 1)\n\t\talert(1);\n</s' + 'cript>');
@@ -422,7 +422,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with a HTML comment and less than with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script><!-- 1 < 2; // --></s' + 'cript>');
@@ -430,7 +430,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with a HTML comment and less than', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script><!-- 1 < 2; // --></s' + 'cript>');
@@ -438,7 +438,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with white space in beginning, comment and less than with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>\n\n<!-- 1 < 2;\n\n--></s' + 'cript>');
@@ -446,7 +446,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with white space in beginning, comment and less than', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>\n\n<!-- 1 < 2;\n\n--></s' + 'cript>');
@@ -454,7 +454,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with comments and cdata with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>// <![CDATA[1 < 2; // ]]></s' + 'cript>');
@@ -462,7 +462,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with comments and cdata', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>// <![CDATA[1 < 2; // ]]></s' + 'cript>');
@@ -470,7 +470,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with cdata with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script><![CDATA[1 < 2; ]]></s' + 'cript>');
@@ -478,7 +478,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with cdata', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script><![CDATA[1 < 2; ]]></s' + 'cript>');
@@ -486,7 +486,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script whitespace in beginning/end and cdata with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>\n\n<![CDATA[\n\n1 < 2;\n\n]]>\n\n</s' + 'cript>');
@@ -494,7 +494,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script whitespace in beginning/end and cdata', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>\n\n<![CDATA[\n\n1 < 2;\n\n]]>\n\n</s' + 'cript>');
@@ -502,7 +502,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Whitespace preserve in pre', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('pre');
 
     DOM.setHTML('test', '<pre>  </pre>');
@@ -510,7 +510,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with src attr', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script src="test.js" data-mce-src="test.js"></s' + 'cript>');
@@ -518,7 +518,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with HTML comment, comment and CDATA with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script><!--// <![CDATA[var hi = "hello";// ]]>--></s' + 'cript>');
@@ -526,7 +526,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with HTML comment, comment and CDATA', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script><!--// <![CDATA[var hi = "hello";// ]]>--></s' + 'cript>');
@@ -534,7 +534,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with block comment around cdata with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>/* <![CDATA[ */\nvar hi = "hello";\n/* ]]> */</s' + 'cript>');
@@ -542,7 +542,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with block comment around cdata', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>/* <![CDATA[ */\nvar hi = "hello";\n/* ]]> */</s' + 'cript>');
@@ -550,7 +550,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with html comment and block comment around cdata with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script><!-- /* <![CDATA[ */\nvar hi = "hello";\n/* ]]>*/--></s' + 'cript>');
@@ -558,7 +558,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with html comment and block comment around cdata', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script><!-- /* <![CDATA[ */\nvar hi = "hello";\n/* ]]>*/--></s' + 'cript>');
@@ -566,7 +566,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with line comment and html comment with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>// <!--\nvar hi = "hello";\n// --></s' + 'cript>');
@@ -574,7 +574,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with line comment and html comment', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>// <!--\nvar hi = "hello";\n// --></s' + 'cript>');
@@ -582,7 +582,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with block comment around html comment with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>/* <!-- */\nvar hi = "hello";\n/*-->*/</s' + 'cript>');
@@ -590,7 +590,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Script with block comment around html comment', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
     ser.setRules('script[type|language|src]');
 
     DOM.setHTML('test', '<script>/* <!-- */\nvar hi = "hello";\n/*-->*/</s' + 'cript>');
@@ -598,7 +598,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Protected blocks', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('noscript[test]');
 
@@ -613,7 +613,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Style with whitespace at beginning with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, valid_children: '+body[style]', element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, valid_children: '+body[style]', element_format: 'xhtml' });
     ser.setRules('style');
 
     DOM.setHTML('test', '<style> body { background:#fff }</style>');
@@ -621,7 +621,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Style with whitespace at beginning', function () {
-    const ser = Serializer({ fix_list_elements : true, valid_children: '+body[style]' });
+    const ser = DomSerializer({ fix_list_elements : true, valid_children: '+body[style]' });
     ser.setRules('style');
 
     DOM.setHTML('test', '<style> body { background:#fff }</style>');
@@ -629,7 +629,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Style with cdata with element_format: xhtml', function () {
-    const ser = Serializer({ fix_list_elements : true, valid_children: '+body[style]', element_format: 'xhtml' });
+    const ser = DomSerializer({ fix_list_elements : true, valid_children: '+body[style]', element_format: 'xhtml' });
     ser.setRules('style');
 
     DOM.setHTML('test', '<style>\r\n<![CDATA[\r\n   body { background:#fff }]]></style>');
@@ -637,7 +637,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Style with cdata', function () {
-    const ser = Serializer({ fix_list_elements : true, valid_children: '+body[style]' });
+    const ser = DomSerializer({ fix_list_elements : true, valid_children: '+body[style]' });
     ser.setRules('style');
 
     DOM.setHTML('test', '<style>\r\n<![CDATA[\r\n   body { background:#fff }]]></style>');
@@ -645,7 +645,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('CDATA', function () {
-    const ser = Serializer({ fix_list_elements : true, preserve_cdata: true });
+    const ser = DomSerializer({ fix_list_elements : true, preserve_cdata: true });
     ser.setRules('span');
 
     DOM.setHTML('test', '123<!--[CDATA[<test>]]-->abc');
@@ -656,7 +656,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('BR at end of blocks', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('ul,li,br');
 
@@ -665,7 +665,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Map elements', function () {
-    const ser = Serializer({ fix_list_elements : true });
+    const ser = DomSerializer({ fix_list_elements : true });
 
     ser.setRules('map[id|name],area[shape|coords|href|target|alt]');
 
@@ -680,7 +680,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Custom elements', function () {
-    const ser = Serializer({
+    const ser = DomSerializer({
       custom_elements: 'custom1,~custom2',
       valid_elements: 'custom1,custom2'
     });
@@ -693,7 +693,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Remove internal classes', function () {
-    const ser = Serializer({
+    const ser = DomSerializer({
       valid_elements: 'span[class]'
     });
 
@@ -714,7 +714,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Restore tabindex', function () {
-    const ser = Serializer({
+    const ser = DomSerializer({
       valid_elements: 'span[tabindex]'
     });
 
@@ -723,7 +723,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('Trailing BR (IE11)', function () {
-    const ser = Serializer({
+    const ser = DomSerializer({
       valid_elements: 'p,br'
     });
 
@@ -735,7 +735,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('addTempAttr', function () {
-    const ser = Serializer({});
+    const ser = DomSerializer({});
 
     ser.addTempAttr('data-x');
     ser.addTempAttr('data-y');
@@ -746,8 +746,8 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('addTempAttr same attr twice', function () {
-    const ser1 = Serializer({});
-    const ser2 = Serializer({});
+    const ser1 = DomSerializer({});
+    const ser2 = DomSerializer({});
 
     ser1.addTempAttr('data-x');
     ser2.addTempAttr('data-x');
@@ -760,7 +760,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('trim data-mce-bougs="all"', function () {
-    const ser = Serializer({});
+    const ser = DomSerializer({});
 
     DOM.setHTML('test', 'a<p data-mce-bogus="all">b</p>c');
     LegacyUnit.equal(ser.serialize(DOM.get('test'), { getInner: 1 }), 'ac');
@@ -768,7 +768,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('zwsp should not be treated as contents', function () {
-    const ser = Serializer({ });
+    const ser = DomSerializer({ });
 
     DOM.setHTML('test', '<p>' + Zwsp.ZWSP + '</p>');
     LegacyUnit.equal(
@@ -778,7 +778,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('nested bookmark nodes', () => {
-    const ser = Serializer({ });
+    const ser = DomSerializer({ });
 
     DOM.setHTML('test', '<p>' +
       '<span data-mce-type="bookmark" id="mce_5_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px">' +
@@ -797,7 +797,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
   });
 
   suite.test('addNodeFilter/addAttributeFilter', () => {
-    const ser = Serializer({ });
+    const ser = DomSerializer({ });
     const nodeFilter = () => {};
     const attrFilter = () => {};
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/TreeWalkerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TreeWalkerTest.ts
@@ -1,7 +1,7 @@
 import { Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { LegacyUnit } from '@ephox/mcagar';
-import TreeWalker from 'tinymce/core/api/dom/TreeWalker';
+import DomTreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import ViewBlock from '../../module/test/ViewBlock';
 
 UnitTest.asynctest('browser.tinymce.core.dom.TreeWalkerTest', function (success, failure) {
@@ -61,7 +61,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.TreeWalkerTest', function (success,
   };
 
   suite.test('next', function () {
-    const walker = new TreeWalker(nodes[0], viewBlock.get());
+    const walker = new DomTreeWalker(nodes[0], viewBlock.get());
 
     const actualNodes = [ walker.current() ];
     while ((walker.next())) {
@@ -72,7 +72,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.TreeWalkerTest', function (success,
   });
 
   suite.test('prev2', function () {
-    const walker = new TreeWalker(nodes[nodes.length - 1], viewBlock.get());
+    const walker = new DomTreeWalker(nodes[nodes.length - 1], viewBlock.get());
     let actualNodes;
 
     actualNodes = [ walker.current() ];
@@ -85,7 +85,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.TreeWalkerTest', function (success,
   });
 
   suite.test('prev2(shallow:true)', function () {
-    const walker = new TreeWalker(nodes[nodes.length - 1], viewBlock.get());
+    const walker = new DomTreeWalker(nodes[nodes.length - 1], viewBlock.get());
     let actualNodes;
 
     actualNodes = [ walker.current() ];

--- a/modules/tinymce/src/core/test/ts/browser/dom/TrimHtmlTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TrimHtmlTest.ts
@@ -1,12 +1,12 @@
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
-import { DomSerializer } from 'tinymce/core/dom/DomSerializer';
+import { DomSerializerImpl } from 'tinymce/core/dom/DomSerializerImpl';
 import * as TrimHtml from 'tinymce/core/dom/TrimHtml';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 UnitTest.test('browser.tinymce.core.dom.TrimHtmlTest', function () {
-  const serializer = DomSerializer({}, new Editor('id', {}, EditorManager));
+  const serializer = DomSerializerImpl({}, new Editor('id', {}, EditorManager));
 
   Assert.eq('Should be unchanged', '<p id="a" data-mce-abc="1">a</p>', TrimHtml.trimInternal(serializer, '<p id="a" data-mce-abc="1">a</p>'));
   Assert.eq('Should not have internal attr', '<p>a</p>', TrimHtml.trimInternal(serializer, '<p data-mce-selected="1">a</p>'));

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -6,13 +6,13 @@ import Env from 'tinymce/core/api/Env';
 import { BlobCache } from 'tinymce/core/api/file/BlobCache';
 import DomParser from 'tinymce/core/api/html/DomParser';
 import Schema from 'tinymce/core/api/html/Schema';
-import Serializer from 'tinymce/core/api/html/Serializer';
+import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 
 UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success, failure) {
   const suite = LegacyUnit.createSuite();
 
   const schema = Schema({ valid_elements: '*[class|title]' });
-  const serializer = Serializer({}, schema);
+  const serializer = HtmlSerializer({}, schema);
   let parser, root;
 
   const countNodes = function (node, counter?) {
@@ -625,7 +625,7 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
   suite.test('Pad empty with br', function () {
     const schema = Schema();
     const parser = DomParser({ padd_empty_with_br: true }, schema);
-    const serializer = Serializer({ }, schema);
+    const serializer = HtmlSerializer({ }, schema);
     const root = parser.parse('<p>a</p><p></p>');
     LegacyUnit.equal(serializer.serialize(root), '<p>a</p><p><br /></p>');
   });
@@ -647,7 +647,7 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
   });
 
   suite.test('Bug #7543 removes whitespace between bogus elements before a block', function () {
-    const serializer = Serializer();
+    const serializer = HtmlSerializer();
 
     LegacyUnit.equal(
       serializer.serialize(DomParser().parse(
@@ -658,7 +658,7 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
   });
 
   suite.test('Bug #7582 removes whitespace between bogus elements before a block', function () {
-    const serializer = Serializer();
+    const serializer = HtmlSerializer();
 
     LegacyUnit.equal(
       serializer.serialize(DomParser().parse(
@@ -669,7 +669,7 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
   });
 
   suite.test('do not replace starting linebreak with space', function () {
-    const serializer = Serializer();
+    const serializer = HtmlSerializer();
 
     LegacyUnit.equal(
       serializer.serialize(DomParser().parse(
@@ -680,7 +680,7 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', function (success,
   });
 
   suite.test('parse iframe XSS', function () {
-    const serializer = Serializer();
+    const serializer = HtmlSerializer();
 
     LegacyUnit.equal(
       serializer.serialize(DomParser().parse(

--- a/modules/tinymce/src/core/test/ts/browser/html/NodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/NodeTest.ts
@@ -1,7 +1,7 @@
 import { Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { LegacyUnit } from '@ephox/mcagar';
-import Node from 'tinymce/core/api/html/Node';
+import AstNode from 'tinymce/core/api/html/Node';
 
 UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, failure) {
   const suite = LegacyUnit.createSuite();
@@ -13,39 +13,39 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   suite.test('construction', function () {
     let node;
 
-    node = new Node('#text', 3);
+    node = new AstNode('#text', 3);
     LegacyUnit.equal(node.name, '#text');
     LegacyUnit.equal(node.type, 3);
 
-    node = new Node('#comment', 8);
+    node = new AstNode('#comment', 8);
     LegacyUnit.equal(node.name, '#comment');
     LegacyUnit.equal(node.type, 8);
 
-    node = new Node('b', 1);
+    node = new AstNode('b', 1);
     LegacyUnit.equal(node.name, 'b');
     LegacyUnit.equal(node.type, 1);
     LegacyUnit.deepEqual(node.attributes, []);
 
-    node = new Node('#pi', 7);
+    node = new AstNode('#pi', 7);
     LegacyUnit.equal(node.name, '#pi');
     LegacyUnit.equal(node.type, 7);
 
-    node = new Node('#doctype', 10);
+    node = new AstNode('#doctype', 10);
     LegacyUnit.equal(node.name, '#doctype');
     LegacyUnit.equal(node.type, 10);
 
-    node = new Node('#cdata', 4);
+    node = new AstNode('#cdata', 4);
     LegacyUnit.equal(node.name, '#cdata');
     LegacyUnit.equal(node.type, 4);
 
-    node = new Node('#frag', 11);
+    node = new AstNode('#frag', 11);
     LegacyUnit.equal(node.name, '#frag');
     LegacyUnit.equal(node.type, 11);
   });
 
   suite.test('append inside empty node', function () {
-    const root = new Node('#frag', 11);
-    const node = root.append(new Node('b', 1));
+    const root = new AstNode('#frag', 11);
+    const node = root.append(new AstNode('b', 1));
     LegacyUnit.equal(root.firstChild.parent === root, true);
     LegacyUnit.equal(root.firstChild.next, undefined);
     LegacyUnit.equal(root.firstChild.prev, undefined);
@@ -59,9 +59,9 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('append node after node', function () {
-    const root = new Node('#frag', 11);
-    const node2 = root.append(new Node('a', 1));
-    const node = root.append(new Node('b', 1));
+    const root = new AstNode('#frag', 11);
+    const node2 = root.append(new AstNode('a', 1));
+    const node = root.append(new AstNode('b', 1));
     ok(root.firstChild.parent === root, 'root.firstChild.parent === root');
     ok(root.firstChild === node2, 'root.firstChild');
     ok(root.lastChild === node, 'root.firstChild');
@@ -82,9 +82,9 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('append existing node before other existing node', function () {
-    const root = new Node('#frag', 11);
-    const node = root.append(new Node('a', 1));
-    const node2 = root.append(new Node('b', 1));
+    const root = new AstNode('#frag', 11);
+    const node = root.append(new AstNode('a', 1));
+    const node2 = root.append(new AstNode('b', 1));
     root.append(node);
     ok(root.firstChild === node2, 'root.firstChild');
     ok(root.lastChild === node, 'root.lastChild');
@@ -97,12 +97,12 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('remove unattached node', function () {
-    ok(!new Node('#text', 3).remove().parent);
+    ok(!new AstNode('#text', 3).remove().parent);
   });
 
   suite.test('remove single child', function () {
-    const root = new Node('#frag', 11);
-    root.append(new Node('p', 1));
+    const root = new AstNode('#frag', 11);
+    root.append(new AstNode('p', 1));
     const node = root.firstChild.remove();
     LegacyUnit.equal(root.firstChild, undefined);
     LegacyUnit.equal(root.lastChild, undefined);
@@ -113,10 +113,10 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('remove middle node', function () {
-    const root = new Node('#frag', 11);
-    const node = root.append(new Node('a', 1));
-    const node2 = root.append(new Node('b', 1));
-    const node3 = root.append(new Node('c', 1));
+    const root = new AstNode('#frag', 11);
+    const node = root.append(new AstNode('a', 1));
+    const node2 = root.append(new AstNode('b', 1));
+    const node3 = root.append(new AstNode('c', 1));
     node2.remove();
     LegacyUnit.equal(node2.parent, null);
     LegacyUnit.equal(node2.next, null);
@@ -130,10 +130,10 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('insert after last', function () {
-    const fragment = new Node('#frag', 11);
-    const root = fragment.append(new Node('body', 1));
-    const node = root.append(new Node('a', 1));
-    const node2 = root.insert(new Node('x', 1), node);
+    const fragment = new AstNode('#frag', 11);
+    const root = fragment.append(new AstNode('body', 1));
+    const node = root.append(new AstNode('a', 1));
+    const node2 = root.insert(new AstNode('x', 1), node);
     ok(root.firstChild === node, 'root.firstChild');
     ok(root.lastChild === node2, 'root.lastChild');
     ok(node.next === node2, 'node.next');
@@ -142,10 +142,10 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('insert before first', function () {
-    const fragment = new Node('#frag', 11);
-    const root = fragment.append(new Node('body', 1));
-    const node = root.append(new Node('a', 1));
-    const node2 = root.insert(new Node('x', 1), node, true);
+    const fragment = new AstNode('#frag', 11);
+    const root = fragment.append(new AstNode('body', 1));
+    const node = root.append(new AstNode('a', 1));
+    const node2 = root.insert(new AstNode('x', 1), node, true);
     ok(root.firstChild === node2, 'root.firstChild');
     ok(root.lastChild === node, 'root.lastChild');
     ok(node2.parent === root, 'node2.lastChild');
@@ -157,11 +157,11 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('insert before second', function () {
-    const fragment = new Node('#frag', 11);
-    const root = fragment.append(new Node('body', 1));
-    const node = root.append(new Node('a', 1));
-    const node2 = root.append(new Node('b', 1));
-    const node3 = root.insert(new Node('x', 1), node2, true);
+    const fragment = new AstNode('#frag', 11);
+    const root = fragment.append(new AstNode('body', 1));
+    const node = root.append(new AstNode('a', 1));
+    const node2 = root.append(new AstNode('b', 1));
+    const node3 = root.insert(new AstNode('x', 1), node2, true);
     ok(root.firstChild === node, 'root.firstChild');
     ok(root.lastChild === node2, 'root.lastChild');
     ok(node3.parent === root, 'node3.parent');
@@ -170,11 +170,11 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('insert after and between two nodes', function () {
-    const fragment = new Node('#frag', 11);
-    const root = fragment.append(new Node('body', 1));
-    const node = root.append(new Node('a', 1));
-    const node2 = root.append(new Node('b', 1));
-    const node3 = root.insert(new Node('x', 1), node);
+    const fragment = new AstNode('#frag', 11);
+    const root = fragment.append(new AstNode('body', 1));
+    const node = root.append(new AstNode('a', 1));
+    const node2 = root.append(new AstNode('b', 1));
+    const node3 = root.insert(new AstNode('x', 1), node);
     ok(root.firstChild === node, 'root.firstChild');
     ok(root.lastChild === node2, 'root.lastChild');
     ok(node.next === node3, 'node.next');
@@ -185,9 +185,9 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('replace single child', function () {
-    const root = new Node('#frag', 11);
-    const node1 = root.append(new Node('b', 1));
-    const node2 = root.append(new Node('em', 1));
+    const root = new AstNode('#frag', 11);
+    const node1 = root.append(new AstNode('b', 1));
+    const node2 = root.append(new AstNode('em', 1));
     node1.replace(node2);
     ok(root.firstChild === node2, 'root.firstChild');
     ok(root.lastChild === node2, 'root.lastChild');
@@ -197,10 +197,10 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('replace first child', function () {
-    const root = new Node('#frag', 11);
-    const node1 = root.append(new Node('b', 1));
-    const node2 = root.append(new Node('em', 1));
-    const node3 = root.append(new Node('b', 1));
+    const root = new AstNode('#frag', 11);
+    const node1 = root.append(new AstNode('b', 1));
+    const node2 = root.append(new AstNode('em', 1));
+    const node3 = root.append(new AstNode('b', 1));
     node1.replace(node2);
     ok(root.firstChild === node2, 'root.firstChild');
     ok(root.lastChild === node3, 'root.lastChild');
@@ -210,10 +210,10 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('replace last child', function () {
-    const root = new Node('#frag', 11);
-    const node1 = root.append(new Node('b', 1));
-    const node3 = root.append(new Node('b', 1));
-    const node2 = root.append(new Node('em', 1));
+    const root = new AstNode('#frag', 11);
+    const node1 = root.append(new AstNode('b', 1));
+    const node3 = root.append(new AstNode('b', 1));
+    const node2 = root.append(new AstNode('em', 1));
     node3.replace(node2);
     ok(root.firstChild === node1, 'root.firstChild');
     ok(root.lastChild === node2, 'root.lastChild');
@@ -223,11 +223,11 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('replace middle child', function () {
-    const root = new Node('#frag', 11);
-    const node1 = root.append(new Node('b', 1));
-    const node2 = root.append(new Node('b', 1));
-    const node3 = root.append(new Node('b', 1));
-    const node4 = root.append(new Node('em', 1));
+    const root = new AstNode('#frag', 11);
+    const node1 = root.append(new AstNode('b', 1));
+    const node2 = root.append(new AstNode('b', 1));
+    const node3 = root.append(new AstNode('b', 1));
+    const node4 = root.append(new AstNode('em', 1));
     node2.replace(node4);
     ok(root.firstChild === node1, 'root.firstChild');
     ok(root.lastChild === node3, 'root.lastChild');
@@ -239,7 +239,7 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   suite.test('attr', function () {
     let node;
 
-    node = new Node('b', 1);
+    node = new AstNode('b', 1);
     LegacyUnit.deepEqual(node.attributes, []);
     node.attr('attr1', 'value1');
     LegacyUnit.equal(node.attr('attr1'), 'value1');
@@ -247,7 +247,7 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
     LegacyUnit.deepEqual(node.attributes, [{ name: 'attr1', value: 'value1' }]);
     LegacyUnit.deepEqual(node.attributes.map, { attr1: 'value1' });
 
-    node = new Node('b', 1);
+    node = new AstNode('b', 1);
     LegacyUnit.deepEqual(node.attributes, []);
     node.attr('attr1', 'value1');
     node.attr('attr1', 'valueX');
@@ -255,7 +255,7 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
     LegacyUnit.deepEqual(node.attributes, [{ name: 'attr1', value: 'valueX' }]);
     LegacyUnit.deepEqual(node.attributes.map, { attr1: 'valueX' });
 
-    node = new Node('b', 1);
+    node = new AstNode('b', 1);
     LegacyUnit.deepEqual(node.attributes, []);
     node.attr('attr1', 'value1');
     node.attr('attr2', 'value2');
@@ -264,7 +264,7 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
     LegacyUnit.deepEqual(node.attributes, [{ name: 'attr1', value: 'value1' }, { name: 'attr2', value: 'value2' }]);
     LegacyUnit.deepEqual(node.attributes.map, { attr1: 'value1', attr2: 'value2' });
 
-    node = new Node('b', 1);
+    node = new AstNode('b', 1);
     LegacyUnit.deepEqual(node.attributes, []);
     node.attr('attr1', 'value1');
     node.attr('attr1', null);
@@ -272,12 +272,12 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
     LegacyUnit.deepEqual(node.attributes, []);
     LegacyUnit.deepEqual(node.attributes.map, {});
 
-    node = new Node('b', 1);
+    node = new AstNode('b', 1);
     node.attr({ a: '1', b: '2' });
     LegacyUnit.deepEqual(node.attributes, [{ name: 'a', value: '1' }, { name: 'b', value: '2' }]);
     LegacyUnit.deepEqual(node.attributes.map, { a: '1', b: '2' });
 
-    node = new Node('b', 1);
+    node = new AstNode('b', 1);
     node.attr(null);
     LegacyUnit.deepEqual(node.attributes, []);
     LegacyUnit.deepEqual(node.attributes.map, {});
@@ -286,7 +286,7 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   suite.test('clone', function () {
     let node, clone;
 
-    node = new Node('#text', 3);
+    node = new AstNode('#text', 3);
     node.value = 'value';
     clone = node.clone();
     LegacyUnit.equal(clone.name, '#text');
@@ -296,8 +296,8 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
     LegacyUnit.equal(clone.next, undefined);
     LegacyUnit.equal(clone.prev, undefined);
 
-    const root = new Node('#frag', 11);
-    node = new Node('#text', 3);
+    const root = new AstNode('#frag', 11);
+    node = new AstNode('#text', 3);
     node.value = 'value';
     root.append(node);
     LegacyUnit.equal(clone.name, '#text');
@@ -307,7 +307,7 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
     LegacyUnit.equal(clone.next, undefined);
     LegacyUnit.equal(clone.prev, undefined);
 
-    node = new Node('b', 1);
+    node = new AstNode('b', 1);
     node.attr('id', 'id');
     node.attr('class', 'class');
     node.attr('title', 'title');
@@ -321,18 +321,18 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   suite.test('unwrap', function () {
     let root, node1, node2;
 
-    root = new Node('#frag', 11);
-    node1 = root.append(new Node('b', 1));
-    node2 = node1.append(new Node('em', 1));
+    root = new AstNode('#frag', 11);
+    node1 = root.append(new AstNode('b', 1));
+    node2 = node1.append(new AstNode('em', 1));
     node1.unwrap();
     ok(root.firstChild === node2, 'root.firstChild');
     ok(root.lastChild === node2, 'root.lastChild');
     ok(node2.parent === root, 'node2.parent');
 
-    root = new Node('#frag', 11);
-    node1 = root.append(new Node('b', 1));
-    node2 = node1.append(new Node('em', 1));
-    const node3 = node1.append(new Node('span', 1));
+    root = new AstNode('#frag', 11);
+    node1 = root.append(new AstNode('b', 1));
+    node2 = node1.append(new AstNode('em', 1));
+    const node3 = node1.append(new AstNode('span', 1));
     node1.unwrap();
     ok(root.firstChild === node2, 'root.firstChild');
     ok(root.lastChild === node3, 'root.lastChild');
@@ -341,8 +341,8 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   });
 
   suite.test('empty', function () {
-    const root = new Node('#frag', 11);
-    const node1 = root.append(new Node('b', 1));
+    const root = new AstNode('#frag', 11);
+    const node1 = root.append(new AstNode('b', 1));
     node1.empty();
     ok(root.firstChild === node1, 'root.firstChild');
     ok(root.lastChild === node1, 'root.firstChild');
@@ -353,46 +353,46 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', function (success, fail
   suite.test('isEmpty', function () {
     let root, node1, node2;
 
-    root = new Node('#frag', 11);
-    node1 = root.append(new Node('p', 1));
-    node2 = node1.append(new Node('b', 1));
+    root = new AstNode('#frag', 11);
+    node1 = root.append(new AstNode('p', 1));
+    node2 = node1.append(new AstNode('b', 1));
     ok(root.isEmpty({ img: 1 }), 'Is empty 1');
     ok(node1.isEmpty({ img: 1 }), 'Is empty 2');
 
-    root = new Node('#frag', 11);
-    node1 = root.append(new Node('p', 1));
-    node2 = node1.append(new Node('img', 1));
+    root = new AstNode('#frag', 11);
+    node1 = root.append(new AstNode('p', 1));
+    node2 = node1.append(new AstNode('img', 1));
     ok(!root.isEmpty({ img: 1 }), 'Is not empty 1');
     ok(!node1.isEmpty({ img: 1 }), 'Is not empty 2');
 
-    root = new Node('#frag', 11);
-    node1 = root.append(new Node('p', 1));
-    node2 = node1.append(new Node('#text', 3));
+    root = new AstNode('#frag', 11);
+    node1 = root.append(new AstNode('p', 1));
+    node2 = node1.append(new AstNode('#text', 3));
     node2.value = 'X';
     ok(!root.isEmpty({ img: 1 }), 'Is not empty 3');
     ok(!node1.isEmpty({ img: 1 }), 'Is not empty 4');
 
-    root = new Node('#frag', 11);
-    node1 = root.append(new Node('p', 1));
-    node2 = node1.append(new Node('#text', 3));
+    root = new AstNode('#frag', 11);
+    node1 = root.append(new AstNode('p', 1));
+    node2 = node1.append(new AstNode('#text', 3));
     node2.value = '';
     ok(root.isEmpty({ img: 1 }), 'Is empty 4');
     ok(node1.isEmpty({ img: 1 }), 'Is empty 5');
 
-    root = new Node('#frag', 11);
-    node1 = root.append(new Node('a', 1)).attr('name', 'x');
+    root = new AstNode('#frag', 11);
+    node1 = root.append(new AstNode('a', 1)).attr('name', 'x');
     ok(!root.isEmpty({ img: 1 }), 'Contains anchor with name attribute.');
 
     const isSpan = function (node) {
       return node.name === 'span';
     };
 
-    root = new Node('#frag', 11);
-    node1 = root.append(new Node('span', 1));
+    root = new AstNode('#frag', 11);
+    node1 = root.append(new AstNode('span', 1));
     LegacyUnit.equal(root.isEmpty({ img: 1 }, {}, isSpan), false, 'Should be false since the predicate says true.');
 
-    root = new Node('#frag', 11);
-    node1 = root.append(new Node('b', 1));
+    root = new AstNode('#frag', 11);
+    node1 = root.append(new AstNode('b', 1));
     LegacyUnit.equal(root.isEmpty({ img: 1 }, {}, isSpan), true, 'Should be true since the predicate says false.');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
@@ -3,13 +3,13 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { LegacyUnit } from '@ephox/mcagar';
 import DomParser from 'tinymce/core/api/html/DomParser';
 import Schema from 'tinymce/core/api/html/Schema';
-import Serializer from 'tinymce/core/api/html/Serializer';
+import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 
 UnitTest.asynctest('browser.tinymce.core.html.SerializerTest', function (success, failure) {
   const suite = LegacyUnit.createSuite();
 
   suite.test('Basic serialization', function () {
-    const serializer = Serializer();
+    const serializer = HtmlSerializer();
 
     LegacyUnit.equal(serializer.serialize(DomParser().parse('text<text&')), 'text&lt;text&amp;');
     LegacyUnit.equal(
@@ -23,7 +23,7 @@ UnitTest.asynctest('browser.tinymce.core.html.SerializerTest', function (success
   });
 
   suite.test('Sorting of attributes', function () {
-    const serializer = Serializer();
+    const serializer = HtmlSerializer();
 
     LegacyUnit.equal(
       serializer.serialize(DomParser().parse('<b class="class" id="id">x</b>')),
@@ -33,7 +33,7 @@ UnitTest.asynctest('browser.tinymce.core.html.SerializerTest', function (success
 
   suite.test('Serialize with validate: true, when parsing with validate:false bug', function () {
     const schema = Schema({ valid_elements: 'b' });
-    const serializer = Serializer({}, schema);
+    const serializer = HtmlSerializer({}, schema);
 
     LegacyUnit.equal(
       serializer.serialize(DomParser({ validate: false }, schema).parse('<b a="1" b="2">a</b><i a="1" b="2">b</i>')),

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
@@ -5,14 +5,14 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Node from 'tinymce/core/api/html/Node';
 import Editor from 'tinymce/core/api/Editor';
+import AstNode from 'tinymce/core/api/html/Node';
 
 // Note: node.firstChild check is for the 'allow_html_in_named_anchor' setting
 // Only want to add contenteditable attributes if there is no text within the anchor
-const isNamedAnchorNode = (node: Node) => !node.attr('href') && (node.attr('id') || node.attr('name')) && !node.firstChild;
+const isNamedAnchorNode = (node: AstNode) => !node.attr('href') && (node.attr('id') || node.attr('name')) && !node.firstChild;
 
-const setContentEditable = (state: string | null) => (nodes: Node[]) => {
+const setContentEditable = (state: string | null) => (nodes: AstNode[]) => {
   for (let i = 0; i < nodes.length; i++) {
     if (isNamedAnchorNode(nodes[i])) {
       nodes[i].attr('contenteditable', state);

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
@@ -7,8 +7,8 @@
 
 import Editor from 'tinymce/core/api/Editor';
 import DomParser from 'tinymce/core/api/html/DomParser';
-import Node from 'tinymce/core/api/html/Node';
-import Serializer from 'tinymce/core/api/html/Serializer';
+import AstNode from 'tinymce/core/api/html/Node';
+import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 
@@ -60,7 +60,7 @@ const htmlToData = function (editor: Editor, head: string) {
   }
 
   // Parse meta elements
-  Tools.each<Node>(headerFragment.getAll('meta'), function (meta) {
+  Tools.each<AstNode>(headerFragment.getAll('meta'), function (meta) {
     const name = meta.attr('name');
     const httpEquiv = meta.attr('http-equiv');
     let matches;
@@ -123,7 +123,7 @@ const dataToHtml = function (editor: Editor, data, head) {
   headElement = headerFragment.getAll('head')[0];
   if (!headElement) {
     elm = headerFragment.getAll('html')[0];
-    headElement = new Node('head', 1);
+    headElement = new AstNode('head', 1);
 
     if (elm.firstChild) {
       elm.insert(headElement, elm.firstChild, true);
@@ -142,7 +142,7 @@ const dataToHtml = function (editor: Editor, data, head) {
     }
 
     if (elm.type !== 7) {
-      elm = new Node('xml', 7);
+      elm = new AstNode('xml', 7);
       headerFragment.insert(elm, headerFragment.firstChild, true);
     }
 
@@ -155,7 +155,7 @@ const dataToHtml = function (editor: Editor, data, head) {
   elm = headerFragment.getAll('#doctype')[0];
   if (data.doctype) {
     if (!elm) {
-      elm = new Node('#doctype', 10);
+      elm = new AstNode('#doctype', 10);
 
       if (data.xml_pi) {
         headerFragment.insert(elm, headerFragment.firstChild);
@@ -179,7 +179,7 @@ const dataToHtml = function (editor: Editor, data, head) {
 
   if (data.docencoding) {
     if (!elm) {
-      elm = new Node('meta', 1);
+      elm = new AstNode('meta', 1);
       elm.attr('http-equiv', 'Content-Type');
       elm.shortEnded = true;
       addHeadNode(elm);
@@ -194,13 +194,13 @@ const dataToHtml = function (editor: Editor, data, head) {
   elm = headerFragment.getAll('title')[0];
   if (data.title) {
     if (!elm) {
-      elm = new Node('title', 1);
+      elm = new AstNode('title', 1);
       addHeadNode(elm);
     } else {
       elm.empty();
     }
 
-    elm.append(new Node('#text', 3)).value = data.title;
+    elm.append(new AstNode('#text', 3)).value = data.title;
   } else if (elm) {
     elm.remove();
   }
@@ -226,7 +226,7 @@ const dataToHtml = function (editor: Editor, data, head) {
     }
 
     if (value) {
-      elm = new Node('meta', 1);
+      elm = new AstNode('meta', 1);
       elm.attr('name', name);
       elm.attr('content', value);
       elm.shortEnded = true;
@@ -235,7 +235,7 @@ const dataToHtml = function (editor: Editor, data, head) {
     }
   });
 
-  const currentStyleSheetsMap: Record<string, Node> = {};
+  const currentStyleSheetsMap: Record<string, AstNode> = {};
   Tools.each(headerFragment.getAll('link'), function (stylesheet) {
     if (stylesheet.attr('rel') === 'stylesheet') {
       currentStyleSheetsMap[stylesheet.attr('href')] = stylesheet;
@@ -245,7 +245,7 @@ const dataToHtml = function (editor: Editor, data, head) {
   // Add new
   Tools.each(data.stylesheets, function (stylesheet) {
     if (!currentStyleSheetsMap[stylesheet]) {
-      elm = new Node('link', 1);
+      elm = new AstNode('link', 1);
       elm.attr({
         rel: 'stylesheet',
         text: 'text/css',
@@ -295,7 +295,7 @@ const dataToHtml = function (editor: Editor, data, head) {
   }
 
   // Serialize header fragment and crop away body part
-  const html = Serializer({
+  const html = HtmlSerializer({
     validate: false,
     indent: true,
     indent_before: 'head,html,body,meta,title,script,link,style',

--- a/modules/tinymce/src/plugins/image/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/FilterContent.ts
@@ -5,19 +5,19 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Tools from 'tinymce/core/api/util/Tools';
-import Node from 'tinymce/core/api/html/Node';
 import Editor from 'tinymce/core/api/Editor';
+import AstNode from 'tinymce/core/api/html/Node';
+import Tools from 'tinymce/core/api/util/Tools';
 
-const hasImageClass = (node: Node) => {
+const hasImageClass = (node: AstNode) => {
   const className = node.attr('class');
   return className && /\bimage\b/.test(className);
 };
 
-const toggleContentEditableState = (state: boolean) => (nodes: Node[]) => {
+const toggleContentEditableState = (state: boolean) => (nodes: AstNode[]) => {
   let i = nodes.length;
 
-  const toggleContentEditable = (node: Node) => {
+  const toggleContentEditable = (node: AstNode) => {
     node.attr('contenteditable', state ? 'true' : null);
   };
 

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -7,7 +7,7 @@
 
 import { Element, HTMLAnchorElement, Node, Range } from '@ephox/dom-globals';
 import { Arr, Obj, Option, Type } from '@ephox/katamari';
-import TreeWalker from 'tinymce/core/api/dom/TreeWalker';
+import DomTreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
@@ -22,7 +22,7 @@ const collectNodesInRange = <T extends Node>(rng: Range, predicate: (node) => no
     return [];
   } else {
     const contents = rng.cloneContents();
-    const walker = new TreeWalker(contents.firstChild, contents);
+    const walker = new DomTreeWalker(contents.firstChild, contents);
     const elements: T[] = [];
     let current = contents.firstChild;
     do {

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -10,7 +10,7 @@ import { Arr } from '@ephox/katamari';
 import { Compare, SugarElement } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import RangeUtils from 'tinymce/core/api/dom/RangeUtils';
-import TreeWalker from 'tinymce/core/api/dom/TreeWalker';
+import DomTreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import Editor from 'tinymce/core/api/Editor';
 import VK from 'tinymce/core/api/util/VK';
 import { flattenListSelection, outdentListSelection } from '../actions/Indendation';
@@ -34,7 +34,7 @@ const findNextCaretContainer = function (editor: Editor, rng: Range, isForward: 
     node = RangeUtils.getNode(node, offset);
   }
 
-  const walker = new TreeWalker(node, root);
+  const walker = new DomTreeWalker(node, root);
 
   // Delete at <li>|<br></li> then jump over the bogus br
   if (isForward) {

--- a/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
@@ -6,7 +6,7 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
-import Node from 'tinymce/core/api/html/Node';
+import AstNode from 'tinymce/core/api/html/Node';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Nodes from './Nodes';
 import * as Sanitize from './Sanitize';
@@ -55,7 +55,7 @@ const setup = function (editor: Editor) {
         }
 
         realElmName = node.attr(name);
-        realElm = new Node(realElmName, 1);
+        realElm = new AstNode(realElmName, 1);
 
         // Add width/height to everything but audio
         if (realElmName !== 'audio' && realElmName !== 'script') {
@@ -95,7 +95,7 @@ const setup = function (editor: Editor) {
         // Inject innerhtml
         innerHtml = node.attr('data-mce-html');
         if (innerHtml) {
-          innerNode = new Node('#text', 3);
+          innerNode = new AstNode('#text', 3);
           innerNode.raw = true;
           innerNode.value = Sanitize.sanitize(editor, unescape(innerHtml));
           realElm.append(innerNode);

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -7,17 +7,17 @@
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import Node from 'tinymce/core/api/html/Node';
+import AstNode from 'tinymce/core/api/html/Node';
 import * as Settings from '../api/Settings';
 import * as Sanitize from './Sanitize';
 import * as VideoScript from './VideoScript';
 
 declare let escape: any;
 
-const createPlaceholderNode = function (editor: Editor, node: Node) {
+const createPlaceholderNode = function (editor: Editor, node: AstNode) {
   const name = node.name;
 
-  const placeHolder = new Node('img', 1);
+  const placeHolder = new AstNode('img', 1);
   placeHolder.shortEnded = true;
 
   retainAttributesAndInnerHtml(editor, node, placeHolder);
@@ -34,10 +34,10 @@ const createPlaceholderNode = function (editor: Editor, node: Node) {
   return placeHolder;
 };
 
-const createPreviewIframeNode = function (editor: Editor, node: Node) {
+const createPreviewIframeNode = function (editor: Editor, node: AstNode) {
   const name = node.name;
 
-  const previewWrapper = new Node('span', 1);
+  const previewWrapper = new AstNode('span', 1);
   previewWrapper.attr({
     'contentEditable': 'false',
     'style': node.attr('style'),
@@ -47,7 +47,7 @@ const createPreviewIframeNode = function (editor: Editor, node: Node) {
 
   retainAttributesAndInnerHtml(editor, node, previewWrapper);
 
-  const previewNode = new Node(name, 1);
+  const previewNode = new AstNode(name, 1);
   previewNode.attr({
     src: node.attr('src'),
     allowfullscreen: node.attr('allowfullscreen'),
@@ -58,7 +58,7 @@ const createPreviewIframeNode = function (editor: Editor, node: Node) {
     frameborder: '0'
   });
 
-  const shimNode = new Node('span', 1);
+  const shimNode = new AstNode('span', 1);
   shimNode.attr('class', 'mce-shim');
 
   previewWrapper.append(previewNode);
@@ -67,7 +67,7 @@ const createPreviewIframeNode = function (editor: Editor, node: Node) {
   return previewWrapper;
 };
 
-const retainAttributesAndInnerHtml = function (editor: Editor, sourceNode: Node, targetNode: Node) {
+const retainAttributesAndInnerHtml = function (editor: Editor, sourceNode: AstNode, targetNode: AstNode) {
   let attrName;
   let attrValue;
   let ai;
@@ -98,12 +98,12 @@ const retainAttributesAndInnerHtml = function (editor: Editor, sourceNode: Node,
   }
 };
 
-const isPageEmbedWrapper = (node: Node) => {
+const isPageEmbedWrapper = (node: AstNode) => {
   const nodeClass = node.attr('class');
   return nodeClass && /\btiny-pageembed\b/.test(nodeClass);
 };
 
-const isWithinEmbedWrapper = function (node: Node) {
+const isWithinEmbedWrapper = function (node: AstNode) {
   while ((node = node.parent)) {
     if (node.attr('data-ephox-embed-iri') || isPageEmbedWrapper(node)) {
       return true;

--- a/modules/tinymce/src/plugins/paste/main/ts/core/ProcessFilters.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/ProcessFilters.ts
@@ -7,11 +7,11 @@
 
 import Editor from 'tinymce/core/api/Editor';
 import DomParser from 'tinymce/core/api/html/DomParser';
-import Serializer from 'tinymce/core/api/html/Serializer';
+import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Events from '../api/Events';
-import * as WordFilter from './WordFilter';
 import * as Settings from '../api/Settings';
+import * as WordFilter from './WordFilter';
 
 const preProcess = (editor: Editor, html: string) => {
   const parser = DomParser({ }, editor.schema);
@@ -22,7 +22,7 @@ const preProcess = (editor: Editor, html: string) => {
   });
 
   const fragment = parser.parse(html, { forced_root_block: false, isRootContent: true });
-  return Serializer({ validate: Settings.getValidate(editor) }, editor.schema).serialize(fragment);
+  return HtmlSerializer({ validate: Settings.getValidate(editor) }, editor.schema).serialize(fragment);
 };
 
 const processResult = function (content: string, cancelled: boolean) {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/WordFilter.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/WordFilter.ts
@@ -8,9 +8,9 @@
 import { Unicode } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import DomParser from 'tinymce/core/api/html/DomParser';
-import Node from 'tinymce/core/api/html/Node';
+import AstNode from 'tinymce/core/api/html/Node';
 import Schema from 'tinymce/core/api/html/Schema';
-import Serializer from 'tinymce/core/api/html/Serializer';
+import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 import * as Utils from './Utils';
@@ -140,7 +140,7 @@ function convertFakeListsToProperLists(node) {
 
     if (!currentListNode || currentListNode.name !== listName) {
       prevListNode = prevListNode || currentListNode;
-      currentListNode = new Node(listName, 1);
+      currentListNode = new AstNode(listName, 1);
 
       if (start > 1) {
         currentListNode.attr('start', '' + start);
@@ -303,13 +303,13 @@ function filterStyles(editor, validStyles, node, styleValue) {
   // Convert bold style to "b" element
   if (/(bold)/i.test(outputStyles['font-weight'])) {
     delete outputStyles['font-weight'];
-    node.wrap(new Node('b', 1));
+    node.wrap(new AstNode('b', 1));
   }
 
   // Convert italic style to "i" element
   if (/(italic)/i.test(outputStyles['font-style'])) {
     delete outputStyles['font-style'];
-    node.wrap(new Node('i', 1));
+    node.wrap(new AstNode('i', 1));
   }
 
   // Serialize the styles and see if there is something left to keep
@@ -473,7 +473,7 @@ const filterWordContent = function (editor: Editor, content: string) {
   }
 
   // Serialize DOM back to HTML
-  content = Serializer({
+  content = HtmlSerializer({
     validate: Settings.getValidate(editor)
   }, schema).serialize(rootNode);
 

--- a/modules/tinymce/src/plugins/quickbars/main/ts/selection/Unlink.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/selection/Unlink.ts
@@ -7,7 +7,7 @@
 
 import { HTMLElement, Node } from '@ephox/dom-globals';
 import RangeUtils from 'tinymce/core/api/dom/RangeUtils';
-import TreeWalker from 'tinymce/core/api/dom/TreeWalker';
+import DomTreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Bookmark from './Bookmark';
@@ -23,7 +23,7 @@ const getSelectedElements = function (rootElm: HTMLElement, startNode: Node, end
   let node;
   const elms = [];
 
-  const walker = new TreeWalker(startNode, rootElm);
+  const walker = new DomTreeWalker(startNode, rootElm);
   for (node = startNode; node; node = walker.next()) {
     if (node.nodeType === 1) {
       elms.push(node);

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/FindMark.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/FindMark.ts
@@ -9,7 +9,7 @@ import { HTMLElement, Node } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import { Attribute, Insert, SugarElement, SugarText } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
-import Selection from 'tinymce/core/api/dom/Selection';
+import EditorSelection from 'tinymce/core/api/dom/Selection';
 import * as TextCollect from './TextCollect';
 import * as TextPosition from './TextPosition';
 import { Pattern, TextMatch, TextSection } from './Types';
@@ -49,7 +49,7 @@ const findAndMark = (dom: DOMUtils, pattern: Pattern, node: Node, replacementNod
   return matches.length;
 };
 
-const findAndMarkInSelection = (dom: DOMUtils, pattern: Pattern, selection: Selection, replacementNode: HTMLElement) => {
+const findAndMarkInSelection = (dom: DOMUtils, pattern: Pattern, selection: EditorSelection, replacementNode: HTMLElement) => {
   const bookmark = selection.getBookmark();
 
   // Handle table cell selection as the table plugin enables

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
@@ -10,7 +10,7 @@ import { Arr, Fun, Obj } from '@ephox/katamari';
 import { SandNode } from '@ephox/sand';
 import { SelectorFilter, SugarElement, Traverse } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
-import TreeWalker from 'tinymce/core/api/dom/TreeWalker';
+import DomTreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import { TextSection } from './Types';
 
 interface WalkerCallbacks {
@@ -75,7 +75,7 @@ const collectTextToBoundary = (dom: DOMUtils, section: TextSection, node: Node, 
   }
 
   const rootBlock = dom.getParent(rootNode, dom.isBlock);
-  const walker = new TreeWalker(node, rootBlock);
+  const walker = new DomTreeWalker(node, rootBlock);
   const walkerFn = forwards ? walker.next : walker.prev;
 
   // Walk over and add text nodes to the section and increase the offsets
@@ -95,7 +95,7 @@ const collectTextToBoundary = (dom: DOMUtils, section: TextSection, node: Node, 
 };
 
 const collect = (dom: DOMUtils, rootNode: Node, startNode: Node, endNode?: Node, callbacks?: CollectCallbacks, skipStart: boolean = true) => {
-  const walker = new TreeWalker(startNode, rootNode);
+  const walker = new DomTreeWalker(startNode, rootNode);
   const sections: TextSection[] = [];
   let current: TextSection = nuSection();
 

--- a/modules/tinymce/src/plugins/wordcount/main/ts/core/GetText.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/core/GetText.ts
@@ -7,7 +7,7 @@
 
 import { Node, Text } from '@ephox/dom-globals';
 import { Unicode } from '@ephox/katamari';
-import TreeWalker from 'tinymce/core/api/dom/TreeWalker';
+import DomTreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import Schema, { SchemaMap } from 'tinymce/core/api/html/Schema';
 
 const getText = (node: Node, schema: Schema): string[] => {
@@ -18,7 +18,7 @@ const getText = (node: Node, schema: Schema): string[] => {
 
   const textBlocks: string[] = [];
   let txt = '';
-  const treeWalker = new TreeWalker(node, node);
+  const treeWalker = new DomTreeWalker(node, node);
 
   while ((node = treeWalker.next())) {
     if (node.nodeType === 3) {


### PR DESCRIPTION
Related Ticket: TINY-3785

Description of Changes:
This is similar to #5897 except this time it's the TinyMCE modules, which can't be renamed publicly. As such I've kept the filenames and exported variable names the same and instead only renamed the types and internal class/variable names. This also removes the last of the aliasing of dom globals.

Here's what's been renamed (let me know if you have a better suggestion):
* `Node` -> `AstNode`
* `Selection` -> `EditorSelection` (also considered DomSelection) 
* `TreeWalker` -> `DomTreeWalker`
* `Serializer` -> `DomSerializer`
* `Serializer` -> `HtmlSerializer`

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
