### PR TITLE
TINY-6659: Fixed Clipboard not exposed in agar

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/Main.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Main.ts
@@ -5,6 +5,7 @@ import * as Assertions from './Assertions';
 import { Chain } from './Chain';
 import * as ChainSequence from './ChainSequence';
 import { Cleaner } from './Cleaner';
+import * as Clipboard from './Clipboard';
 import * as Cursors from './Cursors';
 import * as DragnDrop from './DragnDrop';
 import * as FileInput from './FileInput';
@@ -41,6 +42,7 @@ export {
   Chain,
   ChainSequence,
   Cleaner,
+  Clipboard,
   Cursors,
   FocusTools,
   GeneralSteps,

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,6 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 
+agar@5.1.0
 mcagar@5.1.0
 alloy@8.1.0


### PR DESCRIPTION
Related Ticket: TINY-6659

Description of Changes:
* Fixed the clipboard module not exposed in agar, which prevented us from using it elsewhere.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
