### PR TITLE
Make endCommentRegexp sticky to fix parsing of comments with mismatching sequence

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -160,7 +160,7 @@ const findCommentEndIndex = (html: string, isBogus: boolean, startIndex: number 
       const endIndex = lcHtml.indexOf('>', startIndex);
       return endIndex !== -1 ? endIndex : lcHtml.length;
     } else {
-      const endCommentRegexp = /--!?>/;
+      const endCommentRegexp = /--!?>/y;
       endCommentRegexp.lastIndex = startIndex;
       const match = endCommentRegexp.exec(html);
       return match ? match.index + match[0].length : lcHtml.length;

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -160,10 +160,10 @@ const findCommentEndIndex = (html: string, isBogus: boolean, startIndex: number 
       const endIndex = lcHtml.indexOf('>', startIndex);
       return endIndex !== -1 ? endIndex : lcHtml.length;
     } else {
-      const endCommentRegexp = /--!?>/y;
+      const endCommentRegexp = /--!?>/;
       endCommentRegexp.lastIndex = startIndex;
       const match = endCommentRegexp.exec(html);
-      return match ? match.index + match[0].length : lcHtml.length;
+      return (match && endCommentRegexp.lastIndex > startIndex) ? match.index + match[0].length : lcHtml.length;
     }
   }
 };

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -514,6 +514,13 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', function (success,
     parser.parse('<! value --!>');
     LegacyUnit.equal(writer.getContent(), '<!-- value --!-->', 'Parse comment with exclamation and missing hyphens.');
     LegacyUnit.deepEqual(counter.counts, { comment: 1 }, 'Parse comment with exclamation and missing hyphens counts.');
+
+    counter = createCounter(writer);
+    parser = SaxParser(counter, schema);
+    writer.reset();
+    parser.parse('<!-- value -->\n<!-- value');
+    LegacyUnit.equal(writer.getContent(), '<!-- value -->\n<!-- value-->', 'Parse comment with mismatching end sequence.');
+    LegacyUnit.deepEqual(counter.counts, { comment: 2, text: 1 }, 'Parse comment with mismatching end sequence counts.');
   });
 
   suite.test('Parse PI', function () {


### PR DESCRIPTION

Related Ticket:

Description of Changes:
* Make endCommentRegexp sticky so that the parser doesn't look for a matching end-comment before the malformed comment

Pre-checks:
* [ ] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
#6014 
