### PR TITLE
Strict CSP-compatibility: move event handlers and javascript: URIs

### DIFF
--- a/src/plugins/compat3x/main/js/tiny_mce_popup.js
+++ b/src/plugins/compat3x/main/js/tiny_mce_popup.js
@@ -90,6 +90,50 @@ var tinyMCEPopup = {
 
     self.isWindow = !self.getWindowArg('mce_inline');
     self.id = self.getWindowArg('mce_window_id');
+
+    document.addEventListener('click', function (event) {
+      switch(event.target.className) {
+        case 'pickcolor':
+          tinyMCEPopup.pickColor(e, event.target.dataset.targetFormElement);
+          event.preventDefault();
+          break;
+        case 'pickcolor-span':
+          tinyMCEPopup.pickColor(e, event.target.parentElement.dataset.targetFormElement);
+          event.stopImmediatePropagation();
+          event.preventDefault();
+          break;
+        case 'browse':
+          openBrowser(event.target.dataset.id, event.target.dataset.targetFormElement, event.target.dataset.type, event.target.dataset.option);
+          event.preventDefault();
+          break;
+        case 'browse-span':
+          openBrowser(event.target.parentElement.dataset.id, event.target.parentElement.dataset.targetFormElement, event.target.parentElement.dataset.type, event.target.parentElement.dataset.option);
+          event.stopImmediatePropagation();
+          event.preventDefault();
+          break;
+        default:
+          break;
+      }
+    });
+
+    document.addEventListener('mousedown', function (event) {
+      switch(event.target.className) {
+        case 'pickcolor':
+          event.preventDefault();
+          break;
+        case 'pickcolor-span':
+          event.preventDefault();
+          break;
+        case 'browse':
+          event.preventDefault();
+          break;
+        case 'browse-span':
+          event.preventDefault();
+          break;
+        default:
+          break;
+      }
+    });
   },
 
   /**

--- a/src/plugins/compat3x/main/js/utils/form_utils.js
+++ b/src/plugins/compat3x/main/js/utils/form_utils.js
@@ -20,35 +20,6 @@ function getColorPickerHTML(id, target_form_element) {
   h += '<a role="button" aria-labelledby="' + id + '_label" id="' + id + '_link" href="about:blank" data-target-form-element="' + target_form_element + '" class="pickcolor">';
   h += '<span id="' + id + '" title="' + tinyMCEPopup.getLang('browse') + '" class="pickcolor-span">&nbsp;<span id="' + id + '_label" class="mceVoiceLabel mceIconOnly" style="display:none;">' + tinyMCEPopup.getLang('browse') + '</span></span></a>';
 
-  document.addEventListener('click', function (event) {
-    switch(event.target.className) {
-      case 'pickcolor':
-        tinyMCEPopup.pickColor(e, event.target.dataset.targetFormElement);
-        event.preventDefault();
-        break;
-      case 'pickcolor-span':
-        tinyMCEPopup.pickColor(e, event.target.parentElement.dataset.targetFormElement);
-        event.stopImmediatePropagation();
-        event.preventDefault();
-        break;
-      default:
-        break;
-    }
-  });
-
-  document.addEventListener('mousedown', function (event) {
-    switch(event.target.className) {
-      case 'pickcolor':
-        event.preventDefault();
-        break;
-      case 'pickcolor-span':
-        event.preventDefault();
-        break;
-      default:
-        break;
-    }
-  });
-
   return h;
 }
 
@@ -87,35 +58,6 @@ function getBrowserHTML(id, target_form_element, type, prefix) {
   html = "";
   html += '<a id="' + id + '_link" href="about:blank" data-id="' + id + '" data-target-form-element="' + target_form_element + '" data-type="' + type + '" data-option="' + option + '" class="browse">';
   html += '<span id="' + id + '" title="' + tinyMCEPopup.getLang('browse') + '" class="browse-span">&nbsp;</span></a>';
-
-  document.addEventListener('click', function (event) {
-    switch(event.target.className) {
-      case 'browse':
-        openBrowser(event.target.dataset.id, event.target.dataset.targetFormElement, event.target.dataset.type, event.target.dataset.option);
-        event.preventDefault();
-        break;
-      case 'browse-span':
-        openBrowser(event.target.parentElement.dataset.id, event.target.parentElement.dataset.targetFormElement, event.target.parentElement.dataset.type, event.target.parentElement.dataset.option);
-        event.stopImmediatePropagation();
-        event.preventDefault();
-        break;
-      default:
-        break;
-    }
-  });
-
-  document.addEventListener('mousedown', function (event) {
-    switch(event.target.className) {
-      case 'browse':
-        event.preventDefault();
-        break;
-      case 'browse-span':
-        event.preventDefault();
-        break;
-      default:
-        break;
-    }
-  });
 
   return html;
 }

--- a/src/plugins/compat3x/main/js/utils/form_utils.js
+++ b/src/plugins/compat3x/main/js/utils/form_utils.js
@@ -17,8 +17,37 @@ function getColorPickerHTML(id, target_form_element) {
     label.id = label.id || dom.uniqueId();
   }
 
-  h += '<a role="button" aria-labelledby="' + id + '_label" id="' + id + '_link" href="javascript:;" onclick="tinyMCEPopup.pickColor(event,\'' + target_form_element + '\');" onmousedown="return false;" class="pickcolor">';
-  h += '<span id="' + id + '" title="' + tinyMCEPopup.getLang('browse') + '">&nbsp;<span id="' + id + '_label" class="mceVoiceLabel mceIconOnly" style="display:none;">' + tinyMCEPopup.getLang('browse') + '</span></span></a>';
+  h += '<a role="button" aria-labelledby="' + id + '_label" id="' + id + '_link" href="about:blank" data-target-form-element="' + target_form_element + '" class="pickcolor">';
+  h += '<span id="' + id + '" title="' + tinyMCEPopup.getLang('browse') + '" class="pickcolor-span">&nbsp;<span id="' + id + '_label" class="mceVoiceLabel mceIconOnly" style="display:none;">' + tinyMCEPopup.getLang('browse') + '</span></span></a>';
+
+  document.addEventListener('click', function (event) {
+    switch(event.target.className) {
+      case 'pickcolor':
+        tinyMCEPopup.pickColor(e, event.target.dataset.targetFormElement);
+        event.preventDefault();
+        break;
+      case 'pickcolor-span':
+        tinyMCEPopup.pickColor(e, event.target.parentElement.dataset.targetFormElement);
+        event.stopImmediatePropagation();
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  });
+
+  document.addEventListener('mousedown', function (event) {
+    switch(event.target.className) {
+      case 'pickcolor':
+        event.preventDefault();
+        break;
+      case 'pickcolor-span':
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  });
 
   return h;
 }
@@ -56,8 +85,37 @@ function getBrowserHTML(id, target_form_element, type, prefix) {
   }
 
   html = "";
-  html += '<a id="' + id + '_link" href="javascript:openBrowser(\'' + id + '\',\'' + target_form_element + '\', \'' + type + '\',\'' + option + '\');" onmousedown="return false;" class="browse">';
-  html += '<span id="' + id + '" title="' + tinyMCEPopup.getLang('browse') + '">&nbsp;</span></a>';
+  html += '<a id="' + id + '_link" href="about:blank" data-id="' + id + '" data-target-form-element="' + target_form_element + '" data-type="' + type + '" data-option="' + option + '" class="browse">';
+  html += '<span id="' + id + '" title="' + tinyMCEPopup.getLang('browse') + '" class="browse-span">&nbsp;</span></a>';
+
+  document.addEventListener('click', function (event) {
+    switch(event.target.className) {
+      case 'browse':
+        openBrowser(event.target.dataset.id, event.target.dataset.targetFormElement, event.target.dataset.type, event.target.dataset.option);
+        event.preventDefault();
+        break;
+      case 'browse-span':
+        openBrowser(event.target.parentElement.dataset.id, event.target.parentElement.dataset.targetFormElement, event.target.parentElement.dataset.type, event.target.parentElement.dataset.option);
+        event.stopImmediatePropagation();
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  });
+
+  document.addEventListener('mousedown', function (event) {
+    switch(event.target.className) {
+      case 'browse':
+        event.preventDefault();
+        break;
+      case 'browse-span':
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  });
 
   return html;
 }


### PR DESCRIPTION
Description of Changes:
* Refactor of inline event handlers and `javascript:` URIs generated by compat3x's `getColorPickerHTML` and `getBrowserHTML` to enable [**strict CSP**-compatibility](https://csp.withgoogle.com/docs/adopting-csp.html).

Why:
Content Security Policy is a mechanism designed to make applications more secure against common web vulnerabilities, particularly cross-site scripting. It is enabled by setting the Content-Security-Policy HTTP response header.
An application can add a critical defense-in-depth layer against markup injection attacks by adopting a strict policy that prevents the loading of untrusted scripts or plugins.
To make an application compatible with strict CSP, it is necessary to make changes to HTML templates and client-side code and add the policy header:

1. Add nonces to <script> elements;
2. Refactor inline event handlers and javascript: URIs;
3. Refactor calls to JS APIs incompatible with CSP;
4. Serve the Content-Security-Policy header.

[More on CSP.](https://csp.withgoogle.com/)

This PR is related to a series of efforts to make WordPress strict CSP compatible, more on that [here](https://core.trac.wordpress.org/ticket/51407).

Pre-checks:
* [ ] Changelog entry added

Review:
* [ ] Milestone set
* [ ] Review comments resolved

