### PR TITLE
TINY-3926: Fixed stylesheets not cleaned up when all editors are destroyed

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,7 +7,9 @@ Version 5.5.0 (TBD)
     Added the ability to delete and navigate HTML media elements without the media plugin #TINY-4211
     Added `fullscreen_native` setting to the fullscreen plugin to enable use of the entire monitor #TINY-6284
     Added the `origin` property to the `ObjectResized` and `ObjectResizeStart` events, to specify which handle the resize was preformed on #TINY-6242
+    Added new StyleSheetLoader `unload` and `unloadAll` APIs to allow loaded stylesheets to be removed #TINY-3926
     Changed the `target` property on fired events to use the native event target. The original target for an open shadow root can be obtained using `event.getComposedPath()` #TINY-6128
+    Changed the editor to cleanup loaded CSS stylesheets when all editors using the stylesheet have been removed #TINY-3926
     Changed `imagetools` context menu icon for accessing the `image` settings to use the same icon #TINY-4141
     Deprecated the `Env.experimentalShadowDom` flag #TINY-6128
     Fixed the `event.getComposedPath()` function on events fired from TinyMCE. This was throwing an exception, but now works as expected. #TINY-6128

--- a/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
@@ -1,5 +1,6 @@
 import { Assertions, Chain, Log, NamedChain, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { Editor as McEditor } from '@ephox/mcagar';
 import { Attribute, Remove, SugarElement, Truncate } from '@ephox/sugar';
 
@@ -12,10 +13,17 @@ UnitTest.asynctest('browser.tinymce.core.EditorCleanupTest', (success, failure) 
   Theme();
   VisualBlocksPlugin();
 
-  const cTestCleanup = (settings: RawEditorSettings, html: string = '<div></div>') => NamedChain.asChain([
-    // spin the editor up and down, getting a reference to its target element inbetween
+  const cAssertPageLinkPresence = (url: string, exists: boolean) => Chain.op(() => {
+    const links = document.head.querySelectorAll(`link[href="${url}"]`);
+    Assert.eq(`Should have link with url="${url}"`, exists, links.length > 0);
+  });
+
+  const cTestCleanup = (settings: RawEditorSettings, html: string = '<div></div>', additionalChains: Array<Chain<any, any>> = []) => NamedChain.asChain([
+    // spin the editor up and down, getting a reference to its target element in between
     NamedChain.write('editor', McEditor.cFromHtml(html, { base_url: '/project/tinymce/js/tinymce', ...settings })),
     NamedChain.direct('editor', Chain.mapper((editor: Editor) => SugarElement.fromDom(editor.getElement())), 'element'),
+    // Run any additional chains
+    ...Arr.map(additionalChains, (chain) => NamedChain.read('editor', chain)),
     NamedChain.read('editor', Chain.op((editor: Editor) => editor.remove())),
     // first, remove the id of the element, as that's inserted from McEditor.cFromHtml and is out of our control
     NamedChain.read('element', Chain.op((element: SugarElement<HTMLDivElement>) => Attribute.remove(element, 'id'))),
@@ -49,6 +57,17 @@ UnitTest.asynctest('browser.tinymce.core.EditorCleanupTest', (success, failure) 
 
     Log.chainsAsStep('TINY-4001', 'Visual blocks plugin should not leave classes on target', [
       cTestCleanup({ plugins: 'visualblocks' })
+    ]),
+
+    Log.chainsAsStep('TINY-3926', 'Styles loaded via StyleSheetLoader or editor.dom.loadCss() are cleaned up', [
+      cTestCleanup({ inline: true }, '<div></div>', [
+        Chain.op<Editor>((editor) => editor.dom.loadCSS('/project/tinymce/js/tinymce/skins/ui/dark/skin.css'))
+      ]),
+      // Loaded via StyleSheetLoader
+      cAssertPageLinkPresence('/project/tinymce/js/tinymce/skins/ui/content/default/content.inline.css', false),
+      cAssertPageLinkPresence('/project/tinymce/js/tinymce/skins/ui/oxide/skin.css', false),
+      // Loaded via DOMUtils as per above
+      cAssertPageLinkPresence('/project/tinymce/js/tinymce/skins/ui/dark/skin.css', false)
     ])
   ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/StyleSheetLoaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/StyleSheetLoaderTest.ts
@@ -1,0 +1,68 @@
+import { Log, Pipeline, Step, UiFinder } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Attribute, SelectorFilter, SugarHead } from '@ephox/sugar';
+import { StyleSheetLoader } from 'tinymce/core/api/dom/StyleSheetLoader';
+
+UnitTest.asynctest('browser.tinymce.core.dom.StyleSheetLoaderTest', (success, failure) => {
+  const contentCss = '/project/tinymce/js/tinymce/skins/content/default/content.css';
+  const skinCss = '/project/tinymce/js/tinymce/skins/ui/oxide/skin.css';
+  const loader = StyleSheetLoader(document, {
+    maxLoadTime: 500,
+    contentCssCors: true,
+    referrerPolicy: 'origin'
+  });
+
+  const sLinkExists = (url: string) => Step.sync(() => {
+    const head = SugarHead.head();
+    const links = SelectorFilter.descendants(head, `link[href="${url}"]`);
+    Assert.eq('Should have one link loaded', true, links.length === 1);
+    Assert.eq('Should have referrer policy attribute', 'origin', Attribute.get(links[0], 'referrerPolicy'));
+    Assert.eq('Should have crossorigin attribute', 'anonymous', Attribute.get(links[0], 'crossorigin'));
+  });
+  const sLinkNotExists = (url: string) => UiFinder.sNotExists(SugarHead.head(), `link[href="${url}"]`);
+
+  const sLoadUrl = (url: string) => Step.async((next, die) => {
+    loader.load(url, next, () => die('Failed to load url: ' + url));
+  });
+
+  const sLoadAllUrls = (urls: string[]) => Step.async((next, die) => {
+    loader.loadAll(urls, next, (failedUrls) => die('Failed to load urls: ' + failedUrls.join(', ')));
+  });
+
+  const sUnloadUrl = (url: string) => Step.sync(() => {
+    loader.unload(url);
+  });
+
+  const sUnloadAllUrls = (urls: string[]) => Step.sync(() => {
+    loader.unloadAll(urls);
+  });
+
+  Pipeline.async({}, [
+    Log.stepsAsStep('TINY-3926', 'Load and then unload removes the loaded stylesheet', [
+      sLoadUrl(contentCss),
+      sLinkExists(contentCss),
+      sUnloadUrl(contentCss),
+      sLinkNotExists(contentCss)
+    ]),
+    Log.stepsAsStep('TINY-3926', 'Load and then unload all urls should leave no stylesheets', [
+      sLoadAllUrls([ contentCss, skinCss ]),
+      sLinkExists(contentCss),
+      sLinkExists(skinCss),
+      sUnloadAllUrls([ skinCss, contentCss ]),
+      sLinkNotExists(contentCss),
+      sLinkNotExists(skinCss)
+    ]),
+    Log.stepsAsStep('TINY-3926', 'Unload removes loaded stylesheets, but only on last reference', [
+      // Load 2 links and ensure only one link is loaded
+      sLoadUrl(contentCss),
+      sLoadUrl(contentCss),
+      sLinkExists(contentCss),
+      // Unload once shouldn't remove the link
+      sUnloadUrl(contentCss),
+      sLinkExists(contentCss),
+      // Unload a second time should remove since the stylesheet was loaded twice
+      sUnloadUrl(contentCss),
+      sLinkNotExists(contentCss)
+    ])
+  ], success, failure);
+});

--- a/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
@@ -37,8 +37,10 @@ const renderMobileTheme = (editor: Editor) => {
     const cssUrls = CssUrls.derive(editor);
 
     if (Settings.isSkinDisabled(editor) === false) {
+      const styleSheetLoader = DOMUtils.DOM.styleSheetLoader;
       editor.contentCSS.push(cssUrls.content);
-      DOMUtils.DOM.styleSheetLoader.load(cssUrls.ui, SkinLoaded.fireSkinLoaded(editor));
+      styleSheetLoader.load(cssUrls.ui, SkinLoaded.fireSkinLoaded(editor));
+      editor.on('remove', () => styleSheetLoader.unload(cssUrls.ui));
     } else {
       SkinLoaded.fireSkinLoaded(editor)();
     }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
@@ -22,7 +22,9 @@ const loadSkin = (isInline: boolean, editor: Editor) => {
   // In Modern Inline, this is explicitly called in editor.on('focus', ...) as well as in render().
   // Seems to work without, but adding a note in case things break later
   if (isSkinDisabled(editor) === false && skinUiCss) {
-    editor.ui.styleSheetLoader.load(skinUiCss, SkinLoaded.fireSkinLoaded(editor), SkinLoaded.fireSkinLoadError(editor, 'Skin could not be loaded'));
+    const styleSheetLoader = editor.ui.styleSheetLoader;
+    styleSheetLoader.load(skinUiCss, SkinLoaded.fireSkinLoaded(editor), SkinLoaded.fireSkinLoadError(editor, 'Skin could not be loaded'));
+    editor.on('remove', () => styleSheetLoader.unload(skinUiCss));
   } else {
     SkinLoaded.fireSkinLoaded(editor)();
   }


### PR DESCRIPTION
Related Ticket: TINY-3926

Description of Changes:
* Cleans up stylesheets loaded via `StyleSheetLoader` or `editor.dom.loadCss()` when all editors using the related stylesheets have been removed. This uses a counter to determine how many times the stylesheet has been loaded and then decrements the counter on unload calls. If the loader believes nothing is using it, then it'll remove the stylesheet from the DOM.
* This also cleans up the `loadCss` API to use the `StyleSheetLoader` to remove duplicate code. It should functionally be identical.

Note: Added Tyler as there's new APIs here, so need to check the API jsdoc strings.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
