### PR TITLE
TINY-6745: Fixed an issue where the writer settings weren't being used for RTC

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -121,6 +121,21 @@ const createDummyUndoLevel = (): UndoLevel => ({
   beforeBookmark: null
 });
 
+const createSerializer = (editor: Editor, inner?: boolean) => {
+  const settings = editor.settings;
+  return HtmlSerializer({
+    inner,
+
+    // Writer settings
+    element_format: settings.element_format,
+    entities: settings.entities,
+    entity_encoding: settings.entity_encoding,
+    indent: settings.indent,
+    indent_after: settings.indent_after,
+    indent_before: settings.indent_before
+  });
+};
+
 const makePlainAdaptor = (editor: Editor): RtcAdaptor => ({
   undoManager: {
     beforeChange: (locks, beforeBookmark) => Operations.beforeChange(editor, locks, beforeBookmark),
@@ -204,7 +219,7 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
       getContent: (args, format) => {
         if (format === 'html' || format === 'tree') {
           const fragment = rtcEditor.getContent();
-          const serializer = HtmlSerializer({ inner: true });
+          const serializer = createSerializer(tinymceEditor, true);
 
           runSerializerFiltersOnFragment(tinymceEditor, fragment);
 
@@ -241,7 +256,7 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
       getContent: (format, args) => {
         if (format === 'html' || format === 'tree') {
           const fragment = rtcEditor.getSelectedContent();
-          const serializer = HtmlSerializer({});
+          const serializer = createSerializer(tinymceEditor);
 
           runSerializerFiltersOnFragment(tinymceEditor, fragment);
 


### PR DESCRIPTION
Related Ticket: TINY-6745

Description of Changes:
The RTC HTML serializer wasn't using the relevant writer editor settings, which meant indent, entities, etc... weren't working when serialising the content.

Note: I tested this works locally by pulling in the RTC plugin from cloud as an external plugin.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
