### PR TITLE
TINY-6050: Exposed warehouse to the world.

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
@@ -1,8 +1,8 @@
 import { Arr, Optional } from '@ephox/katamari';
 import { Attribute, InsertAll, Replication, SugarElement } from '@ephox/sugar';
 import { onCells, TargetSelection } from '../model/RunOperation';
-import { Warehouse } from '../model/Warehouse';
 import * as CellUtils from '../util/CellUtils';
+import { Warehouse } from './Warehouse';
 
 const constrainSpan = (element: SugarElement, property: 'colspan' | 'rowspan', value: number) => {
   const currentColspan = CellUtils.getSpan(element, property);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyRows.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyRows.ts
@@ -2,9 +2,9 @@ import { Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { onCells, TargetSelection, toDetailList } from '../model/RunOperation';
 import * as Transitions from '../model/Transitions';
-import { Warehouse } from '../model/Warehouse';
 import * as Redraw from '../operate/Redraw';
 import { Generators } from './Generators';
+import { Warehouse } from './Warehouse';
 
 const copyRows = function (table: SugarElement, target: TargetSelection, generators: Generators): Optional<SugarElement<HTMLTableRowElement>[]> {
   const house = Warehouse.fromTable(table);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
@@ -1,9 +1,9 @@
 import { Arr, Obj } from '@ephox/katamari';
 import { Attribute, Css, Insert, Remove, Selectors, SugarElement } from '@ephox/sugar';
 import * as DetailsList from '../model/DetailsList';
-import { Warehouse } from '../model/Warehouse';
 import * as LayerSelector from '../util/LayerSelector';
 import { DetailExt, RowData } from './Structs';
+import { Warehouse } from './Warehouse';
 
 interface StatsStruct {
   readonly minRow: number;

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Main.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Main.ts
@@ -24,6 +24,7 @@ import * as TablePositions from './TablePositions';
 import * as TableRender from './TableRender';
 import { TableResize } from './TableResize';
 import { TableSize } from './TableSize';
+import * as Warehouse from './Warehouse';
 
 export {
   Adjustments,
@@ -52,5 +53,6 @@ export {
   TableSize,
   RunOperation,
   GridRow,
-  OtherCells
+  OtherCells,
+  Warehouse
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/api/OtherCells.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/OtherCells.ts
@@ -2,7 +2,7 @@ import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { onCells, TargetSelection, toDetailList } from '../model/RunOperation';
 import * as Transitions from '../model/Transitions';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from './Warehouse';
 import { Generators } from './Generators';
 import { DetailExt, RowCells } from './Structs';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
@@ -1,6 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Css, Height, SugarElement, Width } from '@ephox/sugar';
-import { Warehouse } from '../model/Warehouse';
 import * as BarPositions from '../resize/BarPositions';
 import * as ColumnSizes from '../resize/ColumnSizes';
 import * as Redistribution from '../resize/Redistribution';
@@ -8,6 +7,7 @@ import * as Sizes from '../resize/Sizes';
 import * as CellUtils from '../util/CellUtils';
 import { DetailExt, RowData } from './Structs';
 import { TableSize } from './TableSize';
+import { Warehouse } from './Warehouse';
 
 type BarPositions<A> = BarPositions.BarPositions<A>;
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableGridSize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableGridSize.ts
@@ -1,5 +1,5 @@
 import { SugarElement } from '@ephox/sugar';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from './Warehouse';
 
 const getGridSize = function (table: SugarElement) {
   const warehouse = Warehouse.fromTable(table);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -6,7 +6,6 @@ import {
 } from '../model/RunOperation';
 import * as TableMerge from '../model/TableMerge';
 import * as Transitions from '../model/Transitions';
-import { Warehouse } from '../model/Warehouse';
 import * as MergingOperations from '../operate/MergingOperations';
 import * as ModificationOperations from '../operate/ModificationOperations';
 import * as TransformOperations from '../operate/TransformOperations';
@@ -15,6 +14,7 @@ import { Generators, GeneratorsMerging, GeneratorsModification, GeneratorsTransf
 import * as Structs from './Structs';
 import * as TableContent from './TableContent';
 import * as TableLookup from './TableLookup';
+import { Warehouse } from './Warehouse';
 
 export interface TableOperationResult {
   readonly grid: Structs.RowCells[];

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TablePositions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TablePositions.ts
@@ -1,9 +1,9 @@
 import { Optional } from '@ephox/katamari';
 import { Compare, SugarElement } from '@ephox/sugar';
-import { Warehouse } from '../model/Warehouse';
 import * as CellFinder from '../selection/CellFinder';
 import * as CellGroup from '../selection/CellGroup';
 import * as TableLookup from './TableLookup';
+import { Warehouse } from './Warehouse';
 
 const moveBy = function (cell: SugarElement, deltaRow: number, deltaColumn: number) {
   return TableLookup.table(cell).bind(function (table) {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableSize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableSize.ts
@@ -1,9 +1,9 @@
 import { Cell, Fun } from '@ephox/katamari';
 import { SugarElement, Width } from '@ephox/sugar';
-import { Warehouse } from '../model/Warehouse';
 import * as ColumnSizes from '../resize/ColumnSizes';
 import * as Sizes from '../resize/Sizes';
 import * as CellUtils from '../util/CellUtils';
+import { Warehouse } from './Warehouse';
 
 export interface TableSize {
   readonly width: () => number;

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Warehouse.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Warehouse.ts
@@ -1,7 +1,7 @@
 import { Arr, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import * as Structs from '../api/Structs';
-import * as DetailsList from './DetailsList';
+import * as DetailsList from '../model/DetailsList';
 
 export interface Warehouse {
   readonly grid: Structs.Grid;

--- a/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
@@ -1,7 +1,7 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { DetailExt } from '../api/Structs';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from '../api/Warehouse';
 
 /*
  * Identify for each column, a cell that has colspan 1. Note, this

--- a/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
@@ -8,8 +8,8 @@ import { TableOperationResult } from '../api/TableOperations';
 import { TableSize } from '../api/TableSize';
 import * as Redraw from '../operate/Redraw';
 import * as Bars from '../resize/Bars';
+import { Warehouse } from '../api/Warehouse';
 import * as Transitions from './Transitions';
-import { Warehouse } from './Warehouse';
 
 type DetailExt = Structs.DetailExt;
 type DetailNew = Structs.DetailNew;

--- a/modules/snooker/src/main/ts/ephox/snooker/model/Transitions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/Transitions.ts
@@ -2,8 +2,8 @@ import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { Generators } from '../api/Generators';
 import * as Structs from '../api/Structs';
+import { Warehouse } from '../api/Warehouse';
 import * as TableGrid from './TableGrid';
-import { Warehouse } from './Warehouse';
 
 const toDetails = function (grid: Structs.RowCells[], comparator: (a: SugarElement, b: SugarElement) => boolean) {
   const seen = Arr.map(grid, function (row) {

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
@@ -4,7 +4,7 @@ import { ResizeBehaviour } from '../api/ResizeBehaviour';
 import { Detail, RowData } from '../api/Structs';
 import { TableSize } from '../api/TableSize';
 import * as Deltas from '../calc/Deltas';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from '../api/Warehouse';
 import * as CellUtils from '../util/CellUtils';
 import * as ColumnSizes from './ColumnSizes';
 import * as Recalculations from './Recalculations';

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Bars.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Bars.ts
@@ -2,7 +2,7 @@ import { Arr, Optional } from '@ephox/katamari';
 import { Class, Css, Height, Insert, Remove, SelectorFilter, SugarElement, SugarLocation, SugarPosition, Width } from '@ephox/sugar';
 import { ResizeWire } from '../api/ResizeWire';
 import * as Blocks from '../lookup/Blocks';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from '../api/Warehouse';
 import * as Styles from '../style/Styles';
 import * as Bar from './Bar';
 import * as BarPositions from './BarPositions';

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
@@ -2,7 +2,7 @@ import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Css, SugarElement } from '@ephox/sugar';
 import { TableSize } from '../api/TableSize';
 import * as Blocks from '../lookup/Blocks';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from '../api/Warehouse';
 import * as CellUtils from '../util/CellUtils';
 import * as Util from '../util/Util';
 import { width, BarPositions, RowInfo } from './BarPositions';

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Recalculations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Recalculations.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from '../api/Warehouse';
 
 // Returns the sum of elements of measures in the half-open range [start, end)
 // Measures is in pixels, treated as an array of integers or integers in string format.

--- a/modules/snooker/src/main/ts/ephox/snooker/selection/CellBounds.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/selection/CellBounds.ts
@@ -1,6 +1,6 @@
 import { Fun, Optional } from '@ephox/katamari';
 import { Bounds, DetailExt } from '../api/Structs';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from '../api/Warehouse';
 
 const inSelection = function (bounds: Bounds, detail: DetailExt) {
   const leftEdge = detail.column;

--- a/modules/snooker/src/main/ts/ephox/snooker/selection/CellFinder.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/selection/CellFinder.ts
@@ -1,6 +1,6 @@
 import { Arr, Fun } from '@ephox/katamari';
 import { Compare, SugarElement } from '@ephox/sugar';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from '../api/Warehouse';
 import * as CellBounds from './CellBounds';
 import * as CellGroup from './CellGroup';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/selection/CellGroup.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/selection/CellGroup.ts
@@ -1,6 +1,6 @@
 import { Compare, SugarElement } from '@ephox/sugar';
 import * as Structs from '../api/Structs';
-import { Warehouse } from '../model/Warehouse';
+import { Warehouse } from '../api/Warehouse';
 import * as CellBounds from './CellBounds';
 
 const getBounds = function (detailA: Structs.DetailExt, detailB: Structs.DetailExt) {

--- a/modules/snooker/src/test/ts/atomic/lookup/BlocksTest.ts
+++ b/modules/snooker/src/test/ts/atomic/lookup/BlocksTest.ts
@@ -2,7 +2,7 @@ import { assert, UnitTest } from '@ephox/bedrock-client';
 import { SugarElement } from '@ephox/sugar';
 import * as Structs from 'ephox/snooker/api/Structs';
 import * as Blocks from 'ephox/snooker/lookup/Blocks';
-import { Warehouse } from 'ephox/snooker/model/Warehouse';
+import { Warehouse } from 'ephox/snooker/api/Warehouse';
 
 UnitTest.test('BlocksTest', function () {
   const s = (fakeEle: any, rowspan: number, colspan: number) => Structs.detail(fakeEle as SugarElement, rowspan, colspan);

--- a/modules/snooker/src/test/ts/atomic/model/WarehouseTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/WarehouseTest.ts
@@ -2,7 +2,7 @@ import { assert, UnitTest } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import * as Structs from 'ephox/snooker/api/Structs';
-import { Warehouse } from 'ephox/snooker/model/Warehouse';
+import { Warehouse } from 'ephox/snooker/api/Warehouse';
 
 UnitTest.test('WarehouseTest', function () {
   const check = function (expected: Record<string, string>, input: Structs.RowData<Structs.Detail>[]) {

--- a/modules/snooker/src/test/ts/atomic/resize/RecalculationsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/resize/RecalculationsTest.ts
@@ -2,7 +2,7 @@ import { assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import * as Structs from 'ephox/snooker/api/Structs';
-import { Warehouse } from 'ephox/snooker/model/Warehouse';
+import { Warehouse } from 'ephox/snooker/api/Warehouse';
 import * as Recalculations from 'ephox/snooker/resize/Recalculations';
 
 UnitTest.test('RecalculationsTest', function () {

--- a/modules/snooker/src/test/ts/atomic/selection/CellBoundsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/selection/CellBoundsTest.ts
@@ -2,7 +2,7 @@ import { assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import * as Structs from 'ephox/snooker/api/Structs';
-import { Warehouse } from 'ephox/snooker/model/Warehouse';
+import { Warehouse } from 'ephox/snooker/api/Warehouse';
 import * as CellBounds from 'ephox/snooker/selection/CellBounds';
 
 UnitTest.test('CellBounds.isWithin Test', function () {

--- a/modules/snooker/src/test/ts/browser/RedrawSectionOrderTest.ts
+++ b/modules/snooker/src/test/ts/browser/RedrawSectionOrderTest.ts
@@ -4,7 +4,7 @@ import { Arr, Unicode } from '@ephox/katamari';
 import { Compare, SugarElement, Traverse } from '@ephox/sugar';
 import * as Structs from 'ephox/snooker/api/Structs';
 import * as Transitions from 'ephox/snooker/model/Transitions';
-import { Warehouse } from 'ephox/snooker/model/Warehouse';
+import { Warehouse } from 'ephox/snooker/api/Warehouse';
 import * as Redraw from 'ephox/snooker/operate/Redraw';
 import * as Bridge from 'ephox/snooker/test/Bridge';
 

--- a/modules/snooker/src/test/ts/browser/ResizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/ResizeTest.ts
@@ -4,7 +4,7 @@ import { Css, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import * as ResizeBehaviour from 'ephox/snooker/api/ResizeBehaviour';
 import { TableSize } from 'ephox/snooker/api/TableSize';
 import * as Deltas from 'ephox/snooker/calc/Deltas';
-import { Warehouse } from 'ephox/snooker/model/Warehouse';
+import { Warehouse } from 'ephox/snooker/api/Warehouse';
 
 UnitTest.test('ResizeTest', function () {
   const resizing = ResizeBehaviour.preserveTable();

--- a/modules/snooker/src/test/ts/browser/TableSizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableSizeTest.ts
@@ -3,7 +3,7 @@ import { Optional, OptionalInstances } from '@ephox/katamari';
 import { Css, Insert, Remove, SelectorFind, SugarBody, SugarElement, Width } from '@ephox/sugar';
 import * as fc from 'fast-check';
 import { TableSize } from 'ephox/snooker/api/TableSize';
-import { Warehouse } from 'ephox/snooker/model/Warehouse';
+import { Warehouse } from 'ephox/snooker/api/Warehouse';
 
 const tOptional = OptionalInstances.tOptional;
 


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Exposed Warehouse in snooker for use in the Table plugin. Internal change.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
