### PR TITLE
TINY-6036: Added the ability to show context menus below specified nodes

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,9 +7,10 @@ Version 5.5.0 (TBD)
     Added the ability to delete and navigate HTML media elements without the media plugin #TINY-4211
     Added `fullscreen_native` setting to the fullscreen plugin to enable use of the entire monitor #TINY-6284
     Added table related oxide variables to the Style API for more granular control over table cell selection appearance #TINY-6311
-    Changed how CSS manipulates table cells when selecting multiple cells to achieve a semi-transparent selection #TINY-6311
     Added the `origin` property to the `ObjectResized` and `ObjectResizeStart` events, to specify which handle the resize was preformed on #TINY-6242
     Added new StyleSheetLoader `unload` and `unloadAll` APIs to allow loaded stylesheets to be removed #TINY-3926
+    Added a new `contextmenu_avoid_overlap` setting to allow contextmenus to avoid overlapping matched nodes #TINY-6036
+    Changed how CSS manipulates table cells when selecting multiple cells to achieve a semi-transparent selection #TINY-6311
     Changed the `target` property on fired events to use the native event target. The original target for an open shadow root can be obtained using `event.getComposedPath()` #TINY-6128
     Changed the editor to cleanup loaded CSS stylesheets when all editors using the stylesheet have been removed #TINY-3926
     Changed `imagetools` context menu icon for accessing the `image` settings to use the same icon #TINY-4141

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Settings.ts
@@ -30,8 +30,11 @@ const getContextMenu = function (editor: Editor): string[] {
   return getMenuItems(editor, 'contextmenu', 'link linkchecker image imagetools table spellchecker configurepermanentpen');
 };
 
+const getAvoidOverlapSelector = (editor: Editor): string => editor.getParam('contextmenu_avoid_overlap', '', 'string');
+
 export {
   shouldNeverUseNative,
   getContextMenu,
-  isContextMenuDisabled
+  isContextMenuDisabled,
+  getAvoidOverlapSelector
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/DesktopContextMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/DesktopContextMenu.ts
@@ -8,11 +8,9 @@ import * as NestedMenus from '../../menu/NestedMenus';
 import { SingleMenuItemSpec } from '../../menu/SingleMenuTypes';
 import { getNodeAnchor, getPointAnchor } from '../Coords';
 
-const getAnchorSpec = (editor: Editor, e: EditorEvent<PointerEvent>, isTriggeredByKeyboardEvent: boolean) => isTriggeredByKeyboardEvent ? getNodeAnchor(editor) : getPointAnchor(editor, e);
-
-export const initAndShow = (editor: Editor, e: EditorEvent<PointerEvent>, buildMenu: () => string | Array<string | SingleMenuItemSpec>, backstage: UiFactoryBackstage, contextmenu: AlloyComponent, isTriggeredByKeyboardEvent: boolean) => {
+export const initAndShow = (editor: Editor, e: EditorEvent<PointerEvent>, buildMenu: () => string | Array<string | SingleMenuItemSpec>, backstage: UiFactoryBackstage, contextmenu: AlloyComponent, useNodeAnchor: boolean) => {
   const items = buildMenu();
-  const anchorSpec = getAnchorSpec(editor, e, isTriggeredByKeyboardEvent);
+  const anchorSpec = useNodeAnchor ? getNodeAnchor(editor) : getPointAnchor(editor, e);
 
   NestedMenus.build(items, ItemResponse.CLOSE_ON_EXECUTE, backstage, false).map((menuData) => {
     e.preventDefault();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/MobileContextMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/MobileContextMenu.ts
@@ -51,18 +51,15 @@ const isTouchWithinSelection = (editor: Editor, e: EditorEvent<TouchEvent>) => {
   }
 };
 
-const getAnchorSpec = (editor: Editor, isTriggeredByKeyboardEvent: boolean, e: EditorEvent<TouchEvent>) => {
-  const anchorSpec = isTriggeredByKeyboardEvent ? getNodeAnchor(editor) : getPointAnchor(editor, e);
-  return {
-    bubble: Bubble.nu(0, bubbleSize, bubbleAlignments),
-    layouts,
-    overrides: {
-      maxWidthFunction: MaxWidth.expandable(),
-      maxHeightFunction: MaxHeight.expandable()
-    },
-    ...anchorSpec
-  };
-};
+const getPointAnchorSpec = (editor: Editor, e: EditorEvent<TouchEvent>) => ({
+  bubble: Bubble.nu(0, bubbleSize, bubbleAlignments),
+  layouts,
+  overrides: {
+    maxWidthFunction: MaxWidth.expandable(),
+    maxHeightFunction: MaxHeight.expandable()
+  },
+  ...getPointAnchor(editor, e)
+});
 
 const setupiOSOverrides = (editor: Editor) => {
   // iOS will change the selection due to longpress also being a range selection gesture. As such we
@@ -95,8 +92,8 @@ const setupiOSOverrides = (editor: Editor) => {
   };
 };
 
-const show = (editor: Editor, e: EditorEvent<TouchEvent>, items: MenuItems, backstage: UiFactoryBackstage, contextmenu: AlloyComponent, isTriggeredByKeyboardEvent: boolean, highlightImmediately: boolean) => {
-  const anchorSpec = getAnchorSpec(editor, isTriggeredByKeyboardEvent, e);
+const show = (editor: Editor, e: EditorEvent<TouchEvent>, items: MenuItems, backstage: UiFactoryBackstage, contextmenu: AlloyComponent, useNodeAnchor: boolean, highlightImmediately: boolean) => {
+  const anchorSpec = useNodeAnchor ? getNodeAnchor(editor) : getPointAnchorSpec(editor, e);
 
   NestedMenus.build(items, ItemResponse.CLOSE_ON_EXECUTE, backstage, true).map((menuData) => {
     e.preventDefault();
@@ -116,7 +113,7 @@ const show = (editor: Editor, e: EditorEvent<TouchEvent>, items: MenuItems, back
   });
 };
 
-export const initAndShow = (editor: Editor, e: EditorEvent<TouchEvent>, buildMenu: () => MenuItems, backstage: UiFactoryBackstage, contextmenu: AlloyComponent, isTriggeredByKeyboardEvent: boolean): void => {
+export const initAndShow = (editor: Editor, e: EditorEvent<TouchEvent>, buildMenu: () => MenuItems, backstage: UiFactoryBackstage, contextmenu: AlloyComponent, useNodeAnchor: boolean): void => {
   const detection = PlatformDetection.detect();
   const isiOS = detection.os.isiOS();
   const isOSX = detection.os.isOSX();
@@ -127,13 +124,13 @@ export const initAndShow = (editor: Editor, e: EditorEvent<TouchEvent>, buildMen
 
   const open = () => {
     const items = buildMenu();
-    show(editor, e, items, backstage, contextmenu, isTriggeredByKeyboardEvent, shouldHighlightImmediately());
+    show(editor, e, items, backstage, contextmenu, useNodeAnchor, shouldHighlightImmediately());
   };
 
   // On iOS/iPadOS if we've long pressed on a ranged selection then we've already selected the content
   // and just need to open the menu. Otherwise we need to wait for a selection change to occur as long
   // press triggers a ranged selection on iOS.
-  if ((isOSX || isiOS) && !isTriggeredByKeyboardEvent) {
+  if ((isOSX || isiOS) && !useNodeAnchor) {
     const openiOS = () => {
       setupiOSOverrides(editor);
       open();
@@ -148,7 +145,7 @@ export const initAndShow = (editor: Editor, e: EditorEvent<TouchEvent>, buildMen
   } else {
     // On Android editor.selection hasn't updated yet at this point, so need to do it manually
     // Without this longpress causes drag-n-drop duplication of code on Android
-    if (isAndroid && !isTriggeredByKeyboardEvent) {
+    if (isAndroid && !useNodeAnchor) {
       editor.selection.setCursorLocation(e.target, 0);
     }
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuPositionTest.ts
@@ -1,0 +1,38 @@
+import { Log, Pipeline } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import LinkPlugin from 'tinymce/plugins/link/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+import { sAssertContentMenuPosition, sOpenContextMenu } from '../../../module/ContextMenuUtils';
+
+UnitTest.asynctest('browser.tinymce.themes.silver.editor.contextmenu.ContextMenuPositionTest', (success, failure) => {
+  SilverTheme();
+  LinkPlugin();
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+    const tinyUi = TinyUi(editor);
+
+    Pipeline.async({}, [
+      Log.stepsAsStep('TINY-6036', 'Context menu opened on node should open at right click position', [
+        tinyApis.sSetContent('<p>Some <strong>bold</strong> content</p>'),
+        tinyApis.sSetCursor([ 0, 1, 0 ], 0),
+        sOpenContextMenu(tinyUi, editor, 'strong'), // Will trigger from the top right corner of the node
+        sAssertContentMenuPosition(61, -182)
+      ]),
+      Log.stepsAsStep('TINY-6036', 'Context menu opened on "overlap avoid" element should dock to node', [
+        tinyApis.sSetContent('<p>Some <span class="mce-spellchecker-word">invalud</span> word</p>'),
+        tinyApis.sSetCursor([ 0, 1, 0 ], 0),
+        sOpenContextMenu(tinyUi, editor, 'span.mce-spellchecker-word'),
+        sAssertContentMenuPosition(61, -163)
+      ])
+    ], onSuccess, onFailure);
+  }, {
+    theme: 'silver',
+    plugins: 'link',
+    indent: false,
+    height: 200,
+    base_url: '/project/tinymce/js/tinymce',
+    contextmenu_avoid_overlap: '.mce-spellchecker-word'
+  }, success, failure);
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/SilverContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/SilverContextMenuTest.ts
@@ -9,6 +9,7 @@ import ImageToolsPlugin from 'tinymce/plugins/imagetools/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
+import { sOpenContextMenu } from '../../../module/ContextMenuUtils';
 
 UnitTest.asynctest('SilverContextMenuTest', (success, failure) => {
   SilverTheme();
@@ -23,11 +24,6 @@ UnitTest.asynctest('SilverContextMenuTest', (success, failure) => {
 
     const doc = SugarElement.fromDom(document);
     const editorBody = SugarElement.fromDom(editor.getBody());
-
-    const sOpenContextMenu = (target) => Chain.asStep(editor, [
-      tinyUi.cTriggerContextMenu('trigger context menu', target, '.tox-silver-sink .tox-collection [role="menuitem"]'),
-      Chain.wait(0)
-    ]);
 
     // Assert focus is on the expected menu item
     const sAssertFocusOnItem = (label, selector) => FocusTools.sTryOnSelector(`Focus should be on: ${label}`, doc, selector);
@@ -92,7 +88,7 @@ UnitTest.asynctest('SilverContextMenuTest', (success, failure) => {
     Pipeline.async({}, [
       tinyApis.sFocus(),
       Log.stepsAsStep('TBA', 'Test context menus on empty editor', [
-        sOpenContextMenu('p'),
+        sOpenContextMenu(tinyUi, editor, 'p'),
         sAssertFocusOnItem('Link', '.tox-collection__item:contains("Link...")'),
         sPressEnterKey,
         sWaitForAndCloseDialog
@@ -100,7 +96,7 @@ UnitTest.asynctest('SilverContextMenuTest', (success, failure) => {
       Log.stepsAsStep('TBA', 'Test context menus on a link', [
         tinyApis.sSetContent('<p><a href="http://tiny.cloud/">Tiny</a></p>'),
         tinyApis.sSetSelection([ 0, 0, 0 ], 'Ti'.length, [ 0, 0, 0 ], 'Ti'.length),
-        sOpenContextMenu('a'),
+        sOpenContextMenu(tinyUi, editor, 'a'),
         sAssertFocusOnItem('Link', '.tox-collection__item:contains("Link...")'),
         sPressDownArrowKey,
         sAssertFocusOnItem('Remove Link', '.tox-collection__item:contains("Remove link")'),
@@ -110,14 +106,14 @@ UnitTest.asynctest('SilverContextMenuTest', (success, failure) => {
         sAssertFocusOnItem('Link', '.tox-collection__item:contains("Link...")'),
         sPressEnterKey,
         sWaitForAndCloseDialog,
-        sOpenContextMenu('a'),
+        sOpenContextMenu(tinyUi, editor, 'a'),
         sPressDownArrowKey,
         sPressEnterKey,
         sAssertRemoveLinkHtmlStructure
       ]),
       Log.stepsAsStep('TBA', 'Test context menus on a table', [
         tinyApis.sSetContent(tableHtml),
-        sOpenContextMenu('td'),
+        sOpenContextMenu(tinyUi, editor, 'td'),
         sAssertFocusOnItem('Link', '.tox-collection__item:contains("Link...")'),
         sPressDownArrowKey,
         sAssertFocusOnItem('Cell', '.tox-collection__item:contains("Cell")'),
@@ -135,7 +131,7 @@ UnitTest.asynctest('SilverContextMenuTest', (success, failure) => {
       ]),
       Log.stepsAsStep('TBA', 'Test context menus on image inside a table', [
         tinyApis.sSetContent(imageInTableHtml),
-        sOpenContextMenu('img'),
+        sOpenContextMenu(tinyUi, editor, 'img'),
         sAssertFocusOnItem('Link', '.tox-collection__item:contains("Link...")'),
         sPressDownArrowKey,
         sAssertFocusOnItem('Image', '.tox-collection__item:contains("Image")'),
@@ -155,7 +151,7 @@ UnitTest.asynctest('SilverContextMenuTest', (success, failure) => {
         sRepeatDownArrowKey(2),
         sPressEnterKey,
         sWaitForAndCloseDialog,
-        sOpenContextMenu('img'),
+        sOpenContextMenu(tinyUi, editor, 'img'),
         // Navigate to the "Image tools" menu item
         sRepeatDownArrowKey(2),
         sPressEnterKey,
@@ -163,7 +159,7 @@ UnitTest.asynctest('SilverContextMenuTest', (success, failure) => {
       ]),
       Log.stepsAsStep('TBA', 'Test context menus on link inside a table', [
         tinyApis.sSetContent(linkInTableHtml),
-        sOpenContextMenu('a'),
+        sOpenContextMenu(tinyUi, editor, 'a'),
         sAssertFocusOnItem('Link', '.tox-collection__item:contains("Link...")'),
         sPressDownArrowKey,
         sAssertFocusOnItem('Remove Link', '.tox-collection__item:contains("Remove link")'),
@@ -184,7 +180,7 @@ UnitTest.asynctest('SilverContextMenuTest', (success, failure) => {
         // Placeholder images shouldn't show the image/image tools options
         tinyApis.sSetContent(placeholderImageInTableHtml),
         tinyApis.sSelect('img', []),
-        sOpenContextMenu('img'),
+        sOpenContextMenu(tinyUi, editor, 'img'),
         sAssertFocusOnItem('Link', '.tox-collection__item:contains("Link...")'),
         sPressDownArrowKey,
         sAssertFocusOnItem('Cell', '.tox-collection__item:contains("Cell")'),

--- a/modules/tinymce/src/themes/silver/test/ts/module/ContextMenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ContextMenuUtils.ts
@@ -1,0 +1,25 @@
+import { Chain, UiFinder } from '@ephox/agar';
+import { Assert } from '@ephox/bedrock-client';
+import { TinyUi } from '@ephox/mcagar';
+import { Css, SugarBody } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+
+const sOpenContextMenu = (tinyUi: TinyUi, editor: Editor, selector: string) => Chain.asStep(editor, [
+  tinyUi.cTriggerContextMenu('trigger context menu', selector, '.tox-silver-sink .tox-menu.tox-collection [role="menuitem"]'),
+  Chain.wait(0)
+]);
+
+const sAssertContentMenuPosition = (left: number, top: number, diff: number = 3) => Chain.asStep(SugarBody.body(), [
+  UiFinder.cFindIn('.tox-silver-sink .tox-menu.tox-collection'),
+  Chain.op((menu) => {
+    const topStyle = parseInt(Css.getRaw(menu, 'top').getOr('0').replace('px', ''), 10);
+    const leftStyle = parseInt(Css.getRaw(menu, 'left').getOr('0').replace('px', ''), 10);
+    Assert.eq(`Assert context menu top position - ${topStyle}px ~= ${top}px`, true, Math.abs(topStyle - top) <= diff);
+    Assert.eq(`Assert context menu left position - ${leftStyle}px ~= ${left}px`, true, Math.abs(leftStyle - left) <= diff);
+  })
+]);
+
+export {
+  sOpenContextMenu,
+  sAssertContentMenuPosition
+};


### PR DESCRIPTION
Related Ticket: TINY-6036

Description of Changes:
* Adds a new `contextmenu_avoid_overlap` setting that will force the context menu to use "node" anchoring, instead of "point" anchoring for anything that matches the specified selector. This will cause the context menu to appear below the selected node, instead of the exact location of the click (this already happened when activated via the keyboard).

Note: We ideally should add more tests for positioning, however, I was short on time so I've just done the bare minimum for this.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
