### PR TITLE
TINY-6058: Fixed clicking on notifications causing inline editors to hide

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.4.2 (TBD)
+    Fixed clicking on notifications causing inline editors to hide #TINY-6058
     Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false` #TINY-6256
     Fixed an exception thrown when positioning the context toolbar on Internet Explorer 11 in some edge cases #TINY-6271
 Version 5.4.1 (2020-07-08)

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -5,12 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Element } from '@ephox/dom-globals';
+import { Element, HTMLElement } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
 import * as EditorView from '../EditorView';
 import { NotificationManagerImpl } from '../ui/NotificationManagerImpl';
-import * as Settings from './Settings';
 import Editor from './Editor';
+import * as Settings from './Settings';
 import Delay from './util/Delay';
 
 export interface NotificationManagerImpl {
@@ -37,7 +37,7 @@ export interface NotificationApi {
   text: (text: string) => void;
   moveTo: (x: number, y: number) => void;
   moveRel: (element: Element, rel: 'tc-tc' | 'bc-bc' | 'bc-tc' | 'tc-bc' | 'banner') => void;
-  getEl: () => Element;
+  getEl: () => HTMLElement;
   settings: NotificationSpec;
 }
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, AlloySpec, Behaviour, Button, GuiFactory, Memento, Replacing, Sketcher, UiSketcher } from '@ephox/alloy';
+import { AlloyComponent, AlloySpec, Behaviour, Button, Focusing, GuiFactory, Memento, Replacing, Sketcher, UiSketcher } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Option } from '@ephox/katamari';
 import { TranslatedString, Untranslated } from 'tinymce/core/api/util/I18n';
@@ -144,24 +144,14 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
     detail.level.bind((level) => Option.from(notificationIconMap[level])).toArray()
   ]);
 
-  return {
-    uid: detail.uid,
-    dom: {
-      tag: 'div',
-      attributes: {
-        role: 'alert'
-      },
-      classes: detail.level.map((level) => [ 'tox-notification', 'tox-notification--in', `tox-notification--${level}` ]).getOr(
-        [ 'tox-notification', 'tox-notification--in' ]
-      )
-    },
-    components: [ {
+  const components: AlloySpec[] = [
+    {
       dom: {
         tag: 'div',
         classes: [ 'tox-notification__icon' ],
         innerHtml: getFirst(iconChoices, detail.iconProvider)
       }
-    } as AlloySpec,
+    },
     {
       dom: {
         tag: 'div',
@@ -173,29 +163,46 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
       behaviours: Behaviour.derive([
         Replacing.config({ })
       ])
-    } as AlloySpec
-    ]
+    }
+  ];
+
+  return {
+    uid: detail.uid,
+    dom: {
+      tag: 'div',
+      attributes: {
+        role: 'alert'
+      },
+      classes: detail.level.map((level) => [ 'tox-notification', 'tox-notification--in', `tox-notification--${level}` ]).getOr(
+        [ 'tox-notification', 'tox-notification--in' ]
+      )
+    },
+    behaviours: Behaviour.derive([
+      Focusing.config({ })
+    ]),
+    components: components
       .concat(detail.progress ? [ memBannerProgress.asSpec() ] : [])
-      .concat(!detail.closeButton ? [] : [ Button.sketch({
-        dom: {
-          tag: 'button',
-          classes: [ 'tox-notification__dismiss', 'tox-button', 'tox-button--naked', 'tox-button--icon' ]
-        },
-        components: [{
+      .concat(!detail.closeButton ? [] : [
+        Button.sketch({
           dom: {
-            tag: 'div',
-            classes: [ 'tox-icon' ],
-            innerHtml: getIcon('close', detail.iconProvider),
-            attributes: {
-              'aria-label': detail.translationProvider('Close')
+            tag: 'button',
+            classes: [ 'tox-notification__dismiss', 'tox-button', 'tox-button--naked', 'tox-button--icon' ]
+          },
+          components: [{
+            dom: {
+              tag: 'div',
+              classes: [ 'tox-icon' ],
+              innerHtml: getIcon('close', detail.iconProvider),
+              attributes: {
+                'aria-label': detail.translationProvider('Close')
+              }
             }
+          }],
+          action: (comp) => {
+            detail.onAction(comp);
           }
-        }],
-        action: (comp) => {
-          detail.onAction(comp);
-        }
-      }) ]
-      ),
+        })
+      ]),
     apis
   };
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, Chain, Guard, Mouse, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { HTMLElement } from '@ephox/dom-globals';
 import { Editor as McEditor } from '@ephox/mcagar';
-import { Body, Element, Traverse } from '@ephox/sugar';
+import { Body, Compare, Element, Focus, Traverse } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { NotificationApi } from 'tinymce/core/api/NotificationManager';
@@ -24,6 +24,13 @@ UnitTest.asynctest('NotificationManagerImpl test', (success, failure) => {
 
   const cSetProgress = (progress: number) => Chain.op((notification: NotificationApi) => {
     notification.progressBar.value(progress);
+  });
+
+  const cAssertFocusable = Chain.op((notification: NotificationApi) => {
+    const elm = Element.fromDom(notification.getEl());
+    Focus.focus(elm);
+    const notificationFocused = Focus.active().exists((focusedElm) => Compare.eq(elm, focusedElm));
+    Assert.eq('Notification should be focused', true, notificationFocused);
   });
 
   const cAssertPosition = (prefix: string, x: number, y: number, diff: number = 5) => Chain.op((notification: NotificationApi) => {
@@ -203,6 +210,10 @@ UnitTest.asynctest('NotificationManagerImpl test', (success, failure) => {
             // Check items are positioned so that they are stacked
             NamedChain.direct('nError', cAssertPosition('Error notification', 220, -299), '_'),
             NamedChain.direct('nWarn', cAssertPosition('Warning notification', 220, -251), '_'),
+
+            // Check the notification can be focused
+            NamedChain.read('nError', cAssertFocusable),
+            NamedChain.read('nWarn', cAssertFocusable),
 
             NamedChain.direct('nError', cCloseNotification, '_'),
             NamedChain.direct('nWarn', cCloseNotification, '_')


### PR DESCRIPTION
Related Ticket: TINY-6058

Description of Changes:
This fixes an issue whereby clicking the notification would cause inline editors to hide, since the focus would move back to the body.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #5702