### PR TITLE
Fixed duplicate and inconsistent test names

### DIFF
--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -170,6 +170,7 @@ const move = (state: Singleton.Value<State>, editor: Editor) => {
     editor._selectionOverrides.hideFakeCaret();
     editor.selection.placeCaretAt(clientX, clientY);
   }, 0);
+  editor.on('remove', throttledPlaceCaretAt.stop);
 
   return (e: EditorEvent<MouseEvent>) => state.on((state) => {
     const movement = Math.max(Math.abs(e.screenX - state.screenX), Math.abs(e.screenY - state.screenY));

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -4,7 +4,7 @@ import { Obj, Optional } from '@ephox/katamari';
 import { KAssert } from '@ephox/katamari-assertions';
 import { Base64Extract, extractBase64DataUris, parseDataUri, restoreDataUris, UriMap } from 'tinymce/core/html/Base64Uris';
 
-UnitTest.test('Base64Uris Test', () => {
+UnitTest.test('atomic.tinymce.core.html.Base64UrisTest', () => {
   const replacePrefix = (value: string, prefix: string) => value.replace(/\$prefix/g, prefix);
   const replaceUrisPrefix = (uris: UriMap, prefix: string): UriMap => Obj.tupleMap(uris, (value, key) => ({ k: replacePrefix(key, prefix), v: value }));
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -8,7 +8,7 @@ import * as HtmlUtils from '../../module/test/HtmlUtils';
 
 const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
 
-UnitTest.test('DOMUtils.parseStyle', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.parseStyle', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   const dom = DOMUtils(document, {
@@ -53,7 +53,7 @@ UnitTest.test('DOMUtils.parseStyle', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.addClass', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.addClass', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.get('test').className = '';
@@ -73,7 +73,7 @@ UnitTest.test('DOMUtils.addClass', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.removeClass', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.removeClass', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.get('test').className = 'abc 123 xyz';
@@ -95,7 +95,7 @@ UnitTest.test('DOMUtils.removeClass', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.hasClass', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.hasClass', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.get('test').className = 'abc 123 xyz';
@@ -116,7 +116,7 @@ UnitTest.test('DOMUtils.hasClass', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.add', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.add', () => {
   let e;
 
   DOM.add(document.body, 'div', { id: 'test' });
@@ -144,7 +144,7 @@ UnitTest.test('DOMUtils.add', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.create', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.create', () => {
   const e = DOM.create('span', { class: 'abc 123' }, 'content <b>abc</b>');
 
   Assert.eq('incorrect nodeName', 'SPAN', e.nodeName);
@@ -152,7 +152,7 @@ UnitTest.test('DOMUtils.create', () => {
   Assert.eq('innerHTML was wrong', 'content <b>abc</b>', e.innerHTML.toLowerCase());
 });
 
-UnitTest.test('DOMUtils.createHTML', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.createHTML', () => {
   Assert.eq('', '<span id="id1" class="abc 123">content <b>abc</b></span>', DOM.createHTML('span', {
     id: 'id1',
     class: 'abc 123'
@@ -163,13 +163,13 @@ UnitTest.test('DOMUtils.createHTML', () => {
   Assert.eq('', '<span>content <b>abc</b></span>', DOM.createHTML('span', null, 'content <b>abc</b>'));
 });
 
-UnitTest.test('DOMUtils.uniqueId', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.uniqueId', () => {
   Assert.eq('', 'mce_0', DOM.uniqueId());
   Assert.eq('', 'mce_1', DOM.uniqueId());
   Assert.eq('', 'mce_2', DOM.uniqueId());
 });
 
-UnitTest.test('DOMUtils.showHide', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.showHide', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.show('test');
@@ -186,7 +186,7 @@ UnitTest.test('DOMUtils.showHide', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.select', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.select', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.setHTML('test', '<div>test 1</div><div>test 2 <div>test 3</div></div><div>test 4</div>');
@@ -203,7 +203,7 @@ UnitTest.test('DOMUtils.select', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.is', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.is', () => {
   DOM.add(document.body, 'div', { id: 'test' });
   DOM.setHTML('test', '<div id="textX" class="test">test 1</div>');
 
@@ -220,11 +220,11 @@ UnitTest.test('DOMUtils.is', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.encode', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.encode', () => {
   Assert.eq('', 'abc&lt;&gt;&quot;&amp;&#39;\u00e5\u00e4\u00f6', DOM.encode(`abc<>"&'\u00e5\u00e4\u00f6`));
 });
 
-UnitTest.test('DOMUtils.setGetAttrib', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.setGetAttrib', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.setAttrib('test', 'class', 'test 123');
@@ -260,12 +260,12 @@ UnitTest.test('DOMUtils.setGetAttrib', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.setGetAttrib on null', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.setGetAttrib on null', () => {
   Assert.eq('', '', DOM.getAttrib(null, 'test'));
   DOM.setAttrib(null, 'test', null);
 });
 
-UnitTest.test('DOMUtils.getAttribs', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getAttribs', () => {
   const check = (obj: NamedNodeMap | Attr[], val: string) => {
     let count = 0;
 
@@ -291,7 +291,7 @@ UnitTest.test('DOMUtils.getAttribs', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.setGetStyles', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.setGetStyles', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.setStyle('test', 'font-size', '20px');
@@ -321,7 +321,7 @@ UnitTest.test('DOMUtils.setGetStyles', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.getPos', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getPos', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.setStyles('test', { position: 'absolute', left: 100, top: 110 });
@@ -335,7 +335,7 @@ UnitTest.test('DOMUtils.getPos', () => {
 
 const eqNodeName = (name) => (n) => n.nodeName === name;
 
-UnitTest.test('DOMUtils.getParent', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getParent', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.get('test').innerHTML = '<div><span>ab<a id="test2" href="">abc</a>c</span></div>';
@@ -352,7 +352,7 @@ UnitTest.test('DOMUtils.getParent', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.getParents', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getParents', () => {
   DOM.add(document.body, 'div', { id: 'test' });
   DOM.get('test').innerHTML = '<div><span class="test">ab<span><a id="test2" href="">abc</a>c</span></span></div>';
 
@@ -364,7 +364,7 @@ UnitTest.test('DOMUtils.getParents', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.getViewPort', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getViewPort', () => {
   const wp = DOM.getViewPort();
   Assert.eq('', 0, wp.x);
   Assert.eq('', 0, wp.y);
@@ -372,7 +372,7 @@ UnitTest.test('DOMUtils.getViewPort', () => {
   Assert.eq('', true, wp.h > 0);
 });
 
-UnitTest.test('DOMUtils.getRect', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getRect', () => {
   let r;
 
   DOM.add(document.body, 'div', { id: 'test' });
@@ -393,7 +393,7 @@ UnitTest.test('DOMUtils.getRect', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.getSize', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getSize', () => {
   let r;
 
   DOM.add(document.body, 'div', { id: 'test' });
@@ -410,7 +410,7 @@ UnitTest.test('DOMUtils.getSize', () => {
 });
 
 // TODO: Add test comments
-UnitTest.test('DOMUtils.getNext', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getNext', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.get('test').innerHTML = '<strong>A</strong><span>B</span><em>C</em>';
@@ -423,7 +423,7 @@ UnitTest.test('DOMUtils.getNext', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.getPrev', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getPrev', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.get('test').innerHTML = '<strong>A</strong><span>B</span><em>C</em>';
@@ -436,7 +436,7 @@ UnitTest.test('DOMUtils.getPrev', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.loadCSS', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.loadCSS', () => {
   let c = 0;
 
   DOM.loadCSS('tinymce/dom/test.css?a=1,tinymce/dom/test.css?a=2,tinymce/dom/test.css?a=3');
@@ -450,7 +450,7 @@ UnitTest.test('DOMUtils.loadCSS', () => {
   Assert.eq('', 3, c);
 });
 
-UnitTest.test('DOMUtils.loadCSS contentCssCors enabled', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.loadCSS contentCssCors enabled', () => {
   let c = 0;
 
   // The crossorigin attribute isn't supported in IE11
@@ -481,7 +481,7 @@ UnitTest.test('DOMUtils.loadCSS contentCssCors enabled', () => {
   Assert.eq('', 3, c);
 });
 
-UnitTest.test('DOMUtils.insertAfter', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.insertAfter', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.setHTML('test', '<span id="test2"></span>');
@@ -495,14 +495,14 @@ UnitTest.test('DOMUtils.insertAfter', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.isBlock', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.isBlock', () => {
   Assert.eq('', true, DOM.isBlock(DOM.create('div')));
   Assert.eq('', true, DOM.isBlock('DIV'));
   Assert.eq('', false, DOM.isBlock('SPAN'));
   Assert.eq('', true, DOM.isBlock('div'));
 });
 
-UnitTest.test('DOMUtils.remove', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.remove', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.setHTML('test', '<span id="test2"><span>test</span><span>test2</span></span>');
@@ -515,7 +515,7 @@ UnitTest.test('DOMUtils.remove', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.replace', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.replace', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.setHTML('test', '<span id="test2"><span>test</span><span>test2</span></span>');
@@ -529,7 +529,7 @@ UnitTest.test('DOMUtils.replace', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.toHex', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.toHex', () => {
   Assert.eq('', '#00ffff', DOM.toHex('rgb(0, 255, 255)'));
   Assert.eq('', '#ff0000', DOM.toHex('rgb(255, 0, 0)'));
   Assert.eq('', '#0000ff', DOM.toHex('rgb(0, 0, 255)'));
@@ -537,7 +537,7 @@ UnitTest.test('DOMUtils.toHex', () => {
   Assert.eq('', '#0000ff', DOM.toHex('   RGB  (  0  , 0  , 255  )  '));
 });
 
-UnitTest.test('DOMUtils.getOuterHTML', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.getOuterHTML', () => {
   DOM.add(document.body, 'div', { id: 'test' });
 
   DOM.setHTML('test', '<span id="test2"><span>test</span><span>test2</span></span>');
@@ -557,12 +557,12 @@ UnitTest.test('DOMUtils.getOuterHTML', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.encodeDecode', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.encodeDecode', () => {
   Assert.eq('', '\u00e5\u00e4\u00f6&amp;&lt;&gt;&quot;', DOM.encode('\u00e5\u00e4\u00f6&<>"'));
   Assert.eq('', '\u00e5\u00e4\u00f6&<>"', DOM.decode('&aring;&auml;&ouml;&amp;&lt;&gt;&quot;'));
 });
 
-UnitTest.test('DOMUtils.split', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.split', () => {
   let point: Element;
   let parent: Element;
   DOM.add(document.body, 'div', { id: 'test' });
@@ -612,7 +612,7 @@ UnitTest.test('DOMUtils.split', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.nodeIndex', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.nodeIndex', () => {
   DOM.add(document.body, 'div', { id: 'test' }, 'abc<b>abc</b>abc');
 
   Assert.eq('', 0, DOM.nodeIndex(DOM.get('test').childNodes[0]));
@@ -628,7 +628,7 @@ UnitTest.test('DOMUtils.nodeIndex', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.isEmpty without defined schema', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.isEmpty without defined schema', () => {
   DOM.add(document.body, 'div', { id: 'test' }, '');
 
   const domUtils = DOMUtils(document);
@@ -642,7 +642,7 @@ UnitTest.test('DOMUtils.isEmpty without defined schema', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.isEmpty', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.isEmpty', () => {
   DOM.schema = Schema(); // A schema will be added when used within a editor instance
   DOM.add(document.body, 'div', { id: 'test' }, '');
 
@@ -714,34 +714,34 @@ UnitTest.test('DOMUtils.isEmpty', () => {
   DOM.remove('test');
 });
 
-UnitTest.test('DOMUtils.isEmpty with list of elements considered non-empty', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.isEmpty with list of elements considered non-empty', () => {
   const elm = DOM.create('p', null, '<img>');
   Assert.eq('', DOM.isEmpty(elm, { img: true }), false);
 });
 
-UnitTest.test('DOMUtils.isEmpty on pre', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.isEmpty on pre', () => {
   const elm = DOM.create('pre', null, '  ');
   Assert.eq('', DOM.isEmpty(elm), false);
 });
 
-UnitTest.test('DOMUtils.isEmpty with list of elements considered non-empty without schema', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.isEmpty with list of elements considered non-empty without schema', () => {
   const domWithoutSchema = DOMUtils(document, { keep_values: true });
 
   const elm = domWithoutSchema.create('p', null, '<img>');
   Assert.eq('', domWithoutSchema.isEmpty(elm, { img: true }), false);
 });
 
-UnitTest.test('DOMUtils.isEmpty on P with BR in EM', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.isEmpty on P with BR in EM', () => {
   const elm = DOM.create('p', null, '<em><br></em>');
   Assert.eq('', true, DOM.isEmpty(elm));
 });
 
-UnitTest.test('DOMUtils.isEmpty on P with two BR in EM', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.isEmpty on P with two BR in EM', () => {
   const elm = DOM.create('p', null, '<em><br><br></em>');
   Assert.eq('', DOM.isEmpty(elm), false);
 });
 
-UnitTest.test('DOMUtils.bind/unbind/fire', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.bind/unbind/fire', () => {
   let count = 0;
 
   DOM.bind(document, 'click', () => {
@@ -767,7 +767,7 @@ UnitTest.test('DOMUtils.bind/unbind/fire', () => {
   Assert.eq('', 0, count);
 });
 
-UnitTest.test('DOMUtils.get - by id in head', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.get - by id in head', () => {
   const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
 
   const meta: HTMLMetaElement = document.createElement('meta');
@@ -778,7 +778,7 @@ UnitTest.test('DOMUtils.get - by id in head', () => {
   document.head.removeChild(meta);
 });
 
-UnitTest.test('DOMUtils.get - does not find element by name in head', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.get - does not find element by name in head', () => {
   const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
 
   const meta: HTMLMetaElement = document.createElement('meta');
@@ -789,7 +789,7 @@ UnitTest.test('DOMUtils.get - does not find element by name in head', () => {
   document.head.removeChild(meta);
 });
 
-UnitTest.test('DOMUtils.get - does not find element by name in body', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.get - does not find element by name in body', () => {
   const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
 
   const meta: HTMLMetaElement = document.createElement('meta');
@@ -800,7 +800,7 @@ UnitTest.test('DOMUtils.get - does not find element by name in body', () => {
   document.body.removeChild(meta);
 });
 
-UnitTest.test('DOMUtils.get - finds element by id in body, not element by name in head', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.get - finds element by id in body, not element by name in head', () => {
   const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
 
   const meta = document.createElement('meta');
@@ -816,7 +816,7 @@ UnitTest.test('DOMUtils.get - finds element by id in body, not element by name i
   document.body.removeChild(div);
 });
 
-UnitTest.test('DOMUtils.get - returns element', () => {
+UnitTest.test('browser.tinymce.core.dom.DOMUtils.get - returns element', () => {
   const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
   const e = document.createElement('div');
   Assert.eq('get', e, DOM.get(e), Testable.tStrict);

--- a/modules/tinymce/src/core/test/ts/browser/dom/StyleSheetLoaderRegistryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/StyleSheetLoaderRegistryTest.ts
@@ -4,14 +4,14 @@ import { SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { StyleSheetLoader } from 'tinymce/core/api/dom/StyleSheetLoader';
 import * as StyleSheetLoaderRegistry from 'tinymce/core/dom/StyleSheetLoaderRegistry';
 
-UnitTest.test('StyleSheetLoaderRegistry - same element gets same instance (document)', () => {
+UnitTest.test('browser.tinymce.core.dom.StyleSheetLoaderRegistry - same element gets same instance (document)', () => {
   const sslr = StyleSheetLoaderRegistry.create();
   const ssl1: StyleSheetLoader = sslr.forElement(SugarDocument.getDocument(), {});
   const ssl2: StyleSheetLoader = sslr.forElement(SugarDocument.getDocument(), {});
   Assert.eq('Should be the same', ssl1, ssl2, Testable.tStrict);
 });
 
-UnitTest.test('StyleSheetLoaderRegistry - same element gets same instance (ShadowRoot)', () => {
+UnitTest.test('browser.tinymce.core.dom.StyleSheetLoaderRegistry - same element gets same instance (ShadowRoot)', () => {
   if (!SugarShadowDom.isSupported()) {
     return;
   }

--- a/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
@@ -7,7 +7,7 @@ import FocusManager from 'tinymce/core/api/FocusManager';
 import * as FocusController from 'tinymce/core/focus/FocusController';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.focus.FocusControllerTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.core.focus.FocusControllerTest', function (success, failure) {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Theme();

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
@@ -6,7 +6,7 @@ import Env from 'tinymce/core/api/Env';
 import Theme from 'tinymce/themes/silver/Theme';
 import * as HtmlUtils from '../../module/test/HtmlUtils';
 
-UnitTest.asynctest('browser.tinymce.util.QuirksWekbitTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.core.util.QuirksWebkitTest', function (success, failure) {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Theme();

--- a/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
@@ -9,7 +9,7 @@ import * as PluginAssert from '../module/PluginAssert';
 
 import { selectors } from '../module/Selectors';
 
-UnitTest.asynctest('browser.plugin.IgnoreForcedPluginsTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.help.IgnoreForcedPluginsTest', (success, failure) => {
   HelpPlugin();
   LinkPlugin();
   SilverTheme();

--- a/modules/tinymce/src/plugins/help/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/PluginTest.ts
@@ -8,7 +8,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 import * as PluginAssert from '../module/PluginAssert';
 import { selectors } from '../module/Selectors';
 
-UnitTest.asynctest('browser.plugin.PluginTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.help.PluginTest', (success, failure) => {
 
   Theme();
   HelpPlugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyDlTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyDlTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.ApplyTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.ApplyDlTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
@@ -7,7 +7,7 @@ import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.ApplyTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.ApplyTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
@@ -7,7 +7,7 @@ import EditorManager from 'tinymce/core/api/EditorManager';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.BackspaceDeleteInlineTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.BackspaceDeleteInlineTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver//Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.BackspaceDeleteTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.BackspaceDeleteTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.IndentTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.IndentTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/InlineTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/InlineTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.IndentTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.InlineTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListModelTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListModelTest.ts
@@ -9,7 +9,7 @@ import { normalizeEntries } from 'tinymce/plugins/lists/listModel/NormalizeEntri
 import { parseLists } from 'tinymce/plugins/lists/listModel/ParseLists';
 import { ListType } from 'tinymce/plugins/lists/listModel/Util';
 
-UnitTest.test('tinymce.lists.browser.ListModelTest', () => {
+UnitTest.test('browser.tinymce.plugins.lists.ListModelTest', () => {
   const arbitratyContent = Jsc.bless({
     generator: Arbitraries.content('inline').generator.map((el) => [ el ])
   });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -7,7 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.ListPropertiesTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.ListPropertiesTest', (success, failure) => {
   Plugin();
   Theme();
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.OutdentTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.OutdentTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockAttrsTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockAttrsTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.RemoveForcedRootBlockAttrsTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.RemoveForcedRootBlockAttrsTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.RemoveForcedRootBlockFalseTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.RemoveForcedRootBlockFalseTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.RemoveTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.RemoveTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListWithEmptyLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListWithEmptyLiTest.ts
@@ -5,7 +5,7 @@ import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.lists.browser.ToggleListWithEmptyLiTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', (success, failure) => {
   ListsPlugin();
   SilverTheme();
 

--- a/modules/tinymce/src/plugins/media/test/ts/atomic/HtmlToDataTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/atomic/HtmlToDataTest.ts
@@ -1,7 +1,7 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import * as HtmlToData from 'tinymce/plugins/media/core/HtmlToData';
 
-UnitTest.test('atomic.core.HtmlToDataTest', function () {
+UnitTest.test('atomic.tinymce.plugins.media.core.HtmlToDataTest', function () {
   const testHtmlToData = function (html, expected) {
     const actual = HtmlToData.htmlToData([], html);
     Assert.eq('Assert equal', expected, actual);

--- a/modules/tinymce/src/plugins/media/test/ts/atomic/UpdateHtmlTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/atomic/UpdateHtmlTest.ts
@@ -2,7 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { MediaData } from 'tinymce/plugins/media/core/Types';
 import * as UpdateHtml from 'tinymce/plugins/media/core/UpdateHtml';
 
-UnitTest.test('atomic.plugins.media.UpdateHtmlTest', () => {
+UnitTest.test('atomic.tinymce.plugins.media.core.UpdateHtmlTest', () => {
   const testHtmlUpdate = (description: string, html: string, newData: Partial<MediaData>, updateAll: boolean, expected: string) => {
     const actual = UpdateHtml.updateHtml(html, newData, updateAll);
     Assert.eq(description, expected, actual);

--- a/modules/tinymce/src/plugins/media/test/ts/atomic/UrlPatternsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/atomic/UrlPatternsTest.ts
@@ -1,7 +1,7 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
 import * as UrlPatterns from 'tinymce/plugins/media/core/UrlPatterns';
 
-UnitTest.test('atomic.core.UrlPatternsTest', function () {
+UnitTest.test('atomic.tinymce.plugins.media.core.UrlPatternsTest', function () {
   const check = (url, expected) => {
     const pattern = UrlPatterns.matchPattern(url);
     assert.eq(expected, pattern.url);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
@@ -8,7 +8,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.plugins.media.DataAttributeTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.plugins.media.DataAttributeTest', function (success, failure) {
   Plugin();
   Theme();
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
@@ -7,7 +7,7 @@ import * as DataToHtml from 'tinymce/plugins/media/core/DataToHtml';
 import Plugin from 'tinymce/plugins/media/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.core.DataToHtmlTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.plugins.media.core.DataToHtmlTest', function (success, failure) {
   Plugin();
   Theme();
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataUnwrapTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataUnwrapTest.ts
@@ -6,7 +6,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 import { MediaData, MediaDialogData } from '../../../main/ts/core/Types';
 import * as Dialog from '../../../main/ts/ui/Dialog';
 
-UnitTest.asynctest('browser.core.DataToHtmlTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.plugins.media.core.DataUnwrapTest', function (success, failure) {
   Plugin();
   Theme();
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
@@ -9,7 +9,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.core.EphoxEmbedTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.plugins.media.core.EphoxEmbedTest', function (success, failure) {
   Plugin();
   Theme();
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/IframeNodeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/IframeNodeTest.ts
@@ -7,7 +7,7 @@ import Delay from 'tinymce/core/api/util/Delay';
 import Plugin from 'tinymce/plugins/media/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.core.IframeNodeTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.plugins.media.core.IframeNodeTest', function (success, failure) {
   Plugin();
   Theme();
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
@@ -7,7 +7,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.core.MediaEmbedTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.plugins.media.core.MediaEmbedTest', function (success, failure) {
 
   Plugin();
   Theme();

--- a/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
@@ -8,7 +8,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.core.PlaceholderTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.plugins.media.core.PlaceholderTest', function (success, failure) {
   Plugin();
   Theme();
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
@@ -7,7 +7,7 @@ import Plugin from 'tinymce/plugins/media/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.core.SubmitTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.media.core.SubmitTest', (success, failure) => {
   Plugin();
   Theme();
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/UpdateMediaPosterAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/UpdateMediaPosterAttributeTest.ts
@@ -6,7 +6,7 @@ import Plugin from 'tinymce/plugins/media/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.plugins.media.UpdateMediaPosterAttributeTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.media.UpdateMediaPosterAttributeTest', (success, failure) => {
   Plugin();
   Theme();
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
@@ -10,7 +10,7 @@ import { Clipboard } from 'tinymce/plugins/paste/api/Clipboard';
 import Plugin from 'tinymce/plugins/paste/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.plugins.paste.browser.ImagePasteTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/NewlinesTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/NewlinesTest.ts
@@ -6,7 +6,7 @@ import * as Newlines from 'tinymce/plugins/paste/core/Newlines';
 import PastePlugin from 'tinymce/plugins/paste/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.test('tinymce.plugins.paste.browser.NewlinesTest', function () {
+UnitTest.test('browser.tinymce.plugins.paste.NewlinesTest', function () {
   Theme();
   PastePlugin();
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
@@ -7,7 +7,7 @@ import { getPasteBinParent, PasteBin } from 'tinymce/plugins/paste/core/PasteBin
 import PastePlugin from 'tinymce/plugins/paste/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.plugins.paste.browser.PasteBin', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.paste.PasteBin', (success, failure) => {
 
   Theme();
   PastePlugin();

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteFormatToggleTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteFormatToggleTest.ts
@@ -8,7 +8,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Paste from '../module/test/Paste';
 
-UnitTest.asynctest('tinymce.plugins.paste.browser.PasteFormatToggleTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.paste.PasteFormatToggleTest', (success, failure) => {
   Theme();
   PastePlugin();
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
@@ -5,7 +5,7 @@ import { Editor as McEditor } from '@ephox/mcagar';
 import Plugin from 'tinymce/plugins/paste/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.plugins.paste.browser.PasteSettingsTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.paste.PasteSettingsTest', (success, failure) => {
   Theme();
   Plugin();
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
@@ -11,7 +11,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Strings from '../module/test/Strings';
 
-UnitTest.asynctest('tinymce.plugins.paste.browser.PasteTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.paste.PasteTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
@@ -8,7 +8,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 
 import * as MockDataTransfer from '../module/test/MockDataTransfer';
 
-UnitTest.asynctest('tinymce.plugins.paste.browser.PlainTextPaste', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.paste.PlainTextPaste', (success, failure) => {
   Theme();
   PastePlugin();
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ProcessFiltersTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ProcessFiltersTest.ts
@@ -7,7 +7,7 @@ import * as ProcessFilters from 'tinymce/plugins/paste/core/ProcessFilters';
 import PastePlugin from 'tinymce/plugins/paste/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.plugins.paste.browser.ProcessFiltersTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.paste.ProcessFiltersTest', (success, failure) => {
 
   Theme();
   PastePlugin();

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
@@ -18,7 +18,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 // |Paste as text turned off  | paste image URL -> image | paste image URL -> text |
 // |Paste as text turned on   | paste image URL -> text  | paste image URL -> text |
 
-UnitTest.asynctest('tinymce.plugins.paste.browser.SmartPasteTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.paste.SmartPasteTest', (success, failure) => {
   const suite = LegacyUnit.createSuite<Editor>();
 
   Plugin();

--- a/modules/tinymce/src/plugins/paste/test/ts/webdriver/CutTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/webdriver/CutTest.ts
@@ -6,7 +6,7 @@ import { PlatformDetection } from '@ephox/sand';
 import PastePlugin from 'tinymce/plugins/paste/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.plugins.paste.webdriver.CutTest', (success, failure) => {
+UnitTest.asynctest('webdriver.tinymce.plugins.paste.CutTest', (success, failure) => {
 
   Theme();
   PastePlugin();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
@@ -6,7 +6,7 @@ import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.plugins.table.IndentListsInTableTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.table.IndentListsInTableTest', (success, failure) => {
   SilverTheme();
   TablePlugin();
   ListsPlugin();

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/FindInlinePatternTest.ts
@@ -10,7 +10,7 @@ import { InlinePattern, InlinePatternMatch } from 'tinymce/plugins/textpattern/c
 import { PathRange } from 'tinymce/plugins/textpattern/utils/PathRange';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('textpattern.browser.FindInlinePatternTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.plugins.textpattern.FindInlinePatternTest', (success, failure) => {
   Theme();
 
   const mockEditor = {

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Keyboard.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Keyboard.ts
@@ -22,6 +22,8 @@ const setup = (editor: Editor, toggleState) => {
       }
     });
   }
+
+  editor.on('remove', debouncedToggle.stop);
 };
 
 export {

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/autocomplete/ParserTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/autocomplete/ParserTest.ts
@@ -1,7 +1,7 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
 import * as AutocompleteContext from 'tinymce/themes/silver/autocomplete/AutocompleteContext';
 
-UnitTest.test('atomic - AutocompleteContext', () => {
+UnitTest.test('atomic.tinymce.themes.silver.autocomplete.AutocompleteContext', () => {
   const testFindChar = () => {
     assert.eq(-1, AutocompleteContext.findChar('', 0, '@').getOr(null));
     assert.eq(-1, AutocompleteContext.findChar('abc', 0, '@').getOr(null));

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/menus/menu/MenuConversionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/menus/menu/MenuConversionTest.ts
@@ -2,7 +2,7 @@ import { assert, UnitTest } from '@ephox/bedrock-client';
 import { Menu } from '@ephox/bridge';
 import * as MenuConversion from 'tinymce/themes/silver/ui/menus/menu/MenuConversion';
 
-UnitTest.test('themes.silver.ui.menus.MenuConversion', () => {
+UnitTest.test('atomic.themes.silver.ui.menus.MenuConversion', () => {
   const buildMenuItem = (name: string): Menu.MenuItemSpec => ({
     type: 'menuitem',
     text: name,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
@@ -5,7 +5,7 @@ import { SugarBody, Visibility } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce/themes.silver.ShowHideTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.themes.silver.ShowHideTest', (success, failure) => {
   Theme();
 
   const base_url = '/project/tinymce/js/tinymce';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
@@ -7,7 +7,7 @@ import { Attribute, Class, SugarBody, SugarElement, Traverse } from '@ephox/suga
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('Editor (Silver) test', (success, failure) => {
+UnitTest.asynctest('Editor (Silver) tox wrapping test', (success, failure) => {
   Theme();
 
   TinyLoader.setupLight(

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -9,7 +9,7 @@ import { SugarBody, SugarElement } from '@ephox/sugar';
 import Theme from 'tinymce/themes/silver/Theme';
 import * as MenuUtils from '../../../module/MenuUtils';
 
-UnitTest.asynctest('Editor (Silver) test', (success, failure) => {
+UnitTest.asynctest('Editor (Silver) bespoke toolbar buttons test', (success, failure) => {
   Theme();
   TinyLoader.setup(
     (editor, onSuccess, onFailure) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/LineHeightTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/LineHeightTest.ts
@@ -50,7 +50,7 @@ const sAssertOptions = (ui: TinyUi, mode: 'menu' | 'toolbar', ideal: string[], c
   })
 ]);
 
-UnitTest.asyncTest('browser.tinymce.LineHeightTest', (success, failure) => {
+UnitTest.asyncTest('browser.tinymce.themes.silver.editor.core.LineHeightTest', (success, failure) => {
   Theme();
 
   const settings = {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarSettingsTest.ts
@@ -7,7 +7,7 @@ import { SugarBody } from '@ephox/sugar';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 import { cCountNumber, cExtractOnlyOne } from '../../../module/UiChainUtils';
 
-UnitTest.asynctest('Editor (Silver) test', (success, failure) => {
+UnitTest.asynctest('Editor (Silver) menubar settings test', (success, failure) => {
   SilverTheme();
 
   const cCreateEditorWithMenubar = (menubar) => McagarEditor.cFromSettings({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarSettingsTest.ts
@@ -7,7 +7,7 @@ import { SugarBody } from '@ephox/sugar';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 import { cCountNumber, cExtractOnlyOne } from '../../../module/UiChainUtils';
 
-UnitTest.asynctest('Editor (Silver) test', (success, failure) => {
+UnitTest.asynctest('Editor (Silver) toolbar settings test', (success, failure) => {
   SilverTheme();
 
   const cCreateEditorWithToolbar = (toolbarVal, toolbarVal1?, toolbarVal2?, toolbarVal9?, toolbarVal20?) => McagarEditor.cFromSettings({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -11,7 +11,7 @@ interface EventLog {
   index: number;
 }
 
-UnitTest.asynctest('tinymce.themes.silver.test.browser.sidebar.SidebarTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.themes.silver.sidebar.SidebarTest', function (success, failure) {
   const store = TestHelpers.TestStore();
   Theme();
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberTest.ts
@@ -4,7 +4,7 @@ import { TinyLoader } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('tinymce.themes.silver.test.browser.throbber.ThrobberTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.themes.silver.throbber.ThrobberTest', (success, failure) => {
   Theme();
 
   const sAssertThrobberHiddenStructure = Chain.asStep(SugarBody.body(), [


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Fixed a number of duplicate or incorrectly named tests (they didn't follow the naming convention). This also makes bedrock happy so that it now reports `COMPLETE` instead of `STOPPED`.
* Fixed 2 minor issues where the editor wasn't cleaning up debounced functions properly, which could cause exceptions. I found this by watching the test names and just coincidently noticed it. Can't really add a test for these though.

Pre-checks:
* [x] ~Changelog entry added~ (2 minor issues aren't something a customer would notice, so no changelog)
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
