### PR TITLE
TINY-6242: Fixed an issue when resizing used fixed table sizing mode

### DIFF
--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -274,13 +274,17 @@ const cGetWidth = Chain.control(
   Guard.addLogging('Get table width')
 );
 
+const getCellWidth = (editor: Editor, table: SugarElement<HTMLTableElement>, rowNumber: number, columnNumber: number) => {
+  const row = SelectorFilter.descendants<HTMLTableRowElement>(table, 'tr')[rowNumber];
+  const cell = SelectorFilter.descendants<HTMLTableCellElement>(row, 'th,td')[columnNumber];
+  return getWidths(editor, cell.dom);
+};
+
 const cGetCellWidth = (rowNumber: number, columnNumber: number) => Chain.control(
   Chain.mapper((input: any) => {
     const editor = input.editor;
     const elm = input.element;
-    const row = SelectorFilter.descendants<HTMLTableRowElement>(elm, 'tr')[rowNumber];
-    const cell = SelectorFilter.descendants<HTMLTableCellElement>(row, 'th,td')[columnNumber];
-    return getWidths(editor, cell.dom);
+    return getCellWidth(editor, elm, rowNumber, columnNumber);
   }),
   Guard.addLogging('Get cell width')
 );
@@ -416,6 +420,7 @@ const sAssertTableStructureWithSizes = (editor: Editor, cols: number, rows: numb
 ]);
 
 export {
+  getCellWidth,
   sAssertDialogPresence,
   sAssertSelectValue,
   sChooseTab,


### PR DESCRIPTION
Related Ticket: TINY-6242

Description of Changes:
* Fixed an issue I originally missed that got picked up during QA. The issue was that we were syncing the cell sizes before doing the column resize, which meant the column resize calculations were incorrect.

Pre-checks:
* [x] ~Changelog entry added~ (Fix for an unreleased change that already has a changelog)
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
