### PR TITLE
TINY-6216: Fixed inline formats not able to be removed when more than 1 removeformat exists

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,6 +2,7 @@ Version 5.4.2 (TBD)
     Fixed clicking on notifications causing inline editors to hide #TINY-6058
     Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false` #TINY-6256
     Fixed an exception thrown when positioning the context toolbar on Internet Explorer 11 in some edge cases #TINY-6271
+    Fixed inline formats not removed when more than one `removeformat` format rule existed #TINY-6216
     Fixed list toolbar buttons not showing as active when a list is selected #TINY-6286
 Version 5.4.1 (2020-07-08)
     Fixed the Search and Replace plugin incorrectly including zero-width caret characters in search results #TINY-4599

--- a/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
@@ -6,7 +6,7 @@
  */
 
 import { Document, Node, Range } from '@ephox/dom-globals';
-import { Arr, Fun, Obj, Option } from '@ephox/katamari';
+import { Arr, Fun, Obj, Option, Strings } from '@ephox/katamari';
 import { Attr, Element, Insert, Node as SugarNode, Remove } from '@ephox/sugar';
 import TreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
@@ -176,7 +176,7 @@ const cleanFormatNode = (editor: Editor, caretContainer: Node, formatNode: Node,
   const dom = editor.dom;
 
   // Find all formats present on the format node
-  const validFormats = Arr.filter(Obj.keys(formatter.get()), (formatName) => formatName !== 'removeformat' && formatName !== name);
+  const validFormats = Arr.filter(Obj.keys(formatter.get()), (formatName) => formatName !== name && !Strings.contains(formatName, 'removeformat'));
   const matchedFormats = MatchFormat.matchAllOnNode(editor, formatNode, validFormats);
   // Filter out any matched formats that are 'visually' equivalent to the 'name' format since they are not unique formats on the node
   const uniqueFormats = Arr.filter(matchedFormats, (fmtName) => !FormatUtils.areSimilarFormats(editor, fmtName, name));

--- a/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
@@ -535,6 +535,16 @@ UnitTest.asynctest('browser.tinymce.core.fmt.CaretFormatTest', function (success
   }, {
     plugins: '',
     toolbar: '',
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    formats: {
+      formatpainter_removeformat: [
+        {
+          selector: 'b,strong,em,i,font,u,strike,sub,sup,dfn,code,samp,kbd,var,cite,mark,q,del,ins',
+          remove: 'all', split: true, expand: false, block_expand: true, deep: true
+        },
+        { selector: 'span', attributes: [ 'style', 'class' ], remove: 'empty', split: true, expand: false, deep: true },
+        { selector: '*:not(tr,td,th,table)', attributes: [ 'style', 'class' ], split: false, expand: false, deep: true }
+      ]
+    }
   }, success, failure);
 });


### PR DESCRIPTION
Related Ticket: TINY-6216

Description of Changes:
* While fixing TINY-6288, I ran into this and realised it was a quick fix which had rather bad side effects when using format painter. The idea behind this fix is we treat any format with `removeformat` in the name, to be a "remove" only format.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
