### PR TITLE
TINY-6658: Bump versions and added changelog dates for 5.6 release

### DIFF
--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@ephox/acid",
   "description": "Color library including Alloy UI component for a color picker",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
   },
   "dependencies": {
-    "@ephox/alloy": "^8.0.1",
-    "@ephox/boulder": "^5.0.1",
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/alloy": "^8.1.0",
+    "@ephox/boulder": "^5.0.2",
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/sugar": "^7.0.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation",

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/agar",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Testing infrastructure",
   "repository": {
     "type": "git",
@@ -24,15 +24,15 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ephox/bedrock-client": "^9.3.2",
-    "@ephox/jax": "^5.0.1",
-    "@ephox/sand": "^4.0.1",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/jax": "^5.0.2",
+    "@ephox/sand": "^4.0.2",
+    "@ephox/sugar": "^7.0.2",
     "@ephox/wrap-jsverify": "^2.0.1",
     "@ephox/wrap-sizzle": "^4.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^2.0.1"
+    "@ephox/katamari-assertions": "^2.0.2"
   },
   "files": [
     "lib/main",

--- a/modules/alloy/changelog.md
+++ b/modules/alloy/changelog.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-# [8.1.0] - TBD
+# [8.1.0] - 2020-11-18
 
 ### Added
 - Added a `Blocking` behaviour for elements that can enter a busy state

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ephox/alloy",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "description": "Ui Framework",
   "dependencies": {
-    "@ephox/agar": "^5.0.1",
-    "@ephox/boulder": "^5.0.1",
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/sand": "^4.0.1",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/agar": "^5.1.0",
+    "@ephox/boulder": "^5.0.2",
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/sand": "^4.0.2",
+    "@ephox/sugar": "^7.0.2",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/boss",
   "description": "Generic wrapper to document models - DomUniverse vs TestUniverse",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,12 +18,12 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/sugar": "^7.0.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^2.0.1"
+    "@ephox/katamari-assertions": "^2.0.2"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/boulder/package.json
+++ b/modules/boulder/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@ephox/boulder",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Basic javascript object validation",
   "dependencies": {
-    "@ephox/katamari": "^7.0.1"
+    "@ephox/katamari": "^7.1.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^2.0.1"
+    "@ephox/katamari-assertions": "^2.0.2"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test/ts",

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/bridge",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Ui API for TinyMCE 5",
   "repository": {
     "type": "git",
@@ -12,8 +12,8 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
   "dependencies": {
-    "@ephox/boulder": "^5.0.1",
-    "@ephox/katamari": "^7.0.1",
+    "@ephox/boulder": "^5.0.2",
+    "@ephox/katamari": "^7.1.0",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/darwin",
   "description": "This project's purpose is to handle selection and cursor navigation.",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,12 +18,12 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/phoenix": "^6.0.1",
-    "@ephox/robin": "^8.0.2",
-    "@ephox/sand": "^4.0.1",
-    "@ephox/snooker": "^7.0.2",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/phoenix": "^6.0.2",
+    "@ephox/robin": "^8.0.3",
+    "@ephox/sand": "^4.0.2",
+    "@ephox/snooker": "^7.1.0",
+    "@ephox/sugar": "^7.0.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/dragster",
   "description": "This project handles dragging.",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,9 +18,9 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/porkbun": "^5.0.1",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/porkbun": "^5.0.2",
+    "@ephox/sugar": "^7.0.2",
     "tslib": "^2.0.0"
   },
   "scripts": {

--- a/modules/imagetools/package.json
+++ b/modules/imagetools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/imagetools",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Image tools for tinymce and textbox.io",
   "keywords": [
     "image",

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/jax",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "AJAX library",
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/katamari": "^7.0.1",
+    "@ephox/katamari": "^7.1.0",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari-assertions",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Bedrock test assertions for Katamari",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ephox/bedrock-client": "^9.3.2",
     "@ephox/dispute": "^1.0.3",
-    "@ephox/katamari": "^7.0.1",
+    "@ephox/katamari": "^7.1.0",
     "@ephox/wrap-promise-polyfill": "^2.2.0",
     "tslib": "^2.0.0"
   },

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "Basic data type library",
   "repository": {
     "type": "git",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/mcagar",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Tinymce agar wrapper",
   "repository": {
     "type": "git",
@@ -23,10 +23,10 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/agar": "^5.0.1",
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/sand": "^4.0.1",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/agar": "^5.1.0",
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/sand": "^4.0.2",
+    "@ephox/sugar": "^7.0.2",
     "@ephox/wrap-jsverify": "^2.0.1",
     "tslib": "^2.0.0"
   },

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "TinyMCE 5 Oxide skin",
   "scripts": {
     "test": "echo 'No tests'",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/phoenix",
   "description": "DOM node text gathering library, rose from the ashes of some other projects we can't remember the names of now (edit: seek, sherlock, gift)",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,14 +18,14 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^4.0.1",
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/polaris": "^4.0.1",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/boss": "^4.0.2",
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/polaris": "^4.0.2",
+    "@ephox/sugar": "^7.0.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^2.0.1"
+    "@ephox/katamari-assertions": "^2.0.2"
   },
   "scripts": {
     "test-manual": "bedrock -d src/test",

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/polaris",
   "description": "This project does data manipulation on arrays and strings.",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,11 +18,11 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^7.0.1",
+    "@ephox/katamari": "^7.1.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^2.0.1"
+    "@ephox/katamari-assertions": "^2.0.2"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/porkbun",
   "description": "Event framework for JavaScript",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,7 +18,7 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^7.0.1"
+    "@ephox/katamari": "^7.1.0"
   },
   "scripts": {
     "test": "bedrock-auto -b phantomjs -d src/test/ts",

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/robin",
   "description": "This project is for grouping sibling DOM nodes together by boundary points, for example the list of elements and nodes representing a word.",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce"
@@ -18,15 +18,15 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^4.0.1",
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/phoenix": "^6.0.1",
-    "@ephox/polaris": "^4.0.1",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/boss": "^4.0.2",
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/phoenix": "^6.0.2",
+    "@ephox/polaris": "^4.0.2",
+    "@ephox/sugar": "^7.0.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^2.0.1"
+    "@ephox/katamari-assertions": "^2.0.2"
   },
   "author": "Ephox Corporation",
   "license": "Apache-2.0",

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sand",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Platform detection library",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/katamari": "^7.0.1",
+    "@ephox/katamari": "^7.1.0",
     "tslib": "^2.0.0"
   },
   "main": "./lib/main/ts/ephox/sand/api/Main.js",

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/snooker",
   "description": "This project implements the table model.",
-  "version": "7.0.2",
+  "version": "7.1.0",
   "files": [
     "lib/main",
     "lib/demo",
@@ -18,11 +18,11 @@
     "url": "https://github.com/tinymce/tinymce"
   },
   "dependencies": {
-    "@ephox/dragster": "^5.0.1",
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/porkbun": "^5.0.1",
-    "@ephox/robin": "^8.0.2",
-    "@ephox/sugar": "^7.0.1",
+    "@ephox/dragster": "^5.0.2",
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/porkbun": "^5.0.2",
+    "@ephox/robin": "^8.0.3",
+    "@ephox/sugar": "^7.0.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation",

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sugar",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Basic DOM manipulation",
   "repository": {
     "type": "git",
@@ -21,11 +21,11 @@
   "author": "Ephox Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/katamari": "^7.0.1",
-    "@ephox/sand": "^4.0.1"
+    "@ephox/katamari": "^7.1.0",
+    "@ephox/sand": "^4.0.2"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^2.0.1"
+    "@ephox/katamari-assertions": "^2.0.2"
   },
   "files": [
     "lib/main",

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,4 @@
-Version 5.6.0 (TBD)
+Version 5.6.0 (2020-11-18)
     Added new `BeforeOpenNotification` and `OpenNotification` events which allow internal notifications to be captured and modified before display #TINY-6528
     Added support for `block` and `unblock` methods on inline dialogs #TINY-6487
     Added new `TableModified` event which is fired whenever changes are made to a table #TINY-6629

--- a/versions.txt
+++ b/versions.txt
@@ -1,8 +1,2 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
-
-agar@5.1.0
-mcagar@5.1.0
-alloy@8.1.0
-katamari@7.1.0
-snooker@7.1.0


### PR DESCRIPTION
Related Ticket: TINY-6658

Description of changes:
- Bumped TinyMCE and Alloy changelog dates
- Bumped versions as per versions.txt, see:
```
Changes:
 - @ephox/acid: 2.0.1 => 2.0.2
 - @ephox/agar: 5.0.1 => 5.1.0
 - @ephox/alloy: 8.0.1 => 8.1.0
 - @ephox/boss: 4.0.1 => 4.0.2
 - @ephox/boulder: 5.0.1 => 5.0.2
 - @ephox/bridge: 2.0.1 => 2.1.0
 - @ephox/darwin: 5.0.2 => 5.0.3
 - @ephox/dragster: 5.0.1 => 5.0.2
 - @ephox/imagetools: 4.0.1 => 4.0.2
 - @ephox/jax: 5.0.1 => 5.0.2
 - @ephox/katamari-assertions: 2.0.1 => 2.0.2
 - @ephox/katamari: 7.0.1 => 7.1.0
 - @ephox/mcagar: 5.0.1 => 5.1.0
 - @tinymce/oxide: 1.5.1 => 1.6.0
 - @ephox/phoenix: 6.0.1 => 6.0.2
 - @ephox/polaris: 4.0.1 => 4.0.2
 - @ephox/porkbun: 5.0.1 => 5.0.2
 - @ephox/robin: 8.0.2 => 8.0.3
 - @ephox/sand: 4.0.1 => 4.0.2
 - @ephox/snooker: 7.0.2 => 7.1.0
 - @ephox/sugar: 7.0.1 => 7.0.2
```

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
