### PR TITLE
TINY-6256: Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false`

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,3 +1,5 @@
+Version 5.4.2 (TBD)
+    Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false` #TINY-6256
 Version 5.4.1 (2020-07-08)
     Fixed the Search and Replace plugin incorrectly including zero-width caret characters in search results #TINY-4599
     Fixed dragging and dropping unsupported files navigating the browser away from the editor #TINY-6027

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -48,8 +48,8 @@ interface BaseEditorSettings {
   allow_html_in_named_anchor?: boolean;
   allow_script_urls?: boolean;
   allow_unsafe_link_target?: boolean;
-  anchor_bottom?: boolean | string;
-  anchor_top?: boolean | string;
+  anchor_bottom?: false | string;
+  anchor_top?: false | string;
   auto_focus?: string | true;
   automatic_uploads?: boolean;
   base_url?: string;

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AnchorFalseTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AnchorFalseTest.ts
@@ -1,0 +1,51 @@
+import { Chain, FocusTools, Log, Pipeline, Step, UiFinder } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { Body, Document } from '@ephox/sugar';
+import LocalStorage from 'tinymce/core/api/util/LocalStorage';
+import LinkPlugin from 'tinymce/plugins/link/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+
+import { TestLinkUi } from '../module/TestLinkUi';
+
+UnitTest.asynctest('browser.tinymce.plugins.link.AnchorFalseTest', (success, failure) => {
+  SilverTheme();
+  LinkPlugin();
+
+  TinyLoader.setup((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+    const tinyUi = TinyUi(editor);
+    const doc = Document.getDocument();
+
+    Pipeline.async({}, [
+      tinyApis.sFocus(),
+      Step.sync(() => {
+        LocalStorage.setItem('tinymce-url-history', JSON.stringify({
+          file: [ 'http://www.tiny.cloud/' ]
+        }));
+      }),
+      Log.stepsAsStep('TINY-6256', 'With anchor top/bottom set to false, they shouldn\'t be shown in the url list options', [
+        TestLinkUi.sOpenLinkDialog(tinyUi),
+        FocusTools.sSetActiveValue(doc, 't'),
+        Chain.asStep(doc, [
+          FocusTools.cGetFocused,
+          TestLinkUi.cFireEvent('input')
+        ]),
+        tinyUi.sWaitForUi('Wait for the typeahead to open', '.tox-dialog__popups .tox-menu'),
+        UiFinder.sNotExists(Body.body(), '.tox-dialog__popups .tox-menu .tox-collection__item:contains(<top>)'),
+        UiFinder.sNotExists(Body.body(), '.tox-dialog__popups .tox-menu .tox-collection__item:contains(<bottom>)')
+      ]),
+      Step.sync(() => {
+        LocalStorage.removeItem('tinymce-url-history');
+      })
+    ], onSuccess, onFailure);
+  }, {
+    theme: 'silver',
+    plugins: 'link',
+    toolbar: 'link',
+    menubar: false,
+    base_url: '/project/tinymce/js/tinymce',
+    anchor_top: false,
+    anchor_bottom: false
+  }, success, failure);
+});

--- a/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Option, Obj, Type } from '@ephox/katamari';
+import { Arr, Obj, Option, Type } from '@ephox/katamari';
 import { Body, Element, SelectorFind } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -142,9 +142,9 @@ const getFileBrowserCallbackTypes = (editor: Editor) => editor.getParam('file_br
 
 const noTypeaheadUrls = (editor: Editor) => editor.getParam('typeahead_urls') === false;
 
-const getAnchorTop = (editor: Editor): string => editor.getParam('anchor_top', '#top', 'string');
+const getAnchorTop = (editor: Editor): string | false => editor.getParam('anchor_top', '#top');
 
-const getAnchorBottom = (editor: Editor): string => editor.getParam('anchor_bottom', '#bottom', 'string');
+const getAnchorBottom = (editor: Editor): string | false => editor.getParam('anchor_bottom', '#bottom');
 
 const getFilePickerValidatorHandler = (editor: Editor) => {
   const handler = editor.getParam('file_picker_validator_handler', undefined, 'function');

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
@@ -10,9 +10,9 @@ import { Future, Obj, Option, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
+import * as Settings from '../api/Settings';
 import { LinkTarget, LinkTargets } from '../ui/core/LinkTargets';
 import { addToHistory, getHistory } from './UrlInputHistory';
-import * as Settings from '../api/Settings';
 
 type PickerCallback = (value: string, meta: Record<string, any>) => void;
 type Picker = (callback: PickerCallback, value: string, meta: Record<string, any>) => void;
@@ -65,8 +65,8 @@ const makeMap = (value: any): Record<string, boolean> => Obj.map(Tools.makeMap(v
 const getPicker = (editor: Editor): Option<Picker> => Option.from(Settings.getFilePickerCallback(editor)).filter(Type.isFunction) as Option<Picker>;
 
 const getPickerTypes = (editor: Editor): boolean | Record<string, boolean> => {
-  const optFileTypes = Option.some(Settings.getFilePickerTypes(editor)).filter(isTruthy);;
-  const optLegacyTypes = Option.some(Settings.getFileBrowserCallbackTypes(editor)).filter(isTruthy);;
+  const optFileTypes = Option.some(Settings.getFilePickerTypes(editor)).filter(isTruthy);
+  const optLegacyTypes = Option.some(Settings.getFileBrowserCallbackTypes(editor)).filter(isTruthy);
   const optTypes = optFileTypes.or(optLegacyTypes).map(makeMap);
   return getPicker(editor).fold(
     () => false,
@@ -105,6 +105,8 @@ const getUrlPicker = (editor: Editor, filetype: string): Option<UrlPicker> => ge
   picker.call(editor, handler, entry.value, meta);
 }));
 
+const getTextSetting = (value: string | boolean): string | undefined => Option.from(value).filter(Type.isString).getOrUndefined();
+
 export const getLinkInformation = (editor: Editor): Option<LinkInformation> => {
   if (Settings.noTypeaheadUrls(editor)) {
     return Option.none();
@@ -112,8 +114,8 @@ export const getLinkInformation = (editor: Editor): Option<LinkInformation> => {
 
   return Option.some({
     targets: LinkTargets.find(editor.getBody()),
-    anchorTop: Settings.getAnchorTop(editor),
-    anchorBottom: Settings.getAnchorBottom(editor)
+    anchorTop: getTextSetting(Settings.getAnchorTop(editor)),
+    anchorBottom: getTextSetting(Settings.getAnchorBottom(editor))
   });
 };
 export const getValidationHandler = (editor: Editor): Option<UrlValidationHandler> => Option.from(Settings.getFilePickerValidatorHandler(editor));


### PR DESCRIPTION
Related Ticket: TINY-6256

Description of Changes:
This fixes a regression introduced in 5.4.0 via 5ceb2d15cc20a42b3224392759efa05a17443666, as it was changed so that the setting would only allow string values, which is incorrect as it should be `false | string`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #5904 