### PR TITLE
TINY-6626: Components rendered after ui has been disabled should be disabled

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,7 +1,7 @@
 Version 5.6.0 (TBD)
     Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste when using the `paste` plugin #TINY-6306
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
-    Added new user interface `enable`, `disable` and `isDisabled` methods #TINY-6397
+    Added new user interface `enable`, `disable`, and `isDisabled` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
     Added new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
     Changed `readonly` mode to allow hyperlinks to be clickable #TINY-6248

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,7 +1,7 @@
 Version 5.6.0 (TBD)
     Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste when using the `paste` plugin #TINY-6306
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
-    Added new user interface `enable` and `disable` methods #TINY-6397
+    Added new user interface `enable`, `disable` and `isDisabled` methods #TINY-6397
     Added new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
     Added new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
     Changed `readonly` mode to allow hyperlinks to be clickable #TINY-6248

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -332,7 +332,8 @@ class Editor implements EditorObservable {
       show: Fun.noop,
       hide: Fun.noop,
       enable: Fun.noop,
-      disable: Fun.noop
+      disable: Fun.noop,
+      isDisabled: Fun.never
     };
 
     const self = this;

--- a/modules/tinymce/src/core/main/ts/api/ui/Ui.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Ui.ts
@@ -18,6 +18,7 @@ export interface EditorUiApi {
   hide: () => void;
   enable: () => void;
   disable: () => void;
+  isDisabled: () => boolean;
 }
 
 export interface EditorUi extends EditorUiApi {

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -162,6 +162,7 @@ const augmentEditorUiApi = (editor: Editor, api: Partial<EditorUiApi>) => {
     show: Optional.from(api.show).getOr(Fun.noop),
     hide: Optional.from(api.hide).getOr(Fun.noop),
     disable: Optional.from(api.disable).getOr(Fun.noop),
+    isDisabled: Optional.from(api.isDisabled).getOr(Fun.never),
     enable: () => {
       if (!editor.mode.isReadOnly()) {
         Optional.from(api.enable).map(Fun.call);

--- a/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
@@ -104,7 +104,7 @@ const setupDemo = () => {
         icons: () => <Record<string, string>> {},
         menuItems: () => <Record<string, any>> {},
         translate: I18n.translate,
-        isReadOnly: () => false
+        isDisabled: () => false
       },
       interpreter: (x) => x,
       getSink: () => Result.value(sink),

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -5,13 +5,14 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Gui, GuiFactory, Keying, Memento, Positioning, SimpleSpec, SystemEvents, VerticalDir } from '@ephox/alloy';
+import { AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Disabling, Gui, GuiFactory, Keying, Memento, Positioning, SimpleSpec, SystemEvents, VerticalDir } from '@ephox/alloy';
 import { Arr, Obj, Optional, Result } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Css } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
+import * as ReadOnly from './ReadOnly';
 import * as Settings from './api/Settings';
 import * as Backstage from './backstage/Backstage';
 import * as ContextToolbar from './ContextToolbar';
@@ -310,6 +311,10 @@ const setup = (editor: Editor): RenderInfo => {
       },
       components: containerComponents,
       behaviours: Behaviour.derive([
+        ReadOnly.receivingConfig(),
+        Disabling.config({
+          disableClass: 'tox-tinymce--disabled'
+        }),
         Keying.config({
           mode: 'cyclic',
           selector: '.tox-menubar, .tox-toolbar, .tox-toolbar__primary, .tox-toolbar__overflow--open, .tox-sidebar__overflow--open, .tox-statusbar__path, .tox-statusbar__wordcount, .tox-statusbar__branding a'

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -66,7 +66,7 @@ const init = (sink: AlloyComponent, editor: Editor, lazyAnchorbar: () => AlloyCo
         icons: () => editor.ui.registry.getAll().icons,
         menuItems: () => editor.ui.registry.getAll().menuItems,
         translate: I18n.translate,
-        isReadOnly: () => editor.mode.isReadOnly()
+        isReadOnly: () => editor.mode.isReadOnly() || editor.ui.isDisabled()
       },
       interpreter: (s) => UiFactory.interpretWithoutForm(s, backstage),
       anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -28,7 +28,7 @@ export interface UiFactoryBackstageProviders {
   icons: IconProvider;
   menuItems: () => Record<string, Menu.MenuItemSpec | Menu.NestedMenuItemSpec | Menu.ToggleMenuItemSpec>;
   translate: (any) => TranslatedString;
-  isReadOnly: () => boolean;
+  isDisabled: () => boolean;
 }
 
 type UiFactoryBackstageForStyleButton = SelectData;
@@ -66,7 +66,7 @@ const init = (sink: AlloyComponent, editor: Editor, lazyAnchorbar: () => AlloyCo
         icons: () => editor.ui.registry.getAll().icons,
         menuItems: () => editor.ui.registry.getAll().menuItems,
         translate: I18n.translate,
-        isReadOnly: () => editor.mode.isReadOnly() || editor.ui.isDisabled()
+        isDisabled: () => editor.mode.isReadOnly() || editor.ui.isDisabled()
       },
       interpreter: (s) => UiFactory.interpretWithoutForm(s, backstage),
       anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Attachment } from '@ephox/alloy';
+import { Attachment, Disabling } from '@ephox/alloy';
 import { Cell, Throttler } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Css, DomEvent, SugarElement, SugarPosition, SugarShadowDom } from '@ephox/sugar';
@@ -158,7 +158,8 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     },
     disable: () => {
       ReadOnly.broadcastReadonly(uiComponents, true);
-    }
+    },
+    isDisabled: () => Disabling.isDisabled(outerContainer)
   };
 
   return {

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, Attachment, Boxes } from '@ephox/alloy';
+import { AlloyComponent, Attachment, Boxes, Disabling } from '@ephox/alloy';
 import { Cell, Singleton } from '@ephox/katamari';
 import { DomEvent, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
@@ -140,7 +140,8 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     },
     disable: () => {
       ReadOnly.broadcastReadonly(uiComponents, true);
-    }
+    },
+    isDisabled: () => Disabling.isDisabled(outerContainer)
   };
 
   return {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
@@ -61,8 +61,8 @@ export const renderCollection = (spec: CollectionSpec, providersBackstage: UiFac
       // But if only the title attribute is used instead, the names are read out twice. i.e., the description followed by the item.text.
       const ariaLabel = itemText.replace(/\_| \- |\-/g, (match) => mapItemName[match]);
 
-      const readonlyClass = providersBackstage.isReadOnly() ? ' tox-collection__item--state-disabled' : '';
-      return `<div class="tox-collection__item${readonlyClass}" tabindex="-1" data-collection-item-value="${escapeAttribute(item.value)}" title="${ariaLabel}" aria-label="${ariaLabel}">${iconContent}${textContent}</div>`;
+      const disabledClass = providersBackstage.isDisabled() ? ' tox-collection__item--state-disabled' : '';
+      return `<div class="tox-collection__item${disabledClass}" tabindex="-1" data-collection-item-value="${escapeAttribute(item.value)}" title="${ariaLabel}" aria-label="${ariaLabel}">${iconContent}${textContent}</div>`;
     });
 
     const chunks = spec.columns !== 'auto' && spec.columns > 1 ? Arr.chunk(htmlLines, spec.columns) : [ htmlLines ];
@@ -73,7 +73,7 @@ export const renderCollection = (spec: CollectionSpec, providersBackstage: UiFac
 
   const onClick = runOnItem((comp, se, tgt, itemValue) => {
     se.stop();
-    if (!providersBackstage.isReadOnly()) {
+    if (!providersBackstage.isDisabled()) {
       AlloyTriggers.emitWith(comp, formActionEvent, {
         name: spec.name,
         value: itemValue
@@ -118,7 +118,7 @@ export const renderCollection = (spec: CollectionSpec, providersBackstage: UiFac
     factory: { sketch: Fun.identity },
     behaviours: Behaviour.derive([
       Disabling.config({
-        disabled: providersBackstage.isReadOnly,
+        disabled: providersBackstage.isDisabled,
         onDisabled: (comp) => {
           iterCollectionItems(comp, (childElm) => {
             Class.add(childElm, 'tox-collection__item--state-disabled');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
@@ -49,7 +49,7 @@ export const renderColorInput = (spec: ColorInputSpec, sharedBackstage: UiFactor
 
     inputBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: sharedBackstage.providers.isReadOnly
+        disabled: sharedBackstage.providers.isDisabled
       }),
       ReadOnly.receivingConfig(),
       Tabstopping.config({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -136,7 +136,7 @@ export const renderDropZone = (spec: DropZoneSpec, providersBackstage: UiFactory
             },
             buttonBehaviours: Behaviour.derive([
               Tabstopping.config({ }),
-              DisablingConfigs.button(providersBackstage.isReadOnly),
+              DisablingConfigs.button(providersBackstage.isDisabled),
               ReadOnly.receivingConfig()
             ])
           })

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
@@ -38,7 +38,7 @@ export const renderSelectBox = (spec: SelectBoxSpec, providersBackstage: UiFacto
     factory: AlloyHtmlSelect,
     selectBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: () => spec.disabled || providersBackstage.isReadOnly()
+        disabled: () => spec.disabled || providersBackstage.isDisabled()
       }),
       Tabstopping.config({ }),
       AddEventsBehaviour.config('selectbox-change', [
@@ -74,7 +74,7 @@ export const renderSelectBox = (spec: SelectBoxSpec, providersBackstage: UiFacto
     components: Arr.flatten<AlloySpec>([ pLabel.toArray(), [ selectWrap ]]),
     fieldBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: () => spec.disabled || providersBackstage.isReadOnly(),
+        disabled: () => spec.disabled || providersBackstage.isDisabled(),
         onDisabled: (comp) => {
           AlloyFormField.getField(comp).each(Disabling.disable);
         },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -55,7 +55,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     ],
     buttonBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: () => spec.disabled || providersBackstage.isReadOnly()
+        disabled: () => spec.disabled || providersBackstage.isDisabled()
       }),
       ReadOnly.receivingConfig(),
       Tabstopping.config({})
@@ -75,7 +75,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     inputClasses: [ 'tox-textfield' ],
     inputBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: () => spec.disabled || providersBackstage.isReadOnly()
+        disabled: () => spec.disabled || providersBackstage.isDisabled()
       }),
       ReadOnly.receivingConfig(),
       Tabstopping.config({}),
@@ -145,7 +145,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     },
     coupledFieldBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: () => spec.disabled || providersBackstage.isReadOnly(),
+        disabled: () => spec.disabled || providersBackstage.isDisabled(),
         onDisabled: (comp) => {
           AlloyFormCoupledInputs.getField1(comp).bind(AlloyFormField.getField).each(Disabling.disable);
           AlloyFormCoupledInputs.getField2(comp).bind(AlloyFormField.getField).each(Disabling.disable);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -23,7 +23,7 @@ const renderTextField = function (spec: TextField, providersBackstage: UiFactory
 
   const baseInputBehaviours = [
     Disabling.config({
-      disabled: () => spec.disabled || providersBackstage.isReadOnly()
+      disabled: () => spec.disabled || providersBackstage.isDisabled()
     }),
     ReadOnly.receivingConfig(),
     Keying.config({
@@ -88,7 +88,7 @@ const renderTextField = function (spec: TextField, providersBackstage: UiFactory
 
   const extraBehaviours = [
     Disabling.config({
-      disabled: () => spec.disabled || providersBackstage.isReadOnly(),
+      disabled: () => spec.disabled || providersBackstage.isDisabled(),
       onDisabled: (comp) => {
         AlloyFormField.getField(comp).each(Disabling.disable);
       },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -119,7 +119,7 @@ export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage
       ).toArray(),
       [
         Disabling.config({
-          disabled: () => spec.disabled || providersBackstage.isReadOnly()
+          disabled: () => spec.disabled || providersBackstage.isDisabled()
         }),
         Tabstopping.config({}),
         AddEventsBehaviour.config('urlinput-events', Arr.flatten([
@@ -215,7 +215,7 @@ export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage
       components: [ pField, memStatus.asSpec() ],
       behaviours: Behaviour.derive([
         Disabling.config({
-          disabled: () => spec.disabled || providersBackstage.isReadOnly()
+          disabled: () => spec.disabled || providersBackstage.isDisabled()
         })
       ])
     }
@@ -264,7 +264,7 @@ export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage
     ]),
     fieldBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: () => spec.disabled || providersBackstage.isReadOnly(),
+        disabled: () => spec.disabled || providersBackstage.isDisabled(),
         onDisabled: (comp) => {
           AlloyFormField.getField(comp).each(Disabling.disable);
           memUrlPickerButton.getOpt(comp).each(Disabling.disable);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -130,7 +130,7 @@ const renderCommonDropdown = <T>(
       // TODO: Not quite working. Can still get the button focused.
       dropdownBehaviours: Behaviour.derive([
         ...spec.dropdownBehaviours,
-        DisablingConfigs.button(() => spec.disabled || sharedBackstage.providers.isReadOnly()),
+        DisablingConfigs.button(() => spec.disabled || sharedBackstage.providers.isDisabled()),
         ReadOnly.receivingConfig(),
         Unselecting.config({ }),
         Replacing.config({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -38,7 +38,7 @@ const renderCommonSpec = (spec, actionOpt: Optional<(comp: AlloyComponent) => vo
 
   const common = {
     buttonBehaviours: Behaviour.derive([
-      DisablingConfigs.button(() => spec.disabled || providersBackstage.isReadOnly()),
+      DisablingConfigs.button(() => spec.disabled || providersBackstage.isDisabled()),
       ReadOnly.receivingConfig(),
       Tabstopping.config({}),
       AddEventsBehaviour.config('button press', [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -53,7 +53,7 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
     behaviours: Behaviour.derive([
       ComposingConfigs.self(),
       Disabling.config({
-        disabled: () => spec.disabled || providerBackstage.isReadOnly()
+        disabled: () => spec.disabled || providerBackstage.isDisabled()
       }),
       Tabstopping.config({}),
       Focusing.config({ }),
@@ -119,7 +119,7 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
     ],
     fieldBehaviours: Behaviour.derive([
       Disabling.config({
-        disabled: () => spec.disabled || providerBackstage.isReadOnly(),
+        disabled: () => spec.disabled || providerBackstage.isDisabled(),
         disableClass: 'tox-checkbox--disabled',
         onDisabled: (comp) => {
           AlloyFormField.getField(comp).each(Disabling.disable);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
@@ -38,7 +38,7 @@ export const renderPanelButton = (spec: SwatchPanelButtonSpec, sharedBackstage: 
   toggleClass: 'mce-active',
 
   dropdownBehaviours: Behaviour.derive([
-    DisablingConfigs.button(sharedBackstage.providers.isReadOnly),
+    DisablingConfigs.button(sharedBackstage.providers.isDisabled),
     ReadOnly.receivingConfig(),
     Unselecting.config({}),
     Tabstopping.config({})

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
@@ -48,7 +48,7 @@ const renderCommonItem = <T>(spec: CommonMenuItemSpec<T>, structure: ItemStructu
           onControlAttached(spec, editorOffCell),
           onControlDetached(spec, editorOffCell)
         ]),
-        DisablingConfigs.item(() => spec.disabled || providersbackstage.isReadOnly()),
+        DisablingConfigs.item(() => spec.disabled || providersbackstage.isDisabled()),
         ReadOnly.receivingConfig(),
         Replacing.config({ })
       ].concat(spec.itemBehaviours)
@@ -75,7 +75,7 @@ const renderCommonChoice = (spec: CommonCollectionItemSpec, structure: ItemStruc
       AddEventsBehaviour.config('item-events', [
         AlloyEvents.run(NativeEvents.mouseover(), Focusing.focus)
       ]),
-      DisablingConfigs.item(() => spec.disabled || providersbackstage.isReadOnly()),
+      DisablingConfigs.item(() => spec.disabled || providersbackstage.isDisabled()),
       ReadOnly.receivingConfig()
     ]
   ),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
@@ -52,7 +52,7 @@ const renderElementPath = (editor: Editor, settings, providersBackstage: UiFacto
         editor.nodeChanged();
       },
       buttonBehaviours: Behaviour.derive([
-        DisablingConfigs.button(providersBackstage.isReadOnly),
+        DisablingConfigs.button(providersBackstage.isDisabled),
         ReadOnly.receivingConfig()
       ])
     }));
@@ -115,7 +115,7 @@ const renderElementPath = (editor: Editor, settings, providersBackstage: UiFacto
         selector: 'div[role=button]'
       }),
       Disabling.config({
-        disabled: providersBackstage.isReadOnly
+        disabled: providersBackstage.isDisabled
       }),
       ReadOnly.receivingConfig(),
       Tabstopping.config({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
@@ -30,7 +30,7 @@ export const renderWordCount = (editor: Editor, providersBackstage: UiFactoryBac
     },
     components: [ ],
     buttonBehaviours: Behaviour.derive([
-      DisablingConfigs.button(providersBackstage.isReadOnly),
+      DisablingConfigs.button(providersBackstage.isDisabled),
       ReadOnly.receivingConfig(),
       Tabstopping.config({ }),
       Replacing.config({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -82,7 +82,7 @@ const getToolbarbehaviours = (toolbarSpec: ToolbarSpec, modeName) => {
   });
 
   return Behaviour.derive([
-    DisablingConfigs.toolbarButton(toolbarSpec.providers.isReadOnly),
+    DisablingConfigs.toolbarButton(toolbarSpec.providers.isDisabled),
     ReadOnly.receivingConfig(),
     Keying.config({
       // Tabs between groups

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -123,7 +123,7 @@ const renderCommonStructure = (
 
     buttonBehaviours: Behaviour.derive(
       [
-        DisablingConfigs.toolbarButton(providersBackstage.isReadOnly),
+        DisablingConfigs.toolbarButton(providersBackstage.isDisabled),
         ReadOnly.receivingConfig(),
         AddEventsBehaviour.config('common-button-display-events', [
           AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousedown(), (button, se) => {
@@ -187,7 +187,7 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
           onControlAttached(specialisation, editorOffCell),
           onControlDetached(specialisation, editorOffCell)
         ]),
-        DisablingConfigs.toolbarButton(() => spec.disabled || providersBackstage.isReadOnly()),
+        DisablingConfigs.toolbarButton(() => spec.disabled || providersBackstage.isDisabled()),
         ReadOnly.receivingConfig()
       ].concat(specialisation.toolbarButtonBehaviours)
     )
@@ -308,7 +308,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
     onItemExecute: (_a, _b, _c) => { },
 
     splitDropdownBehaviours: Behaviour.derive([
-      DisablingConfigs.splitButton(sharedBackstage.providers.isReadOnly),
+      DisablingConfigs.splitButton(sharedBackstage.providers.isDisabled),
       ReadOnly.receivingConfig(),
       AddEventsBehaviour.config('split-dropdown-events', [
         AlloyEvents.run(focusButtonEvent, Focusing.focus),
@@ -344,7 +344,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
           innerHtml: Icons.get('chevron-down', sharedBackstage.providers.icons)
         },
         buttonBehaviours: Behaviour.derive([
-          DisablingConfigs.splitButton(sharedBackstage.providers.isReadOnly),
+          DisablingConfigs.splitButton(sharedBackstage.providers.isDisabled),
           ReadOnly.receivingConfig()
         ])
       }),

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/DisableTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/DisableTest.ts
@@ -1,44 +1,60 @@
 import { ApproxStructure, Assertions, Chain, GeneralSteps, Guard, Log, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyLoader } from '@ephox/mcagar';
-import { SugarBody } from '@ephox/sugar';
+import { SugarBody, SugarElement } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
 UnitTest.asynctest('browser.tinymce.themes.silver.editor.DisableTest', (success, failure) => {
   Theme();
 
   TinyLoader.setup(
-    (editor, onSuccess, onFailure) => {
-      const sAssertToolbarState = (label: string, disabled: boolean) => Chain.asStep(SugarBody.body(), [
-        UiFinder.cFindIn('.tox-toolbar-overlord'),
-        Chain.control(
-          Assertions.cAssertStructure(label, ApproxStructure.build((s, str, arr) =>
-            s.element('div', {
-              classes: [
-                arr.has('tox-toolbar-overlord'),
-                disabled ? arr.has('tox-tbtn--disabled') : arr.not('tox-tbtn--disabled')
-              ],
-              attrs: { 'aria-disabled': str.is(disabled + '') }
-            })
-          )),
-          Guard.tryUntil('Waiting for toolbar state')
-        )
-      ]);
+    (editor: Editor, onSuccess, onFailure) => {
+
+      const sAssertUiDisabled = (label: string, disabled: boolean) => Step.label(label, GeneralSteps.sequence([
+        Chain.asStep(SugarBody.body(), [
+          UiFinder.cFindIn('.tox-toolbar-overlord'),
+          Chain.control(
+            Assertions.cAssertStructure('Toolbar should be in correct disabled state', ApproxStructure.build((s, str, arr) =>
+              s.element('div', {
+                classes: [
+                  arr.has('tox-toolbar-overlord'),
+                  disabled ? arr.has('tox-tbtn--disabled') : arr.not('tox-tbtn--disabled')
+                ],
+                attrs: { 'aria-disabled': str.is(disabled ? 'true' : 'false') }
+              })
+            )),
+            Guard.tryUntil('Waiting for toolbar state')
+          )
+        ]),
+        Step.sync(() => {
+          Assertions.assertStructure(
+            'Editor container should have disabled class if disabled',
+            ApproxStructure.build((s, str, arr) => s.element('div', {
+              classes: [ arr.has('tox-tinymce') ].concat(disabled ? [ arr.has('tox-tinymce--disabled') ] : [])
+            })),
+            SugarElement.fromDom(editor.editorContainer)
+          );
+        }),
+        Step.sync(() => {
+          Assertions.assertEq('Editor isDisabled should return current disabled state', disabled, editor.ui.isDisabled());
+        })
+      ]));
 
       Pipeline.async({ }, [
         Log.stepsAsStep('TINY-6397', 'Test disable/enable APIs', [
           Step.label('Should be able to enable and disable the UI', GeneralSteps.sequence([
             Step.sync(() => editor.ui.disable()),
-            sAssertToolbarState('Toolbar should be disabled', true),
+            sAssertUiDisabled('Editor UI should be disabled', true),
             Step.sync(() => editor.ui.enable()),
-            sAssertToolbarState('Toolbar should be enabled', false)
+            sAssertUiDisabled('Editor UI should be enabled', false)
           ])),
 
           Step.label('Should not be able to enable the UI when in readonly mode', GeneralSteps.sequence([
             Step.sync(() => editor.mode.set('readonly')),
-            sAssertToolbarState('Sanity check, toolbar should be disabled since editor is in readonly mode', true),
+            sAssertUiDisabled('Sanity check, should be disabled since editor is in readonly mode', true),
             Step.sync(() => editor.ui.enable()),
-            sAssertToolbarState('Toolbar should remain disabled since editor is in readonly mode', true),
+            sAssertUiDisabled('Should remain disabled since editor is in readonly mode', true),
             Step.sync(() => editor.mode.set('design'))
           ]))
         ])

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -4,5 +4,5 @@ export default {
   icons: () => <Record<string, string>> {},
   menuItems: () => <Record<string, any>> {},
   translate: I18n.translate,
-  isReadOnly: () => false
+  isDisabled: () => false
 };

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
@@ -13,7 +13,7 @@ UnitTest.asynctest('AlertBanner component Test', (success, failure) => {
     },
     menuItems: () => <Record<string, any>> {},
     translate: I18n.translate,
-    isReadOnly: () => false
+    isDisabled: () => false
   };
 
   TestHelpers.GuiSetup.setup(

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/checkbox/BasicCheckboxTest.ts
@@ -14,7 +14,7 @@ UnitTest.asynctest('Checkbox component Test', (success, failure) => {
     },
     menuItems: () => <Record<string, any>> {},
     translate: I18n.translate,
-    isReadOnly: () => false
+    isDisabled: () => false
   };
 
   TestHelpers.GuiSetup.setup(

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
@@ -85,7 +85,7 @@ UnitTest.asynctest('SilverDialog Event Test', (success, failure) => {
                 icons: () => <Record<string, string>> {},
                 menuItems: () => <Record<string, any>> {},
                 translate: I18n.translate,
-                isReadOnly: () => false
+                isDisabled: () => false
               }
             },
             dialog: {

--- a/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
+++ b/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
@@ -55,12 +55,12 @@
  */
 
 /**
- * Returns true/false if the editor user interface is disabled or not.
+ * Determines if the editor user interface is `disabled` (`true`) or not (`false`).
  * <br>
  * <em>Added in TinyMCE 5.6</em>
  *
  * @method tinymce.editor.ui.isDisabled
- * @return {Boolean} true/false if the editor user interface is disabled or not.
+ * @return {Boolean} true/false if the editor user interface is `disabled` (`true`) or not (`false`).
  */
 
 /**

--- a/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
+++ b/modules/tinymce/tools/docs/tinymce.editor.ui.Ui.js
@@ -55,6 +55,15 @@
  */
 
 /**
+ * Returns true/false if the editor user interface is disabled or not.
+ * <br>
+ * <em>Added in TinyMCE 5.6</em>
+ *
+ * @method tinymce.editor.ui.isDisabled
+ * @return {Boolean} true/false if the editor user interface is disabled or not.
+ */
+
+/**
  * Editor UI stylesheet loader instance. StyleSheetLoader for styles in the editor UI. For content styles, use editor.dom.styleSheetLoader.
  * <br>
  * <em>Added in TinyMCE 5.4</em>


### PR DESCRIPTION
Related Ticket: [TINY-6626](https://ephocks.atlassian.net/browse/TINY-6626)

Description of Changes:
* TINY-6626: Add isDisabled method and fix components not rendering into disabled state
* TINY-6626: Rename UiBackstage isReadOnly to isDisabled
_(Renamed because it's not restriced to ReadOnly anymore and I think isDisabled captures the concept well since it's part of the Ui backstage. Open for suggestions)_

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
