### PR TITLE
TINY-6648: Expand types for entity encoding

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -8,7 +8,7 @@ Version 5.6.0 (TBD)
     Added new `emoticons_database` setting to configure which emoji database to use #TINY-6021
     Added new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
     Changed `readonly` mode to allow hyperlinks to be clickable #TINY-6248
-    Fixed type signature for `entity_encoding` setting not accepting delimited lists #TINY-6648
+    Fixed the type signature for the `entity_encoding` setting not accepting delimited lists #TINY-6648
     Fixed layout issues when empty `tr` elements were incorrectly removed from tables #TINY-4679
     Fixed a security issue where URLs in attributes weren't correctly sanitized #TINY-6518
     Fixed `DOMUtils.getParents` incorrectly including the shadow root in the array of elements returned #TINY-6540

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -8,6 +8,7 @@ Version 5.6.0 (TBD)
     Added new `emoticons_database` setting to configure which emoji database to use #TINY-6021
     Added new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
     Changed `readonly` mode to allow hyperlinks to be clickable #TINY-6248
+    Fixed type signature for `entity_encoding` setting not accepting delimited lists #TINY-6648
     Fixed layout issues when empty `tr` elements were incorrectly removed from tables #TINY-4679
     Fixed a security issue where URLs in attributes weren't correctly sanitized #TINY-6518
     Fixed `DOMUtils.getParents` incorrectly including the shadow root in the array of elements returned #TINY-6540

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -12,7 +12,8 @@ import { AllowedFormat } from './fmt/StyleFormat';
 import { SchemaType } from './html/Schema';
 import { EditorUiApi } from './ui/Ui';
 
-export type EntityEncoding = 'named' | 'numeric' | 'raw';
+// Can take a list of named / numeric / raw values, delimited by '+' or ','
+export type EntityEncoding = 'named' | 'numeric' | 'raw' | string;
 
 export type ThemeInitFunc = (editor: Editor, elm: HTMLElement) => {
   editorContainer: HTMLElement;

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -12,8 +12,7 @@ import { AllowedFormat } from './fmt/StyleFormat';
 import { SchemaType } from './html/Schema';
 import { EditorUiApi } from './ui/Ui';
 
-// Can take a list of named / numeric / raw values, delimited by '+' or ','
-export type EntityEncoding = 'named' | 'numeric' | 'raw' | string;
+export type EntityEncoding = 'named' | 'numeric' | 'raw' | 'named,numeric' | 'named+numeric' | 'numeric,named' | 'numeric+named';
 
 export type ThemeInitFunc = (editor: Editor, elm: HTMLElement) => {
   editorContainer: HTMLElement;

--- a/modules/tinymce/src/core/main/ts/api/html/Writer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Writer.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { EntityEncoding } from '../SettingsTypes';
 import Tools from '../util/Tools';
 import Entities from './Entities';
 import { Attributes } from './Node';
@@ -27,7 +28,7 @@ const makeMap = Tools.makeMap;
 export interface WriterSettings {
   element_format?: 'xhtml' | 'html';
   entities?: string;
-  entity_encoding?: string;
+  entity_encoding?: EntityEncoding;
   indent?: boolean;
   indent_after?: string;
   indent_before?: string;


### PR DESCRIPTION
Related Ticket: TINY-6648

Description of Changes:
* The entity_encoding setting type was incorrect, and overly restrictive. While it would be nice to fix this properly with TypeScript's new template types, for now I've just widened it to accept any string.

Pre-checks:
* [x] Changelog entry added
* ~[ ] Tests have been added (if applicable)~
* ~[ ] Branch prefixed with `feature/` for new features (if applicable)~
* ~[ ] License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
