### PR TITLE
TINY-6656: Fixed inserting a table via the mceInsertTable command incorrectly creating 2 undo levels

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -18,6 +18,7 @@ Version 5.6.0 (TBD)
     Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root #TINY-6363
     Fixed `getContent` with text format returning a new line when the editor is empty #TINY-6281
     Fixed table column and row resizers not respecting the `data-mce-resize` attribute #TINY-6600
+    Fixed inserting a table via the `mceInsertTable` command incorrectly creating 2 undo levels #TINY-6656
     Fixed nested tables with `colgroup` elements incorrectly always resizing the inner table #TINY-6623
     Fixed the `visualchars` plugin causing the editor to steal focus when initialized #TINY-6282
     Fixed `fullpage` plugin altering text content in `editor.getContent()` #TINY-6541

--- a/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
@@ -43,12 +43,17 @@ const insert = (editor: Editor, columns: number, rows: number, colHeaders: numbe
     colGroups: useColumnGroup(editor)
   };
 
-  const table = TableRender.render(rows, columns, rowHeaders, colHeaders, getTableHeaderType(editor), options);
-  Attribute.set(table, 'data-mce-id', '__mce');
+  // Don't create an undo level when inserting the base table HTML otherwise we can end up with 2 undo levels
+  editor.undoManager.ignore(() => {
+    const table = TableRender.render(rows, columns, rowHeaders, colHeaders, getTableHeaderType(editor), options);
+    Attribute.set(table, 'data-mce-id', '__mce');
 
-  const html = Html.getOuter(table);
-  editor.insertContent(html);
+    const html = Html.getOuter(table);
+    editor.insertContent(html);
+    editor.addVisual();
+  });
 
+  // Enforce the sizing mode of the table
   return SelectorFind.descendant<HTMLTableElement>(Util.getBody(editor), 'table[data-mce-id="__mce"]').map((table) => {
     if (isPixelsForced(editor)) {
       enforcePixels(editor, table);

--- a/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
@@ -23,9 +23,14 @@ const setClipboardElements = (setClipboard: (elems: Optional<SugarElement[]>) =>
   setClipboard(elmsOpt);
 };
 
+const insertTable = (editor: Editor) => (columns: number, rows: number, options: Record<string, number> = {}) => {
+  const table = insertTableWithDataValidation(editor, rows, columns, options, 'Invalid values for insertTable - rows and columns values are required to insert a table.');
+  editor.undoManager.add();
+  return table;
+};
+
 const getApi = (editor: Editor, clipboard: Clipboard, resizeHandler: ResizeHandler, selectionTargets: SelectionTargets) => ({
-  insertTable: (columns: number, rows: number, options: Record<string, number> = {}) =>
-    insertTableWithDataValidation(editor, rows, columns, options, 'Invalid values for insertTable - rows and columns values are required to insert a table.'),
+  insertTable: insertTable(editor),
   setClipboardRows: setClipboardElements(clipboard.setRows),
   getClipboardRows: getClipboardElements(clipboard.getRows),
   setClipboardCols: setClipboardElements(clipboard.setColumns),

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -8,20 +8,18 @@
 import { SugarNode } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
-import * as InsertTable from '../actions/InsertTable';
 import { hasTableGrid } from '../api/Settings';
 import { Clipboard } from '../core/Clipboard';
 import { SelectionTargets } from '../selection/SelectionTargets';
 
 const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipboard: Clipboard) => {
-  const cmd = (command) => () => editor.execCommand(command);
+  const cmd = (command: string) => () => editor.execCommand(command);
 
-  const insertTableAction = ({ numRows, numColumns }) => {
-    editor.undoManager.transact(function () {
-      InsertTable.insert(editor, numColumns, numRows, 0, 0);
+  const insertTableAction = (data: { numRows: number; numColumns: number }) => {
+    editor.execCommand('mceInsertTable', false, {
+      rows: data.numRows,
+      columns: data.numColumns
     });
-
-    editor.addVisual();
   };
 
   const tableProperties = {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandTest.ts
@@ -1,5 +1,5 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { Log, Pipeline, Step } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 
 import Plugin from 'tinymce/plugins/table/Plugin';
@@ -13,69 +13,82 @@ UnitTest.asynctest('browser.tinymce.plugins.table.command.InsertTableCommandTest
   TinyLoader.setup((editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
 
+    const sResetContent = Step.sync(() => editor.resetContent(''));
+    const sAssertNumNewUndoLevels = (expected: number) => Step.sync(() => {
+      Assert.eq('Number of new undo levels', expected, editor.undoManager.data.length - 1);
+    });
+
     Pipeline.async({}, [
       Log.stepsAsStep('TBA', 'Table: Try to insert table with incorrect data', [
-        tinyApis.sSetContent(''),
+        sResetContent,
         sInsertTable(editor, { incorrect: 'data' }),
+        sAssertNumNewUndoLevels(0),
         tinyApis.sAssertContent('')
       ]),
       Log.stepsAsStep('TBA', 'Table: Try to insert table with incorrect rows value', [
-        tinyApis.sSetContent(''),
+        sResetContent,
         sInsertTable(editor, { rows: 'two' }),
+        sAssertNumNewUndoLevels(0),
         tinyApis.sAssertContent('')
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2', [
-        tinyApis.sSetContent(''),
+        sResetContent,
         sInsertTable(editor, { rows: 2, columns: 2 }),
         sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
           [ 50, 50 ],
           [ 50, 50 ]
         ], false),
+        sAssertNumNewUndoLevels(1),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 1 header row', [
-        tinyApis.sSetContent(''),
+        sResetContent,
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 1 }}),
         sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
           [ 50, 50 ],
           [ 50, 50 ]
         ], false, { headerRows: 1, headerCols: 0 }),
+        sAssertNumNewUndoLevels(1),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 1 header column', [
-        tinyApis.sSetContent(''),
+        sResetContent,
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerColumns: 1 }}),
         sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
           [ 50, 50 ],
           [ 50, 50 ]
         ], false, { headerRows: 0, headerCols: 1 }),
+        sAssertNumNewUndoLevels(1),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 1 header row and 1 header column', [
-        tinyApis.sSetContent(''),
+        sResetContent,
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 1, headerColumns: 1 }}),
         sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
           [ 50, 50 ],
           [ 50, 50 ]
         ], false, { headerRows: 1, headerCols: 1 }),
+        sAssertNumNewUndoLevels(1),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 2 header rows and 2 header columns', [
-        tinyApis.sSetContent(''),
+        sResetContent,
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 2, headerColumns: 2 }}),
         sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
           [ 50, 50 ],
           [ 50, 50 ]
         ], false, { headerRows: 2, headerCols: 2 }),
+        sAssertNumNewUndoLevels(1),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ]),
       Log.stepsAsStep('TBA', 'Table: Insert table 2x2 with 3 header rows and 3 header columns - should only get 2', [
-        tinyApis.sSetContent(''),
+        sResetContent,
         sInsertTable(editor, { rows: 2, columns: 2, options: { headerRows: 3, headerColumns: 3 }}),
         sAssertTableStructureWithSizes(editor, 2, 2, '%', 100, [
           [ 50, 50 ],
           [ 50, 50 ]
         ], false, { headerRows: 2, headerCols: 2 }),
+        sAssertNumNewUndoLevels(1),
         tinyApis.sAssertSelection([ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 0)
       ])
     ], onSuccess, onFailure);


### PR DESCRIPTION
Related Ticket: TINY-6656

Description of Changes:
This fixes calling the `mceInsertTable` command incorrectly creating 2 undo levels. This was caused by calling `editor.insertContent()` which creates a undo level and then further manipulating the dom after to ensure the table sizing is correct. This wasn't an issue with the menu item, as it was wrapped in an undo transaction (I've also made the menu item use the command to keep things consistent). This also fixes another issue I noticed where the plugin API wasn't creating an undo level.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
