### PR TITLE
TINY-6479: Bold/Italic buttons not enabled when toggling caret format in rtc mode

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.6.0 (TBD)
+    Added new formatter `closest` API to get the closest matching selection format from a set of formats. #TINY-6479
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282
     Fixed `fullpage` plugin altering text content in `editor.getContent()` #TINY-6541

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.6.0 (TBD)
-    Added new formatter `closest` API to get the closest matching selection format from a set of formats. #TINY-6479
+    Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282
     Fixed `fullpage` plugin altering text content in `editor.getContent()` #TINY-6541

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -43,7 +43,7 @@ interface RtcRuntimeApi {
   applyFormat: (format: string, vars: Record<string, string>) => void;
   removeFormat: (format: string, vars: Record<string, string>) => void;
   toggleFormat: (format: string, vars: Record<string, string>) => void;
-  formatChanged: (formats: string, callback: FormatChangeCallback, similar?: boolean) => UnbindFormatChanged;
+  formatChanged: (formats: string, callback: FormatChangeCallback, similar: boolean) => UnbindFormatChanged;
   getContent: () => AstNode | null;
   setContent: (node: AstNode) => void;
   insertContent: (node: AstNode) => void;
@@ -331,7 +331,7 @@ export const toggleFormat = (editor: Editor, name: string, vars: Record<string, 
   getRtcInstanceWithError(editor).formatter.toggle(name, vars, node);
 };
 
-export const formatChanged = (editor: Editor, registeredFormatListeners: Cell<RegisteredFormats>, formats: string, callback: FormatChangeCallback, similar?: boolean): UnbindFormatChanged =>
+export const formatChanged = (editor: Editor, registeredFormatListeners: Cell<RegisteredFormats>, formats: string, callback: FormatChangeCallback, similar: boolean = false): UnbindFormatChanged =>
   getRtcInstanceWithError(editor).formatter.formatChanged(registeredFormatListeners, formats, callback, similar);
 
 export const getContent = (editor: Editor, args: GetContentArgs, format: ContentFormat): Content =>

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -14,6 +14,7 @@ import { Content, ContentFormat, GetContentArgs, SetContentArgs } from './conten
 import { getContentInternal } from './content/GetContentImpl';
 import { insertHtmlAtCaret } from './content/InsertContentImpl';
 import { setContentInternal } from './content/SetContentImpl';
+import { addVisualInternal } from './view/VisualAidsImpl';
 import * as ApplyFormat from './fmt/ApplyFormat';
 import { FormatChangeCallback, UnbindFormatChanged, RegisteredFormats, formatChangedInternal } from './fmt/FormatChanged';
 import * as RemoveFormat from './fmt/RemoveFormat';
@@ -83,6 +84,7 @@ interface RtcAdaptor {
     getContent: (args: GetContentArgs, format: ContentFormat) => Content;
     setContent: (content: Content, args: SetContentArgs) => Content;
     insertContent: (value: string, details) => void;
+    addVisual: (elm?: HTMLElement) => void;
   };
   selection: {
     getContent: (format: ContentFormat, args: GetSelectionContentArgs) => Content;
@@ -134,7 +136,8 @@ const makePlainAdaptor = (editor: Editor): RtcAdaptor => ({
   editor: {
     getContent: (args, format) => getContentInternal(editor, args, format),
     setContent: (content, args) => setContentInternal(editor, content, args),
-    insertContent: (value, details) => insertHtmlAtCaret(editor, value, details)
+    insertContent: (value, details) => insertHtmlAtCaret(editor, value, details),
+    addVisual: (elm) => addVisualInternal(editor, elm)
   },
   selection: {
     getContent: (format, args) => getSelectedContentInternal(editor, format, args)
@@ -204,7 +207,8 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
         );
         const fragment = isTreeNode(value) ? value : tinymceEditor.parser.parse(value, { ...contextArgs, insert: true });
         rtcEditor.insertContent(fragment);
-      }
+      },
+      addVisual: (_elm) => {}
     },
     selection: {
       getContent: (format, args) => {
@@ -341,3 +345,6 @@ export const insertContent = (editor: Editor, value: string, details): void =>
 
 export const getSelectedContent = (editor: Editor, format: ContentFormat, args: GetSelectionContentArgs): Content =>
   getRtcInstanceWithError(editor).selection.getContent(format, args);
+
+export const addVisual = (editor: Editor, elm: HTMLElement): void =>
+  getRtcInstanceWithError(editor).editor.addVisual(elm);

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -41,6 +41,7 @@ interface RtcRuntimeApi {
   hasUndo: () => boolean;
   hasRedo: () => boolean;
   transact: (fn: () => void) => void;
+  canApplyFormat: (format: string) => boolean;
   matchFormat: (format: string, vars: Record<string, string>) => boolean;
   closestFormat: (formats: string) => string;
   applyFormat: (format: string, vars: Record<string, string>) => void;
@@ -79,6 +80,9 @@ interface RtcAdaptor {
   };
   formatter: {
     match: Formatter['match'];
+    matchAll: Formatter['matchAll'];
+    matchNode: Formatter['matchNode'];
+    canApply: Formatter['canApply'];
     closest: Formatter['closest'];
     apply: Formatter['apply'];
     remove: Formatter['remove'];
@@ -134,6 +138,9 @@ const makePlainAdaptor = (editor: Editor): RtcAdaptor => ({
   },
   formatter: {
     match: (name, vars?, node?) => MatchFormat.match(editor, name, vars, node),
+    matchAll: (names, vars) => MatchFormat.matchAll(editor, names, vars),
+    matchNode: (node, name, vars, similar) => MatchFormat.matchNode(editor, node, name, vars, similar),
+    canApply: (name) => MatchFormat.canApply(editor, name),
     closest: (names) => MatchFormat.closest(editor, names),
     apply: (name, vars?, node?) => ApplyFormat.applyFormat(editor, name, vars, node),
     remove: (name, vars, node, similar?) => RemoveFormat.remove(editor, name, vars, node, similar),
@@ -183,6 +190,9 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
     },
     formatter: {
       match: (name, vars?, _node?) => rtcEditor.matchFormat(name, defaultVars(vars)),
+      matchAll: unsupported,
+      matchNode: unsupported,
+      canApply: (name) => rtcEditor.canApplyFormat(name),
       closest: (names) => rtcEditor.closestFormat(names),
       apply: (name, vars, _node) => rtcEditor.applyFormat(name, defaultVars(vars)),
       remove: (name, vars, _node, _similar?) => rtcEditor.removeFormat(name, defaultVars(vars)),
@@ -328,6 +338,22 @@ export const matchFormat = (
   name: string,
   vars?: Record<string, string>,
   node?: Node): boolean => getRtcInstanceWithError(editor).formatter.match(name, vars, node);
+
+export const matchAllFormats = (
+  editor: Editor,
+  names: string[],
+  vars?: Record<string, string>): string[] => getRtcInstanceWithError(editor).formatter.matchAll(names, vars);
+
+export const matchNodeFormat = (
+  editor: Editor,
+  node: Node,
+  name: string,
+  vars?: Record<string, string>,
+  similar?: boolean): boolean => getRtcInstanceWithError(editor).formatter.matchNode(node, name, vars, similar);
+
+export const canApplyFormat = (
+  editor: Editor,
+  name: string): boolean => getRtcInstanceWithError(editor).formatter.canApply(name);
 
 export const closestFormat = (
   editor: Editor,

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -17,6 +17,7 @@ import { NodeChange } from '../NodeChange';
 import SelectionOverrides from '../SelectionOverrides';
 import { UndoManager } from '../undo/UndoManagerTypes';
 import Quirks from '../util/Quirks';
+import * as VisualAids from '../view/VisualAids';
 import AddOnManager from './AddOnManager';
 import Annotator from './Annotator';
 import DomQuery, { DomQueryConstructor } from './dom/DomQuery';
@@ -1082,50 +1083,7 @@ class Editor implements EditorObservable {
    * @param {Element} elm Optional root element to loop though to find tables etc that needs the visual aid.
    */
   public addVisual(elm?: HTMLElement) {
-    const self = this;
-    const settings = self.settings;
-    const dom: DOMUtils = self.dom;
-    let cls;
-
-    elm = elm || self.getBody();
-
-    if (self.hasVisual === undefined) {
-      self.hasVisual = settings.visual;
-    }
-
-    each(dom.select('table,a', elm), function (elm) {
-      let value;
-
-      switch (elm.nodeName) {
-        case 'TABLE':
-          cls = settings.visual_table_class || 'mce-item-table';
-          value = dom.getAttrib(elm, 'border');
-
-          if ((!value || value === '0') && self.hasVisual) {
-            dom.addClass(elm, cls);
-          } else {
-            dom.removeClass(elm, cls);
-          }
-
-          return;
-
-        case 'A':
-          if (!dom.getAttrib(elm, 'href')) {
-            value = dom.getAttrib(elm, 'name') || elm.id;
-            cls = settings.visual_anchor_class || 'mce-item-anchor';
-
-            if (value && self.hasVisual) {
-              dom.addClass(elm, cls);
-            } else {
-              dom.removeClass(elm, cls);
-            }
-          }
-
-          return;
-      }
-    });
-
-    self.fire('VisualAid', { element: elm, hasVisual: self.hasVisual });
+    VisualAids.addVisual(this, elm);
   }
 
   /**

--- a/modules/tinymce/src/core/main/ts/api/Formatter.ts
+++ b/modules/tinymce/src/core/main/ts/api/Formatter.ts
@@ -175,7 +175,7 @@ const Formatter = function (editor: Editor): Formatter {
      * @param {function} callback Callback with state and args when the format is changed/toggled on/off.
      * @param {Boolean} similar True/false state if the match should handle similar or exact formats.
      */
-    formatChanged: Fun.curry(FormatChanged.formatChanged, editor, formatChangeState),
+    formatChanged: (formats: string, callback: FormatChanged.FormatChangeCallback, similar?: boolean) => Rtc.formatChanged(editor, formatChangeState, formats, callback, similar),
 
     /**
      * Returns a preview css text for the specified format.

--- a/modules/tinymce/src/core/main/ts/api/Formatter.ts
+++ b/modules/tinymce/src/core/main/ts/api/Formatter.ts
@@ -137,6 +137,8 @@ const Formatter = function (editor: Editor): Formatter {
 
     /**
      * Finds the closest matching format from a set of formats at the current selection.
+     * <br>
+     * <em>Added in TinyMCE 5.6</em>
      *
      * @method closest
      * @param {Array} names Format names to check for.

--- a/modules/tinymce/src/core/main/ts/api/Formatter.ts
+++ b/modules/tinymce/src/core/main/ts/api/Formatter.ts
@@ -37,6 +37,7 @@ interface Formatter extends FormatRegistry {
   remove (name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean): void;
   toggle (name: string, vars?: FormatVars, node?: Node): void;
   match (name: string, vars?: FormatVars, node?: Node): boolean;
+  closest (names): string | null;
   matchAll (names: string[], vars?: FormatVars): string[];
   matchNode (node: Node, name: string, vars?: FormatVars, similar?: boolean): boolean;
   canApply (name: string): boolean;
@@ -133,7 +134,16 @@ const Formatter = function (editor: Editor): Formatter {
      * @param {Node} node Optional node to check.
      * @return {boolean} true/false if the specified selection/node matches the format.
      */
-    match: Fun.curry(MatchFormat.match, editor),
+    match: (name, vars?, node?) => Rtc.matchFormat(editor, name, vars, node),
+
+    /**
+     * Finds the closest matching format from a set of formats at the current selection.
+     *
+     * @method closest
+     * @param {Array} names Format names to check for.
+     * @return {String} The closest matching format name or null.
+     */
+    closest: (names) => Rtc.closestFormat(editor, names),
 
     /**
      * Matches the current selection against the array of formats and returns a new array with matching formats.

--- a/modules/tinymce/src/core/main/ts/api/Formatter.ts
+++ b/modules/tinymce/src/core/main/ts/api/Formatter.ts
@@ -10,7 +10,6 @@ import * as CaretFormat from '../fmt/CaretFormat';
 import * as FormatChanged from '../fmt/FormatChanged';
 import { FormatRegistry } from '../fmt/FormatRegistry';
 import { Format, FormatVars } from '../fmt/FormatTypes';
-import * as MatchFormat from '../fmt/MatchFormat';
 import * as Preview from '../fmt/Preview';
 import * as FormatShortcuts from '../keyboard/FormatShortcuts';
 import * as Rtc from '../Rtc';
@@ -153,7 +152,7 @@ const Formatter = function (editor: Editor): Formatter {
      * @param {Object} vars Optional list of variables to replace before checking it.
      * @return {Array} Array with matched formats.
      */
-    matchAll: Fun.curry(MatchFormat.matchAll, editor),
+    matchAll: (names, vars?) => Rtc.matchAllFormats(editor, names, vars),
 
     /**
      * Return true/false if the specified node has the specified format.
@@ -165,7 +164,7 @@ const Formatter = function (editor: Editor): Formatter {
      * @param {Boolean} similar Match format that has similar properties.
      * @return {Object} Returns the format object it matches or undefined if it doesn't match.
      */
-    matchNode: Fun.curry(MatchFormat.matchNode, editor),
+    matchNode: (node, names, vars?, similar?) => Rtc.matchNodeFormat(editor, node, names, vars, similar),
 
     /**
      * Returns true/false if the specified format can be applied to the current selection or not. It
@@ -175,7 +174,7 @@ const Formatter = function (editor: Editor): Formatter {
      * @param {String} name Name of format to check.
      * @return {boolean} true/false if the specified format can be applied to the current selection/node.
      */
-    canApply: Fun.curry(MatchFormat.canApply, editor),
+    canApply: (name) => Rtc.canApplyFormat(editor, name),
 
     /**
      * Executes the specified callback when the current selection matches the formats or not.

--- a/modules/tinymce/src/core/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/core/main/ts/api/Settings.ts
@@ -191,6 +191,12 @@ const getExternalPlugins = (editor: Editor) => editor.getParam('external_plugins
 
 const shouldBlockUnsupportedDrop = (editor: Editor) => editor.getParam('block_unsupported_drop', true, 'boolean');
 
+const isVisualAidsEnabled = (editor: Editor) => editor.getParam('visual', true, 'boolean');
+
+const getVisualAidsTableClass = (editor: Editor) => editor.getParam('visual_table_class', 'mce-item-table', 'string');
+
+const getVisualAidsAnchorClass = (editor: Editor) => editor.getParam('visual_anchor_class', 'mce-item-anchor', 'string');
+
 export {
   getIframeAttrs,
   getDocType,
@@ -251,5 +257,8 @@ export {
   hasContentCssCors,
   getPlugins,
   getExternalPlugins,
-  shouldBlockUnsupportedDrop
+  shouldBlockUnsupportedDrop,
+  isVisualAidsEnabled,
+  getVisualAidsTableClass,
+  getVisualAidsAnchorClass
 };

--- a/modules/tinymce/src/core/main/ts/fmt/FormatChanged.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatChanged.ts
@@ -12,9 +12,12 @@ import * as FormatUtils from './FormatUtils';
 import * as MatchFormat from './MatchFormat';
 
 export type FormatChangeCallback = (state: boolean, data: { node: Node; format: string; parents: any }) => void;
-type FormatCallbacks = Record<string, FormatChangeCallback[]>;
-type FormatData = { similar?: boolean; callbacks: FormatChangeCallback[] };
-type RegisteredFormats = Record<string, FormatData>;
+export type FormatCallbacks = Record<string, FormatChangeCallback[]>;
+export type FormatData = { similar?: boolean; callbacks: FormatChangeCallback[] };
+export type RegisteredFormats = Record<string, FormatData>;
+export type UnbindFormatChanged = {
+  unbind: () => void;
+};
 
 const setup = (registeredFormatListeners: Cell<RegisteredFormats>, editor: Editor) => {
   const currentFormats = Cell<Record<string, FormatChangeCallback[]>>({ });
@@ -108,7 +111,7 @@ const removeListeners = (registeredFormatListeners: Cell<RegisteredFormats>, for
   registeredFormatListeners.set(formatChangeItems);
 };
 
-const formatChanged = (editor: Editor, registeredFormatListeners: Cell<RegisteredFormats>, formats: string, callback: FormatChangeCallback, similar?: boolean) => {
+const formatChangedInternal = (editor: Editor, registeredFormatListeners: Cell<RegisteredFormats>, formats: string, callback: FormatChangeCallback, similar?: boolean): UnbindFormatChanged => {
   if (registeredFormatListeners.get() === null) {
     setup(registeredFormatListeners, editor);
   }
@@ -121,5 +124,5 @@ const formatChanged = (editor: Editor, registeredFormatListeners: Cell<Registere
 };
 
 export {
-  formatChanged
+  formatChangedInternal
 };

--- a/modules/tinymce/src/core/main/ts/fmt/FormatChanged.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatChanged.ts
@@ -12,10 +12,17 @@ import * as FormatUtils from './FormatUtils';
 import * as MatchFormat from './MatchFormat';
 
 export type FormatChangeCallback = (state: boolean, data: { node: Node; format: string; parents: any }) => void;
+
 export type FormatCallbacks = Record<string, FormatChangeCallback[]>;
-export type FormatData = { similar?: boolean; callbacks: FormatChangeCallback[] };
+
+export interface FormatData {
+  similar?: boolean;
+  callbacks: FormatChangeCallback[];
+};
+
 export type RegisteredFormats = Record<string, FormatData>;
-export type UnbindFormatChanged = {
+
+export interface UnbindFormatChanged {
   unbind: () => void;
 };
 

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -5,7 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr } from '@ephox/katamari';
+import { Arr, Optional } from '@ephox/katamari';
+import { Compare, SugarElement, TransformFind } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import { FormatVars, SelectorFormat } from './FormatTypes';
@@ -179,6 +180,14 @@ const matchAll = function (editor: Editor, names: string[], vars: FormatVars) {
   return matchedFormatNames;
 };
 
+const closest = (editor: Editor, names: string[]): string | null => {
+  const isRoot = (elm: SugarElement<Node>) => Compare.eq(elm, SugarElement.fromDom(editor.getBody()));
+  const match = (elm: SugarElement<Node>, name: string): Optional<string> => matchNode(editor, elm.dom, name) ? Optional.some(name) : Optional.none();
+  return Optional.from(editor.selection.getStart(true)).bind((rawElm) =>
+    TransformFind.closest(SugarElement.fromDom(rawElm), (elm) => Arr.findMap(names, (name) => match(elm, name)), isRoot)
+  ).getOrNull();
+};
+
 const canApply = function (editor: Editor, name: string) {
   const formatList = editor.formatter.get(name);
   let startNode, parents, i, x, selector;
@@ -225,6 +234,7 @@ export {
   matchNode,
   matchName,
   match,
+  closest,
   matchAll,
   matchAllOnNode,
   canApply,

--- a/modules/tinymce/src/core/main/ts/view/VisualAids.ts
+++ b/modules/tinymce/src/core/main/ts/view/VisualAids.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import Editor from '../api/Editor';
+import * as Rtc from '../Rtc';
+
+export const addVisual = (editor: Editor, elm?: HTMLElement) => Rtc.addVisual(editor, elm);

--- a/modules/tinymce/src/core/main/ts/view/VisualAidsImpl.ts
+++ b/modules/tinymce/src/core/main/ts/view/VisualAidsImpl.ts
@@ -5,41 +5,41 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr } from '@ephox/katamari';
+import { Arr, Type } from '@ephox/katamari';
 import Editor from '../api/Editor';
 import * as Settings from '../api/Settings';
 
 export const addVisualInternal = (editor: Editor, elm?: HTMLElement) => {
   const dom = editor.dom;
-  elm = elm || editor.getBody();
+  const scope = Type.isNonNullable(elm) ? elm : editor.getBody();
 
-  if (editor.hasVisual === undefined) {
+  if (Type.isUndefined(editor.hasVisual)) {
     editor.hasVisual = Settings.isVisualAidsEnabled(editor);
   }
 
-  Arr.each(dom.select('table,a', elm), (elm) => {
-    switch (elm.nodeName) {
+  Arr.each(dom.select('table,a', scope), (matchedElm) => {
+    switch (matchedElm.nodeName) {
       case 'TABLE':
         const cls = Settings.getVisualAidsTableClass(editor);
-        const value = dom.getAttrib(elm, 'border');
+        const value = dom.getAttrib(matchedElm, 'border');
 
         if ((!value || value === '0') && editor.hasVisual) {
-          dom.addClass(elm, cls);
+          dom.addClass(matchedElm, cls);
         } else {
-          dom.removeClass(elm, cls);
+          dom.removeClass(matchedElm, cls);
         }
 
         break;
 
       case 'A':
-        if (!dom.getAttrib(elm, 'href')) {
-          const value = dom.getAttrib(elm, 'name') || elm.id;
+        if (!dom.getAttrib(matchedElm, 'href')) {
+          const value = dom.getAttrib(matchedElm, 'name') || matchedElm.id;
           const cls = Settings.getVisualAidsAnchorClass(editor);
 
           if (value && editor.hasVisual) {
-            dom.addClass(elm, cls);
+            dom.addClass(matchedElm, cls);
           } else {
-            dom.removeClass(elm, cls);
+            dom.removeClass(matchedElm, cls);
           }
         }
 

--- a/modules/tinymce/src/core/main/ts/view/VisualAidsImpl.ts
+++ b/modules/tinymce/src/core/main/ts/view/VisualAidsImpl.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Arr } from '@ephox/katamari';
+import Editor from '../api/Editor';
+import * as Settings from '../api/Settings';
+
+export const addVisualInternal = (editor: Editor, elm?: HTMLElement) => {
+  const dom = editor.dom;
+  elm = elm || editor.getBody();
+
+  if (editor.hasVisual === undefined) {
+    editor.hasVisual = Settings.isVisualAidsEnabled(editor);
+  }
+
+  Arr.each(dom.select('table,a', elm), (elm) => {
+    switch (elm.nodeName) {
+      case 'TABLE':
+        const cls = Settings.getVisualAidsTableClass(editor);
+        const value = dom.getAttrib(elm, 'border');
+
+        if ((!value || value === '0') && editor.hasVisual) {
+          dom.addClass(elm, cls);
+        } else {
+          dom.removeClass(elm, cls);
+        }
+
+        break;
+
+      case 'A':
+        if (!dom.getAttrib(elm, 'href')) {
+          const value = dom.getAttrib(elm, 'name') || elm.id;
+          const cls = Settings.getVisualAidsAnchorClass(editor);
+
+          if (value && editor.hasVisual) {
+            dom.addClass(elm, cls);
+          } else {
+            dom.removeClass(elm, cls);
+          }
+        }
+
+        break;
+    }
+  });
+
+  editor.fire('VisualAid', { element: elm, hasVisual: editor.hasVisual });
+};

--- a/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
@@ -1,0 +1,62 @@
+import { Log, Pipeline, Step } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.core.FormatterClosestTest', (success, failure) => {
+  Theme();
+
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+
+    const sAssertClosest = (names: string[], expectedName: string) =>
+      Step.sync(() => {
+        const actualName = editor.formatter.closest(names);
+        Assert.eq('Should match expected format name', expectedName, actualName);
+      });
+
+    Pipeline.async({}, [
+      tinyApis.sFocus(),
+      Log.stepsAsStep('TBA', 'Should return null since the caret is not inside a bold format', [
+        tinyApis.sSetContent('<p>a</p>'),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        sAssertClosest([ 'bold' ], null)
+      ]),
+      Log.stepsAsStep('TBA', 'Should return p block format since caret is inside a p', [
+        tinyApis.sSetContent('<p>a</p>'),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        sAssertClosest([ 'p', 'h1' ], 'p')
+      ]),
+      Log.stepsAsStep('TBA', 'Should return h1 block format since caret is inside a h1', [
+        tinyApis.sSetContent('<h1>a</h1>'),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        sAssertClosest([ 'p', 'h1' ], 'h1')
+      ]),
+      Log.stepsAsStep('TBA', 'Should return italic inline format since caret is inside a em element', [
+        tinyApis.sSetContent('<p><em>a<em></p>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        sAssertClosest([ 'p', 'italic' ], 'italic')
+      ]),
+      Log.stepsAsStep('TBA', 'Should return aligncenter selector format since caret is in a paragraph that is center aligned', [
+        tinyApis.sSetContent('<p style="text-align: center">a</p>'),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        sAssertClosest([ 'aligncenter', 'p' ], 'aligncenter')
+      ]),
+      Log.stepsAsStep('TBA', 'Should return p block format since caret is inside a em inside a p element', [
+        tinyApis.sSetContent('<p><em>a<em></p>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        sAssertClosest([ 'p' ], 'p')
+      ]),
+      Log.stepsAsStep('TBA', 'Should return aligncenter selector format since caret is inside a em inside a p element that is center aligned', [
+        tinyApis.sSetContent('<p style="text-align: center"><em>a<em></p>'),
+        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
+        sAssertClosest([ 'aligncenter', 'p' ], 'aligncenter')
+      ])
+    ], () => {
+      onSuccess();
+    }, onFailure);
+  }, {
+    selector: 'textarea',
+    base_url: '/project/tinymce/js/tinymce'
+  }, success, failure);
+});

--- a/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
@@ -47,6 +47,16 @@ UnitTest.asynctest('browser.tinymce.core.FormatterClosestTest', (success, failur
         tinyApis.sSetCursor([ 0, 0, 0 ], 0),
         sAssertClosest([ 'p' ], 'p')
       ]),
+      Log.stepsAsStep('TBA', 'Should return aligncenter since that format is before the also matching p format', [
+        tinyApis.sSetContent('<p style="text-align: center">a</p>'),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        sAssertClosest([ 'aligncenter', 'p' ], 'aligncenter')
+      ]),
+      Log.stepsAsStep('TBA', 'Should return p since that format is before the also matching aligncenter format', [
+        tinyApis.sSetContent('<p style="text-align: center">a</p>'),
+        tinyApis.sSetCursor([ 0, 0 ], 0),
+        sAssertClosest([ 'p', 'aligncenter' ], 'p')
+      ]),
       Log.stepsAsStep('TBA', 'Should return aligncenter selector format since caret is inside a em inside a p element that is center aligned', [
         tinyApis.sSetContent('<p style="text-align: center"><em>a<em></p>'),
         tinyApis.sSetCursor([ 0, 0, 0 ], 0),

--- a/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
@@ -52,9 +52,7 @@ UnitTest.asynctest('browser.tinymce.core.FormatterClosestTest', (success, failur
         tinyApis.sSetCursor([ 0, 0, 0 ], 0),
         sAssertClosest([ 'aligncenter', 'p' ], 'aligncenter')
       ])
-    ], () => {
-      onSuccess();
-    }, onFailure);
+    ], onSuccess, onFailure);
   }, {
     selector: 'textarea',
     base_url: '/project/tinymce/js/tinymce'

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
@@ -13,7 +13,7 @@ import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
-import { findNearest, getCurrentSelectionParents } from './utils/FormatDetection';
+import { findNearest } from './utils/FormatDetection';
 import { onActionToggleFormat } from './utils/Utils';
 
 const defaultBlocks = (
@@ -28,8 +28,6 @@ const defaultBlocks = (
 );
 
 const getSpec = (editor: Editor): SelectSpec => {
-  const getMatchingValue = (nodeChangeEvent) => findNearest(editor, () => dataset.data, nodeChangeEvent);
-
   const isSelectedFor = (format: string) => () => editor.formatter.match(format);
 
   const getPreviewFor = (format: string) => () => {
@@ -40,20 +38,17 @@ const getSpec = (editor: Editor): SelectSpec => {
     });
   };
 
-  const updateSelectMenuText = (parents: Element[], comp: AlloyComponent) => {
-    const detectedFormat = getMatchingValue(parents);
+  const updateSelectMenuText = (comp: AlloyComponent) => {
+    const detectedFormat = findNearest(editor, () => dataset.data);
     const text = detectedFormat.fold(() => 'Paragraph', (fmt) => fmt.title);
     AlloyTriggers.emitWith(comp, updateMenuText, {
       text
     });
   };
 
-  const nodeChangeHandler = Optional.some((comp: AlloyComponent) => (e) => updateSelectMenuText(e.parents, comp));
+  const nodeChangeHandler = Optional.some((comp: AlloyComponent) => () => updateSelectMenuText(comp));
 
-  const setInitialValue = Optional.some((comp: AlloyComponent) => {
-    const parents = getCurrentSelectionParents(editor);
-    updateSelectMenuText(parents, comp);
-  });
+  const setInitialValue = Optional.some((comp: AlloyComponent) => updateSelectMenuText(comp));
 
   const dataset = buildBasicSettingsDataset(editor, 'block_formats', defaultBlocks, Delimiter.SemiColon);
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleSelect.ts
@@ -14,7 +14,7 @@ import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { AdvancedSelectDataset, SelectDataset } from './SelectDatasets';
 import { getStyleFormats } from './StyleFormat';
-import { findNearest, getCurrentSelectionParents } from './utils/FormatDetection';
+import { findNearest } from './utils/FormatDetection';
 import { onActionToggleFormat } from './utils/Utils';
 
 const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
@@ -28,25 +28,22 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
     }) : Optional.none();
   };
 
-  const updateSelectMenuText = (parents: Element[], comp: AlloyComponent) => {
+  const updateSelectMenuText = (comp: AlloyComponent) => {
     const getFormatItems = (fmt) => {
       const subs = fmt.items;
       return subs !== undefined && subs.length > 0 ? Arr.bind(subs, getFormatItems) : [{ title: fmt.title, format: fmt.format }];
     };
     const flattenedItems = Arr.bind(getStyleFormats(editor), getFormatItems);
-    const detectedFormat = findNearest(editor, () => flattenedItems, parents);
+    const detectedFormat = findNearest(editor, () => flattenedItems);
     const text = detectedFormat.fold(() => 'Paragraph', (fmt) => fmt.title);
     AlloyTriggers.emitWith(comp, updateMenuText, {
       text
     });
   };
 
-  const nodeChangeHandler = Optional.some((comp: AlloyComponent) => (e) => updateSelectMenuText(e.parents, comp));
+  const nodeChangeHandler = Optional.some((comp: AlloyComponent) => () => updateSelectMenuText(comp));
 
-  const setInitialValue = Optional.some((comp: AlloyComponent) => {
-    const parents = getCurrentSelectionParents(editor);
-    updateSelectMenuText(parents, comp);
-  });
+  const setInitialValue = Optional.some((comp: AlloyComponent) => updateSelectMenuText(comp));
 
   return {
     tooltip: 'Formats',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatDetection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatDetection.ts
@@ -7,22 +7,16 @@
 
 import { Arr, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
+import { BasicSelectItem } from '../SelectDatasets';
 
-const findNearest = (editor: Editor, getStyles, parents: Element[]) => {
+export const findNearest = (editor: Editor, getStyles: () => BasicSelectItem[]) => {
   const styles = getStyles();
+  const formats = Arr.map(styles, (style) => style.format);
 
-  return Arr.findMap(parents, (parent) => Arr.find(styles, (fmt) => editor.formatter.matchNode(parent, fmt.format))).orThunk(() => {
+  return Optional.from(editor.formatter.closest(formats)).bind((fmt) =>
+    Arr.find(styles, (data) => data.format === fmt)
+  ).orThunk(() => {
     if (editor.formatter.match('p')) { return Optional.some({ title: 'Paragraph', format: 'p' }); }
     return Optional.none();
   });
-};
-
-const getCurrentSelectionParents = (editor: Editor): Element[] => {
-  const currentNode = editor.selection.getStart(true) || editor.getBody();
-  return editor.dom.getParents(currentNode, () => true, editor.getBody());
-};
-
-export {
-  findNearest,
-  getCurrentSelectionParents
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatDetection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatDetection.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Optional, Optionals } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { BasicSelectItem } from '../SelectDatasets';
 
@@ -15,8 +15,5 @@ export const findNearest = (editor: Editor, getStyles: () => BasicSelectItem[]) 
 
   return Optional.from(editor.formatter.closest(formats)).bind((fmt) =>
     Arr.find(styles, (data) => data.format === fmt)
-  ).orThunk(() => {
-    if (editor.formatter.match('p')) { return Optional.some({ title: 'Paragraph', format: 'p' }); }
-    return Optional.none();
-  });
+  ).orThunk(() => Optionals.someIf(editor.formatter.match('p'), { title: 'Paragraph', format: 'p' }));
 };


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Adds a new public closest api to formatter that isn't dom specific and redirects that to rtc.
* Redirects formatter.match to rtc.
* Redirects formatter.formatChanged to rtc.
* Contains rtc ignore for addVisual since it updates the dom view did some minor cleanup on that as well.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
