### PR TITLE
TINY-6229: Fixed unable to play media elements

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -273,7 +273,6 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
   };
 
   const showResizeRect = (targetElm: Element) => {
-    hideResizeRect();
     unbindResizeHandleEvents();
 
     // Get position and size of target
@@ -286,6 +285,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
 
     // Reset width/height if user selects a new image/table
     if (selectedElm !== targetElm) {
+      hideResizeRect();
       selectedElm = targetElm;
       width = height = 0;
     }


### PR DESCRIPTION
Related Ticket: TINY-6229

Description of Changes:
* This fixes video elements unable to be played, as it needs to have `data-mce-selected="2"`, however the current resize logic removes the `data-mce-attribute` even if it's the same element. So this makes it only cleanup the resize handles, if the selected node is a different element.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
