### PR TITLE
TINY-6570: Fixed some memory leaks that prevented editor instances being garbage collected

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -9,6 +9,7 @@ Version 5.6.0 (TBD)
     Fixed font size keywords such as `medium` not displaying correctly in font size menus #TINY-6291
     Fixed an issue where some attributes in table cells were not copied over to new rows or columns #TINY-6485
     Fixed some incorrect types in the new TypeScript declaration file #TINY-6413
+    Fixed a memory leak in IE 11 that prevented editor instances being garbage collected #TINY-6570
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -9,7 +9,7 @@ Version 5.6.0 (TBD)
     Fixed font size keywords such as `medium` not displaying correctly in font size menus #TINY-6291
     Fixed an issue where some attributes in table cells were not copied over to new rows or columns #TINY-6485
     Fixed some incorrect types in the new TypeScript declaration file #TINY-6413
-    Fixed a memory leak in IE 11 that prevented editor instances being garbage collected #TINY-6570
+    Fixed some minor memory leaks that prevented editor instances being garbage collected #TINY-6570
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -9,7 +9,7 @@ Version 5.6.0 (TBD)
     Fixed font size keywords such as `medium` not displaying correctly in font size menus #TINY-6291
     Fixed an issue where some attributes in table cells were not copied over to new rows or columns #TINY-6485
     Fixed some incorrect types in the new TypeScript declaration file #TINY-6413
-    Fixed some minor memory leaks that prevented editor instances being garbage collected #TINY-6570
+    Fixed some minor memory leaks that prevented garbage collection for editor instances #TINY-6570
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475

--- a/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
@@ -200,6 +200,9 @@ const bindOnReady = function (win, callback, eventUtils) {
       eventUtils.domLoaded = true;
       callback(event);
     }
+
+    // Clean memory for IE
+    win = null;
   };
 
   if (isDocReady()) {
@@ -209,7 +212,9 @@ const bindOnReady = function (win, callback, eventUtils) {
   }
 
   // Fallback if any of the above methods should fail for some odd reason
-  addEvent(win, 'load', readyHandler);
+  if (!eventUtils.domLoaded) {
+    addEvent(win, 'load', readyHandler);
+  }
 };
 
 export interface EventUtilsConstructor {

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -85,18 +85,21 @@ class ScriptLoader {
     const dom = DOM;
     let elm;
 
+    const cleanup = () => {
+      dom.remove(id);
+      if (elm) {
+        elm.onerror = elm.onload = elm = null;
+      }
+    };
+
     // Execute callback when script is loaded
     const done = function () {
-      dom.remove(id);
-
-      if (elm) {
-        elm.onreadystatechange = elm.onload = elm = null;
-      }
-
+      cleanup();
       success();
     };
 
     const error = function () {
+      cleanup();
 
       // We can't mark it as done if there is a load error since
       // A) We don't want to produce 404 errors on the server and
@@ -170,10 +173,10 @@ class ScriptLoader {
    */
   public add(url: string, success?: () => void, scope?: any, failure?: () => void) {
     const state = this.states[url];
+    this.queue.push(url);
 
     // Add url to load queue
     if (state === undefined) {
-      this.queue.push(url);
       this.states[url] = QUEUED;
     }
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScriptLoaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScriptLoaderTest.ts
@@ -1,0 +1,75 @@
+import { Log, Pipeline, Step } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
+
+UnitTest.asynctest('browser.tinymce.core.dom.ScriptLoaderTest', (success, failure) => {
+  const testScript = '/project/tinymce/src/core/test/assets/js/test.js';
+  let loadedScripts: string[] = [];
+  let loadedCount = 0;
+
+  const sLoadScript = (url: string) => Step.async((next, die) => {
+    loadedScripts.push(url);
+    ScriptLoader.ScriptLoader.loadScript(url, () => {
+      loadedCount++;
+      next();
+    }, () => die('Failed to load script'));
+  });
+
+  const sLoadScripts = (urls: string[]) => Step.async((next, die) => {
+    loadedScripts.push(...urls);
+    const scriptCount = urls.length;
+    ScriptLoader.ScriptLoader.loadScripts(urls, () => {
+      loadedCount += scriptCount;
+      next();
+    }, () => die('Failed to load scripts'));
+  });
+
+  const sAddToQueue = (url: string) => Step.sync(() => {
+    loadedScripts.push(url);
+    ScriptLoader.ScriptLoader.add(url, () => loadedCount++);
+  });
+
+  const sLoadQueue = Step.async((next, die) => {
+    ScriptLoader.ScriptLoader.loadQueue(next, undefined, () => die('Failed to load queued scripts'));
+  });
+
+  const sAssertQueueLoadedCount = (count: number) => Step.sync(() => {
+    Assert.eq('Loaded script count', count, loadedCount);
+  });
+
+  const sReset = () => Step.sync(() => {
+    Arr.each(loadedScripts, (url) => ScriptLoader.ScriptLoader.remove(url));
+    loadedCount = 0;
+    loadedScripts = [];
+  });
+
+  Pipeline.async({}, [
+    Log.stepsAsStep('TBA', 'Load a single script', [
+      sLoadScript(testScript),
+      sAssertQueueLoadedCount(1),
+      sReset()
+    ]),
+    Log.stepsAsStep('TBA', 'Load scripts', [
+      sLoadScripts([ testScript ]),
+      sAssertQueueLoadedCount(1),
+      sReset()
+    ]),
+    Log.stepsAsStep('TBA', 'Load scripts via a queue', [
+      sAddToQueue(testScript),
+      sAssertQueueLoadedCount(0),
+      sLoadQueue,
+      sAssertQueueLoadedCount(1),
+      sReset()
+    ]),
+    Log.stepsAsStep('TINY-6570', 'Load a script multiple times via a queue', [
+      sAddToQueue(testScript),
+      sLoadQueue,
+      sAssertQueueLoadedCount(1),
+      sAddToQueue(testScript),
+      sLoadQueue,
+      sAssertQueueLoadedCount(2),
+      sReset()
+    ])
+  ], success, failure);
+});

--- a/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
@@ -71,10 +71,8 @@ const restoreDraft = (editor: Editor) => {
 
 const startStoreDraft = (editor: Editor) => {
   const interval = Settings.getAutoSaveInterval(editor);
-  Delay.setInterval(() => {
-    if (!editor.removed) {
-      storeDraft(editor);
-    }
+  Delay.setEditorInterval(editor, () => {
+    storeDraft(editor);
   }, interval);
 };
 


### PR DESCRIPTION
Related Ticket: TINY-6570

Description of Changes:
* Fixed some memory leaks specific to IE that was found when doing some investigation into informant test failures.
* Fixed some other more generic leaks that applied to all browsers.

P.S. Big thanks to @ephox-mogran for the help in diagnosing the Iframe leak.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
