### PR TITLE
TINY-6563: prevent autocompleter from running in rtc mode

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
@@ -214,7 +214,9 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared) => 
     getView: () => InlineView.getContent(autocompleter)
   };
 
-  AutocompleterEditorEvents.setup(autocompleterUiApi, editor);
+  if (editor.hasPlugin('rtc') === false) {
+    AutocompleterEditorEvents.setup(autocompleterUiApi, editor);
+  }
 };
 
 export const Autocompleter = {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* We need to block the autocompleter from running since it's mutating the view directly

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
