### PR TITLE
TINY-5882: Improve image proxy error for images that can't be found

### DIFF
--- a/modules/imagetools/src/main/ts/ephox/imagetools/proxy/Errors.ts
+++ b/modules/imagetools/src/main/ts/ephox/imagetools/proxy/Errors.ts
@@ -9,6 +9,7 @@ const friendlyHttpErrors = [
 ];
 
 const friendlyServiceErrors = [
+  { type: 'not_found', message: 'Failed to load image.' },
   { type: 'key_missing', message: 'The request did not include an api key.' },
   { type: 'key_not_found', message: 'The provided api key could not be found.' },
   { type: 'domain_not_trusted', message: 'The api key is not valid for the request origins.' }
@@ -19,8 +20,8 @@ const traverseJson = (json: any, path: string[]): Optional<any> => {
   return Optional.from(value);
 };
 
-const isServiceErrorCode = (code: number) =>
-  code === 400 || code === 403 || code === 500;
+const isServiceErrorCode = (code: number, blob: Blob | null): blob is Blob =>
+  blob?.type === 'application/json' && (code === 400 || code === 403 || code === 404 || code === 500);
 
 const getHttpErrorMsg = (status: number) => {
   const message = Arr.find(friendlyHttpErrors, (error) => status === error.code).fold(
@@ -58,8 +59,8 @@ const handleServiceError = (blob: Blob) =>
     return Promise.reject(serviceError);
   });
 
-const handleServiceErrorResponse = (status: number, blob: Blob) =>
-  isServiceErrorCode(status) ? handleServiceError(blob) : handleHttpError(status);
+const handleServiceErrorResponse = (status: number, blob: Blob | null) =>
+  isServiceErrorCode(status, blob) ? handleServiceError(blob) : handleHttpError(status);
 
 export {
   handleServiceErrorResponse,

--- a/modules/imagetools/src/test/ts/atomic/proxy/ErrorsTest.ts
+++ b/modules/imagetools/src/test/ts/atomic/proxy/ErrorsTest.ts
@@ -9,6 +9,7 @@ UnitTest.test('ProxyErrorsTest', () => {
   };
 
   const testServiceErrors = () => {
+    Assert.eq('image not found', 'Failed to load image.', Errors.getServiceErrorMsg('not_found'));
     Assert.eq('key missing', 'The request did not include an api key.', Errors.getServiceErrorMsg('key_missing'));
     Assert.eq('key not found', 'The provided api key could not be found.', Errors.getServiceErrorMsg('key_not_found'));
     Assert.eq('key not found', 'The api key is not valid for the request origins.', Errors.getServiceErrorMsg('domain_not_trusted'));

--- a/modules/tinymce/src/core/test/json/routes.json
+++ b/modules/tinymce/src/core/test/json/routes.json
@@ -47,6 +47,21 @@
   {
     "request": {
       "method": "get",
+      "path": "/custom/404data"
+    },
+    "response": {
+      "status": 404,
+      "json": {
+        "error": {
+          "type": "not_found"
+        }
+      }
+    }
+  },
+
+  {
+    "request": {
+      "method": "get",
       "path": "/custom/403"
     },
     "response": {

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
@@ -68,7 +68,10 @@ UnitTest.asynctest('browser.tinymce.plugins.imagetools.ImageToolsErrorTest', fun
           '/custom/404', undefined, 'ImageProxy HTTP error: Could not find Image Proxy'),
 
         sTestImageToolsError('TBA', '404 with api key',
-          '/custom/404', 'fake_key', 'ImageProxy HTTP error: Could not find Image Proxy')
+          '/custom/404', 'fake_key', 'ImageProxy Service error: Invalid JSON in service error message'),
+
+        sTestImageToolsError('TBA', '404 with api key and return error data',
+          '/custom/404data', 'fake_key', 'ImageProxy Service error: Failed to load image.')
 
       ];
 


### PR DESCRIPTION
Related Ticket: TINY-5882

Description of Changes:
* The image proxy service returns a `not_found` key when an image returns a 404, so this improves the handling as previously it'd instead report `ImageProxy HTTP error: Could not find Image Proxy`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
