### PR TITLE
TINY-6286: Fixed a regression causing list toolbar items to not show the active state

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,6 +2,7 @@ Version 5.4.2 (TBD)
     Fixed clicking on notifications causing inline editors to hide #TINY-6058
     Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false` #TINY-6256
     Fixed an exception thrown when positioning the context toolbar on Internet Explorer 11 in some edge cases #TINY-6271
+    Fixed list toolbar buttons not showing as active when a list is selected #TINY-6286
 Version 5.4.1 (2020-07-08)
     Fixed the Search and Replace plugin incorrectly including zero-width caret characters in search results #TINY-4599
     Fixed dragging and dropping unsupported files navigating the browser away from the editor #TINY-6027

--- a/modules/tinymce/src/plugins/lists/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/lists/demo/ts/demo/Demo.ts
@@ -4,7 +4,8 @@ tinymce.init({
   selector: 'textarea.tinymce',
   plugins: 'lists code',
   toolbar: 'numlist bullist | code',
-  height: 600
+  height: 600,
+  contextmenu: 'lists'
 });
 
 export {};

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
@@ -12,16 +12,19 @@ import * as NodeType from './NodeType';
 
 export const isCustomList = (list: HTMLElement) => /\btox\-/.test(list.className);
 
-export const listState = (editor: Editor, listName: string, activate: (active: boolean) => void) =>
-  () => {
-    const nodeChangeHandler = (e) => {
-      const inList = Arr.findUntil(e.parents, NodeType.isListNode, NodeType.isTableCellNode)
-        .filter((list: HTMLElement) => list.nodeName === listName && !isCustomList(list))
-        .isSome();
-      activate(inList);
-    };
-
-    editor.on('NodeChange', nodeChangeHandler);
-
-    return () => editor.off('NodeChange', nodeChangeHandler);
+export const listState = (editor: Editor, listName: string, activate: (active: boolean) => void) => {
+  const nodeChangeHandler = (e) => {
+    const inList = Arr.findUntil(e.parents, NodeType.isListNode, NodeType.isTableCellNode)
+      .filter((list: HTMLElement) => list.nodeName === listName && !isCustomList(list))
+      .isSome();
+    activate(inList);
   };
+
+  // Set the initial state
+  const parents = editor.dom.getParents(editor.selection.getNode());
+  nodeChangeHandler({ parents });
+
+  editor.on('NodeChange', nodeChangeHandler);
+
+  return () => editor.off('NodeChange', nodeChangeHandler);
+};

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -52,7 +52,7 @@ UnitTest.asynctest('tinymce.lists.browser.ListPropertiesTest', (success, failure
 
   const sAssertListPropMenuNotVisible = UiFinder.sNotExists(Body.body(), contentMenuSelector);
 
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+  TinyLoader.setup((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
     const tinyUi = TinyUi(editor);
 
@@ -107,11 +107,30 @@ UnitTest.asynctest('tinymce.lists.browser.ListPropertiesTest', (success, failure
         sUpdateStart('1', '10'),
         tinyUi.sSubmitDialog('[role=dialog]'),
         tinyApis.sAssertContent('<ol start="10"><li>Root Item<ol><li>Item 1</li><li>Item 2</li></ol></li></ol>')
+      ]),
+      Log.stepsAsStep('TINY-6286', 'List properties menu item disabled for UL', [
+        tinyApis.sSetContent('<ul><li>Item 1</li><li>Item 2</li></ul>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        tinyUi.sClickOnMenu('Open custom menu', '.tox-mbtn:contains("Custom")'),
+        tinyUi.sWaitForUi('Check menu item is disabled', '.tox-collection__item--state-disabled:contains("List properties")'),
+        tinyUi.sClickOnMenu('Close custom menu', '.tox-mbtn:contains("Custom")')
+      ]),
+      Log.stepsAsStep('TINY-6286', 'List properties menu item enabled for OL', [
+        tinyApis.sSetContent('<ol><li>Item 1</li><li>Item 2</li></ol>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        tinyUi.sClickOnMenu('Open custom menu', '.tox-mbtn:contains("Custom")'),
+        tinyUi.sWaitForUi('Check menu item is enabled', '.tox-collection__item:contains("List properties"):not(.tox-collection__item--state-disabled)'),
+        tinyUi.sClickOnMenu('Close custom menu', '.tox-mbtn:contains("Custom")')
       ])
     ], onSuccess, onFailure);
   }, {
     plugins: 'lists',
     contextmenu: 'lists bold',
+    menu: {
+      custom: { title: 'Custom', items: 'listprops' }
+    },
+    menubar: 'custom',
+    toolbar: false,
     indent: false,
     theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListWithEmptyLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListWithEmptyLiTest.ts
@@ -1,4 +1,4 @@
-import { Pipeline, Log } from '@ephox/agar';
+import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 
@@ -18,6 +18,7 @@ UnitTest.asynctest('tinymce.lists.browser.ToggleListWithEmptyLiTest', (success, 
         tinyApis.sFocus(),
         tinyApis.sSetContent('<ul><li>a</li><li>&nbsp;</li><li>&nbsp;</li><li>b</li></ul>'),
         tinyApis.sSetSelection([ 0, 0, 0 ], 0, [ 0, 3, 0 ], 1),
+        tinyUi.sWaitForUi('Wait for toolbar button to be active', 'button[aria-label="Bullet list"].tox-tbtn--enabled'),
         tinyUi.sClickOnToolbar('click list', 'button[aria-label="Bullet list"]'),
         tinyApis.sAssertContent('<p>a</p><p>&nbsp;</p><p>&nbsp;</p><p>b</p>')
       ])


### PR DESCRIPTION
Related Ticket: TINY-6286

Description of Changes:
* Fixes a regression introduced in 5.3.0 whereby the lists toolbar state wouldn't toggle, as the listener was only being setup on teardown of the toolbar button.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
