### PR TITLE
TINY-6789: Replaced inline function uses with Fun.noop, Fun.always or Fun.never

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/pipe/GeneralActions.ts
+++ b/modules/agar/src/main/ts/ephox/agar/pipe/GeneralActions.ts
@@ -1,9 +1,11 @@
+import { Fun } from '@ephox/katamari';
+
 const debug = (): void => {
   // eslint-disable-next-line no-debugger
   debugger;
 };
 
-const pass = (): void => {};
+const pass = Fun.noop;
 
 export {
   debug,

--- a/modules/agar/src/test/ts/browser/KeyboardTest.ts
+++ b/modules/agar/src/test/ts/browser/KeyboardTest.ts
@@ -1,4 +1,5 @@
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { DomEvent, Focus, SugarElement } from '@ephox/sugar';
 import * as Assertions from 'ephox/agar/api/Assertions';
 import * as Guard from 'ephox/agar/api/Guard';
@@ -41,7 +42,7 @@ UnitTest.asynctest('KeyboardTest', (success, failure) => {
           sAssertEvent(type, code, modifiers, raw).runStep(value, next, die, logs);
         });
 
-        f(SugarElement.fromDom(document), code, modifiers).runStep(value, () => {}, die);
+        f(SugarElement.fromDom(document), code, modifiers).runStep(value, Fun.noop, die);
       }),
       Guard.timeout('Key event did not fire in time: ' + type, 1000)
     );
@@ -63,7 +64,7 @@ UnitTest.asynctest('KeyboardTest', (success, failure) => {
         });
       });
 
-      Keyboard.sKeystroke(SugarElement.fromDom(document), code, modifiers).runStep(value, () => {}, die, TestLogs.init());
+      Keyboard.sKeystroke(SugarElement.fromDom(document), code, modifiers).runStep(value, Fun.noop, die, TestLogs.init());
     }),
     Guard.timeout('keystroke (keydown + keyup) did not fire', 1000)
   );

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/ToolbarsDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/ToolbarsDemo.ts
@@ -1,4 +1,4 @@
-import { Arr, Result } from '@ephox/katamari';
+import { Arr, Fun, Result } from '@ephox/katamari';
 import { Class, SugarElement } from '@ephox/sugar';
 
 import { LazySink } from 'ephox/alloy/api/component/CommonTypes';
@@ -33,61 +33,61 @@ export default (): void => {
     {
       label: 'group-1',
       items: Arr.map([
-        { text: '1a', action() { } },
-        { text: '1b', action() { } },
-        { text: '1c', action() { } }
+        { text: '1a', action: Fun.noop },
+        { text: '1b', action: Fun.noop },
+        { text: '1c', action: Fun.noop }
 
       ], DemoRenders.toolbarItem)
     },
     {
       label: 'group-2',
       items: Arr.map([
-        { text: '2a', action() { } },
-        { text: '2b', action() { } },
-        { text: '2c', action() { } }
+        { text: '2a', action: Fun.noop },
+        { text: '2b', action: Fun.noop },
+        { text: '2c', action: Fun.noop }
 
       ], DemoRenders.toolbarItem)
     },
     {
       label: 'group-3',
       items: Arr.map([
-        { text: '3a', action() { } },
-        { text: '3b', action() { } },
-        { text: '3c', action() { } }
+        { text: '3a', action: Fun.noop },
+        { text: '3b', action: Fun.noop },
+        { text: '3c', action: Fun.noop }
 
       ], DemoRenders.toolbarItem)
     },
     {
       label: 'group-4',
       items: Arr.map([
-        { text: '4a', action() { } },
-        { text: '4b', action() { } },
-        { text: '4c', action() { } }
+        { text: '4a', action: Fun.noop },
+        { text: '4b', action: Fun.noop },
+        { text: '4c', action: Fun.noop }
 
       ], DemoRenders.toolbarItem)
     },
     {
       label: 'group-5',
       items: Arr.map([
-        { text: '5a', action() { } },
-        { text: '5b', action() { } },
-        { text: '5c', action() { } }
+        { text: '5a', action: Fun.noop },
+        { text: '5b', action: Fun.noop },
+        { text: '5c', action: Fun.noop }
 
       ], DemoRenders.toolbarItem)
     },
     {
       label: 'group-6',
       items: Arr.map([
-        { text: '6a', action() { } },
-        { text: '6b', action() { } }
+        { text: '6a', action: Fun.noop },
+        { text: '6b', action: Fun.noop }
 
       ], DemoRenders.toolbarItem)
     },
     {
       label: 'group-7',
       items: Arr.map([
-        { text: '7a', action() { } },
-        { text: '7b', action() { } }
+        { text: '7a', action: Fun.noop },
+        { text: '7b', action: Fun.noop }
 
       ], DemoRenders.toolbarItem)
     }

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/Gui.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/Gui.ts
@@ -49,7 +49,7 @@ const create = (): GuiSystem => {
 
 const takeover = (root: AlloyComponent): GuiSystem => {
   const isAboveRoot = (el: SugarElement): boolean => Traverse.parent(root.element).fold(
-    () => true,
+    Fun.always,
     (parent) => Compare.eq(el, parent)
   );
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/RepresentState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/RepresentState.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell, Obj, Optional } from '@ephox/katamari';
+import { Arr, Cell, Fun, Obj, Optional } from '@ephox/katamari';
 
 import { ItemDataTuple } from '../../ui/types/ItemTypes';
 import { nuState } from '../common/BehaviourState';
@@ -30,9 +30,7 @@ const memory = (): MemoryRepresentingState => {
 };
 
 const manual = (): ManualRepresentingState => {
-  const readState = () => {
-
-  };
+  const readState = Fun.noop;
 
   return nuState({
     readState

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/touch/TouchDragging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/touch/TouchDragging.ts
@@ -1,5 +1,5 @@
 import { FieldProcessorAdt } from '@ephox/boulder';
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional } from '@ephox/katamari';
 import { EventArgs } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
@@ -33,7 +33,7 @@ const events = <E>(dragConfig: TouchDraggingConfig<E>, dragState: DraggingState,
       const dragApi: BlockerDragApi<TouchEvent> = {
         drop: stop,
         // delayDrop is not used by touch
-        delayDrop() { },
+        delayDrop: Fun.noop,
         forceDrop: stop,
         move(event) {
           DragUtils.move(component, dragConfig, dragState, TouchData, event);

--- a/modules/alloy/src/main/ts/ephox/alloy/events/Triggers.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/Triggers.ts
@@ -1,4 +1,4 @@
-import { Adt, Arr, Cell, Optional } from '@ephox/katamari';
+import { Adt, Arr, Cell, Fun, Optional } from '@ephox/katamari';
 import { SugarElement, Traverse } from '@ephox/sugar';
 
 import { DebuggerLogger } from '../debugging/Debugging';
@@ -71,11 +71,11 @@ const doTriggerHandler = (lookup: LookupEvent, eventType: string, rawEvent: Even
 const doTriggerOnUntilStopped = (lookup: LookupEvent, eventType: string, rawEvent: EventFormat, rawTarget: SugarElement, source: Cell<SugarElement>, logger: DebuggerLogger): boolean =>
   doTriggerHandler(lookup, eventType, rawEvent, rawTarget, source, logger).fold(
     // stopped.
-    () => true,
+    Fun.always,
     // Go again.
     (parent) => doTriggerOnUntilStopped(lookup, eventType, rawEvent, parent, source, logger),
     // completed
-    () => false
+    Fun.never
   );
 
 const triggerHandler = <T extends EventFormat>(lookup: LookupEvent, eventType: string, rawEvent: T, target: SugarElement, logger: DebuggerLogger): TriggerAdt => {

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/build/WidgetParts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/build/WidgetParts.ts
@@ -19,7 +19,7 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
               getValue(_component) {
                 return detail.data;
               },
-              setValue() { }
+              setValue: Fun.noop
             }
           })
         ])

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
@@ -233,7 +233,7 @@ const make: SingleSketchFactory<TieredMenuDetail, TieredMenuSpec> = (detail, _ra
     (container: AlloyComponent, simulatedEvent: NativeSimulatedEvent): Optional<boolean> =>
       SelectorFind.closest(simulatedEvent.getSource(), '.' + detail.markers.item)
         .bind((target) => container.getSystem().getByDom(target).toOptional().bind(
-          (item: AlloyComponent) => f(container, item).map((): boolean => true)
+          (item: AlloyComponent) => f(container, item).map<boolean>(Fun.always)
         ));
 
   const events = AlloyEvents.derive([
@@ -266,7 +266,7 @@ const make: SingleSketchFactory<TieredMenuDetail, TieredMenuSpec> = (detail, _ra
           () => {
             detail.onExecute(component, item);
           },
-          () => { }
+          Fun.noop
         );
       });
     }),

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { Css, Width } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
@@ -69,7 +69,8 @@ const moveBy = (direction: number, spectrum: AlloyComponent, detail: HorizontalS
   return Optional.some(xValue);
 };
 
-const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: HorizontalSliderDetail): Optional<boolean> => moveBy(direction, spectrum, detail).map((): boolean => true);
+const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: HorizontalSliderDetail): Optional<boolean> =>
+  moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
 
 // get x offset from event
 const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent): Optional<number> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { Css, Height, SugarPosition, Width } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
@@ -44,7 +44,8 @@ const moveBy = (direction: number, isVerticalMovement: boolean, spectrum: AlloyC
   return Optional.some(xValue);
 };
 
-const handleMovement = (direction: number, isVerticalMovement: boolean) => (spectrum: AlloyComponent, detail: TwoDSliderDetail): Optional<boolean> => moveBy(direction, isVerticalMovement, spectrum, detail).map((): boolean => true);
+const handleMovement = (direction: number, isVerticalMovement: boolean) => (spectrum: AlloyComponent, detail: TwoDSliderDetail): Optional<boolean> =>
+  moveBy(direction, isVerticalMovement, spectrum, detail).map<boolean>(Fun.always);
 
 // fire a slider change event with the minimum value
 const setToMin = (spectrum: AlloyComponent, detail: TwoDSliderDetail): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { Css, Height } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
@@ -68,7 +68,8 @@ const moveBy = (direction: number, spectrum: AlloyComponent, detail: VerticalSli
   return Optional.some(yValue);
 };
 
-const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: VerticalSliderDetail): Optional<boolean> => moveBy(direction, spectrum, detail).map((): boolean => true);
+const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: VerticalSliderDetail): Optional<boolean> =>
+  moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
 
 // get y offset from event
 const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent): Optional<number> => {

--- a/modules/alloy/src/test/ts/atomic/menu/MenuPathingTest.ts
+++ b/modules/alloy/src/test/ts/atomic/menu/MenuPathingTest.ts
@@ -1,4 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import Jsc from '@ephox/wrap-jsverify';
 
 import * as MenuPathing from 'ephox/alloy/menu/layered/MenuPathing';
@@ -46,6 +47,6 @@ UnitTest.test('MenuPathingTest', () => {
 
   Jsc.property(
     '*** No property checking anything for MenuPathing yet',
-    () => true
+    Fun.always
   );
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/DisablingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/DisablingTest.ts
@@ -1,5 +1,6 @@
 import { ApproxStructure, Assertions, Chain, GeneralSteps, Logger, Mouse, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { Focus } from '@ephox/sugar';
 
 import * as Behaviour from 'ephox/alloy/api/behaviour/Behaviour';
@@ -21,7 +22,7 @@ UnitTest.asynctest('DisablingTest', (success, failure) => {
       },
       buttonBehaviours: Behaviour.derive([
         Disabling.config({
-          disabled: () => true
+          disabled: Fun.always
         })
       ])
     })
@@ -35,7 +36,7 @@ UnitTest.asynctest('DisablingTest', (success, failure) => {
       },
       buttonBehaviours: Behaviour.derive([
         Disabling.config({
-          disabled: () => false,
+          disabled: Fun.never,
           disableClass: 'btn-disabled'
         })
       ])

--- a/modules/alloy/src/test/ts/browser/behaviour/dragging/TouchDraggingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/dragging/TouchDraggingTest.ts
@@ -1,6 +1,6 @@
 import { Chain, Guard, NamedChain, Touch, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Optional, Result } from '@ephox/katamari';
+import { Fun, Optional, Result } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Css, Scroll, SugarPosition } from '@ephox/sugar';
 
@@ -19,7 +19,7 @@ UnitTest.asynctest('TouchDraggingTest', (success, failure) => {
   PlatformDetection.override({
     deviceType: {
       ...origPlatform.deviceType,
-      isTouch: () => true
+      isTouch: Fun.always
     }
   });
 

--- a/modules/alloy/src/test/ts/browser/position/HotspotCustomBoundsPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/HotspotCustomBoundsPositionTest.ts
@@ -1,5 +1,6 @@
 import { Assertions, Chain, NamedChain } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { Css } from '@ephox/sugar';
 
 import * as Boxes from 'ephox/alloy/alien/Boxes';
@@ -18,7 +19,7 @@ UnitTest.asynctest('HotspotPositionTest', (success, failure) => {
   GuiSetup.setup((_store, _doc, _body) => {
     const hotspot = GuiFactory.build(
       Button.sketch({
-        action() { },
+        action: Fun.noop,
         dom: {
           styles: {
             position: 'absolute',

--- a/modules/alloy/src/test/ts/browser/position/HotspotPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/HotspotPositionTest.ts
@@ -1,5 +1,6 @@
 import { Chain, NamedChain } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 
 import * as GuiFactory from 'ephox/alloy/api/component/GuiFactory';
 import { Button } from 'ephox/alloy/api/ui/Button';
@@ -14,7 +15,7 @@ UnitTest.asynctest('HotspotPositionTest', (success, failure) => {
   GuiSetup.setup((_store, _doc, _body) => {
     const hotspot = GuiFactory.build(
       Button.sketch({
-        action() { },
+        action: Fun.noop,
         dom: {
           styles: {
             position: 'absolute',

--- a/modules/alloy/src/test/ts/browser/position/MakeshiftPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/MakeshiftPositionTest.ts
@@ -1,5 +1,7 @@
 import { Assertions, Chain, NamedChain } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+
 import { AlloyComponent } from 'ephox/alloy/api/component/ComponentApi';
 import * as GuiFactory from 'ephox/alloy/api/component/GuiFactory';
 import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
@@ -14,7 +16,7 @@ UnitTest.asynctest('MakeshiftPositionTest', (success, failure) => {
   GuiSetup.setup((_store, _doc, _body) => {
     const button = GuiFactory.build(
       Button.sketch({
-        action() { },
+        action: Fun.noop,
         dom: {
           styles: {
             position: 'absolute',

--- a/modules/bridge/src/demo/ts/buttons/ButtonDemo.ts
+++ b/modules/bridge/src/demo/ts/buttons/ButtonDemo.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from './DemoRegistry';
 
 /* eslint-disable no-console */
@@ -47,7 +48,7 @@ export const registerDemoButtons = (): void => {
     tooltip: 'Bold',
     onSetup: (api) => {
       api.setActive(false);
-      return () => { };
+      return Fun.noop;
     },
     onAction: (_api) => {
       console.log('bold clicked');

--- a/modules/bridge/src/demo/ts/dialogs/DemoDialogHelpers.ts
+++ b/modules/bridge/src/demo/ts/dialogs/DemoDialogHelpers.ts
@@ -1,5 +1,5 @@
 import { Processor, ValueSchema } from '@ephox/boulder';
-import { Cell } from '@ephox/katamari';
+import { Cell, Fun } from '@ephox/katamari';
 import { DialogManager } from '../../../main/ts/ephox/bridge/api/DialogManager';
 import { Dialog, DialogInstanceApi, DialogSpec } from '../../../main/ts/ephox/bridge/components/dialog/Dialog';
 
@@ -20,22 +20,14 @@ const createDemoApi = <T>(internalStructure: Dialog<T>, initalData: T, dataValid
       const newInternalData = ValueSchema.getOrDie(ValueSchema.asRaw('data', dataValidator, mergedData));
       data.set(newInternalData);
     },
-    redial: () => {
-    },
-    focus: (_name: string) => {
-    },
-    showTab: (_title: string) => {
-    },
-    disable: (_name: string) => {
-    },
-    enable: (_name: string) => {
-    },
-    block: (_message: string) => {
-    },
-    unblock: () => {
-    },
-    close: () => {
-    }
+    redial: Fun.noop,
+    focus: (_name: string) => {},
+    showTab: (_title: string) => {},
+    disable: (_name: string) => {},
+    enable: (_name: string) => {},
+    block: (_message: string) => {},
+    unblock: Fun.noop,
+    close: Fun.noop
   };
 };
 

--- a/modules/bridge/src/demo/ts/menus/MenuItemDemo.ts
+++ b/modules/bridge/src/demo/ts/menus/MenuItemDemo.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 export const registerDemoMenuItems = (): void => {
@@ -17,7 +18,7 @@ export const registerDemoMenuItems = (): void => {
       // eslint-disable-next-line no-console
       console.log('bold');
       api.setActive(true);
-      return () => { };
+      return Fun.noop;
     },
     onAction: (_api) => {
       // eslint-disable-next-line no-console

--- a/modules/bridge/src/demo/ts/plugins/MediaItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/MediaItems.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
@@ -13,7 +14,7 @@ export const registerMediaItems = (): void => {
         buttonApi.setActive(e);
         // sets active state based on selection
       });
-      return () => { };
+      return Fun.noop;
     },
     onAction: (_buttonApi) => {
       // opens media dialog

--- a/modules/bridge/src/demo/ts/plugins/PasteItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/PasteItems.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
@@ -12,7 +13,7 @@ export const registerPasteItems = (): void => {
       editor.on('PastePlainTextToggle', (e) => {
         buttonApi.setActive(e.state);
       });
-      return () => { };
+      return Fun.noop;
     },
     onAction: (_buttonApi) => {
       // toggles setting

--- a/modules/bridge/src/demo/ts/plugins/SaveItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/SaveItems.ts
@@ -1,9 +1,10 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
   on: (_s, _f) => { },
   off: (_s, _f) => { },
-  isDirty: () => true
+  isDirty: Fun.always
 };
 
 export const registerSaveItems = (): void => {

--- a/modules/bridge/src/demo/ts/plugins/SpellcheckerItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/SpellcheckerItems.ts
@@ -1,8 +1,9 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
   on: (_s, _f) => { },
-  isDirty: () => true
+  isDirty: Fun.always
 };
 
 export const registerSpellcheckerItems = (): void => {
@@ -14,7 +15,7 @@ export const registerSpellcheckerItems = (): void => {
       editor.on('SpellcheckStart SpellcheckEnd', (e) => {
         buttonApi.setActive(e);
       });
-      return () => { };
+      return Fun.noop;
     },
     fetch: (callback) => {
       // read all the langauges

--- a/modules/bridge/src/demo/ts/plugins/TODO_AdvListItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/TODO_AdvListItems.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 /*
@@ -44,7 +45,7 @@ export const registerAdvListItems = (): void => {
         // FIX: This is missing.
         buttonApi.setActive(state);
       });
-      return () => { };
+      return Fun.noop;
     },
     onAction: (_buttonApi) => {
       // apply basic list command

--- a/modules/bridge/src/demo/ts/plugins/TODO_EmoticonItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/TODO_EmoticonItems.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 // FIX: TODO....
@@ -5,7 +6,7 @@ export const registerEmoticonItems = (): void => {
   getDemoRegistry().addButton('emoticon', {
     type: 'button',
     disabled: false,
-    onSetup: (_buttonApi) => () => { },
+    onSetup: (_buttonApi) => Fun.noop,
     onAction: (_buttonApi) => {
 
     }

--- a/modules/bridge/src/demo/ts/plugins/TocItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/TocItems.ts
@@ -1,8 +1,9 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
   on: (_s, _f) => { },
-  isDirty: () => true
+  isDirty: Fun.always
 };
 
 export const registerTocItems = (): void => {
@@ -13,7 +14,7 @@ export const registerTocItems = (): void => {
       editor.on('LoadContent SetContent change', (e) => {
         buttonApi.setDisabled(e);
       });
-      return () => { };
+      return Fun.noop;
     },
     onAction: (_buttonApi) => {
       // insert Table of contents

--- a/modules/bridge/src/demo/ts/plugins/VisualBlocksItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/VisualBlocksItems.ts
@@ -1,8 +1,9 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
   on: (_s, _f) => { },
-  isDirty: () => true
+  isDirty: Fun.always
 };
 
 export const registerVisualBlocksItems = (): void => {
@@ -13,7 +14,7 @@ export const registerVisualBlocksItems = (): void => {
       editor.on('VisualBlocks', (e) => {
         buttonApi.setActive(e);
       });
-      return () => { };
+      return Fun.noop;
     },
     onAction: (_buttonApi) => {
       // toggles visual blocks

--- a/modules/bridge/src/demo/ts/plugins/VisualCharsItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/VisualCharsItems.ts
@@ -1,8 +1,9 @@
+import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
   on: (_s, _f) => { },
-  isDirty: () => true
+  isDirty: Fun.always
 };
 
 export const registerVisualCharsItems = (): void => {
@@ -13,7 +14,7 @@ export const registerVisualCharsItems = (): void => {
       editor.on('VisualChars', (e) => {
         buttonApi.setActive(e);
       });
-      return () => { };
+      return Fun.noop;
     },
     onAction: (_buttonApi) => {
       // toggles visual chars

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextBar.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextBar.ts
@@ -1,4 +1,5 @@
 import { FieldSchema } from '@ephox/boulder';
+import { Fun } from '@ephox/katamari';
 
 export type ContextPosition = 'node' | 'selection' | 'line';
 export type ContextScope = 'node' | 'editor';
@@ -16,7 +17,7 @@ export interface ContextBar {
 }
 
 export const contextBarFields = [
-  FieldSchema.defaultedFunction('predicate', () => false),
+  FieldSchema.defaultedFunction('predicate', Fun.never),
   FieldSchema.defaultedStringEnum('scope', 'node', [ 'node', 'editor' ]),
   FieldSchema.defaultedStringEnum('position', 'selection', [ 'node', 'selection', 'line' ])
 ];

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
@@ -64,8 +64,8 @@ const call = function (f: () => any): void {
   f();
 };
 
-const never = constant<false>(false) as (...args: any[]) => false;
-const always = constant<true>(true) as (...args: any[]) => true;
+const never: (...args: any[]) => false = constant<false>(false);
+const always: (...args: any[]) => true = constant<true>(true);
 
 /* Used to weaken types */
 const weaken = <A, B extends A>(b: B): A => b;

--- a/modules/katamari/src/main/ts/ephox/katamari/api/StringMatch.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/StringMatch.ts
@@ -1,4 +1,5 @@
 import { Adt } from './Adt';
+import * as Fun from './Fun';
 
 type StringMapper = (str: string) => string;
 
@@ -56,9 +57,7 @@ const matches = function (subject: StringMatch, str: string): boolean {
     return f(str).indexOf(f(value)) >= 0;
   }, function (value, f) {
     return f(str) === f(value);
-  }, function () {
-    return true;
-  }, function (other) {
+  }, Fun.always, function (other) {
     return !matches(other, str);
   });
 };

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
@@ -2,6 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Testable } from '@ephox/dispute';
 import fc from 'fast-check';
 import * as Arr from 'ephox/katamari/api/Arr';
+import * as Fun from 'ephox/katamari/api/Fun';
 import { Optional } from 'ephox/katamari/api/Optional';
 import { tOptional } from 'ephox/katamari/api/OptionalInstances';
 
@@ -49,7 +50,7 @@ UnitTest.test('Arr.find: finds a value in the array', () => {
 
 UnitTest.test('Arr.find: value not found', () => {
   fc.assert(fc.property(fc.array(fc.integer()), (arr) => {
-    const result = Arr.find(arr, () => false);
+    const result = Arr.find(arr, Fun.never);
     Assert.eq('Element not found in array', Optional.none(), result, tOptional(tNumber));
   }));
 });

--- a/modules/katamari/src/test/ts/atomic/api/arr/ExistsTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ExistsTest.ts
@@ -1,10 +1,11 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import fc from 'fast-check';
 import * as Arr from 'ephox/katamari/api/Arr';
+import * as Fun from 'ephox/katamari/api/Fun';
 
 const eqc = (x) => (a) => x === a;
-const never = () => false;
-const always = () => true;
+const never = Fun.never;
+const always = Fun.always;
 const bottom = () => { throw new Error('error'); };
 
 UnitTest.test('Arr.exists: unit test', () => {

--- a/modules/katamari/src/test/ts/atomic/api/arr/FindIndexTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/FindIndexTest.ts
@@ -2,6 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Testable } from '@ephox/dispute';
 import fc from 'fast-check';
 import * as Arr from 'ephox/katamari/api/Arr';
+import * as Fun from 'ephox/katamari/api/Fun';
 import { Optional } from 'ephox/katamari/api/Optional';
 import { tOptional } from 'ephox/katamari/api/OptionalInstances';
 import { arbNegativeInteger } from 'ephox/katamari/test/arb/ArbDataTypes';
@@ -56,7 +57,7 @@ UnitTest.test('Arr.findIndex: Element found passes predicate', () => {
 
 UnitTest.test('Arr.findIndex: If predicate is always false, then index is always none', () => {
   fc.assert(fc.property(fc.array(fc.integer()), (arr) => {
-    Assert.eq('should be none', Optional.none(), Arr.findIndex(arr, () => false), tOptional(tNumber));
+    Assert.eq('should be none', Optional.none(), Arr.findIndex(arr, Fun.never), tOptional(tNumber));
   }));
 });
 

--- a/modules/katamari/src/test/ts/atomic/api/arr/FoldTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/FoldTest.ts
@@ -1,6 +1,7 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import fc from 'fast-check';
 import * as Arr from 'ephox/katamari/api/Arr';
+import * as Fun from 'ephox/katamari/api/Fun';
 
 UnitTest.test('fold: unit tests', () => {
   const checkl = (expected, input: any[], f, acc) => {
@@ -13,15 +14,13 @@ UnitTest.test('fold: unit tests', () => {
     Assert.eq('foldr', expected, Arr.foldr(Object.freeze(input.slice()), f, acc));
   };
 
-  checkl(0, [], () => {
-  }, 0);
+  checkl(0, [], Fun.noop, 0);
   checkl(6, [ 1, 2, 3 ], (acc, x) => acc + x, 0);
   checkl(13, [ 1, 2, 3 ], (acc, x) => acc + x, 7);
   // foldl with cons and [] should reverse the list
   checkl([ 3, 2, 1 ], [ 1, 2, 3 ], (acc, x) => [ x ].concat(acc), []);
 
-  checkr(0, [], () => {
-  }, 0);
+  checkr(0, [], Fun.noop, 0);
   checkr(6, [ 1, 2, 3 ], (acc, x) => acc + x, 0);
   checkr(13, [ 1, 2, 3 ], (acc, x) => acc + x, 7);
   // foldr with cons and [] should be identity

--- a/modules/katamari/src/test/ts/atomic/api/arr/ObjFilterTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ObjFilterTest.ts
@@ -5,7 +5,7 @@ import * as Obj from 'ephox/katamari/api/Obj';
 
 UnitTest.test('Obj.filter: filter const true is identity', () => {
   fc.assert(fc.property(fc.dictionary(fc.asciiString(), fc.integer()), (obj) => {
-    Assert.eq('id', obj, Obj.filter(obj, () => true));
+    Assert.eq('id', obj, Obj.filter(obj, Fun.always));
   }));
 });
 

--- a/modules/katamari/src/test/ts/atomic/api/async/LazyValueTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/async/LazyValueTest.ts
@@ -125,8 +125,7 @@ promiseTest('LazyValue: TINY-6106: LazyValue should only use the value from the 
 }));
 
 promiseTest('LazyValue: TINY-6107: LazyValues.withTimeout - never returns', () => new Promise((resolve, reject) => {
-  LazyValues.withTimeout(() => {
-  }, 1).get((actual) => {
+  LazyValues.withTimeout(Fun.noop, 1).get((actual) => {
     eqAsync('should time out', Optional.none(), actual, reject, tOptional());
     resolve();
   });

--- a/modules/katamari/src/test/ts/atomic/api/str/SupplantTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/str/SupplantTest.ts
@@ -1,4 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
+import * as Fun from 'ephox/katamari/api/Fun';
 import * as Strings from 'ephox/katamari/api/Strings';
 
 UnitTest.test('supplant', function () {
@@ -10,7 +11,7 @@ UnitTest.test('supplant', function () {
   check('', '', {});
   check('', '', { cat: 'dog' });
   check('a', 'a', {});
-  check('${a}', '${a}', { a() {} });
+  check('${a}', '${a}', { a: Fun.noop });
   check('toaster', '${a}', { a: 'toaster' });
   check('cattoastera', 'cat${a}a', { a: 'toaster' });
 });

--- a/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
@@ -2,6 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Pprint, Testable } from '@ephox/dispute';
 import * as fc from 'fast-check';
 import * as Arr from 'ephox/katamari/api/Arr';
+import * as Fun from 'ephox/katamari/api/Fun';
 import * as Type from 'ephox/katamari/api/Type';
 
 const { tNumber } = Testable;
@@ -17,7 +18,7 @@ UnitTest.test('Type.is*: Unit tests', () => {
 
   // eslint-disable-next-line no-new-wrappers
   const objectString = new String('ball');
-  const noop = () => {};
+  const noop = Fun.noop;
 
   const checkIsNull = check(Type.isNull, 'isNull');
   const checkIsUndefined = check(Type.isUndefined, 'isUndefined');

--- a/modules/katamari/src/test/ts/module/ephox/katamari/test/arb/ArbDataTypes.ts
+++ b/modules/katamari/src/test/ts/module/ephox/katamari/test/arb/ArbDataTypes.ts
@@ -1,4 +1,5 @@
 import fc from 'fast-check';
+import * as Fun from 'ephox/katamari/api/Fun';
 import { Future } from 'ephox/katamari/api/Future';
 import { Optional } from 'ephox/katamari/api/Optional';
 import { Result } from 'ephox/katamari/api/Result';
@@ -32,7 +33,7 @@ export const arbFutureSoon = <A> (arbA: Arbitrary<A>): Arbitrary<Future<A>> =>
   }));
 
 export const arbFutureNever = <A> (): Arbitrary<Future<A>> =>
-  fc.constant(Future.nu(() => {}));
+  fc.constant(Future.nu(Fun.noop));
 
 export const arbFutureNowOrSoon = <A> (arbA: Arbitrary<A>): Arbitrary<Future<A>> =>
   fc.oneof(arbFutureNow(arbA), arbFutureSoon(arbA));

--- a/modules/porkbun/src/test/ts/atomic/EventUnbindTest.ts
+++ b/modules/porkbun/src/test/ts/atomic/EventUnbindTest.ts
@@ -1,11 +1,12 @@
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { Event } from 'ephox/porkbun/Event';
 
 UnitTest.test('EventUnbindTest', function () {
   const event = Event([]);
 
-  const first = function () { event.unbind(first); };
-  const second = function () {};
+  const first = () => event.unbind(first);
+  const second = Fun.noop;
 
   event.bind(first);
   event.bind(second);

--- a/modules/robin/src/test/ts/atomic/api/TextZoneTest.ts
+++ b/modules/robin/src/test/ts/atomic/api/TextZoneTest.ts
@@ -51,13 +51,15 @@ UnitTest.test('TextZoneTest', function () {
 
   const checkZone = function (label: string, expected: Optional<RawZone>, actual: Optional<Zone<Gene>>) {
     expected.fold(function () {
-      actual.fold(function () {
+      actual.fold(
         // Good
-      }, function (act) {
-        assert.fail(label + '\nShould not have created zone: ' + JSON.stringify(
-          JSON.stringify(rawOne(doc1, act))
-        ));
-      });
+        Fun.noop,
+        function (act) {
+          assert.fail(label + '\nShould not have created zone: ' + JSON.stringify(
+            JSON.stringify(rawOne(doc1, act))
+          ));
+        }
+      );
     }, function (exp) {
       actual.fold(function () {
         assert.fail(label + '\nDid not find a zone. Expected to find: ' + JSON.stringify(exp, null, 2));

--- a/modules/robin/src/test/ts/browser/api/DomTextSearchTest.ts
+++ b/modules/robin/src/test/ts/browser/api/DomTextSearchTest.ts
@@ -1,5 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Unicode } from '@ephox/katamari';
+import { Fun, Unicode } from '@ephox/katamari';
 import { KAssert } from '@ephox/katamari-assertions';
 import { Spot } from '@ephox/phoenix';
 import { Pattern } from '@ephox/polaris';
@@ -42,8 +42,7 @@ UnitTest.test('DomTextSearchTest', function () {
     });
   };
   const checkAbort = function (result: TextSeekerOutcome<SugarElement>) {
-    result.fold(function () {
-    }, function () {
+    result.fold(Fun.noop, function () {
       Assert.fail('Unexpected edge');
     }, function () {
       Assert.fail('Unexpected info found');

--- a/modules/sand/src/test/ts/atomic/core/BrowserTest.ts
+++ b/modules/sand/src/test/ts/atomic/core/BrowserTest.ts
@@ -1,10 +1,11 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { PlatformDetection } from 'ephox/sand/core/PlatformDetection';
 import * as PlatformQuery from 'ephox/sand/test/PlatformQuery';
 
 UnitTest.test('BrowserTest', function () {
   function check(expectedQuery: string, expectedOs: string, expectedBrowser: string, expectedMajor: number, expectedMinor: number, userAgent: string) {
-    const platform = PlatformDetection.detect(userAgent, () => false);
+    const platform = PlatformDetection.detect(userAgent, Fun.never);
     assert.eq(expectedBrowser, platform.browser.current);
     assert.eq(expectedOs, platform.os.current);
 
@@ -19,7 +20,7 @@ UnitTest.test('BrowserTest', function () {
   }
 
   const checkOSVersion = function (expectedMajor: number, expectedMinor: number, userAgent: string) {
-    const platform = PlatformDetection.detect(userAgent, () => false);
+    const platform = PlatformDetection.detect(userAgent, Fun.never);
     assert.eq(expectedMajor, platform.os.version.major, 'invalid major OS version ' + platform.os.version.major + ' for agent: ' + userAgent);
     assert.eq(expectedMinor, platform.os.version.minor, 'invalid minor OS version ' + platform.os.version.minor + ' for agent: ' + userAgent);
   };

--- a/modules/sand/src/test/ts/atomic/core/DeviceTypeTest.ts
+++ b/modules/sand/src/test/ts/atomic/core/DeviceTypeTest.ts
@@ -1,9 +1,10 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { PlatformDetection } from 'ephox/sand/core/PlatformDetection';
 
 UnitTest.test('DeviceTypeTest', function () {
   const getPlatform = function (userAgent: string) {
-    return PlatformDetection.detect(userAgent, () => false);
+    return PlatformDetection.detect(userAgent, Fun.never);
   };
 
   const checkTablet = function (expected: boolean, userAgent: string) {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Edge.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Edge.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import * as Compare from '../dom/Compare';
 import { SugarElement } from '../node/SugarElement';
 import * as Awareness from './Awareness';
@@ -15,7 +15,7 @@ type AwarenessFn = (element: SugarElement<Node>, offset: number) => boolean;
 
 const isAtEdge = (parent: SugarElement<Node>, current: SugarElement<Node>, currentOffset: number, descent: DescentFn, awareness: AwarenessFn): boolean =>
   descent(parent).fold(
-    () => true,
+    Fun.always,
     (element) => Compare.eq(current, element) && awareness(current, currentOffset)
   );
 

--- a/modules/sugar/src/test/ts/browser/ResizeRaceTest.ts
+++ b/modules/sugar/src/test/ts/browser/ResizeRaceTest.ts
@@ -1,4 +1,5 @@
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as Resize from 'ephox/sugar/api/events/Resize';
@@ -11,8 +12,7 @@ UnitTest.asynctest('ResizeRaceTest', (success, failure) => {
   const div = SugarElement.fromTag('div');
   Insert.append(SugarBody.body(), div);
 
-  // tslint:disable-next-line:no-empty
-  const handler = () => {};
+  const handler = Fun.noop;
   Resize.bind(div, handler);
   Remove.remove(div);
   Resize.unbind(div, handler);

--- a/modules/tinymce/src/core/demo/ts/demo/AnnotationsDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/AnnotationsDemo.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 declare let tinymce: any;
@@ -34,7 +35,7 @@ export default function () {
           editor.annotator.annotationChanged('alpha', (state, _name, _obj) => {
             btnApi.setDisabled(state);
           });
-          return () => {};
+          return Fun.noop;
         }
       });
 

--- a/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Fun } from '@ephox/katamari';
 import { Bookmark } from '../bookmark/BookmarkTypes';
 import * as FontCommands from '../commands/FontCommands';
 import * as LineHeightCommands from '../commands/LineHeight';
@@ -281,7 +282,7 @@ class EditorCommands {
     // Add execCommand overrides
     this.addCommands({
       // Ignore these, added for compatibility
-      'mceResetDesignMode,mceBeginUndoLevel'() { },
+      'mceResetDesignMode,mceBeginUndoLevel': Fun.noop,
 
       // Add undo manager logic
       'mceEndUndoLevel,mceAddUndoLevel'() {
@@ -469,8 +470,7 @@ class EditorCommands {
         IndentOutdent.handle(editor, command);
       },
 
-      'mceRepaint'() {
-      },
+      'mceRepaint': Fun.noop,
 
       'InsertHorizontalRule'() {
         editor.execCommand('mceInsertContent', false, '<hr />');

--- a/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Obj } from '@ephox/katamari';
+import { Fun, Obj } from '@ephox/katamari';
 
 export type EventUtilsCallback<T> = (event: EventUtilsEvent<T>) => void;
 
@@ -53,14 +53,10 @@ const hasIsDefaultPrevented = function (event) {
 };
 
 // Dummy function that gets replaced on the delegation state functions
-const returnFalse = function () {
-  return false;
-};
+const returnFalse = Fun.never;
 
 // Dummy function that gets replaced on the delegation state functions
-const returnTrue = function () {
-  return true;
-};
+const returnTrue = Fun.always;
 
 /**
  * Binds a native event to a callback on the speified target.

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj, Strings, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Strings, Type } from '@ephox/katamari';
 import { Base64Extract, extractBase64DataUris, restoreDataUris } from '../../html/Base64Uris';
 import Tools from '../util/Tools';
 import Entities from './Entities';
@@ -198,21 +198,19 @@ const checkBogusAttribute = (regExp: RegExp, attrString: string): string | null 
  * @param {tinymce.html.Schema} schema HTML Schema class to use when parsing.
  */
 function SaxParser(settings?: SaxParserSettings, schema = Schema()): SaxParser {
-  const noop = function () { };
-
   settings = settings || {};
 
   if (settings.fix_self_closing !== false) {
     settings.fix_self_closing = true;
   }
 
-  const comment = settings.comment ? settings.comment : noop;
-  const cdata = settings.cdata ? settings.cdata : noop;
-  const text = settings.text ? settings.text : noop;
-  const start = settings.start ? settings.start : noop;
-  const end = settings.end ? settings.end : noop;
-  const pi = settings.pi ? settings.pi : noop;
-  const doctype = settings.doctype ? settings.doctype : noop;
+  const comment = settings.comment ? settings.comment : Fun.noop;
+  const cdata = settings.cdata ? settings.cdata : Fun.noop;
+  const text = settings.text ? settings.text : Fun.noop;
+  const start = settings.start ? settings.start : Fun.noop;
+  const end = settings.end ? settings.end : Fun.noop;
+  const pi = settings.pi ? settings.pi : Fun.noop;
+  const doctype = settings.doctype ? settings.doctype : Fun.noop;
 
   const parseInternal = (base64Extract: Base64Extract, format: ParserFormat = 'html') => {
     const html = base64Extract.html;

--- a/modules/tinymce/src/core/main/ts/api/util/Tools.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Tools.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Fun } from '@ephox/katamari';
 import * as ArrUtils from '../../util/ArrUtils';
 import Env from '../Env';
 
@@ -189,7 +190,7 @@ const create = function (s, p, root?) {
 
   // Create default constructor
   if (!p[cn]) {
-    p[cn] = function () { };
+    p[cn] = Fun.noop;
     de = 1;
   }
 

--- a/modules/tinymce/src/core/main/ts/bookmark/ResolveBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/ResolveBookmark.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional, Optionals } from '@ephox/katamari';
+import { Fun, Optional, Optionals } from '@ephox/katamari';
 import DOMUtils from '../api/dom/DOMUtils';
 import EditorSelection from '../api/dom/Selection';
 import Env from '../api/Env';
@@ -53,7 +53,7 @@ const isEmpty = (node: Node) => node.hasChildNodes() === false;
 
 const tryFindRangePosition = (node: Element, rng: Range): boolean =>
   CaretFinder.lastPositionIn(node).fold(
-    () => false,
+    Fun.never,
     (pos) => {
       rng.setStart(pos.container(), pos.offset());
       rng.setEnd(pos.container(), pos.offset());

--- a/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
@@ -77,7 +77,7 @@ const backspaceDeleteRange = (editor: Editor, forward: boolean) => {
         DeleteUtils.paddEmptyBody(editor);
         return true;
       },
-      () => true
+      Fun.always
     );
   }
   return false;

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Fun } from '@ephox/katamari';
 import Editor from '../api/Editor';
 import Env from '../api/Env';
 import * as Settings from '../api/Settings';
@@ -755,9 +756,8 @@ const Quirks = function (editor: Editor): Quirks {
     });
   };
 
-  const refreshContentEditable = function () {
-    // No-op since Mozilla seems to have fixed the caret repaint issues
-  };
+  // No-op since Mozilla seems to have fixed the caret repaint issues
+  const refreshContentEditable = Fun.noop;
 
   const isHidden = function (): boolean {
     if (!isGecko || editor.removed) {

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
@@ -1,5 +1,6 @@
 import { Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import Theme from 'tinymce/themes/silver/Theme';
 
@@ -70,8 +71,7 @@ UnitTest.asynctest('browser.tinymce.core.EditorApiTest', function (success, fail
 
   const sUploadImages = function (editor) {
     return Step.sync(function () {
-      editor.uploadImages(function () {
-      });
+      editor.uploadImages(Fun.noop);
     });
   };
 
@@ -104,7 +104,6 @@ UnitTest.asynctest('browser.tinymce.core.EditorApiTest', function (success, fail
     ], onSuccess, onFailure);
   }, {
     base_url: '/project/tinymce/js/tinymce',
-    test_callback() {
-    }
+    test_callback: Fun.noop
   }, success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/EditorSettingsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorSettingsTest.ts
@@ -1,6 +1,6 @@
 import { Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Obj } from '@ephox/katamari';
+import { Fun, Obj } from '@ephox/katamari';
 import { TinyLoader } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import Editor from 'tinymce/core/api/Editor';
@@ -418,7 +418,7 @@ UnitTest.asynctest('browser.tinymce.core.EditorSettingsTest', function (success,
           num: 2,
           obj: { a: 1 },
           arr: [ 'a' ],
-          fun: () => {},
+          fun: Fun.noop,
           strArr: [ 'a', 'b' ],
           mixedArr: [ 'a', 3 ]
         }, EditorManager);

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -1,5 +1,6 @@
 import { Log, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Attribute, Class, SugarBody } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
@@ -436,7 +437,7 @@ UnitTest.asynctest('browser.tinymce.core.EditorTest', (success, failure) => {
 
     const sCheckWithManager = (title: string, plugins: string, plugin: string, addToManager: boolean, expected: boolean) => Step.sync(() => {
       if (addToManager) {
-        PluginManager.add('ParticularPlugin', () => {});
+        PluginManager.add('ParticularPlugin', Fun.noop);
       }
 
       editor.settings.plugins = plugins;

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -200,7 +200,7 @@ UnitTest.asynctest('browser.tinymce.core.EditorUploadTest', (success, failure) =
       uploadedBlobInfo = null;
       assertEventsLength(0);
 
-      return editor.uploadImages(() => {}).then((result) => {
+      return editor.uploadImages(Fun.noop).then((result) => {
         Assert.eq('uploadImages retain blob urls after upload', 0, result.length);
         Assert.eq('uploadImages retain blob urls after upload', null, uploadedBlobInfo);
       });

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -1,5 +1,6 @@
 import { Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
@@ -200,8 +201,7 @@ UnitTest.asynctest('browser.tinymce.core.UndoManager', function (success, failur
   suite.test('Transact no change', function (editor) {
     editor.undoManager.add();
 
-    const level = editor.undoManager.transact(function () {
-    });
+    const level = editor.undoManager.transact(Fun.noop);
 
     LegacyUnit.equal(level, null);
   });

--- a/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
@@ -1,6 +1,6 @@
 import { Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import { LegacyUnit } from '@ephox/mcagar';
 import EventUtils from 'tinymce/core/api/dom/EventUtils';
 
@@ -340,8 +340,8 @@ UnitTest.asynctest('browser.tinymce.core.dom.EventUtilsTest', function (success,
   */
 
   suite.test('bind unbind fire clean on null', function () {
-    eventUtils.bind(null, 'click', function () {});
-    eventUtils.unbind(null, 'click', function () {});
+    eventUtils.bind(null, 'click', Fun.noop);
+    eventUtils.unbind(null, 'click', Fun.noop);
     eventUtils.fire(null, 'click', {});
     eventUtils.clean(null);
     LegacyUnit.equal(true, true, 'No exception');

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -1,6 +1,6 @@
 import { Pipeline, Step } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import { LegacyUnit } from '@ephox/mcagar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import DomSerializer from 'tinymce/core/api/dom/Serializer';
@@ -797,8 +797,8 @@ UnitTest.asynctest('browser.tinymce.core.dom.SerializerTest', function (success,
 
   suite.test('addNodeFilter/addAttributeFilter', () => {
     const ser = DomSerializer({ });
-    const nodeFilter = () => {};
-    const attrFilter = () => {};
+    const nodeFilter = Fun.noop;
+    const attrFilter = Fun.noop;
 
     ser.addNodeFilter('some-tag', nodeFilter);
     ser.addAttributeFilter('data-something', attrFilter);

--- a/modules/tinymce/src/core/test/ts/browser/util/I18nTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/I18nTest.ts
@@ -1,5 +1,6 @@
 import { Pipeline } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { LegacyUnit } from '@ephox/mcagar';
 import I18n from 'tinymce/core/api/util/I18n';
 
@@ -34,7 +35,7 @@ UnitTest.asynctest('browser.tinymce.core.util.I18nTest', function (success, fail
       `Do not strip tokens that weren't replaced.`);
 
     LegacyUnit.equal(translate([{ }]), '[object Object]');
-    LegacyUnit.equal(translate(function () { }), '[object Function]');
+    LegacyUnit.equal(translate(Fun.noop), '[object Function]');
 
     LegacyUnit.equal(translate(null), '');
     LegacyUnit.equal(translate(undefined), '');

--- a/modules/tinymce/src/core/test/ts/browser/util/PromiseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/PromiseTest.ts
@@ -1,5 +1,6 @@
 import { Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { LegacyUnit } from '@ephox/mcagar';
 import Promise from 'tinymce/core/api/util/Promise';
 
@@ -18,8 +19,7 @@ UnitTest.asynctest('browser.tinymce.core.util.PromiseTest', function (success, f
   suite.asyncTest('Promise reject', function (_, done) {
     new Promise(function (resolve, reject) {
       reject('123');
-    }).then(function () {
-    }, function (result) {
+    }).then(Fun.noop, function (result) {
       LegacyUnit.equal('123', result);
       done();
     });

--- a/modules/tinymce/src/plugins/help/test/ts/module/test/NoMetaFakePlugin.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/test/NoMetaFakePlugin.ts
@@ -1,5 +1,6 @@
+import { Fun } from '@ephox/katamari';
 import PluginManager from 'tinymce/core/api/PluginManager';
 
-PluginManager.add('nometafake', function () {});
+PluginManager.add('nometafake', Fun.noop);
 
 export default function () {}

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
@@ -1,5 +1,6 @@
 import { FocusTools, Keyboard, Keys, Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
 
@@ -62,7 +63,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.DialogTest', (success, failure
       ]),
 
       Log.stepsAsStep('TBA', 'Insert Image Dialog with all options', [
-        api.sSetSetting('file_picker_callback', () => {}),
+        api.sSetSetting('file_picker_callback', Fun.noop),
         api.sSetSetting('image_class_list', [{ title: 'sample', value: 'sample' }]),
         api.sSetSetting('image_list', [{ title: 'sample', value: 'sample' }]),
         api.sSetSetting('image_caption', true),

--- a/modules/tinymce/src/plugins/imagetools/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/core/Actions.ts
@@ -249,10 +249,7 @@ const handleDialogBlob = function (editor: Editor, imageUploadTimerState: Cell<n
       return blob;
     })
     .then(ResultConversions.blobToImageResult)
-    .then((imageResult) => updateSelectedImage(editor, blob, imageResult, true, imageUploadTimerState, img))
-    .catch(() => {
-      // Close dialog
-    });
+    .then((imageResult) => updateSelectedImage(editor, blob, imageResult, true, imageUploadTimerState, img));
 };
 
 export {

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Dialog.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell } from '@ephox/katamari';
+import { Cell, Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 import * as Actions from '../core/Actions';
@@ -60,7 +60,7 @@ const makeOpen = (editor: Editor, imageUploadTimerState: Cell<number>) => () => 
       });
       api.close();
     },
-    onCancel: () => { }, // TODO: reimplement me
+    onCancel: Fun.noop, // TODO: reimplement me
     onAction: (api, details) => {
       switch (details.name) {
         case ImageToolsEvents.saveState:

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { InlineContent } from 'tinymce/core/api/ui/Ui';
 
@@ -75,7 +75,7 @@ const setupContextToolbars = function (editor: Editor) {
   const onSetupLink = (buttonApi: InlineContent.ContextFormButtonInstanceApi) => {
     const node = editor.selection.getNode();
     buttonApi.setDisabled(!Utils.getAnchorElement(editor, node));
-    return () => { };
+    return Fun.noop;
   };
 
   editor.ui.registry.addContextForm('quicklink', {
@@ -107,7 +107,7 @@ const setupContextToolbars = function (editor: Editor) {
           const anchor = Utils.getAnchorElement(editor);
           const value = formApi.getValue();
           if (!anchor) {
-            const attachState = { href: value, attach: () => { } };
+            const attachState = { href: value, attach: Fun.noop };
             const onlyText = Utils.isOnlyTextSelected(editor);
             const text: Optional<string> = onlyText ? Optional.some(Utils.getAnchorText(editor.selection, anchor)).filter((t) => t.length > 0).or(Optional.from(value)) : Optional.none();
             Utils.link(editor, attachState, {

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional, Optionals } from '@ephox/katamari';
+import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 
@@ -42,7 +42,7 @@ const handleSubmit = (editor: Editor, info: LinkDialogInfo) => (api: Dialog.Dial
 
   const attachState = {
     href: data.url.value,
-    attach: data.url.meta !== undefined && data.url.meta.attach ? data.url.meta.attach : () => {}
+    attach: data.url.meta !== undefined && data.url.meta.attach ? data.url.meta.attach : Fun.noop
   };
 
   DialogConfirms.preprocess(editor, changedData).then((pData) => {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/CutCopy.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/CutCopy.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Delay from 'tinymce/core/api/util/Delay';
@@ -112,7 +113,7 @@ const cut = (editor: Editor) => (evt: ClipboardEvent) => {
 
 const copy = (editor: Editor) => (evt: ClipboardEvent) => {
   if (hasSelectedContent(editor)) {
-    setClipboardData(evt, getData(editor), fallback(editor), () => {});
+    setClipboardData(evt, getData(editor), fallback(editor), Fun.noop);
   }
 };
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
@@ -1,6 +1,6 @@
 import { Log, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Arr, Cell } from '@ephox/katamari';
+import { Arr, Cell, Fun } from '@ephox/katamari';
 import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -57,13 +57,10 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     return file;
   };
 
-  const noop = function () {
-  };
-
   const mockEvent = function (type: string, files) {
     const event = {
       type,
-      preventDefault: noop
+      preventDefault: Fun.noop
     };
 
     const transferName = type === 'drop' ? 'dataTransfer' : 'clipboardData';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/alien/DetectProPluginTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/alien/DetectProPluginTest.ts
@@ -1,5 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import PluginManager from 'tinymce/core/api/PluginManager';
@@ -7,7 +8,7 @@ import * as DetectProPlugin from 'tinymce/plugins/paste/alien/DetectProPlugin';
 
 UnitTest.test('browser.tinymce.plugins.paste.alien.DetectProPluginTest', function () {
   // Fake loading of powerpaste
-  PluginManager.add('powerpaste', function () { });
+  PluginManager.add('powerpaste', Fun.noop);
 
   Assertions.assertEq('TestCase-TBA: Paste: Should not have pro plugin', false, DetectProPlugin.hasProPlugin(new Editor('id', { plugins: 'paste' }, EditorManager)));
   Assertions.assertEq('TestCase-TBA: Paste: Should not have pro plugin', false, DetectProPlugin.hasProPlugin(new Editor('id', { plugins: '' }, EditorManager)));

--- a/modules/tinymce/src/plugins/quickbars/main/ts/insert/Toolbars.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/insert/Toolbars.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Fun } from '@ephox/katamari';
 import { PredicateFind, SelectorFind, SugarElement, SugarNode } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../api/Settings';
@@ -20,7 +21,7 @@ const addToEditor = (editor: Editor) => {
         return SelectorFind.closest(sugarNode, 'table', isRoot).fold(
           () => PredicateFind.closest(sugarNode, (elem) =>
             SugarNode.name(elem) in textBlockElementsMap && editor.dom.isEmpty(elem.dom), isRoot).isSome(),
-          () => false
+          Fun.never
         );
       },
       items: insertToolbarItems,

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/alien/DetectProPluginTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/alien/DetectProPluginTest.ts
@@ -1,5 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import PluginManager from 'tinymce/core/api/PluginManager';
@@ -9,7 +10,7 @@ UnitTest.test(
   'browser.tinymce.plugins.spellchecker.alien.DetectProPluginTest',
   function () {
     // Fake loading of tinymcespellchecker
-    PluginManager.add('tinymcespellchecker', function () { });
+    PluginManager.add('tinymcespellchecker', Fun.noop);
 
     Assertions.assertEq('Should not have pro plugin', false, DetectProPlugin.hasProPlugin(new Editor('id', { plugins: 'paste' }, EditorManager)));
     Assertions.assertEq('Should not have pro plugin', false, DetectProPlugin.hasProPlugin(new Editor('id', { plugins: '' }, EditorManager)));

--- a/modules/tinymce/src/themes/mobile/demo/ts/demo/FormDemo.ts
+++ b/modules/tinymce/src/themes/mobile/demo/ts/demo/FormDemo.ts
@@ -1,5 +1,5 @@
 import { Attachment, Gui, GuiFactory } from '@ephox/alloy';
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
 
 import * as Inputs from 'tinymce/themes/mobile/ui/Inputs';
@@ -10,7 +10,7 @@ export default function () {
   const ephoxUi = SelectorFind.first('#ephox-ui').getOrDie();
 
   const form = SerialisedDialog.sketch({
-    onExecute() { },
+    onExecute: Fun.noop,
     getInitialValue() {
       return Optional.some({
         alpha: 'Alpha',

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosKeyboard.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosKeyboard.ts
@@ -69,9 +69,8 @@ const stubborn: IosKeyboardConstructor = (outerBody: SugarElement<Node>, cWin: W
     }
   });
 
-  const onToolbarTouch = function (/* event */) {
-    // Do nothing
-  };
+  // Do nothing
+  const onToolbarTouch = Fun.noop;
 
   const destroy = function () {
     captureInput.unbind();

--- a/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
@@ -104,7 +104,7 @@ const setupDemo = () => {
         icons: () => <Record<string, string>> {},
         menuItems: () => <Record<string, any>> {},
         translate: I18n.translate,
-        isDisabled: () => false,
+        isDisabled: Fun.never,
         getSetting: (_settingName: string, defaultVal: any) => defaultVal
       },
       interpreter: (x) => x,

--- a/modules/tinymce/src/themes/silver/demo/ts/components/searchreplace/SearchReplace.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/components/searchreplace/SearchReplace.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
@@ -100,5 +101,5 @@ export const open = () => {
   const helpers = setupDemo();
   const winMgr = WindowManager.setup(helpers.extras);
   // The end user will use this as config
-  winMgr.open(SearchReplaceDialogSpec, {}, () => {});
+  winMgr.open(SearchReplaceDialogSpec, {}, Fun.noop);
 };

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as MockDemo from './MockDemo';
 
@@ -59,7 +60,7 @@ export default function () {
           const state = DemoState.get();
           console.log(state);
           comp.setActive(state);
-          return () => { };
+          return Fun.noop;
         },
         onAction(comp) {
           DemoState.toggle();
@@ -105,7 +106,7 @@ export default function () {
               const state = DemoState2.get();
               console.log(state);
               comp.setActive(state);
-              return () => { };
+              return Fun.noop;
             },
             onAction(comp) {
               DemoState2.toggle();

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import ButtonSetupDemo from './ButtonSetupDemo';
 
@@ -133,7 +134,7 @@ export default function () {
         },
         onSetup: (api) => {
           console.log(api.element());
-          return () => {};
+          return Fun.noop;
         }
       });
       ed.ui.registry.addContextToolbar('custom', {

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 import * as MockDemo from './MockDemo';
@@ -79,7 +80,7 @@ export default function () {
           const state = DemoState2.get();
           console.log(state);
           comp.setActive(state);
-          return () => { };
+          return Fun.noop;
         },
         onAction(comp) {
           DemoState2.toggle();

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarComponentsDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarComponentsDemo.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { GuiFactory } from '@ephox/alloy';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 import { identifyButtons } from 'tinymce/themes/silver/ui/toolbar/Integration';
@@ -74,14 +74,14 @@ export default function () {
 
   const helpers = setupDemo();
   const mockEditor: Editor = {
-    on: () => { },
+    on: Fun.noop,
     formatter: {
-      canApply: () => true,
-      match: () => true,
-      remove: () => { },
-      apply: () => { }
+      canApply: Fun.always,
+      match: Fun.always,
+      remove: Fun.noop,
+      apply: Fun.noop
     },
-    focus: () => { },
+    focus: Fun.noop,
     undoManager: {
       transact: (f) => f()
     }

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Disabling, Gui, GuiFactory, Keying, Memento, Positioning, SimpleSpec, SystemEvents, VerticalDir } from '@ephox/alloy';
-import { Arr, Merger, Obj, Optional, Result } from '@ephox/katamari';
+import { Arr, Fun, Merger, Obj, Optional, Result } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Compare, Css, SugarBody } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
@@ -364,7 +364,7 @@ const setup = (editor: Editor): RenderInfo => {
     const channels = {
       broadcastAll: uiMothership.broadcast,
       broadcastOn: uiMothership.broadcastOn,
-      register: () => {}
+      register: Fun.noop
     };
 
     return { channels };

--- a/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj, Optional, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Type } from '@ephox/katamari';
 import { SelectorFind, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -75,7 +75,7 @@ const isMultipleToolbars = (editor: Editor): boolean => getMultipleToolbarsSetti
     const toolbar = editor.getParam('toolbar', [], 'string[]');
     return toolbar.length > 0;
   },
-  () => true
+  Fun.always
 );
 
 export enum ToolbarMode {

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
@@ -6,7 +6,7 @@
  */
 
 import { Dialog } from '@ephox/bridge';
-import { Future, Obj, Optional, Type } from '@ephox/katamari';
+import { Fun, Future, Obj, Optional, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
@@ -69,9 +69,9 @@ const getPickerTypes = (editor: Editor): boolean | Record<string, boolean> => {
   const optLegacyTypes = Optional.some(Settings.getFileBrowserCallbackTypes(editor)).filter(isTruthy);
   const optTypes = optFileTypes.or(optLegacyTypes).map(makeMap);
   return getPicker(editor).fold(
-    () => false,
+    Fun.never,
     (_picker) => optTypes.fold<boolean | Record<string, boolean>>(
-      () => true,
+      Fun.always,
       (types) => Obj.keys(types).length > 0 ? types : false)
   );
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
@@ -35,7 +35,7 @@ const renderContextButton = (memInput: MementoRecord, button: InlineContent.Cont
     Toolbar.createToolbarButton({
       ...rest,
       type: 'button',
-      onAction: () => { }
+      onAction: Fun.noop
     })
   );
 
@@ -50,7 +50,7 @@ const renderContextToggleButton = (memInput: MementoRecord, button: InlineConten
     Toolbar.createToggleButton({
       ...rest,
       type: 'togglebutton',
-      onAction: () => { }
+      onAction: Fun.noop
     })
   );
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -137,7 +137,7 @@ const registerTextColorButton = (editor: Editor, name: string, format: string, t
     onAction: (_splitButtonApi) => {
       // do something with last color
       if (lastColor.get() !== null) {
-        applyColor(editor, format, lastColor.get(), () => { });
+        applyColor(editor, format, lastColor.get(), Fun.noop);
       }
     },
     onItemAction: (_splitButtonApi, value) => {
@@ -235,7 +235,7 @@ const colorPickerDialog = (editor: Editor) => (callback, value: string) => {
     initialData,
     onAction,
     onSubmit: submit,
-    onClose: () => { },
+    onClose: Fun.noop,
     onCancel: () => {
       callback(Optional.none());
     }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, AlloyTriggers } from '@ephox/alloy';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
@@ -123,7 +123,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     nodeChangeHandler,
     dataset,
     shouldHide: false,
-    isInvalid: () => false
+    isInvalid: Fun.never
   };
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
@@ -114,7 +114,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     nodeChangeHandler,
     dataset,
     shouldHide: false,
-    isInvalid: () => false
+    isInvalid: Fun.never
   };
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
@@ -10,7 +10,7 @@ import {
   Invalidating, Layout, Memento, Representing, SimpleSpec, Tabstopping
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Future, Id, Optional, Result } from '@ephox/katamari';
+import { Fun, Future, Id, Optional, Result } from '@ephox/katamari';
 import { Css, SugarElement, Traverse } from '@ephox/sugar';
 
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
@@ -45,7 +45,7 @@ export const renderColorInput = (spec: ColorInputSpec, sharedBackstage: UiFactor
     factory: Input,
     inputClasses: [ 'tox-textfield' ],
 
-    onSetValue: (c) => Invalidating.run(c).get(() => { }),
+    onSetValue: (c) => Invalidating.run(c).get(Fun.noop),
 
     inputBehaviours: Behaviour.derive([
       Disabling.config({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/ImagePanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/ImagePanel.ts
@@ -6,7 +6,7 @@
  */
 
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Container, GuiFactory, Memento, Replacing } from '@ephox/alloy';
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional } from '@ephox/katamari';
 import { Attribute, Css, Height, SugarElement, Width } from '@ephox/sugar';
 import Rect, { GeomRect } from 'tinymce/core/api/geom/Rect';
 import Promise from 'tinymce/core/api/util/Promise';
@@ -201,7 +201,7 @@ const renderImagePanel = (initialUrl: string) => {
                   { x: 0, y: 0, w: 200, h: 200 },
                   { x: 0, y: 0, w: 200, h: 200 },
                   el,
-                  () => { } // TODO: Add back keyboard handling for cropping
+                  Fun.noop // TODO: Add back keyboard handling for cropping
                 );
                 cRect.toggleVisibility(false);
                 cRect.on('updateRect', (e) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/state/ImageToolsState.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/state/ImageToolsState.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional } from '@ephox/katamari';
 import Tools from 'tinymce/core/api/util/Tools';
 import UndoStack from '../UndoStack';
 
@@ -73,12 +73,14 @@ const makeState = (initialState: BlobState) => {
     return newState.url;
   };
 
-  const applyTempState = (postApply: () => void): void => tempState.get().fold(() => {
+  const applyTempState = (postApply: () => void): void => tempState.get().fold(
     // TODO: Inform the user of failures somehow
-  }, (temp) => {
-    addBlobState(temp.blob);
-    postApply();
-  });
+    Fun.noop,
+    (temp) => {
+      addBlobState(temp.blob);
+      postApply();
+    }
+  );
 
   const undo = (): string => {
     const currentState = undoStack.undo();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
@@ -9,7 +9,7 @@ import {
   AlloyComponent, AlloySpec, Behaviour, Dropdown as AlloyDropdown, Layouts, RawDomSchema, SketchSpec, Tabstopping, Unselecting
 } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
-import { Future, Id, Merger, Optional } from '@ephox/katamari';
+import { Fun, Future, Id, Merger, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
@@ -59,7 +59,7 @@ export const renderPanelButton = (spec: SwatchPanelButtonSpec, sharedBackstage: 
         spec.presets,
         ItemResponse.CLOSE_ON_EXECUTE,
         // No colour is ever selected on opening
-        () => false,
+        Fun.never,
         sharedBackstage.providers
       ),
       {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
@@ -7,7 +7,7 @@
 
 import { Behaviour, GuiFactory, ItemTypes, MaxHeight, Tooltipping } from '@ephox/alloy';
 import { InlineContent, Toolbar } from '@ephox/bridge';
-import { Obj, Optional } from '@ephox/katamari';
+import { Fun, Obj, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import I18n from 'tinymce/core/api/util/I18n';
@@ -92,9 +92,9 @@ const renderAutocompleteItem = (
   return renderCommonItem({
     data: buildData(spec),
     disabled: spec.disabled,
-    getApi: () => ({}),
+    getApi: Fun.constant({}),
     onAction: (_api) => onItemValueHandler(spec.value, spec.meta),
-    onSetup: () => () => { },
+    onSetup: Fun.constant(Fun.noop),
     triggersSubmenu: false,
     itemBehaviours: tooltipBehaviour(spec.meta, sharedBackstage)
   }, structure, itemResponse, sharedBackstage.providers);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
@@ -7,7 +7,7 @@
 
 import { Disabling, Toggling } from '@ephox/alloy';
 import { Menu, Toolbar } from '@ephox/bridge';
-import { Merger, Optional } from '@ephox/katamari';
+import { Fun, Merger, Optional } from '@ephox/katamari';
 import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import * as ItemClasses from '../ItemClasses';
 import ItemResponse from '../ItemResponse';
@@ -57,7 +57,7 @@ const renderChoiceItem = (
       onAction: (_api) => onItemValueHandler(spec.value),
       onSetup: (api) => {
         api.setActive(isSelected);
-        return () => {};
+        return Fun.noop;
       },
       triggersSubmenu: false,
       itemBehaviours: [ ]

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
@@ -7,7 +7,7 @@
 
 import { ItemTypes, ItemWidget, Menu as AlloyMenu, MenuTypes } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
-import { Id } from '@ephox/katamari';
+import { Fun, Id } from '@ephox/katamari';
 
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import * as ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
@@ -30,7 +30,7 @@ export function renderColorSwatchItem(spec: Menu.FancyMenuItem, backstage: UiFac
     columns,
     presets,
     ItemResponse.CLOSE_ON_EXECUTE,
-    () => false,
+    Fun.never,
     backstage.shared.providers
   );
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -244,7 +244,7 @@ const fetchChoices = (getApi, spec: ChoiceFetcher, providersBackstage: UiFactory
       spec.columns,
       spec.presets,
       ItemResponse.CLOSE_ON_EXECUTE,
-      spec.select.getOr(() => false),
+      spec.select.getOr(Fun.never),
       providersBackstage
     ),
     {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/urlinput/Completions.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/urlinput/Completions.ts
@@ -6,7 +6,7 @@
  */
 
 import { Menu as BridgeMenu } from '@ephox/bridge';
-import { Arr, Optional, Strings } from '@ephox/katamari';
+import { Arr, Fun, Optional, Strings } from '@ephox/katamari';
 
 import { LinkInformation } from '../../backstage/UrlInputBackstage';
 import { LinkTarget, LinkTargetType } from '../core/LinkTargets';
@@ -23,7 +23,7 @@ const toMenuItem = (target: LinkTarget): BridgeMenu.MenuItemSpec => ({
   meta: {
     attach: target.attach
   },
-  onAction: () => { }
+  onAction: Fun.noop
 });
 
 const staticMenuItem = (title: string, url: string): BridgeMenu.MenuItemSpec => ({
@@ -33,7 +33,7 @@ const staticMenuItem = (title: string, url: string): BridgeMenu.MenuItemSpec => 
   meta: {
     attach: undefined
   },
-  onAction: () => { }
+  onAction: Fun.noop
 });
 
 const toMenuItems = (targets: LinkTarget[]): BridgeMenu.MenuItemSpec[] =>

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
@@ -1,6 +1,7 @@
 import { ApproxStructure, Assertions, Chain, FocusTools, GeneralSteps, Keyboard, Keys, Log, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarBody, SugarElement } from '@ephox/sugar';
@@ -229,7 +230,7 @@ UnitTest.asynctest('Editor ContextForm test', (success, failure) => {
         });
 
         ed.ui.registry.addContextToolbar('test-toolbar', {
-          predicate: () => false,
+          predicate: Fun.never,
           items: 'form:test-form'
         });
       }

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { ApproxStructure, Assertions, Chain, Keyboard, Keys, Log, Logger, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Cell } from '@ephox/katamari';
+import { Cell, Fun } from '@ephox/katamari';
 import { TinyLoader, TinyUi } from '@ephox/mcagar';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
@@ -374,7 +374,7 @@ UnitTest.asynctest('Editor (Silver) test', (success, failure) => {
         // }
         ed.ui.registry.addSplitButton('splitbutton1-with-text', {
           text: 'Delta',
-          onItemAction: () => { },
+          onItemAction: Fun.noop,
           fetch: (callback) => {
             callback([
               {
@@ -403,7 +403,7 @@ UnitTest.asynctest('Editor (Silver) test', (success, failure) => {
 
         ed.ui.registry.addSplitButton('splitbutton2-with-icon', {
           icon: 'underline',
-          onItemAction: () => { },
+          onItemAction: Fun.noop,
           fetch: (callback) => {
             callback([
               {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { ApproxStructure, Assertions, Chain, Keyboard, Keys, Log, Logger, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Arr, Cell } from '@ephox/katamari';
+import { Arr, Cell, Fun } from '@ephox/katamari';
 import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import { Css, SugarBody, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
@@ -373,7 +373,7 @@ UnitTest.asynctest('Inline Editor (Silver) test', (success, failure) => {
 
       ed.ui.registry.addSplitButton('splitbutton1-with-text', {
         text: 'Delta',
-        onItemAction: () => { },
+        onItemAction: Fun.noop,
         fetch: (callback) => {
           callback([
             {
@@ -402,7 +402,7 @@ UnitTest.asynctest('Inline Editor (Silver) test', (success, failure) => {
 
       ed.ui.registry.addSplitButton('splitbutton2-with-icon', {
         icon: 'underline',
-        onItemAction: () => { },
+        onItemAction: Fun.noop,
         fetch: (callback) => {
           callback([
             {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -69,7 +69,7 @@ UnitTest.asynctest('ToolbarBottomTest - assert direction that menus open in when
         setup: (editor) => {
           editor.ui.registry.addSplitButton('splitbutton', {
             text: 'Test SplitButton',
-            onItemAction: () => { },
+            onItemAction: Fun.noop,
             fetch: (callback) => {
               callback([
                 {
@@ -78,7 +78,7 @@ UnitTest.asynctest('ToolbarBottomTest - assert direction that menus open in when
                 }
               ]);
             },
-            onAction: () => {}
+            onAction: Fun.noop
           });
         }
       },

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -2,7 +2,7 @@ import {
   ApproxStructure, Assertions, Chain, FocusTools, GeneralSteps, Keyboard, Keys, Log, Logger, Mouse, Pipeline, Step, UiFinder
 } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 
@@ -126,21 +126,21 @@ UnitTest.asynctest('Editor (Silver) bespoke toolbar buttons test', (success, fai
 
         sCheckItemsAtLocation(
           'First paragraph after "Andale Mono"',
-          [ true ].concat(range(16, () => false)),
+          [ true ].concat(range(16, Fun.never)),
           'Andale Mono',
           [ 0, 0, 0 ], 'Fi'.length
         ),
 
         sCheckItemsAtLocation(
           'Second paragraph with no set font',
-          range(14, () => false).concat([ true ]).concat(range(2, () => false)),
+          range(14, Fun.never).concat([ true ]).concat(range(2, Fun.never)),
           'Verdana',
           [ 1, 0 ], 'Se'.length
         ),
 
         sCheckItemsAtLocation(
           'First paragraph with the font set to "Andale Mono" previously',
-          [ true ].concat(range(16, () => false)),
+          [ true ].concat(range(16, Fun.never)),
           'Andale Mono',
           [ 0, 0, 0 ], 'Fi'.length
         )
@@ -156,21 +156,21 @@ UnitTest.asynctest('Editor (Silver) bespoke toolbar buttons test', (success, fai
 
         sCheckItemsAtLocation(
           'First paragraph after "8pt',
-          [ true ].concat(range(6, () => false)),
+          [ true ].concat(range(6, Fun.never)),
           '8pt',
           [ 0, 0, 0 ], 'Fi'.length
         ),
 
         sCheckItemsAtLocation(
           'Second paragraph with no set font size',
-          range(2, () => false).concat([ true ]).concat(range(4, () => false)),
+          range(2, Fun.never).concat([ true ]).concat(range(4, Fun.never)),
           '12pt',
           [ 1, 0 ], 'Se'.length
         ),
 
         sCheckItemsAtLocation(
           'First paragraph with the font set to "8pt" previously',
-          [ true ].concat(range(6, () => false)),
+          [ true ].concat(range(6, Fun.never)),
           '8pt',
           [ 0, 0, 0 ], 'Fi'.length
         )
@@ -188,21 +188,21 @@ UnitTest.asynctest('Editor (Silver) bespoke toolbar buttons test', (success, fai
 
         sCheckItemsAtLocation(
           'First block after "h1',
-          [ false, true ].concat(range(6, () => false)),
+          [ false, true ].concat(range(6, Fun.never)),
           'Heading 1:first',
           [ 0, 0 ], 'Fi'.length
         ),
 
         sCheckItemsAtLocation(
           'Second paragraph with no set format',
-          [ true ].concat(range(7, () => false)),
+          [ true ].concat(range(7, Fun.never)),
           'Paragraph:first',
           [ 1, 0 ], 'Se'.length
         ),
 
         sCheckItemsAtLocation(
           'First block with the "h1" set previously',
-          [ false, true ].concat(range(6, () => false)),
+          [ false, true ].concat(range(6, Fun.never)),
           'Heading 1:first',
           [ 0, 0 ], 'Fi'.length
         ),
@@ -229,7 +229,7 @@ UnitTest.asynctest('Editor (Silver) bespoke toolbar buttons test', (success, fai
         Keyboard.sKeydown(doc, Keys.right(), { }),
         sAssertFocusOnItem('Paragraph'),
         sAssertItemTicks('Checking blocks in menu', [ false, true ].concat(
-          range(6, () => false)
+          range(6, Fun.never)
         )),
         Keyboard.sKeydown(doc, Keys.escape(), { }),
         Keyboard.sKeydown(doc, Keys.escape(), { })
@@ -247,21 +247,21 @@ UnitTest.asynctest('Editor (Silver) bespoke toolbar buttons test', (success, fai
 
         sCheckSubItemsAtLocation('Heading 1')(
           'First block after "h1',
-          [ true ].concat(range(5, () => false)),
+          [ true ].concat(range(5, Fun.never)),
           'Heading 1:last',
           [ 0, 0 ], 'Fi'.length
         ),
 
         sCheckSubItemsAtLocation('Heading 1')(
           'Second paragraph with no set format',
-          range(6, () => false),
+          range(6, Fun.never),
           'Paragraph:last',
           [ 1, 0 ], 'Se'.length
         ),
 
         sCheckSubItemsAtLocation('Heading 1')(
           'First block with the "h1" set previously',
-          [ true ].concat(range(5, () => false)),
+          [ true ].concat(range(5, Fun.never)),
           'Heading 1:last',
           [ 0, 0 ], 'Fi'.length
         ),
@@ -288,7 +288,7 @@ UnitTest.asynctest('Editor (Silver) bespoke toolbar buttons test', (success, fai
         Keyboard.sKeydown(doc, Keys.right(), { }),
         sAssertFocusOnItem('Heading 1'),
         sAssertItemTicks('Checking headings in menu', [ true ].concat(
-          range(5, () => false)
+          range(5, Fun.never)
         )),
         Keyboard.sKeydown(doc, Keys.escape(), { }),
         Keyboard.sKeydown(doc, Keys.escape(), { }),

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/MobileContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/MobileContextMenuTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions, Chain, FocusTools, GeneralSteps, Keyboard, Keys, Log, Pipeline, Touch, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import { TinyApis, TinyDom, TinyLoader, TinyUi } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarBody, SugarElement } from '@ephox/sugar';
@@ -28,7 +28,7 @@ UnitTest.asynctest('MobileContextMenuTest', (success, failure) => {
   PlatformDetection.override({
     deviceType: {
       ...detection.deviceType,
-      isTouch: () => true
+      isTouch: Fun.always
     }
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
@@ -1,5 +1,6 @@
 import { Assertions, Log, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Css, Scroll, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
@@ -116,7 +117,7 @@ UnitTest.asynctest('Distraction free editor ContextToolbar Position test', (succ
       setup: (ed: Editor) => {
         ed.ui.registry.addButton('alpha', {
           text: 'Alpha',
-          onAction: () => {}
+          onAction: Fun.noop
         });
         ed.ui.registry.addContextToolbar('test-toolbar', {
           predicate: (node) => node.nodeName && node.nodeName.toLowerCase() === 'a',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -1,5 +1,6 @@
 import { Assertions, Keys, Log, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyActions, TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import { Css, Scroll, SugarBody, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
@@ -209,7 +210,7 @@ UnitTest.asynctest('IFrame editor ContextToolbar Position test', (success, failu
       setup: (ed: Editor) => {
         ed.ui.registry.addButton('alpha', {
           text: 'Alpha',
-          onAction: () => {}
+          onAction: Fun.noop
         });
         ed.ui.registry.addContextToolbar('test-selection-toolbar', {
           predicate: (node) => node.nodeName && node.nodeName.toLowerCase() === 'a',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
@@ -1,5 +1,6 @@
 import { Assertions, Log, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Css, Scroll, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
@@ -126,7 +127,7 @@ UnitTest.asynctest('Inline editor ContextToolbar Position test', (success, failu
       setup: (ed: Editor) => {
         ed.ui.registry.addButton('alpha', {
           text: 'Alpha',
-          onAction: () => {}
+          onAction: Fun.noop
         });
         ed.ui.registry.addContextToolbar('test-toolbar', {
           predicate: (node) => node.nodeName && node.nodeName.toLowerCase() === 'a',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPositionPriorityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPositionPriorityTest.ts
@@ -1,7 +1,7 @@
 import { Log, Pipeline, Step } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { InlineContent } from '@ephox/bridge';
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import { ContextTypes } from 'tinymce/themes/silver/ContextToolbar';
 import { filterByPositionForAncestorNode, filterByPositionForStartNode } from 'tinymce/themes/silver/ui/context/ContextToolbarLookup';
 
@@ -9,7 +9,7 @@ UnitTest.asynctest('Context toolbar lookup priority by position test', (success,
   const createToolbars = (positions: string[]): ContextTypes[] => Arr.map(positions, (p) => ({
     type: 'contexttoolbar',
     items: 'bold italic',
-    predicate: () => true,
+    predicate: Fun.always,
     position: p,
     scope: 'node'
   } as InlineContent.ContextToolbar));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
@@ -1,7 +1,7 @@
 import { Log, Pipeline, Step } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { InlineContent } from '@ephox/bridge';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { ContextTypes } from 'tinymce/themes/silver/ContextToolbar';
 import { matchStartNode } from 'tinymce/themes/silver/ui/context/ContextToolbarLookup';
@@ -11,7 +11,7 @@ UnitTest.asynctest('Context toolbar prioritisation on lookup test', (success, fa
   const createToolbar = (items): InlineContent.ContextToolbar => ({
     type: 'contexttoolbar',
     items,
-    predicate: () => true,
+    predicate: Fun.always,
     position: 'selection',
     scope: 'node'
   });
@@ -22,17 +22,17 @@ UnitTest.asynctest('Context toolbar prioritisation on lookup test', (success, fa
     label: Optional.none(),
     launch: Optional.none(),
     commands: [{
-      onAction: () => {},
+      onAction: Fun.noop,
       original: {
-        onAction: () => {}
+        onAction: Fun.noop
       },
       disabled: false,
       tooltip: Optional.none(),
       icon: Optional.none(),
       text: Optional.none(),
-      onSetup: () => () => {}
+      onSetup: () => Fun.noop
     }],
-    predicate: () => true,
+    predicate: Fun.always,
     position: 'selection',
     scope: 'node'
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
@@ -1,6 +1,6 @@
 import { GeneralSteps, Log, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Cell, Obj } from '@ephox/katamari';
+import { Cell, Fun, Obj } from '@ephox/katamari';
 import { TinyApis, TinyLoader } from '@ephox/mcagar';
 import { Focus, SelectorFind, SugarBody } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
@@ -128,15 +128,15 @@ UnitTest.asynctest('Inline editor Context Toolbar Lookup test', (success, failur
         // Register buttons to use in the toolbars
         ed.ui.registry.addButton('node', {
           text: 'Node',
-          onAction: () => {}
+          onAction: Fun.noop
         });
         ed.ui.registry.addButton('parentnode', {
           text: 'Parent',
-          onAction: () => {}
+          onAction: Fun.noop
         });
         ed.ui.registry.addButton('editor', {
           text: 'Editor',
-          onAction: () => {}
+          onAction: Fun.noop
         });
 
         // Register toolbars to test with

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -1,6 +1,7 @@
 import { ApproxStructure, Assertions, Chain, GeneralSteps, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyLoader, TinyUi } from '@ephox/mcagar';
 import { SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { Sidebar } from 'tinymce/core/api/ui/Ui';
@@ -86,7 +87,7 @@ UnitTest.asynctest('browser.tinymce.themes.silver.sidebar.SidebarTest', function
       const handleSetup = (eventName: string) => (api: Sidebar.SidebarInstanceApi) => {
         api.element().appendChild(SugarElement.fromHtml('<div style="width: 200px; background: red;"></div>').dom);
         logEvent(eventName)(api);
-        return () => {};
+        return Fun.noop;
       };
       editor.ui.registry.addSidebar('mysidebar1', {
         tooltip: 'My sidebar 1',

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
@@ -38,14 +38,14 @@ export default function (sink?: AlloyComponent): UiFactoryBackstage {
       getSink: () => Result.value(sink)
     },
     urlinput: {
-      getHistory: () => [],
-      addToHistory: () => {},
-      getLinkInformation: () => Optional.none(),
-      getValidationHandler: () => Optional.none(),
+      getHistory: Fun.constant([]),
+      addToHistory: Fun.noop,
+      getLinkInformation: Optional.none,
+      getValidationHandler: Optional.none,
       getUrlPicker: (_filetype) => Optional.some((entry: ApiUrlData) => Future.pure(entry))
     },
     dialog: {
-      isDraggableModal: () => false
+      isDraggableModal: Fun.never
     }
   };
 }

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -1,9 +1,10 @@
+import { Fun } from '@ephox/katamari';
 import I18n from 'tinymce/core/api/util/I18n';
 
 export default {
   icons: () => <Record<string, string>> {},
   menuItems: () => <Record<string, any>> {},
   translate: I18n.translate,
-  isDisabled: () => false,
+  isDisabled: Fun.never,
   getSetting: (_settingName: string, defaultVal: any) => defaultVal
 };

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/alertbanner/AlertBannerTest.ts
@@ -1,6 +1,7 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { GuiFactory, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import I18n from 'tinymce/core/api/util/I18n';
 
 import { renderAlertBanner } from 'tinymce/themes/silver/ui/general/AlertBanner';
@@ -13,7 +14,7 @@ UnitTest.asynctest('AlertBanner component Test', (success, failure) => {
     },
     menuItems: () => <Record<string, any>> {},
     translate: I18n.translate,
-    isDisabled: () => false,
+    isDisabled: Fun.never,
     getSetting: (_settingName: string, defaultVal: any) => defaultVal
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/checkbox/BasicCheckboxTest.ts
@@ -1,6 +1,7 @@
 import { ApproxStructure, Assertions, Chain, Keyboard, Keys, Logger, Step, UiFinder } from '@ephox/agar';
 import { GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import I18n from 'tinymce/core/api/util/I18n';
 
 import { renderCheckbox } from 'tinymce/themes/silver/ui/general/Checkbox';
@@ -14,7 +15,7 @@ UnitTest.asynctest('Checkbox component Test', (success, failure) => {
     },
     menuItems: () => <Record<string, any>> {},
     translate: I18n.translate,
-    isDisabled: () => false,
+    isDisabled: Fun.never,
     getSetting: (_settingName: string, defaultVal: any) => defaultVal
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/colorinput/ColorInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/colorinput/ColorInputTest.ts
@@ -3,7 +3,7 @@ import {
 } from '@ephox/agar';
 import { AlloyTriggers, Container, GuiFactory, Invalidating, NativeEvents, Representing, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
 
 import { renderColorInput } from 'tinymce/themes/silver/ui/dialog/ColorInput';
@@ -29,7 +29,7 @@ UnitTest.asynctest('Color input component Test', (success, failure) => {
             label: Optional.some('test-color-input')
           }, helpers.shared, {
             colorPicker: (_callback, _value) => {},
-            hasCustomColors: () => true,
+            hasCustomColors: Fun.always,
             getColors: () => [
               { type: choiceItem, text: 'Turquoise', value: '#18BC9B' },
               { type: choiceItem, text: 'Green', value: '#2FCC71' },

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/customeditor/BasicCustomEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/customeditor/BasicCustomEditorTest.ts
@@ -2,7 +2,7 @@
 import { ApproxStructure, Assertions, Cleaner, Logger, Step, Waiter } from '@ephox/agar';
 import { GuiFactory, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Cell, Global } from '@ephox/katamari';
+import { Cell, Fun, Global } from '@ephox/katamari';
 import { Class, SugarElement } from '@ephox/sugar';
 import Resource from 'tinymce/core/api/Resource';
 import Delay from 'tinymce/core/api/util/Delay';
@@ -37,7 +37,7 @@ UnitTest.asynctest('CustomEditor component Test', (success, failure) => {
         resolve({
           setValue(s: string) { customEditorValue.set(s); },
           getValue() { return customEditorValue.get(); },
-          destroy() {}
+          destroy: Fun.noop
         });
       }
     }, 100);

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/customeditor/CustomEditorSchemaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/customeditor/CustomEditorSchemaTest.ts
@@ -1,6 +1,7 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { ValueSchema } from '@ephox/boulder';
 import { Dialog } from '@ephox/bridge';
+import { Fun } from '@ephox/katamari';
 
 UnitTest.test('Custom Editor Schema Test', () => {
   const schema = Dialog.customEditorSchema;
@@ -36,9 +37,9 @@ UnitTest.test('Custom Editor Schema Test', () => {
     ...base,
     init(_el) {
       return {
-        setValue: (_value: string) => {},
-        getValue: () => '',
-        destroy: () => {}
+        setValue: Fun.noop,
+        getValue: Fun.constant(''),
+        destroy: Fun.noop
       };
     }
   }).isValue());
@@ -49,9 +50,9 @@ UnitTest.test('Custom Editor Schema Test', () => {
     scriptUrl: 'scriptUrl',
     init(_el) {
       return {
-        setValue: (_value: string) => {},
-        getValue: () => '',
-        destroy: () => {}
+        setValue: Fun.noop,
+        getValue: Fun.constant(''),
+        destroy: Fun.noop
       };
     }
   }).isError());
@@ -84,7 +85,7 @@ UnitTest.test('Custom Editor Schema Test', () => {
     scriptId: 'scriptId',
     scriptUrl: 'scriptUrl',
     settings: {
-      func: () => {}
+      func: Fun.noop
     }
   }).isError());
 });

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/configs/ControlOnSetupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/configs/ControlOnSetupTest.ts
@@ -1,7 +1,7 @@
 import { Log, Logger, Step } from '@ephox/agar';
 import { Behaviour, GuiFactory, Replacing, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Cell } from '@ephox/katamari';
+import { Cell, Fun } from '@ephox/katamari';
 
 import { SimpleBehaviours } from 'tinymce/themes/silver/ui/alien/SimpleBehaviours';
 import { onControlAttached, onControlDetached } from 'tinymce/themes/silver/ui/controls/Controls';
@@ -28,7 +28,7 @@ UnitTest.asynctest('ControlOnSetup Test', (success, failure) => {
           store.adder('onSetup.1')();
           return onDestroy1;
         },
-        getApi: () => { }
+        getApi: Fun.noop
       };
 
       const cellWithoutDestroy = Cell(store.adder('fallbackWithoutDestroy'));
@@ -36,7 +36,7 @@ UnitTest.asynctest('ControlOnSetup Test', (success, failure) => {
         onSetup: () => {
           store.adder('onSetup.2')();
         },
-        getApi: () => { }
+        getApi: Fun.noop
       } as any; // "any" cast to get around Typescript asking for a return function
 
       return [

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/sketchers/SilverMenubarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/sketchers/SilverMenubarTest.ts
@@ -185,7 +185,7 @@ UnitTest.asynctest('SilverMenubar Test', (success, failure) => {
                             type: 'menuitem',
                             icon: 'drop',
                             text: 'Nested menu x 3',
-                            onAction: () => { }
+                            onAction: Fun.noop
                           }
                         ]
                       }

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/toolbar/ToolbarButtonsTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions, Logger, Mouse, Step, Waiter } from '@ephox
 import { AlloyComponent, GuiFactory, TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Menu, Toolbar } from '@ephox/bridge';
-import { Arr, Cell, Optional } from '@ephox/katamari';
+import { Arr, Cell, Fun, Optional } from '@ephox/katamari';
 import { Attribute, Class, SelectorFind } from '@ephox/sugar';
 import { renderMenuButton } from 'tinymce/themes/silver/ui/button/MenuButton';
 import { renderSplitButton, renderToolbarButton, renderToolbarToggleButton } from 'tinymce/themes/silver/ui/toolbar/button/ToolbarButtons';
@@ -37,7 +37,7 @@ UnitTest.asynctest('Toolbar Buttons Test', (success, failure) => {
                 text: Optional.some('button1'),
                 onSetup: (_api: Toolbar.ToolbarButtonInstanceApi) => {
                   store.adder('onSetup.1')();
-                  return () => { };
+                  return Fun.noop;
                 },
                 onAction: (api: Toolbar.ToolbarButtonInstanceApi) => {
                   store.adder('onAction.1')();
@@ -62,7 +62,7 @@ UnitTest.asynctest('Toolbar Buttons Test', (success, failure) => {
                 text: Optional.some('button2'),
                 onSetup: (_api: Toolbar.ToolbarToggleButtonInstanceApi) => {
                   store.adder('onSetup.2')();
-                  return () => { };
+                  return Fun.noop;
                 },
                 onAction: (api: Toolbar.ToolbarToggleButtonInstanceApi) => {
                   store.adder('onToggleAction.2')();
@@ -97,7 +97,7 @@ UnitTest.asynctest('Toolbar Buttons Test', (success, failure) => {
                 },
                 onSetup: (_api: Toolbar.ToolbarToggleButtonInstanceApi) => {
                   store.adder('onSetup.3')();
-                  return () => { };
+                  return Fun.noop;
                 },
                 onAction: (api: Toolbar.ToolbarToggleButtonInstanceApi) => {
                   store.adder('onToggleAction.3')();
@@ -135,7 +135,7 @@ UnitTest.asynctest('Toolbar Buttons Test', (success, failure) => {
                 },
                 onSetup: (_api: Toolbar.ToolbarMenuButtonInstanceApi) => {
                   store.adder('onSetup.4')();
-                  return () => { };
+                  return Fun.noop;
                 }
               }, 'tox-mbtn', helpers.backstage, Optional.none())
             ]

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/window/CustomDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/window/CustomDialogTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Chain, FocusTools, GeneralSteps, Keyboard, Keys, Logger, Mouse, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Arr, Cell } from '@ephox/katamari';
+import { Arr, Cell, Fun } from '@ephox/katamari';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 import TestExtras from '../../module/TestExtras';
@@ -154,7 +154,7 @@ UnitTest.asynctest('WindowManager:custom-dialog Test', (success, failure) => {
             testLog.get().concat([ 'onSubmit' ])
           );
         }
-      }, {}, () => {});
+      }, {}, Fun.noop);
     }),
 
     FocusTools.sTryOnSelector(

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/window/SilverDialogEventTest.ts
@@ -85,12 +85,12 @@ UnitTest.asynctest('SilverDialog Event Test', (success, failure) => {
                 icons: () => <Record<string, string>> {},
                 menuItems: () => <Record<string, any>> {},
                 translate: I18n.translate,
-                isDisabled: () => false,
+                isDisabled: Fun.never,
                 getSetting: (_settingName: string, defaultVal: any) => defaultVal
               }
             },
             dialog: {
-              isDraggableModal: () => false
+              isDraggableModal: Fun.never
             }
           }
         );

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/window/TabbedDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/window/TabbedDialogTest.ts
@@ -1,5 +1,6 @@
 import { ApproxStructure, Assertions, Chain, Mouse, NamedChain, Pipeline, Step, StructAssert, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 import TestExtras from '../../module/TestExtras';
@@ -90,10 +91,8 @@ UnitTest.asynctest('WindowManager:tabbed-dialog Test', (success, failure) => {
           const target = a.name === 'gotoBasic' ? 'basic' : 'advanced';
           api.showTab(target);
         },
-        onSubmit: () => {
-
-        }
-      }, {}, () => {});
+        onSubmit: Fun.noop
+      }, {}, Fun.noop);
     }),
 
     Chain.asStep({ }, [

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/window/WindowManagerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/window/WindowManagerTest.ts
@@ -15,7 +15,7 @@ UnitTest.asynctest('WindowManager:configurations Test', (success, failure) => {
     backstage: {
       ...helpers.extras.backstage,
       dialog: {
-        isDraggableModal: () => true
+        isDraggableModal: Fun.always
       }
     }
   });


### PR DESCRIPTION
Related Ticket: TINY-6789

Description of Changes:
* Replaced inline function uses with `Fun.noop`, `Fun.always` or `Fun.never.` These were detected using the new linter added in https://github.com/tinymce/eslint-plugin/pull/11.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
