### PR TITLE
TINY-6271: Fixed IE 11 throwing an exception when the previous context toolbar element is no longer attached to the dom

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.4.2 (TBD)
     Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false` #TINY-6256
+    Fixed an exception thrown when positioning the context toolbar on Internet Explorer 11 in some edge cases #TINY-6271
 Version 5.4.1 (2020-07-08)
     Fixed the Search and Replace plugin incorrectly including zero-width caret characters in search results #TINY-4599
     Fixed dragging and dropping unsupported files navigating the browser away from the editor #TINY-6027

--- a/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
@@ -6,14 +6,14 @@
  */
 
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, AnchorSpec, Behaviour, Boxes, Bubble, GuiFactory, InlineView,
-  Keying, Layout, LayoutInside, MaxHeight, MaxWidth, Positioning
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, AnchorSpec, Behaviour, Boxes, Bubble, GuiFactory, InlineView, Keying,
+  Layout, LayoutInside, MaxHeight, MaxWidth, Positioning
 } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
 import { Element as DomElement } from '@ephox/dom-globals';
 import { Arr, Cell, Id, Merger, Obj, Option, Thunk } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Css, Element, Focus, Scroll } from '@ephox/sugar';
+import { Body, Css, Element, Focus, Scroll } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
 import { getToolbarMode, ToolbarMode } from './api/Settings';
@@ -104,7 +104,10 @@ const register = (editor: Editor, registryContextToolbars, sink: AlloyComponent,
   const isRangeOverlapping = (aTop: number, aBottom: number, bTop: number, bBottom: number) => Math.max(aTop, bTop) <= Math.min(aBottom, bBottom);
 
   const getLastElementVerticalBound = () => {
-    const nodeBounds = lastElement.get().map((ele) => ele.getBoundingClientRect()).getOrThunk(() => editor.selection.getRng().getBoundingClientRect());
+    const nodeBounds = lastElement.get()
+      .filter((ele) => Body.inBody(Element.fromDom(ele)))
+      .map((ele) => ele.getBoundingClientRect())
+      .getOrThunk(() => editor.selection.getRng().getBoundingClientRect());
 
     // Translate to the top level document, as nodeBounds is relative to the iframe viewport
     const diffTop = editor.inline ? Scroll.get().top() : Boxes.absolute(Element.fromDom(editor.getBody())).y;


### PR DESCRIPTION
Related Ticket: TINY-6271

Description of Changes:
* This fixes an exception that was being thrown on IE 11 due to the previous element no longer being in the dom, since it'd been overwritten when pasting in content.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ (as discussed on slack, we couldn't think of a way to test this)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
