### PR TITLE
TINY-6769: added error handling for rtc setup

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -273,44 +273,49 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
   };
 };
 
-const makeNoopAdaptor = (): RtcAdaptor => ({
-  undoManager: {
-    beforeChange: () => {},
-    addUndoLevel: () => null,
-    undo: () => null,
-    redo: () => null,
-    clear: () => {},
-    reset: () => {},
-    hasUndo: () => false,
-    hasRedo: () => false,
-    transact: () => null,
-    ignore: () => {},
-    extra: () => {}
-  },
-  formatter: {
-    match: () => false,
-    matchAll: () => [],
-    matchNode: () => false,
-    canApply: () => false,
-    closest: () => '',
-    apply: () => {},
-    remove: () => {},
-    toggle: () => {},
-    formatChanged: () => ({ unbind: () => {} })
-  },
-  editor: {
-    getContent: () => '',
-    setContent: () => '',
-    insertContent: () => {},
-    addVisual: () => {}
-  },
-  selection: {
-    getContent: () => ''
-  },
-  raw: {
-    getModel: () => Optional.none()
-  }
-});
+const makeNoopAdaptor = (): RtcAdaptor => {
+  const nul = Fun.constant(null);
+  const empty = Fun.constant('');
+
+  return {
+    undoManager: {
+      beforeChange: Fun.noop,
+      addUndoLevel: nul,
+      undo: nul,
+      redo: nul,
+      clear: Fun.noop,
+      reset: Fun.noop,
+      hasUndo: Fun.never,
+      hasRedo: Fun.never,
+      transact: nul,
+      ignore: Fun.noop,
+      extra: Fun.noop
+    },
+    formatter: {
+      match: Fun.never,
+      matchAll: Fun.constant([]),
+      matchNode: Fun.never,
+      canApply: Fun.never,
+      closest: empty,
+      apply: Fun.noop,
+      remove: Fun.noop,
+      toggle: Fun.noop,
+      formatChanged: Fun.constant({ unbind: Fun.noop })
+    },
+    editor: {
+      getContent: empty,
+      setContent: empty,
+      insertContent: Fun.noop,
+      addVisual: Fun.noop
+    },
+    selection: {
+      getContent: empty
+    },
+    raw: {
+      getModel: Fun.constant(Optional.none())
+    }
+  };
+};
 
 export const isRtc = (editor: Editor) => Obj.has(editor.plugins, 'rtc');
 

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -455,7 +455,7 @@ const initContentBody = function (editor: Editor, skipWrite?: boolean) {
       editor.setProgressState(false);
       preInit(editor, rtcMode);
     }, (err) => {
-      editor.notificationManager.open({ type: 'error', text: err });
+      editor.notificationManager.open({ type: 'error', text: String(err) });
       preInit(editor, true);
     });
   });

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -454,6 +454,9 @@ const initContentBody = function (editor: Editor, skipWrite?: boolean) {
     loadingRtc.then((rtcMode) => {
       editor.setProgressState(false);
       preInit(editor, rtcMode);
+    }, (err) => {
+      editor.notificationManager.open({ type: 'error', text: err });
+      preInit(editor, true);
     });
   });
 };


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This moves the display of rtc setup errors to tinymce core and it uses a no-op adaptor since it would otherwise continue to throw errors while initializing since on preInit it calls various apis we override.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
