### PR TITLE
TINY-4239: added optional name field to style_formats setting enabling a custom name to be registered

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,7 +2,7 @@ Version 5.6.0 (TBD)
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
-    Added new `name` field to the style_select setting object to enable specifying a name for the format. #TINY-4239
+    Added new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
     Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,6 +2,7 @@ Version 5.6.0 (TBD)
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
+    Added new `name` field to the style_select setting object to enable specifying a name for the format. #TINY-4239
     Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282

--- a/modules/tinymce/src/core/main/ts/api/fmt/StyleFormat.ts
+++ b/modules/tinymce/src/core/main/ts/api/fmt/StyleFormat.ts
@@ -27,6 +27,7 @@ export interface NestedFormatting {
 }
 
 interface CommonStyleFormat {
+  name?: string;
   title: string;
   icon?: string;
 }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
@@ -81,10 +81,11 @@ const mapFormats = (userFormats: AllowedFormat[]): CustomFormatMapping => Arr.fo
     };
   } else if (isInlineFormat(fmt) || isBlockFormat(fmt) || isSelectorFormat(fmt)) {
     // Convert the format to a reference and add the original to the custom formats to be registered
-    const formatName = Type.isString(fmt.name) ? fmt.name : `custom-${fmt.title.toLowerCase()}`;
+    const formatName = Type.isString(fmt.name) ? fmt.name : fmt.title.toLowerCase();
+    const formatNameWithPrefix = `custom-${formatName}`;
     return {
-      customFormats: acc.customFormats.concat([{ name: formatName, format: fmt }]),
-      formats: acc.formats.concat([{ title: fmt.title, format: formatName, icon: fmt.icon }])
+      customFormats: acc.customFormats.concat([{ name: formatNameWithPrefix, format: fmt }]),
+      formats: acc.formats.concat([{ title: fmt.title, format: formatNameWithPrefix, icon: fmt.icon }])
     };
   } else {
     return { ...acc, formats: acc.formats.concat(fmt) };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj } from '@ephox/katamari';
+import { Arr, Obj, Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import {
   AllowedFormat, BlockStyleFormat, FormatReference, InlineStyleFormat, NestedFormatting, SelectorStyleFormat, Separator, StyleFormat
@@ -81,7 +81,7 @@ const mapFormats = (userFormats: AllowedFormat[]): CustomFormatMapping => Arr.fo
     };
   } else if (isInlineFormat(fmt) || isBlockFormat(fmt) || isSelectorFormat(fmt)) {
     // Convert the format to a reference and add the original to the custom formats to be registered
-    const formatName = `custom-${fmt.title.toLowerCase()}`;
+    const formatName = Type.isString(fmt.name) ? fmt.name : `custom-${fmt.title.toLowerCase()}`;
     return {
       customFormats: acc.customFormats.concat([{ name: formatName, format: fmt }]),
       formats: acc.formats.concat([{ title: fmt.title, format: formatName, icon: fmt.icon }])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
@@ -39,12 +39,14 @@ const register = (editor: Editor, formats, isSelectedFor: IsSelectedForType, get
   };
 
   const enrichCustom = (item: StyleFormat): FormatterFormatItem => {
-    const formatName = Type.isString(item.name) ? item.name : Id.generate(item.title);
+    const formatName = Type.isString(item.name) ? item.name : Id.generate(item.title);;
+    const formatNameWithPrefix = `custom-${formatName}`;
+
     const customSpec = {
       type: 'formatter' as 'formatter',
-      format: formatName,
-      isSelected: isSelectedFor(formatName),
-      getStylePreview: getPreviewFor(formatName)
+      format: formatNameWithPrefix,
+      isSelected: isSelectedFor(formatNameWithPrefix),
+      getStylePreview: getPreviewFor(formatNameWithPrefix)
     };
 
     const newItem = Merger.deepMerge(item, customSpec);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Id, Merger, Obj, Optional } from '@ephox/katamari';
+import { Arr, Id, Merger, Obj, Optional, Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { StyleFormat } from 'tinymce/core/api/fmt/StyleFormat';
 import { FormatItem, FormatterFormatItem, PreviewSpec, SubMenuFormatItem } from '../BespokeSelect';
@@ -39,7 +39,7 @@ const register = (editor: Editor, formats, isSelectedFor: IsSelectedForType, get
   };
 
   const enrichCustom = (item: StyleFormat): FormatterFormatItem => {
-    const formatName = Id.generate(item.title);
+    const formatName = Type.isString(item.name) ? item.name : Id.generate(item.title);
     const customSpec = {
       type: 'formatter' as 'formatter',
       format: formatName,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/NamedStyleSelectFormatsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/NamedStyleSelectFormatsTest.ts
@@ -94,7 +94,7 @@ UnitTest.asynctest('browser.tinymce.themes.silver.bespoke.NamedStyleSelectFormat
         }
       ]
     },
-    () => success(),
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/NamedStyleSelectFormatsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/NamedStyleSelectFormatsTest.ts
@@ -1,0 +1,101 @@
+import {
+  ApproxStructure, Assertions, Chain, Logger, Pipeline, Step, UiFinder
+} from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyLoader } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
+import Theme from 'tinymce/themes/silver/Theme';
+import * as MenuUtils from '../../../module/MenuUtils';
+
+interface StyleSelectMenuItem {
+  element: string;
+  title: string;
+}
+
+UnitTest.asynctest('browser.tinymce.themes.silver.bespoke.NamedStyleSelectFormatTest', (success, failure) => {
+  Theme();
+  TinyLoader.setup(
+    (editor, onSuccess, onFailure) => {
+      const sAssertStyleSelectMenuItems = (label: string, expectedItems: StyleSelectMenuItem[]) => Logger.t(
+        label,
+        Chain.asStep(SugarBody.body(), [
+          UiFinder.cFindIn('.tox-selected-menu .tox-collection__group'),
+          Assertions.cAssertStructure('Checking structure', ApproxStructure.build((s, str, arr) => s.element('div', {
+            classes: [ arr.has('tox-collection__group') ],
+            children: Arr.map(expectedItems, (expected) => s.element('div', {
+              attrs: {
+                role: str.is('menuitemcheckbox'),
+                title: str.is(expected.title)
+              },
+              children: [
+                s.element('div', {
+                  classes: [ arr.has('tox-collection__item-label') ],
+                  children: [
+                    s.element(expected.element, {
+                      children: [
+                        s.text(str.is(expected.title))
+                      ]
+                    })
+                  ]
+                }),
+                s.element('div', {
+                  classes: [ arr.has('tox-collection__item-checkmark') ],
+                  children: [
+                    s.anything()
+                  ]
+                })
+              ]
+            }))
+          })))
+        ])
+      );
+
+      const sAssertFormatExists = (formatName: string) =>
+        Step.sync(() =>
+          Assert.eq(`Expected format: ${formatName} to exist`, true, editor.formatter.has(formatName))
+        );
+
+      Pipeline.async({ }, [
+        MenuUtils.sOpenMenu('Format', 'Paragraph:last'),
+        sAssertStyleSelectMenuItems('Checking style select items', [
+          { title: 'My inline', element: 'span' },
+          { title: 'My block', element: 'h1' },
+          { title: 'My selector', element: 'div' }
+        ]),
+        sAssertFormatExists('my-inline'),
+        sAssertFormatExists('my-block'),
+        sAssertFormatExists('my-selector')
+      ], onSuccess, onFailure);
+    },
+    {
+      theme: 'silver',
+      toolbar: 'styleselect',
+      base_url: '/project/tinymce/js/tinymce',
+      style_formats: [
+        {
+          name: 'my-inline',
+          title: 'My inline',
+          inline: 'span',
+          classes: [ 'my-inline' ]
+        },
+        {
+          name: 'my-block',
+          title: 'My block',
+          block: 'h1',
+          classes: [ 'my-block' ]
+        },
+        {
+          name: 'my-selector',
+          title: 'My selector',
+          selector: 'p',
+          classes: [ 'my-selector' ]
+        }
+      ]
+    },
+    () => {
+      success();
+    },
+    failure
+  );
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/NamedStyleSelectFormatsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/NamedStyleSelectFormatsTest.ts
@@ -15,7 +15,8 @@ interface StyleSelectMenuItem {
 
 UnitTest.asynctest('browser.tinymce.themes.silver.bespoke.NamedStyleSelectFormatTest', (success, failure) => {
   Theme();
-  TinyLoader.setup(
+
+  TinyLoader.setupLight(
     (editor, onSuccess, onFailure) => {
       const sAssertStyleSelectMenuItems = (label: string, expectedItems: StyleSelectMenuItem[]) => Logger.t(
         label,
@@ -93,9 +94,7 @@ UnitTest.asynctest('browser.tinymce.themes.silver.bespoke.NamedStyleSelectFormat
         }
       ]
     },
-    () => {
-      success();
-    },
+    () => success(),
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/NamedStyleSelectFormatsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/NamedStyleSelectFormatsTest.ts
@@ -64,9 +64,9 @@ UnitTest.asynctest('browser.tinymce.themes.silver.bespoke.NamedStyleSelectFormat
           { title: 'My block', element: 'h1' },
           { title: 'My selector', element: 'div' }
         ]),
-        sAssertFormatExists('my-inline'),
-        sAssertFormatExists('my-block'),
-        sAssertFormatExists('my-selector')
+        sAssertFormatExists('custom-my-inline'),
+        sAssertFormatExists('custom-my-block'),
+        sAssertFormatExists('custom-my-selector')
       ], onSuccess, onFailure);
     },
     {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
@@ -13,7 +13,7 @@ interface StyleSelectMenuItem {
   title: string;
 }
 
-UnitTest.asynctest('browser.tinymce.themes.silver.bespoke.NamedStyleSelectFormatTest', (success, failure) => {
+UnitTest.asynctest('browser.tinymce.themes.silver.bespoke.StyleSelectFormatNamesTest', (success, failure) => {
   Theme();
 
   TinyLoader.setupLight(
@@ -60,13 +60,19 @@ UnitTest.asynctest('browser.tinymce.themes.silver.bespoke.NamedStyleSelectFormat
       Pipeline.async({ }, [
         MenuUtils.sOpenMenu('Format', 'Paragraph:last'),
         sAssertStyleSelectMenuItems('Checking style select items', [
-          { title: 'My inline', element: 'span' },
-          { title: 'My block', element: 'h1' },
-          { title: 'My selector', element: 'div' }
+          { title: 'Named inline format', element: 'span' },
+          { title: 'Named block format', element: 'h1' },
+          { title: 'Named selector format', element: 'div' },
+          { title: 'Unnamed inline format', element: 'span' },
+          { title: 'Unnamed block format', element: 'h1' },
+          { title: 'Unnamed selector format', element: 'div' }
         ]),
         sAssertFormatExists('custom-my-inline'),
         sAssertFormatExists('custom-my-block'),
-        sAssertFormatExists('custom-my-selector')
+        sAssertFormatExists('custom-my-selector'),
+        sAssertFormatExists('custom-unnamed inline format'),
+        sAssertFormatExists('custom-unnamed block format'),
+        sAssertFormatExists('custom-unnamed selector format')
       ], onSuccess, onFailure);
     },
     {
@@ -76,19 +82,34 @@ UnitTest.asynctest('browser.tinymce.themes.silver.bespoke.NamedStyleSelectFormat
       style_formats: [
         {
           name: 'my-inline',
-          title: 'My inline',
+          title: 'Named inline format',
           inline: 'span',
           classes: [ 'my-inline' ]
         },
         {
           name: 'my-block',
-          title: 'My block',
+          title: 'Named block format',
           block: 'h1',
           classes: [ 'my-block' ]
         },
         {
           name: 'my-selector',
-          title: 'My selector',
+          title: 'Named selector format',
+          selector: 'p',
+          classes: [ 'my-selector' ]
+        },
+        {
+          title: 'Unnamed inline format',
+          inline: 'span',
+          classes: [ 'my-inline' ]
+        },
+        {
+          title: 'Unnamed block format',
+          block: 'h1',
+          classes: [ 'my-block' ]
+        },
+        {
+          title: 'Unnamed selector format',
           selector: 'p',
           classes: [ 'my-selector' ]
         }


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This enables you to specify what the name of the format should be when using style_select it's very important for rtc that these names are the same since and not be based on the title that might change by i18n or similar things.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
