### PR TITLE
TINY-3321: Resize the sink when possible.

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -16,6 +16,7 @@ Version 5.6.0 (TBD)
     Fixed incorrectly removing formatting on adjacent spaces when removing formatting on a ranged selection #TINY-6268
     Fixed some incorrect types in the new TypeScript declaration file #TINY-6413
     Fixed a regression whereby a fake offscreen selection element was incorrectly created for the editor root node #TINY-6555
+    Fixed an issue where menus would incorrectly collapse in small containers #TINY-3321
     Fixed some minor memory leaks that prevented garbage collection for editor instances #TINY-6570
     Fixed an issue where spaces were not preserved in pre-blocks when getting text content #TINY-6448
 Version 5.5.1 (2020-10-01)

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, AlloySpec, Behaviour, Gui, GuiFactory, Keying, Memento, Positioning, SimpleSpec, VerticalDir } from '@ephox/alloy';
+import { AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Gui, GuiFactory, Keying, Memento, Positioning, SimpleSpec, SystemEvents, VerticalDir } from '@ephox/alloy';
 import { Arr, Obj, Optional, Result } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Css } from '@ephox/sugar';
@@ -108,16 +108,26 @@ const setup = (editor: Editor): RenderInfo => {
 
   const isHeaderDocked = () => header.isDocked(lazyHeader);
 
+  const resizeUiMothership = () => {
+    Css.set(uiMothership.element, 'width', document.body.clientWidth + 'px');
+  };
+
   const sink = GuiFactory.build({
     dom: {
       tag: 'div',
       classes: [ 'tox', 'tox-silver-sink', 'tox-tinymce-aux' ].concat(platformClasses).concat(deviceClasses),
+      styles: {
+        width: document.body.clientWidth + 'px'
+      },
       ...dirAttributes
     },
     behaviours: Behaviour.derive([
       Positioning.config({
         useFixed: () => isHeaderDocked()
       })
+    ]),
+    events: AlloyEvents.derive([
+      AlloyEvents.run(SystemEvents.windowResize(), resizeUiMothership)
     ])
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Chain, Guard, Mouse, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyLoader } from '@ephox/mcagar';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { SelectorFind, SugarBody, SugarElement, Width } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
 import Theme from 'tinymce/themes/silver/Theme';
@@ -26,6 +26,14 @@ UnitTest.asynctest('Editor resize test', (success, failure) => {
           editor.dom.setStyles(editor.getContainer(), {
             border: '2px solid #ccc'
           });
+        }),
+        Chain.op(() => {
+          const html = SugarBody.body();
+          const sink = SelectorFind.descendant<HTMLElement>(html, '.tox-silver-sink').getOrDie();
+
+          const expectedWidth = Width.get(html);
+
+          Assertions.assertEq(`Sink should be ${expectedWidth}px wide`, expectedWidth, Width.get(sink));
         }),
         Chain.label('Test resize with max/min sizing', NamedChain.asChain([
           NamedChain.direct(NamedChain.inputName(), Chain.identity, 'body'),


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Attempting to resize the sink to match changes to the window, to make sure menus stops contorting when fullscreening or resizing things.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
