### PR TITLE
TINY-6280: Fix fullscreen plugin not working with multiple editors and shadowdom

### DIFF
--- a/modules/oxide/src/less/theme/components/fullscreen/fullscreen.less
+++ b/modules/oxide/src/less/theme/components/fullscreen/fullscreen.less
@@ -22,16 +22,22 @@
   top: 0;
   touch-action: pinch-zoom;
   width: 100%;
+}
 
-  .tox.tox-tinymce.tox-fullscreen .tox-statusbar__resize-handle {
-    display: none;
-  }
+.tox.tox-tinymce.tox-fullscreen .tox-statusbar__resize-handle {
+  display: none;
+}
 
-  .tox.tox-tinymce.tox-fullscreen {
-    z-index: @z-index-fullscreen;
-  }
+.tox.tox-tinymce.tox-fullscreen {
+  z-index: @z-index-fullscreen;
+}
 
-  .tox.tox-tinymce-aux {
-    z-index: @z-index-fullscreen + 1;
-  }
+.tox-shadowhost.tox-fullscreen {
+  z-index: @z-index-fullscreen;
+}
+
+// Body and ShadowDom support
+.tox-fullscreen .tox.tox-tinymce-aux,
+.tox-fullscreen ~ .tox.tox-tinymce-aux {
+  z-index: @z-index-fullscreen + 1;
 }

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -6,6 +6,7 @@ Version 5.6.0 (TBD)
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282
     Fixed `fullpage` plugin altering text content in `editor.getContent()` #TINY-6541
+    Fixed `fullscreen` plugin not working correctly with multiple editors and shadow dom #TINY-6280
     Fixed font size keywords such as `medium` not displaying correctly in font size menus #TINY-6291
     Fixed an issue where some attributes in table cells were not copied over to new rows or columns #TINY-6485
     Fixed incorrectly removing formatting on adjacent spaces when removing formatting on a ranged selection #TINY-6268

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
@@ -6,7 +6,7 @@
  */
 
 import { Cell, Fun, Optional, Singleton } from '@ephox/katamari';
-import { Css, DomEvent, EventUnbinder, SugarElement, Traverse, WindowVisualViewport } from '@ephox/sugar';
+import { Css, DomEvent, EventUnbinder, SugarElement, SugarShadowDom, Traverse, WindowVisualViewport } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
@@ -112,14 +112,21 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
   const iframe = editor.iframeElement;
   const iframeStyle = iframe.style;
 
+  const handleClasses = (handler: (elm: string | Node | Node[], cls: string) => void) => {
+    handler(body, 'tox-fullscreen');
+    handler(documentElement, 'tox-fullscreen');
+    handler(editorContainer, 'tox-fullscreen');
+    if (SugarShadowDom.isOpenShadowHost(fullscreenRoot)) {
+      handler(fullscreenRoot.dom, 'tox-fullscreen tox-shadowhost');
+    }
+  };
+
   const cleanup = () => {
     if (isTouch) {
       Thor.restoreStyles(editor.dom);
     }
 
-    DOM.removeClass(body, 'tox-fullscreen');
-    DOM.removeClass(documentElement, 'tox-fullscreen');
-    DOM.removeClass(editorContainer, 'tox-fullscreen');
+    handleClasses(DOM.removeClass);
 
     viewportUpdate.unbind();
     Optional.from(fullscreenState.get()).each((info) => info.fullscreenChangeHandler.unbind());
@@ -154,9 +161,7 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
     iframeStyle.width = iframeStyle.height = '100%';
     editorContainerStyle.width = editorContainerStyle.height = '';
 
-    DOM.addClass(body, 'tox-fullscreen');
-    DOM.addClass(documentElement, 'tox-fullscreen');
-    DOM.addClass(editorContainer, 'tox-fullscreen');
+    handleClasses(DOM.addClass);
 
     viewportUpdate.bind(editorContainerS);
 

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
@@ -116,9 +116,12 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
     handler(body, 'tox-fullscreen');
     handler(documentElement, 'tox-fullscreen');
     handler(editorContainer, 'tox-fullscreen');
-    if (SugarShadowDom.isOpenShadowHost(fullscreenRoot)) {
-      handler(fullscreenRoot.dom, 'tox-fullscreen tox-shadowhost');
-    }
+    SugarShadowDom.getShadowRoot(editorContainerS)
+      .map((root) => SugarShadowDom.getShadowHost(root).dom)
+      .each((host) => {
+        handler(host, 'tox-fullscreen');
+        handler(host, 'tox-shadowhost');
+      });
   };
 
   const cleanup = () => {

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -86,8 +86,9 @@ const cAssertShadowHostState = (label: string, shouldExist: boolean): Chain<Edit
   Chain.label(
     `${label}: Shadow host should ${shouldExist ? '' : 'not'} have "tox-fullscreen" and "tox-shadowhost" classes and z-index`,
     Chain.op((editor: Editor) => {
-      if (SugarShadowDom.isInShadowRoot(SugarElement.fromDom(editor.getElement()))) {
-        const host = SugarShadowDom.getShadowRoot(SugarElement.fromDom(editor.getElement()))
+      const elm = SugarElement.fromDom(editor.getElement());
+      if (SugarShadowDom.isInShadowRoot(elm)) {
+        const host = SugarShadowDom.getShadowRoot(elm)
           .map(SugarShadowDom.getShadowHost)
           .getOrDie('Expected shadow host');
 
@@ -152,10 +153,10 @@ UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', (s
     },
     cleanupEditor: () => Chain.fromChains([
       Chain.op((editor: Editor) => {
-        const elm = editor.getElement();
+        const elm = SugarElement.fromDom(editor.getElement());
         editor.remove();
-        SugarShadowDom.getShadowRoot(SugarElement.fromDom(elm))
-          .map((root) => SugarShadowDom.getShadowHost(root))
+        SugarShadowDom.getShadowRoot(elm)
+          .map(SugarShadowDom.getShadowHost)
           .each(Remove.remove);
       })
     ])

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -1,17 +1,31 @@
 import { Assertions, Chain, Guard, Log, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { Editor as McEditor } from '@ephox/mcagar';
-import { Attribute, Html, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { Editor as McEditor, TinyLoader } from '@ephox/mcagar';
+import { Attribute, Classes, Css, Html, SelectorFind, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
-export const cWaitForDialog = (ariaLabel) =>
+const getContentContainer = (editor: Editor) =>
+  SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement())));
+
+const cCloseOnlyWindow = Chain.control(
+  Chain.op((editor: Editor) => {
+    const dialogs = () => UiFinder.findAllIn(getContentContainer(editor), '[role="dialog"]');
+    Assertions.assertEq('One window exists', 1, dialogs().length);
+    editor.windowManager.close();
+    Assertions.assertEq('No windows exist', 0, dialogs().length);
+  }),
+  Guard.addLogging('Close window')
+);
+
+const cWaitForDialog = (ariaLabel: string) =>
   Chain.control(
-    Chain.fromChainsWith(SugarBody.body(), [
+    Chain.fromChains([
+      Chain.mapper(getContentContainer),
       UiFinder.cWaitFor('Waiting for dialog', '[role="dialog"]'),
       Chain.op((dialog) => {
         if (Attribute.has(dialog, 'aria-labelledby')) {
@@ -33,78 +47,108 @@ UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', (s
 
   const lastEventArgs = Cell(null);
 
-  const cAssertEditorAndLastEvent = (label: string, state: boolean) =>
-    Chain.control(
+  const cAssertApiAndLastEvent = (label: string, state: boolean) =>
+    Chain.label(
+      `${label}: fullscreen API and event state should return ${state}`,
       Chain.fromChains([
         Chain.op((editor) => Assertions.assertEq('Editor isFullscreen', state, editor.plugins.fullscreen.isFullscreen())),
         Chain.op(() => Assertions.assertEq('FullscreenStateChanged event', state, lastEventArgs.get().state))
-      ]),
-      Guard.addLogging(label)
+      ])
     );
 
-  const cAssertFullscreenClass = (label: string, shouldExist: boolean) => {
+  const cAssertHtmlAndBodyState = (label: string, shouldExist: boolean) => {
     const selector = shouldExist ? 'root:.tox-fullscreen' : 'root::not(.tox-fullscreen)';
-    const label2 = `Body and Html should ${shouldExist ? '' : 'not '}have "tox-fullscreen" class`;
-    return Chain.control(
-      Chain.fromChains([
+    return Chain.label(
+      `${label}: Body and Html should ${shouldExist ? '' : 'not'} have "tox-fullscreen" class`,
+      Chain.fromIsolatedChains([
         Chain.inject(SugarBody.body()),
         UiFinder.cFindIn(selector),
         Chain.inject(SugarElement.fromDom(document.documentElement)),
         UiFinder.cFindIn(selector)
-      ]),
-      Guard.addLogging(`${label}: ${label2}`)
+      ])
     );
   };
 
-  const cCloseOnlyWindow = Chain.control(
-    Chain.op((editor: Editor) => {
-      const dialogs = () => UiFinder.findAllIn(SugarBody.body(), '[role="dialog"]');
-      Assertions.assertEq('One window exists', 1, dialogs().length);
-      editor.windowManager.close();
-      Assertions.assertEq('No windows exist', 0, dialogs().length);
-    }),
-    Guard.addLogging('Close window')
-  );
+  const cAsssertEditorContainerAndSinkState = (label: string, shouldExist: boolean) =>
+    Chain.label(
+      `${label}: Editor container and sink should ${shouldExist ? '' : 'not'} have "tox-fullscreen" class and z-index`,
+      Chain.fromChains([
+        Chain.fromIsolatedChains([
+          Chain.mapper((editor: Editor) => SugarElement.fromDom(editor.getContainer())),
+          UiFinder.cFindIn(shouldExist ? 'root:.tox-fullscreen' : 'root::not(.tox-fullscreen)'),
+          Chain.op((container) => {
+            Assertions.assertEq('Editor container z-index', shouldExist ? '1200' : 'auto', Css.get(container, 'z-index'));
+          })
+        ]),
+        Chain.fromIsolatedChains([
+          Chain.mapper(getContentContainer),
+          UiFinder.cFindIn('.tox-silver-sink.tox-tinymce-aux'),
+          Chain.op((sink) => {
+            Assertions.assertEq('Editor sink z-index', shouldExist ? '1201' : '1300', Css.get(sink, 'z-index'));
+          })
+        ])
+      ])
+    );
 
-  const cSetupEditor = McEditor.cFromSettings({
+  const cAssertShadowHostState = (label: string, shouldExist: boolean) =>
+    Chain.label(
+      `${label}: Shadow host should ${shouldExist ? '' : 'not'} have "tox-fullscreen" and "tox-shadowhost" classes and z-index`,
+      Chain.op((editor: Editor) => {
+        if (SugarShadowDom.isInShadowRoot(SugarElement.fromDom(editor.getElement()))) {
+          const host = SugarShadowDom.getShadowRoot(SugarElement.fromDom(editor.getElement()))
+            .map(SugarShadowDom.getShadowHost)
+            .getOrDie('Expected shadow host');
+
+          Assertions.assertEq('Shadow host classes', shouldExist, Classes.hasAll(host, [ 'tox-fullscreen', 'tox-shadowhost' ]));
+          Assertions.assertEq('Shadow host z-index', shouldExist ? '1200' : 'auto', Css.get(host, 'z-index'));
+        }
+      }));
+
+  const cAssertPageState = (label: string, shouldExist: boolean) =>
+    Chain.fromChains([
+      cAssertHtmlAndBodyState(label, shouldExist),
+      cAsssertEditorContainerAndSinkState(label, shouldExist),
+      cAssertShadowHostState(label, shouldExist)
+    ]);
+
+  TinyLoader.setupInBodyAndShadowRoot((editor: Editor, onSuccess, onFailure) => {
+    Pipeline.async({}, [
+      Log.chainsAsStep('TBA', 'FullScreen: Toggle fullscreen on, open link dialog, insert link, close dialog and toggle fullscreen off', [
+        Chain.inject(editor),
+        Chain.fromParent(Chain.identity, [
+          cAssertPageState('Before fullscreen command', false),
+          Chain.op((editor: Editor) => editor.execCommand('mceFullScreen', true)),
+          cAssertApiAndLastEvent('After fullscreen command', true),
+          cAssertPageState('After fullscreen command', true),
+          Chain.op((editor: Editor) => editor.execCommand('mceLink', true)),
+          cWaitForDialog('Insert/Edit Link'),
+          cCloseOnlyWindow,
+          cAssertPageState('After window is closed', true),
+          Chain.op((editor: Editor) => editor.execCommand('mceFullScreen')),
+          cAssertApiAndLastEvent('After fullscreen toggled', false),
+          cAssertPageState('After fullscreen toggled', false)
+        ])
+      ]),
+      Log.chainsAsStep('TBA', 'FullScreen: Toggle fullscreen and remove editor should clean up classes', [
+        Chain.inject(editor),
+        Chain.fromParent(Chain.identity, [
+          Chain.op((editor: Editor) => editor.execCommand('mceFullScreen', true)),
+          cAssertApiAndLastEvent('After fullscreen command', true),
+          cAssertPageState('After fullscreen command', true)
+        ]),
+        McEditor.cRemove,
+        cAssertHtmlAndBodyState('After editor is closed', false)
+      ])
+    ], onSuccess, onFailure);
+  }, {
     plugins: 'fullscreen link',
     theme: 'silver',
     base_url: '/project/tinymce/js/tinymce',
     setup: (editor: Editor) => {
       lastEventArgs.set(null);
-      editor.on('FullscreenStateChanged', (e: Editor) => {
+      editor.on('FullscreenStateChanged', (e) => {
         lastEventArgs.set(e);
       });
     }
-  });
-
-  Pipeline.async({}, [
-    Log.chainsAsStep('TBA', 'FullScreen: Toggle fullscreen on, open link dialog, insert link, close dialog and toggle fullscreen off', [
-      cSetupEditor,
-      Chain.fromParent(Chain.identity, [
-        cAssertFullscreenClass('Before fullscreen command', false),
-        Chain.op((editor: Editor) => editor.execCommand('mceFullScreen', true)),
-        cAssertEditorAndLastEvent('After fullscreen command', true),
-        cAssertFullscreenClass('After fullscreen command', true),
-        Chain.op((editor: Editor) => editor.execCommand('mceLink', true)),
-        cWaitForDialog('Insert/Edit Link'),
-        cCloseOnlyWindow,
-        cAssertFullscreenClass('After window is closed', true),
-        Chain.op((editor: Editor) => editor.execCommand('mceFullScreen')),
-        cAssertEditorAndLastEvent('After fullscreen toggled', false),
-        cAssertFullscreenClass('After fullscreen toggled', false)
-      ]),
-      McEditor.cRemove
-    ]),
-    Log.chainsAsStep('TBA', 'FullScreen: Toggle fullscreen and remove editor should clean up classes', [
-      cSetupEditor,
-      Chain.fromParent(Chain.identity, [
-        Chain.op((editor: Editor) => editor.execCommand('mceFullScreen', true)),
-        cAssertEditorAndLastEvent('After fullscreen command', true),
-        cAssertFullscreenClass('After fullscreen command', true)
-      ]),
-      McEditor.cRemove,
-      cAssertFullscreenClass('After editor is closed', false)
-    ])
-  ], success, failure);
+  }, success, failure);
 });

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -1,7 +1,7 @@
-import { Assertions, Chain, Guard, Log, Pipeline, UiFinder } from '@ephox/agar';
+import { Assertions, Chain, Log, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { Editor as McEditor, TinyLoader } from '@ephox/mcagar';
+import { ApiChains, Editor as McEditor, TinyLoader } from '@ephox/mcagar';
 import { Attribute, Classes, Css, Html, SelectorFind, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
@@ -12,32 +12,38 @@ import SilverTheme from 'tinymce/themes/silver/Theme';
 const getContentContainer = (editor: Editor) =>
   SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement())));
 
-const cCloseOnlyWindow = Chain.control(
-  Chain.op((editor: Editor) => {
-    const dialogs = () => UiFinder.findAllIn(getContentContainer(editor), '[role="dialog"]');
-    Assertions.assertEq('One window exists', 1, dialogs().length);
-    editor.windowManager.close();
-    Assertions.assertEq('No windows exist', 0, dialogs().length);
-  }),
-  Guard.addLogging('Close window')
+const cCloseOnlyWindow = Chain.label(
+  'Close window',
+  Chain.fromChains([
+    NamedChain.read('editor',
+      Chain.op((editor: Editor) => {
+        const dialogs = () => UiFinder.findAllIn(getContentContainer(editor), '[role="dialog"]');
+        Assertions.assertEq('One window exists', 1, dialogs().length);
+        editor.windowManager.close();
+        Assertions.assertEq('No windows exist', 0, dialogs().length);
+      })
+    )
+  ])
 );
 
 const cWaitForDialog = (ariaLabel: string) =>
-  Chain.control(
+  Chain.label(
+    'Looking for dialog with an aria-label: ' + ariaLabel,
     Chain.fromChains([
-      Chain.mapper(getContentContainer),
-      UiFinder.cWaitFor('Waiting for dialog', '[role="dialog"]'),
-      Chain.op((dialog) => {
-        if (Attribute.has(dialog, 'aria-labelledby')) {
-          const labelledby = Attribute.get(dialog, 'aria-labelledby');
-          const dialogLabel = SelectorFind.descendant<HTMLLabelElement>(dialog, '#' + labelledby).getOrDie('Could not find labelledby');
-          Assertions.assertEq('Checking label text', ariaLabel, Html.get(dialogLabel));
-        } else {
-          throw new Error('Dialog did not have an aria-labelledby');
-        }
-      })
-    ]),
-    Guard.addLogging('Looking for dialog with an aria-label: ' + ariaLabel)
+      NamedChain.direct('editor', Chain.mapper(getContentContainer), 'contentContainer'),
+      NamedChain.direct('contentContainer', UiFinder.cWaitFor('Waiting for dialog', '[role="dialog"]'), 'dialog'),
+      NamedChain.read('dialog',
+        Chain.op((dialog) => {
+          if (Attribute.has(dialog, 'aria-labelledby')) {
+            const labelledby = Attribute.get(dialog, 'aria-labelledby');
+            const dialogLabel = SelectorFind.descendant<HTMLLabelElement>(dialog, '#' + labelledby).getOrDie('Could not find labelledby');
+            Assertions.assertEq('Checking label text', ariaLabel, Html.get(dialogLabel));
+          } else {
+            throw new Error('Dialog did not have an aria-labelledby');
+          }
+        })
+      )
+    ])
   );
 
 UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', (success, failure) => {
@@ -51,7 +57,9 @@ UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', (s
     Chain.label(
       `${label}: fullscreen API and event state should return ${state}`,
       Chain.fromChains([
-        Chain.op((editor) => Assertions.assertEq('Editor isFullscreen', state, editor.plugins.fullscreen.isFullscreen())),
+        NamedChain.read('editor', Chain.op((editor) => {
+          Assertions.assertEq('Editor isFullscreen', state, editor.plugins.fullscreen.isFullscreen());
+        })),
         Chain.op(() => Assertions.assertEq('FullscreenStateChanged event', state, lastEventArgs.get().state))
       ])
     );
@@ -60,11 +68,11 @@ UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', (s
     const selector = shouldExist ? 'root:.tox-fullscreen' : 'root::not(.tox-fullscreen)';
     return Chain.label(
       `${label}: Body and Html should ${shouldExist ? '' : 'not'} have "tox-fullscreen" class`,
-      Chain.fromIsolatedChains([
-        Chain.inject(SugarBody.body()),
-        UiFinder.cFindIn(selector),
-        Chain.inject(SugarElement.fromDom(document.documentElement)),
-        UiFinder.cFindIn(selector)
+      Chain.fromChains([
+        NamedChain.writeValue('docBody', SugarBody.body()),
+        NamedChain.read('docBody', UiFinder.cFindIn(selector)),
+        NamedChain.writeValue('docHTML', SugarElement.fromDom(document.documentElement)),
+        NamedChain.read('docHTML', UiFinder.cFindIn(selector))
       ])
     );
   };
@@ -73,36 +81,39 @@ UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', (s
     Chain.label(
       `${label}: Editor container and sink should ${shouldExist ? '' : 'not'} have "tox-fullscreen" class and z-index`,
       Chain.fromChains([
-        Chain.fromIsolatedChains([
-          Chain.mapper((editor: Editor) => SugarElement.fromDom(editor.getContainer())),
-          UiFinder.cFindIn(shouldExist ? 'root:.tox-fullscreen' : 'root::not(.tox-fullscreen)'),
+        NamedChain.direct('editor', Chain.mapper((editor: Editor) => SugarElement.fromDom(editor.getContainer())), 'editorContainer'),
+        NamedChain.read('editorContainer', UiFinder.cFindIn(shouldExist ? 'root:.tox-fullscreen' : 'root::not(.tox-fullscreen)')),
+        NamedChain.read('editorContainer',
           Chain.op((container) => {
             Assertions.assertEq('Editor container z-index', shouldExist ? '1200' : 'auto', Css.get(container, 'z-index'));
           })
-        ]),
-        Chain.fromIsolatedChains([
-          Chain.mapper(getContentContainer),
-          UiFinder.cFindIn('.tox-silver-sink.tox-tinymce-aux'),
+        ),
+        NamedChain.direct('editor', Chain.mapper(getContentContainer), 'contentContainer'),
+        NamedChain.direct('contentContainer', UiFinder.cFindIn('.tox-silver-sink.tox-tinymce-aux'), 'sink'),
+        NamedChain.read('sink',
           Chain.op((sink) => {
             Assertions.assertEq('Editor sink z-index', shouldExist ? '1201' : '1300', Css.get(sink, 'z-index'));
           })
-        ])
+        )
       ])
     );
 
   const cAssertShadowHostState = (label: string, shouldExist: boolean) =>
     Chain.label(
       `${label}: Shadow host should ${shouldExist ? '' : 'not'} have "tox-fullscreen" and "tox-shadowhost" classes and z-index`,
-      Chain.op((editor: Editor) => {
-        if (SugarShadowDom.isInShadowRoot(SugarElement.fromDom(editor.getElement()))) {
-          const host = SugarShadowDom.getShadowRoot(SugarElement.fromDom(editor.getElement()))
-            .map(SugarShadowDom.getShadowHost)
-            .getOrDie('Expected shadow host');
+      NamedChain.read('editor',
+        Chain.op((editor: Editor) => {
+          if (SugarShadowDom.isInShadowRoot(SugarElement.fromDom(editor.getElement()))) {
+            const host = SugarShadowDom.getShadowRoot(SugarElement.fromDom(editor.getElement()))
+              .map(SugarShadowDom.getShadowHost)
+              .getOrDie('Expected shadow host');
 
-          Assertions.assertEq('Shadow host classes', shouldExist, Classes.hasAll(host, [ 'tox-fullscreen', 'tox-shadowhost' ]));
-          Assertions.assertEq('Shadow host z-index', shouldExist ? '1200' : 'auto', Css.get(host, 'z-index'));
-        }
-      }));
+            Assertions.assertEq('Shadow host classes', shouldExist, Classes.hasAll(host, [ 'tox-fullscreen', 'tox-shadowhost' ]));
+            Assertions.assertEq('Shadow host z-index', shouldExist ? '1200' : 'auto', Css.get(host, 'z-index'));
+          }
+        })
+      )
+    );
 
   const cAssertPageState = (label: string, shouldExist: boolean) =>
     Chain.fromChains([
@@ -114,30 +125,30 @@ UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', (s
   TinyLoader.setupInBodyAndShadowRoot((editor: Editor, onSuccess, onFailure) => {
     Pipeline.async({}, [
       Log.chainsAsStep('TBA', 'FullScreen: Toggle fullscreen on, open link dialog, insert link, close dialog and toggle fullscreen off', [
-        Chain.inject(editor),
-        Chain.fromParent(Chain.identity, [
+        NamedChain.asChain([
+          NamedChain.writeValue('editor', editor),
           cAssertPageState('Before fullscreen command', false),
-          Chain.op((editor: Editor) => editor.execCommand('mceFullScreen', true)),
+          NamedChain.read('editor', ApiChains.cExecCommand('mceFullScreen', true)),
           cAssertApiAndLastEvent('After fullscreen command', true),
           cAssertPageState('After fullscreen command', true),
-          Chain.op((editor: Editor) => editor.execCommand('mceLink', true)),
+          NamedChain.read('editor', ApiChains.cExecCommand('mceLink', true)),
           cWaitForDialog('Insert/Edit Link'),
           cCloseOnlyWindow,
           cAssertPageState('After window is closed', true),
-          Chain.op((editor: Editor) => editor.execCommand('mceFullScreen')),
+          NamedChain.read('editor', ApiChains.cExecCommand('mceFullScreen', null)),
           cAssertApiAndLastEvent('After fullscreen toggled', false),
           cAssertPageState('After fullscreen toggled', false)
         ])
       ]),
       Log.chainsAsStep('TBA', 'FullScreen: Toggle fullscreen and remove editor should clean up classes', [
-        Chain.inject(editor),
-        Chain.fromParent(Chain.identity, [
-          Chain.op((editor: Editor) => editor.execCommand('mceFullScreen', true)),
+        NamedChain.asChain([
+          NamedChain.writeValue('editor', editor),
+          NamedChain.read('editor', ApiChains.cExecCommand('mceFullScreen', true)),
           cAssertApiAndLastEvent('After fullscreen command', true),
-          cAssertPageState('After fullscreen command', true)
-        ]),
-        McEditor.cRemove,
-        cAssertHtmlAndBodyState('After editor is closed', false)
+          cAssertPageState('After fullscreen command', true),
+          NamedChain.read('editor', McEditor.cRemove),
+          cAssertHtmlAndBodyState('After editor is closed', false)
+        ])
       ])
     ], onSuccess, onFailure);
   }, {

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -49,7 +49,7 @@ const cWaitForDialog = (ariaLabel: string): Chain<Editor, Editor> =>
 const cAssertHtmlAndBodyState = (label: string, shouldExist: boolean) => {
   const selector = shouldExist ? 'root:.tox-fullscreen' : 'root::not(.tox-fullscreen)';
   return Chain.label(
-    `${label}: Body and Html should ${shouldExist ? '' : 'not'} have "tox-fullscreen" class`,
+    `${label}: Body and Html should ${shouldExist ? 'have' : 'not have'} "tox-fullscreen" class`,
     Chain.fromIsolatedChains([
       Chain.inject(SugarBody.body()),
       UiFinder.cFindIn(selector),
@@ -61,7 +61,7 @@ const cAssertHtmlAndBodyState = (label: string, shouldExist: boolean) => {
 
 const cAsssertEditorContainerAndSinkState = (label: string, shouldExist: boolean): Chain<Editor, Editor> =>
   Chain.label(
-    `${label}: Editor container and sink should ${shouldExist ? '' : 'not'} have "tox-fullscreen" class and z-index`,
+    `${label}: Editor container and sink should ${shouldExist ? 'have' : 'not have'} "tox-fullscreen" class and z-index`,
     NamedChain.asChain([
       NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
       NamedChain.direct('editor', Chain.mapper((editor: Editor) => SugarElement.fromDom(editor.getContainer())), 'editorContainer'),
@@ -84,7 +84,7 @@ const cAsssertEditorContainerAndSinkState = (label: string, shouldExist: boolean
 
 const cAssertShadowHostState = (label: string, shouldExist: boolean): Chain<Editor, Editor> =>
   Chain.label(
-    `${label}: Shadow host should ${shouldExist ? '' : 'not'} have "tox-fullscreen" and "tox-shadowhost" classes and z-index`,
+    `${label}: Shadow host should ${shouldExist ? 'have' : 'not have'} "tox-fullscreen" and "tox-shadowhost" classes and z-index`,
     Chain.op((editor: Editor) => {
       const elm = SugarElement.fromDom(editor.getElement());
       if (SugarShadowDom.isInShadowRoot(elm)) {


### PR DESCRIPTION
Related Ticket: TINY-6280

Description of Changes:
* Refactor `fullscreen.less` so that the selectors are compatible with both Body and ShadowDom
* Make sure `tox-fullscreen` is added to the shadow host and that it has the correct z-index
* Update test to run in Body and ShadowDom

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):