### PR TITLE
TINY-4058: Fix cursors being placed next to pre elements

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -21,6 +21,8 @@ Version 5.5.0 (TBD)
     Fixed the `DOMUtils.split()` API incorrectly removing some content #TINY-6294
     Fixed pressing escape not focusing the editor when using multiple toolbars #TINY-6230
     Fixed the `dirty` flag not being correctly set during an `AddUndo` event #TINY-4707
+    Fixed `editor.selection.setCursorLocation` moving the cursor immediately outside pre elements in some circumstances #TINY-4058
+    Fixed the `br_in_pre` setting (when false) throwing an exception when pressing enter inside pre elements #TINY-4058
 Version 5.4.2 (2020-08-17)
     Fixed the editor not resizing when resizing the browser window in fullscreen mode #TINY-3511
     Fixed clicking on notifications causing inline editors to hide #TINY-6058

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -21,8 +21,8 @@ Version 5.5.0 (TBD)
     Fixed the `DOMUtils.split()` API incorrectly removing some content #TINY-6294
     Fixed pressing escape not focusing the editor when using multiple toolbars #TINY-6230
     Fixed the `dirty` flag not being correctly set during an `AddUndo` event #TINY-4707
-    Fixed `editor.selection.setCursorLocation` moving the cursor immediately outside pre elements in some circumstances #TINY-4058
-    Fixed the `br_in_pre` setting (when false) throwing an exception when pressing enter inside pre elements #TINY-4058
+    Fixed `editor.selection.setCursorLocation` incorrectly placing the cursor outside `pre` elements in some circumstances #TINY-4058
+    Fixed an exception being thrown when pressing enter inside pre elements while `br_in_pre` setting is false #TINY-4058
 Version 5.4.2 (2020-08-17)
     Fixed the editor not resizing when resizing the browser window in fullscreen mode #TINY-3511
     Fixed clicking on notifications causing inline editors to hide #TINY-6058

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -478,7 +478,8 @@ function Schema(settings?: SchemaSettings): Schema {
     'noshade nowrap readonly selected autoplay loop controls');
   const nonEmptyElementsMap = createLookupTable('non_empty_elements', 'td th iframe video audio object ' +
     'script pre code', shortEndedElementsMap);
-  const moveCaretBeforeOnEnterElementsMap = createLookupTable('move_caret_before_on_enter_elements', 'table', nonEmptyElementsMap);
+  const moveCaretBeforeOnEnterElementsMap = createLookupTable('move_caret_before_on_enter_elements', 'td th igrame video audio object ' +
+    'script code table', shortEndedElementsMap);
   const textBlockElementsMap = createLookupTable('text_block_elements', 'h1 h2 h3 h4 h5 h6 p div address pre form ' +
     'blockquote center dir fieldset header footer article section hgroup aside main nav figure');
   const blockElementsMap = createLookupTable('block_elements', 'hr table tbody thead tfoot ' +

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -476,13 +476,11 @@ function Schema(settings?: SchemaSettings): Schema {
     'meta param embed source wbr track');
   const boolAttrMap = createLookupTable('boolean_attributes', 'checked compact declare defer disabled ismap multiple nohref noresize ' +
     'noshade nowrap readonly selected autoplay loop controls');
-  const [ nonEmptyElementsMap, moveCaretBeforeOnEnterElementsMap ] = (() => {
-    const base = 'td th iframe video audio object script code';
-    return [
-      createLookupTable('non_empty_elements', base + ' pre', shortEndedElementsMap),
-      createLookupTable('move_caret_before_on_enter_elements', base + ' table', shortEndedElementsMap)
-    ];
-  })();
+
+  const nonEmptyOrMoveCaretBeforeOnEnter = 'td th iframe video audio object script code';
+  const nonEmptyElementsMap = createLookupTable('non_empty_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' pre', shortEndedElementsMap);
+  const moveCaretBeforeOnEnterElementsMap = createLookupTable('move_caret_before_on_enter_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' table', shortEndedElementsMap);
+
   const textBlockElementsMap = createLookupTable('text_block_elements', 'h1 h2 h3 h4 h5 h6 p div address pre form ' +
     'blockquote center dir fieldset header footer article section hgroup aside main nav figure');
   const blockElementsMap = createLookupTable('block_elements', 'hr table tbody thead tfoot ' +
@@ -503,7 +501,7 @@ function Schema(settings?: SchemaSettings): Schema {
   const addValidElements = (validElements: string) => {
     let ei, el, ai, al, matches, element, attr, attrData, elementName, attrName, attrType, attributes, attributesOrder,
       prefix, outputName, globalAttributes, globalAttributesOrder, value;
-    const elementRuleRegExp = /^([#+\-])?([^\[!\/]+)(?:\/([^\[!]+))?(?:(!?)\[([^\]]+)\])?$/,
+    const elementRuleRegExp = /^([#+\-])?([^\[!\/]+)(?:\/([^\[!]+))?(?:(!?)\[([^\]]+)])?$/,
       attrRuleRegExp = /^([!\-])?(\w+[\\:]:\w+|[^=:<]+)?(?:([=:<])(.*))?$/,
       hasPatternsRegExp = /[*?+]/;
 
@@ -708,7 +706,7 @@ function Schema(settings?: SchemaSettings): Schema {
   // Adds valid children to the schema object
   const addValidChildren = function (validChildren) {
     // see: https://html.spec.whatwg.org/#valid-custom-element-name
-    const childRuleRegExp = /^([+\-]?)([A-Za-z0-9_\-\.\u00b7\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u037d\u037f-\u1fff\u200c-\u200d\u203f-\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]+)\[([^\]]+)\]$/; // from w3c's custom grammar (above)
+    const childRuleRegExp = /^([+\-]?)([A-Za-z0-9_\-.\u00b7\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u037d\u037f-\u1fff\u200c-\u200d\u203f-\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]+)\[([^\]]+)]$/; // from w3c's custom grammar (above)
 
     // Invalidate the schema cache if the schema is mutated
     mapCache[settings.schema] = null;

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -476,10 +476,13 @@ function Schema(settings?: SchemaSettings): Schema {
     'meta param embed source wbr track');
   const boolAttrMap = createLookupTable('boolean_attributes', 'checked compact declare defer disabled ismap multiple nohref noresize ' +
     'noshade nowrap readonly selected autoplay loop controls');
-  const nonEmptyElementsMap = createLookupTable('non_empty_elements', 'td th iframe video audio object ' +
-    'script pre code', shortEndedElementsMap);
-  const moveCaretBeforeOnEnterElementsMap = createLookupTable('move_caret_before_on_enter_elements', 'td th igrame video audio object ' +
-    'script code table', shortEndedElementsMap);
+  const [ nonEmptyElementsMap, moveCaretBeforeOnEnterElementsMap ] = (() => {
+    const base = 'td th iframe video audio object script code';
+    return [
+      createLookupTable('non_empty_elements', base + ' pre', shortEndedElementsMap),
+      createLookupTable('move_caret_before_on_enter_elements', base + ' table', shortEndedElementsMap)
+    ];
+  })();
   const textBlockElementsMap = createLookupTable('text_block_elements', 'h1 h2 h3 h4 h5 h6 p div address pre form ' +
     'blockquote center dir fieldset header footer article section hgroup aside main nav figure');
   const blockElementsMap = createLookupTable('block_elements', 'hr table tbody thead tfoot ' +

--- a/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Optionals } from '@ephox/katamari';
 import { Compare, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import EditorSelection from '../api/dom/Selection';
@@ -67,13 +67,14 @@ const hasAllContentsSelected = function (elm, rng) {
   }).getOr(false);
 };
 
-const moveEndPoint = (dom: DOMUtils, rng: Range, node, start: boolean): void => {
+const moveEndPoint = (dom: DOMUtils, rng: Range, node: Node, start: boolean): void => {
   const root = node, walker = new DomTreeWalker(node, root);
-  const nonEmptyElementsMap = dom.schema.getNonEmptyElements();
+  const moveCaretBeforeOnEnterElementsMap = Obj.filter(dom.schema.getMoveCaretBeforeOnEnterElements(), (_, name) =>
+    !Arr.contains([ 'td', 'th', 'table' ], name.toLowerCase())
+  );
 
   do {
-    // Text node
-    if (node.nodeType === 3 && Tools.trim(node.nodeValue).length !== 0) {
+    if (NodeType.isText(node) && Tools.trim(node.nodeValue).length !== 0) {
       if (start) {
         rng.setStart(node, 0);
       } else {
@@ -84,7 +85,7 @@ const moveEndPoint = (dom: DOMUtils, rng: Range, node, start: boolean): void => 
     }
 
     // BR/IMG/INPUT elements but not table cells
-    if (nonEmptyElementsMap[node.nodeName] && !/^(TD|TH)$/.test(node.nodeName)) {
+    if (moveCaretBeforeOnEnterElementsMap[node.nodeName]) {
       if (start) {
         rng.setStartBefore(node);
       } else {

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectBeforeBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectBeforeBlockTest.ts
@@ -1,0 +1,37 @@
+import { Chain, Log, Pipeline } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { ApiChains, Editor as McEditor } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import * as InsertNewline from 'tinymce/core/newline/InsertNewLine';
+import Theme from 'tinymce/themes/silver/Theme';
+
+// With a few exceptions, it is considered invalid for the cursor to be immediately before a block level element. These tests address
+// known cases where it was possible to position the cursor in one of those locations.
+UnitTest.asynctest('browser.tinymce.core.selection.SelectBeforeBlock', (success, failure) => {
+  Theme();
+
+  const settings = {
+    base_url: '/project/tinymce/js/tinymce'
+  };
+
+  Pipeline.async({}, [
+    Log.chainsAsStep('TINY-4058', 'Ensure that pressing enter while inside PRE does not move cursor to invalid position', [
+      McEditor.cFromSettings({ ...settings, br_in_pre: false }),
+      ApiChains.cSetContent('<pre>Hello world</pre>'),
+      ApiChains.cSetCursor([ 0, 0 ], 0),
+      Chain.op<Editor>((editor) => InsertNewline.insert(editor, { } as EditorEvent<KeyboardEvent>)),
+      ApiChains.cAssertSelection([ 1, 0 ], 0, [ 1, 0 ], 0),
+      McEditor.cRemove
+    ]),
+
+    Log.chainsAsStep('TINY-4058', 'Ensure that calling setcontent does not move cursor to invalid position', [
+      McEditor.cFromSettings(settings),
+      ApiChains.cFocus,
+      ApiChains.cSetContent('<pre>Hello world</pre>'),
+      Chain.op<Editor>((editor) => editor.selection.setCursorLocation()),
+      ApiChains.cAssertSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
+      McEditor.cRemove
+    ])
+  ], success, failure);
+});


### PR DESCRIPTION
Related Ticket: TINY-4058

Description of Changes:
There were bugs (exceptions being thrown and some content loss) being caused by pressing enter while the cursor was immediately before a `pre` element. I found two ways that the cursor ended up at this invalid location, and prevented them from occurring.
* Pressing enter with the cursor (`|`) like this: `<pre>|Hello</pre>` while `br_in_pre` is set to false in the editor settings
* Calling `editor.selection.setCursorLocation()`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* ~[ ] Branch prefixed with `feature/` for new features (if applicable)~
* ~[ ] License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

Other issues:
* [x] This is currently leading to a different failing test. I'm looking for feedback on how to approach that scenario.

GitHub issues (if applicable): N/A