### PR TITLE
TINY-6555: Fixed an offscreen selection element incorrectly created for the editor root

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -13,6 +13,7 @@ Version 5.6.0 (TBD)
     Fixed an issue where some attributes in table cells were not copied over to new rows or columns #TINY-6485
     Fixed incorrectly removing formatting on adjacent spaces when removing formatting on a ranged selection #TINY-6268
     Fixed some incorrect types in the new TypeScript declaration file #TINY-6413
+    Fixed a regression whereby a fake offscreen selection element was incorrectly created for the editor root node #TINY-6555
     Fixed some minor memory leaks that prevented garbage collection for editor instances #TINY-6570
     Fixed an issue where spaces were not preserved in pre-blocks when getting text content #TINY-6448
 Version 5.5.1 (2020-10-01)

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -50,7 +50,9 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
   let selectedElement;
 
   const isFakeSelectionElement = (node: Node) => dom.hasClass(node, 'mce-offscreen-selection');
-  const isFakeSelectionTargetElement = (node: Node): node is HTMLElement => isContentEditableFalse(node) || NodeType.isMedia(node);
+  // Note: isChildOf will return true if node === rootNode, so we need an additional check for that
+  const isFakeSelectionTargetElement = (node: Node): node is HTMLElement =>
+    node !== rootNode && (isContentEditableFalse(node) || NodeType.isMedia(node)) && dom.isChildOf(node, rootNode);
   const isNearFakeSelectionElement = (pos: CaretPosition) =>
     isBeforeContentEditableFalse(pos) || isAfterContentEditableFalse(pos) || isBeforeMedia(pos) || isAfterMedia(pos);
 

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -89,7 +89,7 @@ UnitTest.asynctest('browser.tinymce.core.SelectionOverridesTest', function (succ
     } as MouseEvent);
 
     const offscreenElements = editor.dom.select('.mce-offscreen-selection');
-    ok(offscreenElements.length === 0, 'No offscreen element shown when');
+    ok(offscreenElements.length === 0, 'No offscreen element shown');
 
     editor.getBody().contentEditable = 'true';
   });

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -72,6 +72,28 @@ UnitTest.asynctest('browser.tinymce.core.SelectionOverridesTest', function (succ
     }
   });
 
+  suite.test('TINY-6555: click on ce=false body should not show offscreen selection', (editor) => {
+    const body = editor.getBody();
+    editor.setContent(
+      '<table contenteditable="true" style="width: 100%; table-layout: fixed">' +
+      '<tbody><tr><td>1</td><td>2</td></tr></tbody>' +
+      '</table>'
+    );
+    editor.getBody().contentEditable = 'false';
+
+    const rect = editor.dom.getRect(body);
+    editor.fire('mousedown', {
+      target: body as EventTarget,
+      clientX: rect.x,
+      clientY: rect.y
+    } as MouseEvent);
+
+    const offscreenElements = editor.dom.select('.mce-offscreen-selection');
+    ok(offscreenElements.length === 0, 'No offscreen element shown when');
+
+    editor.getBody().contentEditable = 'true';
+  });
+
   suite.test('set range after ce=false element but lean backwards', function (editor) {
     editor.setContent('<p contenteditable="false">1</p><p contenteditable="false">2</p>');
 


### PR DESCRIPTION
Related Ticket: TINY-6555

Description of Changes:
* This fixes an issue introduced in TinyMCE 5.5 whereby if the root element was a cef element, then it'd incorrectly show the fake offscreen selection element.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
