### PR TITLE
TINY-4706/TINY-6273: Fixed an issue where link urls couldn't be deleted or edited in some cases

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.4.2 (TBD)
     Fixed clicking on notifications causing inline editors to hide #TINY-6058
+    Fixed an issue where image link urls couldn't be deleted in the link dialog #TINY-4706
     Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false` #TINY-6256
     Fixed an exception thrown when removing inline formats that contained additional styles or classes #TINY-6288
     Fixed an exception thrown when positioning the context toolbar on Internet Explorer 11 in some edge cases #TINY-6271

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,6 @@
 Version 5.4.2 (TBD)
     Fixed clicking on notifications causing inline editors to hide #TINY-6058
-    Fixed an issue where image link urls couldn't be deleted in the link dialog #TINY-4706
+    Fixed an issue where link urls couldn't be deleted or edited in the link dialog in some cases #TINY-4706
     Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false` #TINY-6256
     Fixed an exception thrown when removing inline formats that contained additional styles or classes #TINY-6288
     Fixed an exception thrown when positioning the context toolbar on Internet Explorer 11 in some edge cases #TINY-6271

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
@@ -58,28 +58,28 @@ const collectData = (editor): Promise<LinkDialogInfo> => {
   return DialogInfo.collect(editor, anchorNode);
 };
 
-const getInitialData = (info: LinkDialogInfo, defaultTarget: Option<string>): LinkDialogData => ({
-  url: {
-    value: info.anchor.url.getOr(''),
-    meta: {
-      attach: () => { },
-      text: info.anchor.url.fold(
-        () => '',
-        () => info.anchor.text.getOr('')
-      ),
-      original: {
-        value: info.anchor.url.getOr('')
+const getInitialData = (info: LinkDialogInfo, defaultTarget: Option<string>): LinkDialogData => {
+  const anchor = info.anchor;
+  const url = anchor.url.getOr('');
+
+  return {
+    url: {
+      value: url,
+      meta: {
+        original: {
+          value: url
+        }
       }
-    }
-  },
-  text: info.anchor.text.getOr(''),
-  title: info.anchor.title.getOr(''),
-  anchor: info.anchor.url.getOr(''),
-  link: info.anchor.url.getOr(''),
-  rel: info.anchor.rel.getOr(''),
-  target: info.anchor.target.or(defaultTarget).getOr(''),
-  linkClass: info.anchor.linkClass.getOr('')
-});
+    },
+    text: anchor.text.getOr(''),
+    title: anchor.title.getOr(''),
+    anchor: url,
+    link: url,
+    rel: anchor.rel.getOr(''),
+    target: anchor.target.or(defaultTarget).getOr(''),
+    linkClass: anchor.linkClass.getOr('')
+  };
+};
 
 const makeDialog = (settings: LinkDialogInfo, onSubmit, editor: Editor): Types.Dialog.DialogApi<LinkDialogData> => {
 

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
@@ -111,8 +111,8 @@ const makeDialog = (settings: LinkDialogInfo, onSubmit, editor: Editor): Types.D
   const defaultTarget: Option<string> = Option.from(Settings.getDefaultLinkTarget(editor));
 
   const initialData = getInitialData(settings, defaultTarget);
-  const dialogDelta = DialogChanges.init(initialData, settings);
   const catalogs = settings.catalogs;
+  const dialogDelta = DialogChanges.init(initialData, catalogs);
 
   const body: Types.Dialog.PanelApi = {
     type: 'panel',

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogChanges.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogChanges.ts
@@ -5,9 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Cell, Option, Fun } from '@ephox/katamari';
+import { Arr, Fun, Option, Options } from '@ephox/katamari';
 
-import { LinkDialogData, LinkDialogInfo, ListItem, ListValue, LinkDialogUrlData } from './DialogTypes';
+import { LinkDialogCatalog, LinkDialogData, LinkDialogUrlData, ListItem, ListValue } from './DialogTypes';
 
 export interface DialogDelta {
   url: LinkDialogUrlData;
@@ -17,8 +17,9 @@ export interface DialogDelta {
 const findTextByValue = (value: string, catalog: ListItem[]): Option<ListValue> => Arr.findMap(catalog, (item) =>
 // TODO TINY-2236 re-enable this (support will need to be added to bridge)
 // return 'items' in item ? findTextByValue(value, item.items) :
-  Option.some(item).filter((i) => i.value === value)
+  Options.someIf(item.value === value, item)
 );
+
 const getDelta = (persistentText: string, fieldName: string, catalog: ListItem[], data: Partial<LinkDialogData>): Option<DialogDelta> => {
   const value = data[fieldName];
   const hasPersistentText = persistentText.length > 0;
@@ -34,47 +35,56 @@ const getDelta = (persistentText: string, fieldName: string, catalog: ListItem[]
   })) : Option.none();
 };
 
-const findCatalog = (settings: LinkDialogInfo, fieldName: string): Option<ListItem[]> => {
+const findCatalog = (catalogs: LinkDialogCatalog, fieldName: string): Option<ListItem[]> => {
   if (fieldName === 'link') {
-    return settings.catalogs.link;
+    return catalogs.link;
   } else if (fieldName === 'anchor') {
-    return settings.catalogs.anchor;
+    return catalogs.anchor;
   } else {
     return Option.none();
   }
 };
 
-const init = (initialData: LinkDialogData, linkSettings: LinkDialogInfo) => {
-  const persistentText = Cell(initialData.text);
+const init = (initialData: LinkDialogData, linkCatalog: LinkDialogCatalog) => {
+  const persistentData = {
+    text: initialData.text,
+    title: initialData.title
+  };
 
-  const onUrlChange = (data: LinkDialogData) => {
-    // We are going to change the text, because it has not been manually entered by the user.
-    if (persistentText.get().length <= 0) {
-      const urlText = data.url.meta.text !== undefined ? data.url.meta.text : data.url.value;
-      const urlTitle = data.url.meta.title !== undefined ? data.url.meta.title : '';
+  const getTitleFromUrlChange = (url: LinkDialogUrlData): Option<string> =>
+    Options.someIf(persistentData.title.length <= 0, Option.from(url.meta.title).getOr(''));
+
+  const getTextFromUrlChange = (url: LinkDialogUrlData): Option<string> =>
+    Options.someIf(persistentData.text.length <= 0, Option.from(url.meta.text).getOr(url.value));
+
+  const onUrlChange = (data: LinkDialogData): Option<Partial<LinkDialogData>> => {
+    const text = getTextFromUrlChange(data.url);
+    const title = getTitleFromUrlChange(data.url);
+    // We are going to change the text/title because it has not been manually entered by the user.
+    if (text.isSome() || title.isSome()) {
       return Option.some({
-        text: urlText,
-        title: urlTitle
+        ...text.map((text) => ({ text })).getOr({ }),
+        ...title.map((title) => ({ title })).getOr({ })
       });
     } else {
       return Option.none();
     }
-
   };
 
   const onCatalogChange = (data: LinkDialogData, change: { name: string }): Option<Partial<LinkDialogData>> => {
-    const catalog = findCatalog(linkSettings, change.name).getOr([ ]);
-    return getDelta(persistentText.get(), change.name, catalog, data);
+    const catalog = findCatalog(linkCatalog, change.name).getOr([ ]);
+    return getDelta(persistentData.text, change.name, catalog, data);
   };
 
   const onChange = (getData: () => LinkDialogData, change: { name: string }): Option<Partial<LinkDialogData>> => {
-    if (change.name === 'url') {
+    const name = change.name;
+    if (name === 'url') {
       return onUrlChange(getData());
-    } else if (Arr.contains([ 'anchor', 'link' ], change.name)) {
+    } else if (Arr.contains([ 'anchor', 'link' ], name)) {
       return onCatalogChange(getData(), change);
-    } else if (change.name === 'text') {
-      // Update the persistent text state, as a user has input custom text
-      persistentText.set(getData().text);
+    } else if (name === 'text' || name === 'title') {
+      // Update the persistent text/title state, as a user has input custom text
+      persistentData[name] = getData()[name];
       return Option.none();
     } else {
       return Option.none();

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogTypes.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogTypes.ts
@@ -22,6 +22,14 @@ export interface ListGroup {
 // TODO TINY-2236 re-enable this (support will need to be added to bridge)
 export type ListItem = ListValue/*  | ListGroup */;
 
+export interface LinkDialogCatalog {
+  link: Option<ListItem[]>;
+  targets: Option<ListItem[]>;
+  rels: Option<ListItem[]>;
+  classes: Option<ListItem[]>;
+  anchor: Option<ListItem[]>;
+}
+
 export interface LinkDialogInfo {
   anchor: {
     url: Option<string>;
@@ -31,13 +39,7 @@ export interface LinkDialogInfo {
     linkClass: Option<string>;
     title: Option<string>;
   };
-  catalogs: {
-    link: Option<ListItem[]>;
-    targets: Option<ListItem[]>;
-    rels: Option<ListItem[]>;
-    classes: Option<ListItem[]>;
-    anchor: Option<ListItem[]>;
-  };
+  catalogs: LinkDialogCatalog;
   flags: {
     titleEnabled: boolean;
   };

--- a/modules/tinymce/src/plugins/link/test/ts/atomic/DialogChangesTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/atomic/DialogChangesTest.ts
@@ -1,78 +1,128 @@
 import { Logger } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Fun } from '@ephox/katamari';
+import { Fun, Option, OptionInstances } from '@ephox/katamari';
+import fc from 'fast-check';
 
 import { DialogChanges, DialogDelta } from 'tinymce/plugins/link/ui/DialogChanges';
-import { LinkDialogData, ListItem } from 'tinymce/plugins/link/ui/DialogTypes';
+import { LinkDialogCatalog, LinkDialogData, ListItem } from 'tinymce/plugins/link/ui/DialogTypes';
 
-UnitTest.test('DialogChanges', () => {
+const tOption = OptionInstances.tOption;
 
-  Logger.sync(
-    'Basic test',
-    () => {
-      // TODO TINY-2236 re-enable this (support will need to be added to bridge)
-      const anchorList: ListItem[] = [
-        { value: 'alpha', text: 'Alpha' }
-        /* {
-          text: 'GroupB',
-          items: [
-            { value: 'gamma', text: 'Gamma' }
-          ]
-        } */
-      ];
+UnitTest.test('DialogChanges.getDelta', () => {
+  // TODO TINY-2236 re-enable this (support will need to be added to bridge)
+  const anchorList: ListItem[] = [
+    { value: 'alpha', text: 'Alpha' }
+    /* {
+      text: 'GroupB',
+      items: [
+        { value: 'gamma', text: 'Gamma' }
+      ]
+    } */
+  ];
 
-      const assertNone = (label: string, previousText: string, catalog: ListItem[], data: Partial<LinkDialogData>) => {
-        Logger.sync('assertNone(' + label + ')', () => {
-          const actual = DialogChanges.getDelta(previousText, 'anchor', catalog, data);
-          actual.each(
-            (_a) => { throw new Error('Should not have found replacement text'); }
-          );
-        });
-      };
+  const assertNone = (label: string, previousText: string, catalog: ListItem[], data: Partial<LinkDialogData>) => {
+    Logger.sync('assertNone(' + label + ')', () => {
+      const actual = DialogChanges.getDelta(previousText, 'anchor', catalog, data);
+      Assert.eq('Should not have found replacement text', Option.none(), actual, tOption());
+    });
+  };
 
-      const assertSome = (label: string, expected: DialogDelta, previousText: string, catalog: ListItem[], data: Partial<LinkDialogData>) => {
-        Logger.sync('assertSome(' + label + ')', () => {
-          const actual = DialogChanges.getDelta(previousText, 'anchor', catalog, data);
-          Assert.eq('Checking replacement text', expected, actual.getOrDie(
-            'Should be some'
-          ));
-        });
-      };
+  const assertSome = (label: string, expected: DialogDelta, previousText: string, catalog: ListItem[], data: Partial<LinkDialogData>) => {
+    Logger.sync('assertSome(' + label + ')', () => {
+      const actual = DialogChanges.getDelta(previousText, 'anchor', catalog, data);
+      Assert.eq('Checking replacement text', Option.some(expected), actual, tOption());
+    });
+  };
 
-      assertSome('Current text empty + Has mapping', {
-        url: {
-          value: 'alpha',
-          meta: {
-            attach: Fun.noop,
-            text: 'Alpha'
-          }
-        },
+  assertSome('Current text empty + Has mapping', {
+    url: {
+      value: 'alpha',
+      meta: {
+        attach: Fun.noop,
         text: 'Alpha'
-      }, '', anchorList, {
-        anchor: 'alpha',
-        text: ''
-      });
+      }
+    },
+    text: 'Alpha'
+  }, '', anchorList, {
+    anchor: 'alpha',
+    text: ''
+  });
 
-      assertNone('Current text empty + Has no mapping', '', anchorList, {
-        anchor: 'beta',
-        text: ''
-      });
+  assertNone('Current text empty + Has no mapping', '', anchorList, {
+    anchor: 'beta',
+    text: ''
+  });
 
-      // TODO TINY-2236 re-enable this (support will need to be added to bridge)
-      /* assertSome('Current text empty + Has mapping in nested list', {
-        url: {
-          value: 'gamma',
-          meta: {
-            attach: Fun.noop,
-            text: 'Gamma'
-          }
-        },
+  // TODO TINY-2236 re-enable this (support will need to be added to bridge)
+  /* assertSome('Current text empty + Has mapping in nested list', {
+    url: {
+      value: 'gamma',
+      meta: {
+        attach: Fun.noop,
         text: 'Gamma'
-      }, '', anchorList, {
-        anchor: 'gamma',
-        text: ''
-      }); */
+      }
+    },
+    text: 'Gamma'
+  }, '', anchorList, {
+    anchor: 'gamma',
+    text: ''
+  }); */
+});
 
-    }
-  );
+UnitTest.test('DialogChanges.init - no initial data', () => {
+  const dialogChange = DialogChanges.init({ title: '', text: '' } as LinkDialogData, { } as LinkDialogCatalog);
+
+  fc.assert(fc.property(fc.webUrl(), fc.asciiString(), fc.asciiString(), (url, title, text) => {
+    const data = Fun.constant({ url: {
+      value: url,
+      meta: { title, text }
+    }} as LinkDialogData);
+    const dataNoMeta = Fun.constant({ url: {
+      value: url,
+      meta: { }
+    }} as LinkDialogData);
+
+    Assert.eq('on url change should include url title and text',
+      Option.some<Partial<LinkDialogData>>({ title, text }),
+      dialogChange.onChange(data, { name: 'url' }),
+      tOption()
+    );
+
+    Assert.eq('on url change should fallback to url for text',
+      Option.some<Partial<LinkDialogData>>({ title: '', text: url }),
+      dialogChange.onChange(dataNoMeta, { name: 'url' }),
+      tOption()
+    );
+  }));
+});
+
+UnitTest.test('DialogChanges.init - with original data', () => {
+  const dialogChange = DialogChanges.init({ title: 'orig title', text: 'orig text' } as LinkDialogData, { } as LinkDialogCatalog);
+  const dialogChangeNoTitle = DialogChanges.init({ title: '', text: 'orig text' } as LinkDialogData, { } as LinkDialogCatalog);
+  const dialogChangeNoText = DialogChanges.init({ title: 'orig title', text: '' } as LinkDialogData, { } as LinkDialogCatalog);
+
+  fc.assert(fc.property(fc.webUrl(), fc.asciiString(), fc.asciiString(), (url, title, text) => {
+    const data = Fun.constant({ url: {
+      value: url,
+      meta: { title, text }
+    }} as LinkDialogData);
+
+    Assert.eq('on url change should not try to change title and text',
+      Option.none(),
+      dialogChange.onChange(data, { name: 'url' }),
+      tOption()
+    );
+
+    Assert.eq('No Title - on url change should only try to change title',
+      Option.some<Partial<LinkDialogData>>({ title }),
+      dialogChangeNoTitle.onChange(data, { name: 'url' }),
+      tOption()
+    );
+
+    Assert.eq('No Text - on url change should only try to change text',
+      Option.some<Partial<LinkDialogData>>({ text }),
+      dialogChangeNoText.onChange(data, { name: 'url' }),
+      tOption()
+    );
+  }));
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageLinkTest.ts
@@ -1,4 +1,4 @@
-import { Assertions, Chain, FocusTools, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
+import { Chain, FocusTools, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
 import { TinyApis, TinyDom, TinyLoader, TinyUi } from '@ephox/mcagar';
@@ -52,17 +52,18 @@ UnitTest.asynctest('browser.tinymce.plugins.link.SelectedImageTest', (success, f
         )
       ]),
       Log.stepsAsStep('TINY-4706', 'Link: images link urls should be able to be removed', [
-        tinyApis.sSetContent('<p><a href="http://www.google.com/"><img src="image.png"></a></p>'),
+        tinyApis.sSetContent('<p><a href="http://www.google.com/" title="test"><img src="image.png"></a></p>'),
         tinyApis.sSelect('a', []),
         TestLinkUi.sOpenLinkDialog(tinyUi),
         Chain.asStep(Body.body(), [
           FocusTools.cSetActiveValue(''),
-          TestLinkUi.cFireEvent('input'),
-          Chain.injectThunked(Body.body),
-          UiFinder.cNotExists('.tox-label:contains("Text to display")'),
-          FocusTools.cGetActiveValue,
-          Assertions.cAssertEq('URL should be empty', '')
+          TestLinkUi.cFireEvent('input')
         ]),
+        UiFinder.sNotExists(Body.body(), '.tox-label:contains("Text to display")'),
+        TestLinkUi.sAssertDialogContents({
+          url: '',
+          title: 'test'
+        }),
         TestLinkUi.sClickCancel
       ]),
       TestLinkUi.sClearHistory

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageLinkTest.ts
@@ -1,4 +1,4 @@
-import { FocusTools, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
+import { Assertions, Chain, FocusTools, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
 import { TinyApis, TinyDom, TinyLoader, TinyUi } from '@ephox/mcagar';
@@ -50,6 +50,20 @@ UnitTest.asynctest('browser.tinymce.plugins.link.SelectedImageTest', (success, f
             'p': 1
           })
         )
+      ]),
+      Log.stepsAsStep('TINY-4706', 'Link: images link urls should be able to be removed', [
+        tinyApis.sSetContent('<p><a href="http://www.google.com/"><img src="image.png"></a></p>'),
+        tinyApis.sSelect('a', []),
+        TestLinkUi.sOpenLinkDialog(tinyUi),
+        Chain.asStep(Body.body(), [
+          FocusTools.cSetActiveValue(''),
+          TestLinkUi.cFireEvent('input'),
+          Chain.injectThunked(Body.body),
+          UiFinder.cNotExists('.tox-label:contains("Text to display")'),
+          FocusTools.cGetActiveValue,
+          Assertions.cAssertEq('URL should be empty', '')
+        ]),
+        TestLinkUi.sClickCancel
       ]),
       TestLinkUi.sClearHistory
     ], onSuccess, onFailure);


### PR DESCRIPTION
Related Ticket: TINY-4706 & TINY-6273

Description of Changes:
* This fixes an issue where link urls couldn't be deleted/edited in the dialog. The cause was that we were incorrectly setting the URL "text" metadata which then made the typeahead component believe it was the same as the original url and replaced it with the original url.
* This also fixes another issue reported in one of the linked GitHub issues, that I also later found a JIRA for, in that the title was being incorrectly changed when changing the url.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #4939
Fixes #5403
Fixes #5888