### PR TITLE
TINY-6735 Fixed an issue with external styles bleeding into TinyMCE

### DIFF
--- a/modules/oxide/src/less/theme/globals/reset.less
+++ b/modules/oxide/src/less/theme/globals/reset.less
@@ -10,6 +10,7 @@
 //
 
 .tox {
+  box-shadow: none;
   box-sizing: content-box;
   color: @color-black;
   cursor: auto;
@@ -49,6 +50,7 @@
     // remaining specific reset styles for properties that shouldn't be inherited
     background: transparent;
     border: 0;
+    box-shadow: none;
     float: none;
     height: auto;
     margin: 0;

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -8,6 +8,7 @@ Version 5.7.0 (TBD)
     Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL #TINY-6611
     Fixed an issue where `scope` attributes on table cells would not change as expected when merging or unmerging cells #TINY-6486
     Fixed the plugin documentation links in the `help` plugin #DOC-703
+    Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
 Version 5.6.1 (2020-11-25)
     Fixed the `mceTableRowType` and `mceTableCellType` commands were not firing the `newCell` event #TINY-6692
     Fixed the HTML5 `s` element was not recognized when editing or clearing text formatting #TINY-6681


### PR DESCRIPTION
Related Ticket: TINY-6735

Description of Changes:
* Added box-shadow to the reset styles to prevent styles similar to the below to bleed into TinyMCE

```
:focus {
	box-shadow: 0 0 1px 2px rgba(0,0,0,.75);
	font-weight: bolder;
}
```

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
