### PR TITLE
TINY-6448: We now handle Pre-blocks as we should.

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -3,6 +3,7 @@ Version 5.6.0 (TBD)
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475
+    Fixed an issue where spaces were not preserved in pre-blocks when getting text content #TINY-6448
 Version 5.5.0 (2020-09-29)
     Added a TypeScript declaration file to the bundle output for TinyMCE core #TINY-3785
     Added new `table_column_resizing` setting to control how table columns are resized when using the resize bars #TINY-6001

--- a/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
@@ -1,10 +1,9 @@
-import { Assertions, Chain, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
+import { Assertions, Chain, GeneralSteps, Log, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import Editor from 'tinymce/core/api/Editor';
-import Env from 'tinymce/core/api/Env';
-import * as GetSelectionContent from 'tinymce/core/selection/GetSelectionContent';
+import { GetSelectionContentArgs, getContent } from 'tinymce/core/selection/GetSelectionContent';
 import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.selection.GetSelectionContentTest', (success, failure) => {
@@ -22,7 +21,7 @@ UnitTest.asynctest('browser.tinymce.selection.GetSelectionContentTest', (success
     input.parentNode.removeChild(input);
   });
 
-  const sAddTestDiv = Step.sync(function () {
+  const sAddTestDiv = Step.sync(() => {
     const div = document.createElement('div');
     div.innerHTML = 'xxx';
     div.contentEditable = 'true';
@@ -30,14 +29,17 @@ UnitTest.asynctest('browser.tinymce.selection.GetSelectionContentTest', (success
     document.body.appendChild(div);
   });
 
-  const cGetContent = (args: any) => Chain.mapper((editor: Editor) => GetSelectionContent.getContent(editor, args));
+  const cGetContent = (args: GetSelectionContentArgs) =>
+    Chain.mapper((editor: Editor) =>
+      getContent(editor, args).toString().replace(/[\r]+/g, ''));
 
-  const sAssertGetContent = (label: string, editor: Editor, expectedContents: string, args: any = {}) => Chain.asStep(editor, [
-    cGetContent(args),
-    Assertions.cAssertEq(label + ': Should be expected contents', expectedContents)
-  ]);
+  const sAssertGetContent = (label: string, editor: Editor, expectedContents: string, args: GetSelectionContentArgs = {}) =>
+    Chain.asStep(editor, [
+      cGetContent(args),
+      Assertions.cAssertEq(label + ': Should be expected contents', expectedContents)
+    ]);
 
-  const sAssertGetContentOverrideBeforeGetContent = (label: string, editor: Editor, expectedContents: string, args: any = {}) => {
+  const sAssertGetContentOverrideBeforeGetContent = (label: string, editor: Editor, expectedContents: string, args: GetSelectionContentArgs = {}) => {
     const handler = (e) => {
       if (e.selection === true) {
         e.preventDefault();
@@ -45,63 +47,73 @@ UnitTest.asynctest('browser.tinymce.selection.GetSelectionContentTest', (success
       }
     };
 
-    return GeneralSteps.sequence([
-      Step.sync(function () {
+    return Step.label(label, GeneralSteps.sequence([
+      Step.sync(() => {
         editor.on('BeforeGetContent', handler);
       }),
       Chain.asStep(editor, [
         cGetContent(args),
         Assertions.cAssertEq(label + ': Should be expected contents', expectedContents)
       ]),
-      Step.sync(function () {
+      Step.sync(() => {
         editor.off('BeforeGetContent', handler);
       })
-    ]);
+    ]));
   };
 
   TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
 
     Pipeline.async({}, [
-      Logger.t('Should be empty contents on a caret selection', GeneralSteps.sequence([
+      Log.stepsAsStep('TBA', 'Should be empty contents on a caret selection', [
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 0),
         sAssertGetContent('Should be empty selection on caret', editor, '')
-      ])),
-      Logger.t('Should be text contents on a range selection', GeneralSteps.sequence([
+      ]),
+      Log.stepsAsStep('TBA', 'Should be text contents on a range selection', [
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 1),
         sAssertGetContent('Should be some content', editor, 'a')
-      ])),
-      Logger.t('Should be text contents provided by override handler', GeneralSteps.sequence([
+      ]),
+      Log.stepsAsStep('TBA', 'Should be text contents provided by override handler', [
         tinyApis.sSetContent('<p>a</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 1),
         sAssertGetContentOverrideBeforeGetContent('Should be overridden content', editor, 'X')
-      ])),
-      Logger.t(`Should be text contents when editor isn't focused and format is text`, GeneralSteps.sequence([
+      ]),
+      Log.stepsAsStep('TBA', `Should be text contents when editor isn't focused and format is text`, [
         sAddTestDiv,
         tinyApis.sSetContent('<p>ab</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 2),
         sFocusDiv,
         sAssertGetContent('Should be some content', editor, 'ab', { format: 'text' }),
         sRemoveTestDiv
-      ])),
-      Logger.t('Should be text content with newline', GeneralSteps.sequence([
+      ]),
+      Log.stepsAsStep('TBA', 'Should be text content with newline', [
         tinyApis.sSetContent('<p>ab<br/>cd</p>'),
         tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 2 ], 2),
-        sAssertGetContent('Should be some content', editor, `ab${Env.ie === 11 ? '\r\n' : '\n'}cd`, { format: 'text' })
-      ])),
-      Logger.t('Should be text content with leading visible spaces', GeneralSteps.sequence([
+        sAssertGetContent('Should be some content', editor, 'ab\ncd', { format: 'text' })
+      ]),
+      Log.stepsAsStep('TBA', 'Should be text content with leading visible spaces', [
         tinyApis.sSetContent('<p>content<em> Leading space</em></p>'),
         tinyApis.sSetSelection([ 0 ], 1, [ 0 ], 2),
         sAssertGetContent('Should be some content', editor, ' Leading space', { format: 'text' })
-      ])),
-      Logger.t('Should be text content with trailing visible spaces', GeneralSteps.sequence([
+      ]),
+      Log.stepsAsStep('TBA', 'Should be text content with trailing visible spaces', [
         tinyApis.sSetContent('<p><em>Trailing space </em>content</p>'),
         tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
         sAssertGetContent('Should be some content', editor, 'Trailing space ', { format: 'text' })
-      ])),
-      Logger.t('Should be text content without non-visible leading/trailing spaces', GeneralSteps.sequence([
+      ]),
+      Log.stepsAsStep('TINY-6448', 'pre blocks should have preserved spaces', [
+        tinyApis.sSetContent('<pre>          This      Has\n     Spaces</pre>'),
+        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
+        sAssertGetContent('Should be some content', editor, '          This      Has\n     Spaces', { format: 'text' })
+      ]),
+      Log.stepsAsStep('TINY-6448', 'p blocks should not preserve spaces', [
+        tinyApis.sSetContent('<p>          This      Has\n     Spaces</p>'),
+        tinyApis.sSetSelection([ ], 0, [ ], 1),
+        sAssertGetContent('Should be some content', editor, 'This Has Spaces', { format: 'text' })
+      ]),
+      Log.stepsAsStep('TBA', 'Should be text content without non-visible leading/trailing spaces', [
         tinyApis.sSetContent('<p><em> spaces </em></p>'),
         tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
         // Firefox, IE & Edge actually renders the trailing space within the editor in this case
@@ -113,7 +125,7 @@ UnitTest.asynctest('browser.tinymce.selection.GetSelectionContentTest', (success
         tinyApis.sSetContent('<p> spaces </p>'),
         tinyApis.sSetSelection([ ], 0, [ ], 1),
         sAssertGetContent('Should be some content', editor, 'spaces', { format: 'text' })
-      ]))
+      ])
     ], onSuccess, onFailure);
   }, {
     selector: 'textarea',


### PR DESCRIPTION
Related Ticket:

Description of Changes:
We no longer discard spaces that exists in pre-blocks when getting the content through get selection content.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
