### PR TITLE
TINY-6268: Fixed `TrimNode` removing text nodes in some cases it shouldn't

### DIFF
--- a/modules/tinymce/src/core/main/ts/dom/Empty.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Empty.ts
@@ -12,22 +12,22 @@ import * as CaretCandidate from '../caret/CaretCandidate';
 import { isWhitespaceText } from '../text/Whitespace';
 import * as NodeType from './NodeType';
 
-const hasWhitespacePreserveParent = function (rootNode: Node, node: Node) {
+const hasWhitespacePreserveParent = function (node: Node, rootNode: Node) {
   const rootElement = SugarElement.fromDom(rootNode);
   const startNode = SugarElement.fromDom(node);
   return SelectorExists.ancestor(startNode, 'pre,code', Fun.curry(Compare.eq, rootElement));
 };
 
-const isWhitespace = function (rootNode: Node, node: Node) {
-  return NodeType.isText(node) && isWhitespaceText(node.data) && hasWhitespacePreserveParent(rootNode, node) === false;
+const isWhitespace = function (node: Node, rootNode: Node) {
+  return NodeType.isText(node) && isWhitespaceText(node.data) && hasWhitespacePreserveParent(node, rootNode) === false;
 };
 
 const isNamedAnchor = function (node: Node) {
   return NodeType.isElement(node) && node.nodeName === 'A' && !node.hasAttribute('href') && (node.hasAttribute('name') || node.hasAttribute('id'));
 };
 
-const isContent = function (rootNode: Node, node: Node) {
-  return (CaretCandidate.isCaretCandidate(node) && isWhitespace(rootNode, node) === false) || isNamedAnchor(node) || isBookmark(node);
+const isContent = function (node: Node, rootNode: Node) {
+  return (CaretCandidate.isCaretCandidate(node) && isWhitespace(node, rootNode) === false) || isNamedAnchor(node) || isBookmark(node);
 };
 
 const isBookmark = NodeType.hasAttribute('data-mce-bookmark');
@@ -65,7 +65,7 @@ const isEmptyNode = function (targetNode: Node, skipBogus: boolean) {
         continue;
       }
 
-      if (isContent(targetNode, node)) {
+      if (isContent(node, targetNode)) {
         return false;
       }
 

--- a/modules/tinymce/src/core/main/ts/dom/Empty.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Empty.ts
@@ -79,5 +79,6 @@ const isEmptyNode = function (targetNode: Node, skipBogus: boolean) {
 const isEmpty = (elm: SugarElement<Node>, skipBogus: boolean = true) => isEmptyNode(elm.dom, skipBogus);
 
 export {
-  isEmpty
+  isEmpty,
+  isContent
 };

--- a/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
+++ b/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
@@ -5,26 +5,26 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr } from '@ephox/katamari';
+import { Type } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
-import { isWhitespaceText } from '../text/Whitespace';
+import DomTreeWalker from '../api/dom/TreeWalker';
 import * as ElementType from './ElementType';
+import { isContent } from './Empty';
 import * as NodeType from './NodeType';
-import * as Empty from './Empty';
 
 const isSpan = (node: Node): node is HTMLSpanElement =>
   node.nodeName.toLowerCase() === 'span';
 
-const isNonEmptyText = (node: Node) =>
-  NodeType.isText(node) && !isWhitespaceText(node.data);
+const isInlineContent = (node: Node | null, root: Node) =>
+  node && (isContent(root, node) || ElementType.isInline(SugarElement.fromDom(node)));
 
-const isInlineContent = (node: Node | null) =>
-  node && (isNonEmptyText(node) || ElementType.isInline(SugarElement.fromDom(node)));
-
-const surroundedByInlineContent = (node: Node) => {
-  const prevIsInline = isInlineContent(node.previousSibling);
-  const nextIsInline = isInlineContent(node.nextSibling);
+const surroundedByInlineContent = (node: Node, root: Node) => {
+  const prev = new DomTreeWalker(node, root).prev(false);
+  const next = new DomTreeWalker(node, root).next(false);
+  // Check if the next/previous is either inline content or the start/end (eg is undefined)
+  const prevIsInline = isInlineContent(prev, root) || Type.isUndefined(prev);
+  const nextIsInline = isInlineContent(next, root) || Type.isUndefined(next);
   return prevIsInline && nextIsInline;
 };
 
@@ -33,8 +33,12 @@ const isBookmarkNode = (node: Node) =>
 
 // Keep text nodes with only spaces if surrounded by spans.
 // eg. "<p><span>a</span> <span>b</span></p>" should keep space between a and b
-const isKeepTextNode = (node: Node) =>
-  isNonEmptyText(node) || (NodeType.isText(node) && surroundedByInlineContent(node));
+const isKeepTextNode = (node: Node, root: Node) =>
+  NodeType.isText(node) && node.data.length > 0 && surroundedByInlineContent(node, root);
+
+// Keep elements as long as they have any children
+const isKeepElement = (node: Node) =>
+  NodeType.isElement(node) ? node.childNodes.length > 0 : false;
 
 const isDocument = (node: Node) => NodeType.isDocumentFragment(node) || NodeType.isDocument(node);
 
@@ -46,33 +50,28 @@ const isDocument = (node: Node) => NodeType.isDocumentFragment(node) || NodeType
 //   <p>text 1<span></span></p><b>CHOP</b><p><span></span>text 2</p>
 // this function will then trim off empty edges and produce:
 //   <p>text 1</p><b>CHOP</b><p>text 2</p>
-const trimNode = <T extends Node>(dom: DOMUtils, node: T): T => {
+const trimNode = <T extends Node>(dom: DOMUtils, node: T, root?: Node): T => {
+  const rootNode = root || node;
   if (NodeType.isElement(node) && isBookmarkNode(node)) {
     return node;
   }
 
   const children = node.childNodes;
   for (let i = children.length - 1; i >= 0; i--) {
-    trimNode(dom, children[i]);
+    trimNode(dom, children[i], rootNode);
   }
 
-  if (!isDocument(node) && !isKeepTextNode(node) && Empty.isEmpty(SugarElement.fromDom(node), false)) {
-    if (NodeType.isElement(node)) {
-      const currentChildren = node.childNodes;
-
-      // Don't remove if there's a br as a child, eg: <p><br></p>
-      if (Arr.exists(currentChildren, NodeType.isBr)) {
-        return node;
-      }
-
-      // If the only child is a bookmark then move it up
-      if (currentChildren.length === 1 && isBookmarkNode(currentChildren[0])) {
-        node.parentNode.insertBefore(currentChildren[0], node);
-      }
+  // If the only child is a bookmark then move it up
+  if (NodeType.isElement(node)) {
+    const currentChildren = node.childNodes;
+    if (currentChildren.length === 1 && isBookmarkNode(currentChildren[0])) {
+      node.parentNode.insertBefore(currentChildren[0], node);
     }
+  }
 
+  // Remove any empty nodes
+  if (!isDocument(node) && !isContent(rootNode, node) && !isKeepElement(node) && !isKeepTextNode(node, rootNode)) {
     dom.remove(node);
-    return node;
   }
 
   return node;

--- a/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
+++ b/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
@@ -16,15 +16,15 @@ import * as NodeType from './NodeType';
 const isSpan = (node: Node): node is HTMLSpanElement =>
   node.nodeName.toLowerCase() === 'span';
 
-const isInlineContent = (node: Node | null, root: Node) =>
-  node && (isContent(root, node) || ElementType.isInline(SugarElement.fromDom(node)));
+const isInlineContent = (node: Node | null, root: Node): boolean =>
+  Type.isNonNullable(node) && (isContent(node, root) || ElementType.isInline(SugarElement.fromDom(node)));
 
 const surroundedByInlineContent = (node: Node, root: Node) => {
   const prev = new DomTreeWalker(node, root).prev(false);
   const next = new DomTreeWalker(node, root).next(false);
   // Check if the next/previous is either inline content or the start/end (eg is undefined)
-  const prevIsInline = isInlineContent(prev, root) || Type.isUndefined(prev);
-  const nextIsInline = isInlineContent(next, root) || Type.isUndefined(next);
+  const prevIsInline = Type.isUndefined(prev) || isInlineContent(prev, root);
+  const nextIsInline = Type.isUndefined(next) || isInlineContent(next, root);
   return prevIsInline && nextIsInline;
 };
 
@@ -70,7 +70,7 @@ const trimNode = <T extends Node>(dom: DOMUtils, node: T, root?: Node): T => {
   }
 
   // Remove any empty nodes
-  if (!isDocument(node) && !isContent(rootNode, node) && !isKeepElement(node) && !isKeepTextNode(node, rootNode)) {
+  if (!isDocument(node) && !isContent(node, rootNode) && !isKeepElement(node) && !isKeepTextNode(node, rootNode)) {
     dom.remove(node);
   }
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -597,6 +597,18 @@ UnitTest.test('DOMUtils.split', () => {
   DOM.split(parent, point);
   Assert.eq('', '<p><b><a id="anchor"></a></b></p><span>inner</span><p><b>text2</b></p>', HtmlUtils.cleanHtml(DOM.get('test').innerHTML));
 
+  DOM.setHTML('test', '<p>text<span style="text-decoration: underline;"> <span>t</span></span>ext</p>');
+  parent = DOM.select('span', DOM.get('test'))[0];
+  point = DOM.select('span', DOM.get('test'))[1];
+  DOM.split(parent, point);
+  Assert.eq('TINY-6268: Do not remove spaces at start of split', '<p>text<span style="text-decoration: underline;"> </span><span>t</span>ext</p>', DOM.get('test').innerHTML);
+
+  DOM.setHTML('test', '<p>tex<span style="text-decoration: underline;"><span>t</span> </span>text</p>');
+  parent = DOM.select('span', DOM.get('test'))[0];
+  point = DOM.select('span', DOM.get('test'))[1];
+  DOM.split(parent, point);
+  Assert.eq('TINY-6268: Do not remove spaces at end of split', '<p>tex<span>t</span><span style="text-decoration: underline;"> </span>text</p>', DOM.get('test').innerHTML);
+
   DOM.remove('test');
 });
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
@@ -30,10 +30,11 @@ UnitTest.asynctest('browser.tinymce.core.dom.TrimNodeTest', function (success, f
     const elm = document.createElement('div');
     elm.innerHTML = '<strong>abc</strong>abc';
     elm.insertBefore(emptyTextNode, elm.lastChild);
+    elm.insertBefore(emptyTextNode.cloneNode(), elm.firstChild);
 
     const actual = TrimNode.trimNode(dom, elm);
 
-    Assert.eq('Empty text node shouldn\'t be trimmed', '<strong>abc</strong> abc', actual.innerHTML);
+    Assert.eq('Empty text node shouldn\'t be trimmed', ' <strong>abc</strong> abc', actual.innerHTML);
   });
 
   Pipeline.async({}, [
@@ -46,6 +47,7 @@ UnitTest.asynctest('browser.tinymce.core.dom.TrimNodeTest', function (success, f
     sTestTrim('<p><a id="anchor"></a><span>x</span></p>', '<p><a id="anchor"></a><span>x</span></p>'),
     sTestTrim('<p><br data-mce-bogus="1"></p>', '<p><br data-mce-bogus="1"></p>'),
     sTestTrim('<p><strong>x</strong> <em>y</em></p>', '<p><strong>x</strong> <em>y</em></p>'),
+    sTestTrim('<pre><strong>x</strong>\n<em>y</em></pre>', '<pre><strong>x</strong>\n<em>y</em></pre>'),
     sTestTrimFragmentedTextNode,
     sTestTrimDocumentNode
   ], function () {


### PR DESCRIPTION
Related Ticket: TINY-6268

Description of Changes:
Fixes an issue whereby the `TrimNode` functionality was removing text nodes with content at the start/end of the fragment block.

**Note:** This doesn't solve the actual issue for TINY-6268, only an issue @HAFRMO found when trying to fix the actual issue and this needed to be solved first.

Pre-checks:
* [x] ~Changelog entry added~ (N/A we already have an entry for split losing content and we'll get one later for this specific JIRA)
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
