### PR TITLE
TINY-6413: More incorrect type fixes and fixes for McAgar not working in a shadow root

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/BodyComponent.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/BodyComponent.ts
@@ -5,20 +5,21 @@ import { Checkbox, CheckboxSpec } from './Checkbox';
 import { Collection, CollectionSpec } from './Collection';
 import { ColorInput, ColorInputSpec } from './ColorInput';
 import { ColorPicker, ColorPickerSpec } from './ColorPicker';
+import { CustomEditor, CustomEditorSpec } from './CustomEditor';
 import { DropZone, DropZoneSpec } from './Dropzone';
 import { Grid, GridSpec } from './Grid';
+import { HtmlPanel, HtmlPanelSpec } from './HtmlPanel';
 import { Iframe, IframeSpec } from './Iframe';
 import { ImageTools, ImageToolsSpec } from './ImageTools';
 import { Input, InputSpec } from './Input';
 import { Label, LabelSpec } from './Label';
 import { ListBox, ListBoxSpec } from './ListBox';
+import { Panel, PanelSpec } from './Panel';
 import { SelectBox, SelectBoxSpec } from './SelectBox';
 import { SizeInput, SizeInputSpec } from './SizeInput';
 import { Table, TableSpec } from './Table';
 import { TextArea, TextAreaSpec } from './Textarea';
 import { UrlInput, UrlInputSpec } from './UrlInput';
-import { HtmlPanel, HtmlPanelSpec } from './HtmlPanel';
-import { Panel, PanelSpec } from './Panel';
 
 export type BodyComponentSpec
   = BarSpec
@@ -41,7 +42,8 @@ export type BodyComponentSpec
   | CollectionSpec
   | LabelSpec
   | TableSpec
-  | PanelSpec;
+  | PanelSpec
+  | CustomEditorSpec;
 
 export type BodyComponent
   = Bar
@@ -64,4 +66,5 @@ export type BodyComponent
   | Collection
   | Label
   | Table
-  | Panel;
+  | Panel
+  | CustomEditor;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
@@ -1,6 +1,6 @@
 import { FieldSchema, ValueSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
-import { FormComponent, FormComponentSpec, formComponentFields } from './FormComponent';
+import { FormComponent, formComponentFields, FormComponentSpec } from './FormComponent';
 
 export interface CustomEditorInit {
   setValue: (value: string) => void;
@@ -8,12 +8,12 @@ export interface CustomEditorInit {
   destroy: () => void;
 }
 
-export type CustomEditorInitFn = (elm: Element, settings: any) => Promise<CustomEditorInit>;
+export type CustomEditorInitFn = (elm: HTMLElement, settings: any) => Promise<CustomEditorInit>;
 
 interface CustomEditorOldSpec extends FormComponentSpec {
   type: 'customeditor';
   tag?: string;
-  init: (e: Element) => Promise<CustomEditorInit>;
+  init: (e: HTMLElement) => Promise<CustomEditorInit>;
 }
 
 interface CustomEditorNewSpec extends FormComponentSpec {
@@ -29,7 +29,7 @@ export type CustomEditorSpec = CustomEditorOldSpec | CustomEditorNewSpec;
 export interface CustomEditorOld extends FormComponent {
   type: 'customeditor';
   tag: string;
-  init: (e: Element) => Promise<CustomEditorInit>;
+  init: (e: HTMLElement) => Promise<CustomEditorInit>;
 }
 
 export interface CustomEditorNew extends FormComponent {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
@@ -1,10 +1,10 @@
-type EventCallback = false | ((event: any) => void);
+type EventCallback = (event: any) => void;
 
 export interface Selection {
   win: Window;
 
   setRng: (rng: Range) => void;
-  getRng: () => Range;
+  getRng: () => Range | null;
   select: (node: Node, content?: boolean) => Node;
   setCursorLocation: (node?: Node, offset?: number) => void;
   isCollapsed: () => boolean;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/ApiChains.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/ApiChains.ts
@@ -1,4 +1,5 @@
 import { Assertions, Chain, Cursors, StructAssert, UiFinder } from '@ephox/agar';
+import { Optional } from '@ephox/katamari';
 import { Hierarchy, Html, SugarElement } from '@ephox/sugar';
 import { Editor } from '../alien/EditorTypes';
 import * as TinySelections from '../selection/TinySelections';
@@ -129,7 +130,7 @@ const assertPath = function (label: string, root: SugarElement, expPath: number[
 
 const cAssertSelection = function <T extends Editor> (startPath: number[], soffset: number, finishPath: number[], foffset: number) {
   return Chain.op(function (editor: T) {
-    const actual = editor.selection.getRng();
+    const actual = Optional.from(editor.selection.getRng()).getOrDie('Failed to get range');
     assertPath('start', lazyBody(editor), startPath, soffset, actual.startContainer, actual.startOffset);
     assertPath('finish', lazyBody(editor), finishPath, foffset, actual.endContainer, actual.endOffset);
   });

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyActions.ts
@@ -1,5 +1,5 @@
 import { Keyboard, Step } from '@ephox/agar';
-import { SugarElement } from '@ephox/sugar';
+import { SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { Editor } from '../alien/EditorTypes';
 
 export interface TinyActions {
@@ -12,7 +12,7 @@ export interface TinyActions {
 
 export const TinyActions = function (editor: Editor): TinyActions {
   const iDoc = SugarElement.fromDom(editor.getDoc());
-  const uiDoc = SugarElement.fromDom(document);
+  const uiDoc = SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement()));
 
   const sContentKeydown = function <T> (code: number, modifiers = {}) {
     return Keyboard.sKeydown<T>(iDoc, code, modifiers);

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyApis.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyApis.ts
@@ -1,5 +1,6 @@
 import { Assertions, Chain, Cursors, FocusTools, Step, StructAssert, UiFinder, Waiter } from '@ephox/agar';
-import { Hierarchy, Html, SugarElement } from '@ephox/sugar';
+import { Optional } from '@ephox/katamari';
+import { Hierarchy, Html, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { Editor } from '../alien/EditorTypes';
 import * as TinySelections from '../selection/TinySelections';
 
@@ -30,6 +31,8 @@ export interface TinyApis {
 }
 
 export const TinyApis = function (editor: Editor): TinyApis {
+  const dos = SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement()));
+
   const setContent = function (html: string): void {
     editor.setContent(html);
   };
@@ -148,7 +151,7 @@ export const TinyApis = function (editor: Editor): TinyApis {
 
   const sAssertSelection = function <T> (startPath: number[], soffset: number, finishPath: number[], foffset: number) {
     return Step.sync<T>(function () {
-      const actual = editor.selection.getRng();
+      const actual = Optional.from(editor.selection.getRng()).getOrDie('Failed to get range');
       assertPath('start', lazyBody(), startPath, soffset, actual.startContainer, actual.startOffset);
       assertPath('finish', lazyBody(), finishPath, foffset, actual.endContainer, actual.endOffset);
     });
@@ -166,7 +169,7 @@ export const TinyApis = function (editor: Editor): TinyApis {
     'Waiting for focus on tinymce editor',
     FocusTools.sIsOnSelector(
       'iframe focus',
-      SugarElement.fromDom(document),
+      dos,
       'iframe'
     ),
     100,

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -15,7 +15,7 @@ import Editor from './Editor';
 import Env from './Env';
 import { EditorManagerEventMap } from './EventTypes';
 import { RawEditorSettings } from './SettingsTypes';
-import I18n from './util/I18n';
+import I18n, { TranslatedString, Untranslated } from './util/I18n';
 import Observable from './util/Observable';
 import Promise from './util/Promise';
 import Tools from './util/Tools';
@@ -142,7 +142,7 @@ interface EditorManager extends Observable<EditorManagerEventMap> {
   remove (selector: string | Editor): Editor | void;
   setActive (editor: Editor): void;
   setup (): void;
-  translate (text: string): string;
+  translate (text: Untranslated): TranslatedString;
   triggerSave (): void;
   _setBaseUrl (baseUrl: string): void;
 }


### PR DESCRIPTION
Related Ticket: TINY-6413

Description of Changes:
* Fixed the McAgar "Fake Editor" types I missed last time and fixed other issues found when trying to upgrade other plugins.

Pre-checks:
* [x] ~Changelog entry added~ Added in previous PR
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
