### PR TITLE
TINY-6428: TinyMCE 5.5 release

### DIFF
--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@ephox/acid",
   "description": "Color library including Alloy UI component for a color picker",
-  "version": "1.0.81",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
   },
   "dependencies": {
-    "@ephox/alloy": "^7.0.7",
-    "@ephox/boulder": "^4.0.8",
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/sugar": "^6.1.3",
+    "@ephox/alloy": "^8.0.0",
+    "@ephox/boulder": "^5.0.0",
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/sugar": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation",

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/agar",
-  "version": "4.17.2",
+  "version": "5.0.0",
   "description": "Testing infrastructure",
   "repository": {
     "type": "git",
@@ -24,15 +24,15 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ephox/bedrock-client": "^9.3.2",
-    "@ephox/jax": "^4.1.36",
-    "@ephox/sand": "^3.1.11",
-    "@ephox/sugar": "^6.1.3",
+    "@ephox/jax": "^5.0.0",
+    "@ephox/sand": "^4.0.0",
+    "@ephox/sugar": "^7.0.0",
     "@ephox/wrap-jsverify": "^2.0.1",
     "@ephox/wrap-sizzle": "^4.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.9"
+    "@ephox/katamari-assertions": "^2.0.0"
   },
   "files": [
     "lib/main",

--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-# [8.0.0] - TBD
+# [8.0.0] - 2020-09-29
 
 ### Changed
 - Changed some public APIs (eg Components, Custom Events) to no longer be thunked.

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ephox/alloy",
-  "version": "7.0.7",
+  "version": "8.0.0",
   "description": "Ui Framework",
   "dependencies": {
-    "@ephox/agar": "^4.17.2",
-    "@ephox/boulder": "^4.0.8",
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/sand": "^3.1.11",
-    "@ephox/sugar": "^6.1.3",
+    "@ephox/agar": "^5.0.0",
+    "@ephox/boulder": "^5.0.0",
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/sand": "^4.0.0",
+    "@ephox/sugar": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/boss",
   "description": "Generic wrapper to document models - DomUniverse vs TestUniverse",
-  "version": "3.1.9",
+  "version": "4.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,12 +18,12 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/sugar": "^6.1.3",
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/sugar": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.9"
+    "@ephox/katamari-assertions": "^2.0.0"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/boulder/package.json
+++ b/modules/boulder/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ephox/boulder",
-  "version": "4.0.8",
+  "version": "5.0.0",
   "description": "Basic javascript object validation",
   "dependencies": {
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/sand": "^3.1.11"
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/sand": "^4.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.9"
+    "@ephox/katamari-assertions": "^2.0.0"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test/ts",

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/bridge",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "description": "Ui API for TinyMCE 5",
   "repository": {
     "type": "git",
@@ -12,8 +12,8 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
   "dependencies": {
-    "@ephox/boulder": "^4.0.8",
-    "@ephox/katamari": "^6.1.2",
+    "@ephox/boulder": "^5.0.0",
+    "@ephox/katamari": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/darwin",
   "description": "This project's purpose is to handle selection and cursor navigation.",
-  "version": "4.0.20",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,12 +18,12 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/phoenix": "^5.1.10",
-    "@ephox/robin": "^7.0.57",
-    "@ephox/sand": "^3.1.11",
-    "@ephox/snooker": "^6.0.3",
-    "@ephox/sugar": "^6.1.3",
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/phoenix": "^6.0.0",
+    "@ephox/robin": "^8.0.0",
+    "@ephox/sand": "^4.0.0",
+    "@ephox/snooker": "^7.0.0",
+    "@ephox/sugar": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/dragster",
   "description": "This project handles dragging.",
-  "version": "4.0.52",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,9 +18,9 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/porkbun": "^4.0.38",
-    "@ephox/sugar": "^6.1.3",
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/porkbun": "^5.0.0",
+    "@ephox/sugar": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "scripts": {

--- a/modules/imagetools/package.json
+++ b/modules/imagetools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/imagetools",
-  "version": "3.3.3",
+  "version": "4.0.0",
   "description": "Image tools for tinymce and textbox.io",
   "keywords": [
     "image",

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/jax",
-  "version": "4.1.36",
+  "version": "5.0.0",
   "description": "AJAX library",
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/katamari": "^6.1.2",
+    "@ephox/katamari": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari-assertions",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "Bedrock test assertions for Katamari",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ephox/bedrock-client": "^9.3.2",
     "@ephox/dispute": "^1.0.3",
-    "@ephox/katamari": "^6.1.2",
+    "@ephox/katamari": "^7.0.0",
     "@ephox/wrap-promise-polyfill": "^2.2.0",
     "tslib": "^2.0.0"
   },

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari",
-  "version": "6.1.2",
+  "version": "7.0.0",
   "description": "Basic data type library",
   "repository": {
     "type": "git",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/mcagar",
-  "version": "4.2.4",
+  "version": "5.0.0",
   "description": "Tinymce agar wrapper",
   "repository": {
     "type": "git",
@@ -23,10 +23,10 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/agar": "^4.17.2",
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/sand": "^3.1.11",
-    "@ephox/sugar": "^6.1.3",
+    "@ephox/agar": "^5.0.0",
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/sand": "^4.0.0",
+    "@ephox/sugar": "^7.0.0",
     "@ephox/wrap-jsverify": "^2.0.1",
     "tslib": "^2.0.0"
   },

--- a/modules/oxide-icons-default/package.json
+++ b/modules/oxide-icons-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide-icons-default",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "The default icon pack for TinyMCE",
   "main": "dist/js/icons.js",
   "scripts": {

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "TinyMCE 5 Oxide skin",
   "scripts": {
     "test": "echo 'No tests'",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/phoenix",
   "description": "DOM node text gathering library, rose from the ashes of some other projects we can't remember the names of now (edit: seek, sherlock, gift)",
-  "version": "5.1.10",
+  "version": "6.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,13 +18,13 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^3.1.9",
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/polaris": "^3.0.53",
+    "@ephox/boss": "^4.0.0",
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/polaris": "^4.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.9"
+    "@ephox/katamari-assertions": "^2.0.0"
   },
   "scripts": {
     "test-manual": "bedrock -d src/test",

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/polaris",
   "description": "This project does data manipulation on arrays and strings.",
-  "version": "3.0.53",
+  "version": "4.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,11 +18,11 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^6.1.2",
+    "@ephox/katamari": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.9"
+    "@ephox/katamari-assertions": "^2.0.0"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/porkbun",
   "description": "Event framework for JavaScript",
-  "version": "4.0.38",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,7 +18,7 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^6.1.2"
+    "@ephox/katamari": "^7.0.0"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test/ts",

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/robin",
   "description": "This project is for grouping sibling DOM nodes together by boundary points, for example the list of elements and nodes representing a word.",
-  "version": "7.0.57",
+  "version": "8.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,14 +18,14 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^3.1.9",
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/phoenix": "^5.1.10",
-    "@ephox/polaris": "^3.0.53",
+    "@ephox/boss": "^4.0.0",
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/phoenix": "^6.0.0",
+    "@ephox/polaris": "^4.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.9"
+    "@ephox/katamari-assertions": "^2.0.0"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sand",
-  "version": "3.1.11",
+  "version": "4.0.0",
   "description": "Platform detection library",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/katamari": "^6.1.2",
+    "@ephox/katamari": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "main": "./lib/main/ts/ephox/sand/api/Main.js",

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/snooker",
   "description": "This project implements the table model.",
-  "version": "6.0.3",
+  "version": "7.0.0",
   "files": [
     "lib/main",
     "lib/demo",
@@ -18,11 +18,11 @@
     "url": "https://github.com/tinymce/tinymce"
   },
   "dependencies": {
-    "@ephox/dragster": "^4.0.52",
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/porkbun": "^4.0.38",
-    "@ephox/robin": "^7.0.57",
-    "@ephox/sugar": "^6.1.3",
+    "@ephox/dragster": "^5.0.0",
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/porkbun": "^5.0.0",
+    "@ephox/robin": "^8.0.0",
+    "@ephox/sugar": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation",

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sugar",
-  "version": "6.1.3",
+  "version": "7.0.0",
   "description": "Basic DOM manipulation",
   "repository": {
     "type": "git",
@@ -21,11 +21,11 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/katamari": "^6.1.2",
-    "@ephox/sand": "^3.1.11"
+    "@ephox/katamari": "^7.0.0",
+    "@ephox/sand": "^4.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^1.0.9"
+    "@ephox/katamari-assertions": "^2.0.0"
   },
   "files": [
     "lib/main",

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,4 @@
-Version 5.5.0 (TBD)
+Version 5.5.0 (2020-09-29)
     Added a TypeScript declaration file to the bundle output for TinyMCE core #TINY-3785
     Added new `table_column_resizing` setting to control how table columns are resized when using the resize bars #TINY-6001
     Added the ability to remove images on a failed upload using the `images_upload_handler` failure callback #TINY-6011

--- a/versions.txt
+++ b/versions.txt
@@ -1,22 +1,2 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
-acid@2.0.0
-agar@5.0.0
-alloy@8.0.0
-boss@4.0.0
-boulder@5.0.0
-bridge@2.0.0
-darwin@5.0.0
-dragster@5.0.0
-imagetools@4.0.0
-jax@5.0.0
-katamari@7.0.0
-katamari-assertions@2.0.0
-mcagar@5.0.0
-phoenix@6.0.0
-polaris@4.0.0
-porkbun@5.0.0
-robin@8.0.0
-sand@4.0.0
-snooker@7.0.0
-sugar@7.0.0


### PR DESCRIPTION
Related Ticket: TINY-6428

Description of Changes:
* Bumped the package versions and adds the release date to the relevant changelogs. Here's the version bumps:
```
Changes:
 - @ephox/acid: 1.0.81 => 2.0.0
 - @ephox/agar: 4.17.2 => 5.0.0
 - @ephox/alloy: 7.0.7 => 8.0.0
 - @ephox/boss: 3.1.9 => 4.0.0
 - @ephox/boulder: 4.0.8 => 5.0.0
 - @ephox/bridge: 1.2.4 => 2.0.0
 - @ephox/darwin: 4.0.20 => 5.0.0
 - @ephox/dragster: 4.0.52 => 5.0.0
 - @ephox/imagetools: 3.3.3 => 4.0.0
 - @ephox/jax: 4.1.36 => 5.0.0
 - @ephox/katamari-assertions: 1.0.9 => 2.0.0
 - @ephox/katamari: 6.1.2 => 7.0.0
 - @ephox/mcagar: 4.2.4 => 5.0.0
 - @tinymce/oxide-icons-default: 1.4.1 => 1.5.0
 - @tinymce/oxide: 1.4.2 => 1.5.0
 - @ephox/phoenix: 5.1.10 => 6.0.0
 - @ephox/polaris: 3.0.53 => 4.0.0
 - @ephox/porkbun: 4.0.38 => 5.0.0
 - @ephox/robin: 7.0.57 => 8.0.0
 - @ephox/sand: 3.1.11 => 4.0.0
 - @ephox/snooker: 6.0.3 => 7.0.0
 - @ephox/sugar: 6.1.3 => 7.0.0
```

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
