### PR TITLE
TINY-6224: Use `image_file_types` setting to allow additional image file types in image file uploads

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.6.0 (TBD)
+    Added support for `image_file_types` setting in image file uploader to determine which image file extensions are valid for upload #TINY-6224
     Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste when using the `paste` plugin #TINY-6306
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added new user interface `enable` and `disable` methods #TINY-6397

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,6 @@
 Version 5.6.0 (TBD)
-    Added support for `image_file_types` setting in image file uploader to determine which image file extensions are valid for upload #TINY-6224
     Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste when using the `paste` plugin #TINY-6306
+    Added support for `image_file_types` setting in the image file uploader to determine which image file extensions are valid for upload #TINY-6224
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added new user interface `enable` and `disable` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479

--- a/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
+++ b/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
@@ -46,7 +46,11 @@ export const BlobCache = (): BlobCache => {
       'image/jpeg': 'jpg',
       'image/jpg': 'jpg',
       'image/gif': 'gif',
-      'image/png': 'png'
+      'image/png': 'png',
+      'image/svg+xml': 'svg',
+      'image/webp': 'webp',
+      'image/bmp': 'bmp',
+      'image/tiff': 'tiff'
     };
 
     return mimes[mime.toLowerCase()] || 'dat';

--- a/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
+++ b/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
@@ -47,6 +47,7 @@ export const BlobCache = (): BlobCache => {
       'image/jpg': 'jpg',
       'image/gif': 'gif',
       'image/png': 'png',
+      'image/apng': 'apng',
       'image/svg+xml': 'svg',
       'image/webp': 'webp',
       'image/bmp': 'bmp',

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -31,10 +31,10 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       ui.sClickOnUi('Close dialog', 'button:contains("Cancel")')
     ]));
 
-    const sTriggerUpload = Logger.t('Trigger upload', Step.async((next, die) => {
+    const sTriggerUpload = (fileExtension: string = 'png') => Logger.t('Trigger upload', Step.async((next, die) => {
       Conversions.uriToBlob(b64).then((blob) => {
         Pipeline.async({}, [
-          FileInput.sRunOnPatchedFileInput([ Files.createFile('logo.png', 0, blob) ], Chain.asStep({}, [
+          FileInput.sRunOnPatchedFileInput([ Files.createFile(`logo.${fileExtension}`, 0, blob) ], Chain.asStep({}, [
             // cPopupToDialog('div[role="dialog"]'),
             ui.cWaitForPopup('Locate popup', 'div[role="dialog"]'),
             UiFinder.cFindIn('button:contains("Browse for an image")'),
@@ -107,7 +107,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       ui.sClickOnToolbar('Trigger Image dialog', 'button[aria-label="Insert/edit image"]'),
       ui.sWaitForPopup('Wait for Image dialog', 'div[role="dialog"]'),
       ui.sClickOnUi('Switch to Upload tab', '.tox-tab:contains("Upload")'),
-      sTriggerUpload,
+      sTriggerUpload(),
       ui.sWaitForUi('Wait for General tab to activate', '.tox-tab:contains("General")'),
       sAssertSrcTextValue('uploaded_image.jpg'),
       api.sDeleteSetting('images_upload_url'),
@@ -120,7 +120,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       ui.sClickOnToolbar('Trigger Image dialog', 'button[aria-label="Insert/edit image"]'),
       ui.sWaitForPopup('Wait for Image dialog', 'div[role="dialog"]'),
       ui.sClickOnUi('Switch to Upload tab', '.tox-tab:contains("Upload")'),
-      sTriggerUpload,
+      sTriggerUpload(),
       ui.sWaitForUi('Wait for General tab to activate', '.tox-tab:contains("General")'),
       sAssertSrcTextValue('file.jpg'),
       ui.sClickOnUi('Close dialog', 'button:contains("Cancel")')
@@ -132,7 +132,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       ui.sClickOnToolbar('Trigger Image dialog', 'button[aria-label="Insert/edit image"]'),
       ui.sWaitForPopup('Wait for Image dialog', 'div[role="dialog"]'),
       ui.sClickOnUi('Switch to Upload tab', '.tox-tab:contains("Upload")'),
-      sTriggerUpload,
+      sTriggerUpload(),
       ui.sWaitForUi('Wait for General tab to activate', '.tox-tab:contains("General")'),
       sAssertSrcTextValue(b64.split(',')[1]),
       ui.sClickOnUi('Close dialog', 'button:contains("Cancel")')
@@ -144,7 +144,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       ui.sClickOnToolbar('Trigger Image dialog', 'button[aria-label="Insert/edit image"]'),
       ui.sWaitForPopup('Wait for Image dialog', 'div[role="dialog"]'),
       ui.sClickOnUi('Switch to Upload tab', '.tox-tab:contains("Upload")'),
-      sTriggerUpload,
+      sTriggerUpload(),
       ui.sWaitForUi('Wait for an alert dialog to appear', '.tox-alert-dialog'),
       ui.sClickOnUi('Switch to Upload tab', '.tox-alert-dialog .tox-button:contains("OK")'),
       UiFinder.sNotExists(SugarBody.body(), '.tox-alert-dialog'),
@@ -158,11 +158,25 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       ui.sClickOnToolbar('Trigger Image dialog', 'button[aria-label="Insert/edit image"]'),
       ui.sWaitForPopup('Wait for Image dialog', 'div[role="dialog"]'),
       ui.sClickOnUi('Switch to Upload tab', '.tox-tab:contains("Upload")'),
-      sTriggerUpload,
+      sTriggerUpload(),
       ui.sWaitForUi('Wait for General tab to activate', '.tox-tab:contains("General")'),
       sAssertSrcTextValueStartsWith('blob:'),
       ui.sClickOnUi('Close dialog', 'button:contains("Cancel")'),
       api.sDeleteSetting('automatic_uploads')
+    ]);
+
+    const uploadWithCustomImageFileTypes = Log.stepsAsStep('TINY-6224', 'Image: Image uploader respects `image_file_types` setting', [
+      api.sSetContent(''),
+      api.sSetSetting('images_upload_handler', (_blobInfo, success) => success('logo.svg')),
+      api.sSetSetting('image_file_types', 'svg'),
+      ui.sClickOnToolbar('Trigger Image dialog', 'button[aria-label="Insert/edit image"]'),
+      ui.sWaitForPopup('Wait for Image dialog', 'div[role="dialog"]'),
+      ui.sClickOnUi('Switch to Upload tab', '.tox-tab:contains("Upload")'),
+      sTriggerUpload('svg'),
+      ui.sWaitForUi('Wait for General tab to activate', '.tox-tab:contains("General")'),
+      sAssertSrcTextValue('logo.svg'),
+      ui.sClickOnUi('Close dialog', 'button:contains("Cancel")'),
+      api.sDeleteSetting('image_file_types')
     ]);
 
     Pipeline.async({}, [
@@ -174,7 +188,8 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       uploadWithCustomHandler,
       uploadCustomHandlerBase64String,
       uploadWithError,
-      uploadWithAutomaticUploadsDisabled
+      uploadWithAutomaticUploadsDisabled,
+      uploadWithCustomImageFileTypes
     ], onSuccess, onFailure);
   }, {
     theme: 'silver',

--- a/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
@@ -104,7 +104,8 @@ const setupDemo = () => {
         icons: () => <Record<string, string>> {},
         menuItems: () => <Record<string, any>> {},
         translate: I18n.translate,
-        isReadOnly: () => false
+        isReadOnly: () => false,
+        getSetting: (_settingName: string, defaultVal: any) => defaultVal
       },
       interpreter: (x) => x,
       getSink: () => Result.value(sink),

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -68,7 +68,11 @@ const init = (sink: AlloyComponent, editor: Editor, lazyAnchorbar: () => AlloyCo
         menuItems: () => editor.ui.registry.getAll().menuItems,
         translate: I18n.translate,
         isReadOnly: () => editor.mode.isReadOnly(),
-        getSetting: editor.getParam.bind(editor) // This bind is important to ensure we don't lose reference to the editor in getParam
+        /*
+          TODO: Remove bind when TINY-6621 is complete
+          This bind is important to ensure we don't lose reference to the editor in getParam
+        */
+        getSetting: editor.getParam.bind(editor)
       },
       interpreter: (s) => UiFactory.interpretWithoutForm(s, backstage),
       anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -29,6 +29,7 @@ export interface UiFactoryBackstageProviders {
   menuItems: () => Record<string, Menu.MenuItemSpec | Menu.NestedMenuItemSpec | Menu.ToggleMenuItemSpec>;
   translate: (any) => TranslatedString;
   isReadOnly: () => boolean;
+  getSetting: Editor['getParam'];
 }
 
 type UiFactoryBackstageForStyleButton = SelectData;
@@ -66,7 +67,8 @@ const init = (sink: AlloyComponent, editor: Editor, lazyAnchorbar: () => AlloyCo
         icons: () => editor.ui.registry.getAll().icons,
         menuItems: () => editor.ui.registry.getAll().menuItems,
         translate: I18n.translate,
-        isReadOnly: () => editor.mode.isReadOnly()
+        isReadOnly: () => editor.mode.isReadOnly(),
+        getSetting: editor.getParam.bind(editor) // This bind is important to ensure we don't lose reference to the editor in getParam
       },
       interpreter: (s) => UiFactory.interpretWithoutForm(s, backstage),
       anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -6,12 +6,15 @@
  */
 
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Button, Disabling, FormField as AlloyFormField, Memento, NativeEvents,
-  Representing, SimpleSpec, SimulatedEvent, SystemEvents, Tabstopping, Toggling
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Button, Disabling,
+  FormField as AlloyFormField, Memento, NativeEvents, Representing, SimpleSpec, SimulatedEvent,
+  SystemEvents, Tabstopping, Toggling
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr } from '@ephox/katamari';
+import { Arr, Strings } from '@ephox/katamari';
 import { EventArgs } from '@ephox/sugar';
+
+import Tools from 'tinymce/core/api/util/Tools';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
@@ -21,11 +24,13 @@ import { renderFormFieldWith, renderLabel } from '../alien/FieldLabeller';
 import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 import { formChangeEvent } from '../general/FormEvents';
 
-const extensionsAccepted = '.jpg,.jpeg,.png,.gif';
+const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jfif,png,gif,bmp,webp';
 
-const filterByExtension = function (files: FileList) {
-  const re = new RegExp('(' + extensionsAccepted.split(/\s*,\s*/).join('|') + ')$', 'i');
-  return Arr.filter(Arr.from(files), (file) => re.test(file.name));
+const filterByExtension = function (files: FileList, providersBackstage: UiFactoryBackstageProviders) {
+  const allowedImageFileTypes = Tools.explode(providersBackstage.getSetting('image_file_types', defaultImageFileTypes, 'string'));
+  const isFileInAllowedTypes = (file: File) => Arr.exists(allowedImageFileTypes, (type) => Strings.endsWith(file.name, `.${type}`));
+
+  return Arr.filter(Arr.from(files), isFileInAllowedTypes);
 };
 
 type DropZoneSpec = Omit<Dialog.DropZone, 'type'>;
@@ -57,7 +62,7 @@ export const renderDropZone = (spec: DropZoneSpec, providersBackstage: UiFactory
   };
 
   const handleFiles = (component, files: FileList) => {
-    Representing.setValue(component, filterByExtension(files));
+    Representing.setValue(component, filterByExtension(files, providersBackstage));
     AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name });
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -4,5 +4,6 @@ export default {
   icons: () => <Record<string, string>> {},
   menuItems: () => <Record<string, any>> {},
   translate: I18n.translate,
-  isReadOnly: () => false
+  isReadOnly: () => false,
+  getSetting: (_settingName: string, defaultVal: any) => defaultVal
 };

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
@@ -13,7 +13,8 @@ UnitTest.asynctest('AlertBanner component Test', (success, failure) => {
     },
     menuItems: () => <Record<string, any>> {},
     translate: I18n.translate,
-    isReadOnly: () => false
+    isReadOnly: () => false,
+    getSetting: (_settingName: string, defaultVal: any) => defaultVal
   };
 
   TestHelpers.GuiSetup.setup(

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/checkbox/BasicCheckboxTest.ts
@@ -14,7 +14,8 @@ UnitTest.asynctest('Checkbox component Test', (success, failure) => {
     },
     menuItems: () => <Record<string, any>> {},
     translate: I18n.translate,
-    isReadOnly: () => false
+    isReadOnly: () => false,
+    getSetting: (_settingName: string, defaultVal: any) => defaultVal
   };
 
   TestHelpers.GuiSetup.setup(

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/dropzone/DropzoneTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/dropzone/DropzoneTest.ts
@@ -42,8 +42,15 @@ UnitTest.asynctest('Dropzone component Test', (success, failure) => {
                 dataTransfer: {
                   files: [
                     { name: 'image1.png' },
-                    { name: 'image2.bmp' },
-                    { name: 'image3.jpg' }
+                    { name: 'image2.svg' },
+                    { name: 'image3.jpg' },
+                    { name: 'image4.jpeg' },
+                    { name: 'image5.jpe' },
+                    { name: 'image6.jfi' },
+                    { name: 'image7.jfif' },
+                    { name: 'image8.gif' },
+                    { name: 'image9.bmp' },
+                    { name: 'image10.webp' }
                   ]
                 }
               }
@@ -59,7 +66,14 @@ UnitTest.asynctest('Dropzone component Test', (success, failure) => {
         const filesValue = Representing.getValue(zone);
         Assertions.assertEq('Checking value of dropzone', [
           { name: 'image1.png' },
-          { name: 'image3.jpg' }
+          { name: 'image3.jpg' },
+          { name: 'image4.jpeg' },
+          { name: 'image5.jpe' },
+          { name: 'image6.jfi' },
+          { name: 'image7.jfif' },
+          { name: 'image8.gif' },
+          { name: 'image9.bmp' },
+          { name: 'image10.webp' }
         ], filesValue);
       })
     ],

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
@@ -85,7 +85,8 @@ UnitTest.asynctest('SilverDialog Event Test', (success, failure) => {
                 icons: () => <Record<string, string>> {},
                 menuItems: () => <Record<string, any>> {},
                 translate: I18n.translate,
-                isReadOnly: () => false
+                isReadOnly: () => false,
+                getSetting: (_settingName: string, defaultVal: any) => defaultVal
               }
             },
             dialog: {


### PR DESCRIPTION
Related Ticket: TINY-6224

**Description of Changes:**

NOTE: Future UX improvements detailed in TINY-6620_

Use `backstage` to provide `editor.getParam` as `editor.getSetting` through to `Dropzone.ts`.

Process files based on the setting, with the default setting the same as in `paste`.

**Pre-checks:**
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~~License headers added on new files (if applicable)~~

**Review:**
* [x] Milestone set
* [x] Review comments resolved

**GitHub issues (if applicable):**
Fixes #6034
