### PR TITLE
TINY-6692: Ensure mceTableCellType and mceTableRowType fire newCell events

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.6.1 (TBD)
+    Fixed the `mceTableRowType` and `mceTableCellType` commands not firing `newCell` event #TINY-6692
     Fixed the HTML5 `s` element not recognized when editing or clearing text formatting #TINY-6681
     Fixed an issue where copying and pasting table columns resulted in invalid HTML when using colgroups #TINY-6684
     Fixed an issue where the toolbar would render with the wrong width for inline editors in some situations #TINY-6683

--- a/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
@@ -13,7 +13,7 @@ import { SugarElement, SugarNode } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import * as Events from '../api/Events';
 import { getCloneElements } from '../api/Settings';
-import { getRowType, switchCellType, switchSectionType } from '../core/TableSections';
+import { getRowType, switchCellsType, switchSectionType } from '../core/TableSections';
 import * as Util from '../core/Util';
 import * as TableSize from '../queries/TableSize';
 import { ephemera } from '../selection/Ephemera';
@@ -116,7 +116,7 @@ export const TableActions = (editor: Editor, lazyWire: () => ResizeWire, selecti
   const setTableCellType = (editor: Editor, args: Record<string, any>) =>
     extractType(args, [ 'td', 'th' ]).each((type) => {
       const cells = Arr.map(getCellsFromSelection(Util.getSelectionStart(editor), selections), (c) => c.dom);
-      switchCellType(editor.dom, cells, type, null);
+      switchCellsType(editor, cells, type, null);
     });
 
   const setTableRowType = (editor: Editor, args: Record<string, any>) =>

--- a/modules/tinymce/src/plugins/table/main/ts/core/TableSections.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/TableSections.ts
@@ -5,11 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Optional, Type } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
 import { SelectorFilter, SugarElement } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
+import * as Events from '../api/Events';
 import { getTableHeaderType } from '../api/Settings';
 import * as Util from './Util';
 
@@ -80,11 +81,27 @@ const switchRowSection = (dom: DOMUtils, rowElm: HTMLElement, newSectionName: st
   }
 };
 
-const switchCellType = (dom: DOMUtils, cells: ArrayLike<HTMLTableCellElement>, newCellType: string, scope: 'col' | null) =>
-  Arr.each(cells, (c) => {
-    const newCell = Util.getNodeName(c) !== newCellType ? dom.rename(c, newCellType) : c;
+const renameCell = (editor: Editor, cell: HTMLTableCellElement, newCellType?: string): HTMLTableCellElement => {
+  if (Type.isNonNullable(newCellType) && Util.getNodeName(cell) !== newCellType) {
+    const newCellElm = editor.dom.rename(cell, newCellType) as HTMLTableCellElement;
+    Events.fireNewCell(editor, newCellElm);
+    return newCellElm;
+  } else {
+    return cell;
+  }
+};
+
+const switchCellType = (editor: Editor, cell: HTMLTableCellElement, newCellType?: string, scope?: 'col' | null): HTMLTableCellElement => {
+  const dom = editor.dom;
+  const newCell = renameCell(editor, cell, newCellType);
+  if (!Type.isUndefined(scope)) {
     dom.setAttrib(newCell, 'scope', scope); // mutates
-  });
+  }
+  return newCell;
+};
+
+const switchCellsType = (editor: Editor, cells: ArrayLike<HTMLTableCellElement>, newCellType?: string, scope?: 'col' | null) =>
+  Arr.each(cells, (c) => switchCellType(editor, c, newCellType, scope));
 
 const switchSectionType = (editor: Editor, rowElm: HTMLTableRowElement, newType: string) => {
   const determineHeaderRowType = (): 'section' | 'cells' | 'sectionCells' => {
@@ -108,13 +125,13 @@ const switchSectionType = (editor: Editor, rowElm: HTMLTableRowElement, newType:
 
     // We're going to always enforce the right td/th and thead/tbody/tfoot type.
     // switchRowSection will short circuit if not necessary to save computation
-    switchCellType(dom, rowElm.cells, headerRowType === 'section' ? 'td' : 'th', 'col');
+    switchCellsType(editor, rowElm.cells, headerRowType === 'section' ? 'td' : 'th', 'col');
     switchRowSection(dom, rowElm, headerRowType === 'cells' ? 'tbody' : 'thead');
   } else {
-    switchCellType(dom, rowElm.cells, 'td', null); // if switching from header to other, may need to switch th to td
+    switchCellsType(editor, rowElm.cells, 'td', null); // if switching from header to other, may need to switch th to td
     switchRowSection(dom, rowElm, newType === 'footer' ? 'tfoot' : 'tbody');
   }
 };
 
-export { getRowType, detectHeaderRow, switchCellType, switchSectionType };
+export { getRowType, detectHeaderRow, switchCellType, switchCellsType, switchSectionType };
 

--- a/modules/tinymce/src/plugins/table/main/ts/core/TableSections.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/TableSections.ts
@@ -81,7 +81,7 @@ const switchRowSection = (dom: DOMUtils, rowElm: HTMLElement, newSectionName: st
   }
 };
 
-const renameCell = (editor: Editor, cell: HTMLTableCellElement, newCellType?: string): HTMLTableCellElement => {
+const renameCell = (editor: Editor, cell: HTMLTableCellElement, newCellType?: 'td' | 'th'): HTMLTableCellElement => {
   if (Type.isNonNullable(newCellType) && Util.getNodeName(cell) !== newCellType) {
     const newCellElm = editor.dom.rename(cell, newCellType) as HTMLTableCellElement;
     Events.fireNewCell(editor, newCellElm);
@@ -91,7 +91,7 @@ const renameCell = (editor: Editor, cell: HTMLTableCellElement, newCellType?: st
   }
 };
 
-const switchCellType = (editor: Editor, cell: HTMLTableCellElement, newCellType?: string, scope?: 'col' | null): HTMLTableCellElement => {
+const switchCellType = (editor: Editor, cell: HTMLTableCellElement, newCellType?: 'td' | 'th', scope?: 'col' | null): HTMLTableCellElement => {
   const dom = editor.dom;
   const newCell = renameCell(editor, cell, newCellType);
   if (!Type.isUndefined(scope)) {
@@ -100,7 +100,7 @@ const switchCellType = (editor: Editor, cell: HTMLTableCellElement, newCellType?
   return newCell;
 };
 
-const switchCellsType = (editor: Editor, cells: ArrayLike<HTMLTableCellElement>, newCellType?: string, scope?: 'col' | null) =>
+const switchCellsType = (editor: Editor, cells: ArrayLike<HTMLTableCellElement>, newCellType?: 'td' | 'th', scope?: 'col' | null) =>
   Arr.each(cells, (c) => switchCellType(editor, c, newCellType, scope));
 
 const switchSectionType = (editor: Editor, rowElm: HTMLTableRowElement, newType: string) => {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -14,6 +14,7 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 import * as Styles from '../actions/Styles';
 import * as Events from '../api/Events';
 import { hasAdvancedCellTab } from '../api/Settings';
+import { switchCellType } from '../core/TableSections';
 import * as Util from '../core/Util';
 import * as TableSelection from '../selection/TableSelection';
 import * as CellDialogGeneralTab from './CellDialogGeneralTab';
@@ -71,7 +72,6 @@ const updateAdvancedProps = (modifier: DomModifier, data: CellData) => {
 // applying any specified alignment.
 
 const applyCellData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[], data: CellData) => {
-  const dom = editor.dom;
   const isSingleCell = cells.length === 1;
 
   if (cells.length >= 1) {
@@ -85,8 +85,7 @@ const applyCellData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>
     getSelectedCells(cells).each((selectedCells) => {
       Arr.each(selectedCells, (item) => {
         // Switch cell type if applicable
-        const cellElement = item.element;
-        const cellElm = data.celltype && Util.getNodeName(cellElement) !== data.celltype ? (dom.rename(cellElement, data.celltype) as HTMLTableCellElement) : cellElement;
+        const cellElm = switchCellType(editor, item.element, data.celltype);
         const modifier = isSingleCell ? DomModifier.normal(editor, cellElm) : DomModifier.ifTruthy(editor, cellElm);
         const colModifier = item.column.map((col) =>
           isSingleCell ? DomModifier.normal(editor, col) : DomModifier.ifTruthy(editor, col)

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -277,7 +277,7 @@ export interface CellData {
   width: string;
   height: string;
   scope: string;
-  celltype: string;
+  celltype: 'td' | 'th';
   class: string;
   halign: string;
   valign: string;
@@ -287,7 +287,7 @@ export interface CellData {
   backgroundcolor?: string;
 }
 
-const extractDataFromCellElement = (editor: Editor, cell: HTMLTableDataCellElement, hasAdvancedCellTab: boolean, column: Optional<HTMLTableColElement>): CellData => {
+const extractDataFromCellElement = (editor: Editor, cell: HTMLTableCellElement, hasAdvancedCellTab: boolean, column: Optional<HTMLTableColElement>): CellData => {
   const dom = editor.dom;
   const colElm = column.getOr(cell);
 
@@ -297,7 +297,7 @@ const extractDataFromCellElement = (editor: Editor, cell: HTMLTableDataCellEleme
     width: getStyle(colElm, 'width'),
     height: getStyle(cell, 'height'),
     scope: dom.getAttrib(cell, 'scope'),
-    celltype: Util.getNodeName(cell),
+    celltype: Util.getNodeName(cell) as 'td' | 'th',
     class: dom.getAttrib(cell, 'class', ''),
     halign: getHAlignment(editor, cell),
     valign: getVAlignment(editor, cell),

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
@@ -159,8 +159,13 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableSectionApiTest', (success
 
   let events = [];
   const logEvent = (event: EditorEvent<{}>) => {
-    events.push(event);
+    events.push(event.type);
   };
+
+  const cClearEvents = Chain.op(() => events = []);
+  const cAssertEvents = (label: string, expectedEvents: string[]) => Chain.op(() => {
+    Assertions.assertEq(label, expectedEvents, events);
+  });
 
   const cSelectAllCells = (type: 'td' | 'th') =>
     Chain.op((editor: Editor) => {
@@ -177,39 +182,43 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableSectionApiTest', (success
     editor.fire('mouseup', { target: endTd, button: 0 } as MouseEvent);
   };
 
-  const cSwitchType = (startContent: string, expectedContent: string, command: string, type: string, selector = 'tr#one td') =>
+  const defaultEvents = [ 'tablemodified' ];
+  const cSwitchType = (startContent: string, expectedContent: string, command: string, type: string, expectedEvents: string[] = defaultEvents, selector = 'tr#one td') =>
     Log.chain('TINY-6150', `Switch to ${type}, command = ${command}`, Chain.fromParent(Chain.identity, [
       ApiChains.cSetContent(startContent),
       Chain.op((editor: Editor) => {
         const row = UiFinder.findIn(SugarElement.fromDom(editor.getBody()), selector).getOrDie();
         editor.selection.select(row.dom);
-        events = [];
-        editor.execCommand(command, false, { type });
-        Assertions.assertEq('TINY-6629: Assert table modified events length', 1, events.length);
-        Assertions.assertEq('TINY-6629: Assert table modified event', 'tablemodified', events[0].type);
-        events = [];
       }),
+      cClearEvents,
+      ApiChains.cExecCommand(command, { type }),
+      cAssertEvents('TINY-6629: Assert table modified events', expectedEvents),
       ApiChains.cAssertContent(expectedContent)
     ]));
 
-  const cSwitchMultipleColumnsType = (startContent: string, expectedContent: string, command: string, type: 'td' | 'th') =>
+  const cSwitchMultipleColumnsType = (startContent: string, expectedContent: string, command: string, type: 'td' | 'th', expectedEvents: string[] = defaultEvents) =>
     Log.chain('TINY-6326', `Switch to ${type}, command = ${command}`, Chain.fromParent(Chain.identity, [
       ApiChains.cSetContent(startContent),
       cSelectAllCells(type),
+      cClearEvents,
       ApiChains.cExecCommand(command, { type }),
+      cAssertEvents('TINY-6692: Assert table modified events', expectedEvents),
       ApiChains.cAssertContent(expectedContent)
     ]));
 
-  const sSwitchTypeAndConfig = (tableHeaderType: string, startContent: string, expectedContent: string, command: string, type: string, selector = 'tr#one td') =>
+  const sSwitchTypeAndConfig = (tableHeaderType: string, startContent: string, expectedContent: string, command: string, type: string, expectedEvents: string[] = defaultEvents, selector = 'tr#one td') =>
     Log.chainsAsStep('TINY-6150', `Switch to ${type}, command = ${command}, table_header_type = ${tableHeaderType}`, [
       McEditor.cFromSettings({
         plugins: 'table',
         theme: 'silver',
         base_url: '/project/tinymce/js/tinymce',
         table_header_type: tableHeaderType,
-        setup: (ed: Editor) => ed.on('tablemodified', logEvent)
+        setup: (ed: Editor) => {
+          ed.on('tablemodified', logEvent);
+          ed.on('newcell', logEvent);
+        }
       }),
-      cSwitchType(startContent, expectedContent, command, type, selector),
+      cSwitchType(startContent, expectedContent, command, type, expectedEvents, selector),
       McEditor.cRemove
     ]);
 
@@ -228,18 +237,21 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableSectionApiTest', (success
   Pipeline.async({}, [
     // Tests to switch between row section types that require changing the editor content
     sSwitchTypeAndConfig('section', bodyContent, theadContent, 'mceTableRowType', 'header'),
-    sSwitchTypeAndConfig('cells', bodyContent, thsContent, 'mceTableRowType', 'header'),
-    sSwitchTypeAndConfig('sectionCells', bodyContent, theadThsContent, 'mceTableRowType', 'header'),
+    sSwitchTypeAndConfig('cells', bodyContent, thsContent, 'mceTableRowType', 'header', [ 'newcell', 'tablemodified' ]),
+    sSwitchTypeAndConfig('sectionCells', bodyContent, theadThsContent, 'mceTableRowType', 'header', [ 'newcell', 'tablemodified' ]),
     sSwitchTypeAndConfig('section', tfootContent, theadContent, 'mceTableRowType', 'header'),
-    sSwitchTypeAndConfig('cells', tfootContent, thsContentReversed, 'mceTableRowType', 'header'),
-    sSwitchTypeAndConfig('sectionCells', tfootContent, theadThsContent, 'mceTableRowType', 'header'),
+    sSwitchTypeAndConfig('cells', tfootContent, thsContentReversed, 'mceTableRowType', 'header', [ 'newcell', 'tablemodified' ]),
+    sSwitchTypeAndConfig('sectionCells', tfootContent, theadThsContent, 'mceTableRowType', 'header', [ 'newcell', 'tablemodified' ]),
     sSwitchTypeAndConfig('foo', bodyContent, theadContent, 'mceTableRowType', 'header'), // setting value is invalid so default to section
     Chain.asStep({}, [
       McEditor.cFromSettings({
         plugins: 'table',
         theme: 'silver',
         base_url: '/project/tinymce/js/tinymce',
-        setup: (ed: Editor) => ed.on('tablemodified', logEvent)
+        setup: (ed: Editor) => {
+          ed.on('tablemodified', logEvent);
+          ed.on('newcell', logEvent);
+        }
       }),
       Chain.fromParent(Chain.identity, [
         // Basic tests to switch between row section types
@@ -248,13 +260,13 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableSectionApiTest', (success
         cSwitchType(bodyContent, tfootContent, 'mceTableRowType', 'footer'),
         cSwitchType(tfootContent, theadContent, 'mceTableRowType', 'header'),
         // Basic tests to switch between column section types
-        cSwitchType(bodyColumnContent, headerColumnContent, 'mceTableColType', 'th'),
-        cSwitchMultipleColumnsType(bodyMultipleChangesColumnContent, headerMultipleChangesColumnContent, 'mceTableColType', 'th'),
-        cSwitchType(headerColumnContent, bodyColumnContent, 'mceTableColType', 'td', 'tr#one th'),
-        cSwitchMultipleColumnsType(headerMultipleChangesColumnContent, bodyMultipleChangesColumnContent, 'mceTableColType', 'td'),
+        cSwitchType(bodyColumnContent, headerColumnContent, 'mceTableColType', 'th', [ 'newcell', 'newcell', 'tablemodified' ]),
+        cSwitchMultipleColumnsType(bodyMultipleChangesColumnContent, headerMultipleChangesColumnContent, 'mceTableColType', 'th', [ 'newcell', 'newcell', 'newcell', 'newcell', 'tablemodified' ]),
+        cSwitchType(headerColumnContent, bodyColumnContent, 'mceTableColType', 'td', [ 'newcell', 'newcell', 'tablemodified' ], 'tr#one th'),
+        cSwitchMultipleColumnsType(headerMultipleChangesColumnContent, bodyMultipleChangesColumnContent, 'mceTableColType', 'td', [ 'newcell', 'newcell', 'newcell', 'newcell', 'tablemodified' ]),
         // Basic tests to switch between cell section types
-        cSwitchType(bodyContent, headerCellContent, 'mceTableCellType', 'th'),
-        cSwitchType(headerCellContent, bodyContent, 'mceTableCellType', 'td', 'tr#one th'),
+        cSwitchType(bodyContent, headerCellContent, 'mceTableCellType', 'th', [ 'newcell', 'tablemodified' ]),
+        cSwitchType(headerCellContent, bodyContent, 'mceTableCellType', 'td', [ 'newcell', 'tablemodified' ], 'tr#one th'),
         // Tests to get the type from the API
         cGetType(bodyContent, 'mceTableRowType', 'body'),
         cGetType(theadContent, 'mceTableRowType', 'header'),

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -33,8 +33,10 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableCellDialogTest', (success
   const sAssertEvents = (expectedEvents: string[] = defaultEvents) => Step.sync(() => {
     if (events.length > 0) {
       Arr.each(events, (event) => {
-        const tableElm = SugarElement.fromDom(event.table);
-        Assertions.assertEq('Expected events should have been fired', true, SugarNode.isTag('table')(tableElm));
+        if (event.type === 'tablemodified') {
+          const tableElm = SugarElement.fromDom(event.table);
+          Assertions.assertEq('Expected events should have been fired', true, SugarNode.isTag('table')(tableElm));
+        }
       });
     }
     Assertions.assertEq('Expected events should have been fired', expectedEvents, Arr.map(events, (event) => event.type));
@@ -164,7 +166,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableCellDialogTest', (success
         TableTestUtils.sSetDialogValues(advData, true, generalSelectors),
         TableTestUtils.sClickDialogButton('submit dialog', true),
         tinyApis.sAssertContent(advHtml),
-        sAssertEvents(),
+        sAssertEvents([ 'newcell', 'tablemodified' ]),
         sClearEvents
       ]);
     };
@@ -256,7 +258,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableCellDialogTest', (success
         TableTestUtils.sSetDialogValues(emptyData, true, generalSelectors),
         TableTestUtils.sClickDialogButton('submit dialog', true),
         tinyApis.sAssertContent(emptyTable),
-        sAssertEvents(),
+        sAssertEvents([ 'tablemodified' ]),
         sClearEvents
       ]);
     };
@@ -323,7 +325,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableCellDialogTest', (success
         tinyApis.sAssertContent(advHtml),
         TableTestUtils.sOpenTableDialog(tinyUi),
         TableTestUtils.sAssertDialogValues(advData, true, generalSelectors),
-        sAssertEvents(),
+        sAssertEvents([ 'newcell', 'tablemodified' ]),
         sClearEvents
       ]);
     };
@@ -350,6 +352,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.TableCellDialogTest', (success
     },
     setup: (editor: Editor) => {
       editor.on('tablemodified', logEvent);
+      editor.on('newcell', logEvent);
     }
   }, success, failure);
 });


### PR DESCRIPTION
**Related Ticket:**

TINY-6692

**Description of Changes:**

`mceTableCellType` and `mceTableRowType` commands now fire `newCell` event whenever cells are modified

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved


