### PR TITLE
TINY-6237: Preserve tab characters better when pasting text by converting them to spaces

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
@@ -82,6 +82,8 @@ export const isNotEmpty = (s: string) => s.length > 0;
 
 export const isEmpty = (s: string) => !isNotEmpty(s);
 
+export const repeat = (s: string, count: number) => count <= 0 ? '' : new Array(count + 1).join(s);
+
 // Extract codepoint a la ES2015 String.fromCodePoint
 // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
 export const fromCodePoint = (...codePoints: number[]): string => {

--- a/modules/katamari/src/test/ts/atomic/api/str/RepeatTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/str/RepeatTest.ts
@@ -1,0 +1,26 @@
+import { UnitTest, Assert } from '@ephox/bedrock-client';
+import fc from 'fast-check';
+import * as Strings from 'ephox/katamari/api/Strings';
+
+UnitTest.test('Strings.repeat: unit tests', () => {
+  Assert.eq('Repeat with positive string', '*****', Strings.repeat('*', 5));
+  Assert.eq('Repeat with 0 should be an empty string', '', Strings.repeat(' ', 0));
+  Assert.eq('Repeat with negative should be an empty string', '', Strings.repeat('-', -1));
+});
+
+UnitTest.test('Strings.repeat: positive range', () => {
+  fc.assert(fc.property(fc.char(), fc.integer(1, 100), (s, count) => {
+    const actual = Strings.repeat(s, count);
+    Assert.eq('length should be the same as count', count, actual.length);
+    Assert.eq('first char should be the same', s, actual.charAt(0));
+    Assert.eq('last char should be the same', s, actual.charAt(actual.length - 1));
+  }));
+});
+
+UnitTest.test('Strings.repeat: negative range', () => {
+  fc.assert(fc.property(fc.char(), fc.integer(-100, 0), (s, count) => {
+    const actual = Strings.repeat(s, count);
+    Assert.eq('length should be 0', 0, actual.length);
+    Assert.eq('should be an empty string', '', actual);
+  }));
+});

--- a/modules/katamari/src/test/ts/atomic/api/str/RepeatTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/str/RepeatTest.ts
@@ -1,6 +1,6 @@
-import { UnitTest, Assert } from '@ephox/bedrock-client';
-import fc from 'fast-check';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import * as Strings from 'ephox/katamari/api/Strings';
+import fc from 'fast-check';
 
 UnitTest.test('Strings.repeat: unit tests', () => {
   Assert.eq('Repeat with positive string', '*****', Strings.repeat('*', 5));
@@ -9,17 +9,24 @@ UnitTest.test('Strings.repeat: unit tests', () => {
 });
 
 UnitTest.test('Strings.repeat: positive range', () => {
-  fc.assert(fc.property(fc.char(), fc.integer(1, 100), (s, count) => {
-    const actual = Strings.repeat(s, count);
+  fc.assert(fc.property(fc.char(), fc.integer(1, 100), (c, count) => {
+    const actual = Strings.repeat(c, count);
     Assert.eq('length should be the same as count', count, actual.length);
-    Assert.eq('first char should be the same', s, actual.charAt(0));
-    Assert.eq('last char should be the same', s, actual.charAt(actual.length - 1));
+    Assert.eq('first char should be the same', c, actual.charAt(0));
+    Assert.eq('last char should be the same', c, actual.charAt(actual.length - 1));
+  }));
+
+  fc.assert(fc.property(fc.asciiString(5), fc.integer(1, 100), (s, count) => {
+    const actual = Strings.repeat(s, count);
+    Assert.eq('length should be count * original length', count * s.length, actual.length);
+    Assert.eq('should start with string', 0, actual.indexOf(s));
+    Assert.eq('should end with string', actual.length - s.length, actual.lastIndexOf(s));
   }));
 });
 
 UnitTest.test('Strings.repeat: negative range', () => {
-  fc.assert(fc.property(fc.char(), fc.integer(-100, 0), (s, count) => {
-    const actual = Strings.repeat(s, count);
+  fc.assert(fc.property(fc.char(), fc.integer(-100, 0), (c, count) => {
+    const actual = Strings.repeat(c, count);
     Assert.eq('length should be 0', 0, actual.length);
     Assert.eq('should be an empty string', '', actual);
   }));

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -10,6 +10,7 @@ Version 5.4.2 (TBD)
     Fixed list toolbar buttons not showing as active when a list is selected #TINY-6286
     Fixed an issue where the UI would sometimes not be shown or hidden when calling show or hide methods on the editor #TINY-6048
     Fixed the list type style not retained when copying list items #TINY-6289
+    Fixed tabs in plain text converted to a single space and added new `paste_tab_spaces` setting to control how many spaces are used to represent a tab #TINY-6237
 Version 5.4.1 (2020-07-08)
     Fixed the Search and Replace plugin incorrectly including zero-width caret characters in search results #TINY-4599
     Fixed dragging and dropping unsupported files navigating the browser away from the editor #TINY-6027

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
@@ -59,6 +59,8 @@ const getForcedRootBlock = (editor: Editor) => editor.getParam('forced_root_bloc
 
 const getForcedRootBlockAttrs = (editor: Editor) => editor.getParam('forced_root_block_attrs');
 
+const getTabSpaces = (editor: Editor) => editor.getParam('paste_tab_spaces', 4, 'number');
+
 export {
   shouldBlockDrop,
   shouldPasteDataImages,
@@ -80,5 +82,6 @@ export {
   getImagesDataImgFilter,
   getImagesReuseFilename,
   getForcedRootBlock,
-  getForcedRootBlockAttrs
+  getForcedRootBlockAttrs,
+  getTabSpaces
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -54,7 +54,7 @@ const pasteHtml = (editor: Editor, html: string, internalFlag: boolean) => {
  */
 const pasteText = (editor: Editor, text: string) => {
   const encodedText = editor.dom.encode(text).replace(/\r\n/g, '\n');
-  const normalizedText = Whitespace.normalizeWhitespace(encodedText);
+  const normalizedText = Whitespace.normalizeWhitespace(editor, encodedText);
   const html = Newlines.convert(normalizedText, Settings.getForcedRootBlock(editor), Settings.getForcedRootBlockAttrs(editor));
   doPaste(editor, html, false, true);
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Whitespace.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Whitespace.ts
@@ -5,21 +5,29 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Unicode } from '@ephox/katamari';
+import { Arr, Strings, Unicode } from '@ephox/katamari';
+import Editor from 'tinymce/core/api/Editor';
+import * as Settings from '../api/Settings';
 
 // Don't compare other unicode spaces here, as we're only concerned about whitespace the browser would collapse
 const isCollapsibleWhitespace = (c: string): boolean => ' \f\t\v'.indexOf(c) !== -1;
 const isNewLineChar = (c: string): boolean => c === '\n' || c === '\r';
 const isNewline = (text: string, idx: number): boolean => (idx < text.length && idx >= 0) ? isNewLineChar(text[idx]) : false;
 
-// Converts duplicate whitespace to alternating space/nbsps
-const normalizeWhitespace = (text: string): string => {
-  const result = Arr.foldl(text, (acc, c) => {
+// Converts duplicate whitespace to alternating space/nbsps and tabs to spaces
+const normalizeWhitespace = (editor: Editor, text: string): string => {
+  // Replace tabs with a variable amount of spaces
+  // Note: We don't use an actual tab character here, as it only works when in a "whitespace: pre" element,
+  // which will cause other issues, such as trying to type the content will also be treated as being in a pre.
+  const tabSpace = Strings.repeat(' ', Settings.getTabSpaces(editor));
+  const normalizedText = text.replace(/\t/g, tabSpace);
+
+  const result = Arr.foldl(normalizedText, (acc, c) => {
     // Are we dealing with a char other than some collapsible whitespace or nbsp? if so then just use it as is
     if (isCollapsibleWhitespace(c) || c === Unicode.nbsp) {
       // If the previous char is a space, we are at the start or end, or if the next char is a new line char, then we need
       // to convert the space to a nbsp
-      if (acc.pcIsSpace || acc.str === '' || acc.str.length === text.length - 1 || isNewline(text, acc.str.length + 1)) {
+      if (acc.pcIsSpace || acc.str === '' || acc.str.length === normalizedText.length - 1 || isNewline(normalizedText, acc.str.length + 1)) {
         return { pcIsSpace: false, str: acc.str + Unicode.nbsp };
       } else {
         return { pcIsSpace: true, str: acc.str + ' ' };

--- a/modules/tinymce/src/plugins/paste/test/ts/atomic/WhitespaceTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/atomic/WhitespaceTest.ts
@@ -1,8 +1,15 @@
+import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Obj } from '@ephox/katamari';
+import Editor from 'tinymce/core/api/Editor';
 import * as Whitespace from 'tinymce/plugins/paste/core/Whitespace';
-import { UnitTest, assert } from '@ephox/bedrock-client';
 
 UnitTest.test('atomic.tinymce.plugins.paste.WhitespaceTest', () => {
-  const check = (expected: string, input: string) => assert.eq(expected, Whitespace.normalizeWhitespace(input));
+  const settings = { paste_tab_spaces: 2 };
+  const mockEditor = {
+    getParam: (name, defaultValue) => Obj.get(settings, name).getOr(defaultValue)
+  } as Editor;
+
+  const check = (expected: string, input: string) => assert.eq(expected, Whitespace.normalizeWhitespace(mockEditor, input));
 
   const single = 'onelineofsmashedtogetherwords';
   const windows = 'one\r\ntwo\r\n\r\nthree';
@@ -11,6 +18,8 @@ UnitTest.test('atomic.tinymce.plugins.paste.WhitespaceTest', () => {
   const leadingSpaces = '\n\n one\n two\n\n three\n\n';
   const trailingSpaces = '\n\none \ntwo \n\nthree \n\n';
   const sequentialSpaces = '\n\n  one   two  \n\nthree';
+  const withTabs = ' \tone\t';
+  const withSequentialTabs = '\t\t\tone\t\t ';
 
   check(single, single);
   check('one\r\ntwo\r\n\r\nthree', windows);
@@ -19,4 +28,6 @@ UnitTest.test('atomic.tinymce.plugins.paste.WhitespaceTest', () => {
   check('\n\n\u00a0one\n\u00a0two\n\n\u00a0three\n\n', leadingSpaces);
   check('\n\none\u00a0\ntwo\u00a0\n\nthree\u00a0\n\n', trailingSpaces);
   check('\n\n\u00a0 one \u00a0 two \u00a0\n\nthree', sequentialSpaces);
+  check('\u00a0 \u00a0one \u00a0', withTabs);
+  check('\u00a0 \u00a0 \u00a0 one \u00a0 \u00a0\u00a0', withSequentialTabs);
 });


### PR DESCRIPTION
Related Ticket: TINY-6237

Description of Changes:
* This fixes tabs incorrectly being replaced with a single space when pasting plain text. It also adds the new `paste_tab_spaces` setting to control how many spaces are used to represent a tab (the default is 4 spaces).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
