### PR TITLE
TINY-6540: Ensure DOMUtils.getParents does not call parentNode on DocumentFragments

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -4,6 +4,7 @@ Version 5.6.0 (TBD)
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
     Added new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
+    Fixed an exception thrown when using Shadow DOM caused by attempting to call `.parentNode` on an object which has no parent #TINY-6540
     Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -5,7 +5,7 @@ Version 5.6.0 (TBD)
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
     Added new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
     Changed `readonly` mode to allow hyperlinks to be clickable #TINY-6248
-    Fixed an exception thrown when using Shadow DOM caused by attempting to call `.parentNode` on an object which has no parent #TINY-6540
+    Fixed `DOMUtils.getParents` incorrectly including the shadow root in the array of elements returned #TINY-6540
     Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -568,7 +568,8 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     }
 
     while (node) {
-      if (node === root || !node.nodeType || NodeType.isDocument(node) || NodeType.isDocumentFragment(node)) {
+      // TODO: Remove nullable check once TINY-6599 is complete
+      if (node === root || Type.isNullable(node.nodeType) || NodeType.isDocument(node) || NodeType.isDocumentFragment(node)) {
         break;
       }
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -568,7 +568,7 @@ function DOMUtils(doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     }
 
     while (node) {
-      if (node === root || !node.nodeType || node.nodeType === 9) {
+      if (node === root || !node.nodeType || NodeType.isDocument(node) || NodeType.isDocumentFragment(node)) {
         break;
       }
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -361,6 +361,12 @@ UnitTest.test('browser.tinymce.core.dom.DOMUtils.getParents', () => {
   Assert.eq('', 1, DOM.getParents('test2', 'span.test').length);
   Assert.eq('', 0, DOM.getParents('test2', 'body', DOM.get('test')).length);
 
+  // getParents should stop at DocumentFragment
+  const frag = document.createDocumentFragment();
+  const inputElm = document.createElement('input');
+  frag.appendChild(inputElm);
+  Assert.eq('', 0, DOM.getParents(inputElm, (d) => d.nodeName === '#document-fragment').length);
+
   DOM.remove('test');
 });
 

--- a/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
@@ -59,7 +59,14 @@ UnitTest.asynctest('browser.tinymce.core.focus.FocusControllerTest', function (s
     LegacyUnit.equal(FocusController.isEditorContentAreaElement(contentAreaElm2), true, 'Should be true since tox-edit-area__iframe is content area container element');
   });
 
-  TinyLoader.setup(function (editor, onSuccess, onFailure) {
+  suite.test('isUIElement on editor sibling is false', (editor) => {
+    const inputElm = DOMUtils.DOM.create('input', { }, null);
+    editor.getContainer().parentNode.appendChild(inputElm);
+    LegacyUnit.equal(FocusController.isUIElement(editor, inputElm), false, 'Should be false as not sitting inside editor');
+    DOMUtils.DOM.remove(inputElm);
+  });
+
+  TinyLoader.setupInBodyAndShadowRoot(function (editor, onSuccess, onFailure) {
     Pipeline.async({}, suite.toSteps(editor), onSuccess, onFailure);
   }, {
     add_unload_trigger: false,


### PR DESCRIPTION
Related Ticket: TINY-6540

Description of Changes:
Don't call `.parentNode` when `node` is a `DocumentFragment`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): #6093, #2697, #6133
