### PR TITLE
TINY-6475: Fixed incorrect `Tools` types and added types to `ArrUtils`

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
+    Fixed incorrect Typescript types for the `Tools` API #TINY-6475
 Version 5.5.0 (2020-09-29)
     Added a TypeScript declaration file to the bundle output for TinyMCE core #TINY-3785
     Added new `table_column_resizing` setting to control how table columns are resized when using the resize bars #TINY-6001

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -766,7 +766,7 @@ class Editor implements EditorObservable {
    */
   public save(args?: any): string {
     const self = this;
-    let elm = self.getElement(), html, form;
+    let elm = self.getElement(), html, form: HTMLFormElement;
 
     if (!elm || !self.initialized || self.removed) {
       return;
@@ -797,8 +797,8 @@ class Editor implements EditorObservable {
       // Update hidden form element
       if ((form = DOM.getParent(self.id, 'form'))) {
         each(form.elements, function (elm) {
-          if (elm.name === self.id) {
-            elm.value = html;
+          if ((elm as any).name === self.id) {
+            (elm as any).value = html;
             return false;
           }
         });

--- a/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
@@ -151,7 +151,7 @@ const EditorObservable: EditorObservable = {
    * @private
    */
   bindPendingEventDelegates() {
-    const self = this;
+    const self = (this as Editor);
 
     Tools.each(self._pendingNativeEvents, function (name) {
       bindEventDelegate(self, name);

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -30,12 +30,12 @@ interface ControlSelection {
 
 type ResizeHandle = [ number, number, number, number ] & { elm?: Element };
 
-interface ResizeHandles {
+type ResizeHandles = {
   ne: ResizeHandle;
   nw: ResizeHandle;
   se: ResizeHandle;
   sw: ResizeHandle;
-}
+};
 
 interface SelectedResizeHandle extends ResizeHandle {
   elm: Element;

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -214,7 +214,7 @@ interface DOMUtils {
   create (name: string, attrs?: Record<string, string | boolean | number>, html?: string | Node): HTMLElement;
   createHTML (name: string, attrs?: Record<string, string>, html?: string): string;
   createFragment (html?: string): DocumentFragment;
-  remove <T extends Node>(node: string | T | T[] | DomQuery, keepChildren?: boolean): T | T[];
+  remove <T extends Node>(node: string | T | T[] | DomQuery<T>, keepChildren?: boolean): T | T[];
   setStyle (elm: string | Node, name: string, value: string | number | null): void;
   setStyle (elm: string | Node, styles: StyleMap): void;
   getStyle (elm: string | Node, name: string, computed?: boolean): string;
@@ -464,7 +464,8 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
       name = Env.browser.isIE() ? 'styleFloat' : 'cssFloat';
     }
 
-    return $elm[0] && $elm[0].style ? $elm[0].style[name] : undefined;
+    // TODO Add a type guard here instead of casting as any
+    return $elm[0] && ($elm[0] as any).style ? ($elm[0] as any).style[name] : undefined;
   };
 
   const getSize = (elm: HTMLElement | string): {w: number; h: number} => {
@@ -746,8 +747,8 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     return frag;
   };
 
-  const remove = <T extends Node>(node: string | T | T[] | DomQuery, keepChildren?: boolean): T | T[] => {
-    const $node = $$(node);
+  const remove = <T extends Node>(node: string | T | T[] | DomQuery<T>, keepChildren?: boolean): T | T[] => {
+    const $node = $$(node) as DomQuery<T>;
 
     if (keepChildren) {
       $node.each(function () {

--- a/modules/tinymce/src/core/main/ts/api/dom/DomQuery.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DomQuery.ts
@@ -82,7 +82,7 @@ export interface DomQueryConstructor {
   filter (expr: string, elems: Node[], not?: boolean);
 }
 
-interface DomQuery<T extends Node = Node> extends Iterable<T> {
+interface DomQuery<T extends Node = Node> extends ArrayLike<T> {
   init: (selector?: DomQueryInitSelector<T>, context?: Node) => void;
 
   context: T;
@@ -98,10 +98,10 @@ interface DomQuery<T extends Node = Node> extends Iterable<T> {
   attr (attrs: Record<string, string | boolean | number | null>): this;
   attr (name: string): string;
   before (content: DomQuerySelector<T>): this;
-  children (selector?: string): this;
+  children (selector?: string): DomQuery<ChildNode>;
   clone (): this;
   closest (selector: DomQuerySelector<T>): this;
-  contents (selector?: string): this;
+  contents (selector?: string): DomQuery<ChildNode>;
   css (name: string, value: string | number | null): this;
   css (styles: Record<string, string | number | null>): this;
   css (name: string): string;
@@ -117,26 +117,26 @@ interface DomQuery<T extends Node = Node> extends Iterable<T> {
   html (): string;
   is (selector: string | ((i: number, item) => boolean)): boolean;
   last (): this;
-  next (selector?: string): this;
-  nextUntil (selector: DomQuerySelector<T>, until?: string): this;
+  next (selector?: string): DomQuery<ChildNode>;
+  nextUntil (selector: DomQuerySelector<T>, until?: string): DomQuery<ChildNode>;
   off <K extends keyof HTMLElementEventMap>(name: K, callback?: EventUtilsCallback<HTMLElementEventMap[K]>): this;
   off <U>(name?: string, callback?: EventUtilsCallback<U>): this;
   offset (offset?: {}): {} | this;
   on <K extends keyof HTMLElementEventMap>(name: K, callback: EventUtilsCallback<HTMLElementEventMap[K]>): this;
   on <U>(name: string, callback: EventUtilsCallback<U>): this;
-  parent (selector?: string): this;
-  parents (selector?: string): this;
-  parentsUntil (selector: DomQuerySelector<T>, filter?: string): this;
+  parent (selector?: string): DomQuery<Node>;
+  parents (selector?: string): DomQuery<Node>;
+  parentsUntil (selector: DomQuerySelector<T>, filter?: string): DomQuery<Node>;
   prepend (content: DomQuerySelector<T>): this;
   prependTo (val: DomQuerySelector<T>): this;
-  prev (selector?: string): this;
-  prevUntil (selector: DomQuerySelector<T>, filter?: string): this;
+  prev (selector?: string): DomQuery<ChildNode>;
+  prevUntil (selector: DomQuerySelector<T>, filter?: string): DomQuery<ChildNode>;
   prop (name: string, value: string): this;
   prop (props: Record<string, string | number>): this;
   prop (name: string): string;
   push (...items: T[]): number;
   remove (): this;
-  removeAttr (name: string): DomQuery | string;
+  removeAttr (name: string): this;
   removeClass (className: string): this;
   replaceWith (content: DomQuerySelector<T>): this;
   show (): this;

--- a/modules/tinymce/src/core/main/ts/api/fmt/Format.ts
+++ b/modules/tinymce/src/core/main/ts/api/fmt/Format.ts
@@ -5,6 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { RangeLikeObject } from '../../selection/RangeTypes';
+
 export type ApplyFormat = BlockFormat | InlineFormat | SelectorFormat;
 export type RemoveFormat = RemoveBlockFormat | RemoveInlineFormat | RemoveSelectorFormat;
 export type Format = ApplyFormat | RemoveFormat;
@@ -25,7 +27,7 @@ export interface CommonFormat<T> {
   expand?: boolean;
   links?: boolean;
   onmatch?: (node: Node, fmt: T, itemName: string) => boolean;
-  onformat?: (node: Node, fmt: T, vars?: FormatVars) => void;
+  onformat?: (elm: Node, fmt: T, vars?: FormatVars, node?: Node | RangeLikeObject) => void;
   remove_similar?: boolean;
 }
 

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -118,7 +118,7 @@ interface Schema {
 const mapCache: any = {}, dummyObj = {};
 const makeMap = Tools.makeMap, each = Tools.each, extend = Tools.extend, explode = Tools.explode, inArray = Tools.inArray;
 
-const split = function (items, delim?) {
+const split = (items: string, delim?: string): string[] => {
   items = Tools.trim(items);
   return items ? items.split(delim || ' ') : [];
 };
@@ -130,8 +130,9 @@ const split = function (items, delim?) {
  * @param {String} type html4, html5 or html5-strict schema type.
  * @return {Object} Schema lookup table.
  */
-const compileSchema = function (type: SchemaType) {
-  const schema: any = {};
+// TODO: Improve return type
+const compileSchema = function (type: SchemaType): Record<string, any> {
+  const schema: Record<string, any> = {};
   let globalAttributes, blockContent;
   let phrasingContent, flowContent, html4BlockContent, html4PhrasingContent;
 
@@ -156,8 +157,8 @@ const compileSchema = function (type: SchemaType) {
       children = split(children);
     }
 
-    name = split(name);
-    ni = name.length;
+    const names = split(name);
+    ni = names.length;
     while (ni--) {
       attributesOrder = split([ globalAttributes, attributes ].join(' '));
 
@@ -167,21 +168,21 @@ const compileSchema = function (type: SchemaType) {
         children: arrayToMap(children, dummyObj)
       };
 
-      schema[name[ni]] = element;
+      schema[names[ni]] = element;
     }
   };
 
   const addAttrs = function (name: string, attributes?: string) {
     let ni, schemaItem, i, l;
 
-    name = split(name);
-    ni = name.length;
-    attributes = split(attributes);
+    const names = split(name);
+    ni = names.length;
+    const attrs = split(attributes);
     while (ni--) {
-      schemaItem = schema[name[ni]];
-      for (i = 0, l = attributes.length; i < l; i++) {
-        schemaItem.attributes[attributes[i]] = {};
-        schemaItem.attributesOrder.push(attributes[i]);
+      schemaItem = schema[names[ni]];
+      for (i = 0, l = attrs.length; i < l; i++) {
+        schemaItem.attributes[attrs[i]] = {};
+        schemaItem.attributesOrder.push(attrs[i]);
       }
     }
   };
@@ -507,7 +508,7 @@ function Schema(settings?: SchemaSettings): Schema {
 
     if (validElements) {
       // Split valid elements into an array with rules
-      validElements = split(validElements, ',');
+      const validElementsArr = split(validElements, ',');
 
       if (elements['@']) {
         globalAttributes = elements['@'].attributes;
@@ -515,9 +516,9 @@ function Schema(settings?: SchemaSettings): Schema {
       }
 
       // Loop all rules
-      for (ei = 0, el = validElements.length; ei < el; ei++) {
+      for (ei = 0, el = validElementsArr.length; ei < el; ei++) {
         // Parse element rule
-        matches = elementRuleRegExp.exec(validElements[ei]);
+        matches = elementRuleRegExp.exec(validElementsArr[ei]);
         if (matches) {
           // Setup local names for matches
           prefix = matches[1];
@@ -773,8 +774,8 @@ function Schema(settings?: SchemaSettings): Schema {
     // Switch these on HTML4
     if (settings.schema !== 'html5') {
       each(split('strong/b em/i'), function (item) {
-        item = split(item, '/');
-        elements[item[1]].outputName = item[0];
+        const items = split(item, '/');
+        elements[items[1]].outputName = items[0];
       });
     }
 

--- a/modules/tinymce/src/core/main/ts/api/util/Tools.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Tools.ts
@@ -8,22 +8,23 @@
 import * as ArrUtils from '../../util/ArrUtils';
 import Env from '../Env';
 
-type ArrayCallback<T, R> = (x: T, i: number, xs: ReadonlyArray<T>) => R;
-type ObjCallback<T, R> = (value: T[keyof T], key: string, obj: T) => R;
+type ArrayCallback<T, R> = ArrUtils.ArrayCallback<T, R>;
+type ObjCallback<T, R> = ArrUtils.ObjCallback<T, R>;
 
 interface Tools {
   is (obj: any, type: string): boolean;
   isArray <T>(arr: any): arr is Array<T>;
   inArray <T>(arr: ArrayLike<T>, value: T): number;
-  grep <T>(arr: ArrayLike<T>, pred?: ArrayCallback<T, boolean>);
+  grep <T>(arr: ArrayLike<T> | null | undefined, pred?: ArrayCallback<T, boolean>): T[];
+  grep <T>(arr: Record<string, T> | null | undefined, pred?: ObjCallback<T, boolean>): T[];
   trim (str: string): string;
   toArray <T>(obj: ArrayLike<T>): T[];
   hasOwn (obj: any, name: string): boolean;
   makeMap <T>(items: ArrayLike<T> | string, delim?: string | RegExp, map?: Record<string, T | string>): Record<string, T | string>;
-  each <T>(arr: ArrayLike<T>, cb: ArrayCallback<T, any>, scope?: any): void;
-  each <T>(obj: T, cb: ObjCallback<T, any>, scope?: any): void;
-  map <T, U>(arr: ArrayLike<T>, cb: ArrayCallback<T, U>, scope?: any): Array<U>;
-  map <T, U>(obj: T, cb: ObjCallback<T, U>, scope?: any): Array<U>;
+  each <T>(arr: ArrayLike<T> | null | undefined, cb: ArrayCallback<T, void | boolean>, scope?: any): boolean;
+  each <T>(obj: Record<string, T> | null | undefined, cb: ObjCallback<T, void | boolean>, scope?: any): boolean;
+  map <T, R>(arr: ArrayLike<T> | null | undefined, cb: ArrayCallback<T, R>): R[];
+  map <T, R>(obj: Record<string, T> | null | undefined, cb: ObjCallback<T, R>): R[];
   extend (obj: Object, ext: Object, ...objs: Object[]): any;
   create (name: string, p: Object, root?: Object);
   walk <T = any>(obj: T, f: Function, n?: keyof T, scope?: any): void;

--- a/modules/tinymce/src/core/main/ts/bookmark/CaretBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/CaretBookmark.ts
@@ -75,7 +75,7 @@ const normalizedTextOffset = (node: Node, offset: number): number => {
 const equal = (a) => (b) => a === b;
 
 const normalizedNodeIndex = (node: Node): number => {
-  let nodes, index;
+  let nodes: Node[], index: number;
 
   nodes = getChildNodes(normalizedParent(node));
   index = ArrUtils.findIndex(nodes, equal(node), node);
@@ -203,16 +203,16 @@ const resolve = (root: Node, path: string): CaretPosition => {
   offset = parts.length > 1 ? parts[1] : 'before';
 
   const container = ArrUtils.reduce(paths, function (result, value) {
-    value = /([\w\-\(\)]+)\[([0-9]+)\]/.exec(value);
-    if (!value) {
+    const match = /([\w\-\(\)]+)\[([0-9]+)\]/.exec(value);
+    if (!match) {
       return null;
     }
 
-    if (value[1] === 'text()') {
-      value[1] = '#text';
+    if (match[1] === 'text()') {
+      match[1] = '#text';
     }
 
-    return resolvePathItem(result, value[1], parseInt(value[2], 10));
+    return resolvePathItem(result, match[1], parseInt(match[2], 10));
   }, root);
 
   if (!container) {

--- a/modules/tinymce/src/core/main/ts/caret/FakeCaret.ts
+++ b/modules/tinymce/src/core/main/ts/caret/FakeCaret.ts
@@ -121,7 +121,7 @@ export const FakeCaret = (editor: Editor, root: HTMLElement, isBlock: (node: Nod
       clientRect = getAbsoluteClientRect(root, element, before);
       DomQuery(caretContainerNode).css('top', clientRect.top);
 
-      const caret = DomQuery('<div class="mce-visual-caret" data-mce-bogus="all"></div>').css(clientRect).appendTo(root)[0];
+      const caret = DomQuery<HTMLElement>('<div class="mce-visual-caret" data-mce-bogus="all"></div>').css(clientRect).appendTo(root)[0];
       lastVisualCaret.set(Optional.some({ caret, element, before }));
 
       lastVisualCaret.get().each((caretState) => {

--- a/modules/tinymce/src/core/main/ts/caret/LineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/caret/LineUtils.ts
@@ -22,8 +22,8 @@ export interface CaretInfo {
 
 const isContentEditableFalse = NodeType.isContentEditableFalse;
 const findNode = CaretUtils.findNode;
-const distanceToRectLeft = (clientRect: NodeClientRect, clientX: number) => Math.abs(clientRect.left - clientX);
-const distanceToRectRight = (clientRect: NodeClientRect, clientX: number) => Math.abs(clientRect.right - clientX);
+const distanceToRectLeft = (clientRect: ClientRect, clientX: number) => Math.abs(clientRect.left - clientX);
+const distanceToRectRight = (clientRect: ClientRect, clientX: number) => Math.abs(clientRect.right - clientX);
 const isInsideX = (clientX: number, clientRect: ClientRect): boolean => clientX >= clientRect.left && clientX <= clientRect.right;
 const isInsideY = (clientY: number, clientRect: ClientRect): boolean => clientY >= clientRect.top && clientY <= clientRect.bottom;
 
@@ -40,7 +40,8 @@ const findClosestClientRect = <T extends ClientRect>(clientRects: T[], clientX: 
   }
 
   // cE=false has higher priority
-  if (newDistance === oldDistance && isContentEditableFalse(clientRect.node)) {
+  // TODO check the types or add a guard as node may not exist
+  if (newDistance === oldDistance && isContentEditableFalse((clientRect as any).node)) {
     return clientRect;
   }
 

--- a/modules/tinymce/src/core/main/ts/file/Uploader.ts
+++ b/modules/tinymce/src/core/main/ts/file/Uploader.ts
@@ -36,6 +36,8 @@ export interface UploadFailureOptions {
 
 export type UploadHandler = (blobInfo: BlobInfo, success: (url: string) => void, failure: (err: string, options?: UploadFailureOptions) => void, progress?: (percent: number) => void) => void;
 
+type ResolveFn<T> = (result?: T | Promise<T>) => void;
+
 export interface UploadResult {
   url: string;
   blobInfo: BlobInfo;
@@ -51,7 +53,7 @@ export interface Uploader {
 }
 
 export function Uploader(uploadStatus, settings): Uploader {
-  const pendingPromises = {};
+  const pendingPromises: Record<string, ResolveFn<UploadResult>[]> = {};
 
   const pathJoin = (path1, path2) => {
     if (path1) {
@@ -117,7 +119,7 @@ export function Uploader(uploadStatus, settings): Uploader {
     }
   });
 
-  const resolvePending = (blobUri, result) => {
+  const resolvePending = (blobUri: string, result) => {
     Tools.each(pendingPromises[blobUri], (resolve) => {
       resolve(result);
     });

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -48,7 +48,7 @@ const applyFormat = function (ed: Editor, name: string, vars?: FormatVars, node?
         fmt.onformat(elm, fmt as any, vars, node);
       }
 
-      each(fmt.styles as Record<string, any>, function (value, name) {
+      each(fmt.styles, function (value, name) {
         dom.setStyle(elm, name, FormatUtils.replaceVars(value, vars));
       });
 

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -8,7 +8,7 @@
 import DOMUtils from '../api/dom/DOMUtils';
 import EditorSelection from '../api/dom/Selection';
 import Editor from '../api/Editor';
-import { FormatVars } from '../api/fmt/Format';
+import { ApplyFormat, FormatVars } from '../api/fmt/Format';
 import Tools from '../api/util/Tools';
 import * as Bookmarks from '../bookmark/Bookmarks';
 import { IdBookmark, IndexBookmark } from '../bookmark/BookmarkTypes';
@@ -39,15 +39,16 @@ const applyFormat = function (ed: Editor, name: string, vars?: FormatVars, node?
   const isCollapsed = !node && ed.selection.isCollapsed();
   const dom = ed.dom, selection: EditorSelection = ed.selection;
 
-  const setElementFormat = function (elm: Node, fmt?) {
+  // TODO: Add actual type for fmt below
+  const setElementFormat = function (elm: Node, fmt?: ApplyFormat) {
     fmt = fmt || format;
 
     if (elm) {
       if (fmt.onformat) {
-        fmt.onformat(elm, fmt, vars, node);
+        fmt.onformat(elm, fmt as any, vars, node);
       }
 
-      each(fmt.styles, function (value, name) {
+      each(fmt.styles as Record<string, any>, function (value, name) {
         dom.setStyle(elm, name, FormatUtils.replaceVars(value, vars));
       });
 
@@ -83,7 +84,7 @@ const applyFormat = function (ed: Editor, name: string, vars?: FormatVars, node?
     }
 
     // Look for matching formats
-    each(formatList, function (format) {
+    each(formatList, function (format: any) {
       // Check collapsed state if it exists
       if ('collapsed' in format && format.collapsed !== isCollapsed) {
         return;

--- a/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
@@ -6,9 +6,9 @@
  */
 
 import DOMUtils from '../api/dom/DOMUtils';
-import * as NodeType from '../dom/NodeType';
 import { Formats, FormatVars } from '../api/fmt/Format';
 import Tools from '../api/util/Tools';
+import * as NodeType from '../dom/NodeType';
 
 const get = function (dom: DOMUtils) {
   const formats: Formats = {
@@ -167,7 +167,7 @@ const get = function (dom: DOMUtils) {
         return NodeType.isElement(node) && node.hasAttribute('href');
       },
 
-      onformat(elm, _fmt, vars: FormatVars | undefined) {
+      onformat(elm, _fmt, vars?: FormatVars) {
         Tools.each(vars, (value, key) => {
           dom.setAttrib(elm, key, value);
         });

--- a/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
@@ -7,7 +7,7 @@
 
 import DOMUtils from '../api/dom/DOMUtils';
 import * as NodeType from '../dom/NodeType';
-import { Formats } from '../api/fmt/Format';
+import { Formats, FormatVars } from '../api/fmt/Format';
 import Tools from '../api/util/Tools';
 
 const get = function (dom: DOMUtils) {
@@ -167,7 +167,7 @@ const get = function (dom: DOMUtils) {
         return NodeType.isElement(node) && node.hasAttribute('href');
       },
 
-      onformat(elm, _fmt, vars) {
+      onformat(elm, _fmt, vars: FormatVars | undefined) {
         Tools.each(vars, (value, key) => {
           dom.setAttrib(elm, key, value);
         });

--- a/modules/tinymce/src/core/main/ts/fmt/Hooks.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/Hooks.ts
@@ -17,7 +17,9 @@ import * as ArrUtils from '../util/ArrUtils';
  * @class tinymce.fmt.Hooks
  */
 
-const postProcessHooks: Record<string, Array<(editor: Editor) => void>> = {}, filter = ArrUtils.filter, each = ArrUtils.each;
+const postProcessHooks: Record<string, Array<(editor: Editor) => void>> = {};
+const filter = ArrUtils.filter;
+const each = ArrUtils.each;
 
 const addPostProcessHook = function (name, hook) {
   const hooks = postProcessHooks[name];

--- a/modules/tinymce/src/core/main/ts/fmt/Hooks.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/Hooks.ts
@@ -17,7 +17,7 @@ import * as ArrUtils from '../util/ArrUtils';
  * @class tinymce.fmt.Hooks
  */
 
-const postProcessHooks = {}, filter = ArrUtils.filter, each = ArrUtils.each;
+const postProcessHooks: Record<string, Array<(editor: Editor) => void>> = {}, filter = ArrUtils.filter, each = ArrUtils.each;
 
 const addPostProcessHook = function (name, hook) {
   const hooks = postProcessHooks[name];

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -59,7 +59,7 @@ const mergeSubSup = function (dom: DOMUtils, format, vars: FormatVars, node: Nod
 
 const mergeWithChildren = function (editor: Editor, formatList, vars: FormatVars, node: Node) {
   // Remove/merge children
-  each(formatList, function (format) {
+  each(formatList, function (format: any) {
     // Merge all children of similar type will move styles from child to parent
     // this: <span style="color:red"><b><span style="color:red; font-size:10px">text</span></b></span>
     // will become: <span style="color:red"><b><span style="font-size:10px">text</span></b></span>

--- a/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
@@ -83,7 +83,7 @@ const clearChildStyles = (dom: DOMUtils, format, node: Node) => {
     const selector = format.links ? '*:not(a)' : '*';
     each(dom.select(selector, node), (node) => {
       if (isElementNode(node)) {
-        each(format.styles, (value, name) => {
+        each(format.styles, (value, name: string) => {
           dom.setStyle(node, name, '');
         });
       }

--- a/modules/tinymce/src/core/main/ts/fmt/Preview.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/Preview.ts
@@ -185,7 +185,7 @@ const parseSelector = function (selector: string) {
   }).reverse();
 };
 
-const getCssText = function (editor: Editor, format) {
+const getCssText = function (editor: Editor, format: any) {
   let name, previewFrag;
   let previewCss = '', parentFontSize;
 
@@ -197,7 +197,7 @@ const getCssText = function (editor: Editor, format) {
   }
 
   // Removes any variables since these can't be previewed
-  const removeVars = function (val) {
+  const removeVars = function (val): string {
     return val.replace(/%(\w+)/g, '');
   };
 
@@ -238,29 +238,29 @@ const getCssText = function (editor: Editor, format) {
   const previewElm = dom.select(name, previewFrag)[0] || previewFrag.firstChild;
 
   // Add format styles to preview element
-  each(format.styles, function (value, name) {
-    value = removeVars(value);
+  each(format.styles, function (value, name: string) {
+    const newValue = removeVars(value);
 
-    if (value) {
-      dom.setStyle(previewElm, name, value);
+    if (newValue) {
+      dom.setStyle(previewElm, name, newValue);
     }
   });
 
   // Add attributes to preview element
-  each(format.attributes, function (value, name) {
-    value = removeVars(value);
+  each(format.attributes, function (value, name: string) {
+    const newValue = removeVars(value);
 
-    if (value) {
-      dom.setAttrib(previewElm, name, value);
+    if (newValue) {
+      dom.setAttrib(previewElm, name, newValue);
     }
   });
 
   // Add classes to preview element
   each(format.classes, function (value) {
-    value = removeVars(value);
+    const newValue = removeVars(value);
 
-    if (!dom.hasClass(previewElm, value)) {
-      dom.addClass(previewElm, value);
+    if (!dom.hasClass(previewElm, newValue)) {
+      dom.addClass(previewElm, newValue);
     }
   });
 

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -251,7 +251,7 @@ const removeFormatInternal = (ed: Editor, format: RemoveFormatPartial, vars?: Fo
   // Should we compare with format attribs and styles
   if (format.remove !== 'all') {
     // Remove styles
-    each(format.styles, (value: FormatAttrOrStyleValue, name: string | number) => {
+    each(format.styles as any, (value: FormatAttrOrStyleValue, name: string | number) => {
       value = FormatUtils.normalizeStyleValue(dom, FormatUtils.replaceVars(value, vars), name + '');
 
       // Indexed array
@@ -274,7 +274,7 @@ const removeFormatInternal = (ed: Editor, format: RemoveFormatPartial, vars?: Fo
     }
 
     // Remove attributes
-    each(format.attributes, (value: FormatAttrOrStyleValue, name: string | number) => {
+    each(format.attributes as any, (value: FormatAttrOrStyleValue, name: string | number) => {
       let valueOut: string;
 
       value = FormatUtils.replaceVars(value, vars);

--- a/modules/tinymce/src/core/main/ts/util/ArrUtils.ts
+++ b/modules/tinymce/src/core/main/ts/util/ArrUtils.ts
@@ -5,6 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Type } from '@ephox/katamari';
+
 /**
  * Array utility class.
  *
@@ -12,26 +14,31 @@
  * @class tinymce.util.Arr
  */
 
+export type ArrayCallback<T, R> = (x: T, i: number, xs: ReadonlyArray<T>) => R;
+export type ObjCallback<T, R> = (value: T, key: string, obj: Record<string, T>) => R;
+
 const isArray = Array.isArray;
 
-const toArray = function (obj) {
-  let array = obj, i, l;
-
+const toArray = <T>(obj: ArrayLike<T>): T[] => {
   if (!isArray(obj)) {
-    array = [];
-    for (i = 0, l = obj.length; i < l; i++) {
+    const array: T[] = [];
+    for (let i = 0, l = obj.length; i < l; i++) {
       array[i] = obj[i];
     }
+    return array;
+  } else {
+    return obj;
   }
-
-  return array;
 };
 
-const each = function (o, cb, s?) {
+const each: {
+  <T>(arr: ArrayLike<T> | null | undefined, cb: ArrayCallback<T, void | boolean>, scope?: any): boolean;
+  <T>(obj: Record<string, T> | null | undefined, cb: ObjCallback<T, void | boolean>, scope?: any): boolean;
+} = (o, cb, s?): boolean => {
   let n, l;
 
   if (!o) {
-    return 0;
+    return false;
   }
 
   s = s || o;
@@ -40,7 +47,7 @@ const each = function (o, cb, s?) {
     // Indexed arrays, needed for Safari
     for (n = 0, l = o.length; n < l; n++) {
       if (cb.call(s, o[n], n, o) === false) {
-        return 0;
+        return false;
       }
     }
   } else {
@@ -48,29 +55,35 @@ const each = function (o, cb, s?) {
     for (n in o) {
       if (o.hasOwnProperty(n)) {
         if (cb.call(s, o[n], n, o) === false) {
-          return 0;
+          return false;
         }
       }
     }
   }
 
-  return 1;
+  return true;
 };
 
-const map = function (array, callback) {
-  const out = [];
+const map: {
+  <T, R>(arr: ArrayLike<T> | null | undefined, cb: ArrayCallback<T, R>): R[];
+  <T, R>(obj: Record<string | null | undefined, T>, cb: ObjCallback<T, R>): R[];
+} = <T, R>(array, callback): R[] => {
+  const out: R[] = [];
 
-  each(array, function (item, index) {
+  each<T>(array, function (item, index) {
     out.push(callback(item, index, array));
   });
 
   return out;
 };
 
-const filter = function (a, f?) {
-  const o = [];
+const filter: {
+  <T>(arr: ArrayLike<T> | null | undefined, f?: ArrayCallback<T, boolean>): T[];
+  <T>(obj: Record<string, T> | null | undefined, f?: ObjCallback<T, boolean>): T[];
+} = <T>(a, f?): T[] => {
+  const o: T[] = [];
 
-  each(a, function (v, index) {
+  each<T>(a, function (v, index) {
     if (!f || f(v, index, a)) {
       o.push(v);
     }
@@ -79,11 +92,9 @@ const filter = function (a, f?) {
   return o;
 };
 
-const indexOf = function (a, v) {
-  let i, l;
-
+const indexOf = <T>(a: ArrayLike<T>, v: T): number => {
   if (a) {
-    for (i = 0, l = a.length; i < l; i++) {
+    for (let i = 0, l = a.length; i < l; i++) {
       if (a[i] === v) {
         return i;
       }
@@ -93,21 +104,20 @@ const indexOf = function (a, v) {
   return -1;
 };
 
-const reduce = function (collection, iteratee, accumulator?, thisArg?) {
-  let i = 0;
+const reduce: {
+  <T, R>(collection: ArrayLike<T>, iteratee: (acc: R, item: T, index: number) => R, accumulator: R, thisArg?: any): R;
+  <T>(collection: ArrayLike<T>, iteratee: (acc: T, item: T, index: number) => T, accumulator?: undefined, thisArg?: any): T;
+} = <T, R>(collection, iteratee, accumulator?, thisArg?): R => {
+  let acc: R = Type.isUndefined(accumulator) ? collection[0] : accumulator;
 
-  if (arguments.length < 3) {
-    accumulator = collection[0];
+  for (let i = 0; i < collection.length; i++) {
+    acc = iteratee.call(thisArg, acc, collection[i], i);
   }
 
-  for (; i < collection.length; i++) {
-    accumulator = iteratee.call(thisArg, accumulator, collection[i], i);
-  }
-
-  return accumulator;
+  return acc;
 };
 
-const findIndex = function (array, predicate, thisArg?) {
+const findIndex = <T>(array: ArrayLike<T>, predicate: ArrayCallback<T, boolean>, thisArg?: any): number => {
   let i, l;
 
   for (i = 0, l = array.length; i < l; i++) {
@@ -119,7 +129,7 @@ const findIndex = function (array, predicate, thisArg?) {
   return -1;
 };
 
-const find = function (array, predicate, thisArg?) {
+const find = <T>(array: ArrayLike<T>, predicate: ArrayCallback<T, boolean>, thisArg?: any): T | undefined => {
   const idx = findIndex(array, predicate, thisArg);
 
   if (idx !== -1) {
@@ -129,9 +139,8 @@ const find = function (array, predicate, thisArg?) {
   return undefined;
 };
 
-const last = function (collection) {
-  return collection[collection.length - 1];
-};
+const last = <T>(collection: ArrayLike<T>): T | undefined =>
+  collection[collection.length - 1];
 
 export {
   isArray,

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -205,7 +205,7 @@ UnitTest.asynctest('browser.tinymce.core.EditorUploadTest', (success, failure) =
       assertResultReusesFilename(editor, uploadedBlobInfo, result);
 
       editor.uploadImages((_result) => {
-        const img = editor.$('img')[0];
+        const img = editor.$<HTMLImageElement>('img')[0];
         Assert.eq('uploadImages reuse filename', false, hasBlobAsSource(img));
         Assert.eq('Check the cache invalidation string was added', true, img.src.indexOf('custom.png?size=small&') !== -1);
         Assert.eq('uploadImages reuse filename', '<p><img src="custom.png?size=small" /></p>', editor.getContent());

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -16,9 +16,9 @@ UnitTest.asynctest('browser.tinymce.core.SelectionOverridesTest', function (succ
     LegacyUnit.equal(a, true, label);
   };
 
-  suite.test('click on link in cE=false', function (editor) {
+  suite.test('click on link in cE=false', function (editor: Editor) {
     editor.setContent('<p contentEditable="false"><a href="#"><strong>link</strong></a></p>');
-    const evt = editor.fire('click', { target: editor.$('strong')[0] } as MouseEvent);
+    const evt = editor.fire('click', { target: editor.$('strong')[0] } as any);
 
     LegacyUnit.equal(evt.isDefaultPrevented(), true);
   });

--- a/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
@@ -76,7 +76,7 @@ UnitTest.asynctest('browser.tinymce.core.caret.FakeCaretTest', function (success
     const $fakeCaretText = $(getRoot()).contents();
 
     LegacyUnit.equal($fakeCaretText[0].nodeName, '#text');
-    LegacyUnit.equal($fakeCaretText[0].data, Zwsp.ZWSP);
+    LegacyUnit.equal(($fakeCaretText[0] as Text).data, Zwsp.ZWSP);
     CaretAsserts.assertRange(rng, CaretAsserts.createRange($fakeCaretText[0], 1));
 
     fakeCaret.hide();
@@ -90,7 +90,7 @@ UnitTest.asynctest('browser.tinymce.core.caret.FakeCaretTest', function (success
     const $fakeCaretText = $(getRoot()).contents();
 
     LegacyUnit.equal($fakeCaretText[1].nodeName, '#text');
-    LegacyUnit.equal($fakeCaretText[1].data, Zwsp.ZWSP);
+    LegacyUnit.equal(($fakeCaretText[1] as Text).data, Zwsp.ZWSP);
     CaretAsserts.assertRange(rng, CaretAsserts.createRange($fakeCaretText[1], 1));
 
     fakeCaret.hide();

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -266,13 +266,13 @@ UnitTest.test('DOMUtils.setGetAttrib on null', () => {
 });
 
 UnitTest.test('DOMUtils.getAttribs', () => {
-  const check = (obj, val) => {
+  const check = (obj: NamedNodeMap | Attr[], val: string) => {
     let count = 0;
 
-    val = val.split(',');
+    const values = val.split(',');
 
     Tools.each(obj, (o) => {
-      if (Tools.inArray(val, o.nodeName.toLowerCase()) !== -1 && o.specified) {
+      if (Tools.inArray(values, o.nodeName.toLowerCase()) !== -1 && o.specified) {
         count++;
       }
     });

--- a/modules/tinymce/src/plugins/advlist/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/api/Settings.ts
@@ -7,12 +7,12 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getNumberStyles = (editor: Editor) => {
+const getNumberStyles = (editor: Editor): string[] => {
   const styles = editor.getParam('advlist_number_styles', 'default,lower-alpha,lower-greek,lower-roman,upper-alpha,upper-roman');
   return styles ? styles.split(/[ ,]/) : [];
 };
 
-const getBulletStyles = (editor: Editor) => {
+const getBulletStyles = (editor: Editor): string[] => {
   const styles = editor.getParam('advlist_bullet_styles', 'default,circle,square');
   return styles ? styles.split(/[ ,]/) : [];
 };

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -42,7 +42,7 @@ const isWithinList = (editor: Editor, e, nodeName) => {
   return lists.length > 0 && lists[0].nodeName === nodeName;
 };
 
-const addSplitButton = function (editor: Editor, id, tooltip, cmd, nodeName, styles) {
+const addSplitButton = function (editor: Editor, id: string, tooltip: string, cmd: string, nodeName: ListType, styles: string[]) {
   editor.ui.registry.addSplitButton(id, {
     tooltip,
     icon: nodeName === ListType.OrderedList ? 'ordered-list' : 'unordered-list',
@@ -99,7 +99,7 @@ const addButton = function (editor: Editor, id, tooltip, cmd, nodeName, _styles)
   });
 };
 
-const addControl = function (editor, id, tooltip, cmd, nodeName, styles) {
+const addControl = function (editor: Editor, id: string, tooltip: string, cmd: string, nodeName: ListType, styles: string[]) {
   if (styles.length > 1) {
     addSplitButton(editor, id, tooltip, cmd, nodeName, styles);
   } else {

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -5,9 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 
-const setDir = function (editor, dir) {
+const setDir = function (editor: Editor, dir: string) {
   const dom = editor.dom;
   let curDir;
   const blocks = editor.selection.getSelectedBlocks();

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
@@ -12,6 +12,23 @@ import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 
+interface Data {
+  fontface?: string;
+  fontsize?: string;
+  xml_pi?: boolean;
+  docencoding?: string;
+  doctype?: string;
+  title?: string;
+  langcode?: string;
+  stylesheets?: string[];
+  dir?: string;
+  langdir?: string;
+  style?: string;
+  visited_color?: string;
+  link_color?: string;
+  active_color?: string;
+}
+
 const parseHeader = function (head: string) {
   // Parse the contents with a DOM parser
   return DomParser({
@@ -23,7 +40,7 @@ const parseHeader = function (head: string) {
 
 const htmlToData = function (editor: Editor, head: string) {
   const headerFragment = parseHeader(head);
-  const data: any = {};
+  const data: Data = {};
   let elm, matches;
 
   function getAttr(elm, name) {
@@ -103,7 +120,7 @@ const htmlToData = function (editor: Editor, head: string) {
   return data;
 };
 
-const dataToHtml = function (editor: Editor, data, head) {
+const dataToHtml = function (editor: Editor, data: Data, head) {
   let headElement, elm, value;
   const dom = editor.dom;
 

--- a/modules/tinymce/src/plugins/image/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/ListUtils.ts
@@ -7,13 +7,13 @@
 
 import { Arr, Optional, Type } from '@ephox/katamari';
 import Tools from 'tinymce/core/api/util/Tools';
-import { ListGroup, ListItem, ListValue } from '../ui/DialogTypes';
+import { ListGroup, ListItem, ListValue, UserListItem } from '../ui/DialogTypes';
 
 export type ListExtractor = (item: any) => string;
 
 const getValue: ListExtractor = (item) => Type.isString(item.value) ? item.value : '';
 
-const sanitizeList = (list: any, extractValue: ListExtractor): ListItem[] => {
+const sanitizeList = (list: UserListItem[], extractValue: ListExtractor): ListItem[] => {
   const out: ListItem[] = [];
   Tools.each(list, function (item) {
     const text: string = Type.isString(item.text) ? item.text : Type.isString(item.title) ? item.title : '';
@@ -28,7 +28,7 @@ const sanitizeList = (list: any, extractValue: ListExtractor): ListItem[] => {
   return out;
 };
 
-const sanitizer = (extracter = getValue) => (list: any): Optional<ListItem[]> => {
+const sanitizer = (extracter = getValue) => (list: UserListItem[]): Optional<ListItem[]> => {
   if (list) {
     return Optional.from(list).map((list) => sanitizeList(list, extracter));
   } else {
@@ -36,7 +36,7 @@ const sanitizer = (extracter = getValue) => (list: any): Optional<ListItem[]> =>
   }
 };
 
-const sanitize = (list: any) => sanitizer(getValue)(list);
+const sanitize = (list: UserListItem[]) => sanitizer(getValue)(list);
 
 const isGroup = (item: ListItem): item is ListGroup => Object.prototype.hasOwnProperty.call(item, 'items');
 

--- a/modules/tinymce/src/plugins/image/main/ts/ui/DialogTypes.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/DialogTypes.ts
@@ -15,6 +15,12 @@ export type ListValue = Dialog.ListBoxSingleItemSpec;
 export type ListGroup = Dialog.ListBoxNestedItemSpec;
 export type ListItem = Dialog.ListBoxItemSpec;
 
+export interface UserListItem {
+  text?: string;
+  title?: string;
+  menu?: UserListItem[];
+}
+
 export interface ImageDialogInfo {
   image: ImageData;
   imageList: Optional<ListItem[]>;

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -65,11 +65,14 @@ const compileFilter = function (filter: string | RegExp | ((value: string) => bo
   return filter;
 };
 
+const isCssImportRule = (rule: CSSRule): rule is CSSImportRule => (rule as any).styleSheet;
+const isCssPageRule = (rule: CSSRule): rule is CSSPageRule => (rule as any).selectorText;
+
 const getSelectors = function (editor: Editor, doc, fileFilter) {
   const selectors = [], contentCSSUrls = {};
 
   function append(styleSheet, imported?) {
-    let href = styleSheet.href, rules;
+    let href = styleSheet.href, rules: CSSRule[];
 
     href = removeCacheSuffix(href);
 
@@ -89,9 +92,9 @@ const getSelectors = function (editor: Editor, doc, fileFilter) {
     }
 
     Tools.each(rules, function (cssRule) {
-      if (cssRule.styleSheet) {
+      if (isCssImportRule(cssRule)) {
         append(cssRule.styleSheet, true);
-      } else if (cssRule.selectorText) {
+      } else if (isCssPageRule(cssRule)) {
         Tools.each(cssRule.selectorText.split(','), function (selector) {
           selectors.push(Tools.trim(selector));
         });

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Settings.ts
@@ -13,7 +13,7 @@ const getTimeFormat = function (editor) {
   return editor.getParam('insertdatetime_timeformat', editor.translate('%H:%M:%S'));
 };
 
-const getFormats = function (editor) {
+const getFormats = function (editor): string[] {
   return editor.getParam('insertdatetime_formats', [ '%H:%M:%S', '%Y-%m-%d', '%I:%M:%S %p', '%D' ]);
 };
 

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
@@ -21,7 +21,9 @@ const register = function (editor: Editor) {
     tooltip: 'Insert date/time',
     select: (value) => value === defaultFormat.get(),
     fetch: (done) => {
-      done(Tools.map(formats, (format): Menu.ChoiceMenuItemSpec => ({ type: 'choiceitem', text: Actions.getDateTime(editor, format), value: format })));
+      done(Tools.map(formats, (format): Menu.ChoiceMenuItemSpec =>
+        ({ type: 'choiceitem', text: Actions.getDateTime(editor, format), value: format })
+      ));
     },
     onAction: (_api) => {
       Actions.insertDateTime(editor, defaultFormat.get());

--- a/modules/tinymce/src/plugins/link/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/api/Settings.ts
@@ -7,7 +7,7 @@
 
 import { Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
-import { ListItem } from '../ui/DialogTypes';
+import { UserListItem } from '../ui/DialogTypes';
 import { AssumeExternalTargets } from './Types';
 
 const assumeExternalTargets = (editor: Editor): AssumeExternalTargets => {
@@ -24,15 +24,15 @@ const assumeExternalTargets = (editor: Editor): AssumeExternalTargets => {
 
 const hasContextToolbar = (editor: Editor) => editor.getParam('link_context_toolbar', false, 'boolean');
 
-const getLinkList = (editor: Editor): string | ListItem[] | ((success: (val: any) => void) => void) => editor.getParam('link_list');
+const getLinkList = (editor: Editor): string | UserListItem[] | ((success: (val: any) => void) => void) => editor.getParam('link_list');
 
 const getDefaultLinkTarget = (editor: Editor) => editor.getParam('default_link_target');
 
-const getTargetList = (editor: Editor): boolean | ListItem[] => editor.getParam('target_list', true);
+const getTargetList = (editor: Editor): boolean | UserListItem[] => editor.getParam('target_list', true);
 
-const getRelList = (editor: Editor): ListItem[] => editor.getParam('rel_list', [], 'array');
+const getRelList = (editor: Editor): UserListItem[] => editor.getParam('rel_list', [], 'array');
 
-const getLinkClassList = (editor: Editor): ListItem[] => editor.getParam('link_class_list', [], 'array');
+const getLinkClassList = (editor: Editor): UserListItem[] => editor.getParam('link_class_list', [], 'array');
 
 const shouldShowLinkTitle = (editor: Editor) => editor.getParam('link_title', true, 'boolean');
 

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -14,7 +14,7 @@ import * as Dialog from '../ui/Dialog';
 import * as OpenUrl from './OpenUrl';
 import * as Utils from './Utils';
 
-const getLink = (editor: Editor, elm) => editor.dom.getParent(elm, 'a[href]');
+const getLink = (editor: Editor, elm: Node) => editor.dom.getParent<HTMLAnchorElement>(elm, 'a[href]');
 
 const getSelectedLink = (editor: Editor) => getLink(editor, editor.selection.getStart());
 
@@ -22,11 +22,11 @@ const hasOnlyAltModifier = function (e) {
   return e.altKey === true && e.shiftKey === false && e.ctrlKey === false && e.metaKey === false;
 };
 
-const gotoLink = (editor: Editor, a) => {
+const gotoLink = (editor: Editor, a: HTMLAnchorElement | null) => {
   if (a) {
     const href = Utils.getHref(a);
     if (/^#/.test(href)) {
-      const targetEl = editor.$(href);
+      const targetEl = editor.$<Element>(href);
       if (targetEl.length) {
         editor.selection.scrollIntoView(targetEl[0], true);
       }

--- a/modules/tinymce/src/plugins/link/main/ts/core/ListOptions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/ListOptions.ts
@@ -8,11 +8,11 @@
 import { Optional, Type } from '@ephox/katamari';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 import Tools from 'tinymce/core/api/util/Tools';
-import { ListItem } from '../ui/DialogTypes';
+import { ListItem, UserListItem } from '../ui/DialogTypes';
 
 const getValue = (item): string => Type.isString(item.value) ? item.value : '';
 
-const sanitizeList = (list, extractValue: (item) => string): ListItem[] => {
+const sanitizeList = (list: UserListItem[], extractValue: (item) => string): ListItem[] => {
   const out: ListItem[] = [];
   Tools.each(list, (item) => {
     const text: string = Type.isString(item.text) ? item.text : Type.isString(item.title) ? item.title : '';
@@ -27,10 +27,10 @@ const sanitizeList = (list, extractValue: (item) => string): ListItem[] => {
   return out;
 };
 
-const sanitizeWith = (extracter: (item: any) => string = getValue) => (list: any[]): Optional<ListItem[]> =>
+const sanitizeWith = (extracter: (item: any) => string = getValue) => (list: UserListItem[]): Optional<ListItem[]> =>
   Optional.from(list).map((list) => sanitizeList(list, extracter));
 
-const sanitize = (list: any[]): Optional<ListItem[]> => sanitizeWith(getValue)(list);
+const sanitize = (list: UserListItem[]): Optional<ListItem[]> => sanitizeWith(getValue)(list);
 
 // NOTE: May need to care about flattening.
 const createUi = (name: string, label: string) => (items: ListItem[]): Dialog.ListBoxSpec => ({

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogTypes.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogTypes.ts
@@ -12,6 +12,12 @@ export type ListValue = Dialog.ListBoxSingleItemSpec;
 export type ListGroup = Dialog.ListBoxNestedItemSpec;
 export type ListItem = Dialog.ListBoxItemSpec;
 
+export interface UserListItem {
+  text?: string;
+  title?: string;
+  menu?: UserListItem[];
+}
+
 export interface LinkDialogCatalog {
   link: Optional<ListItem[]>;
   targets: Optional<ListItem[]>;

--- a/modules/tinymce/src/plugins/link/main/ts/ui/sections/LinkListOptions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/sections/LinkListOptions.ts
@@ -10,7 +10,7 @@ import Promise from 'tinymce/core/api/util/Promise';
 import XHR from 'tinymce/core/api/util/XHR';
 import * as Settings from '../../api/Settings';
 import { ListOptions } from '../../core/ListOptions';
-import { ListItem } from '../DialogTypes';
+import { ListItem, UserListItem } from '../DialogTypes';
 
 const parseJson = (text: string): Optional<ListItem[]> => {
   // Do some proper modelling.
@@ -25,7 +25,7 @@ const getLinks = (editor): Promise<Optional<ListItem[]>> => {
   const extractor = (item) => editor.convertURL(item.value || item.url, 'href');
 
   const linkList = Settings.getLinkList(editor);
-  return new Promise<Optional<ListItem[]>>((callback) => {
+  return new Promise<Optional<UserListItem[]>>((callback) => {
     // TODO - better handling of failure
     if (Type.isString(linkList)) {
       XHR.send({

--- a/modules/tinymce/src/plugins/media/main/ts/core/Types.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Types.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-export interface MediaData {
+export type MediaData = {
   allowFullscreen?: boolean;
   source: string;
   sourcemime?: string;
@@ -16,7 +16,7 @@ export interface MediaData {
   altsource: string;
   altsourcemime?: string;
   type?: 'ephox-embed-iri' | 'script' | 'object' | 'iframe' | 'embed' | 'video' | 'audio';
-}
+};
 
 export interface DialogSubData {
   value: string;

--- a/modules/tinymce/src/plugins/paste/main/ts/core/PasteBin.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/PasteBin.ts
@@ -103,9 +103,9 @@ const getHtml = (editor: Editor): string => {
   };
 
   // find only top level elements (there might be more nested inside them as well, see TINY-1162)
-  const pasteBinClones = Tools.grep(getPasteBinParent(editor).childNodes, function (elm: Element) {
-    return elm.id === 'mcepastebin';
-  });
+  const pasteBinClones = Tools.grep(getPasteBinParent(editor).childNodes, function (elm: ChildNode) {
+    return (elm as HTMLElement).id === 'mcepastebin';
+  }) as HTMLElement[];
   const pasteBinElm = pasteBinClones.shift();
 
   // if clones were found, move their content into the first bin

--- a/modules/tinymce/src/plugins/paste/main/ts/core/ProcessFilters.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/ProcessFilters.ts
@@ -18,7 +18,9 @@ const preProcess = (editor: Editor, html: string) => {
 
   // Strip meta elements
   parser.addNodeFilter('meta', (nodes) => {
-    Tools.each(nodes, (node) => node.remove());
+    Tools.each(nodes, (node) => {
+      node.remove();
+    });
   });
 
   const fragment = parser.parse(html, { forced_root_block: false, isRootContent: true });

--- a/modules/tinymce/src/plugins/paste/main/ts/core/WordFilter.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/WordFilter.ts
@@ -226,7 +226,7 @@ function convertFakeListsToProperLists(node) {
   }
 }
 
-function filterStyles(editor, validStyles, node, styleValue) {
+function filterStyles(editor: Editor, validStyles, node, styleValue) {
   let outputStyles = {}, matches;
   const styles = editor.dom.parseStyle(styleValue);
 

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/api/Settings.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getLanguages = function (editor: Editor) {
+const getLanguages = function (editor: Editor): string {
   const defaultLanguages = 'English=en,Danish=da,Dutch=nl,Finnish=fi,French=fr_FR,German=de,Italian=it,Polish=pl,Portuguese=pt_BR,Spanish=es,Swedish=sv';
   return editor.getParam('spellchecker_languages', defaultLanguages);
 };

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/core/Actions.ts
@@ -154,8 +154,8 @@ const getElmIndex = function (elm: HTMLElement) {
   return value;
 };
 
-const findSpansByIndex = function (editor: Editor, index: string) {
-  const spans = [];
+const findSpansByIndex = function (editor: Editor, index: string): HTMLSpanElement[] {
+  const spans: HTMLSpanElement[] = [];
 
   const nodes = Tools.toArray(editor.getBody().getElementsByTagName('span'));
   if (nodes.length) {

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/ui/Buttons.ts
@@ -15,9 +15,14 @@ import { DomTextMatcher } from '../core/DomTextMatcher';
 
 type LastSuggestion = Actions.LastSuggestion;
 
+interface LanguageValue {
+  name: string;
+  value: string;
+}
+
 const spellcheckerEvents = 'SpellcheckStart SpellcheckEnd';
 
-const buildMenuItems = function (listName: string, languageValues) {
+const buildMenuItems = function (listName: string, languageValues: LanguageValue[]) {
   const items = [];
 
   Tools.each(languageValues, function (languageValue) {
@@ -31,13 +36,13 @@ const buildMenuItems = function (listName: string, languageValues) {
   return items;
 };
 
-const getItems = function (editor) {
+const getItems = function (editor: Editor): LanguageValue[] {
   return Tools.map(Settings.getLanguages(editor).split(','), function (langPair) {
-    langPair = langPair.split('=');
+    const langPairs = langPair.split('=');
 
     return {
-      name: langPair[0],
-      value: langPair[1]
+      name: langPairs[0],
+      value: langPairs[1]
     };
   });
 };

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
@@ -15,7 +15,8 @@ type LastSuggestion = Actions.LastSuggestion;
 
 const ignoreAll = true;
 
-const getSuggestions = (editor: Editor, pluginUrl: string, lastSuggestionsState, startedState, textMatcherState, currentLanguageState, word, spans) => {
+const getSuggestions = (editor: Editor, pluginUrl: string, lastSuggestionsState: Cell<LastSuggestion>, startedState: Cell<boolean>,
+                        textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, word: string, spans: HTMLSpanElement[]) => {
   const items = [];
   const suggestions = lastSuggestionsState.get().suggestions[word];
 
@@ -62,8 +63,8 @@ const getSuggestions = (editor: Editor, pluginUrl: string, lastSuggestionsState,
   return items;
 };
 
-const setup = function (editor: Editor, pluginUrl: string, lastSuggestionsState: Cell<LastSuggestion>, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>) {
-
+const setup = function (editor: Editor, pluginUrl: string, lastSuggestionsState: Cell<LastSuggestion>, startedState: Cell<boolean>,
+                        textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>) {
   const update = (element: HTMLElement) => {
     const target = element;
     if (target.className === 'mce-spellchecker-word') {

--- a/modules/tinymce/src/plugins/tabfocus/main/ts/core/Keyboard.ts
+++ b/modules/tinymce/src/plugins/tabfocus/main/ts/core/Keyboard.ts
@@ -24,14 +24,14 @@ const tabCancel = function (e) {
 
 const setup = function (editor: Editor) {
   function tabHandler(e) {
-    let x, el, i;
+    let x: number, i: number;
 
     if (e.keyCode !== VK.TAB || e.ctrlKey || e.altKey || e.metaKey || e.isDefaultPrevented()) {
       return;
     }
 
     function find(direction) {
-      el = DOM.select(':input:enabled,*[tabindex]:not(iframe)');
+      const el = DOM.select(':input:enabled,*[tabindex]:not(iframe)');
 
       function canSelectRecursive(e) {
         return e.nodeName === 'BODY' || (e.type !== 'hidden' &&
@@ -74,6 +74,7 @@ const setup = function (editor: Editor) {
     }
 
     // Find element to focus
+    let el: HTMLElement;
     if (e.shiftKey) {
       if (v[0] === ':prev') {
         el = find(-1);
@@ -89,7 +90,7 @@ const setup = function (editor: Editor) {
     }
 
     if (el) {
-      const focusEditor = EditorManager.get(el.id || el.name);
+      const focusEditor = EditorManager.get(el.id || (el as any).name);
 
       if (el.id && focusEditor) {
         focusEditor.focus();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -373,7 +373,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
   });
 
   suite.test('TestCase-TBA: Table: row clipboard api', (editor) => {
-    const createRow = (cellContents) => {
+    const createRow = (cellContents: string[]) => {
       const tr = editor.dom.create('tr');
 
       Tools.each(cellContents, (html) => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/GridSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/GridSelectionTest.ts
@@ -2,6 +2,7 @@ import { Assertions, Log, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { LegacyUnit, TinyApis, TinyLoader } from '@ephox/mcagar';
 
+import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
@@ -11,14 +12,14 @@ UnitTest.asynctest('browser.tinymce.plugins.table.GridSelectionTest', (success, 
   SilverTheme();
   Plugin();
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  TinyLoader.setupLight(function (editor: Editor, onSuccess, onFailure) {
     const tinyApis = TinyApis(editor);
 
     const sAssertTableSelection = function (tableHtml: string, selectCells: string[], cellContents: string[]) {
       const selectRangeXY = (table, startTd, endTd) => {
-        editor.fire('mousedown', { target: startTd, button: 0 });
-        editor.fire('mouseover', { target: endTd, button: 0 });
-        editor.fire('mouseup', { target: endTd, button: 0 });
+        editor.fire('mousedown', { target: startTd, button: 0 } as MouseEvent);
+        editor.fire('mouseover', { target: endTd, button: 0 } as MouseEvent);
+        editor.fire('mouseup', { target: endTd, button: 0 } as MouseEvent);
       };
 
       const getCells = (table): HTMLTableCellElement[] => editor.$(table).find('td').toArray();

--- a/modules/tinymce/src/plugins/template/main/ts/core/Templates.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/Templates.ts
@@ -63,7 +63,7 @@ const hasClass = function (n, c) {
   return new RegExp('\\b' + c + '\\b', 'g').test(n.className);
 };
 
-const insertTemplate = function (editor, ui, html) {
+const insertTemplate = function (editor: Editor, _ui: boolean, html: string) {
   // Note: ui is unused here but is required since this can be called by execCommand
   let el;
   const dom = editor.dom;

--- a/modules/tinymce/src/plugins/toc/main/ts/core/Toc.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/core/Toc.ts
@@ -6,6 +6,7 @@
  */
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
@@ -13,7 +14,7 @@ import * as Guid from './Guid';
 
 const tocId = Guid.create('mcetoc_');
 
-const generateSelector = function generateSelector(depth) {
+const generateSelector = function (depth: number) {
   let i;
   const selector = [];
   for (i = 1; i <= depth; i++) {
@@ -22,11 +23,11 @@ const generateSelector = function generateSelector(depth) {
   return selector.join(',');
 };
 
-const hasHeaders = function (editor) {
+const hasHeaders = function (editor: Editor) {
   return readHeaders(editor).length > 0;
 };
 
-const readHeaders = function (editor) {
+const readHeaders = function (editor: Editor) {
   const tocClass = Settings.getTocClass(editor);
   const headerTag = Settings.getTocHeader(editor);
   const selector = generateSelector(Settings.getTocDepth(editor));
@@ -40,8 +41,9 @@ const readHeaders = function (editor) {
   }
 
   return Tools.map(headers, function (h) {
+    const id = (h as Element).id;
     return {
-      id: h.id ? h.id : tocId(),
+      id: id ? id : tocId(),
       level: parseInt(h.nodeName.replace(/^H/i, ''), 10),
       title: editor.$.text(h),
       element: h

--- a/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
+++ b/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
@@ -45,7 +45,7 @@ UnitTest.asynctest('browser.tinymce.plugins.toc.TocPluginTest', (success, failur
     LegacyUnit.setSelection(editor, 'h1', 0);
     editor.execCommand('mceInsertToc');
 
-    const $toc = editor.$('.tst-toc');
+    const $toc = editor.$<Element>('.tst-toc');
 
     LegacyUnit.equal($toc.length, 2, 'ToC inserted');
     LegacyUnit.equal($toc.attr('contentEditable'), 'false', 'cE=false');
@@ -87,7 +87,7 @@ UnitTest.asynctest('browser.tinymce.plugins.toc.TocPluginTest', (success, failur
     LegacyUnit.setSelection(editor, 'h1', 0);
     editor.execCommand('mceInsertToc');
 
-    const $toc = editor.$('.tst-toc');
+    const $toc = editor.$<Element>('.tst-toc');
 
     stripAttribs($toc, [ 'data-mce-href', 'data-mce-selected' ]);
 
@@ -152,7 +152,7 @@ UnitTest.asynctest('browser.tinymce.plugins.toc.TocPluginTest', (success, failur
 
     editor.setContent(contents);
 
-    const $toc = editor.$('.tst-toc');
+    const $toc = editor.$<Element>('.tst-toc');
     LegacyUnit.deepEqual($toc.attr('contentEditable'), 'false', 'cE added back after setContent()');
     LegacyUnit.deepEqual($toc.find(':first-child').attr('contentEditable'), 'true',
       'cE added back to title after setContent()');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/CropRect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/CropRect.ts
@@ -26,7 +26,7 @@ export interface CropRect extends Observable<any> {
 }
 
 const create = (currentRect, viewPortRect, clampRect, containerElm, action): CropRect => {
-  let dragHelpers;
+  let dragHelpers: any[];
   const prefix = 'tox-';
   const id = prefix + 'crid-' + count++;
 


### PR DESCRIPTION
Related Ticket: TINY-6475

Description of Changes:
* Fixes incorrect types discovered in the `Tools` API. Note given the time constraints a lot of places have just been updated to use `any` for now. Also if you see `interface` converted to `type` it's because the type needs to be iterable.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
