### PR TITLE
TINY-6530: disabled loading of the rtc plugin on IE 11 since that plugin.js file will not even be parsable

### DIFF
--- a/modules/tinymce/src/core/main/ts/EditorSettings.ts
+++ b/modules/tinymce/src/core/main/ts/EditorSettings.ts
@@ -9,6 +9,7 @@ import { Arr, Fun, Merger, Obj, Optional, Strings, Type } from '@ephox/katamari'
 import { PlatformDetection } from '@ephox/sand';
 
 import Editor from './api/Editor';
+import Env from './api/Env';
 import { EditorSettings, RawEditorSettings } from './api/SettingsTypes';
 import Tools from './api/util/Tools';
 
@@ -175,6 +176,10 @@ const processPlugins = function (isMobileDevice: boolean, sectionResult: Section
         desktopPlugins;
 
   const combinedPlugins = combinePlugins(forcedPlugins, platformPlugins);
+
+  if (Env.browser.isIE() && Arr.contains(combinedPlugins, 'rtc')) {
+    throw new Error('RTC plugin is not supported on IE 11.');
+  }
 
   return Tools.extend(settings, {
     plugins: combinedPlugins.join(' ')

--- a/modules/tinymce/src/core/main/ts/init/Render.ts
+++ b/modules/tinymce/src/core/main/ts/init/Render.ts
@@ -6,6 +6,7 @@
  */
 
 import { Arr, Fun, Optional, Optionals, Type } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 import { Attribute, SugarElement } from '@ephox/sugar';
 import { UrlObject } from '../api/AddOnManager';
 import DOMUtils from '../api/dom/DOMUtils';
@@ -99,6 +100,8 @@ const loadIcons = (scriptLoader: ScriptLoader, editor: Editor, suffix: string) =
 };
 
 const loadPlugins = (editor: Editor, suffix: string) => {
+  const platform = PlatformDetection.detect();
+
   Tools.each(Settings.getExternalPlugins(editor), (url: string, name: string): void => {
     PluginManager.load(name, url, Fun.noop, undefined, () => {
       ErrorReporter.pluginLoadError(editor, url, name);
@@ -111,6 +114,10 @@ const loadPlugins = (editor: Editor, suffix: string) => {
     plugin = Tools.trim(plugin);
 
     if (plugin && !PluginManager.urls[plugin]) {
+      if (plugin === 'rtc' && platform.browser.isIE()) {
+        throw new Error('RTC plugin is not supported on IE 11.');
+      }
+
       if (hasSkipLoadPrefix(plugin)) {
         plugin = plugin.substr(1, plugin.length);
 

--- a/modules/tinymce/src/core/main/ts/init/Render.ts
+++ b/modules/tinymce/src/core/main/ts/init/Render.ts
@@ -6,7 +6,6 @@
  */
 
 import { Arr, Fun, Optional, Optionals, Type } from '@ephox/katamari';
-import { PlatformDetection } from '@ephox/sand';
 import { Attribute, SugarElement } from '@ephox/sugar';
 import { UrlObject } from '../api/AddOnManager';
 import DOMUtils from '../api/dom/DOMUtils';
@@ -100,8 +99,6 @@ const loadIcons = (scriptLoader: ScriptLoader, editor: Editor, suffix: string) =
 };
 
 const loadPlugins = (editor: Editor, suffix: string) => {
-  const platform = PlatformDetection.detect();
-
   Tools.each(Settings.getExternalPlugins(editor), (url: string, name: string): void => {
     PluginManager.load(name, url, Fun.noop, undefined, () => {
       ErrorReporter.pluginLoadError(editor, url, name);
@@ -114,10 +111,6 @@ const loadPlugins = (editor: Editor, suffix: string) => {
     plugin = Tools.trim(plugin);
 
     if (plugin && !PluginManager.urls[plugin]) {
-      if (plugin === 'rtc' && platform.browser.isIE()) {
-        throw new Error('RTC plugin is not supported on IE 11.');
-      }
-
       if (hasSkipLoadPrefix(plugin)) {
         plugin = plugin.substr(1, plugin.length);
 


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Since the RTC plugin doesn't support IE 11 the script has modern JS concepts that IE 11 won't even parse. So we need to detect if the RTC plugin is being loaded on IE 11 before it's being loaded to present a better error message than a JS parse error.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
