### PR TITLE
Add the possibility to add a nonce attribute for script and css loading.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ standardProperties()
 
 node("primary") {
   timestamps {
-    def primaryBranch = "master"
+    def primaryBranch = "release/5.4"
 
     def gitMerge = {
       if (BRANCH_NAME != primaryBranch) {

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -311,6 +311,11 @@ class Editor implements EditorObservable {
       ScriptLoader.ScriptLoader._setReferrerPolicy(this.settings.referrer_policy);
       DOMUtils.DOM.styleSheetLoader._setReferrerPolicy(this.settings.referrer_policy);
     }
+    if (this.settings.nonce) {
+      ScriptLoader.ScriptLoader._setNonce(this.settings.nonce);
+      DOMUtils.DOM.styleSheetLoader._setNonce(this.settings.nonce);
+    }
+
 
     AddOnManager.languageLoad = this.settings.language_load;
     AddOnManager.baseURL = editorManager.baseURL;

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -137,6 +137,7 @@ interface BaseEditorSettings {
   min_height?: number;
   min_width?: number;
   no_newline_selector?: string;
+  nonce?: string;
   nowrap?: boolean;
   object_resizing?: boolean | string;
   placeholder?: string;

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -42,6 +42,7 @@ const each = Tools.each, grep = Tools.grep;
 
 export interface ScriptLoaderSettings {
   referrerPolicy?: ReferrerPolicy;
+  nonce?: string;
 }
 
 export interface ScriptLoaderConstructor {
@@ -61,6 +62,7 @@ interface ScriptLoader {
   remove (url: string);
   loadQueue (success?: () => void, scope?: {}, failure?: (urls: string[]) => void): void;
   _setReferrerPolicy (referrerPolicy: ReferrerPolicy): void;
+  _setNonce (nonce: string): void;
 }
 
 const QUEUED = 0;
@@ -84,6 +86,9 @@ class ScriptLoader {
 
   public _setReferrerPolicy(referrerPolicy: ReferrerPolicy) {
     this.settings.referrerPolicy = referrerPolicy;
+  }
+  public _setNonce(nonce: string) {
+    this.settings.nonce = nonce;
   }
 
   /**
@@ -139,6 +144,10 @@ class ScriptLoader {
     if (this.settings.referrerPolicy) {
       // Note: Don't use elm.referrerPolicy = ... here as it doesn't work on Safari
       dom.setAttrib(elm, 'referrerpolicy', this.settings.referrerPolicy);
+    }
+
+    if (this.settings.nonce) {
+      elm.setAttribute('nonce', this.settings.nonce);
     }
 
     elm.onload = done;

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -22,12 +22,14 @@ export interface StyleSheetLoader {
   load: (url: string, loadedCallback: Function, errorCallback?: Function) => void;
   loadAll: (urls: string[], success: Function, failure: Function) => void;
   _setReferrerPolicy: (referrerPolicy: ReferrerPolicy) => void;
+  _setNonce: (nonce: string) => void;
 }
 
 export interface StyleSheetLoaderSettings {
   maxLoadTime: number;
   contentCssCors: boolean;
   referrerPolicy: ReferrerPolicy;
+  nonce: string;
 }
 
 export function StyleSheetLoader(documentOrShadowRoot: DomDocument | ShadowRoot, settings: Partial<StyleSheetLoaderSettings> = {}): StyleSheetLoader {
@@ -41,6 +43,10 @@ export function StyleSheetLoader(documentOrShadowRoot: DomDocument | ShadowRoot,
 
   const _setReferrerPolicy = (referrerPolicy: ReferrerPolicy) => {
     settings.referrerPolicy = referrerPolicy;
+  };
+
+  const _setNonce = (nonce: string) => {
+    settings.nonce = nonce;
   };
 
   const addStyle = (element: Element<DomNode>) => {
@@ -199,6 +205,9 @@ export function StyleSheetLoader(documentOrShadowRoot: DomDocument | ShadowRoot,
       // Note: Don't use link.referrerPolicy = ... here as it doesn't work on Safari
       Attr.set(Element.fromDom(link), 'referrerpolicy', settings.referrerPolicy);
     }
+    if (settings.nonce) {
+      link.setAttribute('nonce', settings.nonce);
+    }
 
     // Feature detect onload on link element and sniff older webkits since it has an broken onload event
     if ('onload' in link && !isOldWebKit()) {
@@ -259,6 +268,7 @@ export function StyleSheetLoader(documentOrShadowRoot: DomDocument | ShadowRoot,
   return {
     load,
     loadAll,
-    _setReferrerPolicy
+    _setReferrerPolicy,
+    _setNonce
   };
 }


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Add an optional "nonce" option to the the script- and stylesheet-loaders in order to allow the use in
  conjunction with CSP policies using the "nonce" feature.

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [ ] License headers added on new files (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
