### PR TITLE
TINY-6495: Fixed a regression that caused the selection to be hidden in tables with backgrounds

### DIFF
--- a/modules/oxide/src/less/theme/content/selection/selection.less
+++ b/modules/oxide/src/less/theme/content/selection/selection.less
@@ -10,7 +10,7 @@
 //
 
 @document-selection-color: initial;
-@table-selection-color: fade(#b4d7ff, 35%);
+@table-selection-color: fade(#b4d7ff, 70%);
 @table-selection-border-color: @table-selection-color;
 @table-selection-blend-mode: multiply;
 @object-block-selected-color: #b4d7ff;

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -32,7 +32,7 @@ Version 5.6.0 (TBD)
     Fixed some minor memory leaks that prevented garbage collection for editor instances #TINY-6570
     Fixed resizing a `responsive` table not working when using the column resize handles #TINY-6601
     Fixed an issue where spaces were not preserved in pre-blocks when getting text content #TINY-6448
-    Fixed a regression that caused the selection to be hidden in tables with backgrounds #TINY-6495
+    Fixed a regression that caused the selection to be difficult to see in tables with backgrounds #TINY-6495
 Version 5.5.1 (2020-10-01)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -32,6 +32,7 @@ Version 5.6.0 (TBD)
     Fixed some minor memory leaks that prevented garbage collection for editor instances #TINY-6570
     Fixed resizing a `responsive` table not working when using the column resize handles #TINY-6601
     Fixed an issue where spaces were not preserved in pre-blocks when getting text content #TINY-6448
+    Fixed a regression that caused the selection to be hidden in tables with backgrounds #TINY-6495
 Version 5.5.1 (2020-10-01)
     Fixed pressing the down key near the end of a document incorrectly raising an exception #TINY-6471
     Fixed incorrect Typescript types for the `Tools` API #TINY-6475


### PR DESCRIPTION
Related Ticket: TINY-6495

Description of Changes:
* This fixes a regression introduced in TinyMCE 5.5 that made the selection be unable to be seen when a table had a background.

This is what it looks like after this change:
![image](https://user-images.githubusercontent.com/1575550/98928434-80366c00-2525-11eb-83a2-31120686ff96.png)

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
