### PR TITLE
TINY-3511: Fixed the visual viewport bind function not working, which also caused fullscreen plugin issues

### DIFF
--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/VisualViewport.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/VisualViewport.ts
@@ -25,6 +25,7 @@ interface VisualViewport {
   readonly scale: number;
   readonly addEventListener: (event: string, handler: EventListenerOrEventListenerObject) => void;
   readonly removeEventListener: (event: string, handler: EventListenerOrEventListenerObject) => void;
+  readonly dispatchEvent: (evt: Event) => boolean;
 }
 
 const get = (_win?: Window): Option<VisualViewport> => {
@@ -64,7 +65,7 @@ const getBounds = (_win?: Window): Bounds => {
 };
 
 const bind = (name: string, callback: EventHandler, _win?: Window) => get(_win).map((visualViewport) => {
-  const handler = (e: Event) => fromRawEvent(e);
+  const handler = (e: Event) => callback(fromRawEvent(e));
   visualViewport.addEventListener(name, handler);
 
   return {

--- a/modules/sugar/src/test/ts/browser/VisualViewportTest.ts
+++ b/modules/sugar/src/test/ts/browser/VisualViewportTest.ts
@@ -1,0 +1,32 @@
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { document, UIEvent } from '@ephox/dom-globals';
+import { PlatformDetection } from '@ephox/sand';
+import * as VisualViewport from 'ephox/sugar/api/view/VisualViewport';
+
+UnitTest.test('VisualViewport.getBounds', () => {
+  const deviceType = PlatformDetection.detect().deviceType;
+  if (deviceType.isDesktop()) {
+    const bounds = VisualViewport.getBounds();
+    Assert.eq('Top is 0', 0, bounds.y);
+    Assert.eq('Left is 0', 0, bounds.x);
+    Assert.eq('Height is the same as the document height', document.documentElement.clientHeight, bounds.height);
+    Assert.eq('Width is the same as the document width', document.documentElement.clientWidth, bounds.width);
+  }
+});
+
+UnitTest.test('VisualViewport.bind', () => {
+  let resizeCount = 0;
+  const binder = VisualViewport.bind('resize', () => {
+    resizeCount += 1;
+  });
+
+  // Trigger resize
+  // Note: Won't work on IE/Edge as they don't support the visual viewport API
+  VisualViewport.get().each((viewport) => {
+    const resizeEvent = new UIEvent('resize');
+    viewport.dispatchEvent(resizeEvent);
+    Assert.eq('Check resize event handled', 1, resizeCount);
+  });
+
+  binder.unbind();
+});

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.4.2 (TBD)
+    Fixed resizing the window not resizing the editor in fullscreen mode #TINY-3511
     Fixed clicking on notifications causing inline editors to hide #TINY-6058
     Fixed a regression where the `anchor_top` and `anchor_bottom` settings weren't working when set to `false` #TINY-6256
     Fixed an exception thrown when removing inline formats that contained additional styles or classes #TINY-6288


### PR DESCRIPTION
Related Ticket: TINY-3511

Description of Changes:
* We had broken the `VisualViewport.bind` function at some stage while refactoring and as such it was never calling the callback. This then meant the fullscreen plugin wasn't adjusting the editor to match the new viewport size.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
