### PR TITLE
TINY-6207: Fix font select menu items not handling multiple fonts in selection correctly

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -14,6 +14,7 @@ Version 5.5.0 (TBD)
     Fixed the `media` plugin not saving the alternative source url in some situations #TINY-4113
     Fixed an issue where column resizing using the resize bars was inconsistent between fixed and relative table widths #TINY-6001
     Fixed an issue where dragging and dropping within a table would select table cells #TINY-5950
+    Fixed font select menu items not handling multiple fonts in selection correctly #TINY-6207
     Fixed up and down keyboard navigation not working for inline `contenteditable="false"` elements #TINY-6226
     Fixed the `unlink` toolbar button not working when selecting multiple links #TINY-4867
     Fixed the `link` dialog not showing the "Text to display" field in some valid cases #TINY-5205

--- a/modules/tinymce/src/core/main/ts/commands/FontCommands.ts
+++ b/modules/tinymce/src/core/main/ts/commands/FontCommands.ts
@@ -47,16 +47,12 @@ const normalizeFontNames = (font: string) => {
 
 const fontQuery = (editor: Editor, fontProp: FontInfo.FontProp) => {
   const getter = fontProp === 'font-family' ? FontInfo.getFontFamily : FontInfo.getFontSize;
-  const selection = editor.selection.getRng().cloneRange();
-  const isTextSelection = NodeType.isText(selection.startContainer) && selection.startContainer === selection.endContainer;
+  const rng = editor.selection.getRng().cloneRange();
+  const isTextRng = NodeType.isText(rng.startContainer) && rng.startContainer === rng.endContainer;
   // Have to directly use text node instead of selectionRng for text selection as there are cases where
   // RangeWalker used in the getter fn will not return results otherwise
-  const rngOrNode: Range | Node = isTextSelection ? selection.startContainer : selection;
-  if (rngOrNode) {
-    return getter(editor.getBody(), rngOrNode);
-  } else {
-    return '';
-  }
+  const rngOrNode: Range | Node = isTextRng ? rng.startContainer : rng;
+  return getter(editor.getBody(), rngOrNode);
 };
 
 export const fontNameAction = (editor: Editor, value: string) => {
@@ -65,13 +61,11 @@ export const fontNameAction = (editor: Editor, value: string) => {
   editor.nodeChanged();
 };
 
-export const fontNameQuery = (editor: Editor) =>
-  fontQuery(editor, 'font-family');
+export const fontNameQuery = (editor: Editor) => fontQuery(editor, 'font-family');
 
 export const fontSizeAction = (editor: Editor, value: string) => {
   editor.formatter.toggle('fontsize', { value: fromFontSizeNumber(editor, value) });
   editor.nodeChanged();
 };
 
-export const fontSizeQuery = (editor: Editor) =>
-  fontQuery(editor, 'font-size');
+export const fontSizeQuery = (editor: Editor) => fontQuery(editor, 'font-size');

--- a/modules/tinymce/src/core/main/ts/commands/FontCommands.ts
+++ b/modules/tinymce/src/core/main/ts/commands/FontCommands.ts
@@ -5,24 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional, Strings } from '@ephox/katamari';
+import { Arr, Strings } from '@ephox/katamari';
 import Editor from '../api/Editor';
 import * as Settings from '../api/Settings';
-import * as CaretFinder from '../caret/CaretFinder';
 import * as NodeType from '../dom/NodeType';
 import * as FontInfo from '../fmt/FontInfo';
-
-const findFirstCaretElement = (editor: Editor) => CaretFinder.firstPositionIn(editor.getBody()).map((caret) => {
-  const container = caret.container();
-  return NodeType.isText(container) ? container.parentNode : container;
-});
-
-const isRangeAtStartOfNode = (rng: Range, root: Node) => rng.startContainer === root && rng.startOffset === 0;
-
-const getCaretElement = (editor: Editor): Optional<Node> => Optional.from(editor.selection.getRng()).bind((rng) => {
-  const root = editor.getBody();
-  return isRangeAtStartOfNode(rng, root) ? Optional.none() : Optional.from(editor.selection.getStart(true));
-});
 
 const fromFontSizeNumber = (editor: Editor, value: string): string => {
   if (/^[0-9\.]+$/.test(value)) {
@@ -58,23 +45,33 @@ const normalizeFontNames = (font: string) => {
   }).join(',');
 };
 
+const fontQuery = (editor: Editor, fontProp: FontInfo.FontProp) => {
+  const getter = fontProp === 'font-family' ? FontInfo.getFontFamily : FontInfo.getFontSize;
+  const selection = editor.selection.getRng().cloneRange();
+  const isTextSelection = NodeType.isText(selection.startContainer) && selection.startContainer === selection.endContainer;
+  // Have to directly use text node instead of selectionRng for text selection as there are cases where
+  // RangeWalker used in the getter fn will not return results otherwise
+  const rngOrNode: Range | Node = isTextSelection ? selection.startContainer : selection;
+  if (rngOrNode) {
+    return getter(editor.getBody(), rngOrNode);
+  } else {
+    return '';
+  }
+};
+
 export const fontNameAction = (editor: Editor, value: string) => {
   const font = fromFontSizeNumber(editor, value);
   editor.formatter.toggle('fontname', { value: normalizeFontNames(font) });
   editor.nodeChanged();
 };
 
-export const fontNameQuery = (editor: Editor) => getCaretElement(editor).fold(
-  () => findFirstCaretElement(editor).map((caretElement) => FontInfo.getFontFamily(editor.getBody(), caretElement)).getOr(''),
-  (caretElement) => FontInfo.getFontFamily(editor.getBody(), caretElement)
-);
+export const fontNameQuery = (editor: Editor) =>
+  fontQuery(editor, 'font-family');
 
 export const fontSizeAction = (editor: Editor, value: string) => {
   editor.formatter.toggle('fontsize', { value: fromFontSizeNumber(editor, value) });
   editor.nodeChanged();
 };
 
-export const fontSizeQuery = (editor: Editor) => getCaretElement(editor).fold(
-  () => findFirstCaretElement(editor).map((caretElement) => FontInfo.getFontSize(editor.getBody(), caretElement)).getOr(''),
-  (caretElement) => FontInfo.getFontSize(editor.getBody(), caretElement)
-);
+export const fontSizeQuery = (editor: Editor) =>
+  fontQuery(editor, 'font-size');

--- a/modules/tinymce/src/core/main/ts/fmt/FontInfo.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FontInfo.ts
@@ -5,26 +5,54 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun, Obj, Optional } from '@ephox/katamari';
-import { Attribute, Compare, Css, SugarElement, SugarNode, TransformFind } from '@ephox/sugar';
+import { Arr, Obj, Optional, Fun } from '@ephox/katamari';
+import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
+import * as NodeType from '../dom/NodeType';
+import * as RangeWalk from '../selection/RangeWalk';
+import { isNode } from './FormatUtils';
 
-const legacyPropNames: Record<string, string> = {
+export type FontProp = 'font-size' | 'font-family';
+
+const legacyPropNames: Record<FontProp, string> = {
   'font-size': 'size',
   'font-family': 'face'
 };
 
-const getSpecifiedFontProp = (propName: string, rootElm: Element, elm: HTMLElement): Optional<string> => {
-  const getProperty = (elm: SugarElement) => Css.getRaw(elm, propName).orThunk(() => {
-    if (SugarNode.name(elm) === 'font') {
-      return Obj.get(legacyPropNames, propName).bind((legacyPropName) => Attribute.getOpt(elm, legacyPropName));
-    } else {
-      return Optional.none();
-    }
-  });
-  const isRoot = (elm: SugarElement) => Compare.eq(SugarElement.fromDom(rootElm), elm);
+const collect = (dom: DOMUtils, rngOrNode: Range | Node, rootNode: Element, propName: FontProp): string[] => {
+  const collector: string[] = [];
 
-  return TransformFind.closest(SugarElement.fromDom(elm), (elm) => getProperty(elm), isRoot);
+  const process = (nodes: Node[], limit: Node, getComputed: boolean) => {
+    Arr.each(nodes, (node) => {
+      const matches = dom.getParents(node, '*[style],font', limit);
+      Arr.findMap(matches, (match) => getSpecifiedFontProp(propName, SugarElement.fromDom(match)))
+        .orThunk(() => {
+          // Cannot find computed style on text node so have get parent node if required
+          const elm = NodeType.isText(node) ? dom.getParent(node, '*', rootNode) : node as Element;
+          return getComputed ? getComputedFontProp(propName, elm) : Optional.none();
+        })
+        .each((value) => {
+          // Make sure value is unique
+          if (Arr.forall(collector, (existing) => existing !== value)) {
+            collector.push(value);
+          };
+        });
+
+      // Don't need to worry about potentially getting the computed value for children as if no fonts are found on the child,
+      // it will inherit the 'node' font value which may be computed
+      process(Arr.from(node.childNodes), node, false);
+    });
+  };
+
+  if (isNode(rngOrNode)) {
+    process([ rngOrNode ], rootNode, true);
+  } else {
+    RangeWalk.walk(dom, rngOrNode, (nodes) => {
+      process(nodes, rootNode, true);
+    });
+  }
+
+  return collector;
 };
 
 const round = (number: number, precision: number) => {
@@ -44,18 +72,33 @@ const normalizeFontFamily = (fontFamily: string) =>
   // 'Font name', Font -> Font name,Font
   fontFamily.replace(/[\'\"\\]/g, '').replace(/,\s+/g, ',');
 
-const getComputedFontProp = (propName: string, elm: HTMLElement): Optional<string> => Optional.from(DOMUtils.DOM.getStyle(elm, propName, true));
+const getSpecifiedFontProp = (propName: FontProp, elm: SugarElement): Optional<string> =>
+  Css.getRaw(elm, propName).orThunk(() => {
+    if (SugarNode.name(elm) === 'font') {
+      return Obj.get(legacyPropNames, propName).bind((legacyPropName) => Attribute.getOpt(elm, legacyPropName));
+    } else {
+      return Optional.none();
+    }
+  });
 
-const getFontProp = (propName: string) => (rootElm: Element, elm: Node): string => Optional.from(elm)
-  .map(SugarElement.fromDom)
-  .filter(SugarNode.isElement)
-  .bind((element: any) => getSpecifiedFontProp(propName, rootElm, element.dom)
-    .or(getComputedFontProp(propName, element.dom)))
-  .getOr('');
+const getComputedFontProp = (propName: FontProp, elm: Element): Optional<string> =>
+  Optional.from(DOMUtils.DOM.getStyle(elm, propName, true));
 
-const getFontSize = getFontProp('font-size');
+const getFontInfo = (propName: FontProp, normalize: (str: string) => string) => (rootNode: Element, rngOrNode: Range | Node) => {
+  const fontProps = Arr.map(collect(DOMUtils.DOM, rngOrNode, rootNode, propName), normalize);
+  // If there is more than one font prop found, cannot declare that there is a single font
+  if (fontProps.length === 0 || fontProps.length > 1) {
+    return '';
+  } else {
+    return fontProps[0];
+  }
+};
 
-const getFontFamily = Fun.compose(normalizeFontFamily, getFontProp('font-family')) as (rootElm: Element, elm: Node) => string;
+const getFontSize =
+  getFontInfo('font-size', Fun.identity);
+
+const getFontFamily =
+  getFontInfo('font-family', normalizeFontFamily);
 
 export {
   getFontSize,

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -114,19 +114,21 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
       ]),
 
       Log.stepsAsStep('TINY-6207', 'Font family and font size on paragraph with words of different families and sizes', [
-        tinyApis.sSetContent(`<p>font1 <span style="font-family: 'arial black', sans-serif; font-size: 24pt;">font2 </span> font3</p>`),
+        tinyApis.sSetContent(`<p>font1 <span style="font-size: 24pt; font-family: 'arial black', sans-serif;">font2</span> <span style="font-family: terminal, monaco, monospace;">font3</span></p>`),
         tinyApis.sFocus(),
         // Check first font is detected
         sAssertFontsForSelections('Check font family and font size are found (0)', [ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
         // Check second font is detected
         sAssertFontsForSelections('Check font family and fontsize are found (1)', [ selObj([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1) ], '24pt', 'Arial Black'),
+        // Check space in beween two fonts get correct familay
+        sAssertFontsForSelections('Check font family and fontsize are found for space', [ selObj([ 0, 2 ], 1, [ 0, 2 ], 1) ], '12px', 'Arial'),
         // Check no font is found when multiple fonts are selected
         sAssertFontsForSelections(
           'Check no font family or font size is found for multi font selections',
           [
             selObj([ 0, 0 ], 1, [ 0, 1, 0 ], 1),
-            selObj([ 0, 1, 0 ], 1, [ 0, 2 ], 1),
-            selObj([], 0, [], 0)
+            selObj([ 0, 1, 0 ], 1, [ 0, 3 ], 1),
+            selObj([], 0, [], 1)
           ], '', '')
       ]),
 
@@ -150,7 +152,7 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
           'Check no font family or font size is found for multi font selections',
           [
             selObj([ 0, 1, 1, 0 ], 0, [ 0, 1, 2 ], 1), // ab|cd|e
-            selObj([], 0, [], 0)
+            selObj([], 0, [], 1)
           ], '', '')
       ]),
 
@@ -163,7 +165,7 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
           'Check no font family or font size is found for multi font selections',
           [
             selObj([ 0, 0 ], 0, [ 0, 1, 0 ], 0),
-            selObj([], 0, [], 0)
+            selObj([], 0, [], 1)
           ], '', '')
       ]),
 
@@ -183,7 +185,26 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         sAssertFontsForSelections(
           'Check no font family or font size is found for multi font selections',
           [
-            selObj([ 1 ], 0, [ 2 ], 0)
+            selObj([ 1 ], 0, [ 2 ], 1)
+          ], '', '')
+      ]),
+
+      // Add test for including strong content_style
+      Log.stepsAsStep('TINY-6207', 'Font family and font size with an inline element that has a content_style', [
+        // tinyApis.sSetContent(`<p>a<strong>b<span style="font-family: impact, sans-serif;">c</span>d</strong>e</p>`),
+        tinyApis.sSetContent(`<p>a<span style="font-family: 'arial black', sans-serif;">b<strong>cd</strong>e</span>f</p>`),
+        tinyApis.sFocus(),
+        // a
+        sAssertFontsForSelections('Check font family and font size are found (0)', [ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
+        // b
+        sAssertFontsForSelections('Check font family and font size are found (1)', [ selObj([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1) ], '12px', 'Arial Black'),
+        // c - font size and fant family should be calculated from content_style for strong tag (the size is auto  converted from px to pt)
+        sAssertFontsForSelections('Check font family and font size are found (2)', [ selObj([ 0, 1, 1, 0 ], 1, [ 0, 1, 1, 0 ], 1) ], '8pt', 'Impact'),
+        sAssertFontsForSelections(
+          'Check no font family or font size is found for multi font selections',
+          [
+            selObj([ 0, 1, 0 ], 0, [ 0, 1, 1, 0 ], 1), // a|bc|def
+            selObj([ ], 0, [ ], 1)
           ], '', '')
       ])
     ], onSuccess, onFailure);
@@ -193,7 +214,8 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
     content_style: [
       '.mce-content-body { font-family: Helvetica; font-size: 42px; }',
       '.mce-content-body p { font-family: Arial; font-size: 12px; }',
-      '.mce-content-body h1 { font-family: Arial; font-size: 32px; }'
+      '.mce-content-body h1 { font-family: Arial; font-size: 32px; }',
+      '.mce-content-body strong { font-family: Impact; font-size: 10px; }'
     ].join(''),
     fontsize_formats: '8pt=1 12pt 12.75pt 13pt 24pt 32pt'
   }, success, failure);

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -1,9 +1,25 @@
-import { Assertions, Chain, GeneralSteps, Logger, Pipeline, UiFinder } from '@ephox/agar';
+import { Assertions, Chain, GeneralSteps, Log, Pipeline, UiFinder, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun, Strings } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { SugarElement, TextContent } from '@ephox/sugar';
 import Theme from 'tinymce/themes/silver/Theme';
+import Editor from 'tinymce/core/api/Editor';
+
+interface Sel {
+  startPath: number[];
+  soffset: number;
+  finishPath: number[];
+  foffset: number;
+}
+
+const selObj = (startPath: number[], soffset: number, finishPath: number[], foffset: number): Sel =>
+  ({
+    startPath,
+    soffset,
+    finishPath,
+    foffset
+  });
 
 UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, failure) {
   Theme();
@@ -14,80 +30,157 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
     '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;' // Wordpress
   ];
 
-  const sAssertSelectBoxDisplayValue = function (editor, title, expectedValue) {
-    return Chain.asStep(SugarElement.fromDom(document.body), [
+  const sAssertSelectBoxDisplayValue = (title: string, expectedValue: string) =>
+    Chain.asStep(SugarElement.fromDom(document.body), [
       UiFinder.cFindIn('*[title="' + title + '"]'),
       Chain.mapper(Fun.compose(Strings.trim, TextContent.get)),
       Assertions.cAssertEq('Should be the expected display value', expectedValue)
     ]);
-  };
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
 
+    const sAssertFontsForSelections = (selections: Sel[], expectedFontSize: string, expectedFontFamily: string): Step<unknown, unknown>[] =>
+      Arr.bind(selections, (selection) => [
+        tinyApis.sSetSelection(selection.startPath, selection.soffset, selection.finishPath, selection.foffset),
+        tinyApis.sNodeChanged(),
+        sAssertSelectBoxDisplayValue('Font sizes', expectedFontSize),
+        sAssertSelectBoxDisplayValue('Fonts', expectedFontFamily)
+      ]);
+
     Pipeline.async({}, [
-      Logger.t('Font family and font size on initial page load', GeneralSteps.sequence([
-        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '12px'),
-        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Arial')
+      Log.step('', 'Font family and font size on initial page load', GeneralSteps.sequence([
+        sAssertSelectBoxDisplayValue('Font sizes', '12px'),
+        sAssertSelectBoxDisplayValue('Fonts', 'Arial')
       ])),
 
-      Logger.t('Font family and font size on paragraph with no styles', GeneralSteps.sequence([
+      Log.step('', 'Font family and font size on paragraph with no styles', GeneralSteps.sequence([
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
         tinyApis.sNodeChanged(),
         // p content style is 12px which does not match any pt values in the font size select values
-        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '12px'),
-        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Arial')
+        sAssertSelectBoxDisplayValue('Font sizes', '12px'),
+        sAssertSelectBoxDisplayValue('Fonts', 'Arial')
       ])),
 
-      Logger.t('Font family and font size on heading with no styles', GeneralSteps.sequence([
+      Log.step('', 'Font family and font size on heading with no styles', GeneralSteps.sequence([
         tinyApis.sSetContent('<h1>a</h1>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
         tinyApis.sNodeChanged(),
         // h1 content style is 32px which matches 24pt in the font size select values so it should be converted
-        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '24pt'),
-        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Arial')
+        sAssertSelectBoxDisplayValue('Font sizes', '24pt'),
+        sAssertSelectBoxDisplayValue('Fonts', 'Arial')
       ])),
 
-      Logger.t('Font family and font size on paragraph with styles that do match font size select values', GeneralSteps.sequence([
+      Log.step('', 'Font family and font size on paragraph with styles that do match font size select values', GeneralSteps.sequence([
         tinyApis.sSetContent('<p style="font-family: Times; font-size: 17px;">a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
         tinyApis.sNodeChanged(),
         // the following should be converted and pick up 12.75pt, although there's a rounded 13pt in the dropdown as well
-        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '12.75pt'),
-        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
+        sAssertSelectBoxDisplayValue('Font sizes', '12.75pt'),
+        sAssertSelectBoxDisplayValue('Fonts', 'Times')
       ])),
 
-      Logger.t('Font family and font size on paragraph with styles that do not match font size select values', GeneralSteps.sequence([
+      Log.step('', 'Font family and font size on paragraph with styles that do not match font size select values', GeneralSteps.sequence([
         tinyApis.sSetContent('<p style="font-family: Times; font-size: 18px;">a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
         tinyApis.sNodeChanged(),
         // the following should stay as 18px because there's no matching pt value in the font size select values
-        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '18px'),
-        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
+        sAssertSelectBoxDisplayValue('Font sizes', '18px'),
+        sAssertSelectBoxDisplayValue('Fonts', 'Times')
       ])),
 
-      Logger.t('Font family and font size on paragraph with legacy font elements', GeneralSteps.sequence([
+      Log.step('', 'Font family and font size on paragraph with legacy font elements', GeneralSteps.sequence([
         tinyApis.sSetRawContent('<p><font face="Times" size="1">a</font></p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0, 0 ], 0),
         tinyApis.sNodeChanged(),
-        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '8pt'),
-        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
+        sAssertSelectBoxDisplayValue('Font sizes', '8pt'),
+        sAssertSelectBoxDisplayValue('Fonts', 'Times')
       ])),
 
-      Logger.t('System font stack variants on a paragraph show "System Font" as the font name', GeneralSteps.sequence([
+      Log.step('', 'System font stack variants on a paragraph show "System Font" as the font name', GeneralSteps.sequence([
         tinyApis.sSetContent(Arr.foldl(systemFontStackVariants, (acc, font) => acc + '<p style="font-family: ' + font.replace(/"/g, `'`) + '"></p>', '')),
         tinyApis.sFocus(),
         ...Arr.bind(systemFontStackVariants, (_, idx) => [
           tinyApis.sSetCursor([ idx, 0 ], 0),
           tinyApis.sNodeChanged(),
-          sAssertSelectBoxDisplayValue(editor, 'Fonts', 'System Font')
+          sAssertSelectBoxDisplayValue('Fonts', 'System Font')
         ])
+      ])),
+
+      Log.step('TINY-6207', 'Font family and font size on paragraph with words of different families and sizes', GeneralSteps.sequence([
+        tinyApis.sSetContent(`<p>font1 <span style="font-family: 'arial black', sans-serif; font-size: 24pt;">font2 </span> font3</p>`),
+        tinyApis.sFocus(),
+        // Check first font is detected
+        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
+        // Check second font is detected
+        ...sAssertFontsForSelections([ selObj([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1) ], '24pt', 'Arial Black'),
+        // Check no font is found when multiple fonts are selected
+        ...sAssertFontsForSelections(
+          [
+            selObj([ 0, 0 ], 1, [ 0, 1, 0 ], 1),
+            selObj([ 0, 1, 0 ], 1, [ 0, 2 ], 1),
+            selObj([], 0, [], 0)
+          ], '', '')
+      ])),
+
+      Log.step('TINY-6207', 'Font family and font size on paragraph with nested families and sizes', GeneralSteps.sequence([
+        tinyApis.sSetContent(`<p>a<span style="font-family: 'arial black', sans-serif;">b<span style="font-family: impact, sans-serif; font-size: 12pt;">c</span>d</span>e</p>`),
+        tinyApis.sFocus(),
+        // a
+        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
+        // b
+        ...sAssertFontsForSelections([ selObj([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1) ], '12px', 'Arial Black'),
+        // c
+        ...sAssertFontsForSelections([ selObj([ 0, 1, 1, 0 ], 1, [ 0, 1, 1, 0 ], 1) ], '12pt', 'Impact'),
+        // d
+        ...sAssertFontsForSelections([ selObj([ 0, 1, 2 ], 1, [ 0, 1, 2 ], 1) ], '12px', 'Arial Black'),
+        // e
+        ...sAssertFontsForSelections([ selObj([ 0, 2 ], 1, [ 0, 2 ], 1) ], '12px', 'Arial'),
+        // |ab|cde
+        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 0, [ 0, 1, 0 ], 1) ], '12px', ''),
+        // Multi font selection
+        ...sAssertFontsForSelections(
+          [
+            selObj([ 0, 1, 1, 0 ], 0, [ 0, 1, 2 ], 1), // ab|cd|e
+            selObj([], 0, [], 0)
+          ], '', '')
+      ])),
+
+      Log.step('TINY-6207', 'Font family and font size on empty span', GeneralSteps.sequence([
+        tinyApis.sSetContent(`<p>abc<span style="font-family: 'arial black', sans-serif; font-size: 13pt;"><br></span></p>`),
+        tinyApis.sFocus(),
+        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
+        ...sAssertFontsForSelections([ selObj([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0) ], '13pt', 'Arial Black'),
+        ...sAssertFontsForSelections(
+          [
+            selObj([ 0, 0 ], 0, [ 0, 1, 0 ], 0),
+            selObj([], 0, [], 0)
+          ], '', '')
+      ])),
+
+      Log.step('TINY-6207', 'Font family and font size with multiple paragraphs', GeneralSteps.sequence([
+        tinyApis.sSetContent(
+          `<p>test1</p>` +
+          `<p>tes<span style="font-size: 13pt;">t2</span></p>` +
+          `<p><span style="font-family: 'arial black', sans-serif; font-size: 13pt;">test3</span></p>`
+        ),
+        tinyApis.sFocus(),
+        // t|est1\nt|est2
+        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 1, 0 ], 1) ], '12px', 'Arial'),
+        // t|est1\ntest|2
+        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 1, 1, 0 ], 1) ], '', 'Arial'),
+        // // test|2\nte|st3
+        ...sAssertFontsForSelections([ selObj([ 1, 1, 0 ], 1, [ 2, 0, 0 ], 1) ], '13pt', ''),
+        ...sAssertFontsForSelections(
+          [
+            selObj([ 1 ], 0, [ 2 ], 0)
+          ], '', '')
       ]))
     ], onSuccess, onFailure);
   }, {

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -1,4 +1,4 @@
-import { Assertions, Chain, GeneralSteps, Log, Pipeline, UiFinder, Step } from '@ephox/agar';
+import { Assertions, Chain, Log, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun, Strings } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
@@ -40,21 +40,21 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
   TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
 
-    const sAssertFontsForSelections = (selections: Sel[], expectedFontSize: string, expectedFontFamily: string): Step<unknown, unknown>[] =>
-      Arr.bind(selections, (selection) => [
+    const sAssertFontsForSelections = (description: string, selections: Sel[], expectedFontSize: string, expectedFontFamily: string) =>
+      Log.stepsAsStep('TBA', description, Arr.bind(selections, (selection) => [
         tinyApis.sSetSelection(selection.startPath, selection.soffset, selection.finishPath, selection.foffset),
         tinyApis.sNodeChanged(),
         sAssertSelectBoxDisplayValue('Font sizes', expectedFontSize),
         sAssertSelectBoxDisplayValue('Fonts', expectedFontFamily)
-      ]);
+      ]));
 
     Pipeline.async({}, [
-      Log.step('', 'Font family and font size on initial page load', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on initial page load', [
         sAssertSelectBoxDisplayValue('Font sizes', '12px'),
         sAssertSelectBoxDisplayValue('Fonts', 'Arial')
-      ])),
+      ]),
 
-      Log.step('', 'Font family and font size on paragraph with no styles', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on paragraph with no styles', [
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
@@ -62,9 +62,9 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         // p content style is 12px which does not match any pt values in the font size select values
         sAssertSelectBoxDisplayValue('Font sizes', '12px'),
         sAssertSelectBoxDisplayValue('Fonts', 'Arial')
-      ])),
+      ]),
 
-      Log.step('', 'Font family and font size on heading with no styles', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on heading with no styles', [
         tinyApis.sSetContent('<h1>a</h1>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
@@ -72,9 +72,9 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         // h1 content style is 32px which matches 24pt in the font size select values so it should be converted
         sAssertSelectBoxDisplayValue('Font sizes', '24pt'),
         sAssertSelectBoxDisplayValue('Fonts', 'Arial')
-      ])),
+      ]),
 
-      Log.step('', 'Font family and font size on paragraph with styles that do match font size select values', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on paragraph with styles that do match font size select values', [
         tinyApis.sSetContent('<p style="font-family: Times; font-size: 17px;">a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
@@ -82,9 +82,9 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         // the following should be converted and pick up 12.75pt, although there's a rounded 13pt in the dropdown as well
         sAssertSelectBoxDisplayValue('Font sizes', '12.75pt'),
         sAssertSelectBoxDisplayValue('Fonts', 'Times')
-      ])),
+      ]),
 
-      Log.step('', 'Font family and font size on paragraph with styles that do not match font size select values', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on paragraph with styles that do not match font size select values', [
         tinyApis.sSetContent('<p style="font-family: Times; font-size: 18px;">a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
@@ -92,18 +92,18 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         // the following should stay as 18px because there's no matching pt value in the font size select values
         sAssertSelectBoxDisplayValue('Font sizes', '18px'),
         sAssertSelectBoxDisplayValue('Fonts', 'Times')
-      ])),
+      ]),
 
-      Log.step('', 'Font family and font size on paragraph with legacy font elements', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on paragraph with legacy font elements', [
         tinyApis.sSetRawContent('<p><font face="Times" size="1">a</font></p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0, 0 ], 0),
         tinyApis.sNodeChanged(),
         sAssertSelectBoxDisplayValue('Font sizes', '8pt'),
         sAssertSelectBoxDisplayValue('Fonts', 'Times')
-      ])),
+      ]),
 
-      Log.step('', 'System font stack variants on a paragraph show "System Font" as the font name', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'System font stack variants on a paragraph show "System Font" as the font name', [
         tinyApis.sSetContent(Arr.foldl(systemFontStackVariants, (acc, font) => acc + '<p style="font-family: ' + font.replace(/"/g, `'`) + '"></p>', '')),
         tinyApis.sFocus(),
         ...Arr.bind(systemFontStackVariants, (_, idx) => [
@@ -111,60 +111,63 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
           tinyApis.sNodeChanged(),
           sAssertSelectBoxDisplayValue('Fonts', 'System Font')
         ])
-      ])),
+      ]),
 
-      Log.step('TINY-6207', 'Font family and font size on paragraph with words of different families and sizes', GeneralSteps.sequence([
+      Log.stepsAsStep('TINY-6207', 'Font family and font size on paragraph with words of different families and sizes', [
         tinyApis.sSetContent(`<p>font1 <span style="font-family: 'arial black', sans-serif; font-size: 24pt;">font2 </span> font3</p>`),
         tinyApis.sFocus(),
         // Check first font is detected
-        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
+        sAssertFontsForSelections('Check font family and font size are found (0)', [ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
         // Check second font is detected
-        ...sAssertFontsForSelections([ selObj([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1) ], '24pt', 'Arial Black'),
+        sAssertFontsForSelections('Check font family and fontsize are found (1)', [ selObj([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1) ], '24pt', 'Arial Black'),
         // Check no font is found when multiple fonts are selected
-        ...sAssertFontsForSelections(
+        sAssertFontsForSelections(
+          'Check no font family or font size is found for multi font selections',
           [
             selObj([ 0, 0 ], 1, [ 0, 1, 0 ], 1),
             selObj([ 0, 1, 0 ], 1, [ 0, 2 ], 1),
             selObj([], 0, [], 0)
           ], '', '')
-      ])),
+      ]),
 
-      Log.step('TINY-6207', 'Font family and font size on paragraph with nested families and sizes', GeneralSteps.sequence([
+      Log.stepsAsStep('TINY-6207', 'Font family and font size on paragraph with nested families and sizes', [
         tinyApis.sSetContent(`<p>a<span style="font-family: 'arial black', sans-serif;">b<span style="font-family: impact, sans-serif; font-size: 12pt;">c</span>d</span>e</p>`),
         tinyApis.sFocus(),
         // a
-        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
+        sAssertFontsForSelections('Check font family and font size are found (0)', [ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
         // b
-        ...sAssertFontsForSelections([ selObj([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1) ], '12px', 'Arial Black'),
+        sAssertFontsForSelections('Check font family and font size are found (1)', [ selObj([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1) ], '12px', 'Arial Black'),
         // c
-        ...sAssertFontsForSelections([ selObj([ 0, 1, 1, 0 ], 1, [ 0, 1, 1, 0 ], 1) ], '12pt', 'Impact'),
+        sAssertFontsForSelections('Check font family and font size are found (2)', [ selObj([ 0, 1, 1, 0 ], 1, [ 0, 1, 1, 0 ], 1) ], '12pt', 'Impact'),
         // d
-        ...sAssertFontsForSelections([ selObj([ 0, 1, 2 ], 1, [ 0, 1, 2 ], 1) ], '12px', 'Arial Black'),
+        sAssertFontsForSelections('Check font family and font size are found (3)', [ selObj([ 0, 1, 2 ], 1, [ 0, 1, 2 ], 1) ], '12px', 'Arial Black'),
         // e
-        ...sAssertFontsForSelections([ selObj([ 0, 2 ], 1, [ 0, 2 ], 1) ], '12px', 'Arial'),
+        sAssertFontsForSelections('Check font family and font size are found (4)', [ selObj([ 0, 2 ], 1, [ 0, 2 ], 1) ], '12px', 'Arial'),
         // |ab|cde
-        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 0, [ 0, 1, 0 ], 1) ], '12px', ''),
+        sAssertFontsForSelections('Check font size is found', [ selObj([ 0, 0 ], 0, [ 0, 1, 0 ], 1) ], '12px', ''),
         // Multi font selection
-        ...sAssertFontsForSelections(
+        sAssertFontsForSelections(
+          'Check no font family or font size is found for multi font selections',
           [
             selObj([ 0, 1, 1, 0 ], 0, [ 0, 1, 2 ], 1), // ab|cd|e
             selObj([], 0, [], 0)
           ], '', '')
-      ])),
+      ]),
 
-      Log.step('TINY-6207', 'Font family and font size on empty span', GeneralSteps.sequence([
+      Log.stepsAsStep('TINY-6207', 'Font family and font size on empty span', [
         tinyApis.sSetContent(`<p>abc<span style="font-family: 'arial black', sans-serif; font-size: 13pt;"><br></span></p>`),
         tinyApis.sFocus(),
-        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
-        ...sAssertFontsForSelections([ selObj([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0) ], '13pt', 'Arial Black'),
-        ...sAssertFontsForSelections(
+        sAssertFontsForSelections('Check computed font family and font size are found', [ selObj([ 0, 0 ], 1, [ 0, 0 ], 1) ], '12px', 'Arial'),
+        sAssertFontsForSelections('Check font family and font size are found in empty span', [ selObj([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0) ], '13pt', 'Arial Black'),
+        sAssertFontsForSelections(
+          'Check no font family or font size is found for multi font selections',
           [
             selObj([ 0, 0 ], 0, [ 0, 1, 0 ], 0),
             selObj([], 0, [], 0)
           ], '', '')
-      ])),
+      ]),
 
-      Log.step('TINY-6207', 'Font family and font size with multiple paragraphs', GeneralSteps.sequence([
+      Log.stepsAsStep('TINY-6207', 'Font family and font size with multiple paragraphs', [
         tinyApis.sSetContent(
           `<p>test1</p>` +
           `<p>tes<span style="font-size: 13pt;">t2</span></p>` +
@@ -172,16 +175,17 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         ),
         tinyApis.sFocus(),
         // t|est1\nt|est2
-        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 1, 0 ], 1) ], '12px', 'Arial'),
+        sAssertFontsForSelections('Check font family and font size are found', [ selObj([ 0, 0 ], 1, [ 1, 0 ], 1) ], '12px', 'Arial'),
         // t|est1\ntest|2
-        ...sAssertFontsForSelections([ selObj([ 0, 0 ], 1, [ 1, 1, 0 ], 1) ], '', 'Arial'),
+        sAssertFontsForSelections('Check font family is found', [ selObj([ 0, 0 ], 1, [ 1, 1, 0 ], 1) ], '', 'Arial'),
         // // test|2\nte|st3
-        ...sAssertFontsForSelections([ selObj([ 1, 1, 0 ], 1, [ 2, 0, 0 ], 1) ], '13pt', ''),
-        ...sAssertFontsForSelections(
+        sAssertFontsForSelections('Check font size is found', [ selObj([ 1, 1, 0 ], 1, [ 2, 0, 0 ], 1) ], '13pt', ''),
+        sAssertFontsForSelections(
+          'Check no font family or font size is found for multi font selections',
           [
             selObj([ 1 ], 0, [ 2 ], 0)
           ], '', '')
-      ]))
+      ])
     ], onSuccess, onFailure);
   }, {
     base_url: '/project/tinymce/js/tinymce',

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FontInfoTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FontInfoTest.ts
@@ -3,10 +3,12 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { LegacyUnit } from '@ephox/mcagar';
 import { Hierarchy, SugarElement } from '@ephox/sugar';
 import * as FontInfo from 'tinymce/core/fmt/FontInfo';
-import Env from 'tinymce/core/api/Env';
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 
 UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, failure) {
   const suite = LegacyUnit.createSuite();
+
+  const dom = DOMUtils.DOM;
 
   const assertComputedFontProp = function (fontProp: string, html: string, path: number[], expected: string) {
     const div = document.createElement('div');
@@ -16,7 +18,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
     div.style[fontProp] = expected;
     div.innerHTML = html;
     const elm = Hierarchy.follow(SugarElement.fromDom(div), path).getOrDie('oh no! ' + path.toString() + '  path was bad');
-    const actual = fontGetProp(div, elm.dom as Element);
+    const actual = fontGetProp(dom, div, elm.dom as Element);
     LegacyUnit.equal(
       actual,
       expected,
@@ -32,7 +34,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
     document.body.appendChild(div);
     div.innerHTML = html;
     const elm = Hierarchy.follow(SugarElement.fromDom(div), path).getOrDie('oh no! ' + path.toString() + '  path was bad');
-    const actual = fontGetProp(div, elm.dom as Element);
+    const actual = fontGetProp(dom, div, elm.dom as Element);
     LegacyUnit.equal(
       actual,
       expected,
@@ -102,7 +104,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
     document.body.appendChild(iframe);
 
     iframe.addEventListener('load', function () {
-      const fontFamily = FontInfo.getFontFamily(iframe.contentDocument.body, iframe.contentDocument.body.firstChild as Element);
+      const fontFamily = FontInfo.getFontFamily(dom, iframe.contentDocument.body, iframe.contentDocument.body.firstChild as Element);
       LegacyUnit.equal(typeof fontFamily, 'string', 'Should always be a string');
       iframe.parentNode.removeChild(iframe);
 
@@ -126,7 +128,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
       iframe.parentNode.removeChild(iframe);
 
       try {
-        const fontFamily = FontInfo.getFontFamily(body, firstChildElement as Element);
+        const fontFamily = FontInfo.getFontFamily(dom, body, firstChildElement as Element);
         LegacyUnit.equal(typeof fontFamily, 'string', 'Should return a string');
         done();
       } catch (error) {
@@ -139,20 +141,18 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
     iframe.contentDocument.close();
   });
 
-  if (!Env.browser.isIE()) {
-    suite.test('comments should always return empty string', function () {
-      assertComputedFontProp('fontFamily', '<!-- comment -->', [ 0 ], '');
-      assertComputedFontProp('fontSize', '<!-- comment -->', [ 0 ], '');
-      assertSpecificFontProp('fontFamily', '<!-- comment -->', [ 0 ], '');
-      assertSpecificFontProp('fontSize', '<!-- comment -->', [ 0 ], '');
-    });
-  }
+  suite.test('comments should always return empty string', function () {
+    assertComputedFontProp('fontFamily', '<!-- comment -->', [ 0 ], '');
+    assertComputedFontProp('fontSize', '<!-- comment -->', [ 0 ], '');
+    assertSpecificFontProp('fontFamily', '<!-- comment -->', [ 0 ], '');
+    assertSpecificFontProp('fontSize', '<!-- comment -->', [ 0 ], '');
+  });
 
   suite.test('should not throw error when passed in element without parent', () => {
     const rootDiv = document.createElement('div');
     const element = document.createElement('p');
 
-    const actual = FontInfo.getFontSize(rootDiv, element);
+    const actual = FontInfo.getFontSize(dom, rootDiv, element);
 
     LegacyUnit.equal('string', typeof actual, 'should return always string');
   });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FontInfoTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FontInfoTest.ts
@@ -3,11 +3,12 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { LegacyUnit } from '@ephox/mcagar';
 import { Hierarchy, SugarElement } from '@ephox/sugar';
 import * as FontInfo from 'tinymce/core/fmt/FontInfo';
+import Env from 'tinymce/core/api/Env';
 
 UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, failure) {
   const suite = LegacyUnit.createSuite();
 
-  const assertComputedFontProp = function (fontProp, html, path, expected) {
+  const assertComputedFontProp = function (fontProp: string, html: string, path: number[], expected: string) {
     const div = document.createElement('div');
     const fontGetProp = fontProp === 'fontSize' ? FontInfo.getFontSize : FontInfo.getFontFamily;
 
@@ -15,7 +16,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
     div.style[fontProp] = expected;
     div.innerHTML = html;
     const elm = Hierarchy.follow(SugarElement.fromDom(div), path).getOrDie('oh no! ' + path.toString() + '  path was bad');
-    const actual = fontGetProp(div, elm.dom);
+    const actual = fontGetProp(div, elm.dom as Element);
     LegacyUnit.equal(
       actual,
       expected,
@@ -24,14 +25,14 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
     div.parentNode.removeChild(div);
   };
 
-  const assertSpecificFontProp = function (fontProp, html, path, expected) {
+  const assertSpecificFontProp = function (fontProp: string, html: string, path: number[], expected: string) {
     const div = document.createElement('div');
     const fontGetProp = fontProp === 'fontSize' ? FontInfo.getFontSize : FontInfo.getFontFamily;
 
     document.body.appendChild(div);
     div.innerHTML = html;
     const elm = Hierarchy.follow(SugarElement.fromDom(div), path).getOrDie('oh no! ' + path.toString() + '  path was bad');
-    const actual = fontGetProp(div, elm.dom);
+    const actual = fontGetProp(div, elm.dom as Element);
     LegacyUnit.equal(
       actual,
       expected,
@@ -101,7 +102,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
     document.body.appendChild(iframe);
 
     iframe.addEventListener('load', function () {
-      const fontFamily = FontInfo.getFontFamily(iframe.contentDocument.body, iframe.contentDocument.body.firstChild);
+      const fontFamily = FontInfo.getFontFamily(iframe.contentDocument.body, iframe.contentDocument.body.firstChild as Element);
       LegacyUnit.equal(typeof fontFamily, 'string', 'Should always be a string');
       iframe.parentNode.removeChild(iframe);
 
@@ -125,7 +126,7 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
       iframe.parentNode.removeChild(iframe);
 
       try {
-        const fontFamily = FontInfo.getFontFamily(body, firstChildElement);
+        const fontFamily = FontInfo.getFontFamily(body, firstChildElement as Element);
         LegacyUnit.equal(typeof fontFamily, 'string', 'Should return a string');
         done();
       } catch (error) {
@@ -138,12 +139,14 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', function (success, f
     iframe.contentDocument.close();
   });
 
-  suite.test('comments should always return empty string', function () {
-    assertComputedFontProp('fontFamily', '<!-- comment -->', [ 0 ], '');
-    assertComputedFontProp('fontSize', '<!-- comment -->', [ 0 ], '');
-    assertSpecificFontProp('fontFamily', '<!-- comment -->', [ 0 ], '');
-    assertSpecificFontProp('fontSize', '<!-- comment -->', [ 0 ], '');
-  });
+  if (!Env.browser.isIE()) {
+    suite.test('comments should always return empty string', function () {
+      assertComputedFontProp('fontFamily', '<!-- comment -->', [ 0 ], '');
+      assertComputedFontProp('fontSize', '<!-- comment -->', [ 0 ], '');
+      assertSpecificFontProp('fontFamily', '<!-- comment -->', [ 0 ], '');
+      assertSpecificFontProp('fontSize', '<!-- comment -->', [ 0 ], '');
+    });
+  }
 
   suite.test('should not throw error when passed in element without parent', () => {
     const rootDiv = document.createElement('div');


### PR DESCRIPTION
Description of Changes:
* Updated the font family and font size detection code to check if multiple font properties are present in a selection. If so, then the menus will be blank instead of just showing one of the present font properties.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [X] ~~License headers added on new files (if applicable)~~

Review:
* [X] Milestone set
* [ ] Review comments resolved
