### PR TITLE
TINY-6050: Now removing data-mce-style on cols and cells.

### DIFF
--- a/modules/tinymce/src/plugins/table/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Util.ts
@@ -25,7 +25,11 @@ const addPxSuffix = (size: string): string => /^\d+(\.\d+)?$/.test(size) ? size 
 
 const removeDataStyle = (table: SugarElement<HTMLElement>): void => {
   Attribute.remove(table, 'data-mce-style');
-  Arr.each(TableLookup.cells(table), (cell) => Attribute.remove(cell, 'data-mce-style'));
+
+  const removeStyleAttribute = (element: SugarElement<HTMLElement>) => Attribute.remove(element, 'data-mce-style');
+
+  Arr.each(TableLookup.cells(table), removeStyleAttribute);
+  Arr.each(TableLookup.columns(table), removeStyleAttribute);
 };
 
 const getRawWidth = (editor: Editor, elm: HTMLElement): Optional<string> => {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Remove `data-mce-style` from cols while removing them from the cells.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
