### PR TITLE
TINY-6484: We now switch scope to/from group as expected

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
@@ -1,5 +1,5 @@
-import { Arr, Cell, Contracts, Optional } from '@ephox/katamari';
-import { Css, SugarElement, SugarNode } from '@ephox/sugar';
+import { Arr, Cell, Fun, Optional, Optionals } from '@ephox/katamari';
+import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
 import { getAttrValue } from '../util/CellUtils';
 
 export interface CellSpan {
@@ -39,7 +39,8 @@ export interface GeneratorsTransform extends GeneratorsWrapper {
 }
 
 export interface GeneratorsMerging extends GeneratorsWrapper {
-  readonly combine: (cell: SugarElement) => () => SugarElement;
+  readonly unmerge: (cell: SugarElement) => () => SugarElement;
+  readonly merge: (cells: SugarElement[]) => () => SugarElement;
 }
 
 interface Recent {
@@ -51,8 +52,6 @@ interface Item {
   readonly item: SugarElement;
   readonly sub: SugarElement;
 }
-
-const verifyGenerators: (gen: Generators) => Generators = Contracts.exactly([ 'cell', 'row', 'replace', 'gap', 'col', 'colgroup' ]);
 
 const elementToData = function (element: SugarElement): CellSpan {
   const colspan = getAttrValue(element, 'colspan', 1);
@@ -66,7 +65,6 @@ const elementToData = function (element: SugarElement): CellSpan {
 
 // note that `toData` seems to be only for testing
 const modification = function (generators: Generators, toData = elementToData): GeneratorsModification {
-  verifyGenerators(generators);
   const position = Cell(Optional.none<SugarElement>());
 
   const nu = function (data: CellSpan) {
@@ -110,7 +108,6 @@ const modification = function (generators: Generators, toData = elementToData): 
 const transform = function <K extends keyof HTMLElementTagNameMap> (scope: string | null, tag: K) {
   return function (generators: Generators): GeneratorsTransform {
     const position = Cell(Optional.none<SugarElement>());
-    verifyGenerators(generators);
     const list: Item[] = [];
 
     const find = function (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) {
@@ -149,15 +146,26 @@ const transform = function <K extends keyof HTMLElementTagNameMap> (scope: strin
   };
 };
 
-const merging = function (generators: Generators) {
-  verifyGenerators(generators);
+const getScopeAttribute = (cell: SugarElement) =>
+  Attribute.getOpt(cell, 'scope').map(
+    (attribute) => attribute.substr(0, 3)
+    // Attribute can be col, colgroup, row, and rowgroup.
+    // As col and colgroup are to be treated as if they are the same, lob off everything after the first three characters and there is no difference.
+  );
+
+const merging = (generators: Generators) => {
   const position = Cell(Optional.none<SugarElement>());
 
-  const combine = function (cell: SugarElement) {
+  const unmerge = (cell: SugarElement) => {
     if (position.get().isNone()) {
       position.set(Optional.some(cell));
     }
-    return function () {
+
+    const scope = getScopeAttribute(cell);
+
+    scope.each((attribute) => Attribute.set(cell, 'scope', attribute));
+
+    return () => {
       const raw = generators.cell({
         element: cell,
         colspan: 1,
@@ -166,12 +174,47 @@ const merging = function (generators: Generators) {
       // Remove any width calculations because they are no longer relevant.
       Css.remove(raw, 'width');
       Css.remove(cell, 'width');
+
+      scope.each((attribute) => Attribute.set(raw, 'scope', attribute));
+
       return raw;
     };
   };
 
+  const merge = (cells: SugarElement[]) => {
+    const getScopeProperty = () => {
+
+      const stringAttributes = Optionals.cat(
+        Arr.map(cells, getScopeAttribute)
+      );
+
+      if (stringAttributes.length === 0) {
+        return Optional.none<string>();
+      } else {
+        const baseScope = stringAttributes[0];
+        const scopes = [ 'row', 'col' ];
+
+        const isMixed = Arr.exists(stringAttributes, (attribute) => {
+          return attribute !== baseScope && Arr.contains(scopes, attribute);
+        });
+
+        return isMixed ? Optional.none<string>() : Optional.from(baseScope);
+      }
+    };
+
+    Css.remove(cells[0], 'width');
+
+    getScopeProperty().fold(
+      () => Attribute.remove(cells[0], 'scope'),
+      (attribute) => Attribute.set(cells[0], 'scope', attribute + 'group')
+    );
+
+    return Fun.constant(cells[0]);
+  };
+
   return {
-    combine,
+    unmerge,
+    merge,
     cursor: position.get
   };
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -227,15 +227,20 @@ const opEraseRows = (grid: Structs.RowCells[], details: Structs.DetailExt[], _co
   return outcome(newGrid, cursor);
 };
 
-const opMergeCells = (grid: Structs.RowCells[], mergable: ExtractMergable, comparator: CompElm, _genWrappers: GeneratorsMerging) => {
+const opMergeCells = (grid: Structs.RowCells[], mergable: ExtractMergable, comparator: CompElm, genWrappers: GeneratorsMerging) => {
   const cells = mergable.cells;
   TableContent.merge(cells);
-  const newGrid = MergingOperations.merge(grid, mergable.bounds, comparator, Fun.constant(cells[0]));
+
+  const newGrid = MergingOperations.merge(grid, mergable.bounds, comparator, genWrappers.merge(cells));
+
   return outcome(newGrid, Optional.from(cells[0]));
 };
 
 const opUnmergeCells = (grid: Structs.RowCells[], unmergable: SugarElement[], comparator: CompElm, genWrappers: GeneratorsMerging) => {
-  const newGrid = Arr.foldr(unmergable, (b, cell) => MergingOperations.unmerge(b, cell, comparator, genWrappers.combine(cell)), grid);
+  const unmerge = (b: Structs.RowCells[], cell: SugarElement) =>
+    MergingOperations.unmerge(b, cell, comparator, genWrappers.unmerge(cell));
+
+  const newGrid = Arr.foldr(unmergable, unmerge, grid);
   return outcome(newGrid, Optional.from(unmergable[0]));
 };
 

--- a/modules/snooker/src/test/ts/browser/MergeOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/MergeOperationsTest.ts
@@ -79,4 +79,156 @@ UnitTest.test('MergeOperationsTest', function () {
     ],
     { startRow: 2, startCol: 0, finishRow: 3, finishCol: 0 }
   );
+
+  Assertions.checkMerge(
+    'TINY-6484 - merge cells where there is one or more row-scopes, resulting in a rowgroup scope.',
+    // Border = 1 would be here, but it is removed so that we can assert html
+    '<table style="border-collapse: collapse;">' +
+      '<tbody>' +
+        '<tr>' +
+          '<td scope="rowgroup" rowspan="2">A1<br>A2<br></td>' +
+          '<td>B1</td>' +
+          '<td>C1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+
+    '<table border="1" style="border-collapse: collapse;">' +
+      '<tbody>' +
+        '<tr>' +
+          '<td scope="row">A1</td>' +
+          '<td>B1</td>' +
+          '<td>C1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>A2</td>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+    [
+      { section: 0, row: 0, column: 0 },
+      { section: 0, row: 1, column: 0 }
+    ],
+    { startRow: 0, startCol: 0, finishRow: 1, finishCol: 0 }
+  );
+
+  Assertions.checkMerge(
+    'TINY-6484 - merge cells where there is one or more col-scopes, resulting in a colgroup scope.',
+    // Border = 1 would be here, but it is removed so that we can assert html
+    '<table style="border-collapse: collapse;">' +
+      '<tbody>' +
+        '<tr>' +
+          '<td scope="colgroup" colspan="2">A1<br>B1<br></td>' +
+          '<td>C1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>A2</td>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+
+    '<table border="1" style="border-collapse: collapse;">' +
+      '<tbody>' +
+        '<tr>' +
+          '<td scope="col">A1</td>' +
+          '<td>B1</td>' +
+          '<td>C1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>A2</td>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+    [
+      { section: 0, row: 0, column: 0 },
+      { section: 0, row: 0, column: 1 }
+    ],
+    { startRow: 0, startCol: 0, finishRow: 0, finishCol: 1 }
+  );
+
+  Assertions.checkMerge(
+    'TINY-6484 - merge cells where there is one or more row-scopes and one or more col-scopes, resulting in the scope attribute being removed.',
+    // Border = 1 would be here, but it is removed so that we can assert html
+    '<table style="border-collapse: collapse;">' +
+      '<tbody>' +
+        '<tr>' +
+          '<td rowspan="2">A1<br>A2<br></td>' +
+          '<td>B1</td>' +
+          '<td>C1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+
+    '<table border="1" style="border-collapse: collapse;">' +
+      '<tbody>' +
+        '<tr>' +
+          '<td scope="row">A1</td>' +
+          '<td>B1</td>' +
+          '<td>C1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td scope="col">A2</td>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+    [
+      { section: 0, row: 0, column: 0 },
+      { section: 0, row: 1, column: 0 }
+    ],
+    { startRow: 0, startCol: 0, finishRow: 1, finishCol: 0 }
+  );
+
+  Assertions.checkMerge(
+    'TINY-6484 - merge cells where there is one or more row-scopes and one or more col-scopes, resulting in the scope attribute being removed, reverse order.',
+    // Border = 1 would be here, but it is removed so that we can assert html
+    '<table style="border-collapse: collapse;">' +
+      '<tbody>' +
+        '<tr>' +
+          '<td rowspan="2">A1<br>A2<br></td>' +
+          '<td>B1</td>' +
+          '<td>C1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+
+    '<table border="1" style="border-collapse: collapse;">' +
+      '<tbody>' +
+        '<tr>' +
+          '<td scope="col">A1</td>' +
+          '<td>B1</td>' +
+          '<td>C1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td scope="row">A2</td>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+    [
+      { section: 0, row: 0, column: 0 },
+      { section: 0, row: 1, column: 0 }
+    ],
+    { startRow: 0, startCol: 0, finishRow: 1, finishCol: 0 }
+  );
 });

--- a/modules/snooker/src/test/ts/browser/UnmergeOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/UnmergeOperationsTest.ts
@@ -3,6 +3,7 @@ import * as Assertions from 'ephox/snooker/test/Assertions';
 
 UnitTest.test('UnmergeOperationsTest', function () {
   Assertions.checkUnmerge(
+    'TBA',
     '<table><tbody>' +
       '<tr><th>A1</th><td>B1</td><td>C1</td><td>D1</td></tr>' +
       '<tr><th>?</th><td>B2</td><td>C2</td><td>D2</td></tr>' +
@@ -21,6 +22,7 @@ UnitTest.test('UnmergeOperationsTest', function () {
   );
 
   Assertions.checkUnmerge(
+    'TBA',
     '<table><tbody>' +
       '<tr><th>' +
       '<table><tbody>' +
@@ -49,6 +51,7 @@ UnitTest.test('UnmergeOperationsTest', function () {
   );
 
   Assertions.checkUnmerge(
+    'TBA',
     '<table><tbody>' +
     '<tr><th rowspan="3">A1</th><td>B1</td><td colspan="2">C1</td></tr>' +
     '<tr><td>B2</td><td>C2</td><td>?</td></tr>' +
@@ -67,6 +70,7 @@ UnitTest.test('UnmergeOperationsTest', function () {
   );
 
   Assertions.checkUnmerge(
+    'TBA',
     '<table><thead>' +
       '<tr><td>A1</td><td>?</td><td>?</td><td>D1</td></tr>' +
       '</thead>' +
@@ -89,6 +93,7 @@ UnitTest.test('UnmergeOperationsTest', function () {
   );
 
   Assertions.checkUnmerge(
+    'TBA',
     '<table><thead>' +
       '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
       '</thead>' +
@@ -107,6 +112,113 @@ UnitTest.test('UnmergeOperationsTest', function () {
 
     [
       { section: 1, row: 0, column: 0 }
+    ]
+  );
+
+  Assertions.checkUnmerge(
+    'TINY-6484: rowgroup-scoped cell split into cells results in all generated spells having scope row',
+    '<table>' +
+      '<tbody>' +
+        '<tr>' +
+          '<th scope="row">A1</th>' +
+          '<td>B1</td>' +
+          '<td>C1</td>' +
+          '<td>D1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<th scope="row">?</th>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+          '<td>D2</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<th scope="row">?</th>' +
+          '<td>B3</td>' +
+          '<td>C3</td>' +
+          '<td>D3</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+
+    '<table>' +
+      '<tbody>' +
+        '<tr>' +
+          '<th rowspan="3" scope="rowgroup">A1</th>' +
+          '<td>B1</td>' +
+          '<td>C1</td>' +
+          '<td>D1</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+          '<td>D2</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>B3</td>' +
+          '<td>C3</td>' +
+          '<td>D3</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+    [
+      {
+        section: 0,
+        row: 0,
+        column: 0
+      }
+    ]
+  );
+
+  Assertions.checkUnmerge(
+    'TINY-6484: colgroup-scoped cell split into cells results in all generated spells having scope col',
+    '<table>' +
+      '<tbody>' +
+        '<tr>' +
+          '<th scope="col">A1</th>' +
+          '<th scope="col">?</th>' +
+          '<th scope="col">?</th>' +
+          '<th scope="col">?</th>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>A2</td>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+          '<td>D2</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>A3</td>' +
+          '<td>B3</td>' +
+          '<td>C3</td>' +
+          '<td>D3</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+
+    '<table>' +
+      '<tbody>' +
+        '<tr>' +
+          '<th colspan="4" scope="colgroup">A1</th>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>A2</td>' +
+          '<td>B2</td>' +
+          '<td>C2</td>' +
+          '<td>D2</td>' +
+        '</tr>' +
+        '<tr>' +
+          '<td>A3</td>' +
+          '<td>B3</td>' +
+          '<td>C3</td>' +
+          '<td>D3</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>',
+    [
+      {
+        section: 0,
+        row: 0,
+        column: 0
+      }
     ]
   );
 });

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
@@ -1,3 +1,4 @@
+import { Assertions } from '@ephox/agar';
 import { assert } from '@ephox/bedrock-client';
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
@@ -232,7 +233,7 @@ const checkMerge = (
   assert.eq('1', Attribute.get(table, 'border'));
   // Get around ordering of attribute differences.
   Attribute.remove(table, 'border');
-  assert.eq(expected, Html.getOuter(table));
+  Assertions.assertHtmlStructure(label, expected, Html.getOuter(table));
 
   Remove.remove(table);
   Remove.remove(expectedDom);
@@ -240,6 +241,7 @@ const checkMerge = (
 };
 
 const checkUnmerge = (
+  label: string,
   expected: string,
   input: string,
   unmergablePaths: { section: number; row: number; column: number }[]
@@ -260,7 +262,7 @@ const checkUnmerge = (
   const all = [ table ].concat(SelectorFilter.descendants(table, 'td,th'));
   Arr.each(all, (elem) => Css.remove(elem, 'width') );
 
-  assert.eq(expected, Html.getOuter(table));
+  Assertions.assertEq(label, expected, Html.getOuter(table));
   Remove.remove(table);
   Bars.destroy(wire);
 };

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,6 +2,7 @@ Version 5.7.0 (TBD)
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
     Changed the z-index of the `setProgressState(true)` throbber so it does not hide notifications #TINY-6686
+    Fixed an issue where `scope` attributes on table cells would not change as expected when merging or unmerging cells #TINY-6486
     Fixed the plugin documentation links in the `help` plugin #DOC-703
 Version 5.6.1 (2020-11-25)
     Fixed the `mceTableRowType` and `mceTableCellType` commands were not firing the `newCell` event #TINY-6692


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Previously scope attributes would not be correctly changed ( colgroup to col, for example ) when merging or unmerging.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
