### PR TITLE
TINY-6668: Fixed image_file_types not respected for pasting images

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
+++ b/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts
@@ -49,6 +49,7 @@ export const BlobCache = (): BlobCache => {
       'image/gif': 'gif',
       'image/png': 'png',
       'image/apng': 'apng',
+      'image/avif': 'avif',
       'image/svg+xml': 'svg',
       'image/webp': 'webp',
       'image/bmp': 'bmp',

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
@@ -63,7 +63,7 @@ const getForcedRootBlockAttrs = (editor: Editor) => editor.getParam('forced_root
 const getTabSpaces = (editor: Editor) => editor.getParam('paste_tab_spaces', 4, 'number');
 
 const getAllowedImageFileTypes = (editor: Editor): string[] => {
-  const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jfif,png,gif,bmp,webp';
+  const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp';
   return Tools.explode(editor.getParam('image_file_types', defaultImageFileTypes, 'string'));
 };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
@@ -62,7 +62,7 @@ const getForcedRootBlockAttrs = (editor: Editor) => editor.getParam('forced_root
 
 const getTabSpaces = (editor: Editor) => editor.getParam('paste_tab_spaces', 4, 'number');
 
-const allowedImageFileTypes = (editor: Editor): string[] => {
+const getAllowedImageFileTypes = (editor: Editor): string[] => {
   const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jfif,png,gif,bmp,webp';
   return Tools.explode(editor.getParam('image_file_types', defaultImageFileTypes, 'string'));
 };
@@ -90,5 +90,5 @@ export {
   getForcedRootBlock,
   getForcedRootBlockAttrs,
   getTabSpaces,
-  allowedImageFileTypes
+  getAllowedImageFileTypes
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
@@ -34,7 +34,7 @@ const isAbsoluteUrl = function (url: string) {
 };
 
 const isImageUrl = function (editor: Editor, url: string) {
-  return isAbsoluteUrl(url) && Arr.exists(Settings.allowedImageFileTypes(editor), (type) => Strings.endsWith(url, `.${type}`));
+  return isAbsoluteUrl(url) && Arr.exists(Settings.getAllowedImageFileTypes(editor), (type) => Strings.endsWith(url, `.${type}`));
 };
 
 const createImage = function (editor: Editor, url: string, pasteHtmlFn: typeof pasteHtml) {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
@@ -136,9 +136,22 @@ function createIdGenerator(prefix: string) {
   };
 }
 
+const getImageMimeType = (ext: string): string => {
+  const mimeOverrides = {
+    jpg: 'jpeg',
+    jpe: 'jpeg',
+    jfif: 'jpeg',
+    pjpeg: 'jpeg',
+    pjp: 'jpeg',
+    svg: 'svg+xml'
+  };
+  return Tools.hasOwn(mimeOverrides, ext) ? 'image/' + mimeOverrides[ext] : 'image/' + ext;
+};
+
 export {
   filter,
   innerText,
   trimHtml,
-  createIdGenerator
+  createIdGenerator,
+  getImageMimeType
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
@@ -140,6 +140,8 @@ const getImageMimeType = (ext: string): string => {
   const mimeOverrides = {
     jpg: 'jpeg',
     jpe: 'jpeg',
+    jfi: 'jpeg',
+    jif: 'jpeg',
     jfif: 'jpeg',
     pjpeg: 'jpeg',
     pjp: 'jpeg',

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
@@ -192,6 +192,27 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     }).catch(die);
   });
 
+  suite.asyncTest('TestCase-TINY-6306: Paste: pasteImages with custom file types', (editor, done, die) => {
+    const clipboard = Clipboard(editor, Cell('html'));
+
+    editor.settings.paste_data_images = true;
+    editor.settings.image_file_types = 'svg,tiff';
+    const rng = setupContent(editor);
+
+    const event = mockEvent('paste', [
+      base64ToBlob(base64ImgSrc, 'image/tiff', 'image.tiff')
+    ]) as ClipboardEvent;
+    clipboard.pasteImageData(event, rng);
+
+    waitForSelector(editor, 'img').then(() => {
+      LegacyUnit.equal(editor.getContent(), '<p><img src=\"data:image/tiff;base64,' + base64ImgSrc + '" />a</p>');
+      LegacyUnit.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
+
+      delete editor.settings.image_file_types;
+      done();
+    }).catch(die);
+  });
+
   suite.asyncTest('TestCase-TBA: Paste: dropImages - images_dataimg_filter', function (editor, done, die) {
     const clipboard = Clipboard(editor, Cell('html'));
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -24,7 +24,7 @@ import { renderFormFieldWith, renderLabel } from '../alien/FieldLabeller';
 import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 import { formChangeEvent } from '../general/FormEvents';
 
-const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jfif,png,gif,bmp,webp';
+const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp';
 
 const filterByExtension = function (files: FileList, providersBackstage: UiFactoryBackstageProviders) {
   const allowedImageFileTypes = Tools.explode(providersBackstage.getSetting('image_file_types', defaultImageFileTypes, 'string'));


### PR DESCRIPTION
Related Ticket: TINY-6306

Description of Changes:
* Fixes the Clipboard image file type logic to respect the new `image_file_types` setting.
* Fixes missing `avif` image file type mapping in `BlobCache`.
* Adds the missing `jif` file extension.

Pre-checks:
* [x] ~Changelog entry added~ Done in previous PRs
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
