### PR TITLE
TINY-4847: Add new toolbar_persist setting

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,8 +7,8 @@ Version 5.5.0 (TBD)
     Added the ability to delete and navigate HTML media elements without the media plugin #TINY-4211
     Added `fullscreen_native` setting to the fullscreen plugin to enable use of the entire monitor #TINY-6284
     Added table related oxide variables to the Style API for more granular control over table cell selection appearance #TINY-6311
-    Added new `toolbar_persist` setting to control the visibility of the inline toolbar.
-    Added new APIs to allow for programmatic control of the inline toolbar visibility.
+    Added new `toolbar_persist` setting to control the visibility of the inline toolbar. #TINY-4847
+    Added new APIs to allow for programmatic control of the inline toolbar visibility. #TINY-4847
     Added the `origin` property to the `ObjectResized` and `ObjectResizeStart` events, to specify which handle the resize was preformed on #TINY-6242
     Added new StyleSheetLoader `unload` and `unloadAll` APIs to allow loaded stylesheets to be removed #TINY-3926
     Added a new `contextmenu_avoid_overlap` setting to allow contextmenus to avoid overlapping matched nodes #TINY-6036

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,6 +7,8 @@ Version 5.5.0 (TBD)
     Added the ability to delete and navigate HTML media elements without the media plugin #TINY-4211
     Added `fullscreen_native` setting to the fullscreen plugin to enable use of the entire monitor #TINY-6284
     Added table related oxide variables to the Style API for more granular control over table cell selection appearance #TINY-6311
+    Added new `toolbar_persist` setting to control the visibility of the inline toolbar.
+    Added new APIs to allow for programmatic control of the inline toolbar visibility.
     Added the `origin` property to the `ObjectResized` and `ObjectResizeStart` events, to specify which handle the resize was preformed on #TINY-6242
     Added new StyleSheetLoader `unload` and `unloadAll` APIs to allow loaded stylesheets to be removed #TINY-3926
     Added a new `contextmenu_avoid_overlap` setting to allow contextmenus to avoid overlapping matched nodes #TINY-6036

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Registry } from '@ephox/bridge';
 import { Arr, Fun } from '@ephox/katamari';
 import * as EditorContent from '../content/EditorContent';
 import * as NodeType from '../dom/NodeType';
@@ -25,7 +24,6 @@ import DOMUtils from './dom/DOMUtils';
 import ScriptLoader from './dom/ScriptLoader';
 import EditorSelection from './dom/Selection';
 import DomSerializer from './dom/Serializer';
-import { StyleSheetLoader } from './dom/StyleSheetLoader';
 import EditorCommands, { EditorCommandCallback } from './EditorCommands';
 import EditorManager from './EditorManager';
 import EditorObservable from './EditorObservable';
@@ -48,6 +46,7 @@ import I18n, { TranslatedString, Untranslated } from './util/I18n';
 import Tools from './util/Tools';
 import URI from './util/URI';
 import WindowManager from './WindowManager';
+import { EditorUi } from './ui/Ui';
 
 /**
  * This class contains the core logic for a TinyMCE editor.
@@ -68,17 +67,6 @@ import WindowManager from './WindowManager';
  *
  * ed.render();
  */
-
-export interface EditorUiApi {
-  show: () => void;
-  hide: () => void;
-}
-
-export interface EditorUi extends EditorUiApi {
-  registry: Registry.Registry;
-  /** StyleSheetLoader for styles in the editor UI. For content styles, use editor.dom.styleSheetLoader. */
-  styleSheetLoader: StyleSheetLoader;
-}
 
 export interface EditorConstructor {
   readonly prototype: Editor;

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -6,7 +6,7 @@
  */
 
 import { Registry } from '@ephox/bridge';
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import * as EditorContent from '../content/EditorContent';
 import * as NodeType from '../dom/NodeType';
 import * as EditorRemove from '../EditorRemove';
@@ -69,7 +69,12 @@ import WindowManager from './WindowManager';
  * ed.render();
  */
 
-export interface EditorUi {
+export interface EditorUiApi {
+  show: () => void;
+  hide: () => void;
+}
+
+export interface EditorUi extends EditorUiApi {
   registry: Registry.Registry;
   /** StyleSheetLoader for styles in the editor UI. For content styles, use editor.dom.styleSheetLoader. */
   styleSheetLoader: StyleSheetLoader;
@@ -334,7 +339,9 @@ class Editor implements EditorObservable {
 
     this.ui = {
       registry: registry(),
-      styleSheetLoader: undefined
+      styleSheetLoader: undefined,
+      show: Fun.noop,
+      hide: Fun.noop
     };
 
     const self = this;

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -6,7 +6,7 @@
  */
 
 import { UploadHandler } from '../file/Uploader';
-import Editor from './Editor';
+import Editor, { EditorUiApi } from './Editor';
 import { Formats } from './fmt/Format';
 import { AllowedFormat } from './fmt/StyleFormat';
 import { SchemaType } from './html/Schema';
@@ -18,6 +18,7 @@ export type ThemeInitFunc = (editor: Editor, elm: HTMLElement) => {
   iframeContainer: HTMLElement;
   height?: number;
   iframeHeight?: number;
+  api?: EditorUiApi;
 };
 
 export type SetupCallback = (editor: Editor) => void;

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -6,10 +6,11 @@
  */
 
 import { UploadHandler } from '../file/Uploader';
-import Editor, { EditorUiApi } from './Editor';
+import Editor from './Editor';
 import { Formats } from './fmt/Format';
 import { AllowedFormat } from './fmt/StyleFormat';
 import { SchemaType } from './html/Schema';
+import { EditorUiApi } from './ui/Ui';
 
 export type EntityEncoding = 'named' | 'numeric' | 'raw';
 

--- a/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
@@ -7,7 +7,7 @@
 
 import AddOnManager from './AddOnManager';
 import { DomQueryConstructor } from './dom/DomQuery';
-import Editor from './Editor';
+import Editor, { EditorUiApi } from './Editor';
 import { NotificationManagerImpl } from './NotificationManager';
 import { WindowManagerImpl } from './WindowManager';
 
@@ -17,7 +17,7 @@ export type Theme = {
   execCommand? (command: string, ui?: boolean, value?: any): boolean;
   destroy? (): void;
   init? (editor: Editor, url: string, $: DomQueryConstructor);
-  renderUI? (): { iframeContainer?: HTMLIFrameElement; editorContainer: HTMLElement };
+  renderUI? (): { iframeContainer?: HTMLIFrameElement; editorContainer: HTMLElement; api?: EditorUiApi };
   getNotificationManagerImpl? (): NotificationManagerImpl;
   getWindowManagerImpl? (): WindowManagerImpl;
 };

--- a/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
@@ -7,9 +7,10 @@
 
 import AddOnManager from './AddOnManager';
 import { DomQueryConstructor } from './dom/DomQuery';
-import Editor, { EditorUiApi } from './Editor';
+import Editor from './Editor';
 import { NotificationManagerImpl } from './NotificationManager';
 import { WindowManagerImpl } from './WindowManager';
+import { EditorUiApi } from './ui/Ui';
 
 export type Theme = {
   ui?: any;

--- a/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
@@ -13,6 +13,7 @@ import { WindowManagerImpl } from './WindowManager';
 
 export type Theme = {
   ui?: any;
+  inline?: any;
   execCommand? (command: string, ui?: boolean, value?: any): boolean;
   destroy? (): void;
   init? (editor: Editor, url: string, $: DomQueryConstructor);

--- a/modules/tinymce/src/core/main/ts/api/ui/Ui.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Ui.ts
@@ -9,8 +9,20 @@ import {
   PublicDialog as Dialog, PublicInlineContent as InlineContent, PublicMenu as Menu, PublicSidebar as Sidebar, PublicToolbar as Toolbar,
   Registry as BridgeRegistry
 } from '@ephox/bridge';
+import { StyleSheetLoader } from '../dom/StyleSheetLoader';
 
 type Registry = BridgeRegistry.Registry;
+
+export interface EditorUiApi {
+  show: () => void;
+  hide: () => void;
+}
+
+export interface EditorUi extends EditorUiApi {
+  registry: Registry;
+  /** StyleSheetLoader for styles in the editor UI. For content styles, use editor.dom.styleSheetLoader. */
+  styleSheetLoader: StyleSheetLoader;
+}
 
 export {
   Registry,

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -124,7 +124,8 @@ const renderFromThemeFunc = function (editor: Editor) {
 const createThemeFalseResult = function (element: HTMLElement) {
   return {
     editorContainer: element,
-    iframeContainer: element
+    iframeContainer: element,
+    api: {}
   };
 };
 
@@ -161,7 +162,12 @@ const init = function (editor: Editor) {
   initIcons(editor);
   initTheme(editor);
   initPlugins(editor);
-  const boxInfo = renderThemeUi(editor);
+  const renderInfo = renderThemeUi(editor);
+  editor.ui = { ...editor.ui, ...renderInfo.api };
+  const boxInfo = {
+    editorContainer: renderInfo.editorContainer,
+    iframeContainer: renderInfo.iframeContainer
+  };
   editor.editorContainer = boxInfo.editorContainer ? boxInfo.editorContainer : null;
   appendContentCssFromSettings(editor);
 

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -9,7 +9,7 @@ import { AlloyComponent, AlloySpec, Behaviour, Gui, GuiFactory, Keying, Memento,
 import { Arr, Obj, Optional, Result } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Css } from '@ephox/sugar';
-import Editor from 'tinymce/core/api/Editor';
+import Editor, { EditorUiApi } from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import * as Settings from './api/Settings';
 import * as Backstage from './backstage/Backstage';
@@ -35,12 +35,12 @@ export interface RenderInfo {
   backstage: Backstage.UiFactoryBackstage;
   renderUI: () => ModeRenderInfo;
   getUi: () => ({ channels: UiChannels });
-  inline: Inline.InlineApi;
 }
 
 export interface ModeRenderInfo {
   iframeContainer?: HTMLIFrameElement;
   editorContainer: HTMLElement;
+  api?: EditorUiApi;
 }
 
 export interface UiChannels {
@@ -395,9 +395,7 @@ const setup = (editor: Editor): RenderInfo => {
     return mode.render(editor, uiComponents, rawUiConfig, backstage, args);
   };
 
-  const inline = Inline.getApi(editor);
-
-  return { mothership, uiMothership, backstage, renderUI, getUi, inline };
+  return { mothership, uiMothership, backstage, renderUI, getUi };
 };
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -35,6 +35,7 @@ export interface RenderInfo {
   backstage: Backstage.UiFactoryBackstage;
   renderUI: () => ModeRenderInfo;
   getUi: () => ({ channels: UiChannels });
+  inline: Inline.InlineApi;
 }
 
 export interface ModeRenderInfo {
@@ -394,7 +395,9 @@ const setup = (editor: Editor): RenderInfo => {
     return mode.render(editor, uiComponents, rawUiConfig, backstage, args);
   };
 
-  return { mothership, uiMothership, backstage, renderUI, getUi };
+  const inline = Inline.getApi(editor);
+
+  return { mothership, uiMothership, backstage, renderUI, getUi, inline };
 };
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -9,8 +9,9 @@ import { AlloyComponent, AlloySpec, Behaviour, Gui, GuiFactory, Keying, Memento,
 import { Arr, Obj, Optional, Result } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Css } from '@ephox/sugar';
-import Editor, { EditorUiApi } from 'tinymce/core/api/Editor';
+import Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
+import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 import * as Settings from './api/Settings';
 import * as Backstage from './backstage/Backstage';
 import * as ContextToolbar from './ContextToolbar';

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -16,7 +16,7 @@ type RenderInfo = Render.RenderInfo;
 
 export default function () {
   ThemeManager.add('silver', (editor): Theme => {
-    const { uiMothership, backstage, renderUI, getUi, inline }: RenderInfo = Render.setup(editor);
+    const { uiMothership, backstage, renderUI, getUi }: RenderInfo = Render.setup(editor);
 
     Autocompleter.register(editor, backstage.shared);
 
@@ -27,8 +27,7 @@ export default function () {
       getWindowManagerImpl: Fun.constant(windowMgr),
       getNotificationManagerImpl: () => NotificationManagerImpl(editor, { backstage }, uiMothership),
       // TODO: move to editor.ui namespace
-      ui: getUi(),
-      inline
+      ui: getUi()
     };
   });
 }

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -16,7 +16,7 @@ type RenderInfo = Render.RenderInfo;
 
 export default function () {
   ThemeManager.add('silver', (editor): Theme => {
-    const { uiMothership, backstage, renderUI, getUi }: RenderInfo = Render.setup(editor);
+    const { uiMothership, backstage, renderUI, getUi, inline }: RenderInfo = Render.setup(editor);
 
     Autocompleter.register(editor, backstage.shared);
 
@@ -27,7 +27,8 @@ export default function () {
       getWindowManagerImpl: Fun.constant(windowMgr),
       getNotificationManagerImpl: () => NotificationManagerImpl(editor, { backstage }, uiMothership),
       // TODO: move to editor.ui namespace
-      ui: getUi()
+      ui: getUi(),
+      inline
     };
   });
 }

--- a/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
@@ -99,6 +99,8 @@ const isToolbarLocationBottom = (editor: Editor) => getToolbarLocation(editor) =
 
 const fixedContainerSelector = (editor): string => editor.getParam('fixed_toolbar_container', '', 'string');
 
+const isToolbarPersist = (editor): string => editor.getParam('toolbar_persist', false, 'boolean');
+
 const fixedContainerElement = (editor): Optional<SugarElement> => {
   const selector = fixedContainerSelector(editor);
   // If we have a valid selector and are in inline mode, try to get the fixed_toolbar_container
@@ -176,6 +178,7 @@ export {
   isMenubarEnabled,
   isMultipleToolbars,
   isToolbarEnabled,
+  isToolbarPersist,
   getMultipleToolbarsSetting,
   getUiContainer,
   useFixedContainer,

--- a/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
@@ -99,7 +99,7 @@ const isToolbarLocationBottom = (editor: Editor) => getToolbarLocation(editor) =
 
 const fixedContainerSelector = (editor): string => editor.getParam('fixed_toolbar_container', '', 'string');
 
-const isToolbarPersist = (editor): string => editor.getParam('toolbar_persist', false, 'boolean');
+const isToolbarPersist = (editor): boolean => editor.getParam('toolbar_persist', false, 'boolean');
 
 const fixedContainerElement = (editor): Optional<SugarElement> => {
   const selector = fixedContainerSelector(editor);

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -8,8 +8,9 @@
 import { AlloyComponent, Attachment, Boxes } from '@ephox/alloy';
 import { Cell, Singleton } from '@ephox/katamari';
 import { DomEvent, SugarElement } from '@ephox/sugar';
-import Editor, { EditorUiApi } from 'tinymce/core/api/Editor';
+import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
+import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 import * as Events from '../api/Events';
 import { getUiContainer, isToolbarPersist } from '../api/Settings';
 import { UiFactoryBackstage } from '../backstage/Backstage';

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -8,7 +8,7 @@
 import { AlloyComponent, Attachment, Boxes } from '@ephox/alloy';
 import { Cell, Singleton } from '@ephox/katamari';
 import { DomEvent, SugarElement } from '@ephox/sugar';
-import Editor from 'tinymce/core/api/Editor';
+import Editor, { EditorUiApi } from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
 import * as Events from '../api/Events';
 import { getUiContainer, isToolbarPersist } from '../api/Settings';
@@ -20,13 +20,6 @@ import { InlineHeader } from '../ui/header/InlineHeader';
 import { identifyMenus } from '../ui/menus/menubar/Integration';
 import { inline as loadInlineSkin } from '../ui/skin/Loader';
 import { setToolbar } from './Toolbars';
-
-export interface InlineApi {
-  ui: {
-    show: () => void;
-    hide: () => void;
-  };
-}
 
 const getTargetPosAndBounds = (targetElm: SugarElement, isToolbarTop: boolean) => {
   const bounds = Boxes.box(targetElm);
@@ -133,23 +126,21 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
 
   ReadOnly.setupReadonlyModeSwitch(editor, uiComponents);
 
+  const api: EditorUiApi = {
+    show: () => {
+      ui.show();
+    },
+    hide: () => {
+      ui.hide();
+    }
+  };
+
   return {
-    editorContainer: outerContainer.element.dom
+    editorContainer: outerContainer.element.dom,
+    api
   };
 };
 
-const getApi = (editor): InlineApi => ({
-  ui: {
-    show: () => {
-      editor.fire('show');
-    },
-    hide: () => {
-      editor.fire('hide');
-    }
-  }
-});
-
 export {
-  render,
-  getApi
+  render
 };

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -29,7 +29,7 @@ const getTargetPosAndBounds = (targetElm: SugarElement, isToolbarTop: boolean) =
   };
 };
 
-const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader) => {
+const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader, toolbarPersist: boolean) => {
   const prevPosAndBounds = Cell(getTargetPosAndBounds(targetElm, ui.isPositionedAtTop()));
 
   const resizeContent = (e) => {
@@ -53,7 +53,7 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader) 
     }
   };
 
-  if (!isToolbarPersist(editor)) {
+  if (!toolbarPersist) {
     editor.on('activate', ui.show);
     editor.on('deactivate', ui.hide);
   }
@@ -80,6 +80,7 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
   const floatContainer = Cell<AlloyComponent>(null);
   const targetElm = SugarElement.fromDom(args.targetNode);
   const ui = InlineHeader(editor, targetElm, uiComponents, backstage, floatContainer);
+  const toolbarPersist = isToolbarPersist(editor);
 
   loadInlineSkin(editor);
 
@@ -105,7 +106,7 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     // Initialise the toolbar - set initial positioning then show
     ui.show();
 
-    setupEvents(editor, targetElm, ui);
+    setupEvents(editor, targetElm, ui, toolbarPersist);
 
     editor.nodeChanged();
   };
@@ -113,13 +114,13 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
   editor.on('show', render);
   editor.on('hide', ui.hide);
 
-  if (!isToolbarPersist(editor)) {
+  if (!toolbarPersist) {
     editor.on('focus', render);
     editor.on('blur', ui.hide);
   }
 
   editor.on('init', () => {
-    if (editor.hasFocus() || isToolbarPersist(editor)) {
+    if (editor.hasFocus() || toolbarPersist) {
       render();
     }
   });

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, Attachment, Boxes } from '@ephox/alloy';
-import { Cell, Singleton, Fun } from '@ephox/katamari';
+import { Cell, Singleton } from '@ephox/katamari';
 import { DomEvent, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
@@ -60,9 +60,10 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader) 
     }
   };
 
-  const toolbarPersist = isToolbarPersist(editor);
-  editor.on('activate', toolbarPersist ? Fun.noop : ui.show);
-  editor.on('deactivate', toolbarPersist ? Fun.noop : ui.hide);
+  if (!isToolbarPersist(editor)) {
+    editor.on('activate', ui.show);
+    editor.on('deactivate', ui.hide);
+  }
 
   editor.on('SkinLoaded ResizeWindow', () => ui.update(true));
 
@@ -116,16 +117,16 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     editor.nodeChanged();
   };
 
-  const toolbarPersist = isToolbarPersist(editor);
-
   editor.on('show', render);
-  editor.on('focus', toolbarPersist ? Fun.noop : render);
-
   editor.on('hide', ui.hide);
-  editor.on('blur', toolbarPersist ? Fun.noop : ui.hide);
+
+  if (!isToolbarPersist(editor)) {
+    editor.on('focus', render);
+    editor.on('blur', ui.hide);
+  }
 
   editor.on('init', () => {
-    if (editor.hasFocus() || toolbarPersist) {
+    if (editor.hasFocus() || isToolbarPersist(editor)) {
       render();
     }
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
@@ -6,10 +6,9 @@ import { Fun } from '@ephox/katamari';
 import Theme from 'tinymce/themes/silver/Theme';
 import Editor from 'tinymce/core/api/Editor';
 
-UnitTest.asynctest('Toolbar persist test', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.themes.silver.editor.ToolbarPersistTest', (success, failure) => {
   Theme();
 
-  const cWaitForVisible = UiChains.cWaitForState(Visibility.isVisible);
   const cWaitForHidden = UiChains.cWaitForState(Fun.not(Visibility.isVisible));
 
   const cShowEditorUi = Chain.op((editor: Editor) => editor.ui.show());
@@ -36,10 +35,10 @@ UnitTest.asynctest('Toolbar persist test', (success, failure) => {
         toolbar_persist: true
       }),
 
-      cWaitForVisible('Wait for editor to be visible', '.tox-tinymce-inline'),
+      UiChains.cWaitForPopup('Wait for editor to be visible', '.tox-tinymce-inline'),
       cUnfocusEditor,
       Chain.wait(200), // Need to wait since nothing should happen.
-      cWaitForVisible('Wait for editor to be visible', '.tox-tinymce-inline'),
+      UiChains.cWaitForPopup('Wait for editor to be visible', '.tox-tinymce-inline'),
 
       cHideEditorUi,
 
@@ -49,7 +48,7 @@ UnitTest.asynctest('Toolbar persist test', (success, failure) => {
       cWaitForHidden('Wait for editor to be hidden', '.tox-tinymce-inline'),
 
       cShowEditorUi,
-      cWaitForVisible('Wait for editor to be visible', '.tox-tinymce-inline'),
+      UiChains.cWaitForPopup('Wait for editor to be visible', '.tox-tinymce-inline'),
 
       McEditor.cRemove
     ])

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
@@ -22,12 +22,12 @@ UnitTest.asynctest('Toolbar persist test', (success, failure) => {
   }));
 
   const cShowEditor = Chain.fromChains([
-    Chain.op((editor: Editor) => editor.theme.inline.ui.show()),
+    Chain.op((editor: Editor) => editor.ui.show()),
     cWaitForEditorVisibility('Wait for editor to be shown', true)
   ]);
 
   const cHideEditor = Chain.fromChains([
-    Chain.op((editor: Editor) => editor.theme.inline.ui.hide()),
+    Chain.op((editor: Editor) => editor.ui.hide()),
     cWaitForEditorVisibility('Wait for editor to be hidden', false)
   ]);
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
@@ -1,0 +1,83 @@
+import { Chain, Log, NamedChain, Pipeline, Assertions, ApproxStructure, Waiter } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Editor as McEditor } from '@ephox/mcagar';
+import { SugarElement, SugarBody, Insert, Focus, Remove } from '@ephox/sugar';
+import Theme from 'tinymce/themes/silver/Theme';
+import Editor from 'tinymce/core/api/Editor';
+
+UnitTest.asynctest('Toolbar persist test', (success, failure) => {
+  Theme();
+
+  const cWaitForEditorVisibility = (message: string, visible: boolean) => Waiter.cTryUntil(message, Chain.op((editor: Editor) => {
+    Assertions.assertStructure(
+      message,
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-tinymce-inline') ],
+        attrs: {
+          style: str.contains('display: ' + (visible ? 'flex' : 'none'))
+        }
+      })),
+      SugarElement.fromDom(editor.getContainer())
+    );
+  }));
+
+  const cShowEditor = Chain.fromChains([
+    Chain.op((editor: Editor) => editor.theme.inline.ui.show()),
+    cWaitForEditorVisibility('Wait for editor to be shown', true)
+  ]);
+
+  const cHideEditor = Chain.fromChains([
+    Chain.op((editor: Editor) => editor.theme.inline.ui.hide()),
+    cWaitForEditorVisibility('Wait for editor to be hidden', false)
+  ]);
+
+  const cFocusEditor = Chain.fromChains([
+    Chain.op((editor: Editor) => editor.focus()),
+    cWaitForEditorVisibility('Wait for editor to be shown', true)
+  ]);
+
+  const cUnfocusEditors = Chain.op((_) => {
+    const div = SugarElement.fromTag('input');
+    Insert.append(SugarBody.body(), div);
+    Focus.focus(div);
+    Remove.remove(div);
+  });
+
+  const settings = {
+    theme: 'silver',
+    inline: true,
+    base_url: '/project/tinymce/js/tinymce'
+  };
+
+  Pipeline.async({}, [
+    Log.chainsAsStep('TINY-4847', 'Test toolbar_persist', [
+      NamedChain.asChain([
+        NamedChain.write('editor1', McEditor.cFromSettings({ ...settings, toolbar_persist: true })),
+        NamedChain.write('editor2', McEditor.cFromSettings({ ...settings, toolbar_persist: false })),
+
+        NamedChain.read('editor2', cFocusEditor),
+
+        NamedChain.read('editor1', cWaitForEditorVisibility('Inline editor 1 should be shown', true)),
+        NamedChain.read('editor2', cWaitForEditorVisibility('Inline editor 2 should be shown', true)),
+
+        cUnfocusEditors,
+
+        NamedChain.read('editor1', cWaitForEditorVisibility('Inline editor 1 should be shown', true)),
+        NamedChain.read('editor2', cWaitForEditorVisibility('Inline editor 2 should be hidden', false)),
+
+        NamedChain.read('editor1', cHideEditor),
+
+        NamedChain.read('editor1', cWaitForEditorVisibility('Inline editor 1 should be hidden', false)),
+        NamedChain.read('editor2', cWaitForEditorVisibility('Inline editor 2 should be hidden', false)),
+
+        NamedChain.read('editor1', cShowEditor),
+
+        NamedChain.read('editor1', cWaitForEditorVisibility('Inline editor 1 should be shown', true)),
+        NamedChain.read('editor2', cWaitForEditorVisibility('Inline editor 2 should be hidden', false)),
+
+        NamedChain.read('editor1', McEditor.cRemove),
+        NamedChain.read('editor2', McEditor.cRemove)
+      ])
+    ])
+  ], success, failure);
+});

--- a/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
+++ b/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
@@ -12,6 +12,22 @@
  */
 
 /**
+ * Editor UI show method.
+ * <br>
+ * <em>Added in TinyMCE 5.5</em>
+ *
+ * @method tinymce.editor.ui.show
+ */
+
+/**
+ * Editor UI hide method.
+ * <br>
+ * <em>Added in TinyMCE 5.5</em>
+ *
+ * @method tinymce.editor.ui.hide
+ */
+
+/**
  * Editor UI stylesheet loader instance. StyleSheetLoader for styles in the editor UI. For content styles, use editor.dom.styleSheetLoader.
  * <br>
  * <em>Added in TinyMCE 5.4</em>

--- a/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
+++ b/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * Editor UI show method.
+ * Editor UI show method. Only works in inline mode.
  * <br>
  * <em>Added in TinyMCE 5.5</em>
  *
@@ -20,7 +20,7 @@
  */
 
 /**
- * Editor UI hide method.
+ * Editor UI hide method. Only works in inline mode.
  * <br>
  * <em>Added in TinyMCE 5.5</em>
  *


### PR DESCRIPTION
Description of Changes:
Added new boolean `toolbar_persist` setting. Used to permanently display/hide the inline editor.

Added new APIs for programmatically controlling the visibility of the inline editor:
```
tinyMCE.activeEditor.theme.inline.ui.show()
tinyMCE.activeEditor.theme.inline.ui.hide()
```

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved