### PR TITLE
TINY-6672: Renamed image_file_types to images_file_types

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,8 +2,8 @@ Version 5.6.0 (TBD)
     Added new `BeforeOpenNotification` and `OpenNotification` events which allow internal notifications to be captured and modified before display #TINY-6528
     Added support for `block` and `unblock` methods on inline dialogs #TINY-6487
     Added new `TableModified` event which is fired whenever changes are made to a table #TINY-6629
-    Added new `image_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste when using the `paste` plugin #TINY-6306
-    Added support for `image_file_types` setting in the image file uploader to determine which image file extensions are valid for upload #TINY-6224
+    Added new `images_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste when using the `paste` plugin #TINY-6306
+    Added support for `images_file_types` setting in the image file uploader to determine which image file extensions are valid for upload #TINY-6224
     Added new `format_empty_lines` setting to control if empty lines are formatted in a ranged selection #TINY-6483
     Added template support to the `autocompleter` for customizing the autocompleter items #TINY-6505
     Added new user interface `enable`, `disable`, and `isDisabled` methods #TINY-6397

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -165,10 +165,10 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       api.sDeleteSetting('automatic_uploads')
     ]);
 
-    const uploadWithCustomImageFileTypes = Log.stepsAsStep('TINY-6224', 'Image: Image uploader respects `image_file_types` setting', [
+    const uploadWithCustomImageFileTypes = Log.stepsAsStep('TINY-6224', 'Image: Image uploader respects `images_file_types` setting', [
       api.sSetContent(''),
       api.sSetSetting('images_upload_handler', (_blobInfo, success) => success('logo.svg')),
-      api.sSetSetting('image_file_types', 'svg'),
+      api.sSetSetting('images_file_types', 'svg'),
       ui.sClickOnToolbar('Trigger Image dialog', 'button[aria-label="Insert/edit image"]'),
       ui.sWaitForPopup('Wait for Image dialog', 'div[role="dialog"]'),
       ui.sClickOnUi('Switch to Upload tab', '.tox-tab:contains("Upload")'),
@@ -176,7 +176,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, fa
       ui.sWaitForUi('Wait for General tab to activate', '.tox-tab:contains("General")'),
       sAssertSrcTextValue('logo.svg'),
       ui.sClickOnUi('Close dialog', 'button:contains("Cancel")'),
-      api.sDeleteSetting('image_file_types')
+      api.sDeleteSetting('images_file_types')
     ]);
 
     const uploadWithAlternativeExtension = Log.stepsAsStep('TINY-6622', 'Image: Image uploader retains the file name/extension', [

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
@@ -64,7 +64,7 @@ const getTabSpaces = (editor: Editor) => editor.getParam('paste_tab_spaces', 4, 
 
 const getAllowedImageFileTypes = (editor: Editor): string[] => {
   const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp';
-  return Tools.explode(editor.getParam('image_file_types', defaultImageFileTypes, 'string'));
+  return Tools.explode(editor.getParam('images_file_types', defaultImageFileTypes, 'string'));
 };
 
 export {

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
@@ -196,7 +196,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     const clipboard = Clipboard(editor, Cell('html'));
 
     editor.settings.paste_data_images = true;
-    editor.settings.image_file_types = 'svg,tiff';
+    editor.settings.images_file_types = 'svg,tiff';
     const rng = setupContent(editor);
 
     const event = mockEvent('paste', [
@@ -208,7 +208,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
       LegacyUnit.equal(editor.getContent(), '<p><img src=\"data:image/tiff;base64,' + base64ImgSrc + '" />a</p>');
       LegacyUnit.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
 
-      delete editor.settings.image_file_types;
+      delete editor.settings.images_file_types;
       done();
     }).catch(die);
   });

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
@@ -51,7 +51,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.SmartPasteTest', (success, fai
     LegacyUnit.equal(SmartPaste.isImageUrl(editor, ''), false);
   });
 
-  suite.test('TINY-6306: New image_file_types defaults', (editor) => {
+  suite.test('TINY-6306: New images_file_types defaults', (editor) => {
     Arr.map([
       'jpeg',
       'jpg',
@@ -81,17 +81,17 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.SmartPasteTest', (success, fai
     );
   });
 
-  suite.test('TINY-6306: New image_file_types settings', (editor) => {
-    editor.settings.image_file_types = 'svg';
+  suite.test('TINY-6306: New images_file_types settings', (editor) => {
+    editor.settings.images_file_types = 'svg';
     LegacyUnit.equal(
       SmartPaste.isImageUrl(editor, 'https://www.site.com/file.svg'),
       true,
       'File type "svg" is valid when set by settings'
     );
-    delete editor.settings.image_file_types;
+    delete editor.settings.images_file_types;
   });
 
-  suite.test('TINY-6306: Smart paste enabled (with custom image_file_types settings)', function (editor) {
+  suite.test('TINY-6306: Smart paste enabled (with custom images_file_types settings)', function (editor) {
     editor.focus();
     editor.undoManager.clear();
     editor.setContent('<p></p>');
@@ -109,11 +109,11 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.SmartPasteTest', (success, fai
     editor.undoManager.add();
 
     // svg detected as image
-    editor.settings.image_file_types = 'svg';
+    editor.settings.images_file_types = 'svg';
     editor.execCommand('mceInsertClipboardContent', false, { content: 'http://www.site.com/my.svg' });
     LegacyUnit.equal(editor.getContent(), '<p><img src="http://www.site.com/my.svg" /></p>');
 
-    delete editor.settings.image_file_types;
+    delete editor.settings.images_file_types;
   });
 
   suite.test('TestCase-TBA: Paste: smart paste enabled, paste as content, paste url on selection', function (editor) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -27,7 +27,7 @@ import { formChangeEvent } from '../general/FormEvents';
 const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp';
 
 const filterByExtension = function (files: FileList, providersBackstage: UiFactoryBackstageProviders) {
-  const allowedImageFileTypes = Tools.explode(providersBackstage.getSetting('image_file_types', defaultImageFileTypes, 'string'));
+  const allowedImageFileTypes = Tools.explode(providersBackstage.getSetting('images_file_types', defaultImageFileTypes, 'string'));
   const isFileInAllowedTypes = (file: File) => Arr.exists(allowedImageFileTypes, (type) => Strings.endsWith(file.name, `.${type}`));
 
   return Arr.filter(Arr.from(files), isFileInAllowedTypes);


### PR DESCRIPTION
Related Ticket: TINY-6672

Description of Changes:
* Renamed `image_file_types` to `images_file_types` for consistency

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
