### PR TITLE
TINY-6541: Ensure fullpage plugin does not modify text content

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.6.0 (TBD)
+    Fixed `fullpage` plugin altering text content in `editor.getContent()` #TINY-6541
     Fixed font size keywords such as `medium` not displaying correctly in font size menus #TINY-6291
     Fixed some incorrect types in the new TypeScript declaration file #TINY-6413
 Version 5.5.1 (TBD)

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/FilterContent.ts
@@ -6,6 +6,7 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import { GetContentEvent } from 'tinymce/core/api/EventTypes';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 import * as Parser from './Parser';
@@ -156,8 +157,8 @@ const getDefaultHeader = function (editor) {
   return header;
 };
 
-const handleGetContent = function (editor: Editor, head, foot, evt) {
-  if (!evt.selection && (!evt.source_view || !Settings.shouldHideInSourceView(editor))) {
+const handleGetContent = function (editor: Editor, head, foot, evt: GetContentEvent) {
+  if (evt.format === 'html' && !evt.selection && (!evt.source_view || !Settings.shouldHideInSourceView(editor))) {
     evt.content = Protect.unprotectHtml(Tools.trim(head) + '\n' + Tools.trim(evt.content) + '\n' + Tools.trim(foot));
   }
 };

--- a/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
+++ b/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
@@ -174,12 +174,20 @@ UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPagePluginTest', functi
   };
 
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
-    Pipeline.async({}, Log.steps('TBA', 'FullPage: Test full page header, footer, body attributes, hide in source view and adding and removing stylesheets',
-      [
-        sParseStyles(editor),
-        sProtectConditionalCommentsInHeadFoot(editor)
-      ].concat(suite.toSteps(editor))
-    ), onSuccess, onFailure);
+    Pipeline.async({}, [
+      Log.stepsAsStep('TBA', 'FullPage: Test full page header, footer, body attributes, hide in source view and adding and removing stylesheets',
+        [
+          sParseStyles(editor),
+          sProtectConditionalCommentsInHeadFoot(editor)
+        ].concat(suite.toSteps(editor))
+      ),
+      Log.stepsAsStep('TINY-6541', 'FullPage: Text content should not be modified', [
+        Step.sync(() => {
+          editor.setContent('some plain text');
+          Assertions.assertEq('should return plain text content', 'some plain text', editor.getContent({ format: 'text' }));
+        })
+      ])
+    ], onSuccess, onFailure);
 
     teardown(editor);
   }, {


### PR DESCRIPTION
Related Ticket: TINY-6541

Description of Changes:
The result from `editor.getContent({ format: 'text' })` was being incorrectly modified by the fullpage plugin.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #4556
