### PR TITLE
TINY-6354: Fixed notifications not appearing when the editor is within a ShadowRoot

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -13,6 +13,7 @@ Version 5.5.0 (TBD)
     Changed `imagetools` context menu icon for accessing the `image` settings to use the same icon #TINY-4141
     Deprecated the `Env.experimentalShadowDom` flag #TINY-6128
     Fixed the `event.getComposedPath()` function on events fired from TinyMCE. This was throwing an exception, but now works as expected. #TINY-6128
+    Fixed notifications not appearing when the editor is within a ShadowRoot #TINY-6354
     Fixed the `template` plugin previews missing some content styles #TINY-6115
     Fixed the `media` plugin not saving the alternative source url in some situations #TINY-4113
     Fixed an issue where column resizing using the resize bars was inconsistent between fixed and relative table widths #TINY-6001

--- a/modules/tinymce/src/core/test/ts/browser/EditorViewIframeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorViewIframeTest.ts
@@ -1,7 +1,8 @@
-import { Assertions, Chain, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { Assertions, Chain, Log, Pipeline, Step } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Css, Scroll, SelectorFind, SugarElement } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
 import * as EditorView from 'tinymce/core/EditorView';
 import Theme from 'tinymce/themes/silver/Theme';
 
@@ -64,7 +65,12 @@ UnitTest.asynctest('browser.tinymce.core.EditorViewIframeTest', function (succes
     ]));
   };
 
-  TinyLoader.setup(function (editor, onSuccess, onFailure) {
+  const sAssertIsAttachedToDom = (editor: Editor) => Step.sync(() => {
+    const attached = EditorView.isEditorAttachedToDom(editor);
+    Assert.eq('Editor should be attached to the DOM', true, attached);
+  });
+
+  TinyLoader.setupInBodyAndShadowRoot(function (editor, onSuccess, onFailure) {
     const tinyApis = TinyApis(editor);
 
     const sSetContentToBigDiv = Step.label(
@@ -73,17 +79,19 @@ UnitTest.asynctest('browser.tinymce.core.EditorViewIframeTest', function (succes
     );
 
     Pipeline.async({}, isPhantomJs() ? [] : [
-      Logger.t('isXYInContentArea without borders, margin', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'isXYInContentArea without borders, margin', [
         sSetBodyStyles(editor, { border: '0', margin: '0' }),
         sSetContentToBigDiv,
         sTestIsXYInContentArea(editor, 0, 0)
-      ])),
+      ]),
 
-      Logger.t('isXYInContentArea with borders, margin', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'isXYInContentArea with borders, margin', [
         sSetBodyStyles(editor, { border: '5px', margin: '15px' }),
         sSetContentToBigDiv,
         sTestIsXYInContentArea(editor, 0, 0)
-      ]))
+      ]),
+
+      Log.step('TINY-6354', 'isEditorAttachedToDom should return true', sAssertIsAttachedToDom(editor))
     ], onSuccess, onFailure);
   }, {
     base_url: '/project/tinymce/js/tinymce'

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -130,7 +130,7 @@ UnitTest.asynctest('browser.tinymce.core.NotificationManagerTest', function (suc
     teardown(editor);
   });
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  TinyLoader.setupInBodyAndShadowRoot(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, Log.steps('TBA', 'Testing the notifications api', suite.toSteps(editor)), onSuccess, onFailure);
   }, {
     add_unload_trigger: false,


### PR DESCRIPTION
Related Ticket: TINY-6354

Description of Changes:
* Fixes an issue reported by @tiny-james whereby notifications weren't working when the editor was within a ShadowRoot.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
