### PR TITLE
TINY-6601: Fixed resizing a `responsive` table not working when using the column resize handles

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -19,6 +19,7 @@ Version 5.6.0 (TBD)
     Fixed a regression whereby a fake offscreen selection element was incorrectly created for the editor root node #TINY-6555
     Fixed an issue where menus would incorrectly collapse in small containers #TINY-3321
     Fixed some minor memory leaks that prevented garbage collection for editor instances #TINY-6570
+    Fixed resizing a `responsive` table not working when using the column resize handles #TINY-6601
     Fixed an issue where spaces were not preserved in pre-blocks when getting text content #TINY-6448
 Version 5.5.1 (2020-10-01)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -22,6 +22,8 @@ export interface ResizeHandler {
   destroy: () => void;
 }
 
+const barResizerPrefix = 'bar-';
+
 export const getResizeHandler = function (editor: Editor): ResizeHandler {
   let selectionRng = Optional.none<Range>();
   let resize = Optional.none<TableResize>();
@@ -51,6 +53,12 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
     // Origin will tell us which handle was clicked, eg corner-se or corner-nw
     // so check to see if it ends with `e` (eg east edge)
     const isRightEdgeResize = Strings.endsWith(origin, 'e');
+
+    // Responsive tables don't have a width so we need to convert it to a relative/percent
+    // table instead, as that's closer to responsive sizing than fixed sizing
+    if (startRawW === '') {
+      enforcePercentage(editor, table);
+    }
 
     // Adjust the column sizes and update the table width to use the right sizing, if the table changed size.
     // This is needed as core will always use pixels when setting the width.
@@ -101,7 +109,7 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
 
       sz.events.beforeResize.bind(function (event) {
         const rawTable = event.table.dom;
-        Events.fireObjectResizeStart(editor, rawTable, Util.getPixelWidth(rawTable), Util.getPixelHeight(rawTable), 'bar-' + event.type);
+        Events.fireObjectResizeStart(editor, rawTable, Util.getPixelWidth(rawTable), Util.getPixelHeight(rawTable), barResizerPrefix + event.type);
       });
 
       sz.events.afterResize.bind(function (event) {
@@ -114,7 +122,7 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
           editor.focus();
         });
 
-        Events.fireObjectResized(editor, rawTable, Util.getPixelWidth(rawTable), Util.getPixelHeight(rawTable), 'bar-' + event.type);
+        Events.fireObjectResized(editor, rawTable, Util.getPixelWidth(rawTable), Util.getPixelHeight(rawTable), barResizerPrefix + event.type);
         editor.undoManager.add();
       });
 
@@ -139,6 +147,12 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
         enforcePercentage(editor, table);
       }
 
+      // TINY-6601: If resizing using a bar, then snooker will base the resizing on the initial size. So
+      // when using a responsive table we need to ensure we convert to a relative table before resizing
+      if (Sizes.isNoneSizing(table) && Strings.startsWith(e.origin, barResizerPrefix)) {
+        enforcePercentage(editor, table);
+      }
+
       startW = e.width;
       startRawW = Settings.isResponsiveForced(editor) ? '' : Util.getRawWidth(editor, targetElm).getOr('');
     }
@@ -148,12 +162,6 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
     const targetElm = e.target;
     if (isTable(targetElm)) {
       const table = SugarElement.fromDom(targetElm);
-
-      // Responsive tables don't have a width so we need to convert it to a relative/percent
-      // table instead, as that's closer to responsive sizing than fixed sizing
-      if (startRawW === '') {
-        enforcePercentage(editor, table);
-      }
 
       // Resize based on the snooker logic to adjust the individual col/rows if resized from a corner
       const origin = e.origin;

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
@@ -386,6 +386,30 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
 
       NamedChain.read('editor', McEditor.cRemove)
+    ]),
+
+    Log.chainsAsStep('TINY-6601', 'Test [table_column_resizing="resizetable"] with colgroup, adjusting an inner column should change the table width', [
+      NamedChain.write('editor', McEditor.cFromSettings({
+        plugins: 'table',
+        width: 400,
+        theme: 'silver',
+        base_url: '/project/tinymce/js/tinymce',
+        table_toolbar: '',
+        table_column_resizing: 'resizetable',
+        table_use_colgroups: true,
+        table_sizing_mode: 'responsive'
+      })),
+
+      cClearResizeEventData,
+      NamedChain.read('editor', ApiChains.cSetContent('')),
+      NamedChain.direct('editor', cInsertResizeMeasure(TableTestUtils.cDragResizeBar('column', 0, 100, 0), TableTestUtils.cInsertTable(2, 2)), 'widths'),
+      NamedChain.read('widths', cAssertUnitBeforeResize(null)),
+      NamedChain.read('widths', cAssertUnitAfterResize('%')),
+      NamedChain.read('widths', cAssertWidthAfterResize(35, true)),
+      cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
+      cAssertEventData(lastObjectResizedEvent, 'objectresized'),
+
+      NamedChain.read('editor', McEditor.cRemove)
     ])
   ], success, failure, TestLogs.init());
 });


### PR DESCRIPTION
Related Ticket: TINY-6601

Description of Changes:
* When using the resize bars on a `responsive` table, because they work using Snooker's logic, the table needs to be converted to a `relative` table when the resize starts. Without this, it calculates all the table widths as 0 and as such doesn't make any changes during the initial resize.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
