### PR TITLE
TINY-6684: Fixed copying and pasting table columns with a colgroup resulted in invalid HTML

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableLookup.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableLookup.ts
@@ -28,9 +28,15 @@ const cell = (element: SugarElement, isRoot?: (e: SugarElement) => boolean) => l
 
 const cells = (ancestor: SugarElement): SugarElement<HTMLTableCellElement>[] => LayerSelector.firstLayer(ancestor, 'th,td');
 
-const columns = (ancestor: SugarElement): SugarElement<HTMLTableColElement>[] => Arr.bind(columnGroups(ancestor), (columnGroup) =>
-  SelectorFilter.children<HTMLTableColElement>(columnGroup, 'col')
-);
+const columns = (ancestor: SugarElement): SugarElement<HTMLTableColElement>[] => {
+  if (Selectors.is(ancestor, 'colgroup')) {
+    return SelectorFilter.children<HTMLTableColElement>(ancestor, 'col');
+  } else {
+    return Arr.bind(columnGroups(ancestor), (columnGroup) =>
+      SelectorFilter.children<HTMLTableColElement>(columnGroup, 'col')
+    );
+  }
+};
 
 const notCell = (element: SugarElement, isRoot?: (e: SugarElement) => boolean) => lookup<Element>([ 'caption', 'tr', 'tbody', 'tfoot', 'thead' ], element, isRoot);
 

--- a/modules/snooker/src/test/ts/browser/TableLookupTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableLookupTest.ts
@@ -194,6 +194,14 @@ UnitTest.test('TableLookupTest - columns', () => {
     });
   };
 
+  const testDetachedColumn = (label: string, triggerSelector: string, expectedCount: number) => {
+    testWithSelector(html, triggerSelector, (triggerElement) => {
+      Remove.remove(triggerElement);
+      const columns = TableLookup.columns(triggerElement);
+      Assert.eq(label, expectedCount, columns.length);
+    });
+  };
+
   testColumnGroup('Column group from table', 'body > table', 1);
   testColumnGroup('Column group from table cell', 'body > table > tbody > tr > td', 1);
   testColumnGroup('Column group from nested table', 'body > table > tbody > tr > td:nth-child(1) > table', 2);
@@ -205,4 +213,6 @@ UnitTest.test('TableLookupTest - columns', () => {
   testColumn('Column from nested table', 'body > table > tbody > tr > td:nth-child(1) > table', 1);
   testColumn('Column from nested table colgroup', 'body > table > tbody > tr > td:nth-child(1) > table > colgroup', 1);
   testColumn('Column from nested table cell ', 'body > table > tbody > tr > td:nth-child(1) > table > tbody > tr > td', 1);
+
+  testDetachedColumn('Column from detached table colgroup', 'body > table > colgroup', 2);
 });

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,3 +1,5 @@
+Version 5.6.1 (TBD)
+    Fixed copying and pasting table columns with a colgroup resulted in invalid HTML #TINY-6684
 Version 5.6.0 (2020-11-18)
     Added new `BeforeOpenNotification` and `OpenNotification` events which allow internal notifications to be captured and modified before display #TINY-6528
     Added support for `block` and `unblock` methods on inline dialogs #TINY-6487

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.6.1 (TBD)
-    Fixed copying and pasting table columns with a colgroup resulted in invalid HTML #TINY-6684
+    Fixed an issue where copying and pasting table columns resulted in invalid HTML when using colgroups #TINY-6684
 Version 5.6.0 (2020-11-18)
     Added new `BeforeOpenNotification` and `OpenNotification` events which allow internal notifications to be captured and modified before display #TINY-6528
     Added support for `block` and `unblock` methods on inline dialogs #TINY-6487

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -70,12 +70,13 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
       '<table>' +
       '<tr><td>1</td><td>2</td></tr>' +
       '<tr><td>2</td><td>3</td></tr>' +
+      '<tr><td>3</td><td>4</td></tr>' +
       '</table>'
     );
 
     selectOne(editor, 'tr:nth-child(1) td');
     editor.execCommand('mceTableCopyRow');
-    selectOne(editor, 'tr:nth-child(2) td');
+    selectOne(editor, 'tr:nth-child(3) td');
     editor.execCommand('mceTablePasteRowBefore');
 
     LegacyUnit.equal(
@@ -84,13 +85,14 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
       '<table>' +
       '<tbody>' +
       '<tr><td>1</td><td>2</td></tr>' +
-      '<tr><td>1</td><td>2</td></tr>' +
       '<tr><td>2</td><td>3</td></tr>' +
+      '<tr><td>1</td><td>2</td></tr>' +
+      '<tr><td>3</td><td>4</td></tr>' +
       '</tbody>' +
       '</table>'
     );
 
-    selectOne(editor, 'tr:nth-child(2) td');
+    selectOne(editor, 'tr:nth-child(3) td');
     editor.execCommand('mceTablePasteRowBefore');
 
     LegacyUnit.equal(
@@ -99,9 +101,10 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
       '<table>' +
       '<tbody>' +
       '<tr><td>1</td><td>2</td></tr>' +
-      '<tr><td>1</td><td>2</td></tr>' +
-      '<tr><td>1</td><td>2</td></tr>' +
       '<tr><td>2</td><td>3</td></tr>' +
+      '<tr><td>1</td><td>2</td></tr>' +
+      '<tr><td>1</td><td>2</td></tr>' +
+      '<tr><td>3</td><td>4</td></tr>' +
       '</tbody>' +
       '</table>'
     );
@@ -424,14 +427,14 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
   suite.test('TestCase-TINY-6006: Table: mceTablePasteColBefore command', (editor) => {
     editor.setContent(
       '<table>' +
-      '<tr><td>1</td><td>2</td></tr>' +
-      '<tr><td>2</td><td>3</td></tr>' +
+      '<tr><td>1</td><td>2</td><td>3</td></tr>' +
+      '<tr><td>2</td><td>3</td><td>4</td></tr>' +
       '</table>'
     );
 
     selectOne(editor, 'tr td:nth-child(1)');
     editor.execCommand('mceTableCopyCol');
-    selectOne(editor, 'tr td:nth-child(2)');
+    selectOne(editor, 'tr td:nth-child(3)');
     editor.execCommand('mceTablePasteColBefore');
 
     LegacyUnit.equal(
@@ -439,8 +442,8 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
 
       '<table>' +
       '<tbody>' +
-      '<tr><td>1</td><td>1</td><td>2</td></tr>' +
-      '<tr><td>2</td><td>2</td><td>3</td></tr>' +
+      '<tr><td>1</td><td>2</td><td>1</td><td>3</td></tr>' +
+      '<tr><td>2</td><td>3</td><td>2</td><td>4</td></tr>' +
       '</tbody>' +
       '</table>'
     );
@@ -449,14 +452,14 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
   suite.test('TestCase-TINY-6006: Table: mceTablePasteColAfter command', (editor) => {
     editor.setContent(
       '<table>' +
-      '<tr><td>1</td><td>2</td></tr>' +
-      '<tr><td>2</td><td>3</td></tr>' +
+      '<tr><td>1</td><td>2</td><td>3</td></tr>' +
+      '<tr><td>2</td><td>3</td><td>4</td></tr>' +
       '</table>'
     );
 
     selectOne(editor, 'tr td:nth-child(2)');
     editor.execCommand('mceTableCopyCol');
-    selectOne(editor, 'tr td:nth-child(2)');
+    selectOne(editor, 'tr td:nth-child(3)');
     editor.execCommand('mceTablePasteColAfter');
 
     LegacyUnit.equal(
@@ -464,8 +467,8 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
 
       '<table>' +
       '<tbody>' +
-      '<tr><td>1</td><td>2</td><td>2</td></tr>' +
-      '<tr><td>2</td><td>3</td><td>3</td></tr>' +
+      '<tr><td>1</td><td>2</td><td>3</td><td>2</td></tr>' +
+      '<tr><td>2</td><td>3</td><td>4</td><td>3</td></tr>' +
       '</tbody>' +
       '</table>'
     );
@@ -571,27 +574,27 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
   suite.test('TestCase-TINY-6684: Table: mceTablePasteColAfter command with colgroups', (editor) => {
     editor.setContent(
       '<table>' +
-      '<colgroup><col><col></colgroup>' +
+      '<colgroup><col><col><col></colgroup>' +
       '<tbody>' +
-      '<tr><td>1</td><td>2</td></tr>' +
-      '<tr><td>2</td><td>3</td></tr>' +
+      '<tr><td>1</td><td>2</td><td>3</td></tr>' +
+      '<tr><td>2</td><td>3</td><td>4</td></tr>' +
       '</tbody>' +
       '</table>'
     );
 
     selectOne(editor, 'tr td:nth-child(1)');
     editor.execCommand('mceTableCopyCol');
-    selectOne(editor, 'tr td:nth-child(1)');
+    selectOne(editor, 'tr td:nth-child(2)');
     editor.execCommand('mceTablePasteColAfter');
 
     LegacyUnit.equal(
       cleanTableHtml(editor.getContent()),
 
       '<table>' +
-      '<colgroup><col /><col /><col /></colgroup>' +
+      '<colgroup><col /><col /><col /><col /></colgroup>' +
       '<tbody>' +
-      '<tr><td>1</td><td>1</td><td>2</td></tr>' +
-      '<tr><td>2</td><td>2</td><td>3</td></tr>' +
+      '<tr><td>1</td><td>2</td><td>1</td><td>3</td></tr>' +
+      '<tr><td>2</td><td>3</td><td>2</td><td>4</td></tr>' +
       '</tbody>' +
       '</table>'
     );

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -550,9 +550,9 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
       '</table>'
     );
 
-    selectOne(editor, 'tr td:nth-child(1)');
-    editor.execCommand('mceTableCopyCol');
     selectOne(editor, 'tr td:nth-child(2)');
+    editor.execCommand('mceTableCopyCol');
+    selectOne(editor, 'tr td:nth-child(1)');
     editor.execCommand('mceTablePasteColBefore');
 
     LegacyUnit.equal(
@@ -561,14 +561,14 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
       '<table>' +
       '<colgroup><col /><col /><col /></colgroup>' +
       '<tbody>' +
-      '<tr><td>1</td><td>1</td><td>2</td></tr>' +
-      '<tr><td>2</td><td>2</td><td>3</td></tr>' +
+      '<tr><td>2</td><td>1</td><td>2</td></tr>' +
+      '<tr><td>3</td><td>2</td><td>3</td></tr>' +
       '</tbody>' +
       '</table>'
     );
   });
 
-  suite.test('TestCase-TINY-6684: Table: mceTablePasteColBefore command with colgroups', (editor) => {
+  suite.test('TestCase-TINY-6684: Table: mceTablePasteColAfter command with colgroups', (editor) => {
     editor.setContent(
       '<table>' +
       '<colgroup><col><col></colgroup>' +
@@ -582,7 +582,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ClipboardTest', (success, fail
     selectOne(editor, 'tr td:nth-child(1)');
     editor.execCommand('mceTableCopyCol');
     selectOne(editor, 'tr td:nth-child(1)');
-    editor.execCommand('mceTablePasteColBefore');
+    editor.execCommand('mceTablePasteColAfter');
 
     LegacyUnit.equal(
       cleanTableHtml(editor.getContent()),


### PR DESCRIPTION
Related Ticket: TINY-6684

Description of Changes:
Fixed a regression that caused invalid HTML to be created when copying and pasting within a table that used colgroups. This was because the `col` lookup was failing when a detached colgroup was passed.

Note: Ideally we need to look at supporting copying/pasting between tables that either use colgroups or don't, however that's a much larger scope and not something that worked in TinyMCE 5.5.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
