### PR TITLE
DOC-636: Version required note on 5.5 API docs

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -447,7 +447,7 @@ class Editor implements EditorObservable {
   /**
    * Checks that the plugin is in the editor configuration and can optionally check if the plugin has been loaded.
    * <br>
-   * <em>Added in TinyMCE 5.4</em>
+   * <em>Added in TinyMCE 5.5</em>
    *
    * @method hasPlugin
    * @param {String} name The name of the plugin, as specified for the TinyMCE `plugins` option.

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -220,6 +220,8 @@ export function StyleSheetLoader(documentOrShadowRoot: Document | ShadowRoot, se
 
   /**
    * Unloads the specified CSS file if no resources currently depend on it.
+   * <br>
+   * <em>Added in TinyMCE 5.5</em>
    *
    * @method unload
    * @param {String} url URL to unload or remove.
@@ -237,6 +239,8 @@ export function StyleSheetLoader(documentOrShadowRoot: Document | ShadowRoot, se
 
   /**
    * Unloads each specified CSS file if no resources currently depend on it.
+   * <br>
+   * <em>Added in TinyMCE 5.5</em>
    *
    * @method unloadAll
    * @param {Array} urls URLs to unload or remove.


### PR DESCRIPTION
Related Ticket: DOC-636

Description of Changes:
* Fixing 5.5 version release notes (API Docs)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
