### PR TITLE
TINY-6289: Fixed the list type style not retained when copying list items

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -5,6 +5,7 @@ Version 5.4.2 (TBD)
     Fixed an exception thrown when positioning the context toolbar on Internet Explorer 11 in some edge cases #TINY-6271
     Fixed inline formats not removed when more than one `removeformat` format rule existed #TINY-6216
     Fixed list toolbar buttons not showing as active when a list is selected #TINY-6286
+    Fixed the list type style not retained when copying list items #TINY-6289
 Version 5.4.1 (2020-07-08)
     Fixed the Search and Replace plugin incorrectly including zero-width caret characters in search results #TINY-4599
     Fixed dragging and dropping unsupported files navigating the browser away from the editor #TINY-6027

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -5,9 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { HTMLBRElement, HTMLElement, HTMLHeadingElement, HTMLTableCellElement, HTMLTableElement } from '@ephox/dom-globals';
 import { Arr, Fun } from '@ephox/katamari';
-import { Node, Element } from '@ephox/sugar';
-import { HTMLHeadingElement, HTMLElement, HTMLTableElement, HTMLBRElement } from '@ephox/dom-globals';
+import { Element, Node } from '@ephox/sugar';
 
 const blocks = [
   'article', 'aside', 'details', 'div', 'dt', 'figcaption', 'footer',
@@ -55,7 +55,7 @@ const isList = lazyLookup(lists);
 const isListItem = lazyLookup(listItems);
 const isVoid = lazyLookup(voids);
 const isTableSection = lazyLookup(tableSections);
-const isTableCell = lazyLookup(tableCells);
+const isTableCell = lazyLookup<HTMLTableCellElement>(tableCells);
 const isWsPreserveElement = lazyLookup(wsElements);
 
 export {

--- a/modules/tinymce/src/core/main/ts/selection/FragmentReader.ts
+++ b/modules/tinymce/src/core/main/ts/selection/FragmentReader.ts
@@ -5,97 +5,85 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun } from '@ephox/katamari';
-import { Compare, Insert, Replication, Element, Fragment, Node, SelectorFind, Traverse } from '@ephox/sugar';
+import { HTMLLIElement, HTMLOListElement, HTMLTableCellElement, HTMLTableElement, Node, Range } from '@ephox/dom-globals';
+import { Arr, Fun, Obj, Option, Strings } from '@ephox/katamari';
+import { Compare, Css, Element, Fragment, Insert, Node as SugarNode, Replication, SelectorFind, Traverse } from '@ephox/sugar';
 import * as ElementType from '../dom/ElementType';
 import * as Parents from '../dom/Parents';
 import * as SelectionUtils from './SelectionUtils';
 import * as SimpleTableModel from './SimpleTableModel';
 import * as TableCellSelection from './TableCellSelection';
 
-const findParentListContainer = function (parents) {
-  return Arr.find(parents, function (elm) {
-    return Node.name(elm) === 'ul' || Node.name(elm) === 'ol';
-  });
-};
+const findParentListContainer = (parents: Element[]): Option<Element<HTMLLIElement | HTMLOListElement>> =>
+  Arr.find(parents, (elm) => SugarNode.name(elm) === 'ul' || SugarNode.name(elm) === 'ol');
 
-const getFullySelectedListWrappers = function (parents, rng) {
-  return Arr.find(parents, function (elm) {
-    return Node.name(elm) === 'li' && SelectionUtils.hasAllContentsSelected(elm, rng);
-  }).fold(
+const getFullySelectedListWrappers = (parents: Element<Node>[], rng: Range) =>
+  Arr.find(parents, (elm) => SugarNode.name(elm) === 'li' && SelectionUtils.hasAllContentsSelected(elm, rng)).fold(
     Fun.constant([]),
-    function (_li) {
-      return findParentListContainer(parents).map(function (listCont) {
+    (_li) =>
+      findParentListContainer(parents).map((listCont) => {
+        const listElm = Element.fromTag(SugarNode.name(listCont));
+        // Retain any list-style* styles when generating the new fragment
+        const listStyles = Obj.filter(Css.getAllRaw(listCont), (_style, name) => Strings.startsWith(name, 'list-style'));
+        Css.setAll(listElm, listStyles);
         return [
           Element.fromTag('li'),
-          Element.fromTag(Node.name(listCont))
+          listElm
         ];
-      }).getOr([]);
-    }
+      }).getOr([])
   );
-};
 
-const wrap = function (innerElm, elms) {
-  const wrapped = Arr.foldl(elms, function (acc, elm) {
+const wrap = (innerElm: Element<Node>, elms: Element<Node>[]) => {
+  const wrapped = Arr.foldl(elms, (acc, elm) => {
     Insert.append(elm, acc);
     return elm;
   }, innerElm);
   return elms.length > 0 ? Fragment.fromElements([ wrapped ]) : wrapped;
 };
 
-const directListWrappers = function (commonAnchorContainer) {
+const directListWrappers = (commonAnchorContainer: Element<Node>) => {
   if (ElementType.isListItem(commonAnchorContainer)) {
     return Traverse.parent(commonAnchorContainer).filter(ElementType.isList).fold(
       Fun.constant([]),
-      function (listElm) {
-        return [ commonAnchorContainer, listElm ];
-      }
+      (listElm) => [ commonAnchorContainer, listElm ]
     );
   } else {
     return ElementType.isList(commonAnchorContainer) ? [ commonAnchorContainer ] : [ ];
   }
 };
 
-const getWrapElements = function (rootNode, rng) {
+const getWrapElements = (rootNode: Element<Node>, rng: Range) => {
   const commonAnchorContainer = Element.fromDom(rng.commonAncestorContainer);
   const parents = Parents.parentsAndSelf(commonAnchorContainer, rootNode);
-  const wrapElements = Arr.filter(parents, function (elm) {
-    return ElementType.isInline(elm) || ElementType.isHeading(elm);
-  });
+  const wrapElements = Arr.filter(parents, (elm) => ElementType.isInline(elm) || ElementType.isHeading(elm));
   const listWrappers = getFullySelectedListWrappers(parents, rng);
   const allWrappers = wrapElements.concat(listWrappers.length ? listWrappers : directListWrappers(commonAnchorContainer));
   return Arr.map(allWrappers, Replication.shallow);
 };
 
-const emptyFragment = function () {
-  return Fragment.fromElements([]);
-};
+const emptyFragment = () => Fragment.fromElements([]);
 
-const getFragmentFromRange = function (rootNode, rng) {
-  return wrap(Element.fromDom(rng.cloneContents()), getWrapElements(rootNode, rng));
-};
+const getFragmentFromRange = (rootNode: Element<Node>, rng: Range) =>
+  wrap(Element.fromDom(rng.cloneContents()), getWrapElements(rootNode, rng));
 
-const getParentTable = function (rootElm, cell) {
-  return SelectorFind.ancestor(cell, 'table', Fun.curry(Compare.eq, rootElm));
-};
+const getParentTable = (rootElm: Element<Node>, cell: Element<HTMLTableCellElement>): Option<Element<HTMLTableElement>> =>
+  SelectorFind.ancestor(cell, 'table', Fun.curry(Compare.eq, rootElm));
 
-const getTableFragment = function (rootNode, selectedTableCells) {
-  return getParentTable(rootNode, selectedTableCells[0]).bind(function (tableElm) {
+const getTableFragment = (rootNode: Element<Node>, selectedTableCells: Element<HTMLTableCellElement>[]) =>
+  getParentTable(rootNode, selectedTableCells[0]).bind((tableElm) => {
     const firstCell = selectedTableCells[0];
     const lastCell = selectedTableCells[selectedTableCells.length - 1];
     const fullTableModel = SimpleTableModel.fromDom(tableElm);
 
-    return SimpleTableModel.subsection(fullTableModel, firstCell, lastCell).map(function (sectionedTableModel) {
-      return Fragment.fromElements([ SimpleTableModel.toDom(sectionedTableModel) ]);
-    });
+    return SimpleTableModel.subsection(fullTableModel, firstCell, lastCell).map((sectionedTableModel) =>
+      Fragment.fromElements([ SimpleTableModel.toDom(sectionedTableModel) ])
+    );
   }).getOrThunk(emptyFragment);
-};
 
-const getSelectionFragment = function (rootNode, ranges) {
-  return ranges.length > 0 && ranges[0].collapsed ? emptyFragment() : getFragmentFromRange(rootNode, ranges[0]);
-};
+const getSelectionFragment = (rootNode: Element<Node>, ranges: Range[]) =>
+  ranges.length > 0 && ranges[0].collapsed ? emptyFragment() : getFragmentFromRange(rootNode, ranges[0]);
 
-const read = function (rootNode, ranges) {
+const read = (rootNode: Element<Node>, ranges: Range[]) => {
   const selectedCells = TableCellSelection.getCellsFromElementOrRanges(ranges, rootNode);
   return selectedCells.length > 0 ? getTableFragment(rootNode, selectedCells) : getSelectionFragment(rootNode, ranges);
 };

--- a/modules/tinymce/src/core/main/ts/selection/TableCellSelection.ts
+++ b/modules/tinymce/src/core/main/ts/selection/TableCellSelection.ts
@@ -5,18 +5,20 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Range } from '@ephox/dom-globals';
+import { HTMLTableCellElement, Range } from '@ephox/dom-globals';
 import { Arr } from '@ephox/katamari';
 import { Element, SelectorFilter } from '@ephox/sugar';
 import Editor from '../api/Editor';
 import * as ElementType from '../dom/ElementType';
 import * as MultiRange from './MultiRange';
 
-const getCellsFromRanges = (ranges: Range[]) => Arr.filter(MultiRange.getSelectedNodes(ranges), ElementType.isTableCell);
+const getCellsFromRanges = (ranges: Range[]): Element<HTMLTableCellElement>[] =>
+  Arr.filter(MultiRange.getSelectedNodes(ranges), ElementType.isTableCell);
 
-const getCellsFromElement = (elm: Element) => SelectorFilter.descendants(elm, 'td[data-mce-selected],th[data-mce-selected]');
+const getCellsFromElement = (elm: Element): Element<HTMLTableCellElement>[] =>
+  SelectorFilter.descendants(elm, 'td[data-mce-selected],th[data-mce-selected]');
 
-const getCellsFromElementOrRanges = (ranges: Range[], element: Element) => {
+const getCellsFromElementOrRanges = (ranges: Range[], element: Element): Element<HTMLTableCellElement>[] => {
   const selectedCells = getCellsFromElement(element);
   return selectedCells.length > 0 ? selectedCells : getCellsFromRanges(ranges);
 };

--- a/modules/tinymce/src/core/test/ts/browser/selection/FragmentReaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/FragmentReaderTest.ts
@@ -1,10 +1,10 @@
 import { Assertions, Chain, GeneralSteps, Logger, Pipeline } from '@ephox/agar';
-import { Arr } from '@ephox/katamari';
-import { Hierarchy, Insert, Element, Html } from '@ephox/sugar';
-import * as FragmentReader from 'tinymce/core/selection/FragmentReader';
-import ViewBlock from '../../module/test/ViewBlock';
 import { UnitTest } from '@ephox/bedrock-client';
 import { document } from '@ephox/dom-globals';
+import { Arr } from '@ephox/katamari';
+import { Element, Hierarchy, Html, Insert } from '@ephox/sugar';
+import * as FragmentReader from 'tinymce/core/selection/FragmentReader';
+import ViewBlock from '../../module/test/ViewBlock';
 
 UnitTest.asynctest('browser.tinymce.core.selection.FragmentReaderTest', function (success, failure) {
   const viewBlock = ViewBlock();
@@ -126,6 +126,16 @@ UnitTest.asynctest('browser.tinymce.core.selection.FragmentReaderTest', function
         cSetHtml('<ol><li>a</li></ol>'),
         cReadFragment([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1),
         cAssertFragmentHtml('<ol><li>a</li></ol>')
+      ])),
+      Logger.t('Get fragment from fully selected li contents text in ul with list style', Chain.asStep(viewBlock, [
+        cSetHtml('<ul style="list-style-type: circle;"><li>a</li></ul>'),
+        cReadFragment([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1),
+        cAssertFragmentHtml('<ul style="list-style-type: circle;"><li>a</li></ul>')
+      ])),
+      Logger.t('Get fragment from fully selected li contents text in ol with list style', Chain.asStep(viewBlock, [
+        cSetHtml('<ol style="list-style-type: upper-roman;"><li>a</li></ol>'),
+        cReadFragment([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1),
+        cAssertFragmentHtml('<ol style="list-style-type: upper-roman;"><li>a</li></ol>')
       ])),
       Logger.t('Get fragment from fully selected li contents text in ul in ol', Chain.asStep(viewBlock, [
         cSetHtml('<ol><li><ul><li>a</li></ul></li></ol>'),


### PR DESCRIPTION
Related Ticket: TINY-6289

Description of Changes:
* Fixed an issue where the list type styles weren't included when getting using the selection API for a contextual cut/copy operation.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
