### PR TITLE
TINY-6629: Fix missing events for table sizing mode change and resize

### DIFF
--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -124,7 +124,6 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
         });
 
         Events.fireObjectResized(editor, rawTable, Util.getPixelWidth(rawTable), Util.getPixelHeight(rawTable), barResizerPrefix + event.type);
-        Events.fireTableModified(editor, rawTable);
         editor.undoManager.add();
       });
 
@@ -172,6 +171,7 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
       }
 
       Util.removeDataStyle(table);
+      Events.fireTableModified(editor, table.dom);
     }
   });
 

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -124,6 +124,7 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
         });
 
         Events.fireObjectResized(editor, rawTable, Util.getPixelWidth(rawTable), Util.getPixelHeight(rawTable), barResizerPrefix + event.type);
+        Events.fireTableModified(editor, rawTable);
         editor.undoManager.add();
       });
 

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -62,6 +62,7 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
           enforceNone(table);
         }
         Util.removeDataStyle(table);
+        Events.fireTableModified(editor, table.dom);
       });
     }
   });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
@@ -130,10 +130,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
     Assertions.assertEq('Should be expected resize event', expectedEventName, state.get().type);
     Assertions.assertEq('Should have width', 'number', typeof state.get().width);
     Assertions.assertEq('Should have height', 'number', typeof state.get().height);
-  });
-
-  const cAssertTableModifiedEventLength = (expectedLength: number = 1) => Chain.op((_) => {
-    Assertions.assertEq('Should have a table modified event', expectedLength, tableModifiedEvents.length);
+    Assertions.assertEq('Should have a table modified event', 1, tableModifiedEvents.length);
   });
 
   Pipeline.async({}, [
@@ -146,7 +143,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('%')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       cClearEventData,
       NamedChain.read('editor', ApiChains.cSetContent('')),
@@ -154,7 +150,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('px')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -170,7 +165,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertWidths),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       cClearEventData,
       NamedChain.read('editor', ApiChains.cSetContent('')),
@@ -179,7 +173,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('%')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       // Force % on unset tables with [table_sizing_mode="relative"]
       cClearEventData,
@@ -188,7 +181,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('%')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       // Force % on tables with that are initially set to px with [table_sizing_mode="relative"]
       cClearEventData,
@@ -197,8 +189,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('%')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
-
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -216,7 +206,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('px')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       // Force px on unset tables with [table_sizing_mode="fixed"]
       cClearEventData,
@@ -225,7 +214,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('px')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       // Force px on tables with that are initially set to % with [table_sizing_mode="fixed"]
       cClearEventData,
@@ -234,7 +222,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('px')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -253,7 +240,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertWidthBeforeResize(null)),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       // Force % on unset tables with [table_sizing_mode="responsive"]
       cClearEventData,
@@ -262,7 +248,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('%')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       // Force % on tables with that are initially set to px with [table_sizing_mode="responsive"]
       cClearEventData,
@@ -271,7 +256,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertUnitAfterResize('%')),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -289,7 +273,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertWidthAfterResize(200)),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -307,7 +290,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertWidthAfterResize(220)),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -334,7 +316,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       })),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -363,7 +344,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       })),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -389,7 +369,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       })),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -410,7 +389,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       NamedChain.read('widths', cAssertWidthAfterResize(35, true)),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ]),
@@ -434,7 +412,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       })),
       cAssertEventData(lastObjectResizeStartEvent, 'objectresizestart'),
       cAssertEventData(lastObjectResizedEvent, 'objectresized'),
-      cAssertTableModifiedEventLength(1),
 
       NamedChain.read('editor', McEditor.cRemove)
     ])

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
@@ -5,6 +5,7 @@ import { ApiChains, Editor as McEditor } from '@ephox/mcagar';
 import { TableGridSize } from '@ephox/snooker';
 import { SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 import * as TableTestUtils from '../module/test/TableTestUtils';
@@ -55,7 +56,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
       lastObjectResizedEvent.set(e);
     };
 
-    const tableModified = (e) => {
+    const tableModified = (e: EditorEvent<{}>) => {
       tableModifiedEvents.push(e);
     };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
@@ -62,7 +62,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
 
     input.editor.on('ObjectResizeStart', objectResizeStart);
     input.editor.on('ObjectResized', objectResized);
-    input.editor.on('tablemodified', tableModified);
+    input.editor.on('TableModified', tableModified);
 
     return {
       objectResizeStart,
@@ -74,7 +74,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
   const cUnbindResizeEvents = Chain.mapper(function (input: any) {
     input.editor.off('ObjectResizeStart', input.events.objectResizeStart);
     input.editor.off('ObjectResized', input.events.objectResized);
-    input.editor.off('tablemodified', input.events.tableModified);
+    input.editor.off('TableModified', input.events.tableModified);
     return {};
   });
 

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableSizingModeCommandUtil.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableSizingModeCommandUtil.ts
@@ -1,6 +1,7 @@
-import { Log } from '@ephox/agar';
+import { Assertions, Log, Step } from '@ephox/agar';
 import { Arr } from '@ephox/katamari';
 import { TinyApis } from '@ephox/mcagar';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { sAssertTableStructureWithSizes } from './TableTestUtils';
 
 type SizingMode = 'relative' | 'fixed' | 'responsive';
@@ -57,13 +58,22 @@ const generateTable = (mode: SizingMode, width: number, rows: number, cols: numb
   return `<table border="1" style="border-collapse: collapse;${tableWidth}">${getColumns()}<tbody>${renderedRows}</tbody></table>`;
 };
 
-const sTableSizingModeScenarioTest = (editor, tinyApis: TinyApis, title: string, description: string, withColGroups: boolean, scenario: Scenario) =>
-  Log.stepsAsStep(title, description, [
+const sTableSizingModeScenarioTest = (editor, tinyApis: TinyApis, title: string, description: string, withColGroups: boolean, scenario: Scenario, expectedEventsLength: number = 1) => {
+  let events = [];
+  editor.on('tablemodified', (e: EditorEvent<{}>) => events.push(e));
+  const clearEvents = Step.sync(() => events = []);
+
+  return Log.stepsAsStep(title, description, [
+    clearEvents,
+    Step.sync(() => Assertions.assertEq('Number of events starts at 0', 0, events.length)),
     tinyApis.sSetContent(generateTable(scenario.mode, scenario.tableWidth, scenario.rows, scenario.cols, withColGroups)),
     tinyApis.sSetSelection([ 0, withColGroups ? 1 : 0, 0, 0 ], 0, [ 0, withColGroups ? 1 : 0, 0, 0 ], 0),
     tinyApis.sExecCommand('mceTableSizingMode', scenario.newMode),
-    sAssertTableStructureWithSizes(editor, scenario.cols, scenario.rows, getUnit(scenario.newMode), scenario.expectedTableWidth, scenario.expectedWidths, withColGroups)
+    sAssertTableStructureWithSizes(editor, scenario.cols, scenario.rows, getUnit(scenario.newMode), scenario.expectedTableWidth, scenario.expectedWidths, withColGroups),
+    Step.sync(() => Assertions.assertEq('Expected events fired', expectedEventsLength, events.length)),
+    clearEvents,
   ]);
+};
 
 export {
   sTableSizingModeScenarioTest

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableSizingModeCommandUtil.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableSizingModeCommandUtil.ts
@@ -60,12 +60,11 @@ const generateTable = (mode: SizingMode, width: number, rows: number, cols: numb
 
 const sTableSizingModeScenarioTest = (editor, tinyApis: TinyApis, title: string, description: string, withColGroups: boolean, scenario: Scenario, expectedEventsLength: number = 1) => {
   let events = [];
-  editor.on('tablemodified', (e: EditorEvent<{}>) => events.push(e));
+  editor.on('TableModified', (e: EditorEvent<{}>) => events.push(e));
   const clearEvents = Step.sync(() => events = []);
 
   return Log.stepsAsStep(title, description, [
     clearEvents,
-    Step.sync(() => Assertions.assertEq('Number of events starts at 0', 0, events.length)),
     tinyApis.sSetContent(generateTable(scenario.mode, scenario.tableWidth, scenario.rows, scenario.cols, withColGroups)),
     tinyApis.sSetSelection([ 0, withColGroups ? 1 : 0, 0, 0 ], 0, [ 0, withColGroups ? 1 : 0, 0, 0 ], 0),
     tinyApis.sExecCommand('mceTableSizingMode', scenario.newMode),


### PR DESCRIPTION
**Related Ticket:**

TINY-6629

**Description of Changes:**

Add missing events for changing resize mode and resizing table.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

