### PR TITLE
TINY-6288: Fixed an exception thrown when removing inline formats with preserve_attributes configured

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.4.2 (TBD)
     Fixed clicking on notifications causing inline editors to hide #TINY-6058
     Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false` #TINY-6256
+    Fixed an exception thrown when removing inline formats that contained additional styles or classes #TINY-6288
     Fixed an exception thrown when positioning the context toolbar on Internet Explorer 11 in some edge cases #TINY-6271
     Fixed list toolbar buttons not showing as active when a list is selected #TINY-6286
 Version 5.4.1 (2020-07-08)

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -5,104 +5,17 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Element, Node } from '@ephox/dom-globals';
-import * as Bookmarks from '../bookmark/Bookmarks';
-import ElementUtils from '../api/dom/ElementUtils';
-import * as NodeType from '../dom/NodeType';
+import { Node } from '@ephox/dom-globals';
+import DOMUtils from '../api/dom/DOMUtils';
+import Editor from '../api/Editor';
+import { FormatVars } from '../api/fmt/Format';
+import Tools from '../api/util/Tools';
 import * as FormatUtils from './FormatUtils';
 import * as MatchFormat from './MatchFormat';
+import { applyStyle, clearChildStyles, hasStyle, isElementNode, mergeSiblings, processChildElements } from './MergeUtils';
 import * as RemoveFormat from './RemoveFormat';
-import Tools from '../api/util/Tools';
-import { isCaretNode } from '../fmt/FormatContainer';
-import Editor from '../api/Editor';
-import DOMUtils from '../api/dom/DOMUtils';
-import { FormatVars } from '../api/fmt/Format';
 
 const each = Tools.each;
-
-const isElementNode = function (node: Node) {
-  return NodeType.isElement(node) && !Bookmarks.isBookmarkNode(node) && !isCaretNode(node) && !NodeType.isBogus(node);
-};
-
-const findElementSibling = function (node: Node, siblingName: 'nextSibling' | 'previousSibling') {
-  let sibling;
-
-  for (sibling = node; sibling; sibling = sibling[siblingName]) {
-    if (NodeType.isText(sibling) && sibling.nodeValue.length !== 0) {
-      return node;
-    }
-
-    if (NodeType.isElement(sibling) && !Bookmarks.isBookmarkNode(sibling)) {
-      return sibling;
-    }
-  }
-
-  return node;
-};
-
-const mergeSiblingsNodes = function (dom: DOMUtils, prev: Node, next: Node) {
-  let sibling, tmpSibling;
-  const elementUtils = new ElementUtils(dom);
-
-  // Check if next/prev exists and that they are elements
-  if (prev && next) {
-    // If previous sibling is empty then jump over it
-    prev = findElementSibling(prev, 'previousSibling');
-    next = findElementSibling(next, 'nextSibling');
-
-    // Compare next and previous nodes
-    if (elementUtils.compare(prev, next)) {
-      // Append nodes between
-      for (sibling = prev.nextSibling; sibling && sibling !== next;) {
-        tmpSibling = sibling;
-        sibling = sibling.nextSibling;
-        prev.appendChild(tmpSibling);
-      }
-
-      dom.remove(next);
-
-      Tools.each(Tools.grep(next.childNodes), function (node) {
-        prev.appendChild(node);
-      });
-
-      return prev;
-    }
-  }
-
-  return next;
-};
-
-const processChildElements = function (node: Node, filter: (node: Node) => boolean, process: (node: Node) => void) {
-  each(node.childNodes, function (node) {
-    if (isElementNode(node)) {
-      if (filter(node)) {
-        process(node);
-      }
-      if (node.hasChildNodes()) {
-        processChildElements(node, filter, process);
-      }
-    }
-  });
-};
-
-const hasStyle = (dom: DOMUtils, name: string) => (node: Node): boolean =>
-  !!(node && FormatUtils.getStyle(dom, node, name));
-
-const applyStyle = (dom: DOMUtils, name: string, value: string) => (node: Element): void => {
-  dom.setStyle(node, name, value);
-
-  if (node.getAttribute('style') === '') {
-    node.removeAttribute('style');
-  }
-
-  unwrapEmptySpan(dom, node);
-};
-
-const unwrapEmptySpan = function (dom: DOMUtils, node: Node) {
-  if (node.nodeName === 'SPAN' && dom.getAttribs(node).length === 0) {
-    dom.remove(node, true);
-  }
-};
 
 const mergeTextDecorationsAndColor = function (dom: DOMUtils, format, vars: FormatVars, node: Node) {
   const processTextDecorationsAndColor = function (n: Node) {
@@ -134,7 +47,7 @@ const mergeBackgroundColorAndFontSize = function (dom: DOMUtils, format, vars: F
 };
 
 const mergeSubSup = function (dom: DOMUtils, format, vars: FormatVars, node: Node) {
-  // Remove font size on all chilren of a sub/sup and remove the inverse element
+  // Remove font size on all children of a sub/sup and remove the inverse element
   if (format.inline === 'sub' || format.inline === 'sup') {
     processChildElements(node,
       hasStyle(dom, 'fontSize'),
@@ -142,27 +55,6 @@ const mergeSubSup = function (dom: DOMUtils, format, vars: FormatVars, node: Nod
     );
 
     dom.remove(dom.select(format.inline === 'sup' ? 'sub' : 'sup', node), true);
-  }
-};
-
-const mergeSiblings = function (dom: DOMUtils, format, vars: FormatVars, node: Node) {
-  // Merge next and previous siblings if they are similar <b>text</b><b>text</b> becomes <b>texttext</b>
-  if (node && format.merge_siblings !== false) {
-    node = mergeSiblingsNodes(dom, FormatUtils.getNonWhiteSpaceSibling(node), node);
-    node = mergeSiblingsNodes(dom, node, FormatUtils.getNonWhiteSpaceSibling(node, true));
-  }
-};
-
-const clearChildStyles = function (dom: DOMUtils, format, node: Node) {
-  if (format.clear_child_styles) {
-    const selector = format.links ? '*:not(a)' : '*';
-    each(dom.select(selector, node), function (node) {
-      if (isElementNode(node)) {
-        each(format.styles, function (value, name) {
-          dom.setStyle(node, name, '');
-        });
-      }
-    });
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Element, Node } from '@ephox/dom-globals';
+import DOMUtils from '../api/dom/DOMUtils';
+import ElementUtils from '../api/dom/ElementUtils';
+import { FormatVars } from '../api/fmt/Format';
+import Tools from '../api/util/Tools';
+import * as Bookmarks from '../bookmark/Bookmarks';
+import * as NodeType from '../dom/NodeType';
+import { isCaretNode } from './FormatContainer';
+import * as FormatUtils from './FormatUtils';
+
+const each = Tools.each;
+
+const isElementNode = (node: Node) =>
+  NodeType.isElement(node) && !Bookmarks.isBookmarkNode(node) && !isCaretNode(node) && !NodeType.isBogus(node);
+
+const findElementSibling = (node: Node, siblingName: 'nextSibling' | 'previousSibling') => {
+  let sibling;
+
+  for (sibling = node; sibling; sibling = sibling[siblingName]) {
+    if (NodeType.isText(sibling) && sibling.nodeValue.length !== 0) {
+      return node;
+    }
+
+    if (NodeType.isElement(sibling) && !Bookmarks.isBookmarkNode(sibling)) {
+      return sibling;
+    }
+  }
+
+  return node;
+};
+
+const mergeSiblingsNodes = (dom: DOMUtils, prev: Node, next: Node) => {
+  let sibling, tmpSibling;
+  const elementUtils = new ElementUtils(dom);
+
+  // Check if next/prev exists and that they are elements
+  if (prev && next) {
+    // If previous sibling is empty then jump over it
+    prev = findElementSibling(prev, 'previousSibling');
+    next = findElementSibling(next, 'nextSibling');
+
+    // Compare next and previous nodes
+    if (elementUtils.compare(prev, next)) {
+      // Append nodes between
+      for (sibling = prev.nextSibling; sibling && sibling !== next;) {
+        tmpSibling = sibling;
+        sibling = sibling.nextSibling;
+        prev.appendChild(tmpSibling);
+      }
+
+      dom.remove(next);
+
+      Tools.each(Tools.grep(next.childNodes), (node) => {
+        prev.appendChild(node);
+      });
+
+      return prev;
+    }
+  }
+
+  return next;
+};
+
+
+const mergeSiblings = (dom: DOMUtils, format, vars: FormatVars, node: Node) => {
+  // Merge next and previous siblings if they are similar <b>text</b><b>text</b> becomes <b>texttext</b>
+  if (node && format.merge_siblings !== false) {
+    node = mergeSiblingsNodes(dom, FormatUtils.getNonWhiteSpaceSibling(node), node);
+    node = mergeSiblingsNodes(dom, node, FormatUtils.getNonWhiteSpaceSibling(node, true));
+  }
+};
+
+const clearChildStyles = (dom: DOMUtils, format, node: Node) => {
+  if (format.clear_child_styles) {
+    const selector = format.links ? '*:not(a)' : '*';
+    each(dom.select(selector, node), (node) => {
+      if (isElementNode(node)) {
+        each(format.styles, (value, name) => {
+          dom.setStyle(node, name, '');
+        });
+      }
+    });
+  }
+};
+
+const processChildElements = (node: Node, filter: (node: Node) => boolean, process: (node: Node) => void) => {
+  each(node.childNodes, (node) => {
+    if (isElementNode(node)) {
+      if (filter(node)) {
+        process(node);
+      }
+      if (node.hasChildNodes()) {
+        processChildElements(node, filter, process);
+      }
+    }
+  });
+};
+
+const unwrapEmptySpan = (dom: DOMUtils, node: Node) => {
+  if (node.nodeName === 'SPAN' && dom.getAttribs(node).length === 0) {
+    dom.remove(node, true);
+  }
+};
+
+const hasStyle = (dom: DOMUtils, name: string) => (node: Node): boolean =>
+  !!(node && FormatUtils.getStyle(dom, node, name));
+
+const applyStyle = (dom: DOMUtils, name: string, value: string) => (node: Element): void => {
+  dom.setStyle(node, name, value);
+
+  if (node.getAttribute('style') === '') {
+    node.removeAttribute('style');
+  }
+
+  unwrapEmptySpan(dom, node);
+};
+
+export {
+  applyStyle,
+  clearChildStyles,
+  hasStyle,
+  isElementNode,
+  mergeSiblings,
+  processChildElements
+};

--- a/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
@@ -72,8 +72,10 @@ const mergeSiblingsNodes = (dom: DOMUtils, prev: Node, next: Node) => {
 const mergeSiblings = (dom: DOMUtils, format, vars: FormatVars, node: Node) => {
   // Merge next and previous siblings if they are similar <b>text</b><b>text</b> becomes <b>texttext</b>
   if (node && format.merge_siblings !== false) {
-    node = mergeSiblingsNodes(dom, FormatUtils.getNonWhiteSpaceSibling(node), node);
-    node = mergeSiblingsNodes(dom, node, FormatUtils.getNonWhiteSpaceSibling(node, true));
+    // Previous sibling
+    const newNode = mergeSiblingsNodes(dom, FormatUtils.getNonWhiteSpaceSibling(node), node);
+    // Next sibling
+    mergeSiblingsNodes(dom, newNode, FormatUtils.getNonWhiteSpaceSibling(newNode, true));
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -6,7 +6,7 @@
  */
 
 import { Element as DomElement, Node, Range } from '@ephox/dom-globals';
-import { Arr, Option, Type } from '@ephox/katamari';
+import { Adt, Arr, Fun, Option, Type } from '@ephox/katamari';
 import { Element, Insert, InsertAll, Traverse } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import TreeWalker from '../api/dom/TreeWalker';
@@ -25,6 +25,31 @@ import * as CaretFormat from './CaretFormat';
 import * as ExpandRange from './ExpandRange';
 import * as FormatUtils from './FormatUtils';
 import * as MatchFormat from './MatchFormat';
+import { mergeSiblings } from './MergeUtils';
+
+interface RemoveFormatAdt {
+  fold: <T> (
+    keep: () => T,
+    rename: (name: string) => T,
+    removed: () => T
+  ) => T;
+  match: <T>(branches: {
+    keep: () => T;
+    rename: (name: string) => T;
+    removed: () => T;
+  }) => T;
+  log: (label: string) => void;
+}
+
+const removeResult: {
+  keep: () => RemoveFormatAdt;
+  rename: (name: string) => RemoveFormatAdt;
+  removed: () => RemoveFormatAdt;
+} = Adt.generate([
+  { keep: [] },
+  { rename: [ 'name' ] },
+  { removed: [] }
+]);
 
 const MCE_ATTR_RE = /^(src|href|style)$/;
 const each = Tools.each;
@@ -199,24 +224,13 @@ const removeNode = (ed: Editor, node: Node, format: RemoveFormatPartial) => {
   dom.remove(node, true);
 };
 
-/**
- * Removes the specified format for the specified node. It will also remove the node if it doesn't have
- * any attributes if the format specifies it to do so.
- *
- * @private
- * @param {Object} format Format object with items to remove from node.
- * @param {Object} vars Name/value object with variables to apply to format.
- * @param {Node} node Node to remove the format styles on.
- * @param {Node} compareNode Optional compare node, if specified the styles will be compared to that node.
- * @return {Boolean} True/false if the node was removed or not.
- */
-const removeFormat = (ed: Editor, format: RemoveFormatPartial, vars?: FormatVars, node?: Node, compareNode?: Node) => {
+const removeFormatInternal = (ed: Editor, format: RemoveFormatPartial, vars?: FormatVars, node?: Node, compareNode?: Node): RemoveFormatAdt => {
   let stylesModified: boolean;
   const dom = ed.dom;
 
   // Check if node matches format
   if (!matchName(dom, node, format) && !isColorFormatAndAnchor(node, format)) {
-    return false;
+    return removeResult.keep();
   }
 
   // "matchName" will made sure we're dealing with an element, so cast as one
@@ -231,8 +245,7 @@ const removeFormat = (ed: Editor, format: RemoveFormatPartial, vars?: FormatVars
     // Note: If there are no attributes left, the element will be removed as normal at the end of the function
     if (attrsToPreserve.length > 0) {
       // Convert inline element to span if necessary
-      ed.dom.rename(node, 'span');
-      return true;
+      return removeResult.rename('span');
     }
   }
 
@@ -322,7 +335,7 @@ const removeFormat = (ed: Editor, format: RemoveFormatPartial, vars?: FormatVars
     for (let i = 0; i < attrs.length; i++) {
       const attrName = attrs[i].nodeName;
       if (attrName.indexOf('_') !== 0 && attrName.indexOf('data-') !== 0) {
-        return false;
+        return removeResult.keep();
       }
     }
   }
@@ -330,9 +343,32 @@ const removeFormat = (ed: Editor, format: RemoveFormatPartial, vars?: FormatVars
   // Remove the inline child if it's empty for example <b> or <span>
   if (format.remove !== 'none') {
     removeNode(ed, elm, format);
-    return true;
+    return removeResult.removed();
   }
+
+  return removeResult.keep();
 };
+
+/**
+ * Removes the specified format for the specified node. It will also remove the node if it doesn't have
+ * any attributes if the format specifies it to do so.
+ *
+ * @private
+ * @param {Object} format Format object with items to remove from node.
+ * @param {Object} vars Name/value object with variables to apply to format.
+ * @param {Node} node Node to remove the format styles on.
+ * @param {Node} compareNode Optional compare node, if specified the styles will be compared to that node.
+ * @return {Boolean} True/false if the node was removed or not.
+ */
+const removeFormat = (ed: Editor, format: RemoveFormatPartial, vars?: FormatVars, node?: Node, compareNode?: Node): boolean =>
+  removeFormatInternal(ed, format, vars, node, compareNode).fold(
+    Fun.never,
+    (newName) => {
+      ed.dom.rename(node, newName);
+      return true;
+    },
+    Fun.always
+  );
 
 const findFormatRoot = (editor: Editor, container: Node, name: string, vars: FormatVars, similar: boolean) => {
   let formatRoot: Node;
@@ -352,8 +388,20 @@ const findFormatRoot = (editor: Editor, container: Node, name: string, vars: For
   return formatRoot;
 };
 
+const removeFormatFromClone = (editor: Editor, format: RemoveFormatPartial, vars: FormatVars, clone: Node) =>
+  removeFormatInternal(editor, format, vars, clone, clone).fold(
+    Fun.constant(clone),
+    (newName) => {
+      // To rename a node, it needs to be a child of another node
+      const fragment = editor.dom.createFragment();
+      fragment.appendChild(clone);
+      return editor.dom.rename(clone, newName);
+    },
+    Fun.constant(null)
+  );
+
 const wrapAndSplit = (editor: Editor, formatList: RemoveFormatPartial[], formatRoot: Node, container: Node, target: Node, split: boolean, format: RemoveFormatPartial, vars: FormatVars) => {
-  let clone, lastClone: Node, firstClone: Node;
+  let clone: Node | null, lastClone: Node, firstClone: Node;
   const dom = editor.dom;
 
   // Format root found then clone formats and split it
@@ -364,8 +412,8 @@ const wrapAndSplit = (editor: Editor, formatList: RemoveFormatPartial[], formatR
       clone = dom.clone(parent, false);
 
       for (let i = 0; i < formatList.length; i++) {
-        if (removeFormat(editor, formatList[i], vars, clone, clone)) {
-          clone = 0;
+        clone = removeFormatFromClone(editor, formatList[i], vars, clone);
+        if (clone === null) {
           break;
         }
       }
@@ -393,6 +441,12 @@ const wrapAndSplit = (editor: Editor, formatList: RemoveFormatPartial[], formatR
     if (lastClone) {
       target.parentNode.insertBefore(lastClone, target);
       firstClone.appendChild(target);
+
+      // After splitting the nodes may match with other siblings so we need to attempt to merge them
+      // Note: We can't use MergeFormats, as that'd create a circular dependency
+      if (format.inline) {
+        mergeSiblings(dom, format, vars, lastClone);
+      }
     }
   }
 

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -472,6 +472,21 @@ UnitTest.asynctest('browser.tinymce.core.FormatterRemoveTest', function (success
     Assert.eq('Inline element on selected text with preserve_attributes flag (bold)', '<p><span style="color: red;" class="abc">1234</span></p>', getContent(editor));
   });
 
+  suite.test('Complex inline element using ranged selection with preserve_attributes flag (bold)', (editor) => {
+    editor.formatter.register('format', { inline: 'b', preserve_attributes: [ 'class', 'style' ], remove: 'all' });
+    editor.getBody().innerHTML = '<p><b style="text-align: left;">If the situation of the pandemic does not improve<span style="color: #172b4d;">, there will be no spectators, no museum, no stores open, and money will continue to be lost.</span></b></p>';
+    LegacyUnit.setSelection(editor, 'b', 24, 'span', 56);
+    editor.formatter.remove('format');
+    Assert.eq(
+      'Inline element on selected text with preserve_attributes flag (bold)',
+      '<p>' +
+        '<b style="text-align: left;">if the situation of the </b>' +
+        '<span style="text-align: left;">pandemic does not improve<span style="color: #172b4d;">, there will be no spectators, no museum, no stores open</span></span>' +
+        '<b style="text-align: left;"><span style="color: #172b4d;">, and money will continue to be lost.</span></b>' +
+      '</p>',
+      getContent(editor));
+  });
+
   suite.test('Inline element on selected text with preserve_attributes flag (italic)', (editor) => {
     editor.formatter.register('format', { inline: 'em', preserve_attributes: [ 'class', 'style' ], remove: 'all' });
     editor.getBody().innerHTML = '<p><em class="abc" style="color: red;" data-test="1">1234</em></p>';
@@ -510,7 +525,7 @@ UnitTest.asynctest('browser.tinymce.core.FormatterRemoveTest', function (success
     Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
   }, {
     indent: false,
-    extended_valid_elements: 'b,i,span[style|contenteditable|class]',
+    extended_valid_elements: 'b[style],i,span[style|contenteditable|class]',
     entities: 'raw',
     valid_styles: {
       '*': 'color,font-size,font-family,background-color,font-weight,font-style,text-decoration,float,' +


### PR DESCRIPTION
Related Ticket: TINY-6288

Description of Changes:
* This fixes an exception that's thrown when only partially removing an inline format that contains styles or classes. This can end up in the editor when copying and pasting HTML from outside the editor. It also fixes an issue missed when the preserve attributes logic was added, where sibling nodes that had the same styles wouldn't be merged.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
