### PR TITLE
TINY-6413: Fixed more incorrect public types

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Tinymce.ts
+++ b/modules/tinymce/src/core/main/ts/api/Tinymce.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { RangeLikeObject } from '../selection/RangeTypes';
 import { UndoManager as UndoManagerType } from '../undo/UndoManagerTypes';
 import AddOnManager from './AddOnManager';
 import Annotator from './Annotator';
@@ -61,6 +62,44 @@ import VK from './util/VK';
 import XHR from './util/XHR';
 import WindowManager from './WindowManager';
 
+interface DOMUtilsNamespace {
+  new (doc: Document, settings: Partial<DOMUtilsSettings>): DOMUtils;
+
+  DOM: DOMUtils;
+  nodeIndex: (node: Node, normalized?: boolean) => number;
+}
+
+interface RangeUtilsNamespace {
+  new (dom: DOMUtils): RangeUtils;
+
+  compareRanges: (rng1: RangeLikeObject, rng2: RangeLikeObject) => boolean;
+  getCaretRangeFromPoint: (clientX: number, clientY: number, doc: Document) => Range;
+  getSelectedNode: (range: Range) => Node;
+  getNode: (container: Node, offset: number) => Node;
+}
+
+interface AddOnManagerNamesapce {
+  new <T>(): AddOnManager<T>;
+
+  language: string;
+  languageLoad: boolean;
+  baseURL: string;
+  PluginManager: PluginManager;
+  ThemeManager: ThemeManager;
+}
+
+interface BookmarkManagerNamespace {
+  (selection: EditorSelection): BookmarkManager;
+
+  isBookmarkNode: (node: Node) => boolean;
+}
+
+interface SaxParserNamespace {
+  new (settings?: SaxParserSettings, schema?: Schema): SaxParser;
+
+  findEndTag: (schema: Schema, html: string, startIndex: number) => number;
+}
+
 interface TinyMCE extends EditorManager {
 
   geom: {
@@ -91,12 +130,12 @@ interface TinyMCE extends EditorManager {
     DomQuery: DomQueryConstructor;
     TreeWalker: DomTreeWalkerConstructor;
     TextSeeker: new (dom: DOMUtils, isBlockBoundary?: (node: Node) => boolean) => TextSeeker;
-    DOMUtils: new (doc: Document, settings: Partial<DOMUtilsSettings>) => DOMUtils;
+    DOMUtils: DOMUtilsNamespace;
     ScriptLoader: ScriptLoaderConstructor;
-    RangeUtils: new (dom: DOMUtils) => RangeUtils;
+    RangeUtils: RangeUtilsNamespace;
     Serializer: new (settings: DomSerializerSettings, editor?: Editor) => DomSerializer;
     ControlSelection: (selection: EditorSelection, editor: Editor) => ControlSelection;
-    BookmarkManager: (selection: EditorSelection) => BookmarkManager;
+    BookmarkManager: BookmarkManagerNamespace;
     Selection: new (dom: DOMUtils, win: Window, serializer: DomSerializer, editor: Editor) => EditorSelection;
     StyleSheetLoader: new (documentOrShadowRoot: Document | ShadowRoot, settings: StyleSheetLoaderSettings) => StyleSheetLoader;
     Event: EventUtils;
@@ -107,13 +146,13 @@ interface TinyMCE extends EditorManager {
     Entities: Entities;
     Node: AstNodeConstructor;
     Schema: new (settings?: SchemaSettings) => Schema;
-    SaxParser: new (settings?: SaxParserSettings, schema?: Schema) => SaxParser;
+    SaxParser: SaxParserNamespace;
     DomParser: new (settings?: DomParserSettings, schema?: Schema) => DomParser;
     Writer: new (settings?: WriterSettings) => Writer;
     Serializer: new (settings?: HtmlSerializerSettings, schema?: Schema) => HtmlSerializer;
   };
 
-  AddOnManager: new <T>() => AddOnManager<T>;
+  AddOnManager: AddOnManagerNamesapce;
   Annotator: new (editor: Editor) => Annotator;
   Editor: EditorConstructor;
   EditorCommands: EditorCommandsConstructor;
@@ -293,6 +332,7 @@ const publicApi = {
 };
 
 const tinymce: TinyMCE = Tools.extend(EditorManager, publicApi);
+
 export {
   TinyMCE,
   tinymce

--- a/modules/tinymce/src/core/main/ts/api/Tinymce.ts
+++ b/modules/tinymce/src/core/main/ts/api/Tinymce.ts
@@ -78,7 +78,7 @@ interface RangeUtilsNamespace {
   getNode: (container: Node, offset: number) => Node;
 }
 
-interface AddOnManagerNamesapce {
+interface AddOnManagerNamespace {
   new <T>(): AddOnManager<T>;
 
   language: string;
@@ -152,7 +152,7 @@ interface TinyMCE extends EditorManager {
     Serializer: new (settings?: HtmlSerializerSettings, schema?: Schema) => HtmlSerializer;
   };
 
-  AddOnManager: AddOnManagerNamesapce;
+  AddOnManager: AddOnManagerNamespace;
   Annotator: new (editor: Editor) => Annotator;
   Editor: EditorConstructor;
   EditorCommands: EditorCommandsConstructor;

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -154,9 +154,8 @@ const findNodeIndex = function (node: Node, normalized?: boolean) {
 export interface DOMUtilsSettings {
   schema: Schema;
   url_converter: URLConverter;
-  url_converter_scope: {};
+  url_converter_scope: any;
   ownEvents: boolean;
-  proxy: any;
   keep_values: boolean;
   hex_colors: boolean;
   update_styles: boolean;

--- a/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
+++ b/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
@@ -35,7 +35,7 @@ export interface BlobInfo {
   blob: () => Blob;
   base64: () => string;
   blobUri: () => string;
-  uri: () => string;
+  uri: () => string | undefined;
 }
 
 export const BlobCache = (): BlobCache => {


### PR DESCRIPTION
Related Ticket: TINY-6413

Description of Changes:
This just fixes a few issues I found from typing the Premium plugins that I've been meaning to fix for a while.

Note: I'm not entirely happy about how we're doing the namespace declarations in `Tinymce.ts`, however we're a bit stuck here because of the fact those implementations really should be using classes to get the proper types. Atm it's using declaration merging to merge the namespace and function, however that has issues with the constructor function since it's supposed to be called with `new`.

Pre-checks:
* [x] Changelog entry added (already exists from a previous PR)
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
