### PR TITLE
TINY-6783: Fixed a regression when the document body used flexbox

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,3 +1,5 @@
+Version 5.6.2 (2020-12-08)
+    Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)
     Fixed the `mceTableRowType` and `mceTableCellType` commands were not firing the `newCell` event #TINY-6692
     Fixed the HTML5 `s` element was not recognized when editing or clearing text formatting #TINY-6681

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -90,7 +90,7 @@ const setup = (editor: Editor): RenderInfo => {
   const touchPlatformClass = 'tox-platform-touch';
   const deviceClasses = isTouch ? [ touchPlatformClass ] : [];
   const isToolbarBottom = Settings.isToolbarLocationBottom(editor);
-  const isUiContainerInBody = Compare.eq(SugarBody.body(), Settings.getUiContainer(editor));
+  const uiContainer = Settings.getUiContainer(editor);
 
   const dirAttributes = I18n.isRtl() ? {
     attributes: {
@@ -115,6 +115,9 @@ const setup = (editor: Editor): RenderInfo => {
   };
 
   const makeSinkDefinition = (): AlloySpec => {
+    // TINY-3321: When the body is using a grid layout, we need to ensure the sink width is manually set
+    const isGridUiContainer = Compare.eq(SugarBody.body(), uiContainer) && Css.get(uiContainer, 'display') === 'grid';
+
     const sinkSpec = {
       dom: {
         tag: 'div',
@@ -137,7 +140,7 @@ const setup = (editor: Editor): RenderInfo => {
       ])
     };
 
-    return Merger.deepMerge(sinkSpec, isUiContainerInBody ? reactiveWidthSpec : {});
+    return Merger.deepMerge(sinkSpec, isGridUiContainer ? reactiveWidthSpec : {});
   };
 
   const sink = GuiFactory.build(makeSinkDefinition());

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
@@ -1,0 +1,43 @@
+import { Assertions, Chain, Log, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { TinyLoader } from '@ephox/mcagar';
+import { Insert, Remove, SugarBody, SugarElement, SugarHead, TextContent, Width } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asynctest('Grid sink sizing test', (success, failure) => {
+  Theme();
+
+  const style = SugarElement.fromTag('style');
+  TextContent.set(style, `
+body {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+}
+`);
+  Insert.append(SugarHead.head(), style);
+
+  TinyLoader.setup((editor: Editor, onSuccess, onFailure) => {
+    Pipeline.async({}, [
+      Log.chainsAsStep('TINY-6783', 'Sink width matches body width when in display grid', [
+        NamedChain.asChain([
+          NamedChain.writeValue('body', SugarBody.body()),
+          NamedChain.direct('body', Chain.mapper((body) => Width.get(body)), 'bodyWidth'),
+          NamedChain.direct('body', UiFinder.cFindIn('.tox-silver-sink'), 'sink'),
+          NamedChain.direct('sink', Chain.mapper((sink) => Width.get(sink)), 'sinkWidth'),
+          NamedChain.merge([ 'bodyWidth', 'sinkWidth' ], 'widths'),
+          NamedChain.read('widths', Chain.op((widths) => {
+            Assertions.assertEq(`Sink should be ${widths.bodyWidth}px wide`, widths.bodyWidth, widths.sinkWidth);
+          }))
+        ]),
+      ])
+    ], onSuccess, onFailure);
+  }, {
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+  }, () => {
+    Remove.remove(style);
+    success();
+  }, failure);
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Chain, Guard, Mouse, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { TinyLoader } from '@ephox/mcagar';
-import { SelectorFind, SugarBody, SugarElement, Width } from '@ephox/sugar';
+import { SugarBody, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
 import Theme from 'tinymce/themes/silver/Theme';
@@ -26,14 +26,6 @@ UnitTest.asynctest('Editor resize test', (success, failure) => {
           editor.dom.setStyles(editor.getContainer(), {
             border: '2px solid #ccc'
           });
-        }),
-        Chain.op(() => {
-          const html = SugarBody.body();
-          const sink = SelectorFind.descendant<HTMLElement>(html, '.tox-silver-sink').getOrDie();
-
-          const expectedWidth = Width.get(html);
-
-          Assertions.assertEq(`Sink should be ${expectedWidth}px wide`, expectedWidth, Width.get(sink));
         }),
         Chain.label('Test resize with max/min sizing', NamedChain.asChain([
           NamedChain.direct(NamedChain.inputName(), Chain.identity, 'body'),


### PR DESCRIPTION
Related Ticket: TINY-6783

Description of Changes:
* Fixes a regression when the document body is using flexbox. This just makes it so the fix done for TINY-3321 only works when the body is using `display: grid`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
