### PR TITLE
Added ability to pass custom container via init config

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -259,6 +259,7 @@ class Editor implements EditorObservable {
   public serializer: DomSerializer;
   public startContent: string;
   public targetElm: HTMLElement;
+  public targetContainer?: HTMLElement;
   public theme: Theme;
   public undoManager: UndoManager;
   public validate: boolean;

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -492,6 +492,7 @@ const EditorManager: EditorManager = {
         });
 
         editor.targetElm = editor.targetElm || targetElm;
+        editor.targetContainer = editor.targetContainer || settings.targetContainer;
         editor.render();
       };
 

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -164,6 +164,7 @@ interface BaseEditorSettings {
   submit_patch?: boolean;
   suffix?: string;
   target?: HTMLElement;
+  targetContainer?: HTMLElement;
   theme?: string | ThemeInitFunc;
   theme_url?: string;
   toolbar?: boolean | string | string[] | Array<ToolbarGroup>;

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -72,6 +72,7 @@ export interface RenderUiConfig extends RenderToolbarConfig {
 
 export interface RenderArgs {
   targetNode: HTMLElement;
+  targetContainer: HTMLElement;
   height: string;
 }
 
@@ -389,9 +390,10 @@ const setup = (editor: Editor): RenderInfo => {
 
     const elm = editor.getElement();
     const height = setEditorSize();
+    const targetContainer = editor.targetContainer;
 
     const uiComponents: RenderUiComponents = { mothership, uiMothership, outerContainer };
-    const args: RenderArgs = { targetNode: elm, height };
+    const args: RenderArgs = { targetNode: elm, height, targetContainer };
     return mode.render(editor, uiComponents, rawUiConfig, backstage, args);
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -75,7 +75,8 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
   loadIframeSkin(editor);
 
   const eTargetNode = Element.fromDom(args.targetNode);
-  const uiRoot = ShadowDom.getContentContainer(ShadowDom.getRootNode(eTargetNode));
+  const eContainerNode = args.targetContainer && Element.fromDom(args.targetContainer);
+  const uiRoot = eContainerNode || ShadowDom.getContentContainer(ShadowDom.getRootNode(eTargetNode));
 
   Attachment.attachSystemAfter(eTargetNode, uiComponents.mothership);
   Attachment.attachSystem(uiRoot, uiComponents.uiMothership);


### PR DESCRIPTION
Description of Changes:
The main issue is that the portals are created inside the body element and cannot be changed here.
This PR adds a new parameter for settings: **targetContainer**. If the **targetContainer** exists, it will be used as a parent for the portals.

GitHub issues (if applicable):
https://github.com/tinymce/tinymce/issues/5097
https://github.com/tinymce/tinymce/issues/5905