### PR TITLE
TINY-6686: Lower z-index of throbber

### DIFF
--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -61,8 +61,8 @@
 @z-index-dialogs: 1100;
 @z-index-menu: 1150;
 @z-index-fullscreen: 1200;
+@z-index-throbber: 1299;
 @z-index-sink: 1300;
-@z-index-throbber: 1300;
 
 // Responsive breakpoints
 @breakpoint-md: ~"only screen and (min-width:1000px)";

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -62,7 +62,7 @@
 @z-index-menu: 1150;
 @z-index-fullscreen: 1200;
 @z-index-sink: 1300;
-@z-index-throbber: 1400;
+@z-index-throbber: 1300;
 
 // Responsive breakpoints
 @breakpoint-md: ~"only screen and (min-width:1000px)";

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.7.0 (TBD)
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
+    Changed the z-index of the `setProgressState(true)` throbber so it does not hide notifications #TINY-6686
 Version 5.6.0 (2020-11-18)
     Added new `BeforeOpenNotification` and `OpenNotification` events which allow internal notifications to be captured and modified before display #TINY-6528
     Added support for `block` and `unblock` methods on inline dialogs #TINY-6487


### PR DESCRIPTION
Related Ticket: TINY-6686

Description of Changes:
This is a partial implementation of the ticket to help with the RTC demo. The rest of the implementation (dismissing active popups) can be done later to resolve the potential UI weirdness that edge cases will now produce.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
