### PR TITLE
TINY-6360: Fixed focus issues with inline dialogs when the editor is within a ShadowRoot

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
@@ -1,5 +1,5 @@
 import { Result } from '@ephox/katamari';
-import { Compare, Focus, SugarElement, Traverse, Truncate } from '@ephox/sugar';
+import { Compare, Focus, SugarElement, SugarShadowDom, Truncate } from '@ephox/sugar';
 
 import * as SizzleFind from '../alien/SizzleFind';
 import { Chain } from './Chain';
@@ -20,12 +20,12 @@ const cGetFocused: Chain<SugarElement<any>, SugarElement<any>> =
 const cSetFocused: Chain<SugarElement<any>, SugarElement<any>> =
   Chain.op(Focus.focus);
 
-const cGetOwnerDoc: Chain<SugarElement<Node>, SugarElement<Document>> =
-  Chain.mapper(Traverse.owner);
+const cGetRootNode: Chain<SugarElement<Node>, SugarElement<Document | ShadowRoot>> =
+  Chain.mapper(SugarShadowDom.getRootNode);
 
 const sIsOn = <T>(label: string, element: SugarElement<any>): Step<T, T> =>
   Chain.asStep<T, SugarElement>(element, [
-    cGetOwnerDoc,
+    cGetRootNode,
     cGetFocused,
     Chain.binder((active: SugarElement<any>): Result<SugarElement, string> =>
       Compare.eq(element, active) ? Result.value(active) : Result.error(
@@ -68,7 +68,7 @@ const cSetFocus = (label: string, selector: string): Chain<SugarElement, SugarEl
 const cSetActiveValue = (newValue: string): Chain<SugarElement, SugarElement> =>
   // Input: container
   Chain.fromChains([
-    cGetOwnerDoc,
+    cGetRootNode,
     cGetFocused,
     UiControls.cSetValue(newValue)
   ]);
@@ -76,7 +76,7 @@ const cSetActiveValue = (newValue: string): Chain<SugarElement, SugarElement> =>
 // Input: container
 const cGetActiveValue: Chain<SugarElement, string> =
   Chain.fromChains([
-    cGetOwnerDoc,
+    cGetRootNode,
     cGetFocused,
     UiControls.cGetValue
   ]);

--- a/modules/agar/src/test/ts/browser/FocusToolsTest.ts
+++ b/modules/agar/src/test/ts/browser/FocusToolsTest.ts
@@ -1,104 +1,116 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { SugarElement, Value } from '@ephox/sugar';
+import { SugarElement, SugarShadowDom, Value } from '@ephox/sugar';
 import * as Assertions from 'ephox/agar/api/Assertions';
 import { Chain } from 'ephox/agar/api/Chain';
 import * as FocusTools from 'ephox/agar/api/FocusTools';
+import * as GeneralSteps from 'ephox/agar/api/GeneralSteps';
 import * as Guard from 'ephox/agar/api/Guard';
+import * as Log from 'ephox/agar/api/Log';
 import { Pipeline } from 'ephox/agar/api/Pipeline';
 import { Step } from 'ephox/agar/api/Step';
 import * as DomContainers from 'ephox/agar/test/DomContainers';
 
 UnitTest.asynctest('FocusToolsTest', (success, failure) => {
 
+  const sTestFocusTools = (doc: SugarElement, docNode: SugarElement) =>
+    GeneralSteps.sequence([
+      FocusTools.sSetFocus('Focusing div', docNode, 'div[test-id]'),
+      FocusTools.sIsOnSelector('Should be on div[test-id]', doc, 'div[test-id]'),
+      FocusTools.sSetFocus('Focusing input', docNode, 'div[test-id] input'),
+      FocusTools.sIsOnSelector('Should be on div[test-id] input', doc, 'div[test-id] input'),
+      FocusTools.sSetActiveValue(doc, 'new value'),
+
+      Chain.asStep(doc, [
+        FocusTools.cGetFocused,
+        Chain.control(
+          Chain.on((active, next, die, logs) => {
+            Assert.eq('Should be expected value', 'new value', Value.get(active));
+            next(active, logs);
+          }),
+          Guard.addLogging('Asserting the value of the input field after it has been set.')
+        )
+      ]),
+      Step.raw((state, next, die, logs) => {
+        FocusTools.sIsOn('checking that sIsOn works', state.input).runStep(state, next, die, logs);
+      }),
+      FocusTools.sTryOnSelector(
+        'Should be on div[test-id] input',
+        doc,
+        'div[test-id] input'
+      ),
+      FocusTools.sSetFocus('Focusing div again', docNode, 'div[test-id]'),
+      FocusTools.sIsOnSelector('Should be on div again', doc, 'div[test-id]'),
+
+      // Check that try until not is working for sIsOn, sIsOnSelector and sTryOnSelector
+      Step.control(
+        FocusTools.sIsOn('tryUntilNotCheck (sIsOn)', SugarElement.fromTag('span')),
+        Guard.tryUntilNot(
+          'Focus should not be on something that is not in the DOM'
+        )
+      ),
+
+      Step.control(
+        FocusTools.sIsOnSelector('tryUntilNotCheck (sIsOnSelector)', doc, '.not-really-there'),
+        Guard.tryUntilNot(
+          'Focus should not be on something that is not there'
+        )
+      ),
+
+      Step.control(
+        FocusTools.sTryOnSelector('tryUntilNotCheck (sTryOnSelector)', doc, '.not-really-there'),
+        Guard.tryUntilNot(
+          'Focus should not be on something that is not there'
+        )
+      ),
+
+      // TODO: Need to get rid of this boilerplate
+      Step.raw((value, next, die, logs) => {
+        Chain.asStep(value.container, [
+          FocusTools.cSetFocus('Setting focus via chains on the input', 'input')
+        ]).runStep(value, next, die, logs);
+      }),
+      FocusTools.sIsOnSelector('Should now be on input again', doc, 'input'),
+
+      Step.raw((value, next, die, logs) => {
+        Chain.asStep(value.container, [
+          FocusTools.cSetActiveValue('chained.value')
+        ]).runStep(value, next, die, logs);
+      }),
+
+      Step.raw((value, next, die, logs) => {
+        Chain.asStep(value.container, [
+          FocusTools.cGetActiveValue,
+          Assertions.cAssertEq('Checking the value of input after set by chaining APIs', 'chained.value')
+        ]).runStep(value, next, die, logs);
+      }),
+
+      Step.raw((value, next, die, logs) => {
+        Chain.asStep(doc, [
+          FocusTools.cGetFocused,
+          Assertions.cAssertDomEq('Checking that focused element is the input', value.input)
+        ]).runStep(value, next, die, logs);
+      })
+    ]);
+
   const doc = SugarElement.fromDom(document);
   const docNode = SugarElement.fromDom(document.documentElement);
 
   Pipeline.async({}, [
-    DomContainers.mSetup,
-    Step.log('cat1'),
-    FocusTools.sSetFocus('Focusing body', docNode, 'body'),
-
-    Step.log('cat2'),
-    FocusTools.sIsOnSelector('Should be on body', doc, 'body'),
-    FocusTools.sSetFocus('Focusing div', docNode, 'div[test-id]'),
-    FocusTools.sIsOnSelector('Should be on div[test-id]', doc, 'div[test-id]'),
-    FocusTools.sSetFocus('Focusing input', docNode, 'div[test-id] input'),
-    FocusTools.sIsOnSelector('Should be on div[test-id] input', doc, 'div[test-id] input'),
-    FocusTools.sSetActiveValue(doc, 'new value'),
-
-    Chain.asStep(doc, [
-      FocusTools.cGetFocused,
-      Chain.control(
-        Chain.on((active, next, die, logs) => {
-          Assert.eq('Should be expected value', 'new value', Value.get(active));
-          next(active, logs);
-        }),
-        Guard.addLogging('Asserting the value of the input field after it has been set.')
-      )
+    Log.stepsAsStep('TBA', 'Within Document', [
+      DomContainers.mSetup,
+      FocusTools.sSetFocus('Focusing body', docNode, 'body'),
+      FocusTools.sIsOnSelector('Should be on body', doc, 'body'),
+      sTestFocusTools(doc, docNode),
+      DomContainers.mTeardown
     ]),
-    Step.raw((state, next, die, logs) => {
-      FocusTools.sIsOn('checking that sIsOn works', state.input).runStep(state, next, die, logs);
-    }),
-    FocusTools.sTryOnSelector(
-      'Should be on div[test-id] input',
-      doc,
-      'div[test-id] input'
-    ),
-    FocusTools.sSetFocus('Focusing div again', docNode, 'div[test-id]'),
-    FocusTools.sIsOnSelector('Should be on div again', doc, 'div[test-id]'),
 
-    // Check that try until not is working for sIsOn, sIsOnSelector and sTryOnSelector
-    Step.control(
-      FocusTools.sIsOn('tryUntilNotCheck (sIsOn)', SugarElement.fromTag('span')),
-      Guard.tryUntilNot(
-        'Focus should not be on something that is not in the DOM'
-      )
-    ),
-
-    Step.control(
-      FocusTools.sIsOnSelector('tryUntilNotCheck (sIsOnSelector)', doc, '.not-really-there'),
-      Guard.tryUntilNot(
-        'Focus should not be on something that is not there'
-      )
-    ),
-
-    Step.control(
-      FocusTools.sTryOnSelector('tryUntilNotCheck (sTryOnSelector)', doc, '.not-really-there'),
-      Guard.tryUntilNot(
-        'Focus should not be on something that is not there'
-      )
-    ),
-
-    // TODO: Need to get rid of this boilerplate
-    Step.raw((value, next, die, logs) => {
-      Chain.asStep(value.container, [
-        FocusTools.cSetFocus('Setting focus via chains on the input', 'input')
-      ]).runStep(value, next, die, logs);
-    }),
-    FocusTools.sIsOnSelector('Should now be on input again', doc, 'input'),
-
-    Step.raw((value, next, die, logs) => {
-      Chain.asStep(value.container, [
-        FocusTools.cSetActiveValue('chained.value')
-      ]).runStep(value, next, die, logs);
-    }),
-
-    Step.raw((value, next, die, logs) => {
-      Chain.asStep(value.container, [
-        FocusTools.cGetActiveValue,
-        Assertions.cAssertEq('Checking the value of input after set by chaining APIs', 'chained.value')
-      ]).runStep(value, next, die, logs);
-    }),
-
-    Step.raw((value, next, die, logs) => {
-      Chain.asStep(doc, [
-        FocusTools.cGetFocused,
-        Assertions.cAssertDomEq('Checking that focused element is the input', value.input)
-      ]).runStep(value, next, die, logs);
-    }),
-
-    DomContainers.mTeardown
-
+    SugarShadowDom.isSupported() ? Log.stepsAsStep('TINY-6360', 'Within ShadowRoot', [
+      DomContainers.mSetupShadowRoot,
+      Step.raw((state, next, die, logs) => {
+        sTestFocusTools(state.shadowRoot, state.shadowRoot).runStep(state, next, die, logs);
+      }),
+      DomContainers.mTeardown
+    ]) : Step.pass
   ], (_, _logs) => {
     success();
   }, failure);

--- a/modules/agar/src/test/ts/browser/FocusToolsTest.ts
+++ b/modules/agar/src/test/ts/browser/FocusToolsTest.ts
@@ -23,9 +23,8 @@ UnitTest.asynctest('FocusToolsTest', (success, failure) => {
       Chain.asStep(doc, [
         FocusTools.cGetFocused,
         Chain.control(
-          Chain.on((active, next, die, logs) => {
+          Chain.op((active) => {
             Assert.eq('Should be expected value', 'new value', Value.get(active));
-            next(active, logs);
           }),
           Guard.addLogging('Asserting the value of the input field after it has been set.')
         )

--- a/modules/agar/src/test/ts/module/ephox/agar/test/DomContainers.ts
+++ b/modules/agar/src/test/ts/module/ephox/agar/test/DomContainers.ts
@@ -1,7 +1,7 @@
-import { Attribute, Insert, Remove, SugarElement } from '@ephox/sugar';
+import { Attribute, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { Step } from 'ephox/agar/api/Step';
 
-const mSetup = Step.stateful((state, next, _die) => {
+const createContainer = () => {
   const container = SugarElement.fromTag('div');
   Attribute.set(container, 'tabindex', '-1');
   Attribute.set(container, 'test-id', 'true');
@@ -9,10 +9,33 @@ const mSetup = Step.stateful((state, next, _die) => {
   const input = SugarElement.fromTag('input');
   Insert.append(container, input);
 
-  Insert.append(SugarElement.fromDom(document.body), container);
+  return {
+    container,
+    input
+  };
+};
+
+const mSetup = Step.stateful((state, next, _die) => {
+  const { container, input } = createContainer();
+  Insert.append(SugarBody.body(), container);
   next({
     container,
     input
+  });
+});
+
+const mSetupShadowRoot = Step.stateful((state, next, _die) => {
+  const { container, input } = createContainer();
+
+  const shadowHost = SugarElement.fromTag('div');
+  const shadowRoot = SugarElement.fromDom(shadowHost.dom.attachShadow({ mode: 'open' }));
+  Insert.append(shadowRoot, container);
+
+  Insert.append(SugarBody.body(), shadowHost);
+  next({
+    container,
+    input,
+    shadowRoot
   });
 });
 
@@ -27,5 +50,6 @@ const mTeardown = Step.stateful<TeardownState, TeardownState>((state, next, _die
 
 export {
   mSetup,
+  mSetupShadowRoot,
   mTeardown
 };

--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Changed some public APIs (eg Components, Custom Events) to no longer be thunked.
 
+### Fixed
+- Fixed `AriaOwner` not able to find the owner component when rendered within a ShadowRoot.
+- Fixed `AriaFocus` not preserving focus when the component is rendered within a ShadowRoot.
+
 # [7.0.2] - 2020-05-25
 
 ### Fixed

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaFocus.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaFocus.ts
@@ -1,10 +1,10 @@
 import { Fun, Optional } from '@ephox/katamari';
-import { Compare, Focus, PredicateFind, SugarElement, Traverse } from '@ephox/sugar';
+import { Compare, Focus, PredicateFind, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 const preserve = <T>(f: (e: SugarElement) => T, container: SugarElement): T => {
-  const ownerDoc = Traverse.owner(container);
+  const dos = SugarShadowDom.getRootNode(container);
 
-  const refocus = Focus.active(ownerDoc).bind((focused: SugarElement) => {
+  const refocus = Focus.active(dos).bind((focused: SugarElement) => {
     const hasFocus = (elem: SugarElement) => Compare.eq(focused, elem);
     return hasFocus(container) ? Optional.some(container) : PredicateFind.descendant(container, hasFocus);
   });
@@ -13,7 +13,7 @@ const preserve = <T>(f: (e: SugarElement) => T, container: SugarElement): T => {
 
   // If there is a focussed element, the F function may cause focus to be lost (such as by hiding elements). Restore it afterwards.
   refocus.each((oldFocus: SugarElement) => {
-    Focus.active(ownerDoc).filter((newFocus) => Compare.eq(newFocus, oldFocus)).fold(() => {
+    Focus.active(dos).filter((newFocus) => Compare.eq(newFocus, oldFocus)).fold(() => {
       // Only refocus if the focus has changed, otherwise we break IE
       Focus.focus(oldFocus);
     }, Fun.noop);

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaOwner.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaOwner.ts
@@ -1,5 +1,5 @@
 import { Id, Optional } from '@ephox/katamari';
-import { Attribute, PredicateFind, SelectorFind, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import { Attribute, PredicateFind, SelectorFind, SugarElement, SugarNode, SugarShadowDom } from '@ephox/sugar';
 
 const find = (queryElem: SugarElement): Optional<SugarElement> => {
   const dependent: Optional<SugarElement> = PredicateFind.closest(queryElem, (elem) => {
@@ -12,9 +12,9 @@ const find = (queryElem: SugarElement): Optional<SugarElement> => {
 
   return dependent.bind((dep) => {
     const id = Attribute.get(dep, 'id');
-    const doc = Traverse.owner(dep);
+    const dos = SugarShadowDom.getRootNode(dep);
 
-    return SelectorFind.descendant(doc, '[aria-owns="' + id + '"]');
+    return SelectorFind.descendant(dos, '[aria-owns="' + id + '"]');
   });
 };
 

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -18,6 +18,7 @@ Version 5.5.0 (TBD)
     Fixed loss of whitespace when inserting content after a non-breaking space #TINY-5966
     Fixed the `event.getComposedPath()` function on events fired from TinyMCE. This was throwing an exception, but now works as expected. #TINY-6128
     Fixed notifications not appearing when the editor is within a ShadowRoot #TINY-6354
+    Fixed focus issues with inline dialogs when the editor is within a ShadowRoot #TINY-6360
     Fixed the `template` plugin previews missing some content styles #TINY-6115
     Fixed the `media` plugin not saving the alternative source url in some situations #TINY-4113
     Fixed an issue where column resizing using the resize bars was inconsistent between fixed and relative table widths #TINY-6001

--- a/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
@@ -11,6 +11,7 @@ export default function (init: ShadowRootInit) {
   shadow.appendChild(node);
 
   tinymce.init({
-    target: node
+    target: node,
+    plugins: ' advlist charmap code codesample emoticons image link lists media paste preview searchreplace table wordcount'
   });
 }

--- a/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
@@ -12,6 +12,6 @@ export default function (init: ShadowRootInit) {
 
   tinymce.init({
     target: node,
-    plugins: ' advlist charmap code codesample emoticons image link lists media paste preview searchreplace table wordcount'
+    plugins: 'advlist charmap code codesample emoticons image link lists media paste preview searchreplace table wordcount'
   });
 }

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
@@ -13,7 +13,7 @@ UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplaceDialogTes
   SearchreplacePlugin();
   const browser = PlatformDetection.detect().browser;
 
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+  TinyLoader.setupInBodyAndShadowRoot((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
     const tinyUi = TinyUi(editor);
 
@@ -92,6 +92,7 @@ UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplaceDialogTes
     ], onSuccess, onFailure);
   }, {
     plugins: 'searchreplace',
+    menubar: false,
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
     theme: 'silver'

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, Bubble, HotspotAnchorSpec, Layout, LayoutInside, MaxHeight, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
-import { SimSelection, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { SimSelection, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import { useFixedContainer } from '../api/Settings';
 
@@ -23,7 +23,7 @@ const getInlineDialogAnchor = (contentAreaElement: () => SugarElement, lazyAncho
 
   const editableAreaAnchor = (): NodeAnchorSpec => ({
     anchor: 'node',
-    root: SugarBody.getBody(Traverse.owner(contentAreaElement())),
+    root: SugarShadowDom.getContentContainer(contentAreaElement()),
     node: Optional.from(contentAreaElement()),
     bubble,
     layouts: {
@@ -50,7 +50,7 @@ const getInlineDialogAnchor = (contentAreaElement: () => SugarElement, lazyAncho
 const getBannerAnchor = (contentAreaElement: () => SugarElement, lazyAnchorbar: () => AlloyComponent, lazyUseEditableAreaAnchor: () => boolean): () => HotspotAnchorSpec | NodeAnchorSpec => {
   const editableAreaAnchor = (): NodeAnchorSpec => ({
     anchor: 'node',
-    root: SugarBody.getBody(Traverse.owner(contentAreaElement())),
+    root: SugarShadowDom.getContentContainer(contentAreaElement()),
     node: Optional.from(contentAreaElement()),
     layouts: {
       onRtl: () => [ LayoutInside.north ],

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
@@ -8,7 +8,7 @@
 import { AlloyComponent, AlloyEvents, AlloyTriggers, CustomEvent, Keying, NativeEvents, Reflecting, Representing } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Result } from '@ephox/katamari';
-import { Attribute, Compare, Focus, SugarElement } from '@ephox/sugar';
+import { Attribute, Compare, Focus, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import {
   formActionEvent, FormActionEvent, formBlockEvent, FormBlockEvent, formCancelEvent, FormCancelEvent, FormChangeEvent, formChangeEvent,
@@ -91,11 +91,12 @@ const initDialog = <T>(getInstanceApi: () => Dialog.DialogInstanceApi<T>, extras
     fireApiEvent<FormActionEvent>(formActionEvent, (api, spec, event, component) => {
       const focusIn = () => Keying.focusIn(component);
       const isDisabled = (focused: SugarElement<HTMLElement>) => Attribute.has(focused, 'disabled') || Attribute.getOpt(focused, 'aria-disabled').exists((val) => val === 'true');
-      const current = Focus.active();
+      const rootNode = SugarShadowDom.getRootNode(component.element);
+      const current = Focus.active(rootNode);
 
       spec.onAction(api, { name: event.name, value: event.value });
 
-      Focus.active().fold(focusIn, (focused) => {
+      Focus.active(rootNode).fold(focusIn, (focused) => {
         // We need to check if the focused element is disabled because apparently firefox likes to leave focus on disabled elements.
         if (isDisabled(focused)) {
           focusIn();


### PR DESCRIPTION
Related Ticket: TINY-6360

Description of Changes:
Fixed the search and replace dialog closing and having focus issues when rendered within a ShadowRoot. The primary cause was there were a few places trying to look up the `activeElement` on the root document, not the shadow root.

Note: I also fixed the Agar FocusTools not working when the passed element was in a ShadowRoot.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
