### PR TITLE
TINY-6032: Add 'ToggleToolbarDrawer' command and query command

### DIFF
--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Changed some public APIs (eg Components, Custom Events) to no longer be thunked.
 
+### Added
+- Added new `isOn` API to the `SplitFloatingToolbar` and `SplitSlidingToolbar` components.
+
 # [7.0.2] - 2020-05-25
 
 ### Fixed

--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed some public APIs (eg Components, Custom Events) to no longer be thunked.
 
 ### Added
-- Added new `isOn` API to the `SplitFloatingToolbar` and `SplitSlidingToolbar` components.
+- Added new `isOpen` API to the `SplitFloatingToolbar` and `SplitSlidingToolbar` components.
 
 ### Fixed
 - Fixed `AriaOwner` not able to find the owner component when rendered within a ShadowRoot.

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -156,7 +156,7 @@ const factory: CompositeSketchFactory<FloatingToolbarButtonDetail, FloatingToolb
     getToolbar(button: AlloyComponent) {
       return Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox'));
     },
-    isOn(button: AlloyComponent) {
+    isOpen(button: AlloyComponent) {
       return Sandboxing.isOpen(Coupling.getCoupled(button, 'toolbarSandbox'));
     }
   }
@@ -178,7 +178,7 @@ const FloatingToolbarButton: FloatingToolbarButtonSketcher = Sketcher.composite<
       apis.toggle(button);
     },
     getToolbar: (apis, button) => apis.getToolbar(button),
-    isOn: (apis, button) => apis.isOn(button)
+    isOpen: (apis, button) => apis.isOpen(button)
   }
 });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -155,6 +155,9 @@ const factory: CompositeSketchFactory<FloatingToolbarButtonDetail, FloatingToolb
     },
     getToolbar(button: AlloyComponent) {
       return Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox'));
+    },
+    isOn(button: AlloyComponent) {
+      return Sandboxing.isOpen(Coupling.getCoupled(button, 'toolbarSandbox'));
     }
   }
 });
@@ -174,7 +177,8 @@ const FloatingToolbarButton: FloatingToolbarButtonSketcher = Sketcher.composite<
     toggle: (apis, button) => {
       apis.toggle(button);
     },
-    getToolbar: (apis, button) => apis.getToolbar(button)
+    getToolbar: (apis, button) => apis.getToolbar(button),
+    isOn: (apis, button) => apis.isOn(button)
   }
 });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
@@ -86,17 +86,15 @@ const factory: CompositeSketchFactory<SplitFloatingToolbarDetail, SplitFloatingT
           FloatingToolbarButton.toggle(floatingToolbarButton);
         });
       },
-      isOn: (toolbar: AlloyComponent) =>
-        memFloatingToolbarButton.getOpt(toolbar).map((floatingToolbarButton) => FloatingToolbarButton.isOn(floatingToolbarButton)).getOr(false),
+      isOpen: (toolbar: AlloyComponent) =>
+        memFloatingToolbarButton.getOpt(toolbar).map(FloatingToolbarButton.isOpen).getOr(false),
       reposition: (toolbar: AlloyComponent) => {
         memFloatingToolbarButton.getOpt(toolbar).each((floatingToolbarButton) => {
           FloatingToolbarButton.reposition(floatingToolbarButton);
         });
       },
       getOverflow: (toolbar: AlloyComponent) =>
-        memFloatingToolbarButton.getOpt(toolbar).bind(
-          (floatingToolbarButton) => FloatingToolbarButton.getToolbar(floatingToolbarButton)
-        )
+        memFloatingToolbarButton.getOpt(toolbar).bind(FloatingToolbarButton.getToolbar)
     },
 
     domModification: {
@@ -123,7 +121,7 @@ const SplitFloatingToolbar: SplitFloatingToolbarSketcher = Sketcher.composite<Sp
     toggle: (apis, toolbar) => {
       apis.toggle(toolbar);
     },
-    isOn: (apis, toolbar) => apis.isOn(toolbar),
+    isOpen: (apis, toolbar) => apis.isOpen(toolbar),
     getOverflow: (apis, toolbar) => apis.getOverflow(toolbar)
   }
 });

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
@@ -86,6 +86,8 @@ const factory: CompositeSketchFactory<SplitFloatingToolbarDetail, SplitFloatingT
           FloatingToolbarButton.toggle(floatingToolbarButton);
         });
       },
+      isOn: (toolbar: AlloyComponent) =>
+        memFloatingToolbarButton.getOpt(toolbar).map((floatingToolbarButton) => FloatingToolbarButton.isOn(floatingToolbarButton)).getOr(false),
       reposition: (toolbar: AlloyComponent) => {
         memFloatingToolbarButton.getOpt(toolbar).each((floatingToolbarButton) => {
           FloatingToolbarButton.reposition(floatingToolbarButton);
@@ -121,6 +123,7 @@ const SplitFloatingToolbar: SplitFloatingToolbarSketcher = Sketcher.composite<Sp
     toggle: (apis, toolbar) => {
       apis.toggle(toolbar);
     },
+    isOn: (apis, toolbar) => apis.isOn(toolbar),
     getOverflow: (apis, toolbar) => apis.getOverflow(toolbar)
   }
 });

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
@@ -22,11 +22,17 @@ import { Toolbar } from './Toolbar';
 import { ToolbarGroup } from './ToolbarGroup';
 import { CompositeSketchFactory } from './UiSketcher';
 
+const isOn = (toolbar: AlloyComponent, detail: SplitSlidingToolbarDetail) =>
+  AlloyParts.getPart(toolbar, detail, 'overflow').map((overflow) => Sliding.hasGrown(overflow)).getOr(false);
+
 const toggleToolbar = (toolbar: AlloyComponent, detail: SplitSlidingToolbarDetail) => {
-  AlloyParts.getPart(toolbar, detail, 'overflow').each((overf) => {
-    refresh(toolbar, detail);
-    Sliding.toggleGrow(overf);
-  });
+  // Make sure that the toolbar needs to toggled by checking for overflow button presence
+  AlloyParts.getPart(toolbar, detail, 'overflow-button')
+    .bind(() => AlloyParts.getPart(toolbar, detail, 'overflow'))
+    .each((overf) => {
+      refresh(toolbar, detail);
+      Sliding.toggleGrow(overf);
+    });
 };
 
 const refresh = (toolbar: AlloyComponent, detail: SplitSlidingToolbarDetail) => {
@@ -80,10 +86,7 @@ const factory: CompositeSketchFactory<SplitSlidingToolbarDetail, SplitSlidingToo
         }),
         AddEventsBehaviour.config('toolbar-toggle-events', [
           AlloyEvents.run(toolbarToggleEvent, (toolbar) => {
-            AlloyParts.getPart(toolbar, detail, 'overflow').each((overf) => {
-              refresh(toolbar, detail);
-              Sliding.toggleGrow(overf);
-            });
+            toggleToolbar(toolbar, detail);
           })
         ])
       ]
@@ -94,7 +97,8 @@ const factory: CompositeSketchFactory<SplitSlidingToolbarDetail, SplitSlidingToo
         refresh(toolbar, detail);
       },
       refresh: (toolbar: AlloyComponent) => refresh(toolbar, detail),
-      toggle: (toolbar: AlloyComponent) => toggleToolbar(toolbar, detail)
+      toggle: (toolbar: AlloyComponent) => toggleToolbar(toolbar, detail),
+      isOn: (toolbar: AlloyComponent) => isOn(toolbar, detail)
     },
     domModification: {
       attributes: { role: 'group' }
@@ -116,7 +120,8 @@ const SplitSlidingToolbar: SplitSlidingToolbarSketcher = Sketcher.composite<Spli
     },
     toggle: (apis, toolbar) => {
       apis.toggle(toolbar);
-    }
+    },
+    isOn: (apis, toolbar) => apis.isOn(toolbar)
   }
 });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
@@ -22,8 +22,8 @@ import { Toolbar } from './Toolbar';
 import { ToolbarGroup } from './ToolbarGroup';
 import { CompositeSketchFactory } from './UiSketcher';
 
-const isOn = (toolbar: AlloyComponent, detail: SplitSlidingToolbarDetail) =>
-  AlloyParts.getPart(toolbar, detail, 'overflow').map((overflow) => Sliding.hasGrown(overflow)).getOr(false);
+const isOpen = (toolbar: AlloyComponent, detail: SplitSlidingToolbarDetail) =>
+  AlloyParts.getPart(toolbar, detail, 'overflow').map(Sliding.hasGrown).getOr(false);
 
 const toggleToolbar = (toolbar: AlloyComponent, detail: SplitSlidingToolbarDetail) => {
   // Make sure that the toolbar needs to toggled by checking for overflow button presence
@@ -98,7 +98,7 @@ const factory: CompositeSketchFactory<SplitSlidingToolbarDetail, SplitSlidingToo
       },
       refresh: (toolbar: AlloyComponent) => refresh(toolbar, detail),
       toggle: (toolbar: AlloyComponent) => toggleToolbar(toolbar, detail),
-      isOn: (toolbar: AlloyComponent) => isOn(toolbar, detail)
+      isOpen: (toolbar: AlloyComponent) => isOpen(toolbar, detail)
     },
     domModification: {
       attributes: { role: 'group' }
@@ -121,7 +121,7 @@ const SplitSlidingToolbar: SplitSlidingToolbarSketcher = Sketcher.composite<Spli
     toggle: (apis, toolbar) => {
       apis.toggle(toolbar);
     },
-    isOn: (apis, toolbar) => apis.isOn(toolbar)
+    isOpen: (apis, toolbar) => apis.isOpen(toolbar)
   }
 });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
@@ -25,7 +25,7 @@ export interface FloatingToolbarButtonApis {
   reposition: (floatingToolbarButton: AlloyComponent) => void;
   toggle: (floatingToolbarButton: AlloyComponent) => void;
   getToolbar: (floatingToolbarButton: AlloyComponent) => Optional<AlloyComponent>;
-  isOn: (floatingToolbarButton: AlloyComponent) => boolean;
+  isOpen: (floatingToolbarButton: AlloyComponent) => boolean;
 }
 
 export interface FloatingToolbarButtonSpec extends CompositeSketchSpec, HasLayoutAnchorSpec {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
@@ -25,6 +25,7 @@ export interface FloatingToolbarButtonApis {
   reposition: (floatingToolbarButton: AlloyComponent) => void;
   toggle: (floatingToolbarButton: AlloyComponent) => void;
   getToolbar: (floatingToolbarButton: AlloyComponent) => Optional<AlloyComponent>;
+  isOn: (floatingToolbarButton: AlloyComponent) => boolean;
 }
 
 export interface FloatingToolbarButtonSpec extends CompositeSketchSpec, HasLayoutAnchorSpec {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
@@ -19,7 +19,7 @@ export interface SplitToolbarBaseApis {
   setGroups: (toolbar: AlloyComponent, groups: SketchSpec[]) => void;
   refresh: (toolbar: AlloyComponent) => void;
   toggle: (toolbar: AlloyComponent) => void;
-  isOn: (toolbar: AlloyComponent) => boolean;
+  isOpen: (toolbar: AlloyComponent) => boolean;
 }
 
 export interface SplitToolbarBaseSpec extends CompositeSketchSpec {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
@@ -19,6 +19,7 @@ export interface SplitToolbarBaseApis {
   setGroups: (toolbar: AlloyComponent, groups: SketchSpec[]) => void;
   refresh: (toolbar: AlloyComponent) => void;
   toggle: (toolbar: AlloyComponent) => void;
+  isOn: (toolbar: AlloyComponent) => boolean;
 }
 
 export interface SplitToolbarBaseSpec extends CompositeSketchSpec {

--- a/modules/alloy/src/test/ts/browser/ui/button/FloatingToolbarButtonTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/button/FloatingToolbarButtonTest.ts
@@ -73,6 +73,14 @@ UnitTest.asynctest('FloatingToolbarButtonTest', (success, failure) => {
       )
     ]);
 
+    const sAssertFloatingToolbarToggleState = (expected: boolean) => Step.sync(() => {
+      Assertions.assertEq('Expected floating toolbar toggle state to be ' + expected, expected, FloatingToolbarButton.isOn(component));
+    });
+
+    const sToggleFloatingToolbar = () => Step.sync(() => {
+      FloatingToolbarButton.toggle(component);
+    });
+
     const sAssertFloatingToolbarOpened = () => GeneralSteps.sequence([
       Assertions.sAssertStructure(
         'Assert floating toolbar structure',
@@ -107,11 +115,13 @@ UnitTest.asynctest('FloatingToolbarButtonTest', (success, failure) => {
           ]
         })),
         sinkComp.element
-      )
+      ),
+      sAssertFloatingToolbarToggleState(true)
     ]);
 
     const sAssertFloatingToolbarClosed = () => Step.sync(() => {
       Assertions.assertEq('Floating toolbar should not exist', false, SelectorExists.descendant(sinkComp.element, 'test-toolbar'));
+      sAssertFloatingToolbarToggleState(false);
     });
 
     return [
@@ -132,6 +142,14 @@ UnitTest.asynctest('FloatingToolbarButtonTest', (success, failure) => {
 
       Log.stepsAsStep('', 'Escape should close floating toolbar', [
         Keyboard.sKeydown(doc, Keys.escape(), { }),
+        sAssertFloatingToolbarClosed()
+      ]),
+
+      Log.stepsAsStep('TINY-6032', 'Using the API to toggle the floating toolbar should work', [
+        sToggleFloatingToolbar(),
+        sAssertButtonStructure(true),
+        sAssertFloatingToolbarOpened(),
+        sToggleFloatingToolbar(),
         sAssertFloatingToolbarClosed()
       ]),
 

--- a/modules/alloy/src/test/ts/browser/ui/button/FloatingToolbarButtonTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/button/FloatingToolbarButtonTest.ts
@@ -74,7 +74,7 @@ UnitTest.asynctest('FloatingToolbarButtonTest', (success, failure) => {
     ]);
 
     const sAssertFloatingToolbarToggleState = (expected: boolean) => Step.sync(() => {
-      Assertions.assertEq('Expected floating toolbar toggle state to be ' + expected, expected, FloatingToolbarButton.isOn(component));
+      Assertions.assertEq('Expected floating toolbar toggle state to be ' + expected, expected, FloatingToolbarButton.isOpen(component));
     });
 
     const sToggleFloatingToolbar = () => Step.sync(() => {

--- a/modules/alloy/src/test/ts/browser/ui/toolbar/SplitFloatingToolbarTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/toolbar/SplitFloatingToolbarTest.ts
@@ -160,7 +160,7 @@ UnitTest.asynctest('SplitFloatingToolbarTest', (success, failure) => {
     ]);
 
     const sAssertSplitFloatingToolbarToggleState = (expected: boolean) => Step.sync(() => {
-      Assertions.assertEq('Expected split floating toolbar toggle state to be ' + expected, expected, SplitFloatingToolbar.isOn(component));
+      Assertions.assertEq('Expected split floating toolbar toggle state to be ' + expected, expected, SplitFloatingToolbar.isOpen(component));
     });
 
     const sToggleSplitFloatingToolbar = () => Step.sync(() => {

--- a/modules/alloy/src/test/ts/browser/ui/toolbar/SplitFloatingToolbarTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/toolbar/SplitFloatingToolbarTest.ts
@@ -159,6 +159,14 @@ UnitTest.asynctest('SplitFloatingToolbarTest', (success, failure) => {
       )
     ]);
 
+    const sAssertSplitFloatingToolbarToggleState = (expected: boolean) => Step.sync(() => {
+      Assertions.assertEq('Expected split floating toolbar toggle state to be ' + expected, expected, SplitFloatingToolbar.isOn(component));
+    });
+
+    const sToggleSplitFloatingToolbar = () => Step.sync(() => {
+      SplitFloatingToolbar.toggle(component);
+    });
+
     return [
       GuiSetup.mAddStyles(doc, [
         '.test-toolbar-group { display: flex; }',
@@ -169,6 +177,8 @@ UnitTest.asynctest('SplitFloatingToolbarTest', (success, failure) => {
         '.test-split-toolbar button.more-button { width: 50px; }'
       ]),
 
+      sAssertSplitFloatingToolbarToggleState(false),
+
       Step.sync(() => {
         const groups = TestPartialToolbarGroup.createGroups([
           { items: Arr.map([{ text: 'A' }, { text: 'B' }], makeButton) },
@@ -178,6 +188,8 @@ UnitTest.asynctest('SplitFloatingToolbarTest', (success, failure) => {
         SplitFloatingToolbar.setGroups(component, groups);
         SplitFloatingToolbar.toggle(component);
       }),
+
+      sAssertSplitFloatingToolbarToggleState(true),
 
       sAssertGroups('width=400px (1 +)', [ group1, oGroup ], [ group2, group3 ]),
 
@@ -202,6 +214,12 @@ UnitTest.asynctest('SplitFloatingToolbarTest', (success, failure) => {
 
       sResetWidth('400px'),
       sAssertGroups('width=400px (1 +)', [ group1, oGroup ], [ group2, group3 ]),
+
+      sToggleSplitFloatingToolbar(),
+      sAssertSplitFloatingToolbarToggleState(false),
+
+      sToggleSplitFloatingToolbar(),
+      sAssertSplitFloatingToolbarToggleState(true),
 
       GuiSetup.mRemoveStyles
     ];

--- a/modules/alloy/src/test/ts/browser/ui/toolbar/SplitSlidingToolbarTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/toolbar/SplitSlidingToolbarTest.ts
@@ -136,7 +136,7 @@ UnitTest.asynctest('SplitSlidingToolbarTest', (success, failure) => {
 
     const sAssertSplitSlidingToolbarToggleState = (expected: boolean) =>
       Waiter.sTryUntil(`Wait for toolbar to be completely ${expected ? 'opened' : 'closed'}`, Step.sync(() => {
-        Assertions.assertEq('Expected split floating toolbar toggle state to be ' + expected, expected, SplitSlidingToolbar.isOn(component));
+        Assertions.assertEq('Expected split floating toolbar toggle state to be ' + expected, expected, SplitSlidingToolbar.isOpen(component));
       }));
 
     const sToggleSplitSlidingToolbar = () => Step.sync(() => {

--- a/modules/alloy/src/test/ts/browser/ui/toolbar/SplitSlidingToolbarTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/toolbar/SplitSlidingToolbarTest.ts
@@ -134,6 +134,15 @@ UnitTest.asynctest('SplitSlidingToolbarTest', (success, failure) => {
       component.element
     );
 
+    const sAssertSplitSlidingToolbarToggleState = (expected: boolean) =>
+      Waiter.sTryUntil(`Wait for toolbar to be completely ${expected ? 'opened' : 'closed'}`, Step.sync(() => {
+        Assertions.assertEq('Expected split floating toolbar toggle state to be ' + expected, expected, SplitSlidingToolbar.isOn(component));
+      }));
+
+    const sToggleSplitSlidingToolbar = () => Step.sync(() => {
+      SplitSlidingToolbar.toggle(component);
+    });
+
     return [
       GuiSetup.mAddStyles(doc, [
         '.test-sliding-closed { visibility: hidden; opacity: 0; }',
@@ -149,6 +158,7 @@ UnitTest.asynctest('SplitSlidingToolbarTest', (success, failure) => {
       ]),
 
       store.sAssertEq('Assert initial store state', [ ]),
+      sAssertSplitSlidingToolbarToggleState(false),
 
       Step.sync(() => {
         const groups = TestPartialToolbarGroup.createGroups([
@@ -161,6 +171,7 @@ UnitTest.asynctest('SplitSlidingToolbarTest', (success, failure) => {
       }),
 
       Waiter.sTryUntil('Wait for toolbar to be completely open', store.sAssertEq('Assert store contains opened state', [ 'onOpened' ])),
+      sAssertSplitSlidingToolbarToggleState(true),
       store.sClear,
 
       sAssertGroups('width=400px (1 +)', [ group1, oGroup ], [ group2, group3 ]),
@@ -187,10 +198,9 @@ UnitTest.asynctest('SplitSlidingToolbarTest', (success, failure) => {
       sResetWidth('400px'),
       sAssertGroups('width=400px (1 +)', [ group1, oGroup ], [ group2, group3 ]),
 
-      Step.sync(() => {
-        SplitSlidingToolbar.toggle(component);
-      }),
+      sToggleSplitSlidingToolbar(),
       Waiter.sTryUntil('Wait for toolbar to be completely closed', store.sAssertEq('Assert store contains closed state', [ 'onClosed' ])),
+      sAssertSplitSlidingToolbarToggleState(false),
 
       // TODO: Add testing for sliding?
       GuiSetup.mRemoveStyles

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -4,6 +4,7 @@ Version 5.5.0 (TBD)
     Added ability to load TinyMCE in inline mode within a ShadowRoot #TINY-6128
     Added the ability to remove images on a failed upload using the `images_upload_handler` failure callback #TINY-6011
     Added `hasPlugin` function to the editor API to determine if a plugin exists or not #TINY-766
+    Added new `ToggleToolbar` command and query state handler to allow the toolbar to be programmatically toggled and its toggle state to be checked #TINY-6032
     Added the ability to delete and navigate HTML media elements without the media plugin #TINY-4211
     Added `fullscreen_native` setting to the fullscreen plugin to enable use of the entire monitor #TINY-6284
     Added table related oxide variables to the Style API for more granular control over table cell selection appearance #TINY-6311

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -4,7 +4,7 @@ Version 5.5.0 (TBD)
     Added ability to load TinyMCE in inline mode within a ShadowRoot #TINY-6128
     Added the ability to remove images on a failed upload using the `images_upload_handler` failure callback #TINY-6011
     Added `hasPlugin` function to the editor API to determine if a plugin exists or not #TINY-766
-    Added new `ToggleToolbar` command and query state handler to allow the toolbar to be programmatically toggled and its toggle state to be checked #TINY-6032
+    Added new `ToggleToolbarDrawer` command and query state handler to allow the toolbar drawer to be programmatically toggled and its toggle state to be checked #TINY-6032
     Added the ability to delete and navigate HTML media elements without the media plugin #TINY-4211
     Added `fullscreen_native` setting to the fullscreen plugin to enable use of the entire monitor #TINY-6284
     Added table related oxide variables to the Style API for more granular control over table cell selection appearance #TINY-6311

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -317,12 +317,12 @@ const setup = (editor: Editor): RenderInfo => {
     OuterContainer.focusToolbar(outerContainer);
   });
 
-  editor.addCommand('ToggleToolbar', () => {
-    OuterContainer.toggleToolbar(outerContainer);
+  editor.addCommand('ToggleToolbarDrawer', () => {
+    OuterContainer.toggleToolbarDrawer(outerContainer);
     // TODO: Consider firing event - TINY-6371
   });
 
-  editor.addQueryStateHandler('ToggleToolbar', () => OuterContainer.isToolbarToggled(outerContainer));
+  editor.addQueryStateHandler('ToggleToolbarDrawer', () => OuterContainer.isToolbarDrawerToggled(outerContainer));
 
   const mothership = Gui.takeover(
     outerContainer

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -315,6 +315,13 @@ const setup = (editor: Editor): RenderInfo => {
     OuterContainer.focusToolbar(outerContainer);
   });
 
+  editor.addCommand('ToggleToolbar', () => {
+    OuterContainer.toggleToolbar(outerContainer);
+    // TODO: Consider firing event - TINY-6371
+  });
+
+  editor.addQueryStateHandler('ToggleToolbar', () => OuterContainer.isToolbarToggled(outerContainer));
+
   const mothership = Gui.takeover(
     outerContainer
   );

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -9,7 +9,7 @@ import {
   AlloyComponent, AlloySpec, Behaviour, Composite, CustomList, Keying, RawDomSchema, Sketcher, SketchSpec, Toolbar, UiSketcher
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
-import { Arr, Id, Optional, Result } from '@ephox/katamari';
+import { Arr, Id, Optional, Optionals, Result } from '@ephox/katamari';
 import { ToolbarMode } from '../../api/Settings';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 
@@ -64,8 +64,8 @@ interface OuterContainerApis {
   setToolbar: (comp: AlloyComponent, groups) => void;
   setToolbars: (comp: AlloyComponent, toolbars) => void;
   refreshToolbar: (comp: AlloyComponent) => void;
-  toggleToolbar: (comp: AlloyComponent) => void;
-  isToolbarToggled: (comp: AlloyComponent) => boolean;
+  toggleToolbarDrawer: (comp: AlloyComponent) => void;
+  isToolbarDrawerToggled: (comp: AlloyComponent) => boolean;
   getThrobber: (comp: AlloyComponent) => Optional<AlloyComponent>;
   focusToolbar: (comp: AlloyComponent) => void;
   setMenubar: (comp: AlloyComponent, groups) => void;
@@ -76,7 +76,7 @@ interface ToolbarApis {
   setGroups: (toolbar: AlloyComponent, groups: SketchSpec[]) => void;
   refresh: (toolbar: AlloyComponent) => void;
   toggle?: (toolbar: AlloyComponent) => void;
-  isOn?: (toolbar: AlloyComponent) => boolean;
+  isOpen?: (toolbar: AlloyComponent) => boolean;
 }
 
 const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, OuterContainerSketchSpec> = function (detail, components, _spec) {
@@ -119,20 +119,15 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
       const toolbar = Composite.parts.getPart(comp, detail, 'toolbar');
       toolbar.each((toolbar) => toolbar.getApis<ToolbarApis>().refresh(toolbar));
     },
-    toggleToolbar(comp) {
-      // toggle may not be defined on all toolbars e.g. 'scrolling' and 'wrap'
-      Composite.parts.getPart(comp, detail, 'toolbar')
-        .each((toolbar) => {
-          Optional.from(toolbar.getApis<ToolbarApis>().toggle)
-            .each((toggle) => {
-              toggle(toolbar);
-            });
-        });
+    toggleToolbarDrawer(comp) {
+      Composite.parts.getPart(comp, detail, 'toolbar').each((toolbar) => {
+        Optionals.mapFrom(toolbar.getApis<ToolbarApis>().toggle, (toggle) => toggle(toolbar));
+      });
     },
-    isToolbarToggled(comp) {
-      // isOn may not be defined on all toolbars e.g. 'scrolling' and 'wrap'
+    isToolbarDrawerToggled(comp) {
+      // isOpen may not be defined on all toolbars e.g. 'scrolling' and 'wrap'
       return Composite.parts.getPart(comp, detail, 'toolbar')
-        .bind((toolbar) => Optional.from(toolbar.getApis<ToolbarApis>().isOn).map((isOn) => isOn(toolbar)))
+        .bind((toolbar) => Optional.from(toolbar.getApis<ToolbarApis>().isOpen).map((isOpen) => isOpen(toolbar)))
         .getOr(false);
     },
     getThrobber(comp) {
@@ -343,11 +338,11 @@ export default Sketcher.composite<OuterContainerSketchSpec, OuterContainerSketch
     refreshToolbar(apis, comp) {
       return apis.refreshToolbar(comp);
     },
-    toggleToolbar(apis, comp) {
-      apis.toggleToolbar(comp);
+    toggleToolbarDrawer(apis, comp) {
+      apis.toggleToolbarDrawer(comp);
     },
-    isToolbarToggled(apis, comp) {
-      return apis.isToolbarToggled(comp);
+    isToolbarDrawerToggled(apis, comp) {
+      return apis.isToolbarDrawerToggled(comp);
     },
     getThrobber(apis, comp) {
       return apis.getThrobber(comp);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -64,6 +64,8 @@ interface OuterContainerApis {
   setToolbar: (comp: AlloyComponent, groups) => void;
   setToolbars: (comp: AlloyComponent, toolbars) => void;
   refreshToolbar: (comp: AlloyComponent) => void;
+  toggleToolbar: (comp: AlloyComponent) => void;
+  isToolbarToggled: (comp: AlloyComponent) => boolean;
   getThrobber: (comp: AlloyComponent) => Optional<AlloyComponent>;
   focusToolbar: (comp: AlloyComponent) => void;
   setMenubar: (comp: AlloyComponent, groups) => void;
@@ -73,6 +75,8 @@ interface OuterContainerApis {
 interface ToolbarApis {
   setGroups: (toolbar: AlloyComponent, groups: SketchSpec[]) => void;
   refresh: (toolbar: AlloyComponent) => void;
+  toggle?: (toolbar: AlloyComponent) => void;
+  isOn?: (toolbar: AlloyComponent) => boolean;
 }
 
 const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, OuterContainerSketchSpec> = function (detail, components, _spec) {
@@ -114,6 +118,22 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
     refreshToolbar(comp) {
       const toolbar = Composite.parts.getPart(comp, detail, 'toolbar');
       toolbar.each((toolbar) => toolbar.getApis<ToolbarApis>().refresh(toolbar));
+    },
+    toggleToolbar(comp) {
+      // toggle may not be defined on all toolbars e.g. 'scrolling' and 'wrap'
+      Composite.parts.getPart(comp, detail, 'toolbar')
+        .each((toolbar) => {
+          Optional.from(toolbar.getApis<ToolbarApis>().toggle)
+            .each((toggle) => {
+              toggle(toolbar);
+            });
+        });
+    },
+    isToolbarToggled(comp) {
+      // isOn may not be defined on all toolbars e.g. 'scrolling' and 'wrap'
+      return Composite.parts.getPart(comp, detail, 'toolbar')
+        .bind((toolbar) => Optional.from(toolbar.getApis<ToolbarApis>().isOn).map((isOn) => isOn(toolbar)))
+        .getOr(false);
     },
     getThrobber(comp) {
       return Composite.parts.getPart(comp, detail, 'throbber');
@@ -322,6 +342,12 @@ export default Sketcher.composite<OuterContainerSketchSpec, OuterContainerSketch
     },
     refreshToolbar(apis, comp) {
       return apis.refreshToolbar(comp);
+    },
+    toggleToolbar(apis, comp) {
+      apis.toggleToolbar(comp);
+    },
+    isToolbarToggled(apis, comp) {
+      return apis.isToolbarToggled(comp);
     },
     getThrobber(apis, comp) {
       return apis.getThrobber(comp);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -5,15 +5,15 @@ import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.themes.silver.editor.toolbar.ToolbarToggleTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest', (success, failure) => {
   SilverTheme();
 
   const sAssertToolbarToggleState = (editor: Editor, expected: boolean) => Step.sync(() => {
-    Assertions.assertEq('Expected toolbar toggle state to be ' + expected, expected, editor.queryCommandState('ToggleToolbar'));
+    Assertions.assertEq('Expected toolbar toggle state to be ' + expected, expected, editor.queryCommandState('ToggleToolbarDrawer'));
   });
 
   const sToggleToolbar = (editor: Editor) => Step.sync(() => {
-    editor.execCommand('ToggleToolbar');
+    editor.execCommand('ToggleToolbarDrawer');
   });
 
   const cTestToggle = (label: string, settings: RawEditorSettings, shouldToggle: boolean) => Chain.label(label, Chain.fromChains([
@@ -49,7 +49,7 @@ UnitTest.asynctest('browser.tinymce.themes.silver.editor.toolbar.ToolbarToggleTe
     ]);
 
   Pipeline.async({}, [
-    Log.chainsAsStep('TINY-6032', `Using the 'ToggleToolbar' command should toggle the toolbar if applicable`, [
+    Log.chainsAsStep('TINY-6032', `Using the 'ToggleToolbarDrawer' command should toggle the toolbar if applicable`, [
       cTestToolbarMode('floating', true),
       cTestToolbarMode('sliding', true),
       cTestToolbarMode('wrap', false),

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarToggleTest.ts
@@ -1,0 +1,61 @@
+import { Chain, Log, Pipeline, Step, Assertions } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { ApiChains, Editor as McEditor } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.themes.silver.editor.toolbar.ToolbarToggleTest', (success, failure) => {
+  SilverTheme();
+
+  const sAssertToolbarToggleState = (editor: Editor, expected: boolean) => Step.sync(() => {
+    Assertions.assertEq('Expected toolbar toggle state to be ' + expected, expected, editor.queryCommandState('ToggleToolbar'));
+  });
+
+  const sToggleToolbar = (editor: Editor) => Step.sync(() => {
+    editor.execCommand('ToggleToolbar');
+  });
+
+  const cTestToggle = (label: string, settings: RawEditorSettings, shouldToggle: boolean) => Chain.label(label, Chain.fromChains([
+    McEditor.cFromSettings({
+      toolbar: 'undo redo | bold italic',
+      menubar: false,
+      statusbar: false,
+      width: 200,
+      ...settings,
+      base_url: '/project/tinymce/js/tinymce'
+    }),
+    ApiChains.cFocus,
+    Chain.runStepsOnValue((editor: Editor) =>
+      [
+        sAssertToolbarToggleState(editor, false),
+        sToggleToolbar(editor),
+        sAssertToolbarToggleState(editor, shouldToggle),
+        sToggleToolbar(editor),
+        sAssertToolbarToggleState(editor, false)
+      ]
+    ),
+    McEditor.cRemove
+  ]));
+
+  const cTestToolbarMode = (toolbarMode: 'floating' | 'sliding' | 'scrolling' | 'wrap', shouldToggle: boolean) =>
+    Log.chainsAsChain('TINY-6032', `Check toolbar toggling: ${toolbarMode}`, [
+      // Test iframe
+      cTestToggle(`${toolbarMode} toolbar`, { toolbar_mode: toolbarMode }, false),
+      cTestToggle(`${toolbarMode} toolbar - small width`, { toolbar_mode: toolbarMode, width: 50 }, shouldToggle),
+      // Test inline
+      cTestToggle(`${toolbarMode} toolbar (inline)`, { toolbar_mode: toolbarMode, inline: true }, false),
+      cTestToggle(`${toolbarMode} toolbar - small width (inline)`, { toolbar_mode: toolbarMode, width: 50, inline: true }, shouldToggle)
+    ]);
+
+  Pipeline.async({}, [
+    Log.chainsAsStep('TINY-6032', `Using the 'ToggleToolbar' command should toggle the toolbar if applicable`, [
+      cTestToolbarMode('floating', true),
+      cTestToolbarMode('sliding', true),
+      cTestToolbarMode('wrap', false),
+      cTestToolbarMode('scrolling', false),
+      cTestToggle('Multiple toolbars', { toolbar: [ 'undo redo', 'bold italic' ] }, false),
+      cTestToggle('Multiple toolbars (inline)', { toolbar: [ 'undo redo', 'bold italic' ], inline: true }, false)
+    ])
+  ], success, failure);
+});


### PR DESCRIPTION
Description of Changes:
* Expose new command to be able to toggle the toolbar and check toolbar toggle state
```
tinyMCE.activeEditor.execCommand('ToggleToolbarDrawer')
tinyMCE.activeEditor.queryCommandState('ToggleToolbarDrawer')
```
* Works for `sliding` and `floating` toolbar modes. Is a noop for the other toolbar modes.

One thing I noticed during some manual testing was that a `max call stack` error was sometimes thrown when executing the command on init for `inline` mode. I haven't had a chance to investigate this.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] ~~License headers added on new files (if applicable)~~

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #5616 
Fixes #5041
