### PR TITLE
TINY-6291: Map font keywords to pt values in font size menus

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.6.0 (TBD)
-
+    Fixed keyword font sizes such as `medium` not displaying correctly in font select menus
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.6.0 (TBD)
-    Fixed keyword font sizes such as `medium` not displaying correctly in font select menus #TINY-6291
+    Fixed keyword font sizes such as `medium` not displaying correctly in font size menus #TINY-6291
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.6.0 (TBD)
-    Fixed keyword font sizes such as `medium` not displaying correctly in font size menus #TINY-6291
+    Fixed font size keywords such as `medium` not displaying correctly in font size menus #TINY-6291
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.6.0 (TBD)
-    Fixed keyword font sizes such as `medium` not displaying correctly in font select menus
+    Fixed keyword font sizes such as `medium` not displaying correctly in font select menus #TINY-6291
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -1,4 +1,4 @@
-import { Assertions, Chain, GeneralSteps, Logger, Pipeline, UiFinder } from '@ephox/agar';
+import { Assertions, Chain, Log, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun, Strings } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
@@ -26,12 +26,12 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
     const tinyApis = TinyApis(editor);
 
     Pipeline.async({}, [
-      Logger.t('Font family and font size on initial page load', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on initial page load', [
         sAssertSelectBoxDisplayValue(editor, 'Font sizes', '12px'),
         sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Arial')
-      ])),
+      ]),
 
-      Logger.t('Font family and font size on paragraph with no styles', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on paragraph with no styles', [
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
@@ -39,9 +39,9 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         // p content style is 12px which does not match any pt values in the font size select values
         sAssertSelectBoxDisplayValue(editor, 'Font sizes', '12px'),
         sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Arial')
-      ])),
+      ]),
 
-      Logger.t('Font family and font size on heading with no styles', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on heading with no styles', [
         tinyApis.sSetContent('<h1>a</h1>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
@@ -49,9 +49,9 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         // h1 content style is 32px which matches 24pt in the font size select values so it should be converted
         sAssertSelectBoxDisplayValue(editor, 'Font sizes', '24pt'),
         sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Arial')
-      ])),
+      ]),
 
-      Logger.t('Font family and font size on paragraph with styles that do match font size select values', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on paragraph with styles that do match font size select values', [
         tinyApis.sSetContent('<p style="font-family: Times; font-size: 17px;">a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
@@ -59,9 +59,9 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         // the following should be converted and pick up 12.75pt, although there's a rounded 13pt in the dropdown as well
         sAssertSelectBoxDisplayValue(editor, 'Font sizes', '12.75pt'),
         sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
-      ])),
+      ]),
 
-      Logger.t('Font family and font size on paragraph with styles that do not match font size select values', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on paragraph with styles that do not match font size select values', [
         tinyApis.sSetContent('<p style="font-family: Times; font-size: 18px;">a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
@@ -69,44 +69,37 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         // the following should stay as 18px because there's no matching pt value in the font size select values
         sAssertSelectBoxDisplayValue(editor, 'Font sizes', '18px'),
         sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
-      ])),
+      ]),
 
-      Logger.t('Font family and font size on paragraph with legacy font elements', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Font family and font size on paragraph with legacy font elements', [
         tinyApis.sSetRawContent('<p><font face="Times" size="1">a</font></p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0, 0 ], 0),
         tinyApis.sNodeChanged(),
         sAssertSelectBoxDisplayValue(editor, 'Font sizes', '8pt'),
         sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
-      ])),
+      ]),
 
       // https://websemantics.uk/articles/font-size-conversion/
-      Logger.t('TINY-6291: Font size on paragraph with keyword font size is translated to default size', GeneralSteps.sequence([
-        tinyApis.sSetRawContent('<p style="font-family: Times; font-size: medium;">a</p>'),
+      Log.stepsAsStep('TINY-6291', 'Font size on paragraph with keyword font size is translated to default size', [
+        tinyApis.sSetContent('<p style="font-family: Times; font-size: medium;">a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
         tinyApis.sNodeChanged(),
         sAssertSelectBoxDisplayValue(editor, 'Font sizes', '12pt'),
         sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
-      ])),
+      ]),
 
-      Logger.t('TINY-6291: xx-small and x-small font keywords are both mapped to 8pt', GeneralSteps.sequence([
-        tinyApis.sSetRawContent('<p style="font-family: Times; font-size: xx-small;">a</p>'),
+      Log.stepsAsStep('TINY-6291', 'xx-small will fall back to showing raw font size due to missing 7pt fontsize_format', [
+        tinyApis.sSetContent('<p style="font-family: Times; font-size: xx-small;">a</p>'),
         tinyApis.sFocus(),
         tinyApis.sSetCursor([ 0, 0 ], 0),
         tinyApis.sNodeChanged(),
-        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '8pt'),
-        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times'),
-
-        tinyApis.sSetRawContent('<p style="font-family: Times; font-size: x-small;">a</p>'),
-        tinyApis.sFocus(),
-        tinyApis.sSetCursor([ 0, 0 ], 0),
-        tinyApis.sNodeChanged(),
-        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '8pt'),
+        sAssertSelectBoxDisplayValue(editor, 'Font sizes', 'xx-small'),
         sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
-      ])),
+      ]),
 
-      Logger.t('System font stack variants on a paragraph show "System Font" as the font name', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'System font stack variants on a paragraph show "System Font" as the font name', [
         tinyApis.sSetContent(Arr.foldl(systemFontStackVariants, (acc, font) => acc + '<p style="font-family: ' + font.replace(/"/g, `'`) + '"></p>', '')),
         tinyApis.sFocus(),
         ...Arr.bind(systemFontStackVariants, (_, idx) => [
@@ -114,7 +107,7 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
           tinyApis.sNodeChanged(),
           sAssertSelectBoxDisplayValue(editor, 'Fonts', 'System Font')
         ])
-      ]))
+      ])
     ], onSuccess, onFailure);
   }, {
     base_url: '/project/tinymce/js/tinymce',

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -80,6 +80,32 @@ UnitTest.asynctest('browser.tinymce.core.FontSelectTest', function (success, fai
         sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
       ])),
 
+      // https://websemantics.uk/articles/font-size-conversion/
+      Logger.t('TINY-6291: Font size on paragraph with keyword font size is translated to default size', GeneralSteps.sequence([
+        tinyApis.sSetRawContent('<p style="font-family: Times; font-size: medium;">a</p>'),
+        tinyApis.sFocus(),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        tinyApis.sNodeChanged(),
+        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '12pt'),
+        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
+      ])),
+
+      Logger.t('TINY-6291: xx-small and x-small font keywords are both mapped to 8pt', GeneralSteps.sequence([
+        tinyApis.sSetRawContent('<p style="font-family: Times; font-size: xx-small;">a</p>'),
+        tinyApis.sFocus(),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        tinyApis.sNodeChanged(),
+        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '8pt'),
+        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times'),
+
+        tinyApis.sSetRawContent('<p style="font-family: Times; font-size: x-small;">a</p>'),
+        tinyApis.sFocus(),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        tinyApis.sNodeChanged(),
+        sAssertSelectBoxDisplayValue(editor, 'Font sizes', '8pt'),
+        sAssertSelectBoxDisplayValue(editor, 'Fonts', 'Times')
+      ])),
+
       Logger.t('System font stack variants on a paragraph show "System Font" as the font name', GeneralSteps.sequence([
         tinyApis.sSetContent(Arr.foldl(systemFontStackVariants, (acc, font) => acc + '<p style="font-family: ' + font.replace(/"/g, `'`) + '"></p>', '')),
         tinyApis.sFocus(),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
@@ -27,6 +27,17 @@ const legacyFontSizes: Record<string, string> = {
   '36pt': '7'
 };
 
+// Note: 'xx-small', 'x-small' and 'large' are rounded to fit our default size list
+const keywordFontSizes: Record<string, string> = {
+  'xx-small': '8pt',
+  'x-small': '8pt',
+  'small': '10pt',
+  'medium': '12pt',
+  'large': '14pt',
+  'x-large': '18pt',
+  'xx-large': '24pt'
+};
+
 const round = (number: number, precision: number) => {
   const factor = Math.pow(10, precision);
   return Math.round(number * factor) / factor;
@@ -36,8 +47,9 @@ const toPt = (fontSize: string, precision?: number): string => {
   if (/[0-9.]+px$/.test(fontSize)) {
     // Round to the nearest 0.5
     return round(parseInt(fontSize, 10) * 72 / 96, precision || 0) + 'pt';
+  } else {
+    return Obj.get(keywordFontSizes, fontSize).getOr(fontSize);
   }
-  return fontSize;
 };
 
 const toLegacy = (fontSize: string): string => Obj.get(legacyFontSizes, fontSize).getOr('');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
@@ -27,9 +27,9 @@ const legacyFontSizes: Record<string, string> = {
   '36pt': '7'
 };
 
-// Note: 'xx-small', 'x-small' and 'large' are rounded to fit our default size list
+// Note: 'xx-small', 'x-small' and 'large' are rounded up to nearest whole pt
 const keywordFontSizes: Record<string, string> = {
-  'xx-small': '8pt',
+  'xx-small': '7pt',
   'x-small': '8pt',
   'small': '10pt',
   'medium': '12pt',


### PR DESCRIPTION
Related Ticket: TINY-6291

Description of Changes:
Font keywords such as `medium` and `small` are valid `font-size`s. These are appearing correctly in the editor content but the font size menus were displaying their values incorrectly. These keyword sizes are now mapped to `pt` values from our default font sizes.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
