### PR TITLE
TINY-6058: Additional focus fixes for notifications

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -7,6 +7,7 @@
 
 import { Element, HTMLElement } from '@ephox/dom-globals';
 import { Arr, Option } from '@ephox/katamari';
+import { Element as SugarElement, Focus } from '@ephox/sugar';
 import * as EditorView from '../EditorView';
 import { NotificationManagerImpl } from '../ui/NotificationManagerImpl';
 import Editor from './Editor';
@@ -109,6 +110,12 @@ function NotificationManager(editor: Editor): NotificationManager {
       const notification = getImplementation().open(spec, function () {
         closeNotification(notification);
         reposition();
+        // Move focus back to editor when the last notification is closed,
+        // otherwise focus the top notification
+        getTopNotification().fold(
+          () => editor.focus(),
+          (top) => Focus.focus(SugarElement.fromDom(top.getEl()))
+        );
       });
 
       addNotification(notification);

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -1,6 +1,8 @@
 import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Node } from '@ephox/dom-globals';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+import { Element, Focus } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
 import Tools from 'tinymce/core/api/util/Tools';
@@ -89,6 +91,29 @@ UnitTest.asynctest('browser.tinymce.core.NotificationManagerTest', function (suc
     Delay.setTimeout(() => {
       checkClosed();
     }, 100);
+  });
+
+  suite.test('TestCase-TINY-6058: Should move focus back to the editor when all notifications closed', function (editor) {
+    const testMsg1: NotificationSpec = { type: 'warning', text: 'test message 1' };
+    const testMsg2: NotificationSpec = { type: 'error', text: 'test message 2' };
+    const notifications = editor.notificationManager.getNotifications();
+
+    const n1 = editor.notificationManager.open(testMsg1);
+    const n2 = editor.notificationManager.open(testMsg2);
+    LegacyUnit.equal(notifications.length, 2, 'Should have two messages added.');
+
+    const hasFocus = (node: Node) => Focus.search(Element.fromDom(node)).isSome();
+
+    Focus.focus(Element.fromDom(n2.getEl()));
+    LegacyUnit.equal(true, hasFocus(n2.getEl()), 'Focus should be on notification 2');
+
+    n2.close();
+    LegacyUnit.equal(true, hasFocus(n1.getEl()), 'Focus should be on notification 1');
+
+    n1.close();
+    LegacyUnit.equal(true, editor.hasFocus(), 'Focus should be on the editor');
+
+    teardown(editor);
   });
 
   suite.test('TestCase-TBA: Should not open notification if editor is removed', function (editor) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
@@ -5,7 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, AlloySpec, Behaviour, Button, Focusing, GuiFactory, Memento, Replacing, Sketcher, UiSketcher } from '@ephox/alloy';
+import {
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Focusing, GuiFactory, Memento, NativeEvents, Replacing, Sketcher,
+  UiSketcher
+} from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Option } from '@ephox/katamari';
 import { TranslatedString, Untranslated } from 'tinymce/core/api/util/I18n';
@@ -144,6 +147,26 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
     detail.level.bind((level) => Option.from(notificationIconMap[level])).toArray()
   ]);
 
+  const memButton = Memento.record(Button.sketch({
+    dom: {
+      tag: 'button',
+      classes: [ 'tox-notification__dismiss', 'tox-button', 'tox-button--naked', 'tox-button--icon' ]
+    },
+    components: [{
+      dom: {
+        tag: 'div',
+        classes: [ 'tox-icon' ],
+        innerHtml: getIcon('close', detail.iconProvider),
+        attributes: {
+          'aria-label': detail.translationProvider('Close')
+        }
+      }
+    }],
+    action: (comp) => {
+      detail.onAction(comp);
+    }
+  }));
+
   const components: AlloySpec[] = [
     {
       dom: {
@@ -178,31 +201,16 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
       )
     },
     behaviours: Behaviour.derive([
-      Focusing.config({ })
+      Focusing.config({ }),
+      AddEventsBehaviour.config('notification-events', [
+        AlloyEvents.run(NativeEvents.focusin(), (comp) => {
+          memButton.getOpt(comp).each(Focusing.focus);
+        })
+      ])
     ]),
     components: components
       .concat(detail.progress ? [ memBannerProgress.asSpec() ] : [])
-      .concat(!detail.closeButton ? [] : [
-        Button.sketch({
-          dom: {
-            tag: 'button',
-            classes: [ 'tox-notification__dismiss', 'tox-button', 'tox-button--naked', 'tox-button--icon' ]
-          },
-          components: [{
-            dom: {
-              tag: 'div',
-              classes: [ 'tox-icon' ],
-              innerHtml: getIcon('close', detail.iconProvider),
-              attributes: {
-                'aria-label': detail.translationProvider('Close')
-              }
-            }
-          }],
-          action: (comp) => {
-            detail.onAction(comp);
-          }
-        })
-      ]),
+      .concat(!detail.closeButton ? [] : [ memButton.asSpec() ]),
     apis
   };
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions, Chain, Guard, Mouse, NamedChain, Pipeline,
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { HTMLElement } from '@ephox/dom-globals';
 import { Editor as McEditor } from '@ephox/mcagar';
-import { Body, Compare, Element, Focus, Traverse } from '@ephox/sugar';
+import { Body, Element, Focus, Traverse } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { NotificationApi } from 'tinymce/core/api/NotificationManager';
@@ -29,7 +29,7 @@ UnitTest.asynctest('NotificationManagerImpl test', (success, failure) => {
   const cAssertFocusable = Chain.op((notification: NotificationApi) => {
     const elm = Element.fromDom(notification.getEl());
     Focus.focus(elm);
-    const notificationFocused = Focus.active().exists((focusedElm) => Compare.eq(elm, focusedElm));
+    const notificationFocused = Focus.search(elm).isSome();
     Assert.eq('Notification should be focused', true, notificationFocused);
   });
 


### PR DESCRIPTION
Related Ticket: TINY-6058

Description of Changes:
* This adds additional focus fixes to the notifications found during QA. The focus will now shift to the button by default, so as to allow it to be closed via the keyboard and when closing a notification it'll attempt to move to another notification or if none are shown it'll focus the editor (ie does the same as dialogs).

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
