### PR TITLE
TINY-6681: Recognize HTML5 s element when formatting

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,7 @@
 Version 5.7.0 (TBD)
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
+Version 5.6.1 (TBD)
+    Fixed HTML5 s tag not being recognized when editing or clearing text formatting #TINY-6681
 Version 5.6.0 (2020-11-18)
     Added new `BeforeOpenNotification` and `OpenNotification` events which allow internal notifications to be captured and modified before display #TINY-6528
     Added support for `block` and `unblock` methods on inline dialogs #TINY-6487

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,7 +1,7 @@
 Version 5.7.0 (TBD)
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
 Version 5.6.1 (TBD)
-    Fixed HTML5 s tag not being recognized when editing or clearing text formatting #TINY-6681
+    Fixed HTML5 `s` tag not recognized when editing or clearing text formatting #TINY-6681
 Version 5.6.0 (2020-11-18)
     Added new `BeforeOpenNotification` and `OpenNotification` events which allow internal notifications to be captured and modified before display #TINY-6528
     Added support for `block` and `unblock` methods on inline dialogs #TINY-6487

--- a/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
@@ -147,7 +147,8 @@ const get = function (dom: DOMUtils) {
 
     strikethrough: [
       { inline: 'span', styles: { textDecoration: 'line-through' }, exact: true },
-      { inline: 'strike', remove: 'all', preserve_attributes: [ 'class', 'style' ] }
+      { inline: 'strike', remove: 'all', preserve_attributes: [ 'class', 'style' ] },
+      { inline: 's', remove: 'all', preserve_attributes: [ 'class', 'style' ] }
     ],
 
     forecolor: { inline: 'span', styles: { color: '%value' }, links: true, remove_similar: true, clear_child_styles: true },
@@ -176,7 +177,7 @@ const get = function (dom: DOMUtils) {
 
     removeformat: [
       {
-        selector: 'b,strong,em,i,font,u,strike,sub,sup,dfn,code,samp,kbd,var,cite,mark,q,del,ins',
+        selector: 'b,strong,em,i,font,u,strike,s,sub,sup,dfn,code,samp,kbd,var,cite,mark,q,del,ins',
         remove: 'all',
         split: true,
         expand: false,

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -429,11 +429,12 @@ UnitTest.asynctest('browser.tinymce.core.FormattingCommandsTest', function (succ
 
     editor.setContent(
       '<p><dfn>dfn tag </dfn> <code>code tag </code> <samp>samp tag</samp> ' +
-      '<kbd> kbd tag</kbd> <var> var tag</var> <cite> cite tag</cite> <mark> mark tag</mark> <q> q tag</q></p>'
+      '<kbd> kbd tag</kbd> <var> var tag</var> <cite> cite tag</cite> <mark> mark tag</mark> <q> q tag</q> ' +
+      '<strike>strike tag</strike> <s>s tag</s></p>'
     );
     editor.execCommand('SelectAll');
     editor.execCommand('RemoveFormat');
-    LegacyUnit.equal(editor.getContent(), '<p>dfn tag code tag samp tag kbd tag var tag cite tag mark tag q tag</p>');
+    LegacyUnit.equal(editor.getContent(), '<p>dfn tag code tag samp tag kbd tag var tag cite tag mark tag q tag strike tag s tag</p>');
   });
 
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {


### PR DESCRIPTION
**Related Ticket:**

TINY-6681

**Description of Changes:**

Ensure `<s>` element is recognised as a valid element for strikethrough formatting.

**Pre-checks:**

* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

**Review:**
* [x] Milestone set
* [ ] Review comments resolved

