### PR TITLE
TINY-6727: fixed issue with content filters not being executed on invalid fragments

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -25,6 +25,7 @@ import { getSelectedContentInternal, GetSelectionContentArgs } from './selection
 import { RangeLikeObject } from './selection/RangeTypes';
 import * as Operations from './undo/Operations';
 import { Index, Locks, UndoBookmark, UndoLevel, UndoLevelType, UndoManager } from './undo/UndoManagerTypes';
+import { ParserArgs } from './api/html/DomParser';
 
 const isTreeNode = (content: any): content is AstNode => content instanceof AstNode;
 
@@ -224,7 +225,14 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
           () => ({ }),
           (context) => ({ context })
         );
-        const fragment = isTreeNode(value) ? value : tinymceEditor.parser.parse(value, { ...contextArgs, insert: true });
+        const parserArgs: ParserArgs = { ...contextArgs, insert: true };
+        const fragment = isTreeNode(value) ? value : tinymceEditor.parser.parse(value, parserArgs);
+
+        if (parserArgs.invalid) {
+          const parser = tinymceEditor.parser;
+          FilterNode.filter(parser.getNodeFilters(), parser.getAttributeFilters(), fragment);
+        }
+
         rtcEditor.insertContent(fragment);
       },
       addVisual: (_elm) => {}

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -227,9 +227,9 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
         );
         const parserArgs: ParserArgs = { ...contextArgs, insert: true };
         const fragment = isTreeNode(value) ? value : tinymceEditor.parser.parse(value, parserArgs);
+        const parser = tinymceEditor.parser;
 
         if (parserArgs.invalid) {
-          const parser = tinymceEditor.parser;
           FilterNode.filter(parser.getNodeFilters(), parser.getAttributeFilters(), fragment);
         }
 


### PR DESCRIPTION
Related Ticket: #TINY-6727

Description of Changes:
* Filters are not executed on invalid fragments by default if a context is provided to the parser. So this makes sure that the fragment produced for RTC has filters executed as well processing image blobs etc.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
