### PR TITLE
TINY-6294: Fixed TrimNode.trimNode() removing nodes it shouldn't

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -17,7 +17,7 @@ Version 5.5.0 (TBD)
     Fixed up and down keyboard navigation not working for inline `contenteditable="false"` elements #TINY-6226
     Fixed the `unlink` toolbar button not working when selecting multiple links #TINY-4867
     Fixed the `link` dialog not showing the "Text to display" field in some valid cases #TINY-5205
-    Fixed some content was incorrectly removed when using the `DOMUtils.split()` API #TINY-6294
+    Fixed the `DOMUtils.split()` API incorrectly removing some content #TINY-6294
     Fixed pressing escape not focusing the editor when using multiple toolbars #TINY-6230
     Fixed the `dirty` flag not being correctly set during an `AddUndo` event #TINY-4707
 Version 5.4.2 (TBD)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -17,6 +17,7 @@ Version 5.5.0 (TBD)
     Fixed up and down keyboard navigation not working for inline `contenteditable="false"` elements #TINY-6226
     Fixed the `unlink` toolbar button not working when selecting multiple links #TINY-4867
     Fixed the `link` dialog not showing the "Text to display" field in some valid cases #TINY-5205
+    Fixed some content was incorrectly removed when using the `DOMUtils.split()` API #TINY-6294
     Fixed pressing escape not focusing the editor when using multiple toolbars #TINY-6230
 Version 5.4.2 (TBD)
     Fixed clicking on notifications causing inline editors to hide #TINY-6058

--- a/modules/tinymce/src/core/main/ts/dom/Empty.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Empty.ts
@@ -22,7 +22,7 @@ const isWhitespace = function (rootNode: Node, node: Node) {
 };
 
 const isNamedAnchor = function (node: Node) {
-  return NodeType.isElement(node) && node.nodeName === 'A' && node.hasAttribute('name');
+  return NodeType.isElement(node) && node.nodeName === 'A' && !node.hasAttribute('href') && (node.hasAttribute('name') || node.hasAttribute('id'));
 };
 
 const isContent = function (rootNode: Node, node: Node) {

--- a/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
+++ b/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
@@ -5,20 +5,30 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Arr, Strings } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
-import Tools from '../api/util/Tools';
-import * as ElementType from './ElementType';
+import DOMUtils from '../api/dom/DOMUtils';
 import * as NodeType from './NodeType';
+import * as Empty from './Empty';
 
-const surroundedBySpans = function (node) {
-  const previousIsSpan = node.previousSibling && node.previousSibling.nodeName === 'SPAN';
-  const nextIsSpan = node.nextSibling && node.nextSibling.nodeName === 'SPAN';
+const isSpan = (node: Node): node is HTMLSpanElement =>
+  node && node.nodeName.toLowerCase() === 'span';
+
+const surroundedBySpans = (node: Node) => {
+  const previousIsSpan = isSpan(node.previousSibling);
+  const nextIsSpan = isSpan(node.nextSibling);
   return previousIsSpan && nextIsSpan;
 };
 
-const isBookmarkNode = function (node) {
-  return node && node.tagName === 'SPAN' && node.getAttribute('data-mce-type') === 'bookmark';
-};
+const isBookmarkNode = (node: Node) =>
+  isSpan(node) && node.getAttribute('data-mce-type') === 'bookmark';
+
+// Keep text nodes with only spaces if surrounded by spans.
+// eg. "<p><span>a</span> <span>b</span></p>" should keep space between a and b
+const isKeepTextNode = (node: Node) =>
+  NodeType.isText(node) && (Strings.trim(node.data).length !== 0 || surroundedBySpans(node));
+
+const isDocument = (node: Node) => NodeType.isDocumentFragment(node) || NodeType.isDocument(node);
 
 // W3C valid browsers tend to leave empty nodes to the left/right side of the contents - this makes sense
 // but we don't want that in our code since it serves no purpose for the end user
@@ -28,46 +38,35 @@ const isBookmarkNode = function (node) {
 //   <p>text 1<span></span></p><b>CHOP</b><p><span></span>text 2</p>
 // this function will then trim off empty edges and produce:
 //   <p>text 1</p><b>CHOP</b><p>text 2</p>
-const trimNode = function (dom, node) {
-  let i, children = node.childNodes;
-
+const trimNode = (dom: DOMUtils, node: Node): Node => {
   if (NodeType.isElement(node) && isBookmarkNode(node)) {
-    return;
+    return node;
   }
 
-  for (i = children.length - 1; i >= 0; i--) {
+  const children = node.childNodes;
+  for (let i = children.length - 1; i >= 0; i--) {
     trimNode(dom, children[i]);
   }
 
-  if (NodeType.isDocument(node) === false) {
-    // Keep non whitespace text nodes
-    if (NodeType.isText(node) && node.nodeValue.length > 0) {
-      // Keep if parent element is a block or if there is some useful content
-      const trimmedLength = Tools.trim(node.nodeValue).length;
-      if (dom.isBlock(node.parentNode) || trimmedLength > 0) {
-        return;
+  if (!isDocument(node) && !isKeepTextNode(node) && Empty.isEmpty(SugarElement.fromDom(node), false)) {
+    if (NodeType.isElement(node)) {
+      const currentChildren = node.childNodes;
+
+      // Don't remove if there's a br as a child, eg: <p><br></p>
+      if (Arr.exists(currentChildren, NodeType.isBr)) {
+        return node;
       }
-      // Also keep text nodes with only spaces if surrounded by spans.
-      // eg. "<p><span>a</span> <span>b</span></p>" should keep space between a and b
-      if (trimmedLength === 0 && surroundedBySpans(node)) {
-        return;
-      }
-    } else if (NodeType.isElement(node)) {
+
       // If the only child is a bookmark then move it up
-      children = node.childNodes;
-
-      if (children.length === 1 && isBookmarkNode(children[0])) {
-        node.parentNode.insertBefore(children[0], node);
-      }
-
-      // Keep non empty elements and void elements
-      if (children.length || ElementType.isVoid(SugarElement.fromDom(node))) {
-        return;
+      if (currentChildren.length === 1 && isBookmarkNode(currentChildren[0])) {
+        node.parentNode.insertBefore(currentChildren[0], node);
       }
     }
 
     dom.remove(node);
+    return node;
   }
+
   return node;
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -212,6 +212,11 @@ UnitTest.test('DOMUtils.is', () => {
   Assert.eq('', false, DOM.is(DOM.get('textX'), 'div#textX2'));
   Assert.eq('', false, DOM.is(null, 'div#textX2'));
 
+  DOM.get('test').innerHTML = '<div><span class="test">ab<span><a id="test2" href="">abc</a>c</span></span></div>';
+
+  Assert.eq('', true, DOM.is(DOM.select('span', 'test'), 'span'));
+  Assert.eq('', true, DOM.is(DOM.select('#test2', 'test'), '#test2'));
+
   DOM.remove('test');
 });
 
@@ -355,16 +360,6 @@ UnitTest.test('DOMUtils.getParents', () => {
   Assert.eq('', 2, DOM.getParents('test2', 'span').length);
   Assert.eq('', 1, DOM.getParents('test2', 'span.test').length);
   Assert.eq('', 0, DOM.getParents('test2', 'body', DOM.get('test')).length);
-
-  DOM.remove('test');
-});
-
-UnitTest.test('DOMUtils.is', () => {
-  DOM.add(document.body, 'div', { id: 'test' });
-  DOM.get('test').innerHTML = '<div><span class="test">ab<span><a id="test2" href="">abc</a>c</span></span></div>';
-
-  Assert.eq('', true, DOM.is(DOM.select('span', 'test'), 'span'));
-  Assert.eq('', true, DOM.is(DOM.select('#test2', 'test'), '#test2'));
 
   DOM.remove('test');
 });
@@ -582,6 +577,18 @@ UnitTest.test('DOMUtils.split', () => {
   point = DOM.select('ul li:nth-child(2)', DOM.get('test'))[0];
   DOM.split(parent, point);
   Assert.eq('', '<ul><li>first line<br><ul><li><span>second</span> <span>line</span></li></ul></li><li>third line<br></li></ul>', HtmlUtils.cleanHtml(DOM.get('test').innerHTML));
+
+  DOM.setHTML('test', '<p><b>&nbsp; <span>inner</span>text2</b></p>');
+  parent = DOM.select('p', DOM.get('test'))[0];
+  point = DOM.select('span', DOM.get('test'))[0];
+  DOM.split(parent, point);
+  Assert.eq('', '<p><b>&nbsp; </b></p><span>inner</span><p><b>text2</b></p>', HtmlUtils.cleanHtml(DOM.get('test').innerHTML));
+
+  DOM.setHTML('test', '<p><b><a id="anchor"></a><span>inner</span>text2</b></p>');
+  parent = DOM.select('p', DOM.get('test'))[0];
+  point = DOM.select('span', DOM.get('test'))[0];
+  DOM.split(parent, point);
+  Assert.eq('', '<p><b><a id="anchor"></a></b></p><span>inner</span><p><b>text2</b></p>', HtmlUtils.cleanHtml(DOM.get('test').innerHTML));
 
   DOM.remove('test');
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/EmptyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/EmptyTest.ts
@@ -28,7 +28,8 @@ UnitTest.asynctest('browser.tinymce.core.dom.EmptyTest', function (success, fail
       sTestEmpty('<p><i><b></b></i><b><i></i></b></p>', true),
       sTestEmpty('<span></span>', true),
       sTestEmpty('<p><i><b></b></i><b><i data-mce-bogus="all"><img src="#"></i></b></p>', true),
-      sTestEmpty('<p><br data-mce-bogus="1"><br></p>', true)
+      sTestEmpty('<p><br data-mce-bogus="1"><br></p>', true),
+      sTestEmpty('<a id="link" href="http://some.url/"></a>', true)
     ])),
     Logger.t('Non empty elements', GeneralSteps.sequence([
       sTestEmpty('<br>', false),
@@ -42,7 +43,8 @@ UnitTest.asynctest('browser.tinymce.core.dom.EmptyTest', function (success, fail
       sTestEmpty('<p><br><br></p>', false),
       sTestEmpty('<p><i><b></b></i><b><i><img src="#"></i></b></p>', false),
       sTestEmpty('<span data-mce-bookmark="x"></span>', false),
-      sTestEmpty('<span contenteditable="false"></span>', false)
+      sTestEmpty('<span contenteditable="false"></span>', false),
+      sTestEmpty('<a id="anchor"></a>', false)
     ]))
   ], function () {
     success();

--- a/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
@@ -7,7 +7,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.TrimNodeTest', function (success, f
 
   const dom = DOMUtils(document, {});
 
-  const sTestTrim = function (inputHtml, expectedTrimmedHtml) {
+  const sTestTrim = function (inputHtml: string, expectedTrimmedHtml: string) {
     return Step.sync(function () {
       const elm = document.createElement('div');
       elm.innerHTML = inputHtml;
@@ -31,6 +31,9 @@ UnitTest.asynctest('browser.tinymce.core.dom.TrimNodeTest', function (success, f
     sTestTrim('<p><span>x</span>&nbsp;<span>x</span></p>', '<p><span>x</span>&nbsp;<span>x</span></p>'),
     sTestTrim('<p><span data-mce-type="bookmark"></span> y</p>', '<p><span data-mce-type="bookmark"></span> y</p>'),
     sTestTrim('<p>a <span>b <span data-mce-type="bookmark"></span> c</span></p>', '<p>a <span>b <span data-mce-type="bookmark"></span> c</span></p>'),
+    sTestTrim('<p><strong><span>x</span>&nbsp;</strong></p>', '<p><strong><span>x</span>&nbsp;</strong></p>'),
+    sTestTrim('<p><a id="anchor"></a><span>x</span></p>', '<p><a id="anchor"></a><span>x</span></p>'),
+    sTestTrim('<p><br data-mce-bogus="1"></p>', '<p><br data-mce-bogus="1"></p>'),
     sTestTrimDocumentNode
   ], function () {
     success();

--- a/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
@@ -25,6 +25,17 @@ UnitTest.asynctest('browser.tinymce.core.dom.TrimNodeTest', function (success, f
     Assert.eq('Should return document as is', true, actual === expected);
   });
 
+  const sTestTrimFragmentedTextNode = Step.sync(() => {
+    const emptyTextNode = document.createTextNode(' ');
+    const elm = document.createElement('div');
+    elm.innerHTML = '<strong>abc</strong>abc';
+    elm.insertBefore(emptyTextNode, elm.lastChild);
+
+    const actual = TrimNode.trimNode(dom, elm);
+
+    Assert.eq('Empty text node shouldn\'t be trimmed', '<strong>abc</strong> abc', actual.innerHTML);
+  });
+
   Pipeline.async({}, [
     sTestTrim('<p><span></span>x</p>', '<p>x</p>'),
     sTestTrim('<p><span>x</span>&nbsp;</p>', '<p><span>x</span>&nbsp;</p>'),
@@ -34,6 +45,8 @@ UnitTest.asynctest('browser.tinymce.core.dom.TrimNodeTest', function (success, f
     sTestTrim('<p><strong><span>x</span>&nbsp;</strong></p>', '<p><strong><span>x</span>&nbsp;</strong></p>'),
     sTestTrim('<p><a id="anchor"></a><span>x</span></p>', '<p><a id="anchor"></a><span>x</span></p>'),
     sTestTrim('<p><br data-mce-bogus="1"></p>', '<p><br data-mce-bogus="1"></p>'),
+    sTestTrim('<p><strong>x</strong> <em>y</em></p>', '<p><strong>x</strong> <em>y</em></p>'),
+    sTestTrimFragmentedTextNode,
     sTestTrimDocumentNode
   ], function () {
     success();


### PR DESCRIPTION
Related Ticket: TINY-6294

Description of Changes:

When investigating TINY-6251 (https://github.com/tinymce/tinymce/pull/5937) we found a number of bugs with the with the `TrimNode` module. We deemed they were probably too risky to include in 5.4.2, so we're including a partial fix there and this should be a more in-depth fix. The idea behind this is to re-use an existing isEmpty check instead of trying to reimplement it.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #4995
