### PR TITLE
Split primaryBranch out to a properties file.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ node("primary") {
     assert primaryBranch != null && primaryBranch != ""
 
     stage ("Merge") {
-      // cancel build if master doesn't merge cleanly, otherwise tests wil fail
+      // cancel build if primary branch doesn't merge cleanly
       gitMerge(primaryBranch)
     }
 

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,1 @@
+primaryBranch=develop


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* I'm developing tooling that automates some of the release process. Part of the manual process is to update the "primaryBranch" value, used in two places in the Jenkinsfile. To make this easier to automate, I've split it out into a build.properties file.

Pre-checks:
* ~[ ] Changelog entry added~
* ~[ ] Tests have been added (if applicable)~
* [X] Branch prefixed with `feature/` for new features (if applicable)
* ~[ ] License headers added on new files (if applicable)~

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
