### PR TITLE
TINY-6646: Fixed incorrectly calculating col widths when resizing tables

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
@@ -53,7 +53,7 @@ const redistribute = (table: SugarElement, optWidth: Optional<string>, optHeight
   optWidth.each((newWidth) => {
     const widthUnit = getUnit(newWidth);
     const totalWidth = Width.get(table);
-    const oldWidths = ColumnSizes.getRawWidths(warehouse, tableSize);
+    const oldWidths = ColumnSizes.getRawWidths(warehouse, table, tableSize);
     const nuWidths = Redistribution.redistribute(oldWidths, totalWidth, newWidth);
 
     if (Warehouse.hasColumns(warehouse)) {
@@ -68,7 +68,7 @@ const redistribute = (table: SugarElement, optWidth: Optional<string>, optHeight
   optHeight.each((newHeight) => {
     const hUnit = getUnit(newHeight);
     const totalHeight = Height.get(table);
-    const oldHeights = ColumnSizes.getRawHeights(warehouse, BarPositions.height);
+    const oldHeights = ColumnSizes.getRawHeights(warehouse, table, BarPositions.height);
     const nuHeights = Redistribution.redistribute(oldHeights, totalHeight, newHeight);
     redistributeToH(nuHeights, rows, cells, hUnit);
     Css.set(table, 'height', newHeight);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableSize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableSize.ts
@@ -22,12 +22,15 @@ const noneSize = (table: SugarElement<HTMLTableElement>): TableSize => {
   const getWidth = () => Width.get(table);
   const zero = Fun.constant(0);
 
+  const getWidths = (warehouse: Warehouse, tableSize: TableSize) =>
+    ColumnSizes.getPixelWidths(warehouse, table, tableSize);
+
   // Note: The 3 delta functions below return 0 to signify a change shouldn't be made
   // however this is currently not used, so may need changing if ever used
   return {
     width: getWidth,
     pixelWidth: getWidth,
-    getWidths: ColumnSizes.getPixelWidths,
+    getWidths,
     getCellDelta: zero,
     singleColumnWidth: Fun.constant([ 0 ]),
     minCellWidth: zero,
@@ -46,6 +49,7 @@ const percentageSize = (initialWidth: string, table: SugarElement<HTMLTableEleme
   const singleColumnWidth = (w: number, _delta: number) => [ 100 - w ];
   // Get the width of a 10 pixel wide cell over the width of the table as a percentage
   const minCellWidth = () => CellUtils.minWidth() / pixelWidth.get() * 100;
+
   const adjustTableWidth = (delta: number) => {
     const currentWidth = floatWidth.get();
     const change = delta / 100 * currentWidth;
@@ -55,10 +59,13 @@ const percentageSize = (initialWidth: string, table: SugarElement<HTMLTableEleme
     pixelWidth.set(Width.get(table));
   };
 
+  const getWidths = (warehouse: Warehouse, tableSize: TableSize) =>
+    ColumnSizes.getPercentageWidths(warehouse, table, tableSize);
+
   return {
     width: floatWidth.get,
     pixelWidth: pixelWidth.get,
-    getWidths: ColumnSizes.getPercentageWidths,
+    getWidths,
     getCellDelta,
     singleColumnWidth,
     minCellWidth,
@@ -73,20 +80,25 @@ const pixelSize = (initialWidth: number, table: SugarElement<HTMLTableElement>):
   const width = Cell(initialWidth);
   const getWidth = width.get;
   const getCellDelta = Fun.identity;
+
   const singleColumnWidth = (w: number, delta: number) => {
     const newNext = Math.max(CellUtils.minWidth(), w + delta);
     return [ newNext - w ];
   };
+
   const adjustTableWidth = (delta: number) => {
     const newWidth = getWidth() + delta;
     Sizes.setPixelWidth(table, newWidth);
     width.set(newWidth);
   };
 
+  const getWidths = (warehouse: Warehouse, tableSize: TableSize) =>
+    ColumnSizes.getPixelWidths(warehouse, table, tableSize);
+
   return {
     width: getWidth,
     pixelWidth: getWidth,
-    getWidths: ColumnSizes.getPixelWidths,
+    getWidths,
     getCellDelta,
     singleColumnWidth,
     minCellWidth: CellUtils.minWidth,

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
@@ -47,7 +47,7 @@ const adjustWidth = (table: SugarElement, delta: number, index: number, resizing
 
 const adjustHeight = (table: SugarElement, delta: number, index: number, direction: BarPositions<RowInfo>) => {
   const warehouse = Warehouse.fromTable(table);
-  const heights = ColumnSizes.getPixelHeights(warehouse, direction);
+  const heights = ColumnSizes.getPixelHeights(warehouse, table, direction);
 
   const newHeights = Arr.map(heights, (dy, i) => index === i ? Math.max(delta + dy, CellUtils.minHeight()) : dy);
 

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
@@ -1,5 +1,5 @@
-import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Css, SugarElement } from '@ephox/sugar';
+import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
+import { Css, SugarElement, SugarNode, Width } from '@ephox/sugar';
 import { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
 import * as Blocks from '../lookup/Blocks';
@@ -7,6 +7,8 @@ import * as CellUtils from '../util/CellUtils';
 import * as Util from '../util/Util';
 import { BarPositions, RowInfo, width } from './BarPositions';
 import * as Sizes from './Sizes';
+
+const isCol = SugarNode.isTag('col');
 
 const getRaw = function (cell: SugarElement, property: string, getter: (e: SugarElement) => number) {
   return Css.getRaw(cell, property).fold(function () {
@@ -17,7 +19,9 @@ const getRaw = function (cell: SugarElement, property: string, getter: (e: Sugar
 };
 
 const getRawW = function (cell: SugarElement, tableSize: TableSize) {
-  return getRaw(cell, 'width', (e: SugarElement) => Sizes.getPixelWidth(e, tableSize));
+  // For col elements use the computed width as col elements aren't affected by borders, padding, etc...
+  const fallback = (e: SugarElement) => isCol(e) ? Width.get(e) : Sizes.getPixelWidth(e, tableSize);
+  return getRaw(cell, 'width', fallback);
 };
 
 const getRawH = function (cell: SugarElement) {
@@ -27,23 +31,39 @@ const getRawH = function (cell: SugarElement) {
 const justCols = (warehouse: Warehouse): Optional<SugarElement<HTMLTableColElement>>[] =>
   Arr.map(Warehouse.justColumns(warehouse), (column) => Optional.from(column.element));
 
-const getWidthFrom = function <T> (warehouse: Warehouse, getWidth: (cell: SugarElement, tableSize: TableSize) => T, fallback: (deduced: Optional<number>) => T, tableSize: TableSize) {
-  const columns: Optional<SugarElement>[] = Warehouse.hasColumns(warehouse) ? justCols(warehouse) : Blocks.columns(warehouse);
+// Col elements don't have valid computed widths/positions, so treat them as invalid if they don't have a raw width
+const isValidColumn = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>) =>
+  !isCol(cell) || Css.getRaw(cell, 'width').isSome();
 
-  const backups = Arr.map(columns, function (cellOption) {
-    return cellOption.map(width.edge);
-  });
+const getDimension = <T>(cellOpt: Optional<SugarElement>, index: number, backups: Optional<number>[], filter: (cell: SugarElement) => boolean, getter: (cell: SugarElement) => T, fallback: (deduced: Optional<number>) => T): T =>
+  cellOpt.filter(filter).fold(
+    // Can't just read the width of a cell, so calculate.
+    () => fallback(Util.deduce(backups, index)),
+    (cell) => getter(cell)
+  );
+
+const getWidthFrom = function <T> (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, getWidth: (cell: SugarElement, tableSize: TableSize) => T,
+                                   fallback: (deduced: Optional<number>) => T, tableSize: TableSize) {
+  const columnCells = Blocks.columns(warehouse);
+  const columns: Optional<SugarElement>[] = Warehouse.hasColumns(warehouse) ? justCols(warehouse) : columnCells;
+
+  const backups = [ Optional.some(width.edge(table)) ].concat(Arr.map(width.positions(columnCells, table), (pos) =>
+    pos.map((p) => p.x)
+  ));
+
+  // Only use the width of cells that have no column span (or colspan 1)
+  const colFilter = Fun.not(CellUtils.hasColspan);
 
   return Arr.map(columns, function (cellOption, c) {
-    // Only use the width of cells that have no column span (or colspan 1)
-    const columnCell = cellOption.filter(Fun.not(CellUtils.hasColspan));
-    return columnCell.fold(function () {
-      // Can't just read the width of a cell, so calculate.
-      const deduced = Util.deduce(backups, c);
-      return fallback(deduced);
-    }, function (cell) {
-      return getWidth(cell, tableSize);
-    });
+    return getDimension(cellOption, c, backups, colFilter, (column) => {
+      if (isValidColumn(column)) {
+        return getWidth(column, tableSize);
+      } else {
+        // Invalid column so fallback to trying to get the computed width from the cell
+        const cell = Optionals.bindFrom(columnCells[c], Fun.identity);
+        return getDimension(cell, c, backups, colFilter, (cell) => fallback(Optional.some(Width.get(cell))), fallback);
+      }
+    }, fallback);
   });
 };
 
@@ -51,12 +71,12 @@ const getDeduced = function (deduced: Optional<number>) {
   return deduced.map(function (d) { return d + 'px'; }).getOr('');
 };
 
-const getRawWidths = function (warehouse: Warehouse, tableSize: TableSize) {
-  return getWidthFrom(warehouse, getRawW, getDeduced, tableSize);
+const getRawWidths = function (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, tableSize: TableSize) {
+  return getWidthFrom(warehouse, table, getRawW, getDeduced, tableSize);
 };
 
-const getPercentageWidths = function (warehouse: Warehouse, tableSize: TableSize) {
-  return getWidthFrom(warehouse, Sizes.getPercentageWidth, function (deduced) {
+const getPercentageWidths = function (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, tableSize: TableSize) {
+  return getWidthFrom(warehouse, table, Sizes.getPercentageWidth, function (deduced) {
     return deduced.fold(function () {
       return tableSize.minCellWidth();
     }, function (cellWidth) {
@@ -65,40 +85,33 @@ const getPercentageWidths = function (warehouse: Warehouse, tableSize: TableSize
   }, tableSize);
 };
 
-const getPixelWidths = function (warehouse: Warehouse, tableSize: TableSize) {
-  return getWidthFrom(warehouse, Sizes.getPixelWidth, function (deduced) {
+const getPixelWidths = function (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, tableSize: TableSize) {
+  return getWidthFrom(warehouse, table, Sizes.getPixelWidth, function (deduced) {
     // Minimum cell width when all else fails.
     return deduced.getOrThunk(tableSize.minCellWidth);
   }, tableSize);
 };
 
-const getHeightFrom = function <T> (warehouse: Warehouse, direction: BarPositions<RowInfo>, getHeight: (cell: SugarElement) => T, fallback: (deduced: Optional<number>) => T) {
+const getHeightFrom = function <T> (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, direction: BarPositions<RowInfo>, getHeight: (cell: SugarElement) => T, fallback: (deduced: Optional<number>) => T) {
   const rows = Blocks.rows(warehouse);
 
-  const backups = Arr.map(rows, function (cellOption) {
-    return cellOption.map(direction.edge);
-  });
+  const backups = [ Optional.some(direction.edge(table)) ].concat(Arr.map(direction.positions(rows, table), (pos) =>
+    pos.map((p) => p.y)
+  ));
 
   return Arr.map(rows, function (cellOption, c) {
-    const rowCell = cellOption.filter(Fun.not(CellUtils.hasRowspan));
-
-    return rowCell.fold(function () {
-      const deduced = Util.deduce(backups, c);
-      return fallback(deduced);
-    }, function (cell) {
-      return getHeight(cell);
-    });
+    return getDimension(cellOption, c, backups, Fun.not(CellUtils.hasRowspan), getHeight, fallback);
   });
 };
 
-const getPixelHeights = function (warehouse: Warehouse, direction: BarPositions<RowInfo>) {
-  return getHeightFrom(warehouse, direction, Sizes.getHeight, function (deduced: Optional<number>) {
+const getPixelHeights = function (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, direction: BarPositions<RowInfo>) {
+  return getHeightFrom(warehouse, table, direction, Sizes.getHeight, function (deduced: Optional<number>) {
     return deduced.getOrThunk(CellUtils.minHeight);
   });
 };
 
-const getRawHeights = function (warehouse: Warehouse, direction: BarPositions<RowInfo>) {
-  return getHeightFrom(warehouse, direction, getRawH, getDeduced);
+const getRawHeights = function (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, direction: BarPositions<RowInfo>) {
+  return getHeightFrom(warehouse, table, direction, getRawH, getDeduced);
 };
 
 export { getRawWidths, getPixelWidths, getPercentageWidths, getPixelHeights, getRawHeights };

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -30,7 +30,7 @@ Version 5.6.0 (TBD)
     Fixed an issue where menus would incorrectly collapse in small containers #TINY-3321
     Fixed some minor memory leaks that prevented garbage collection for editor instances #TINY-6570
     Fixed resizing a `responsive` table not working when using the column resize handles #TINY-6601
-    Fixed incorrectly calculating table `col` widths resizing responsive tables #TINY-6646
+    Fixed incorrectly calculating table `col` widths when resizing responsive tables #TINY-6646
     Fixed an issue where spaces were not preserved in pre-blocks when getting text content #TINY-6448
 Version 5.5.1 (2020-10-01)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -30,6 +30,7 @@ Version 5.6.0 (TBD)
     Fixed an issue where menus would incorrectly collapse in small containers #TINY-3321
     Fixed some minor memory leaks that prevented garbage collection for editor instances #TINY-6570
     Fixed resizing a `responsive` table not working when using the column resize handles #TINY-6601
+    Fixed incorrectly calculating table `col` widths resizing responsive tables #TINY-6646
     Fixed an issue where spaces were not preserved in pre-blocks when getting text content #TINY-6448
 Version 5.5.1 (2020-10-01)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
@@ -21,6 +21,15 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
   const pixelTable = '<table style="width: 200px;"><tbody><tr><td></td><td></td></tr></tbody></table>';
   const percentTable = '<table style="width: 100%;"><tbody><tr><td style="width: 50%;"></td><td style="width: 50%;"></td></tr></tbody></table>';
   const responsiveTable = '<table><tbody><tr><td><br></td><td><br></td></tr></tbody></table>';
+  const responsiveTableWithContent = '<table><colgroup><col><col></colgroup><tbody><tr><td>Content</td><td><br></td></tr></tbody></table>';
+
+  const defaultSettings = {
+    plugins: 'table',
+    width: 400,
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+    table_toolbar: ''
+  };
 
   const assertWithin = function (value, min, max) {
     Assertions.assertEq('asserting if value falls within a certain range', true, value >= min && value <= max);
@@ -116,12 +125,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
   Pipeline.async({}, [
     Log.chainsAsStep('TBA', 'Test default config of [table_sizing_mode=unset], resize should detect current unit', [
-      NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce'
-      })),
+      NamedChain.write('editor', McEditor.cFromSettings(defaultSettings)),
 
       cClearResizeEventData,
       NamedChain.read('editor', ApiChains.cSetContent('')),
@@ -142,10 +146,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     Log.chainsAsStep('TBA', 'Test default config of [table_sizing_mode="relative"], new tables should default to % and resize should force %', [
       NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce',
+        ...defaultSettings,
         table_sizing_mode: 'relative'
       })),
 
@@ -184,10 +185,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     Log.chainsAsStep('TBA', 'Test [table_sizing_mode="fixed"], new tables should default to px and resize should force px', [
       NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce',
+        ...defaultSettings,
         table_sizing_mode: 'fixed'
       })),
 
@@ -220,10 +218,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     Log.chainsAsStep('TINY-6051', 'Test [table_sizing_mode="responsive"], new tables should default to no widths and resize should force percentage', [
       NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce',
+        ...defaultSettings,
         table_sizing_mode: 'responsive'
       })),
 
@@ -257,11 +252,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     Log.chainsAsStep('TINY-6001', 'Test [table_column_resizing="preservetable"], adjusting an inner column should not change the table width', [
       NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce',
-        table_toolbar: '',
+        ...defaultSettings,
         table_column_resizing: 'preservetable',
         table_sizing_mode: 'fixed'
       })),
@@ -278,11 +269,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     Log.chainsAsStep('TINY-6001', 'Test [table_column_resizing="resizetable"], adjusting an inner column should change the table width', [
       NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce',
-        table_toolbar: '',
+        ...defaultSettings,
         table_column_resizing: 'resizetable',
         table_sizing_mode: 'fixed'
       })),
@@ -299,11 +286,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     Log.chainsAsStep('TINY-6242', 'Test [table_column_resizing="preservetable"], adjusting the entire table should resize all columns', [
       NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce',
-        table_toolbar: '',
+        ...defaultSettings,
         table_column_resizing: 'preservetable',
         table_sizing_mode: 'fixed'
       })),
@@ -329,11 +312,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     Log.chainsAsStep('TINY-6242', 'Test [table_column_resizing="resizetable"], adjusting the entire table should resize the last column', [
       NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce',
-        table_toolbar: '',
+        ...defaultSettings,
         table_column_resizing: 'resizetable',
         table_sizing_mode: 'fixed'
       })),
@@ -361,11 +340,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     Log.chainsAsStep('TINY-6242', 'Test [table_column_resizing="resizetable"], adjusting the entire table should not resize more than the last column width', [
       NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce',
-        table_toolbar: '',
+        ...defaultSettings,
         table_column_resizing: 'resizetable',
         table_sizing_mode: 'relative'
       })),
@@ -390,11 +365,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     Log.chainsAsStep('TINY-6601', 'Test [table_column_resizing="resizetable"] with colgroup, adjusting an inner column should change the table width', [
       NamedChain.write('editor', McEditor.cFromSettings({
-        plugins: 'table',
-        width: 400,
-        theme: 'silver',
-        base_url: '/project/tinymce/js/tinymce',
-        table_toolbar: '',
+        ...defaultSettings,
         table_column_resizing: 'resizetable',
         table_use_colgroups: true,
         table_sizing_mode: 'responsive'
@@ -406,6 +377,29 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitBeforeResize(null)),
       NamedChain.read('widths', cAssertUnitAfterResize('%')),
       NamedChain.read('widths', cAssertWidthAfterResize(35, true)),
+      cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
+      cAssertEventData(lastObjectResizedEvent, 'objectresized'),
+
+      NamedChain.read('editor', McEditor.cRemove)
+    ]),
+
+    Log.chainsAsStep('TINY-6646', 'Test [table_column_resizing="resizetable"] with responsive colgroup table, adjusting an inner column with content', [
+      NamedChain.write('editor', McEditor.cFromSettings({
+        ...defaultSettings,
+        table_column_resizing: 'resizetable'
+      })),
+
+      cClearResizeEventData,
+      NamedChain.read('editor', ApiChains.cSetContent('')),
+      NamedChain.direct('editor', cInsertResizeMeasure(TableTestUtils.cDragResizeBar('column', 0, 100, 0), TableTestUtils.cInsertRaw(responsiveTableWithContent)), 'widths'),
+      NamedChain.read('widths', cAssertUnitAfterResize('%')),
+      NamedChain.read('widths', cAssertWidthAfterResize(53, true)),
+      NamedChain.read('widths', Chain.op((widths: any) => {
+        const firstColWidth = widths.colWidthsAfter[0];
+        const lastColWidth = widths.colWidthsAfter[1];
+        Assertions.assertEq(`First column computed width ${firstColWidth.px}px should be ~157px`, true, Math.abs(157 - firstColWidth.px) <= pixelDiffThreshold);
+        Assertions.assertEq(`Last column computed width ${lastColWidth.px}px should be ~0px`, true, Math.abs(lastColWidth.px) <= pixelDiffThreshold);
+      })),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
 


### PR DESCRIPTION
Related Ticket: TINY-6646

Description of Changes:
This fixes the widths being calculated incorrectly for `col` elements without raw widths. The problem was most browsers will return 0px for the width, as such if there's no raw width we need to fallback to getting the width from the table cells. It also fixes an issue I found with the fallback logic, as it would never calculate the last column width correctly.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
