### PR TITLE
Make contributions easier via automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: yarn install && yarn build
+    command: yarn start
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,17 @@ This will produce an editor build in `modules/tinymce/js`, with distribution zip
 
 This performs compilation steps which webpack requires but are usually once-off. It also runs `tsc` to make later commands faster (`tsc -b` enforces incremental compilation).
 
+### Online one-click setup
+
+You can use Gitpod(An online IDE which free for Open Source) for making Prs and working on issues online. With a single click. It will launch a workspace and automatically:
+
+- clone the `TinyMCE` repo.
+- install the dependencies.
+- run `yarn build`.
+- run `yarn start`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ### Builds
 
 To build the editor in development, use `yarn tinymce-grunt`. This will output to the `modules/tinymce/js` folder (`build` is effectively `dev` followed by `tinymce-grunt`).


### PR DESCRIPTION
Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `TinyMCE` repo.
- install the dependencies.
- run `yarn build`.
- run `yarn start`

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/tinymce

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/97254318-e9cd2f80-182f-11eb-8b01-9ab9fc7c5d57.png)

Related Ticket:

Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)
* [ ] License headers added on new files (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
