### PR TITLE
TINY-6306: Support common web formats with image smart paste

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.6.0 (TBD)
-    Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste #TINY-6306
+    Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste when using the `paste` plugin #TINY-6306
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.6.0 (TBD)
-    Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags #TINY-6306
+    Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste #TINY-6306
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.6.0 (TBD)
+    Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags #TINY-6306
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
@@ -6,7 +6,6 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
-import Tools from 'tinymce/core/api/util/Tools';
 
 const shouldBlockDrop = (editor: Editor): boolean => editor.getParam('paste_block_drop', false);
 
@@ -62,9 +61,9 @@ const getForcedRootBlockAttrs = (editor: Editor) => editor.getParam('forced_root
 
 const getTabSpaces = (editor: Editor) => editor.getParam('paste_tab_spaces', 4, 'number');
 
-const allowedImageFileTypes = (editor: Editor): string[] => {
-  const defaultImageFileTypes = 'jpeg, jpg, jpe, jfi, jfif, png, gif, bmp, webp';
-  return Tools.explode(editor.getParam('image_file_types', defaultImageFileTypes));
+const allowedImageFileTypes = (editor: Editor): string => {
+  const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jfif,png,gif,bmp,webp';
+  return editor.getParam('image_file_types', defaultImageFileTypes);
 };
 
 export {

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
@@ -6,6 +6,7 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import Tools from 'tinymce/core/api/util/Tools';
 
 const shouldBlockDrop = (editor: Editor): boolean => editor.getParam('paste_block_drop', false);
 
@@ -61,9 +62,9 @@ const getForcedRootBlockAttrs = (editor: Editor) => editor.getParam('forced_root
 
 const getTabSpaces = (editor: Editor) => editor.getParam('paste_tab_spaces', 4, 'number');
 
-const allowedImageFileTypes = (editor: Editor): string => {
+const allowedImageFileTypes = (editor: Editor): string[] => {
   const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jfif,png,gif,bmp,webp';
-  return editor.getParam('image_file_types', defaultImageFileTypes);
+  return Tools.explode(editor.getParam('image_file_types', defaultImageFileTypes, 'string'));
 };
 
 export {

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
@@ -6,6 +6,7 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import Tools from 'tinymce/core/api/util/Tools';
 
 const shouldBlockDrop = (editor: Editor): boolean => editor.getParam('paste_block_drop', false);
 
@@ -61,6 +62,11 @@ const getForcedRootBlockAttrs = (editor: Editor) => editor.getParam('forced_root
 
 const getTabSpaces = (editor: Editor) => editor.getParam('paste_tab_spaces', 4, 'number');
 
+const allowedImageFileTypes = (editor: Editor): string[] => {
+  const defaultImageFileTypes = 'jpeg, jpg, jpe, jfi, jfif, png, gif, bmp, webp';
+  return Tools.explode(editor.getParam('image_file_types', defaultImageFileTypes));
+};
+
 export {
   shouldBlockDrop,
   shouldPasteDataImages,
@@ -83,5 +89,6 @@ export {
   getImagesReuseFilename,
   getForcedRootBlock,
   getForcedRootBlockAttrs,
-  getTabSpaces
+  getTabSpaces,
+  allowedImageFileTypes
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -127,7 +127,7 @@ const isValidDataUriImage = (editor: Editor, imgElm: HTMLImageElement) => {
 };
 
 const extractFilename = (editor: Editor, str: string) => {
-  const m = str.match(/([\s\S]+?)\.(?:jpeg|jpg|png|gif)$/i);
+  const m = str.match(/([\s\S]+?)\.(?:.+)$/i);
   return m ? editor.dom.encode(m[1]) : null;
 };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -127,7 +127,7 @@ const isValidDataUriImage = (editor: Editor, imgElm: HTMLImageElement) => {
 };
 
 const extractFilename = (editor: Editor, str: string) => {
-  const m = str.match(/([\s\S]+?)\.(?:[a-z0-9.]+)$/i);
+  const m = str.match(/([\s\S]+?)(?:\.[a-z0-9.]+)$/i);
   return m ? editor.dom.encode(m[1]) : null;
 };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -127,7 +127,7 @@ const isValidDataUriImage = (editor: Editor, imgElm: HTMLImageElement) => {
 };
 
 const extractFilename = (editor: Editor, str: string) => {
-  const m = str.match(/([\s\S]+?)\.(?:.+)$/i);
+  const m = str.match(/([\s\S]+?)\.(?:[a-z0-9.]+)$/i);
   return m ? editor.dom.encode(m[1]) : null;
 };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -282,7 +282,7 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
     }
   });
 
-  function insertClipboardContent(clipboardContent: ClipboardContents, isKeyBoardPaste: boolean, plainTextMode: boolean, internal: boolean) {
+  function insertClipboardContent(editor: Editor, clipboardContent: ClipboardContents, isKeyBoardPaste: boolean, plainTextMode: boolean, internal: boolean) {
     let content;
 
     // Grab HTML from Clipboard API or paste bin as a fallback
@@ -304,7 +304,7 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
     pasteBin.remove();
 
     const isPlainTextHtml = (internal === false && Newlines.isPlainText(content));
-    const isImage = SmartPaste.isImageUrl(content);
+    const isImage = SmartPaste.isImageUrl(editor, content);
 
     // If we got nothing from clipboard API and pastebin or the content is a plain text (with only
     // some BRs, Ps or DIVs as newlines) then we fallback to plain/text
@@ -389,10 +389,10 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
         internal = InternalHtml.isMarked(clipboardContent['text/html']);
       }
 
-      insertClipboardContent(clipboardContent, isKeyBoardPaste, plainTextMode, internal);
+      insertClipboardContent(editor, clipboardContent, isKeyBoardPaste, plainTextMode, internal);
     } else {
       Delay.setEditorTimeout(editor, function () {
-        insertClipboardContent(clipboardContent, isKeyBoardPaste, plainTextMode, internal);
+        insertClipboardContent(editor, clipboardContent, isKeyBoardPaste, plainTextMode, internal);
       }, 0);
     }
   });

--- a/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Arr } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
@@ -36,7 +37,7 @@ const isAbsoluteUrl = function (url: string) {
 };
 
 const isImageUrl = function (editor: Editor, url: string) {
-  const escapedFileTypes = escapeRegExp(Settings.allowedImageFileTypes(editor)).replace(',', '|');
+  const escapedFileTypes = Arr.map(Settings.allowedImageFileTypes(editor), escapeRegExp).join('|');
   const validImageFileTypes = new RegExp('.(' + escapedFileTypes + ')$');
   return isAbsoluteUrl(url) && validImageFileTypes.test(url);
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
@@ -9,6 +9,10 @@ import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 
+
+// TODO: Used in a few places, we should move this to Katamari
+const escapeRegExp = (text: string) => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const pasteHtml = (editor: Editor, html: string) => {
   editor.insertContent(html, {
     merge: Settings.shouldMergeFormats(editor),
@@ -32,7 +36,8 @@ const isAbsoluteUrl = function (url: string) {
 };
 
 const isImageUrl = function (editor: Editor, url: string) {
-  const validImageFileTypes = new RegExp('.(' + Settings.allowedImageFileTypes(editor).join('|') + ')$');
+  const escapedFileTypes = escapeRegExp(Settings.allowedImageFileTypes(editor)).replace(',', '|');
+  const validImageFileTypes = new RegExp('.(' + escapedFileTypes + ')$');
   return isAbsoluteUrl(url) && validImageFileTypes.test(url);
 };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
@@ -5,14 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr } from '@ephox/katamari';
+import { Arr, Strings } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 
-
-// TODO: Used in a few places, we should move this to Katamari
-const escapeRegExp = (text: string) => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const pasteHtml = (editor: Editor, html: string) => {
   editor.insertContent(html, {
@@ -37,9 +34,7 @@ const isAbsoluteUrl = function (url: string) {
 };
 
 const isImageUrl = function (editor: Editor, url: string) {
-  const escapedFileTypes = Arr.map(Settings.allowedImageFileTypes(editor), escapeRegExp).join('|');
-  const validImageFileTypes = new RegExp('.(' + escapedFileTypes + ')$');
-  return isAbsoluteUrl(url) && validImageFileTypes.test(url);
+  return isAbsoluteUrl(url) && Arr.exists(Settings.allowedImageFileTypes(editor), (type) => Strings.endsWith(url, `.${type}`));
 };
 
 const createImage = function (editor: Editor, url: string, pasteHtmlFn: typeof pasteHtml) {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
@@ -31,8 +31,9 @@ const isAbsoluteUrl = function (url: string) {
   return /^https?:\/\/[\w\?\-\/+=.&%@~#]+$/i.test(url);
 };
 
-const isImageUrl = function (url: string) {
-  return isAbsoluteUrl(url) && /.(gif|jpe?g|png)$/.test(url);
+const isImageUrl = function (editor: Editor, url: string) {
+  const validImageFileTypes = new RegExp('.(' + Settings.allowedImageFileTypes(editor).join('|') + ')$');
+  return isAbsoluteUrl(url) && validImageFileTypes.test(url);
 };
 
 const createImage = function (editor: Editor, url: string, pasteHtmlFn: typeof pasteHtml) {
@@ -60,7 +61,7 @@ const linkSelection = function (editor: Editor, html: string, pasteHtmlFn: typeo
 };
 
 const insertImage = function (editor: Editor, html: string, pasteHtmlFn: typeof pasteHtml) {
-  return isImageUrl(html) ? createImage(editor, html, pasteHtmlFn) : false;
+  return isImageUrl(editor, html) ? createImage(editor, html, pasteHtmlFn) : false;
 };
 
 const smartInsertContent = function (editor: Editor, html: string) {

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
@@ -73,6 +73,12 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.SmartPasteTest', (success, fai
       false,
       'File type "svg" is invalid by default'
     );
+
+    LegacyUnit.equal(
+      SmartPaste.isImageUrl(editor, 'https://www.site.com/filejpeg'),
+      false,
+      'Missing "." but valid extension'
+    );
   });
 
   suite.test('TINY-6306: New image_file_types settings', (editor) => {

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
@@ -1,5 +1,6 @@
 import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -35,19 +36,53 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.SmartPasteTest', (success, fai
     LegacyUnit.equal(SmartPaste.isAbsoluteUrl(''), false);
   });
 
-  suite.test('TestCase-TBA: Paste: isImageUrl', function () {
-    LegacyUnit.equal(SmartPaste.isImageUrl('http://www.site.com'), false);
-    LegacyUnit.equal(SmartPaste.isImageUrl('https://www.site.com'), false);
-    LegacyUnit.equal(SmartPaste.isImageUrl('http://www.site.com/dir-name/file.jpeg'), true);
-    LegacyUnit.equal(SmartPaste.isImageUrl('http://www.site.com/dir-name/file.jpg'), true);
-    LegacyUnit.equal(SmartPaste.isImageUrl('http://www.site.com/dir-name/file.png'), true);
-    LegacyUnit.equal(SmartPaste.isImageUrl('http://www.site.com/dir-name/file.gif'), true);
-    LegacyUnit.equal(SmartPaste.isImageUrl('https://www.site.com/dir-name/file.gif'), true);
-    LegacyUnit.equal(SmartPaste.isImageUrl('https://www.site.com/~dir-name/file.gif'), true);
-    LegacyUnit.equal(SmartPaste.isImageUrl('https://www.site.com/dir-name/file.gif?query=%42'), false);
-    LegacyUnit.equal(SmartPaste.isImageUrl('https://www.site.com/dir-name/file.html?query=%42'), false);
-    LegacyUnit.equal(SmartPaste.isImageUrl('file.gif'), false);
-    LegacyUnit.equal(SmartPaste.isImageUrl(''), false);
+  suite.test('TestCase-TBA: Paste: isImageUrl', function (editor) {
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'http://www.site.com'), false);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'https://www.site.com'), false);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'http://www.site.com/dir-name/file.jpeg'), true);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'http://www.site.com/dir-name/file.jpg'), true);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'http://www.site.com/dir-name/file.png'), true);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'http://www.site.com/dir-name/file.gif'), true);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'https://www.site.com/dir-name/file.gif'), true);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'https://www.site.com/~dir-name/file.gif'), true);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'https://www.site.com/dir-name/file.gif?query=%42'), false);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'https://www.site.com/dir-name/file.html?query=%42'), false);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, 'file.gif'), false);
+    LegacyUnit.equal(SmartPaste.isImageUrl(editor, ''), false);
+  });
+
+  suite.test('TINY-6306: New image_file_types defaults', (editor) => {
+    Arr.map([
+      'jpeg',
+      'jpg',
+      'jpe',
+      'jfi',
+      'jfif',
+      'png',
+      'gif',
+      'bmp',
+      'webp'
+    ], (image_file_type) => LegacyUnit.equal(
+      SmartPaste.isImageUrl(editor, `https://www.site.com/file.${image_file_type}`),
+      true,
+      `File type "${image_file_type}" is valid`
+    ));
+
+    LegacyUnit.equal(
+      SmartPaste.isImageUrl(editor, 'https://www.site.com/file.svg'),
+      false,
+      'File type "svg" is invalid by default'
+    );
+  });
+
+  suite.test('TINY-6306: New image_file_types settings', (editor) => {
+    editor.settings.image_file_types = 'svg';
+    LegacyUnit.equal(
+      SmartPaste.isImageUrl(editor, 'https://www.site.com/file.svg'),
+      true,
+      'File type "svg" is valid when set by settings'
+    );
+    delete editor.settings.image_file_types;
   });
 
   suite.test('TestCase-TBA: Paste: smart paste enabled, paste as content, paste url on selection', function (editor) {

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
@@ -85,6 +85,31 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.SmartPasteTest', (success, fai
     delete editor.settings.image_file_types;
   });
 
+  suite.test('TINY-6306: Smart paste enabled (with custom image_file_types settings)', function (editor) {
+    editor.focus();
+    editor.undoManager.clear();
+    editor.setContent('<p></p>');
+    LegacyUnit.setSelection(editor, 'p', 0);
+    editor.undoManager.add();
+    editor.settings.smart_paste = true;
+
+    // svg not detected as an image
+    editor.execCommand('mceInsertClipboardContent', false, { content: 'http://www.site.com/my.svg' });
+    LegacyUnit.equal(editor.getContent(), '<p>http://www.site.com/my.svg</p>');
+
+    editor.undoManager.clear();
+    editor.setContent('<p></p>');
+    LegacyUnit.setSelection(editor, 'p', 0);
+    editor.undoManager.add();
+
+    // svg detected as image
+    editor.settings.image_file_types = 'svg';
+    editor.execCommand('mceInsertClipboardContent', false, { content: 'http://www.site.com/my.svg' });
+    LegacyUnit.equal(editor.getContent(), '<p><img src="http://www.site.com/my.svg" /></p>');
+
+    delete editor.settings.image_file_types;
+  });
+
   suite.test('TestCase-TBA: Paste: smart paste enabled, paste as content, paste url on selection', function (editor) {
     editor.focus();
     editor.undoManager.clear();


### PR DESCRIPTION
Related Ticket: TINY-6306

Description of Changes:
- new `image_file_types` setting, registered in `paste`
- default image formats: `'jpeg, jpg, jpe, jfi, jfif, png, gif, bmp, webp'`
- smart paste will now insert these file formats into `img` tags on paste

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
