### PR TITLE
TINY-6615: Fixed the `Cut` menu item not working in the latest version of Firefox

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -12,6 +12,7 @@ Version 5.6.0 (TBD)
     Fixed font size keywords such as `medium` not displaying correctly in font size menus #TINY-6291
     Fixed an issue where some attributes in table cells were not copied over to new rows or columns #TINY-6485
     Fixed incorrectly removing formatting on adjacent spaces when removing formatting on a ranged selection #TINY-6268
+    Fixed the `Cut` menu item not working in the latest version of Firefox #TINY-6615
     Fixed some incorrect types in the new TypeScript declaration file #TINY-6413
     Fixed some minor memory leaks that prevented garbage collection for editor instances #TINY-6570
     Fixed an issue where spaces were not preserved in pre-blocks when getting text content #TINY-6448

--- a/modules/tinymce/src/plugins/paste/main/ts/core/CutCopy.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/CutCopy.ts
@@ -92,10 +92,11 @@ const hasSelectedContent = (editor: Editor): boolean => !editor.selection.isColl
 const cut = (editor: Editor) => (evt: ClipboardEvent) => {
   if (hasSelectedContent(editor)) {
     setClipboardData(evt, getData(editor), fallback(editor), () => {
-      if (Env.browser.isChrome()) {
+      if (Env.browser.isChrome() || Env.browser.isFirefox()) {
         const rng = editor.selection.getRng();
         // Chrome fails to execCommand from another execCommand with this message:
         // "We don't execute document.execCommand() this time, because it is called recursively.""
+        // Firefox 82 now also won't run recursive commands, but it doesn't log an error
         Delay.setEditorTimeout(editor, () => { // detach
           // Restore the range before deleting, as Chrome on Android will
           // collapse the selection after a cut event has fired.

--- a/modules/tinymce/src/plugins/paste/test/ts/webdriver/CutTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/webdriver/CutTest.ts
@@ -1,4 +1,4 @@
-import { Chain, Log, Pipeline, RealMouse, Waiter } from '@ephox/agar';
+import { Log, Pipeline, RealMouse, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
@@ -22,16 +22,14 @@ UnitTest.asynctest('webdriver.tinymce.plugins.paste.CutTest', (success, failure)
     const api = TinyApis(editor);
     const ui = TinyUi(editor);
 
-    // Cut doesn't seem to work in webdriver mode on ie, safari has broken webdriver elementClick in 13.0.1, edge fails if it's not observed
-    Pipeline.async({}, (platform.browser.isIE() || platform.browser.isSafari() || platform.browser.isEdge()) ? [] :
+    // Cut doesn't seem to work in webdriver mode on ie
+    Pipeline.async({}, platform.browser.isIE() ? [] :
       Log.steps('TBA', 'Paste: Set and select content, cut using edit menu and assert cut content', [
         api.sSetContent('<p>abc</p>'),
         api.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 2),
         ui.sClickOnMenu('Click Edit menu', 'button:contains("Edit")'),
-        Chain.asStep({}, [
-          ui.cWaitForUi('Wait for menu item', '[role="menuitem"]:contains("Cut")'),
-          RealMouse.cClick()
-        ]),
+        ui.sWaitForUi('Wait for dropdown', '*[role="menu"]'),
+        RealMouse.sClickOn('div[title="Cut"]'),
         Waiter.sTryUntil('Cut is async now, so need to wait for content', api.sAssertContent('<p>ac</p>'))
       ]), onSuccess, onFailure);
   }, {


### PR DESCRIPTION
Related Ticket: TINY-6615

Description of Changes:
* Fixed an issue with the cut menu item not working in the latest versions of Firefox. Note: I've updated the test to match what's used in PowerPaste, as that was causing failures.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
