### PR TITLE
TINY-6284: Make fullscreen mode request browser fullscreen

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -5,6 +5,7 @@ Version 5.5.0 (TBD)
     Added the ability to remove images on a failed upload using the `images_upload_handler` failure callback #TINY-6011
     Added `hasPlugin` function to the editor API to determine if a plugin exists or not #TINY-766
     Added the ability to delete and navigate HTML media elements without the media plugin #TINY-4211
+    Added `fullscreen_native` setting to the fullscreen plugin to enable use of the entire monitor #TINY-6284
     Changed the `target` property on fired events to use the native event target. The original target for an open shadow root can be obtained using `event.getComposedPath()` #TINY-6128
     Changed `imagetools` context menu icon for accessing the `image` settings to use the same icon #TINY-4141
     Deprecated the `Env.experimentalShadowDom` flag #TINY-6128

--- a/modules/tinymce/src/plugins/fullscreen/demo/html/demo.html
+++ b/modules/tinymce/src/plugins/fullscreen/demo/html/demo.html
@@ -7,7 +7,10 @@
   <body>
   <h2>Plugin: fullscreen Demo Page</h2>
     <div id="ephox-ui">
+      <h3>Native browser fullscreen</h3>
       <textarea cols="30" rows="10" class="tinymce"></textarea>
+      <h3>CSS only fullscreen</h3>
+      <textarea cols="30" rows="10" class="tinymce2"></textarea>
     </div>
     <script src="../../../../../js/tinymce/tinymce.js"></script>
     <script src="../../../../../scratch/demos/plugins/fullscreen/demo.js"></script>

--- a/modules/tinymce/src/plugins/fullscreen/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/fullscreen/demo/ts/demo/Demo.ts
@@ -4,6 +4,13 @@ tinymce.init({
   selector: 'textarea.tinymce',
   plugins: 'fullscreen code',
   toolbar: 'fullscreen code',
+  height: 600,
+  fullscreen_native: true
+});
+tinymce.init({
+  selector: 'textarea.tinymce2',
+  plugins: 'fullscreen code',
+  toolbar: 'fullscreen code',
   height: 600
 });
 

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/Plugin.ts
@@ -10,10 +10,11 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Api from './api/Api';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
+import { ScrollInfo } from './core/Actions';
 
 export default function () {
   PluginManager.add('fullscreen', (editor) => {
-    const fullscreenState: Cell<any> = Cell(null);
+    const fullscreenState = Cell<ScrollInfo | null>(null);
 
     if (editor.inline) {
       return Api.get(fullscreenState);

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Api.ts
@@ -5,7 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const get = function (fullscreenState) {
+import { Cell } from '@ephox/katamari';
+import { ScrollInfo } from '../core/Actions';
+
+const get = function (fullscreenState: Cell<ScrollInfo | null>) {
   return {
     isFullscreen() {
       return fullscreenState.get() !== null;

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Commands.ts
@@ -9,7 +9,7 @@ import * as Actions from '../core/Actions';
 import { Cell } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor, fullscreenState: Cell<any>) => {
+const register = (editor: Editor, fullscreenState: Cell<Actions.ScrollInfo | null>) => {
   editor.addCommand('mceFullScreen', () => {
     Actions.toggleFullscreen(editor, fullscreenState);
   });

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Settings.ts
@@ -9,6 +9,9 @@ import Editor from 'tinymce/core/api/Editor';
 
 const getInline = (editor: Editor) => editor.getParam('inline');
 
+const getFullscreenNative = (editor: Editor) => editor.getParam('fullscreen_native', false, 'boolean');
+
 export {
-  getInline
+  getInline,
+  getFullscreenNative
 };

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
@@ -168,11 +168,13 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
     editor.on('remove', cleanup);
 
     fullscreenState.set(newFullScreenInfo);
-    fullscreenRoot.dom.requestFullscreen();
+    if (fullscreenRoot.dom.requestFullscreen) {
+      fullscreenRoot.dom.requestFullscreen();
+    }
     Events.fireFullscreenStateChanged(editor, true);
   } else {
     fullscreenInfo.fullscreenChangeHandler.unbind();
-    if (isFullscreenElement(fullscreenRoot)) {
+    if (isFullscreenElement(fullscreenRoot) && document.exitFullscreen) {
       Traverse.owner(fullscreenRoot).dom.exitFullscreen();
     }
     iframeStyle.width = fullscreenInfo.iframeWidth;

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
@@ -100,7 +100,7 @@ const getFullscreenRoot = (editor: Editor): SugarElement<Element> => {
 };
 
 const isFullscreenElement = (elem: SugarElement<Element>) =>
-  elem.dom() === Traverse.owner(elem).dom().fullscreenElement;
+  elem.dom === Traverse.owner(elem).dom.fullscreenElement;
 
 const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | null>) => {
   const body = document.body;
@@ -168,12 +168,12 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
     editor.on('remove', cleanup);
 
     fullscreenState.set(newFullScreenInfo);
-    fullscreenRoot.dom().requestFullscreen();
+    fullscreenRoot.dom.requestFullscreen();
     Events.fireFullscreenStateChanged(editor, true);
   } else {
     fullscreenInfo.fullscreenChangeHandler.unbind();
     if (isFullscreenElement(fullscreenRoot)) {
-      Traverse.owner(fullscreenRoot).dom().exitFullscreen();
+      Traverse.owner(fullscreenRoot).dom.exitFullscreen();
     }
     iframeStyle.width = fullscreenInfo.iframeWidth;
     iframeStyle.height = fullscreenInfo.iframeHeight;

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
@@ -12,6 +12,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Delay from 'tinymce/core/api/util/Delay';
 import * as Events from '../api/Events';
+import * as Settings from '../api/Settings';
 import * as Thor from './Thor';
 
 export interface ScrollInfo {
@@ -134,9 +135,11 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
 
   if (!fullscreenInfo) {
     const fullscreenChangeHandler = DomEvent.bind(fullscreenRoot, 'fullscreenchange', (_evt) => {
-      // if we have exited browser fullscreen with Escape then exit editor fullscreen too
-      if (!isFullscreenElement(fullscreenRoot) && fullscreenState.get() !== null) {
-        toggleFullscreen(editor, fullscreenState);
+      if (Settings.getFullscreenNative(editor)) {
+        // if we have exited browser fullscreen with Escape then exit editor fullscreen too
+        if (!isFullscreenElement(fullscreenRoot) && fullscreenState.get() !== null) {
+          toggleFullscreen(editor, fullscreenState);
+        }
       }
     });
 
@@ -168,13 +171,13 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
     editor.on('remove', cleanup);
 
     fullscreenState.set(newFullScreenInfo);
-    if (fullscreenRoot.dom.requestFullscreen) {
+    if (Settings.getFullscreenNative(editor) && fullscreenRoot.dom.requestFullscreen) {
       fullscreenRoot.dom.requestFullscreen();
     }
     Events.fireFullscreenStateChanged(editor, true);
   } else {
     fullscreenInfo.fullscreenChangeHandler.unbind();
-    if (isFullscreenElement(fullscreenRoot) && document.exitFullscreen) {
+    if (Settings.getFullscreenNative(editor) && document.exitFullscreen && isFullscreenElement(fullscreenRoot)) {
       Traverse.owner(fullscreenRoot).dom.exitFullscreen();
     }
     iframeStyle.width = fullscreenInfo.iframeWidth;

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/NativeFullscreen.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/NativeFullscreen.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { SugarBody, SugarElement, SugarShadowDom, Traverse } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+
+export const getFullscreenRoot = (editor: Editor): SugarElement<Element> => {
+  const elem = SugarElement.fromDom(editor.getElement());
+  return SugarShadowDom.getShadowRoot(elem).map(SugarShadowDom.getShadowHost).
+    getOrThunk(() => SugarBody.getBody(Traverse.owner(elem)));
+};
+
+export const getFullscreenElement = (root: DocumentOrShadowRoot) => {
+  if (root.fullscreenElement !== undefined) {
+    return root.fullscreenElement;
+  } else if ((root as any).msFullscreenElement !== undefined) {
+    return (root as any).msFullscreenElement;
+  } else if ((root as any).webkitFullscreenElement !== undefined) {
+    return (root as any).webkitFullscreenElement;
+  } else {
+    return null;
+  }
+};
+
+export const getFullscreenchangeEventName = () => {
+  if (document.fullscreenElement !== undefined) {
+    return 'fullscreenchange';
+  } else if ((document as any).msFullscreenElement !== undefined) {
+    return 'MSFullscreenChange'; // warning, seems to be case sensitive
+  } else if ((document as any).webkitFullscreenElement !== undefined) {
+    return 'webkitfullscreenchange';
+  } else {
+    return 'fullscreenchange';
+  }
+};
+
+export const requestFullscreen = (sugarElem: SugarElement<Element>) => {
+  const elem = sugarElem.dom;
+  if (elem.requestFullscreen) {
+    elem.requestFullscreen();
+  } else if ((elem as any).msRequestFullscreen) {
+    (elem as any).msRequestFullscreen();
+  } else if ((elem as any).webkitRequestFullScreen) {
+    (elem as any).webkitRequestFullScreen();
+  }
+};
+
+export const exitFullscreen = (sugarDoc: SugarElement<Document>) => {
+  const doc = sugarDoc.dom;
+  if (doc.exitFullscreen) {
+    doc.exitFullscreen();
+  } else if ((doc as any).msExitFullscreen) {
+    (doc as any).msExitFullscreen();
+  } else if ((doc as any).webkitCancelFullScreen) {
+    (doc as any).webkitCancelFullScreen();
+  }
+};
+
+export const isFullscreenElement = (elem: SugarElement<Element>) =>
+  elem.dom === getFullscreenElement(Traverse.owner(elem).dom);

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/NativeFullscreen.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/NativeFullscreen.ts
@@ -14,19 +14,19 @@ export const getFullscreenRoot = (editor: Editor): SugarElement<Element> => {
     getOrThunk(() => SugarBody.getBody(Traverse.owner(elem)));
 };
 
-export const getFullscreenElement = (root: DocumentOrShadowRoot) => {
+export const getFullscreenElement = (root: DocumentOrShadowRoot): Element | null => {
   if (root.fullscreenElement !== undefined) {
     return root.fullscreenElement;
   } else if ((root as any).msFullscreenElement !== undefined) {
-    return (root as any).msFullscreenElement;
+    return (root as any).msFullscreenElement as Element | null;
   } else if ((root as any).webkitFullscreenElement !== undefined) {
-    return (root as any).webkitFullscreenElement;
+    return (root as any).webkitFullscreenElement as Element | null;
   } else {
     return null;
   }
 };
 
-export const getFullscreenchangeEventName = () => {
+export const getFullscreenchangeEventName = (): string => {
   if (document.fullscreenElement !== undefined) {
     return 'fullscreenchange';
   } else if ((document as any).msFullscreenElement !== undefined) {
@@ -38,7 +38,7 @@ export const getFullscreenchangeEventName = () => {
   }
 };
 
-export const requestFullscreen = (sugarElem: SugarElement<Element>) => {
+export const requestFullscreen = (sugarElem: SugarElement<Element>): void => {
   const elem = sugarElem.dom;
   if (elem.requestFullscreen) {
     elem.requestFullscreen();
@@ -49,7 +49,7 @@ export const requestFullscreen = (sugarElem: SugarElement<Element>) => {
   }
 };
 
-export const exitFullscreen = (sugarDoc: SugarElement<Document>) => {
+export const exitFullscreen = (sugarDoc: SugarElement<Document>): void => {
   const doc = sugarDoc.dom;
   if (doc.exitFullscreen) {
     doc.exitFullscreen();
@@ -60,5 +60,5 @@ export const exitFullscreen = (sugarDoc: SugarElement<Document>) => {
   }
 };
 
-export const isFullscreenElement = (elem: SugarElement<Element>) =>
+export const isFullscreenElement = (elem: SugarElement<Element>): boolean =>
   elem.dom === getFullscreenElement(Traverse.owner(elem).dom);

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
@@ -1,0 +1,68 @@
+import { UnitTest } from '@ephox/bedrock-client';
+
+import { Editor as McEditor } from '@ephox/mcagar';
+import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+import { Pipeline, Log, NamedChain, Chain, UiFinder, RealMouse, Waiter, Step } from '@ephox/agar';
+
+UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginNativeModeTest', (success, failure) => {
+  FullscreenPlugin();
+  SilverTheme();
+
+  const cSetupEditor = McEditor.cFromSettings({
+    plugins: 'fullscreen',
+    toolbar: 'fullscreen',
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+    fullscreen_native: true
+  });
+
+  const getFullscreenElement = () => {
+    if (document.fullscreenElement !== undefined) {
+      return document.fullscreenElement;
+    } else if ((document as any).msFullscreenElement !== undefined) {
+      return (document as any).msFullscreenElement;
+    } else if ((document as any).webkitFullscreenElement !== undefined) {
+      return (document as any).webkitFullscreenElement;
+    } else {
+      return undefined;
+    }
+  };
+
+  const cIsFullscreen = (fullscreen: boolean) => Waiter.cTryUntilPredicate('Waiting for fullscreen mode to ' + (fullscreen ? 'start' : 'end'), (_v) => {
+    if (fullscreen) {
+      return getFullscreenElement() === document.body;
+    } else {
+      return getFullscreenElement() === null;
+    }
+  });
+
+  const unsupportedBrowser = (() => {
+    if (/HeadlessChrome/.test(window.navigator.userAgent)) {
+      return 'headless Chrome';
+    } else if (/PhantomJS/.test(window.navigator.userAgent)) {
+      return 'PhantomJs';
+    }
+    return '';
+  })();
+
+  const skipInUnsupportedBrowsers = (step: Step<unknown, unknown>) => unsupportedBrowser ? Step.log('Skipping test as ' + unsupportedBrowser + ' can not run it') : step;
+
+  Pipeline.async({}, [
+    skipInUnsupportedBrowsers(
+      Log.chainsAsStep('TBA', 'FullScreen: Toggle fullscreen on with real click, check document.fullscreenElement, toggle fullscreen off, check document.fullscreenElement', [
+        NamedChain.asChain([
+          NamedChain.write('editor', cSetupEditor),
+          NamedChain.direct('editor', Chain.mapper((editor) => editor.getContainer()), 'container'),
+          NamedChain.direct('container', UiFinder.cFindIn('button[title="Fullscreen"]'), 'button'),
+          NamedChain.read('editor', cIsFullscreen(false)),
+          NamedChain.read('button', RealMouse.cClick()),
+          NamedChain.read('editor', cIsFullscreen(true)),
+          NamedChain.read('button', RealMouse.cClick()),
+          NamedChain.read('editor', cIsFullscreen(false)),
+          NamedChain.read('editor', McEditor.cRemove)
+        ])
+      ])
+    )
+  ], success, failure);
+});

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
@@ -1,9 +1,9 @@
+import { Chain, Log, NamedChain, Pipeline, RealMouse, Step, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-
 import { Editor as McEditor } from '@ephox/mcagar';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
-import { Pipeline, Log, NamedChain, Chain, UiFinder, RealMouse, Waiter, Step } from '@ephox/agar';
+import { getFullscreenElement } from '../../../main/ts/core/NativeFullscreen';
 
 UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginNativeModeTest', (success, failure) => {
   FullscreenPlugin();
@@ -17,23 +17,11 @@ UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginNativeMod
     fullscreen_native: true
   });
 
-  const getFullscreenElement = () => {
-    if (document.fullscreenElement !== undefined) {
-      return document.fullscreenElement;
-    } else if ((document as any).msFullscreenElement !== undefined) {
-      return (document as any).msFullscreenElement;
-    } else if ((document as any).webkitFullscreenElement !== undefined) {
-      return (document as any).webkitFullscreenElement;
-    } else {
-      return undefined;
-    }
-  };
-
   const cIsFullscreen = (fullscreen: boolean) => Waiter.cTryUntilPredicate('Waiting for fullscreen mode to ' + (fullscreen ? 'start' : 'end'), (_v) => {
     if (fullscreen) {
-      return getFullscreenElement() === document.body;
+      return getFullscreenElement(document) === document.body;
     } else {
-      return getFullscreenElement() === null;
+      return getFullscreenElement(document) === null;
     }
   });
 


### PR DESCRIPTION
Related Ticket: TINY-6284

Description of Changes:
* Allow the fullscreen plugin to actually trigger the fullscreen mode of the browser when setting `fullscreen_native` is set to `true`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #4969