### PR TITLE
TINY-6229: Fixed an issue where audio elements weren't playable

### DIFF
--- a/modules/oxide/src/less/theme/content/resize-handles/resize-handle.less
+++ b/modules/oxide/src/less/theme/content/resize-handles/resize-handle.less
@@ -52,6 +52,7 @@
   }
 
   .mce-clonedresizable {
+    cursor: default;
     opacity: .5;
     outline: 1px dashed black;
     position: absolute;

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -58,6 +58,7 @@ interface SelectedResizeHandle extends ResizeHandle {
 const isContentEditableFalse = NodeType.isContentEditableFalse;
 
 const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSelection => {
+  const elementSelectionAttr = 'data-mce-selected';
   const dom = editor.dom, each = Tools.each;
   let selectedElm, selectedElmGhost: HTMLElement, resizeHelper, selectedHandle: SelectedResizeHandle, resizeBackdrop: HTMLElement;
   let startX, startY, selectedElmX, selectedElmY, startW, startH, ratio, resizeStarted;
@@ -272,7 +273,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
     editor.nodeChanged();
   };
 
-  const showResizeRect = (targetElm: Element) => {
+  const showResizeRect = (targetElm: HTMLElement) => {
     unbindResizeHandleEvents();
 
     // Get position and size of target
@@ -292,6 +293,9 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
 
     // Makes it possible to disable resizing
     const e = editor.fire('ObjectSelected', { target: targetElm });
+
+    // Store the original data-mce-selected value or fallback to '1' if not set
+    const selectedValue = dom.getAttrib(selectedElm, elementSelectionAttr, '1');
 
     if (isResizable(targetElm) && !e.isDefaultPrevented()) {
       each(resizeHandles, (handle, name) => {
@@ -336,7 +340,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
           // Set initial ghost size
           setGhostElmSize(selectedElmGhost, targetWidth, targetHeight);
 
-          selectedElmGhost.removeAttribute('data-mce-selected');
+          selectedElmGhost.removeAttribute(elementSelectionAttr);
           rootElement.appendChild(selectedElmGhost);
 
           dom.bind(editableDoc, 'mousemove', resizeGhostElement);
@@ -392,8 +396,8 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
       hideResizeRect();
     }
 
-    if (!dom.getAttrib(selectedElm, 'data-mce-selected')) {
-      selectedElm.setAttribute('data-mce-selected', '1');
+    if (!dom.getAttrib(selectedElm, elementSelectionAttr)) {
+      selectedElm.setAttribute(elementSelectionAttr, selectedValue);
     }
   };
 
@@ -401,7 +405,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
     unbindResizeHandleEvents();
 
     if (selectedElm) {
-      selectedElm.removeAttribute('data-mce-selected');
+      selectedElm.removeAttribute(elementSelectionAttr);
     }
 
     Obj.each(resizeHandles, (value, name) => {
@@ -433,7 +437,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
 
     // Remove data-mce-selected from all elements since they might have been copied using Ctrl+c/v
     each(dom.select('img[data-mce-selected],hr[data-mce-selected]'), function (img) {
-      img.removeAttribute('data-mce-selected');
+      img.removeAttribute(elementSelectionAttr);
     });
 
     controlElm = e.type === 'mousedown' ? e.target : selection.getNode();

--- a/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
@@ -147,26 +147,36 @@ UnitTest.asynctest('browser.tinymce.core.dom.ControlSelectionTest', function (su
         sResizeAndAssertDimensions(editorBody, 'iframe', '#mceResizeHandlese', 100, 50, 402, 202)
       ]),
       Log.stepsAsStep('TINY-6229', 'data-mce-selected attribute value retained when selecting the same element', [
-        tinyApis.sSetContent('<p><span contenteditable="false" class="mce-preview-object mce-object-video"><video controls width="300" height="150"></video></span><strong>Test</strong></p>'),
+        tinyApis.sSetContent(
+          '<p><span contenteditable="false" class="mce-preview-object mce-object-video"><video controls width="300" height="150"></video></span></p>' +
+          '<p><span contenteditable="false" class="mce-preview-object mce-object-audio"><audio controls></audio></span></p>'
+        ),
         // Select to set the initial selected element in ControlSelection, change and then come back
-        tinyApis.sSelect('span', [ ]),
+        tinyApis.sSelect('span.mce-object-video', [ ]),
         sWaitForDragHandles(editorBody, '#mceResizeHandlenw'),
         tinyApis.sAssertContentPresence({
-          'span[data-mce-selected=1] video': 1
-        }),
-        tinyApis.sSetCursor([ 0, 1, 0 ], 2),
-        Waiter.sTryUntil('Wait for resize handles to disappear', UiFinder.sNotExists(editorBody, '#mceResizeHandlenw')),
-        tinyApis.sAssertContentPresence({
-          'span[data-mce-selected] video': 0
+          'span[data-mce-selected=1] video': 1,
+          'span[data-mce-selected] audio': 0
         }),
         Step.sync(() => {
-          const previewSpan = editor.dom.select('span')[0];
-          editor.dom.setAttrib(previewSpan, 'data-mce-selected', '2');
+          const audioPreviewSpan = editor.dom.select('span')[1];
+          editor.dom.setAttrib(audioPreviewSpan, 'data-mce-selected', '3');
         }),
-        tinyApis.sSelect('span', [ ]),
+        tinyApis.sSelect('span.mce-object-audio', [ ]),
+        Waiter.sTryUntil('Wait for resize handles to disappear', UiFinder.sNotExists(editorBody, '#mceResizeHandlenw')),
+        tinyApis.sAssertContentPresence({
+          'span[data-mce-selected] video': 0,
+          'span[data-mce-selected=3] audio': 1
+        }),
+        Step.sync(() => {
+          const videoPreviewSpan = editor.dom.select('span')[0];
+          editor.dom.setAttrib(videoPreviewSpan, 'data-mce-selected', '2');
+        }),
+        tinyApis.sSelect('span.mce-object-video', [ ]),
         sWaitForDragHandles(editorBody, '#mceResizeHandlenw'),
         tinyApis.sAssertContentPresence({
-          'span[data-mce-selected=2] video': 1
+          'span[data-mce-selected=2] video': 1,
+          'span[data-mce-selected] audio': 0
         })
       ]),
     ], onSuccess, onFailure);


### PR DESCRIPTION
Related Ticket: TINY-6229

Description of Changes:
* An additional fix where audio elements couldn't be played due to `ControlSelection` changing the `data-mce-selected` attribute from `2` to `1` after selecting it.
* Fixes the cursor showing as a text cursor while dragging/resizing.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
