### PR TITLE
TINY-6471: Fixed an exception incorrectly thrown when pressing the down key near the end of a document

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.5.1 (TBD)
-    Fixed an exception incorrectly thrown when pressing the down key near the end of a document #TINY-6471
+    Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
 Version 5.5.0 (2020-09-29)
     Added a TypeScript declaration file to the bundle output for TinyMCE core #TINY-3785
     Added new `table_column_resizing` setting to control how table columns are resized when using the resize bars #TINY-6001

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,3 +1,5 @@
+Version 5.5.1 (TBD)
+    Fixed an exception incorrectly thrown when pressing the down key near the end of a document #TINY-6471
 Version 5.5.0 (2020-09-29)
     Added a TypeScript declaration file to the bundle output for TinyMCE core #TINY-3785
     Added new `table_column_resizing` setting to control how table columns are resized when using the resize bars #TINY-6001

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/core/main/ts/keyboard/NavigationUtils.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/NavigationUtils.ts
@@ -80,7 +80,7 @@ const moveVertically = (editor: Editor, direction: LineWalker.VDirection, range:
   const forwards = direction === LineWalker.VDirection.Down;
 
   if (!caretClientRect) {
-    return null;
+    return Optional.none();
   }
 
   const walkerFn = forwards ? LineWalker.downUntil : LineWalker.upUntil;


### PR DESCRIPTION
Related Ticket: TINY-6471

Description of Changes:
* This fixes a regression introduced in 5.5 due to missing a case where `null` was returned instead of `Optional.none()`. This ideally would be picked up by TS, but we'd need to turn on strict null checks which causes many TS errors.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
