### PR TITLE
TINY-6248: Readonly links should open in a new window or tab

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,6 +2,7 @@ Version 5.6.0 (TBD)
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
+    Fixed `readonly` mode to allow hyperlinks to be clickable #TINY-6248
     Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,7 +2,7 @@ Version 5.6.0 (TBD)
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
-    Fixed `readonly` mode to allow hyperlinks to be clickable #TINY-6248
+    Changed `readonly` mode to allow hyperlinks to be clickable #TINY-6248
     Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282

--- a/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
@@ -6,7 +6,7 @@
  */
 
 import { Obj } from '@ephox/katamari';
-import { isReadOnly, preventReadOnlyEvents } from '../mode/Readonly';
+import { isReadOnly, processReadonlyEvents } from '../mode/Readonly';
 import DOMUtils from './dom/DOMUtils';
 import Editor from './Editor';
 import { EditorEventMap } from './EventTypes';
@@ -65,7 +65,7 @@ const fireEvent = (editor: Editor, eventName: string, e: Event) => {
   if (isListening(editor)) {
     editor.fire(eventName, e);
   } else if (isReadOnly(editor)) {
-    preventReadOnlyEvents(editor, e);
+    processReadonlyEvents(editor, e);
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/mode/Readonly.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Readonly.ts
@@ -130,10 +130,10 @@ const getHrefOpt = (editor: Editor, elm: SugarElement): Optional<string> => {
 
 const processReadonlyEvents = (editor: Editor, e: Event) => {
   /*
-    If an event is a click event on an anchor and the CMD/CTRL key is
-    not held, then we want to prevent default behvariour and either:
+    If an event is a click event on or within an anchor, and the CMD/CTRL key is
+    not held, then we want to prevent default behaviour and either:
       a) scroll to the relevant bookmark
-      b) open an external link using default browser behaviour
+      b) open the link using default browser behaviour
   */
   if (isClickEvent(e) && !VK.metaKeyPressed(e)) {
     const elm = SugarElement.fromDom(e.target as Node);

--- a/modules/tinymce/src/core/main/ts/mode/Readonly.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Readonly.ts
@@ -123,7 +123,7 @@ const isClickEvent = (e: Event): e is MouseEvent => e.type === 'click';
 /*
 * This function is exported for unit testing purposes only
 */
-const getHrefOpt = (editor: Editor, elm: SugarElement): Optional<string> => {
+const getAnchorHrefOpt = (editor: Editor, elm: SugarElement): Optional<string> => {
   const isRoot = (elm: SugarElement<Node>) => Compare.eq(elm, SugarElement.fromDom(editor.getBody()));
   return SelectorFind.closest<HTMLAnchorElement>(elm, 'a', isRoot).bind((a) => Attribute.getOpt(a, 'href'));
 };
@@ -137,7 +137,7 @@ const processReadonlyEvents = (editor: Editor, e: Event) => {
   */
   if (isClickEvent(e) && !VK.metaKeyPressed(e)) {
     const elm = SugarElement.fromDom(e.target as Node);
-    getHrefOpt(editor, elm).each((href) => {
+    getAnchorHrefOpt(editor, elm).each((href) => {
       e.preventDefault();
       if (/^#/.test(href)) {
         const targetEl = editor.dom.select(`${href},[name="${Strings.removeLeading(href, '#')}"]`);
@@ -167,7 +167,7 @@ const registerReadOnlySelectionBlockers = (editor: Editor) => {
 
 export {
   isReadOnly,
-  getHrefOpt,
+  getAnchorHrefOpt,
   toggleReadOnly,
   registerReadOnlyContentFilters,
   processReadonlyEvents,

--- a/modules/tinymce/src/core/main/ts/mode/Readonly.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Readonly.ts
@@ -5,8 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional } from '@ephox/katamari';
-import { Attribute, Class, SelectorFilter, SugarElement } from '@ephox/sugar';
+import { Arr, Optional, Strings } from '@ephox/katamari';
+import { Attribute, Class, Compare, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 import Editor from '../api/Editor';
 import VK from '../api/util/VK';
 import * as EditorFocus from '../focus/EditorFocus';
@@ -120,13 +120,34 @@ const registerReadOnlyContentFilters = (editor: Editor) => {
 
 const isClickEvent = (e: Event): e is MouseEvent => e.type === 'click';
 
-const isInAnchor = (editor: Editor, target: HTMLElement) => editor.dom.getParent(target, 'a') !== null;
+/*
+* This function is exported for unit testing purposes only
+*/
+const getHrefOpt = (editor: Editor, elm: SugarElement): Optional<string> => {
+  const isRoot = (elm: SugarElement<Node>) => Compare.eq(elm, SugarElement.fromDom(editor.getBody()));
+  return SelectorFind.closest<HTMLAnchorElement>(elm, 'a', isRoot).bind((a) => Attribute.getOpt(a, 'href'));
+};
 
-const preventReadOnlyEvents = (editor: Editor, e: Event) => {
-  const target = e.target as HTMLElement;
-
-  if (isClickEvent(e) && !VK.metaKeyPressed(e) && isInAnchor(editor, target)) {
-    e.preventDefault();
+const processReadonlyEvents = (editor: Editor, e: Event) => {
+  /*
+    If an event is a click event on an anchor and the CMD/CTRL key is
+    not held, then we want to prevent default behvariour and either:
+      a) scroll to the relevant bookmark
+      b) open an external link using default browser behaviour
+  */
+  if (isClickEvent(e) && !VK.metaKeyPressed(e)) {
+    const elm = SugarElement.fromDom(e.target as Node);
+    getHrefOpt(editor, elm).each((href) => {
+      e.preventDefault();
+      if (/^#/.test(href)) {
+        const targetEl = editor.dom.select(`${href},[name="${Strings.removeLeading(href, '#')}"]`);
+        if (targetEl.length) {
+          editor.selection.scrollIntoView(targetEl[0], true);
+        }
+      } else {
+        window.open(href, '_blank', 'rel=noopener noreferrer,menubar=yes,toolbar=yes,location=yes,status=yes,resizable=yes,scrollbars=yes');
+      }
+    });
   }
 };
 
@@ -146,8 +167,9 @@ const registerReadOnlySelectionBlockers = (editor: Editor) => {
 
 export {
   isReadOnly,
+  getHrefOpt,
   toggleReadOnly,
   registerReadOnlyContentFilters,
-  preventReadOnlyEvents,
+  processReadonlyEvents,
   registerReadOnlySelectionBlockers
 };

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -243,9 +243,28 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
         tinyApis.sSetContent('<p><a href="https://tiny.cloud"><img src="">nested image </img>inside anchor</a></p>'),
         sAssertHrefOpt('img', Optional.some('https://tiny.cloud'))
       ]),
-      Log.stepsAsStep('TINY-6248', 'processReadonlyEvents should scroll to bookmarks', [
+      Log.stepsAsStep('TINY-6248', 'processReadonlyEvents should scroll to bookmark with id', [
         sSetMode('readonly'),
         tinyApis.sSetContent('<p><a href="#someBookmark">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark"></a></p>'),
+        Chain.asStep(SugarElement.fromDom(editor.getBody()), [
+          NamedChain.asChain([
+            NamedChain.direct(NamedChain.inputName(), Chain.identity, 'body'),
+            NamedChain.write(
+              'yPos',
+              Chain.mapper(() => Scroll.get(eDoc).top),
+            ),
+            NamedChain.direct('body', UiFinder.cFindIn('a[href="#someBookmark"]'), 'anchor'),
+            NamedChain.read('anchor', Mouse.cClick),
+            NamedChain.read('yPos', Chain.op((yPos) => {
+              const newPos = Scroll.get(eDoc).top;
+              Assert.eq('assert yPos has changed i.e. has scrolled', true, yPos !== newPos);
+            }))
+          ])
+        ])
+      ]),
+      Log.stepsAsStep('TINY-6248', 'processReadonlyEvents should scroll to bookmark with name', [
+        sSetMode('readonly'),
+        tinyApis.sSetContent('<p><a href="#someBookmark">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a name="someBookmark"></a></p>'),
         Chain.asStep(SugarElement.fromDom(editor.getBody()), [
           NamedChain.asChain([
             NamedChain.direct(NamedChain.inputName(), Chain.identity, 'body'),

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -244,6 +244,8 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
         sAssertHrefOpt('img', Optional.some('https://tiny.cloud'))
       ]),
       Log.stepsAsStep('TINY-6248', 'processReadonlyEvents should scroll to bookmark with id', [
+        sSetMode('design'),
+        Step.sync(() => editor.resetContent()),
         sSetMode('readonly'),
         tinyApis.sSetContent('<p><a href="#someBookmark">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark"></a></p>'),
         Chain.asStep(SugarElement.fromDom(editor.getBody()), [
@@ -263,6 +265,8 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
         ])
       ]),
       Log.stepsAsStep('TINY-6248', 'processReadonlyEvents should scroll to bookmark with name', [
+        sSetMode('design'),
+        Step.sync(() => editor.resetContent()),
         sSetMode('readonly'),
         tinyApis.sSetContent('<p><a href="#someBookmark">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a name="someBookmark"></a></p>'),
         Chain.asStep(SugarElement.fromDom(editor.getBody()), [

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -81,9 +81,9 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
       })
     ]);
 
-    const sAssertHrefOpt = (selector: string, expectedHref) => Step.sync(() => {
+    const sAssertHrefOpt = (selector: string, expectedHref: Optional<string>) => Step.sync(() => {
       const elm = SugarElement.fromDom(editor.dom.select(selector)[0]);
-      const hrefOpt = Readonly.getHrefOpt(editor, elm);
+      const hrefOpt = Readonly.getAnchorHrefOpt(editor, elm);
       Assert.eq('href options match', expectedHref, hrefOpt, tOptional());
     });
 
@@ -235,7 +235,7 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
         sSetMode('readonly'),
         UiFinder.sNotExists(SugarBody.body(), '.tox-menu')
       ]),
-      Log.stepsAsStep('TINY-6248', 'getHrefOpt should return an Optional of the href of the closest anchor tag', [
+      Log.stepsAsStep('TINY-6248', 'getAnchorHrefOpt should return an Optional of the href of the closest anchor tag', [
         tinyApis.sSetContent('<p><a href="https://tiny.cloud">external link</a></p>'),
         sAssertHrefOpt('a', Optional.some('https://tiny.cloud')),
         tinyApis.sSetContent('<p><a>external link with no href</a></p>'),
@@ -245,7 +245,7 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
       ]),
       Log.stepsAsStep('TINY-6248', 'processReadonlyEvents should scroll to bookmarks', [
         sSetMode('readonly'),
-        tinyApis.sSetContent('<p><a href="#someBookmark">internal bookmark</a></p><div style="padding-top: 2000px;"/><p><a id="someBookmark"></a></p>'),
+        tinyApis.sSetContent('<p><a href="#someBookmark">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark"></a></p>'),
         Chain.asStep(SugarElement.fromDom(editor.getBody()), [
           NamedChain.asChain([
             NamedChain.direct(NamedChain.inputName(), Chain.identity, 'body'),

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -84,7 +84,7 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
     const sAssertHrefOpt = (selector: string, expectedHref) => Step.sync(() => {
       const elm = SugarElement.fromDom(editor.dom.select(selector)[0]);
       const hrefOpt = Readonly.getHrefOpt(editor, elm);
-      Assert.eq('href options should match', expectedHref, hrefOpt, tOptional());
+      Assert.eq('href options match', expectedHref, hrefOpt, tOptional());
     });
 
     Pipeline.async({}, [

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -1,10 +1,14 @@
-import { ApproxStructure, Chain, Log, Mouse, Pipeline, Step, UiFinder } from '@ephox/agar';
+import { ApproxStructure, Chain, Log, NamedChain, Mouse, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Optional, OptionalInstances } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { Class, Css, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { Class, Css, Scroll, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
+import * as Readonly from 'tinymce/core/mode/Readonly';
+
+const tOptional = OptionalInstances.tOptional;
 
 UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) => {
   Theme();
@@ -12,6 +16,7 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
 
   TinyLoader.setup(function (editor: Editor, onSuccess, onFailure) {
     const tinyApis = TinyApis(editor);
+    const eDoc = SugarElement.fromDom(editor.getDoc());
 
     const sSetMode = (mode: string) => Step.label('sSetMode: setting the editor mode to ' + mode, Step.sync(() => {
       editor.mode.set(mode);
@@ -75,6 +80,12 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
         Assert.eq('Button should have expected disabled state', expectedState, Class.has(elm, 'tox-tbtn--disabled'));
       })
     ]);
+
+    const sAssertHrefOpt = (selector: string, expectedHref) => Step.sync(() => {
+      const elm = SugarElement.fromDom(editor.dom.select(selector)[0]);
+      const hrefOpt = Readonly.getHrefOpt(editor, elm);
+      Assert.eq('href options should match', expectedHref, hrefOpt, tOptional());
+    });
 
     Pipeline.async({}, [
       Log.stepsAsStep('TBA', 'Swiching to readonly mode while having cef selection should remove fake selection', [
@@ -223,6 +234,33 @@ UnitTest.asynctest('browser.tinymce.core.ReadOnlyModeTest', (success, failure) =
         UiFinder.sWaitFor('Waited for menu', SugarBody.body(), '.tox-menu'),
         sSetMode('readonly'),
         UiFinder.sNotExists(SugarBody.body(), '.tox-menu')
+      ]),
+      Log.stepsAsStep('TINY-6248', 'getHrefOpt should return an Optional of the href of the closest anchor tag', [
+        tinyApis.sSetContent('<p><a href="https://tiny.cloud">external link</a></p>'),
+        sAssertHrefOpt('a', Optional.some('https://tiny.cloud')),
+        tinyApis.sSetContent('<p><a>external link with no href</a></p>'),
+        sAssertHrefOpt('a', Optional.none()),
+        tinyApis.sSetContent('<p><a href="https://tiny.cloud"><img src="">nested image </img>inside anchor</a></p>'),
+        sAssertHrefOpt('img', Optional.some('https://tiny.cloud'))
+      ]),
+      Log.stepsAsStep('TINY-6248', 'processReadonlyEvents should scroll to bookmarks', [
+        sSetMode('readonly'),
+        tinyApis.sSetContent('<p><a href="#someBookmark">internal bookmark</a></p><div style="padding-top: 2000px;"/><p><a id="someBookmark"></a></p>'),
+        Chain.asStep(SugarElement.fromDom(editor.getBody()), [
+          NamedChain.asChain([
+            NamedChain.direct(NamedChain.inputName(), Chain.identity, 'body'),
+            NamedChain.write(
+              'yPos',
+              Chain.mapper(() => Scroll.get(eDoc).top),
+            ),
+            NamedChain.direct('body', UiFinder.cFindIn('a[href="#someBookmark"]'), 'anchor'),
+            NamedChain.read('anchor', Mouse.cClick),
+            NamedChain.read('yPos', Chain.op((yPos) => {
+              const newPos = Scroll.get(eDoc).top;
+              Assert.eq('assert yPos has changed i.e. has scrolled', true, yPos !== newPos);
+            }))
+          ])
+        ])
       ])
     ], onSuccess, onFailure);
   }, {


### PR DESCRIPTION
Related Ticket: TINY-6248

Description of Changes:
Links clicked in `readonly` mode will now open in a new tab (or scroll to bookmark if appropriate).

Pre-checks:
* [x] Changelog entry added (incoming)
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

