### PR TITLE
Fixed the `InlineToolbarDrawerFloatingPositionTest.ts` intermittently failing

### DIFF
--- a/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
@@ -1,4 +1,4 @@
-import { Assertions, Chain, GeneralSteps, Step } from '@ephox/agar';
+import { Assertions, Chain, GeneralSteps, Guard, Step } from '@ephox/agar';
 import { TinyUi } from '@ephox/mcagar';
 import { Height, SugarBody, SugarLocation, Width } from '@ephox/sugar';
 
@@ -7,15 +7,18 @@ import { sCloseMore, sOpenMore } from './MenuUtils';
 
 const sAssertFloatingToolbarPosition = (tinyUi: TinyUi, getTop: () => number, expectedLeft: number, expectedRight: number) => Chain.asStep(SugarBody.body(), [
   tinyUi.cWaitForUi('Wait for drawer to be visible', '.tox-toolbar__overflow'),
-  Chain.op((toolbar) => {
-    const top = getTop();
-    const diff = 10;
-    const pos = SugarLocation.absolute(toolbar);
-    const right = pos.left + Width.get(toolbar);
-    Assertions.assertEq(`Drawer top position ${pos.top}px should be ~${top}px`, true, Math.abs(pos.top - top) < diff);
-    Assertions.assertEq(`Drawer left position ${pos.left}px should be ~${expectedLeft}px`, true, Math.abs(pos.left - expectedLeft) < diff);
-    Assertions.assertEq(`Drawer right position ${right}px should be ~${expectedRight}px`, true, Math.abs(right - expectedRight) < diff);
-  })
+  Chain.control(
+    Chain.op((toolbar) => {
+      const top = getTop();
+      const diff = 10;
+      const pos = SugarLocation.absolute(toolbar);
+      const right = pos.left + Width.get(toolbar);
+      Assertions.assertEq(`Drawer top position ${pos.top}px should be ~${top}px`, true, Math.abs(pos.top - top) < diff);
+      Assertions.assertEq(`Drawer left position ${pos.left}px should be ~${expectedLeft}px`, true, Math.abs(pos.left - expectedLeft) < diff);
+      Assertions.assertEq(`Drawer right position ${right}px should be ~${expectedRight}px`, true, Math.abs(right - expectedRight) < diff);
+    }),
+    Guard.tryUntil('Wait for toolbar position')
+  )
 ]);
 
 const sAssertFloatingToolbarHeight = (tinyUi: TinyUi, expectedHeight: number) => Chain.asStep(SugarBody.body(), [


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* This fixes the `InlineToolbarDrawerFloatingPositionTest` intermittently failing, as sometimes it'd failed as the NodeChange/ResizeContent event wasn't firing until after the assertion. I could have added a wait for that, but it seemed this would be more foolproof.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
