### PR TITLE
Fix the hover color for menu-item-preview

### DIFF
--- a/src/skins/lightgray/main/less/desktop/MenuItem.less
+++ b/src/skins/lightgray/main/less/desktop/MenuItem.less
@@ -92,6 +92,9 @@
 
     &:hover {
       background: @menuitem-bg-hover;
+      .@{prefix}-text, .@{prefix}-ico {
+        color: @menuitem-text-hover;
+      }
     }
   }
 }


### PR DESCRIPTION
Description of Changes:
It is only visible when the hover style uses text-inverse. See the screenshots.

Before:
![before](https://user-images.githubusercontent.com/148371/92903438-62179700-f422-11ea-924b-78128ab082e9.png)

After:
![after](https://user-images.githubusercontent.com/148371/92903456-65128780-f422-11ea-8a56-9653dabcb1fe.png)
