### PR TITLE
Fix 4.x build instructions: use yarn

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,13 +12,13 @@ Open a console and go to the project directory.
 ```
 $ cd tinymce/
 ```
-Install `grunt` command line tool globally.
+Install the `yarn` and `grunt` command line tools globally.
 ```
-$ npm i -g grunt-cli
+$ npm i -g yarn grunt-cli
 ```
 Install all package dependencies.
 ```
-$ npm install
+$ yarn
 ```
 Now, build TinyMCE by using `grunt`.
 ```


### PR DESCRIPTION
Related Ticket: fixes #5975.

Description of Changes:
* Correct the build documentation for the 4.x branch, indicating that `yarn` should be used instead of `npm` to install the build dependencies.

Pre-checks:
* [x] Changelog entry added -- _not applicable_
* [x] Tests have been added -- _not applicable_
* [x] Branch prefixed with `feature/` for new features -- _not applicable_
* [x] License headers added on new files -- _not applicable_

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #5975
