### PR TITLE
 TINY-4679: Empty tr elements should not be removed by the Schema

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -5,7 +5,7 @@ Version 5.6.0 (TBD)
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
     Added new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
     Changed `readonly` mode to allow hyperlinks to be clickable #TINY-6248
-    Fixed an issue where empty `tr` elements in a table were being removed, causing layout issues with tables using the `rowspan` attribute #TINY-4679
+    Fixed layout issues when empty `tr` elements were incorrectly removed from tables #TINY-4679
     Fixed a security issue where URLs in attributes weren't correctly sanitized #TINY-6518
     Fixed `DOMUtils.getParents` incorrectly including the shadow root in the array of elements returned #TINY-6540
     Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -5,6 +5,7 @@ Version 5.6.0 (TBD)
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
     Added new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
     Changed `readonly` mode to allow hyperlinks to be clickable #TINY-6248
+    Fixed an issue where empty `tr` elements in a table were being removed, causing layout issues with tables using the `rowspan` attribute #TINY-4679
     Fixed a security issue where URLs in attributes weren't correctly sanitized #TINY-6518
     Fixed `DOMUtils.getParents` incorrectly including the shadow root in the array of elements returned #TINY-6540
     Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -783,7 +783,7 @@ function Schema(settings?: SchemaSettings): Schema {
     // elements.img.attributesDefault = [{name: 'alt', value: ''}];
 
     // Remove these if they are empty by default
-    each(split('ol ul sub sup blockquote span font a table tbody tr strong em b i'), function (name) {
+    each(split('ol ul sub sup blockquote span font a table tbody strong em b i'), function (name) {
       if (elements[name]) {
         elements[name].removeEmpty = true;
       }

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -138,6 +138,10 @@ UnitTest.asynctest('browser.tinymce.core.html.SchemaTest', function (success, fa
 
     schema = Schema({ valid_elements: '#span' });
     LegacyUnit.deepEqual(schema.getElementRule('span'), { attributes: {}, attributesOrder: [], paddEmpty: true });
+
+    // Empty table rows should not be removed
+    schema = Schema();
+    LegacyUnit.equal(schema.getElementRule('tr').removeEmpty, undefined);
   });
 
   suite.test('addValidElements', function () {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
@@ -1,7 +1,6 @@
-import { Log, Pipeline, Step } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Log, Pipeline } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { Selectors, SugarElement } from '@ephox/sugar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
@@ -28,10 +27,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.EmptyRowTableTest', (success, 
             </table>
           </div>
         `),
-        Step.sync(() => {
-          const trs = Selectors.all('tr', SugarElement.fromDom(editor.getBody()));
-          Assert.eq('', 4, trs.length);
-        })
+        tinyApis.sAssertContentPresence({ tr: 4 })
       ])
     ], success, failure);
   }, {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
@@ -1,0 +1,49 @@
+import { Log, Pipeline, Step } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { Selectors, SugarElement } from '@ephox/sugar';
+
+import Plugin from 'tinymce/plugins/table/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('browser.tinymce.plugins.table.EmptyRowTableTest', (success, failure) => {
+  Theme();
+  Plugin();
+
+  TinyLoader.setupLight((editor, success, failure) => {
+    const tinyApis = TinyApis(editor);
+
+    Pipeline.async({}, [
+      Log.stepsAsStep('TINY-4679', 'Empty tr elements should not be removed', [
+        tinyApis.sSetContent(`
+          <div>
+            <table>
+              <colgroup>
+                <col>
+              </colgroup>
+              <tbody>
+                <tr>
+                  <td rowspan="2" >TR 1</td>
+                </tr>
+                <tr></tr>
+                <tr>
+                  <td>TR 3</td>
+                </tr>
+                <tr >
+                  <td >TR 4</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        `),
+        Step.sync(() => {
+          const trs = Selectors.all('tr', SugarElement.fromDom(editor.getBody()));
+          Assert.eq('', 4, trs.length);
+        })
+      ])
+    ], success, failure);
+  }, {
+    base_url: '/project/tinymce/js/tinymce',
+    plugins: 'table'
+  }, success, failure);
+});

--- a/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
@@ -18,20 +18,12 @@ UnitTest.asynctest('browser.tinymce.plugins.table.EmptyRowTableTest', (success, 
         tinyApis.sSetContent(`
           <div>
             <table>
-              <colgroup>
-                <col>
-              </colgroup>
+              <colgroup><col></colgroup>
               <tbody>
-                <tr>
-                  <td rowspan="2" >TR 1</td>
-                </tr>
+                <tr><td rowspan="2" >TR 1</td></tr>
                 <tr></tr>
-                <tr>
-                  <td>TR 3</td>
-                </tr>
-                <tr >
-                  <td >TR 4</td>
-                </tr>
+                <tr><td>TR 3</td></tr>
+                <tr><td >TR 4</td></tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
**Related Ticket:** TINY-4679

**Description of Changes:**

Empty `tr` elements are considered valid and should not be removed.

Explicit test added with use case (`rowspan="2"`) to prevent regression.

**Pre-checks:**
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~~License headers added on new files (if applicable)~~

**Review:**
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
