### PR TITLE
TINY-6346: added parser context to rtc insertContent

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -29,6 +29,11 @@ const runSerializerFiltersOnFragment = (editor: Editor, fragment: AstNode) => {
   FilterNode.filter(editor.serializer.getNodeFilters(), editor.serializer.getAttributeFilters(), fragment);
 };
 
+const getInsertContext = (editor: Editor) => {
+  const startElm = editor.selection.getStart(true);
+  return Type.isNullable(startElm) ? 'body' : startElm.nodeName.toLowerCase();
+};
+
 /** API implemented by the RTC plugin */
 interface RtcRuntimeApi {
   undo: () => void;
@@ -191,7 +196,8 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
         return content;
       },
       insertContent: (value, _details) => {
-        const fragment = isTreeNode(value) ? value : tinymceEditor.parser.parse(value, { insert: true });
+        const context = getInsertContext(tinymceEditor);
+        const fragment = isTreeNode(value) ? value : tinymceEditor.parser.parse(value, { context, insert: true });
         rtcEditor.insertContent(fragment);
       }
     },

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -29,10 +29,7 @@ const runSerializerFiltersOnFragment = (editor: Editor, fragment: AstNode) => {
   FilterNode.filter(editor.serializer.getNodeFilters(), editor.serializer.getAttributeFilters(), fragment);
 };
 
-const getInsertContext = (editor: Editor) => {
-  const startElm = editor.selection.getStart(true);
-  return Type.isNullable(startElm) ? 'body' : startElm.nodeName.toLowerCase();
-};
+const getInsertContext = (editor: Editor) => Optional.from(editor.selection.getStart(true)).map((elm) => elm.nodeName.toLowerCase());
 
 /** API implemented by the RTC plugin */
 interface RtcRuntimeApi {
@@ -196,8 +193,11 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
         return content;
       },
       insertContent: (value, _details) => {
-        const context = getInsertContext(tinymceEditor);
-        const fragment = isTreeNode(value) ? value : tinymceEditor.parser.parse(value, { context, insert: true });
+        const contextArgs = getInsertContext(tinymceEditor).fold(
+          () => ({ }),
+          (context) => ({ context })
+        );
+        const fragment = isTreeNode(value) ? value : tinymceEditor.parser.parse(value, { ...contextArgs, insert: true });
         rtcEditor.insertContent(fragment);
       }
     },


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This fixes an issue with the RTC insertContent code always producing a full fragment so there was no way to distinct between `text` and `<p>text</p>` since without a context it would always assume body as the context and wrap the text in a paragraph. Didn't add a changelog entry since this isn't really something that would be used by the public.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
