### PR TITLE
TINY-6683: Sink now only resizes if contained in the body or shadowroot.

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.6.1 (TBD)
     Fixed an issue where copying and pasting table columns resulted in invalid HTML when using colgroups #TINY-6684
+    Fixed an issue where the toolbar would render with the wrong width for inline editors in some situations #TINY-6683
 Version 5.6.0 (2020-11-18)
     Added new `BeforeOpenNotification` and `OpenNotification` events which allow internal notifications to be captured and modified before display #TINY-6528
     Added support for `block` and `unblock` methods on inline dialogs #TINY-6487

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -6,9 +6,9 @@
  */
 
 import { AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Disabling, Gui, GuiFactory, Keying, Memento, Positioning, SimpleSpec, SystemEvents, VerticalDir } from '@ephox/alloy';
-import { Arr, Obj, Optional, Result } from '@ephox/katamari';
+import { Arr, Merger, Obj, Optional, Result } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Css } from '@ephox/sugar';
+import { Css, SugarNode, SugarShadowDom } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
@@ -90,6 +90,9 @@ const setup = (editor: Editor): RenderInfo => {
   const touchPlatformClass = 'tox-platform-touch';
   const deviceClasses = isTouch ? [ touchPlatformClass ] : [];
   const isToolbarBottom = Settings.isToolbarLocationBottom(editor);
+  const container = Settings.getUiContainer(editor);
+
+  const toolbarIsInRoot = SugarNode.isTag('body')(container) || SugarShadowDom.isShadowRoot(container);
 
   const dirAttributes = I18n.isRtl() ? {
     attributes: {
@@ -113,24 +116,33 @@ const setup = (editor: Editor): RenderInfo => {
     Css.set(uiMothership.element, 'width', document.body.clientWidth + 'px');
   };
 
-  const sink = GuiFactory.build({
-    dom: {
-      tag: 'div',
-      classes: [ 'tox', 'tox-silver-sink', 'tox-tinymce-aux' ].concat(platformClasses).concat(deviceClasses),
-      styles: {
-        width: document.body.clientWidth + 'px'
+  const makeSinkDefinition = (): AlloySpec => {
+    const sinkSpec = {
+      dom: {
+        tag: 'div',
+        classes: [ 'tox', 'tox-silver-sink', 'tox-tinymce-aux' ].concat(platformClasses).concat(deviceClasses),
+        ...dirAttributes
       },
-      ...dirAttributes
-    },
-    behaviours: Behaviour.derive([
-      Positioning.config({
-        useFixed: () => isHeaderDocked()
-      })
-    ]),
-    events: AlloyEvents.derive([
-      AlloyEvents.run(SystemEvents.windowResize(), resizeUiMothership)
-    ])
-  });
+      behaviours: Behaviour.derive([
+        Positioning.config({
+          useFixed: () => isHeaderDocked()
+        })
+      ])
+    };
+
+    const reactiveWidthSpec = {
+      dom: {
+        styles: { width: document.body.clientWidth + 'px' }
+      },
+      events: AlloyEvents.derive([
+        AlloyEvents.run(SystemEvents.windowResize(), resizeUiMothership)
+      ])
+    };
+
+    return Merger.deepMerge(sinkSpec, toolbarIsInRoot ? reactiveWidthSpec : {});
+  };
+
+  const sink = GuiFactory.build(makeSinkDefinition());
 
   const lazySink = () => Result.value<AlloyComponent, Error>(sink);
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeNotInRootTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeNotInRootTest.ts
@@ -1,0 +1,42 @@
+import { Assertions, Chain, Log, Pipeline, UiFinder } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { Insert, Remove, SugarBody, SugarElement, Width } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('Editor fixed_toolbar_container resize test', (success, failure) => {
+  Theme();
+
+  const expectedWidth = 300;
+  const toolbarContainer = SugarElement.fromHtml(`<div id="toolbar" style="width: ${expectedWidth}px;"></div>`);
+
+  Insert.append(SugarBody.body(), toolbarContainer);
+
+  TinyLoader.setup((editor: Editor, onSuccess, onFailure) => {
+    const tinyApis = TinyApis(editor);
+
+    Pipeline.async({ }, [
+      Log.stepsAsStep('TINY-6683', 'Should not resize the sink to the body width', [
+        tinyApis.sSetContent('fixed_toolbar_container test'),
+        tinyApis.sFocus(),
+
+        Chain.asStep(SugarBody.body(), [
+          UiFinder.cWaitFor('Wait for the sink to be rendered', '.tox-silver-sink'),
+          Chain.mapper((sink) => Width.get(sink)),
+          Assertions.cAssertEq(`Sink should be ${expectedWidth}px wide`, expectedWidth)
+        ])
+      ])
+    ], onSuccess, onFailure);
+  },
+  {
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+    fixed_toolbar_container: '#toolbar',
+    inline: true,
+  }, () => {
+    Remove.remove(toolbarContainer);
+    success();
+  }, failure);
+});


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Regression where the sink would resize in poor ways when not wanted. Added check to avoid this case.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
