### PR TITLE
TINY-6363: Fixed the root document able to be scrolled when a dialog is open and rendered inside a shadow root

### DIFF
--- a/modules/oxide/src/less/skins/ui/dark/skin.shadowdom.less
+++ b/modules/oxide/src/less/skins/ui/dark/skin.shadowdom.less
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+@import 'src/less/theme/shadowdom';

--- a/modules/oxide/src/less/skins/ui/default/skin.shadowdom.less
+++ b/modules/oxide/src/less/skins/ui/default/skin.shadowdom.less
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+@import 'src/less/theme/shadowdom';

--- a/modules/oxide/src/less/theme/components/dialog/blocker.less
+++ b/modules/oxide/src/less/theme/components/dialog/blocker.less
@@ -1,0 +1,15 @@
+//
+// Copyright (c) Tiny Technologies, Inc. All rights reserved.
+// Licensed under the LGPL or a commercial license.
+// For LGPL see License.txt in the project root for license information.
+// For commercial licenses see https://www.tiny.cloud/
+//
+
+//
+// Dialog root document blocker
+//
+
+// Added to the body to disable scrolling when dialogs are open
+body.tox-dialog__disable-scroll {
+  overflow: hidden;
+}

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -465,11 +465,6 @@
   }
 }
 
-// Added to the body to disable scrolling when dialogs are open
-body.tox-dialog__disable-scroll {
-  overflow: hidden;
-}
-
 .tox.tox-platform-ie {
   /* IE11 CSS styles go here */
   .tox-dialog-wrap {

--- a/modules/oxide/src/less/theme/shadowdom.less
+++ b/modules/oxide/src/less/theme/shadowdom.less
@@ -1,0 +1,15 @@
+//
+// Copyright (c) Tiny Technologies, Inc. All rights reserved.
+// Licensed under the LGPL or a commercial license.
+// For LGPL see License.txt in the project root for license information.
+// For commercial licenses see https://www.tiny.cloud/
+//
+
+//
+// Shadow DOM styles for the root page
+//
+
+@import 'globals/global-variables';
+
+@import 'components/dialog/blocker';
+@import 'components/fullscreen/fullscreen';

--- a/modules/oxide/src/less/theme/shadowdom.less
+++ b/modules/oxide/src/less/theme/shadowdom.less
@@ -6,7 +6,10 @@
 //
 
 //
-// Shadow DOM styles for the root page
+// Shadow DOM styles for the root page.
+//
+// This file contains styles specific the root document, such as blocking scrolling or setting the
+// z-index on the shadow-host. It should not contain any styling for UI components or editor content.
 //
 
 @import 'globals/global-variables';

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -28,6 +28,7 @@
 @import 'components/comments/comment';
 @import 'components/comments/user';
 @import 'components/dialog/dialog';
+@import 'components/dialog/blocker';
 @import 'components/dropzone/dropzone';
 @import 'components/edit-area/edit-area';
 @import 'components/edit-area/inline-edit-area';

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.6.0 (TBD)
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
+    Fixed the root document able to be scrolled when a dialog is open and rendered inside a shadow root #TINY-6363
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282
     Fixed `fullpage` plugin altering text content in `editor.getContent()` #TINY-6541

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,7 +1,7 @@
 Version 5.6.0 (TBD)
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
-    Fixed the root document able to be scrolled when a dialog is open and rendered inside a shadow root #TINY-6363
+    Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282
     Fixed `fullpage` plugin altering text content in `editor.getContent()` #TINY-6541

--- a/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
@@ -12,6 +12,6 @@ export default function (init: ShadowRootInit) {
 
   tinymce.init({
     target: node,
-    plugins: 'advlist charmap code codesample emoticons image link lists media paste preview searchreplace table wordcount'
+    plugins: 'advlist charmap code codesample emoticons fullscreen image link lists media paste preview searchreplace table wordcount'
   });
 }

--- a/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
@@ -7,6 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
 const isSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.min.css');
+const isShadowDomSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.shadowdom.min.css');
 
 const skinSheetsTest = (extraSettings: Record<string, any>) => (success, failure) => {
   if (!SugarShadowDom.isSupported()) {
@@ -18,11 +19,15 @@ const skinSheetsTest = (extraSettings: Record<string, any>) => (success, failure
   TinyLoader.setupInShadowRoot((editor: Editor, shadowRoot: SugarElement<ShadowRoot>, onSuccess, onFailure) => {
     Pipeline.async({}, [
       Step.sync(() => {
-        // TODO TINY-6144: Test that there are no skin stylesheets in the head. We will need to clean up existing stylesheets first, which may require a StyleSheetLoader.removeAll() function
         Assert.eq(
           'There should be a skin stylesheet in the ShadowRoot',
           true,
           Arr.exists(shadowRoot.dom.styleSheets, isSkin)
+        );
+        Assert.eq(
+          'There should only be a shadowdom specific skin stylesheet in the document',
+          true,
+          Arr.exists(document.styleSheets, isShadowDomSkin)
         );
       })
     ], onSuccess, onFailure);

--- a/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
@@ -25,7 +25,7 @@ const skinSheetsTest = (extraSettings: Record<string, any>) => (success, failure
           Arr.exists(shadowRoot.dom.styleSheets, isSkin)
         );
         Assert.eq(
-          'There should only be a shadowdom specific skin stylesheet in the document',
+          'There should be a shadowdom specific skin stylesheet in the document',
           true,
           Arr.exists(document.styleSheets, isShadowDomSkin)
         );

--- a/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
@@ -5,26 +5,51 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun } from '@ephox/katamari';
+import { Fun, Type } from '@ephox/katamari';
+import { SugarElement, SugarShadowDom } from '@ephox/sugar';
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import { StyleSheetLoader } from 'tinymce/core/api/dom/StyleSheetLoader';
 import Editor from 'tinymce/core/api/Editor';
+import Promise from 'tinymce/core/api/util/Promise';
 import { getSkinUrl, isSkinDisabled } from '../../api/Settings';
 import * as SkinLoaded from './SkinLoaded';
 
+const loadStylesheet = (editor: Editor, stylesheetUrl: string, styleSheetLoader: StyleSheetLoader): Promise<void> => new Promise((resolve, reject) => {
+  styleSheetLoader.load(stylesheetUrl, resolve, reject);
+
+  // Ensure the stylesheet is cleaned up when the editor is destroyed
+  editor.on('remove', () => styleSheetLoader.unload(stylesheetUrl));
+});
+
+const loadUiSkins = (editor: Editor, skinUrl: string): Promise<void> => {
+  const skinUiCss = skinUrl + '/skin.min.css';
+  return loadStylesheet(editor, skinUiCss, editor.ui.styleSheetLoader);
+};
+
+const loadShadowDomUiSkins = (editor: Editor, skinUrl: string): Promise<void> => {
+  const isInShadowRoot = SugarShadowDom.isInShadowRoot(SugarElement.fromDom(editor.getElement()));
+  if (isInShadowRoot) {
+    const shadowDomSkinCss = skinUrl + '/skin.shadowdom.min.css';
+    return loadStylesheet(editor, shadowDomSkinCss, DOMUtils.DOM.styleSheetLoader);
+  } else {
+    return Promise.resolve();
+  }
+};
+
 const loadSkin = (isInline: boolean, editor: Editor) => {
   const skinUrl = getSkinUrl(editor);
-  let skinUiCss;
 
   if (skinUrl) {
-    skinUiCss = skinUrl + '/skin.min.css';
     editor.contentCSS.push(skinUrl + (isInline ? '/content.inline' : '/content') + '.min.css');
   }
 
   // In Modern Inline, this is explicitly called in editor.on('focus', ...) as well as in render().
   // Seems to work without, but adding a note in case things break later
-  if (isSkinDisabled(editor) === false && skinUiCss) {
-    const styleSheetLoader = editor.ui.styleSheetLoader;
-    styleSheetLoader.load(skinUiCss, SkinLoaded.fireSkinLoaded(editor), SkinLoaded.fireSkinLoadError(editor, 'Skin could not be loaded'));
-    editor.on('remove', () => styleSheetLoader.unload(skinUiCss));
+  if (isSkinDisabled(editor) === false && Type.isString(skinUrl)) {
+    Promise.all([
+      loadUiSkins(editor, skinUrl),
+      loadShadowDomUiSkins(editor, skinUrl)
+    ]).then(SkinLoaded.fireSkinLoaded(editor), SkinLoaded.fireSkinLoadError(editor, 'Skin could not be loaded'));
   } else {
     SkinLoaded.fireSkinLoaded(editor)();
   }


### PR DESCRIPTION
Related Ticket: TINY-6363

Description of Changes:
* This adds a new `skin.shadowdom.min.css` file to the bundle that has the specific styles that needs to be added to the root document when the editor is rendered within a shadow root.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
