### PR TITLE
TINY-6268: Fixed incorrectly removing formatting on adjacent spaces when removing formatting on a ranged selection

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -8,6 +8,7 @@ Version 5.6.0 (TBD)
     Fixed `fullpage` plugin altering text content in `editor.getContent()` #TINY-6541
     Fixed font size keywords such as `medium` not displaying correctly in font size menus #TINY-6291
     Fixed an issue where some attributes in table cells were not copied over to new rows or columns #TINY-6485
+    Fixed incorrectly removing formatting on adjacent spaces when removing formatting on a ranged selection #TINY-6268
     Fixed some incorrect types in the new TypeScript declaration file #TINY-6413
 Version 5.5.1 (TBD)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -11,6 +11,7 @@ import EditorSelection from '../api/dom/Selection';
 import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import * as NodeType from '../dom/NodeType';
+import * as Whitespace from '../text/Whitespace';
 import { ApplyFormat, BlockFormat, Format, FormatAttrOrStyleValue, FormatVars, InlineFormat, SelectorFormat } from './FormatTypes';
 
 const isNode = (node: any): node is Node => !!(node).nodeType;
@@ -85,11 +86,17 @@ const isValid = function (ed: Editor, parent: string, child: string) {
   return ed.schema.isValidChild(parent, child);
 };
 
-const isWhiteSpaceNode = function (node: Node) {
-  return node && NodeType.isText(node) && /^([\t \r\n]+|)$/.test(node.nodeValue);
+const isWhiteSpaceNode = function (node: Node | null, allowSpaces: boolean = false) {
+  if (node && NodeType.isText(node)) {
+    // If spaces are allowed, treat them as a non-breaking space
+    const data = allowSpaces ? node.data.replace(/ /g, '\u00a0') : node.data;
+    return Whitespace.isWhitespaceText(data);
+  } else {
+    return false;
+  }
 };
 
-const isEmptyTextNode = function (node: Node) {
+const isEmptyTextNode = function (node: Node | null) {
   return node && NodeType.isText(node) && node.length === 0;
 };
 

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -531,7 +531,7 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
   const removeRngStyle = (rng: Range) => {
     let startContainer: Node, endContainer: Node;
 
-    let expandedRng = ExpandRange.expandRng(ed, rng, formatList, true);
+    let expandedRng = ExpandRange.expandRng(ed, rng, formatList, rng.collapsed);
 
     if (format.split) {
       // Split text nodes

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -521,6 +521,20 @@ UnitTest.asynctest('browser.tinymce.core.FormatterRemoveTest', function (success
     Assert.eq('', '<p>test</p><table><tbody><tr><td>cell 1</td><td>cell 2</td></tr><tr><td>cell 3</td><td>cell 4</td></tr></tbody></table>', getContent(editor));
   });
 
+  suite.test('TINY-6268: Remove inline format on text range selection with adjacent spaces', (editor) => {
+    editor.setContent('<p>test<span style="text-decoration: underline;"> t</span>est</p>');
+    LegacyUnit.setSelection(editor, 'span', 1, 'span', 2);
+    editor.formatter.remove('underline');
+    Assert.eq('Formatting on the space should not have been removed', '<p>test<span style="text-decoration: underline;"> </span>test</p>', getContent(editor));
+  });
+
+  suite.test('TINY-6268: Remove inline format on text collapsed selection with adjacent spaces', (editor) => {
+    editor.setContent('<p>test<span style="text-decoration: underline;"> t</span>est</p>');
+    LegacyUnit.setSelection(editor, 'span', 1, 'span', 1);
+    editor.formatter.remove('underline');
+    Assert.eq('Formatting on the space should not have been removed', '<p>test test</p>', getContent(editor));
+  });
+
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
   }, {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
@@ -1,23 +1,18 @@
-import { Assertions, Chain, GeneralSteps, Logger, Pipeline } from '@ephox/agar';
+import { Assertions, Chain, Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { ApiChains, TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Hierarchy, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import * as ExpandRange from 'tinymce/core/fmt/ExpandRange';
+import { ZWSP } from 'tinymce/core/text/Zwsp';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.core.fmt.ExpandRangeTest', function (success, failure) {
+UnitTest.asynctest('browser.tinymce.core.fmt.ExpandRangeTest', (success, failure) => {
 
   Theme();
 
-  const cSetRawContent = function (html: string) {
-    return Chain.op(function (editor: Editor) {
-      editor.getBody().innerHTML = html;
-    });
-  };
-
-  const cExpandRng = function (startPath: number[], startOffset: number, endPath: number[], endOffset: number, format, excludeTrailingSpaces: boolean = false) {
-    return Chain.mapper(function (editor: Editor) {
+  const cExpandRng = (startPath: number[], startOffset: number, endPath: number[], endOffset: number, format, excludeTrailingSpaces: boolean = false) =>
+    Chain.mapper((editor: Editor) => {
       const startContainer = Hierarchy.follow(SugarElement.fromDom(editor.getBody()), startPath).getOrDie();
       const endContainer = Hierarchy.follow(SugarElement.fromDom(editor.getBody()), endPath).getOrDie();
 
@@ -27,10 +22,9 @@ UnitTest.asynctest('browser.tinymce.core.fmt.ExpandRangeTest', function (success
 
       return ExpandRange.expandRng(editor, rng, format, excludeTrailingSpaces);
     });
-  };
 
-  const cAssertRange = function (editor: Editor, startPath: number[], startOffset: number, endPath: number[], endOffset: number) {
-    return Chain.op(function (rng: Range) {
+  const cAssertRange = (editor: Editor, startPath: number[], startOffset: number, endPath: number[], endOffset: number) =>
+    Chain.op((rng: Range) => {
       const startContainer = Hierarchy.follow(SugarElement.fromDom(editor.getBody()), startPath).getOrDie();
       const endContainer = Hierarchy.follow(SugarElement.fromDom(editor.getBody()), endPath).getOrDie();
 
@@ -39,9 +33,8 @@ UnitTest.asynctest('browser.tinymce.core.fmt.ExpandRangeTest', function (success
       Assertions.assertDomEq('Should be expected end container', endContainer, SugarElement.fromDom(rng.endContainer));
       Assertions.assertEq('Should be expected end offset', endOffset, rng.endOffset);
     });
-  };
 
-  TinyLoader.setupLight(function (editor, onSuccess, onFailure) {
+  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
     const inlineFormat = [{ inline: 'b' }];
     const blockFormat = [{ block: 'div' }];
@@ -50,170 +43,190 @@ UnitTest.asynctest('browser.tinymce.core.fmt.ExpandRangeTest', function (success
 
     Pipeline.async({}, [
       tinyApis.sFocus(),
-      Logger.t('Expand inline format words', GeneralSteps.sequence([
-        Logger.t('In middle of single word in paragraph', Chain.asStep(editor, [
-          cSetRawContent('<p>ab</p>'),
+      Log.stepsAsStep('TBA', 'Expand inline format words', [
+        Log.step('TBA', 'In middle of single word in paragraph', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab</p>'),
           cExpandRng([ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('In middle of single word in paragraph with paragraph siblings', Chain.asStep(editor, [
-          cSetRawContent('<p>a</p><p>bc</p><p>de</p>'),
+        Log.step('TBA', 'In middle of single word in paragraph with paragraph siblings', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>a</p><p>bc</p><p>de</p>'),
           cExpandRng([ 1, 0 ], 1, [ 1, 0 ], 1, inlineFormat, false),
           cAssertRange(editor, [], 1, [], 2)
         ])),
-        Logger.t('In middle of single word wrapped in b', Chain.asStep(editor, [
-          cSetRawContent('<p><b>ab</b></p>'),
+        Log.step('TBA', 'In middle of single word wrapped in b', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><b>ab</b></p>'),
           cExpandRng([ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1, inlineFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('In middle of first word', Chain.asStep(editor, [
-          cSetRawContent('<p>ab cd</p>'),
+        Log.step('TBA', 'In middle of first word', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab cd</p>'),
           cExpandRng([ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, false),
           cAssertRange(editor, [], 0, [ 0, 0 ], 2)
         ])),
-        Logger.t('In middle of last word', Chain.asStep(editor, [
-          cSetRawContent('<p>ab cd</p>'),
+        Log.step('TBA', 'In middle of last word', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab cd</p>'),
           cExpandRng([ 0, 0 ], 4, [ 0, 0 ], 4, inlineFormat, false),
           cAssertRange(editor, [ 0, 0 ], 3, [], 1)
         ])),
-        Logger.t('In middle of middle word', Chain.asStep(editor, [
-          cSetRawContent('<p>ab cd ef</p>'),
+        Log.step('TBA', 'In middle of middle word', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab cd ef</p>'),
           cExpandRng([ 0, 0 ], 4, [ 0, 0 ], 4, inlineFormat, false),
           cAssertRange(editor, [ 0, 0 ], 3, [ 0, 0 ], 5)
         ])),
-        Logger.t('In middle of word with bold siblings expand to sibling spaces', Chain.asStep(editor, [
-          cSetRawContent('<p><b>ab </b>cd<b> ef</b></p>'),
+        Log.step('TBA', 'In middle of word with bold siblings expand to sibling spaces', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><b>ab </b>cd<b> ef</b></p>'),
           cExpandRng([ 0, 1 ], 1, [ 0, 1 ], 1, inlineFormat, false),
           cAssertRange(editor, [ 0, 0, 0 ], 3, [ 0, 2, 0 ], 0)
         ])),
-        Logger.t('In middle of word with block sibling and inline sibling expand to sibling space to the right', Chain.asStep(editor, [
-          cSetRawContent('<div><p>ab </p>cd<b> ef</b></div>'),
+        Log.step('TBA', 'In middle of word with block sibling and inline sibling expand to sibling space to the right', Chain.asStep(editor, [
+          ApiChains.cSetContent('<div><p>ab </p>cd<b> ef</b></div>'),
           cExpandRng([ 0, 1 ], 1, [ 0, 1 ], 1, inlineFormat, false),
           cAssertRange(editor, [ 0, 1 ], 0, [ 0, 2, 0 ], 0)
         ])),
-        Logger.t('In middle of word with block sibling and inline sibling expand to sibling space to the left', Chain.asStep(editor, [
-          cSetRawContent('<div><b>ab </b>cd<p> ef</p></div>'),
+        Log.step('TBA', 'In middle of word with block sibling and inline sibling expand to sibling space to the left', Chain.asStep(editor, [
+          ApiChains.cSetContent('<div><b>ab </b>cd<p> ef</p></div>'),
           cExpandRng([ 0, 1 ], 1, [ 0, 1 ], 1, inlineFormat, false),
           cAssertRange(editor, [ 0, 0, 0 ], 3, [ 0, 1 ], 2)
         ])),
-        Logger.t('In middle of middle word separated by nbsp characters', Chain.asStep(editor, [
-          cSetRawContent('<p>ab\u00a0cd\u00a0ef</p>'),
+        Log.step('TBA', 'In middle of middle word separated by nbsp characters', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab\u00a0cd\u00a0ef</p>'),
           cExpandRng([ 0, 0 ], 4, [ 0, 0 ], 4, inlineFormat, false),
           cAssertRange(editor, [ 0, 0 ], 3, [ 0, 0 ], 5)
         ])),
-        Logger.t('In empty paragraph', Chain.asStep(editor, [
-          cSetRawContent('<p><br></p>'),
+        Log.step('TBA', 'In empty paragraph', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><br></p>'),
           cExpandRng([ 0 ], 0, [ 0 ], 0, inlineFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('Fully selected word', Chain.asStep(editor, [
-          cSetRawContent('<p>ab</p>'),
+        Log.step('TBA', 'Fully selected word', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab</p>'),
           cExpandRng([ 0, 0 ], 0, [ 0, 0 ], 2, inlineFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('Partially selected word', Chain.asStep(editor, [
-          cSetRawContent('<p>abc</p>'),
+        Log.step('TBA', 'Partially selected word', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>abc</p>'),
           cExpandRng([ 0, 0 ], 1, [ 0, 0 ], 2, inlineFormat, false),
           cAssertRange(editor, [ 0, 0 ], 1, [ 0, 0 ], 2)
         ])),
-        Logger.t('Whole word selected wrapped in multiple inlines', Chain.asStep(editor, [
-          cSetRawContent('<p><b><i>c</i></b></p>'),
+        Log.step('TBA', 'Whole word selected wrapped in multiple inlines', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><b><i>c</i></b></p>'),
           cExpandRng([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1, inlineFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('Whole word inside td', Chain.asStep(editor, [
-          cSetRawContent('<table><tbody><tr><td>a</td></tr></tbody></table>'),
+        Log.step('TBA', 'Whole word inside td', Chain.asStep(editor, [
+          ApiChains.cSetContent('<table><tbody><tr><td>a</td></tr></tbody></table>'),
           cExpandRng([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1, inlineFormat, false),
           cAssertRange(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1)
         ])),
-        Logger.t('In middle of single word in paragraph (index based)', Chain.asStep(editor, [
-          cSetRawContent('<p>ab</p>'),
+        Log.step('TBA', 'In middle of single word in paragraph (index based)', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab</p>'),
           cExpandRng([ 0 ], 0, [ 0 ], 1, inlineFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('In middle of single word wrapped in bold in paragraph (index based)', Chain.asStep(editor, [
-          cSetRawContent('<p><b>ab</b></p>'),
+        Log.step('TBA', 'In middle of single word wrapped in bold in paragraph (index based)', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><b>ab</b></p>'),
           cExpandRng([ 0 ], 0, [ 0 ], 1, inlineFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('In middle of word inside bookmark then exclude bookmark', Chain.asStep(editor, [
-          cSetRawContent('<p><span data-mce-type="bookmark">ab cd ef</span></p>'),
+        Log.step('TBA', 'In middle of word inside bookmark then exclude bookmark', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><span data-mce-type="bookmark">ab cd ef</span></p>'),
           cExpandRng([ 0, 0, 0 ], 3, [ 0, 0, 0 ], 5, inlineFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ]))
-      ])),
+      ]),
 
-      Logger.t('Expand inline format words (remove format)', GeneralSteps.sequence([
-        Logger.t('In middle of single word in paragraph', Chain.asStep(editor, [
-          cSetRawContent('<p>ab</p>'),
+      Log.stepsAsStep('TBA', 'Expand inline format words (remove format)', [
+        Log.step('TBA', 'In middle of single word in paragraph', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab</p>'),
           cExpandRng([ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, true),
           cAssertRange(editor, [], 0, [], 1)
+        ])),
+        Log.step('TINY-6268', 'Does not extend over space before', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab<u> <span data-mce-type="bookmark">' + ZWSP + '</span>cd</u></p>'),
+          cExpandRng([ 0, 1, 2 ], 0, [ 0, 1, 2 ], 2, inlineFormat, false),
+          cAssertRange(editor, [ 0, 1, 2 ], 0, [], 1)
+        ])),
+        Log.step('TINY-6268', 'Does not extend over space after', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><u>ab<span data-mce-type="bookmark">' + ZWSP + '</span> </u>cd</p>'),
+          cExpandRng([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2, inlineFormat, false),
+          cAssertRange(editor, [], 0, [ 0, 0, 0 ], 2)
+        ])),
+        Log.step('TINY-6268', 'Does extend over collapsible space at start of block', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><u> <span data-mce-type="bookmark">' + ZWSP + '</span>ab</u></p>'),
+          cExpandRng([ 0, 0, 2 ], 0, [ 0, 0, 2 ], 2, inlineFormat, false),
+          cAssertRange(editor, [], 0, [], 1)
+        ])),
+        Log.step('TINY-6268', 'Does extend over collapsible space at end of block', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><u>ab<span data-mce-type="bookmark">' + ZWSP + '</span> </u></p>'),
+          cExpandRng([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2, inlineFormat, false),
+          cAssertRange(editor, [], 0, [], 1)
         ]))
-      ])),
+      ]),
 
-      Logger.t('Expand block format', GeneralSteps.sequence([
-        Logger.t('In middle word', Chain.asStep(editor, [
-          cSetRawContent('<p>ab cd ef</p>'),
+      Log.stepsAsStep('TBA', 'Expand block format', [
+        Log.step('TBA', 'In middle word', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab cd ef</p>'),
           cExpandRng([ 0, 0 ], 4, [ 0, 0 ], 4, blockFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('In middle bold word', Chain.asStep(editor, [
-          cSetRawContent('<p>ab <b>cd</b> ef</p>'),
+        Log.step('TBA', 'In middle bold word', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab <b>cd</b> ef</p>'),
           cExpandRng([ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1, blockFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('Whole word inside td', Chain.asStep(editor, [
-          cSetRawContent('<table><tbody><tr><td>a</td></tr></tbody></table>'),
+        Log.step('TBA', 'Whole word inside td', Chain.asStep(editor, [
+          ApiChains.cSetContent('<table><tbody><tr><td>a</td></tr></tbody></table>'),
           cExpandRng([ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1, blockFormat, false),
           cAssertRange(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1)
         ]))
-      ])),
+      ]),
 
-      Logger.t('Expand selector format', GeneralSteps.sequence([
-        Logger.t('Do not expand over element if selector does not match', Chain.asStep(editor, [
-          cSetRawContent('<p>ab</p>'),
+      Log.stepsAsStep('TBA', 'Expand selector format', [
+        Log.step('TBA', 'Do not expand over element if selector does not match', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab</p>'),
           cExpandRng([ 0, 0 ], 1, [ 0, 0 ], 1, selectorFormat, false),
           cAssertRange(editor, [ 0, 0 ], 0, [ 0, 0 ], 2)
         ])),
-        Logger.t('Do not expand outside of element if selector does not match - from bookmark at middle', Chain.asStep(editor, [
-          cSetRawContent('<p>a<span data-mce-type="bookmark">&#65279;</span>b</p>'),
+        Log.step('TBA', 'Do not expand outside of element if selector does not match - from bookmark at middle', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>a<span data-mce-type="bookmark">&#65279;</span>b</p>'),
           cExpandRng([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0, selectorFormat, false),
           cAssertRange(editor, [ 0, 0 ], 0, [ 0, 2 ], 1)
         ])),
-        Logger.t('Do not expand outside of element if selector does not match - from bookmark at start', Chain.asStep(editor, [
-          cSetRawContent('<p><span data-mce-type="bookmark">&#65279;</span>ab</p>'),
+        Log.step('TBA', 'Do not expand outside of element if selector does not match - from bookmark at start', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p><span data-mce-type="bookmark">&#65279;</span>ab</p>'),
           cExpandRng([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0, selectorFormat, false),
           cAssertRange(editor, [ 0 ], 0, [ 0, 1 ], 2)
         ])),
-        Logger.t('Do not expand outside of element if selector does not match - from bookmark at end', Chain.asStep(editor, [
-          cSetRawContent('<p>ab<span data-mce-type="bookmark">&#65279;</span></p>'),
+        Log.step('TBA', 'Do not expand outside of element if selector does not match - from bookmark at end', Chain.asStep(editor, [
+          ApiChains.cSetContent('<p>ab<span data-mce-type="bookmark">&#65279;</span></p>'),
           cExpandRng([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0, selectorFormat, false),
           cAssertRange(editor, [ 0, 0 ], 0, [ 0 ], 2)
         ])),
-        Logger.t('Expand since selector matches', Chain.asStep(editor, [
-          cSetRawContent('<div>ab</div>'),
+        Log.step('TBA', 'Expand since selector matches', Chain.asStep(editor, [
+          ApiChains.cSetContent('<div>ab</div>'),
           cExpandRng([ 0, 0 ], 1, [ 0, 0 ], 1, selectorFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('Expand since selector matches non collapsed', Chain.asStep(editor, [
-          cSetRawContent('<div>ab</div>'),
+        Log.step('TBA', 'Expand since selector matches non collapsed', Chain.asStep(editor, [
+          ApiChains.cSetContent('<div>ab</div>'),
           cExpandRng([ 0, 0 ], 1, [ 0, 0 ], 2, selectorFormat, false),
           cAssertRange(editor, [], 0, [], 1)
         ]))
-      ])),
+      ]),
 
-      Logger.t('Expand selector format with collapsed property', GeneralSteps.sequence([
-        Logger.t('Expand since selector matches collapsed on collapsed format', Chain.asStep(editor, [
-          cSetRawContent('<div>ab</div>'),
+      Log.stepsAsStep('TBA', 'Expand selector format with collapsed property', [
+        Log.step('TBA', 'Expand since selector matches collapsed on collapsed format', Chain.asStep(editor, [
+          ApiChains.cSetContent('<div>ab</div>'),
           cExpandRng([ 0, 0 ], 1, [ 0, 0 ], 1, selectorFormatCollapsed, false),
           cAssertRange(editor, [], 0, [], 1)
         ])),
-        Logger.t('Expand since selector matches non collapsed on collapsed format', Chain.asStep(editor, [
-          cSetRawContent('<div>ab</div>'),
+        Log.step('TBA', 'Expand since selector matches non collapsed on collapsed format', Chain.asStep(editor, [
+          ApiChains.cSetContent('<div>ab</div>'),
           cExpandRng([ 0, 0 ], 1, [ 0, 0 ], 2, selectorFormatCollapsed, false),
           cAssertRange(editor, [ 0, 0 ], 1, [ 0, 0 ], 2)
         ]))
-      ]))
+      ])
     ], onSuccess, onFailure);
   }, {
     plugins: '',


### PR DESCRIPTION
Related Ticket: TINY-6268 & TINY-6444

Description of Changes:

This finishes up the work @HAFRMO started in #6022. It was on the right track, however, it needed to handle a couple more edge cases which is largely what I've added (eg multiple spaces, or a space at the start/end of a block will be collapsed). I will say I find the name `findParentContainer` a little weird when it also includes a check to see if there is a valid sibling before moving to the parent, but I didn't want to refactor too much, so I added to the existing comment to clarify that.

P.S. Sorry @HAFRMO it took me so long to get around to looking at this.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
