### PR TITLE
TINY-6117: Update paste plugin to match changes in powerpaste

### DIFF
--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -5,18 +5,16 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import {
-  ClipboardEvent, DataTransfer, DragEvent, Event, File, HTMLImageElement, Image, KeyboardEvent, navigator, Range
-} from '@ephox/dom-globals';
+import { ClipboardEvent, DataTransfer, DragEvent, Event, File, HTMLImageElement, Image, KeyboardEvent, navigator, Range } from '@ephox/dom-globals';
 import { Arr, Cell, Singleton } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Delay from 'tinymce/core/api/util/Delay';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Promise from 'tinymce/core/api/util/Promise';
-import Tools from 'tinymce/core/api/util/Tools';
 import VK from 'tinymce/core/api/util/VK';
 import * as Events from '../api/Events';
+import * as Settings from '../api/Settings';
 import * as InternalHtml from './InternalHtml';
 import * as Newlines from './Newlines';
 import { PasteBin } from './PasteBin';
@@ -24,7 +22,6 @@ import * as ProcessFilters from './ProcessFilters';
 import * as SmartPaste from './SmartPaste';
 import * as Utils from './Utils';
 import * as Whitespace from './Whitespace';
-import * as Settings from '../api/Settings';
 
 declare let window: any;
 
@@ -109,12 +106,8 @@ const getDataTransferItems = (dataTransfer: DataTransfer): ClipboardContents => 
  * @param {ClipboardEvent} clipboardEvent Event fired on paste.
  * @return {Object} Object with mime types and data for those mime types.
  */
-const getClipboardContent = (editor: Editor, clipboardEvent: ClipboardEvent) => {
-  const content = getDataTransferItems(clipboardEvent.clipboardData || (editor.getDoc() as any).dataTransfer);
-
-  // Edge 15 has a broken HTML Clipboard API see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11877517/
-  return Utils.isMsEdge() ? Tools.extend(content, { 'text/html': '' }) : content;
-};
+const getClipboardContent = (editor: Editor, clipboardEvent: ClipboardEvent) =>
+  getDataTransferItems(clipboardEvent.clipboardData || (editor.getDoc() as any).dataTransfer);
 
 const hasContentType = (clipboardContent: ClipboardContents, mimeType: string) => mimeType in clipboardContent && clipboardContent[mimeType].length > 0;
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/CutCopy.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/CutCopy.ts
@@ -10,19 +10,17 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Delay from 'tinymce/core/api/util/Delay';
 import * as InternalHtml from './InternalHtml';
-import * as Utils from './Utils';
 
 interface SelectionContentData {
   html: string;
   text: string;
 }
 
-const hasWorkingClipboardApi = (clipboardData: DataTransfer) =>
+const hasWorkingClipboardApi = (clipboardData: DataTransfer | null): clipboardData is DataTransfer =>
   // iOS supports the clipboardData API but it doesn't do anything for cut operations
-  // Edge 15 has a broken HTML Clipboard API see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11780845/
-  Env.iOS === false && clipboardData !== undefined && typeof clipboardData.setData === 'function' && Utils.isMsEdge() !== true;
+  Env.iOS === false && typeof clipboardData?.setData === 'function';
 
-const setHtml5Clipboard = (clipboardData: DataTransfer, html: string, text: string) => {
+const setHtml5Clipboard = (clipboardData: DataTransfer | null, html: string, text: string) => {
   if (hasWorkingClipboardApi(clipboardData)) {
     try {
       clipboardData.clearData();

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
@@ -5,11 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Unicode } from '@ephox/katamari';
 import DomParser from 'tinymce/core/api/html/DomParser';
 import Schema from 'tinymce/core/api/html/Schema';
 import Tools from 'tinymce/core/api/util/Tools';
-import { navigator } from '@ephox/dom-globals';
-import { Unicode } from '@ephox/katamari';
 
 /**
  * This class contails various utility functions for the paste plugin.
@@ -137,14 +136,9 @@ function createIdGenerator(prefix: string) {
   };
 }
 
-const isMsEdge = function () {
-  return navigator.userAgent.indexOf(' Edge/') !== -1;
-};
-
 export {
   filter,
   innerText,
   trimHtml,
-  createIdGenerator,
-  isMsEdge
+  createIdGenerator
 };

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/InternalClipboardTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/InternalClipboardTest.ts
@@ -4,7 +4,6 @@ import { TinyApis, TinyLoader } from '@ephox/mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as InternalHtml from 'tinymce/plugins/paste/core/InternalHtml';
-import * as Utils from 'tinymce/plugins/paste/core/Utils';
 import PastePlugin from 'tinymce/plugins/paste/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
@@ -211,8 +210,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.InternalClipboardTest', (succe
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
     const tinyApis = TinyApis(editor);
 
-    // Disabled tests on Edge 15 due to broken clipboard API
-    Pipeline.async({}, Utils.isMsEdge() ? [ ] : [
+    Pipeline.async({}, [
       sTestCopy(editor, tinyApis),
       sTestCut(editor, tinyApis),
       sTestPaste(editor, tinyApis)


### PR DESCRIPTION
Related Ticket: TINY-6117

Description of Changes:
* Syncs a fix from PowerPaste and removes the Edge 15 checks as it's no longer needed given Edge 15 isn't supported.

Pre-checks:
* [x] ~Changelog entry added~ (no functional change, just a clean up)
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
