### PR TITLE
TINY-3755: Apply list style to text blocks inside a selection containing at least one other list

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.7.0 (TBD)
+    Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
 Version 5.6.1 (2020-11-25)
     Fixed the `mceTableRowType` and `mceTableCellType` commands were not firing the `newCell` event #TINY-6692

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -106,7 +106,7 @@ const getSelectedTextBlocks = function (editor: Editor, rng, root) {
 
     const nextSibling = node.nextSibling;
     if (BookmarkManager.isBookmarkNode(node)) {
-      if (NodeType.isTextBlock(editor, nextSibling) || (!nextSibling && node.parentNode === root)) {
+      if (NodeType.isListNode(nextSibling) || NodeType.isTextBlock(editor, nextSibling) || (!nextSibling && node.parentNode === root)) {
         block = null;
         return;
       }
@@ -233,6 +233,7 @@ const toggleMultipleLists = function (editor, parentList, lists, listName, detai
   if (parentList.nodeName === listName && !hasListStyleDetail(detail)) {
     flattenListSelection(editor);
   } else {
+    applyList(editor, listName, detail);
     const bookmark = Bookmark.createBookmark(editor.selection.getRng(true));
 
     Tools.each([ parentList ].concat(lists), function (elm) {

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
@@ -921,7 +921,7 @@ UnitTest.asynctest('browser.tinymce.plugins.lists.ApplyTest', (success, failure)
         '<tbody>' +
           '<tr>' +
             '<td>' +
-              '<br />' +
+              '<br>' +
             '</td>' +
           '</tr>' +
         '</tbody>' +
@@ -978,6 +978,72 @@ UnitTest.asynctest('browser.tinymce.plugins.lists.ApplyTest', (success, failure)
 
     editor.settings.forced_root_block = 'p';
     delete editor.settings.forced_root_block_attrs;
+  });
+
+  suite.test('TINY-3755: Lists: Apply list on mix of existing lists and other text blocks', (editor) => {
+    editor.getBody().innerHTML = (
+      '<ol>' +
+        '<li>a</li>' +
+        '<li>b' +
+        '<ol>' +
+          '<li>c</li>' +
+          '<li>d</li>' +
+          '<li>e</li>' +
+        '</ol>' +
+        '</li>' +
+        '<li>f</li>' +
+        '<li>g</li>' +
+      '</ol>' +
+      '<p>text1<br>text2<br>text3</p>' +
+      '<p>text4<br>text5<br>text6</p>' +
+      '<ul>' +
+        '<li>h</li>' +
+        '<li>i<br>j' +
+        '<ul>' +
+          '<li>k' +
+            '<ul>' +
+              '<li>l</li>' +
+            '</ul>' +
+          '</li>' +
+          '<li>m</li>' +
+        '</ul>' +
+        '</li>' +
+        '<li>n</li>' +
+      '</ul>'
+    );
+    editor.execCommand('SelectAll');
+    LegacyUnit.execCommand(editor, 'InsertUnorderedList');
+    const expected = (
+      '<ul>' +
+        '<li>a</li>' +
+        '<li>b' +
+        '<ul>' +
+          '<li>c</li>' +
+          '<li>d</li>' +
+          '<li>e</li>' +
+        '</ul>' +
+        '</li>' +
+        '<li>f</li>' +
+        '<li>g</li>' +
+      '</ul>' +
+      '<ul>' +
+        '<li>text1<br>text2<br>text3</li>' +
+        '<li>text4<br>text5<br>text6</li>' +
+        '<li>h</li>' +
+        '<li>i<br>j' +
+        '<ul>' +
+          '<li>k' +
+            '<ul>' +
+              '<li>l</li>' +
+            '</ul>' +
+          '</li>' +
+          '<li>m</li>' +
+        '</ul>' +
+        '</li>' +
+        '<li>n</li>' +
+      '</ul>'
+    );
+    LegacyUnit.equal(editor.getBody().innerHTML, expected);
   });
 
   TinyLoader.setupLight(function (editor, onSuccess, onFailure) {


### PR DESCRIPTION
**Related Ticket:**

TINY-3755

**Description of Changes:**

Allows toggling list type on selections including mixes of text blocks and existing lists

**Pre-checks:**
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

**Review:**
* [x] Milestone set
* [x] Review comments resolved

