### PR TITLE
TINY-6474: Add new default to File menu

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -19,7 +19,7 @@ export interface MenuRegistry {
 const defaultMenubar = 'file edit view insert format tools table help';
 
 const defaultMenus = {
-  file: { title: 'File', items: 'newdocument restoredraft | preview | print | deleteallconversations | export' },
+  file: { title: 'File', items: 'newdocument restoredraft | preview | export print | deleteallconversations' },
   edit: { title: 'Edit', items: 'undo redo | cut copy paste pastetext | selectall | searchreplace' },
   view: { title: 'View', items: 'code | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
   insert: { title: 'Insert', items: 'image link media addcomment pageembed template codesample inserttable | charmap emoticons hr | pagebreak nonbreaking anchor toc | insertdatetime' },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -19,7 +19,7 @@ export interface MenuRegistry {
 const defaultMenubar = 'file edit view insert format tools table help';
 
 const defaultMenus = {
-  file: { title: 'File', items: 'newdocument restoredraft | preview | print | deleteallconversations' },
+  file: { title: 'File', items: 'newdocument restoredraft | preview | print | deleteallconversations | export' },
   edit: { title: 'Edit', items: 'undo redo | cut copy paste pastetext | selectall | searchreplace' },
   view: { title: 'View', items: 'code | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
   insert: { title: 'Insert', items: 'image link media addcomment pageembed template codesample inserttable | charmap emoticons hr | pagebreak nonbreaking anchor toc | insertdatetime' },


### PR DESCRIPTION
Related Ticket: TINY-6474

Description of Changes:
* Add `export` to the default items for the File menu in the menubar.

Pre-checks:
* [X] ~~Changelog entry added~~
* [X] ~~Tests have been added (if applicable)~~
* [X] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [X] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
