### PR TITLE
TINY-5966: Fixed an issue where inserting content was causing spaces to disappear

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -8,7 +8,9 @@ Version 5.5.0 (TBD)
     Added `fullscreen_native` setting to the fullscreen plugin to enable use of the entire monitor #TINY-6284
     Changed the `target` property on fired events to use the native event target. The original target for an open shadow root can be obtained using `event.getComposedPath()` #TINY-6128
     Changed `imagetools` context menu icon for accessing the `image` settings to use the same icon #TINY-4141
+    Changed the `editor.insertContent()` and `editor.selection.setContent()` APIs to retain leading and trailing whitespace #TINY-5966
     Deprecated the `Env.experimentalShadowDom` flag #TINY-6128
+    Fixed loss of whitespace when inserting content after a non-breaking space #TINY-5966
     Fixed the `event.getComposedPath()` function on events fired from TinyMCE. This was throwing an exception, but now works as expected. #TINY-6128
     Fixed the `template` plugin previews missing some content styles #TINY-6115
     Fixed the `media` plugin not saving the alternative source url in some situations #TINY-4113

--- a/modules/tinymce/src/core/main/ts/caret/CaretPositionPredicates.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretPositionPredicates.ts
@@ -7,8 +7,10 @@
 
 import { Fun, Optional } from '@ephox/katamari';
 import { Css, SugarElement } from '@ephox/sugar';
+import BookmarkManager from '../api/dom/BookmarkManager';
 import * as NodeType from '../dom/NodeType';
 import { isWhiteSpace } from '../text/CharType';
+import * as Zwsp from '../text/Zwsp';
 import CaretPosition from './CaretPosition';
 import { getChildNodeAtRelativeOffset } from './CaretUtils';
 
@@ -23,7 +25,7 @@ const isAfterSpace = Fun.curry(isChar, false, isWhiteSpace);
 
 const isEmptyText = (pos: CaretPosition) => {
   const container = pos.container();
-  return NodeType.isText(container) && container.data.length === 0;
+  return NodeType.isText(container) && (container.data.length === 0 || Zwsp.isZwsp(container.data) && BookmarkManager.isBookmarkNode(container.parentNode));
 };
 
 const matchesElementPosition = (before: boolean, predicate: (node: Node) => boolean) => (pos: CaretPosition) =>

--- a/modules/tinymce/src/core/main/ts/content/NbspTrim.ts
+++ b/modules/tinymce/src/core/main/ts/content/NbspTrim.ts
@@ -5,62 +5,31 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Unicode } from '@ephox/katamari';
-import * as NodeType from '../dom/NodeType';
+import { SugarElement } from '@ephox/sugar';
+import DOMUtils from '../api/dom/DOMUtils';
+import CaretPosition from '../caret/CaretPosition';
+import { needsToBeNbspLeft, needsToBeNbspRight } from '../keyboard/Nbsps';
 
-const isAfterNbsp = (container: Node, offset: number) => NodeType.isText(container) && container.nodeValue[offset - 1] === Unicode.nbsp;
+const trimOrPadLeftRight = (dom: DOMUtils, rng: Range, html: string): string => {
+  const root = SugarElement.fromDom(dom.getRoot());
 
-const trimOrPadLeftRight = (rng: Range, html: string): string => {
-  const container = rng.startContainer;
-  const offset = rng.startOffset;
+  // Adjust the start if it needs to be an nbsp
+  if (needsToBeNbspLeft(root, CaretPosition.fromRangeStart(rng))) {
+    html = html.replace(/^ /, '&nbsp;');
+  } else {
+    html = html.replace(/^&nbsp;/, ' ');
+  }
 
-  const hasSiblingText = function (siblingName) {
-    return container[siblingName] && container[siblingName].nodeType === 3;
-  };
-
-  if (NodeType.isText(container)) {
-    if (offset > 0) {
-      html = html.replace(/^&nbsp;/, ' ');
-    } else if (!hasSiblingText('previousSibling')) {
-      html = html.replace(/^ /, '&nbsp;');
-    }
-
-    if (offset < container.length) {
-      html = html.replace(/&nbsp;(<br>|)$/, ' ');
-    } else if (!hasSiblingText('nextSibling')) {
-      html = html.replace(/(&nbsp;| )(<br>|)$/, '&nbsp;');
-    }
+  // Adjust the end if it needs to be an nbsp
+  if (needsToBeNbspRight(root, CaretPosition.fromRangeEnd(rng))) {
+    html = html.replace(/(&nbsp;| )(<br( \/)>)?$/, '&nbsp;');
+  } else {
+    html = html.replace(/&nbsp;(<br( \/)?>)?$/, ' ');
   }
 
   return html;
 };
 
-// Removes &nbsp; from a [b] c -> a &nbsp;c -> a c
-const trimNbspAfterDeleteAndPadValue = (rng: Range, value: string): string => {
-  const container = rng.startContainer;
-  const offset = rng.startOffset;
-
-  if (NodeType.isText(container) && rng.collapsed) {
-    if (container.data[offset] === Unicode.nbsp) {
-      container.deleteData(offset, 1);
-
-      if (!/[\u00a0| ]$/.test(value)) {
-        value += ' ';
-      }
-    } else if (container.data[offset - 1] === Unicode.nbsp) {
-      container.deleteData(offset - 1, 1);
-
-      if (!/[\u00a0| ]$/.test(value)) {
-        value = ' ' + value;
-      }
-    }
-  }
-
-  return value;
-};
-
 export {
-  isAfterNbsp,
-  trimNbspAfterDeleteAndPadValue,
   trimOrPadLeftRight
 };

--- a/modules/tinymce/src/core/main/ts/delete/MergeText.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeText.ts
@@ -6,7 +6,10 @@
  */
 
 import { Arr, Strings, Unicode } from '@ephox/katamari';
-import { Remove, SugarElement } from '@ephox/sugar';
+import { PredicateFind, Remove, SugarElement } from '@ephox/sugar';
+import CaretPosition from '../caret/CaretPosition';
+import * as ElementType from '../dom/ElementType';
+import * as Nbsps from '../keyboard/Nbsps';
 import { isNbsp, isWhiteSpace } from '../text/CharType';
 
 const normalizeContent = (content: string, isStartOfContent: boolean, isEndOfContent: boolean): string => {
@@ -30,13 +33,15 @@ const normalize = (node: Text, offset: number, count: number) => {
   if (count === 0) {
     return;
   }
+  const elm = SugarElement.fromDom(node);
+  const root = PredicateFind.ancestor(elm, ElementType.isBlock).getOr(elm);
 
   // Get the whitespace
   const whitespace = node.data.slice(offset, offset + count);
 
-  // Determine if we're at the end of start of the content
-  const isEndOfContent = offset + count >= node.data.length;
-  const isStartOfContent = offset === 0;
+  // Determine if we're at the end or start of the content
+  const isEndOfContent = offset + count >= node.data.length && Nbsps.needsToBeNbspRight(root, CaretPosition(node, node.data.length));
+  const isStartOfContent = offset === 0 && Nbsps.needsToBeNbspLeft(root, CaretPosition(node, 0));
 
   // Replace the original whitespace with the normalized whitespace content
   node.replaceData(offset, count, normalizeContent(whitespace, isStartOfContent, isEndOfContent));
@@ -56,18 +61,24 @@ const normalizeWhitespaceBefore = (node: Text, offset: number) => {
   return normalize(node, offset - whitespaceCount, whitespaceCount);
 };
 
-const mergeTextNodes = (prevNode: Text, nextNode: Text, normalizeWhitespace?: boolean): Text => {
+const mergeTextNodes = (prevNode: Text, nextNode: Text, normalizeWhitespace?: boolean, mergeToPrev: boolean = true): Text => {
   const whitespaceOffset = Strings.rTrim(prevNode.data).length;
+  const newNode = mergeToPrev ? prevNode : nextNode;
   // Merge the elements
-  prevNode.appendData(nextNode.data);
-  Remove.remove(SugarElement.fromDom(nextNode));
+  if (mergeToPrev) {
+    prevNode.appendData(nextNode.data);
+    Remove.remove(SugarElement.fromDom(nextNode));
+  } else {
+    nextNode.insertData(0, prevNode.data);
+    Remove.remove(SugarElement.fromDom(prevNode));
+  }
 
   // Normalize the whitespace around the merged elements, to ensure it doesn't get lost
   if (normalizeWhitespace) {
-    normalizeWhitespaceAfter(prevNode, whitespaceOffset);
+    normalizeWhitespaceAfter(newNode, whitespaceOffset);
   }
 
-  return prevNode;
+  return newNode;
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/delete/MergeText.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeText.ts
@@ -64,14 +64,15 @@ const normalizeWhitespaceBefore = (node: Text, offset: number) => {
 const mergeTextNodes = (prevNode: Text, nextNode: Text, normalizeWhitespace?: boolean, mergeToPrev: boolean = true): Text => {
   const whitespaceOffset = Strings.rTrim(prevNode.data).length;
   const newNode = mergeToPrev ? prevNode : nextNode;
+  const removeNode = mergeToPrev ? nextNode : prevNode;
+
   // Merge the elements
   if (mergeToPrev) {
-    prevNode.appendData(nextNode.data);
-    Remove.remove(SugarElement.fromDom(nextNode));
+    newNode.appendData(removeNode.data);
   } else {
-    nextNode.insertData(0, prevNode.data);
-    Remove.remove(SugarElement.fromDom(prevNode));
+    newNode.insertData(0, removeNode.data);
   }
+  Remove.remove(SugarElement.fromDom(removeNode));
 
   // Normalize the whitespace around the merged elements, to ensure it doesn't get lost
   if (normalizeWhitespace) {

--- a/modules/tinymce/src/core/main/ts/keyboard/Nbsps.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/Nbsps.ts
@@ -88,15 +88,14 @@ const leanRight = (pos: CaretPosition): CaretPosition => {
 };
 
 const needsToBeNbspRight = (root: SugarElement, pos: CaretPosition) => {
-  const afterPos = leanRight(pos);
-  if (isInPre(afterPos)) {
+  if (isInPre(pos)) {
     return false;
   } else {
-    return isAtEndOfBlock(root, afterPos) || isAfterBlock(root, afterPos) || isBeforeBr(root, afterPos) || hasSpaceAfter(root, afterPos);
+    return isAtEndOfBlock(root, pos) || isAfterBlock(root, pos) || isBeforeBr(root, pos) || hasSpaceAfter(root, pos);
   }
 };
 
-const needsToBeNbsp = (root: SugarElement, pos: CaretPosition) => needsToBeNbspLeft(root, pos) || needsToBeNbspRight(root, pos);
+const needsToBeNbsp = (root: SugarElement, pos: CaretPosition) => needsToBeNbspLeft(root, pos) || needsToBeNbspRight(root, leanRight(pos));
 
 const isNbspAt = (text: string, offset: number) => isNbsp(text.charAt(offset));
 
@@ -167,6 +166,9 @@ const normalizeNbspsInEditor = (editor: Editor) => {
 };
 
 export {
+  needsToBeNbspLeft,
+  needsToBeNbspRight,
+  needsToBeNbsp,
   needsToHaveNbsp,
   normalizeNbspMiddle,
   normalizeNbspsInEditor

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretPositionPredicatesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretPositionPredicatesTest.ts
@@ -1,52 +1,63 @@
-import { Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { LegacyUnit } from '@ephox/mcagar';
+import { Log, Pipeline, Step } from '@ephox/agar';
+import { assert, UnitTest } from '@ephox/bedrock-client';
 import CaretPosition from 'tinymce/core/caret/CaretPosition';
-import { isAfterContentEditableFalse, isBeforeContentEditableFalse } from 'tinymce/core/caret/CaretPositionPredicates';
+import { isAfterContentEditableFalse, isBeforeContentEditableFalse, isEmptyText } from 'tinymce/core/caret/CaretPositionPredicates';
+import { ZWSP } from 'tinymce/core/text/Zwsp';
 import ViewBlock from '../../module/test/ViewBlock';
 
-UnitTest.asynctest('browser.tinymce.core.CaretPositiionPredicateTest', (success, failure) => {
-  const suite = LegacyUnit.createSuite();
+UnitTest.asynctest('browser.tinymce.core.CaretPositionPredicateTest', (success, failure) => {
   const viewBlock = ViewBlock();
 
   const getRoot = () => viewBlock.get();
 
-  const setupHtml = (html) => {
-    viewBlock.update(html);
-  };
-
-  suite.test('isBeforeContentEditableFalse', () => {
-    setupHtml(
-      '<span contentEditable="false"></span>' +
-      '<span contentEditable="false"></span>a'
-    );
-
-    LegacyUnit.strictEqual(isBeforeContentEditableFalse(CaretPosition(getRoot(), 0)), true);
-    LegacyUnit.strictEqual(isBeforeContentEditableFalse(CaretPosition(getRoot(), 1)), true);
-    LegacyUnit.strictEqual(isBeforeContentEditableFalse(CaretPosition(getRoot(), 2)), false);
-    LegacyUnit.strictEqual(isBeforeContentEditableFalse(CaretPosition(getRoot(), 3)), false);
-  });
-
-  suite.test('isBeforeContentEditableFalse/isAfterContentEditableFalse on bogus all element', () => {
-    setupHtml('<input><p contentEditable="false" data-mce-bogus="all"></p><input>');
-    LegacyUnit.strictEqual(isBeforeContentEditableFalse(CaretPosition(getRoot(), 1)), false);
-    LegacyUnit.strictEqual(isAfterContentEditableFalse(CaretPosition(getRoot(), 2)), false);
-  });
-
-  suite.test('isAfterContentEditableFalse', () => {
-    setupHtml(
-      '<span contentEditable="false"></span>' +
-      '<span contentEditable="false"></span>a'
-    );
-
-    LegacyUnit.strictEqual(isAfterContentEditableFalse(CaretPosition(getRoot(), 0)), false);
-    LegacyUnit.strictEqual(isAfterContentEditableFalse(CaretPosition(getRoot(), 1)), true);
-    LegacyUnit.strictEqual(isAfterContentEditableFalse(CaretPosition(getRoot(), 2)), true);
-    LegacyUnit.strictEqual(isAfterContentEditableFalse(CaretPosition(getRoot(), 3)), false);
-  });
+  const setupHtml = (html: string) => viewBlock.update(html);
 
   viewBlock.attach();
-  Pipeline.async({}, suite.toSteps({}), () => {
+  Pipeline.async({}, [
+    Log.step('TBA', 'isBeforeContentEditableFalse', Step.sync(() => {
+      setupHtml(
+        '<span contentEditable="false"></span>' +
+        '<span contentEditable="false"></span>a'
+      );
+
+      assert.eq(isBeforeContentEditableFalse(CaretPosition(getRoot(), 0)), true);
+      assert.eq(isBeforeContentEditableFalse(CaretPosition(getRoot(), 1)), true);
+      assert.eq(isBeforeContentEditableFalse(CaretPosition(getRoot(), 2)), false);
+      assert.eq(isBeforeContentEditableFalse(CaretPosition(getRoot(), 3)), false);
+    })),
+
+    Log.step('TBA', 'isBeforeContentEditableFalse/isAfterContentEditableFalse on bogus all element', Step.sync(() => {
+      setupHtml('<input><p contentEditable="false" data-mce-bogus="all"></p><input>');
+      assert.eq(isBeforeContentEditableFalse(CaretPosition(getRoot(), 1)), false);
+      assert.eq(isAfterContentEditableFalse(CaretPosition(getRoot(), 2)), false);
+    })),
+
+    Log.step('TBA', 'isAfterContentEditableFalse', Step.sync(() => {
+      setupHtml(
+        '<span contentEditable="false"></span>' +
+        '<span contentEditable="false"></span>a'
+      );
+
+      assert.eq(isAfterContentEditableFalse(CaretPosition(getRoot(), 0)), false);
+      assert.eq(isAfterContentEditableFalse(CaretPosition(getRoot(), 1)), true);
+      assert.eq(isAfterContentEditableFalse(CaretPosition(getRoot(), 2)), true);
+      assert.eq(isAfterContentEditableFalse(CaretPosition(getRoot(), 3)), false);
+    })),
+
+    Log.step('TBA', 'isEmptyText', Step.sync(() => {
+      setupHtml('');
+      getRoot().appendChild(document.createTextNode(''));
+      assert.eq(isEmptyText(CaretPosition(getRoot().firstChild, 0)), true);
+      assert.eq(isEmptyText(CaretPosition(getRoot().firstChild, 1)), true);
+
+      setupHtml('<span data-mce-type="bookmark">' + ZWSP + '</span>');
+      const span = getRoot().firstChild;
+      assert.eq(isEmptyText(CaretPosition(span, 0)), false);
+      assert.eq(isEmptyText(CaretPosition(span, 1)), false);
+      assert.eq(isEmptyText(CaretPosition(span.firstChild, 0)), true);
+      assert.eq(isEmptyText(CaretPosition(span.firstChild, 1)), true);
+    }))
+  ], () => {
     viewBlock.detach();
     success();
   }, failure);

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -1,214 +1,329 @@
-import { Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+import { Log, Pipeline, Step } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import * as InsertContent from 'tinymce/core/content/InsertContent';
 import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.core.content.InsertContentTest', (success, failure) => {
-  const suite = LegacyUnit.createSuite<Editor>();
-
   Theme();
 
-  const assertSelection = function (editor, selector, offset) {
-    const node = editor.$(selector)[0];
-    const rng = editor.selection.getRng();
-
-    LegacyUnit.equalDom(rng.startContainer, node.firstChild);
-    LegacyUnit.equal(rng.startOffset, offset);
-    LegacyUnit.equal(rng.collapsed, true);
-  };
-
-  suite.test('insertAtCaret - i inside text, converts to em', function (editor) {
-    editor.setContent('<p>1234</p>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'p', 2);
-    InsertContent.insertAtCaret(editor, '<i>a</i>');
-    LegacyUnit.equal(editor.getContent(), '<p>12<em>a</em>34</p>');
+  const sInsert = (editor: Editor, value: string | { content: string; paste?: boolean; merge?: boolean }) => Step.sync(() => {
+    InsertContent.insertAtCaret(editor, value);
   });
 
-  suite.test('insertAtCaret - ul at beginning of li', function (editor) {
-    editor.setContent('<ul><li>12</li></ul>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li', 0);
-    InsertContent.insertAtCaret(editor, { content: '<ul><li>a</li></ul>', paste: true });
-    LegacyUnit.equal(editor.getContent(), '<ul><li>a</li><li>12</li></ul>');
-    assertSelection(editor, 'li:nth-child(2)', 0);
-  });
+  const getTests = (editor: Editor, tinyApis: TinyApis) => [
+    Log.stepsAsStep('TBA', 'insertAtCaret - i inside text, converts to em', [
+      tinyApis.sSetContent('<p>1234</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 2),
+      sInsert(editor, '<i>a</i>'),
+      tinyApis.sAssertContent('<p>12<em>a</em>34</p>')
+    ]),
 
-  suite.test('insertAtCaret - ul with multiple items at beginning of li', function (editor) {
-    editor.setContent('<ul><li>12</li></ul>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li', 0);
-    InsertContent.insertAtCaret(editor, { content: '<ul><li>a</li><li>b</li></ul>', paste: true });
-    LegacyUnit.equal(editor.getContent(), '<ul><li>a</li><li>b</li><li>12</li></ul>');
-    assertSelection(editor, 'li:nth-child(3)', 0);
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - ul at beginning of li', [
+      tinyApis.sSetContent('<ul><li>12</li></ul>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0),
+      sInsert(editor, { content: '<ul><li>a</li></ul>', paste: true }),
+      tinyApis.sAssertContent('<ul><li>a</li><li>12</li></ul>'),
+      tinyApis.sAssertSelection([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0)
+    ]),
 
-  suite.test('insertAtCaret - ul at end of li', function (editor) {
-    editor.setContent('<ul><li>12</li></ul>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li', 2);
-    InsertContent.insertAtCaret(editor, { content: '<ul><li>a</li></ul>', paste: true });
-    LegacyUnit.equal(editor.getContent(), '<ul><li>12</li><li>a</li></ul>');
-    assertSelection(editor, 'li:nth-child(2)', 1);
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - ul with multiple items at beginning of li', [
+      tinyApis.sSetContent('<ul><li>12</li></ul>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0),
+      sInsert(editor, { content: '<ul><li>a</li><li>b</li></ul>', paste: true }),
+      tinyApis.sAssertContent('<ul><li>a</li><li>b</li><li>12</li></ul>'),
+      tinyApis.sAssertSelection([ 0, 2, 0 ], 0, [ 0, 2, 0 ], 0)
+    ]),
 
-  suite.test('insertAtCaret - ul with multiple items at end of li', function (editor) {
-    editor.setContent('<ul><li>12</li></ul>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li', 2);
-    InsertContent.insertAtCaret(editor, { content: '<ul><li>a</li><li>b</li><li>c</li></ul>', paste: true });
-    LegacyUnit.equal(editor.getContent(), '<ul><li>12</li><li>a</li><li>b</li><li>c</li></ul>');
-    assertSelection(editor, 'li:nth-child(4)', 1);
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - ul at end of li', [
+      tinyApis.sSetContent('<ul><li>12</li></ul>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2),
+      sInsert(editor, { content: '<ul><li>a</li></ul>', paste: true }),
+      tinyApis.sAssertContent('<ul><li>12</li><li>a</li></ul>'),
+      tinyApis.sAssertSelection([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1)
+    ]),
 
-  suite.test('insertAtCaret - ul with multiple items in middle of li', function (editor) {
-    editor.setContent('<ul><li>12</li></ul>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li', 1);
-    InsertContent.insertAtCaret(editor, { content: '<ul><li>a</li><li>b</li></ul>', paste: true });
-    LegacyUnit.equal(editor.getContent(), '<ul><li>1</li><li>a</li><li>b</li><li>2</li></ul>');
-    assertSelection(editor, 'li:nth-child(3)', 1);
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - ul with multiple items at end of li', [
+      tinyApis.sSetContent('<ul><li>12</li></ul>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2),
+      sInsert(editor, { content: '<ul><li>a</li><li>b</li><li>c</li></ul>', paste: true }),
+      tinyApis.sAssertContent('<ul><li>12</li><li>a</li><li>b</li><li>c</li></ul>'),
+      tinyApis.sAssertSelection([ 0, 3, 0 ], 1, [ 0, 3, 0 ], 1)
+    ]),
 
-  suite.test('insertAtCaret - ul in middle of li with formatting', function (editor) {
-    editor.setContent('<ul><li><em><strong>12</strong></em></li></ul>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'strong', 1);
-    InsertContent.insertAtCaret(editor, { content: '<ul><li>a</li></ul>', paste: true });
-    LegacyUnit.equal(
-      editor.getContent(),
-      '<ul><li><em><strong>1</strong></em></li><li>a</li><li><em><strong>2</strong></em></li></ul>'
-    );
-    assertSelection(editor, 'li:nth-child(2)', 1);
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - ul with multiple items in middle of li', [
+      tinyApis.sSetContent('<ul><li>12</li></ul>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1),
+      sInsert(editor, { content: '<ul><li>a</li><li>b</li></ul>', paste: true }),
+      tinyApis.sAssertContent('<ul><li>1</li><li>a</li><li>b</li><li>2</li></ul>'),
+      tinyApis.sAssertSelection([ 0, 2, 0 ], 1, [ 0, 2, 0 ], 1)
+    ]),
 
-  suite.test('insertAtCaret - ul with trailing empty block in middle of li', function (editor) {
-    editor.setContent('<ul><li>a</li><li>d</li></ul>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li:nth-child(1)', 1);
-    InsertContent.insertAtCaret(editor, { content: '<ul><li>b</li><li>c</li></ul><p>\u00a0</p>', paste: true });
-    LegacyUnit.equal(
-      editor.getContent(),
-      '<ul><li>a</li><li>b</li><li>c</li><li>d</li></ul>'
-    );
-    assertSelection(editor, 'li:nth-child(3)', 1);
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - ul in middle of li with formatting', [
+      tinyApis.sSetContent('<ul><li><em><strong>12</strong></em></li></ul>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0, 0, 0 ], 1, [ 0, 0, 0, 0, 0 ], 1),
+      sInsert(editor, { content: '<ul><li>a</li></ul>', paste: true }),
+      tinyApis.sAssertContent('<ul><li><em><strong>1</strong></em></li><li>a</li><li><em><strong>2</strong></em></li></ul>'),
+      tinyApis.sAssertSelection([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1)
+    ]),
 
-  suite.test('insertAtCaret - ul at beginning of li with empty end li', function (editor) {
-    editor.setContent('<ul><li>12</li></ul>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'li', 0);
-    InsertContent.insertAtCaret(editor, { content: '<ul><li>a</li><li></li></ul>', paste: true });
-    LegacyUnit.equal(editor.getContent(), '<ul><li>a</li><li>12</li></ul>');
-    assertSelection(editor, 'li:nth-child(2)', 0);
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - ul with trailing empty block in middle of li', [
+      tinyApis.sSetContent('<ul><li>a</li><li>d</li></ul>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection( [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1),
+      sInsert(editor, { content: '<ul><li>b</li><li>c</li></ul><p>\u00a0</p>', paste: true }),
+      tinyApis.sAssertContent('<ul><li>a</li><li>b</li><li>c</li><li>d</li></ul>'),
+      tinyApis.sAssertSelection([ 0, 2, 0 ], 1, [ 0, 2, 0 ], 1)
+    ]),
 
-  suite.test('insertAtCaret - merge inline elements', function (editor) {
-    editor.setContent('<strong><em>abc</em></strong>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'em', 1);
-    InsertContent.insertAtCaret(editor, { content: '<em><strong>123</strong></em>', merge: true });
-    LegacyUnit.equal(editor.getContent(), '<p><strong><em>a123bc</em></strong></p>');
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - ul at beginning of li with empty end li', [
+      tinyApis.sSetContent('<ul><li>12</li></ul>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0),
+      sInsert(editor, { content: '<ul><li>a</li><li></li></ul>', paste: true }),
+      tinyApis.sAssertContent('<ul><li>a</li><li>12</li></ul>'),
+      tinyApis.sAssertSelection([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0)
+    ]),
 
-  suite.test('insertAtCaret - list into empty table cell with invalid contents #TINY-1231', function (editor) {
-    editor.getBody().innerHTML = '<table class="mce-item-table"><tbody><tr><td><br></td></tr></tbody></table>';
-    editor.focus();
-    const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('td')[0], 0);
-    rng.setEnd(editor.dom.select('td')[0], 0);
-    editor.selection.setRng(rng);
-    InsertContent.insertAtCaret(editor, { content: '<meta http-equiv="content-type" content="text/html; charset=utf-8"><ul><li>a</li></ul>', paste: true });
-    LegacyUnit.equal(editor.getBody().innerHTML, '<table class="mce-item-table"><tbody><tr><td><ul><li>a</li></ul></td></tr></tbody></table>');
-    assertSelection(editor, 'li', 1);
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - merge inline elements', [
+      tinyApis.sSetContent('<p><strong><em>abc</em></strong></p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0, 0 ], 1, [ 0, 0, 0, 0 ], 1),
+      sInsert(editor, { content: '<em><strong>123</strong></em>', merge: true }),
+      tinyApis.sAssertContent('<p><strong><em>a123bc</em></strong></p>')
+    ]),
 
-  suite.test('insertAtCaret - content into single table cell with all content selected', (editor) => {
-    editor.getBody().innerHTML = '<table class="mce-item-table"><tbody><tr><td>content</td></tr></tbody></table>';
-    editor.focus();
-    const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('td')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('td')[0].firstChild, 7);
-    editor.selection.setRng(rng);
-    InsertContent.insertAtCaret(editor, { content: 'replace', paste: true });
-    LegacyUnit.equal(editor.getBody().innerHTML, '<table class="mce-item-table"><tbody><tr><td>replace</td></tr></tbody></table>');
-  });
+    Log.stepsAsStep('TINY-1231', 'insertAtCaret - list into empty table cell with invalid contents', [
+      tinyApis.sSetRawContent('<table class="mce-item-table"><tbody><tr><td><br></td></tr></tbody></table>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0),
+      sInsert(editor, {
+        content: '<meta http-equiv="content-type" content="text/html; charset=utf-8"><ul><li>a</li></ul>',
+        paste: true
+      }),
+      tinyApis.sAssertContent('<table><tbody><tr><td><ul><li>a</li></ul></td></tr></tbody></table>'),
+      tinyApis.sAssertSelection([ 0, 0, 0, 0, 0, 0, 0 ], 1, [ 0, 0, 0, 0, 0, 0, 0 ], 1)
+    ]),
 
-  suite.test('insertAtCaret - empty paragraph pad the empty element with br on insert and nbsp on save', function (editor) {
-    editor.setContent('<p>ab</p>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'p', 1);
-    InsertContent.insertAtCaret(editor, { content: '<p></p>', merge: true });
-    LegacyUnit.equal(editor.getContent({ format: 'raw' }), '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>');
-    LegacyUnit.equal(editor.getContent(), '<p>a</p><p>\u00a0</p><p>b</p>');
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - content into single table cell with all content selected', [
+      tinyApis.sSetRawContent('<table class="mce-item-table"><tbody><tr><td>content</td></tr></tbody></table>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 7),
+      sInsert(editor, { content: 'replace', paste: true }),
+      tinyApis.sAssertContent('<table><tbody><tr><td>replace</td></tr></tbody></table>')
+    ]),
 
-  suite.test('insertAtCaret prevent default of beforeSetContent', function (editor) {
-    let args;
+    Log.stepsAsStep('TBA', 'insertAtCaret - empty paragraph pad the empty element with br on insert and nbsp on save', [
+      tinyApis.sSetContent('<p>ab</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
+      sInsert(editor, { content: '<p></p>', merge: true }),
+      Step.sync(() => {
+        Assert.eq('Raw content', editor.getContent({ format: 'raw' }), '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>');
+      }),
+      tinyApis.sAssertContent('<p>a</p><p>\u00a0</p><p>b</p>')
+    ]),
 
-    const handler = function (e) {
-      if (e.selection === true) {
-        e.preventDefault();
-        e.content = '<h1>b</h1>';
-        editor.getBody().innerHTML = '<h1>c</h1>';
-      }
-    };
+    Log.step('TBA', 'insertAtCaret prevent default of beforeSetContent', Step.sync(() => {
+      let args;
 
-    const collector = function (e) {
-      args = e;
-    };
+      const handler = function (e) {
+        if (e.selection === true) {
+          e.preventDefault();
+          e.content = '<h1>b</h1>';
+          editor.getBody().innerHTML = '<h1>c</h1>';
+        }
+      };
 
-    editor.on('BeforeSetContent', handler);
-    editor.on('SetContent', collector);
+      const collector = function (e) {
+        args = e;
+      };
 
-    editor.setContent('<p>a</p>');
-    LegacyUnit.setSelection(editor, 'p', 0);
-    InsertContent.insertAtCaret(editor, { content: '<p>b</p>', paste: true });
-    LegacyUnit.equal(editor.getContent(), '<h1>c</h1>');
-    LegacyUnit.equal(args.content, '<h1>b</h1>');
-    LegacyUnit.equal(args.type, 'setcontent');
-    LegacyUnit.equal(args.paste, true);
+      editor.on('BeforeSetContent', handler);
+      editor.on('SetContent', collector);
 
-    editor.off('BeforeSetContent', handler);
-    editor.on('BeforeSetContent', collector);
-  });
+      editor.setContent('<p>a</p>');
+      editor.selection.setCursorLocation(editor.dom.select('p')[0].firstChild, 0);
+      InsertContent.insertAtCaret(editor, { content: '<p>b</p>', paste: true });
+      Assert.eq('', editor.getContent(), '<h1>c</h1>');
+      Assert.eq('', args.content, '<h1>b</h1>');
+      Assert.eq('', args.type, 'setcontent');
+      Assert.eq('', args.paste, true);
 
-  suite.test('insertAtCaret - text content at a text node with a trailing nbsp character', function (editor) {
-    editor.setContent('<p>abc&nbsp;</p>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'p', 4);
-    InsertContent.insertAtCaret(editor, 'd');
-    LegacyUnit.equal(editor.getContent(), '<p>abc d</p>');
-  });
+      editor.off('BeforeSetContent', handler);
+      editor.on('BeforeSetContent', collector);
+    })),
 
-  suite.test('insertAtCaret - html at a text node with a trailing nbsp character', function (editor) {
-    editor.setContent('<p>abc&nbsp;</p>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'p', 4);
-    InsertContent.insertAtCaret(editor, '<em>d</em>');
-    LegacyUnit.equal(editor.getContent(), '<p>abc <em>d</em></p>');
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - text content at a text node with a trailing nbsp character', [
+      tinyApis.sSetContent('<p>abc&nbsp;</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 4, [ 0, 0 ], 4),
+      sInsert(editor, 'd'),
+      tinyApis.sAssertContent('<p>abc d</p>')
+    ]),
 
-  suite.test('insertAtCaret - text in the middle of a text node with nbsp characters', function (editor) {
-    editor.setContent('<p>a&nbsp;c</p>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'p', 2);
-    InsertContent.insertAtCaret(editor, 'b');
-    LegacyUnit.equal(editor.getContent(), '<p>a bc</p>');
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - html at a text node with a trailing nbsp character', [
+      tinyApis.sSetContent('<p>abc&nbsp;</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 4, [ 0, 0 ], 4),
+      sInsert(editor, '<em>d</em>'),
+      tinyApis.sAssertContent('<p>abc <em>d</em></p>')
+    ]),
 
-  suite.test('insertAtCaret - html in the middle of a text node with nbsp characters', function (editor) {
-    editor.setContent('<p>a&nbsp;c</p>');
-    editor.focus();
-    LegacyUnit.setSelection(editor, 'p', 2);
-    InsertContent.insertAtCaret(editor, '<em>b</em>');
-    LegacyUnit.equal(editor.getContent(), '<p>a <em>b</em>c</p>');
-  });
+    Log.stepsAsStep('TBA', 'insertAtCaret - text in the middle of a text node with nbsp characters', [
+      tinyApis.sSetContent('<p>a&nbsp;c</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 2),
+      sInsert(editor, 'b'),
+      tinyApis.sAssertContent('<p>a bc</p>')
+    ]),
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
-    Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
+    Log.stepsAsStep('TBA', 'insertAtCaret - html in the middle of a text node with nbsp characters', [
+      tinyApis.sSetContent('<p>a&nbsp;c</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 2),
+      sInsert(editor, '<em>b</em>'),
+      tinyApis.sAssertContent('<p>a <em>b</em>c</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - text content at a text node with a leading nbsp character', [
+      tinyApis.sSetContent('<p>&nbsp;abc</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
+      sInsert(editor, 'd'),
+      tinyApis.sAssertContent('<p>d abc</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - html at a text node with a leading nbsp character', [
+      tinyApis.sSetContent('<p>&nbsp;abc</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
+      sInsert(editor, '<em>d</em>'),
+      tinyApis.sAssertContent('<p><em>d</em> abc</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - text content at a text node with a only a nbsp character', [
+      tinyApis.sSetRawContent('<p>&nbsp;</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
+      sInsert(editor, 'a'),
+      tinyApis.sAssertContent('<p>\u00a0a</p>'),
+
+      tinyApis.sSetRawContent('<p>&nbsp;</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
+      sInsert(editor, 'a'),
+      tinyApis.sAssertContent('<p>a\u00a0</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - html at a text node with a only a nbsp character', [
+      tinyApis.sSetRawContent('<p>&nbsp;</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
+      sInsert(editor, '<em>a</em>'),
+      tinyApis.sAssertContent('<p>\u00a0<em>a</em></p>'),
+
+      tinyApis.sSetRawContent('<p>&nbsp;</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
+      sInsert(editor, '<em>a</em>'),
+      tinyApis.sAssertContent('<p><em>a</em>\u00a0</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - text content at a empty block with leading/trailing spaces', [
+      tinyApis.sSetContent('<p></p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
+      sInsert(editor, ' a '),
+      tinyApis.sAssertContent('<p>\u00a0a\u00a0</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - text content at a text node between 2 spaces with leading/trailing spaces', [
+      tinyApis.sSetContent('<p>a&nbsp; c</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 2),
+      sInsert(editor, ' b '),
+      tinyApis.sAssertContent('<p>a\u00a0 b\u00a0 c</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - text content at a text node before br', [
+      tinyApis.sSetContent('<p>a<br>b</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
+      sInsert(editor, ' c '),
+      tinyApis.sAssertContent('<p>a c\u00a0<br />b</p>'),
+
+      tinyApis.sSetContent('<p>a&nbsp;<br>&nbsp;b</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 2),
+      sInsert(editor, 'c'),
+      tinyApis.sAssertContent('<p>a c<br />\u00a0b</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - html content at a text node before br', [
+      tinyApis.sSetContent('<p>a&nbsp;<br>&nbsp;b</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 2),
+      sInsert(editor, '<em>c</em>'),
+      tinyApis.sAssertContent('<p>a <em>c</em><br />\u00a0b</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - text content at a text node after br', [
+      tinyApis.sSetContent('<p>a<br>b</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 2 ], 0, [ 0, 2 ], 0),
+      sInsert(editor, ' c '),
+      tinyApis.sAssertContent('<p>a<br />\u00a0c b</p>'),
+
+      tinyApis.sSetContent('<p>a&nbsp;<br>&nbsp;b</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 2 ], 0, [ 0, 2 ], 0),
+      sInsert(editor, 'c'),
+      tinyApis.sAssertContent('<p>a\u00a0<br />c b</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - html content at a text node after br', [
+      tinyApis.sSetContent('<p>a&nbsp;<br>&nbsp;b</p>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 2 ], 0, [ 0, 2 ], 0),
+      sInsert(editor, '<em>c</em>'),
+      tinyApis.sAssertContent('<p>a\u00a0<br /><em>c</em> b</p>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - text content with spaces in pre', [
+      tinyApis.sSetContent('<pre></pre>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
+      sInsert(editor, '  a  '),
+      tinyApis.sAssertContent('<pre>  a  </pre>'),
+
+      tinyApis.sSetContent('<pre>a b c</pre>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 3),
+      sInsert(editor, ' b '),
+      tinyApis.sAssertContent('<pre>a  b  c</pre>')
+    ]),
+
+    Log.stepsAsStep('TINY-5966', ' insertAtCaret - html content with spaces in pre', [
+      tinyApis.sSetContent('<pre></pre>'),
+      tinyApis.sFocus(),
+      tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
+      sInsert(editor, ' <strong> a </strong> '),
+      tinyApis.sAssertContent('<pre> <strong> a </strong> </pre>')
+    ])
+  ];
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApi = TinyApis(editor);
+    Pipeline.async({}, getTests(editor, tinyApi), onSuccess, onFailure);
   }, {
     selector: 'textarea',
     add_unload_trigger: false,

--- a/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
@@ -1,4 +1,4 @@
-import { ApproxStructure, Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
+import { ApproxStructure, Assertions, Log, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
@@ -35,20 +35,20 @@ UnitTest.asynctest('browser.tinymce.selection.SetSelectionContentTest', function
     const root = SugarElement.fromDom(editor.getBody());
 
     Pipeline.async({}, [
-      Logger.t('Should insert a before b', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Should insert a before b', [
         tinyApis.sSetContent('<p>b</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
         sSetContent(editor, 'a', {}),
         tinyApis.sAssertContent('<p>ab</p>')
-      ])),
-      Logger.t('Should fill the body with x h1 instead of a before b in a paragraph', GeneralSteps.sequence([
+      ]),
+      Log.stepsAsStep('TBA', 'Should fill the body with x h1 instead of a before b in a paragraph', [
         tinyApis.sSetContent('<p>b</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
         sSetContentOverride(editor, 'a', '<h1>x</h1>', {}),
         tinyApis.sAssertContent('<h1>x</h1>')
-      ])),
+      ]),
 
-      Logger.t('Insert content in middle of word, expanded selection', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Insert content in middle of word, expanded selection', [
         tinyApis.sSetContent('<p>abc</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 2),
         sSetContent(editor, 'X', {}),
@@ -65,9 +65,9 @@ UnitTest.asynctest('browser.tinymce.selection.SetSelectionContentTest', function
           root
         ),
         tinyApis.sAssertSelection([ 0, 0 ], 2, [ 0, 0 ], 2)
-      ])),
+      ]),
 
-      Logger.t('Insert content in middle of word, collapsed selection', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Insert content in middle of word, collapsed selection', [
         tinyApis.sSetContent('<p>ab</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
         sSetContent(editor, 'X', {}),
@@ -84,9 +84,9 @@ UnitTest.asynctest('browser.tinymce.selection.SetSelectionContentTest', function
           root
         ),
         tinyApis.sAssertSelection([ 0, 0 ], 2, [ 0, 0 ], 2)
-      ])),
+      ]),
 
-      Logger.t('Insert content at start of word, collapsed selection', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Insert content at start of word, collapsed selection', [
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
         sSetContent(editor, 'X', {}),
@@ -103,9 +103,9 @@ UnitTest.asynctest('browser.tinymce.selection.SetSelectionContentTest', function
           root
         ),
         tinyApis.sAssertSelection([ 0, 0 ], 1, [ 0, 0 ], 1)
-      ])),
+      ]),
 
-      Logger.t('Insert content at end of word, collapsed selection', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Insert content at end of word, collapsed selection', [
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
         sSetContent(editor, 'X', {}),
@@ -121,9 +121,9 @@ UnitTest.asynctest('browser.tinymce.selection.SetSelectionContentTest', function
           })),
           root
         )
-      ])),
+      ]),
 
-      Logger.t('Insert content at end of word with partial text', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Insert content at end of word with partial text', [
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
         sSetContent(editor, 'b<em>c</em>', {}),
@@ -144,9 +144,9 @@ UnitTest.asynctest('browser.tinymce.selection.SetSelectionContentTest', function
           })),
           root
         )
-      ])),
+      ]),
 
-      Logger.t('Insert content at end of word with partial text', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Insert content at end of word with partial text', [
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
         sSetContent(editor, '<em>b</em>c', {}),
@@ -168,7 +168,81 @@ UnitTest.asynctest('browser.tinymce.selection.SetSelectionContentTest', function
           })),
           root
         )
-      ]))
+      ]),
+
+      Log.stepsAsStep('TINY-5966', 'Set text content at end of word with a space', [
+        tinyApis.sSetContent('<p>a&nbsp;</p>'),
+        tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 2),
+        sSetContent(editor, 'b', {}),
+        Assertions.sAssertStructure('Checking initial structure',
+          ApproxStructure.build((s, str, _arr) => s.element('body', {
+            children: [
+              s.element('p', {
+                children: [
+                  s.text(str.is('a b'))
+                ]
+              })
+            ]
+          })),
+          root
+        )
+      ]),
+
+      Log.stepsAsStep('TINY-5966', 'Set text content with leading/trailing spaces', [
+        tinyApis.sSetContent('<p>a b c</p>'),
+        tinyApis.sSetSelection([ 0, 0 ], 2, [ 0, 0 ], 3),
+        sSetContent(editor, ' b ', {}),
+        Assertions.sAssertStructure('Checking initial structure',
+          ApproxStructure.build((s, str, _arr) => s.element('body', {
+            children: [
+              s.element('p', {
+                children: [
+                  s.text(str.is('a\u00a0 b \u00a0c'))
+                ]
+              })
+            ]
+          })),
+          root
+        )
+      ]),
+
+      Log.stepsAsStep('TINY-5966', 'Set text content in between 2 nbsps', [
+        tinyApis.sSetContent('<p>&nbsp;&nbsp;</p>'),
+        tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
+        sSetContent(editor, ' a b ', {}),
+        Assertions.sAssertStructure('Checking initial structure',
+          ApproxStructure.build((s, str, _arr) => s.element('body', {
+            children: [
+              s.element('p', {
+                children: [
+                  s.text(str.is('\u00a0 a b \u00a0')),
+                  s.zeroOrMore(s.element('br', {}))
+                ]
+              })
+            ]
+          })),
+          root
+        )
+      ]),
+
+      Log.stepsAsStep('TINY-5966', 'Set text content into empty block with leading/trailing spaces', [
+        tinyApis.sSetContent('<p></p>'),
+        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
+        sSetContent(editor, ' a b ', {}),
+        Assertions.sAssertStructure('Checking initial structure',
+          ApproxStructure.build((s, str, _arr) => s.element('body', {
+            children: [
+              s.element('p', {
+                children: [
+                  s.text(str.is('\u00a0a b\u00a0')),
+                  s.zeroOrMore(s.element('br', {}))
+                ]
+              })
+            ]
+          })),
+          root
+        )
+      ])
     ], onSuccess, onFailure);
   }, {
     selector: 'textarea',


### PR DESCRIPTION
Related Ticket: TINY-5966

Description of Changes:
* This fixes issues with spaces being lost due to the browser collapsing them when inserting content using either the `editor.insertContent()` or `editor.selection.setContent()` APIs. The cause here is that it'd insert the content as is, without "normalising" the spaces so they have interleaving spaces and non-breaking spaces. This will by default try to prevent changing the inserted content and instead change the existing content to use spaces or nbsps as needed.
* Note: This also fixes an issue I found while writing tests when setting the content inside a pre block. This was because the parser used to sanitize the content didn't have the context set.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
