### PR TITLE
Tiny 6399 Auto focus on selected items in menus

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitDropdown.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitDropdown.ts
@@ -24,8 +24,13 @@ const factory: CompositeSketchFactory<SplitDropdownDetail, SplitDropdownSpec> = 
 
   const switchToMenu = (sandbox: AlloyComponent) => {
     Composing.getCurrent(sandbox).each((current) => {
-      Highlighting.highlightFirst(current);
-      Keying.focusIn(current);
+      Highlighting.getHighlighted(current).fold(
+        () => {
+          Highlighting.highlightFirst(current);
+          Keying.focusIn(current);
+        },
+        Fun.noop,
+      )
     });
   };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
@@ -183,7 +183,9 @@ const make: SingleSketchFactory<TieredMenuDetail, TieredMenuSpec> = (detail, _ra
         // want to change the active menu. Sometimes, we just want to show it (e.g. hover)
         detail.onOpenSubmenu(container, item, activeMenu, Arr.reverse(path));
         if (decision === ExpandHighlightDecision.HighlightSubmenu) {
-          Highlighting.highlightFirst(activeMenu);
+          if (Highlighting.getHighlighted(activeMenu).isNone()) {
+            Highlighting.highlightFirst(activeMenu);
+          }
           return updateMenuPath(container, layeredState, path);
         } else {
           Highlighting.dehighlightAll(activeMenu);

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,6 +7,7 @@ Version 5.7.0 (TBD)
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
     Changed the z-index of the `setProgressState(true)` throbber so it does not hide notifications #TINY-6686
+    Changed dropdown menus to auto-focus on selected items where possible, instead of the first item #TINY-6399
     Fixed the order of CSS precedence of `content_style` and `content_css` in the `preview` and `template` plugins. `content_style` now has precedence #TINY-6529
     Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL #TINY-6611
     Fixed an issue where `scope` attributes on table cells would not change as expected when merging or unmerging cells #TINY-6486

--- a/modules/tinymce/src/themes/silver/main/ts/ui/controls/Controls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/controls/Controls.ts
@@ -15,7 +15,7 @@ export interface GetApiType<T> {
 export type OnDestroy<T> = (controlApi: T) => void;
 
 export interface OnControlAttachedType<T> extends GetApiType<T> {
-  onSetup: (controlApi: T) => OnDestroy<T>; // TODO: check: no change here?
+  onSetup: (controlApi: T, comp: AlloyComponent) => OnDestroy<T>; // TODO: check: no change here?
 }
 
 const runWithApi = <T>(info: GetApiType<T>, comp: AlloyComponent) => {
@@ -28,7 +28,7 @@ const runWithApi = <T>(info: GetApiType<T>, comp: AlloyComponent) => {
 const onControlAttached = <T>(info: OnControlAttachedType<T>, editorOffCell: Cell<OnDestroy<T>>) => AlloyEvents.runOnAttached((comp) => {
   const run = runWithApi(info, comp);
   run((api) => {
-    const onDestroy = info.onSetup(api);
+    const onDestroy = info.onSetup(api, comp);
     if (onDestroy !== null && onDestroy !== undefined) {
       editorOffCell.set(onDestroy);
     }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/LineHeight.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/LineHeight.ts
@@ -44,6 +44,7 @@ const getLineHeights = (editor: Editor): Menu.ToggleMenuItemSpec[] => {
     (value, i) => ({
       type: 'togglemenuitem',
       text: value,
+      active: normaliseLineHeight(value) === normaliseLineHeight(editor.queryCommandValue('LineHeight')),
       onSetup: (api) => {
         apis.set(normaliseLineHeight(value), api);
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Disabling, Toggling } from '@ephox/alloy';
+import { Disabling, Focusing, Toggling } from '@ephox/alloy';
 import { Menu, Toolbar } from '@ephox/bridge';
 import { Fun, Merger, Optional } from '@ephox/katamari';
 import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
@@ -55,8 +55,11 @@ const renderChoiceItem = (
       disabled: spec.disabled,
       getApi,
       onAction: (_api) => onItemValueHandler(spec.value),
-      onSetup: (api) => {
+      onSetup: (api, comp) => {
         api.setActive(isSelected);
+        if (isSelected) {
+          Focusing.focus(comp);
+        }
         return Fun.noop;
       },
       triggersSubmenu: false,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
@@ -23,7 +23,7 @@ export const componentRenderPipeline = (xs: Array<Optional<AlloySpec>>) =>
 
 export interface CommonMenuItemSpec<T> {
   onAction: (itemApi: T) => void;
-  onSetup: (itemApi: T) => OnDestroy<T>;
+  onSetup: (itemApi: T, component: AlloyComponent) => OnDestroy<T>;
   triggersSubmenu: boolean;
   disabled: boolean;
   itemBehaviours: Array<Behaviour.NamedConfiguredBehaviour<Behaviour.BehaviourConfigSpec, Behaviour.BehaviourConfigDetail>>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Disabling, ItemTypes, Toggling } from '@ephox/alloy';
+import { Disabling, Focusing, ItemTypes, Toggling } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
 import { Merger, Optional } from '@ephox/katamari';
 import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
@@ -50,7 +50,13 @@ const renderToggleMenuItem = (
       disabled: spec.disabled,
       getApi,
       onAction: spec.onAction,
-      onSetup: spec.onSetup,
+      onSetup: (api, comp) => {
+        if (spec.active) {
+          Focusing.focus(comp);
+        }
+        return spec.onSetup(api);
+      },
+
       triggersSubmenu: false,
       itemBehaviours: [ ]
     }, structure, itemResponse, providersBackstage),

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/AccessibleMenuHighlightTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/AccessibleMenuHighlightTest.ts
@@ -1,0 +1,70 @@
+import { FocusTools, Keyboard, Keys, Log, Pipeline, Waiter } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Arr, Fun, Optional } from '@ephox/katamari';
+import { TinyLoader } from '@ephox/mcagar';
+import { SugarDocument, SugarElement } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
+import Theme from 'tinymce/themes/silver/Theme';
+
+UnitTest.asyncTest('browser.tinymce.themes.silver.editor.AccessibleMenuHighlightTest', (success, failure) => {
+  Theme();
+
+  const settings: RawEditorSettings = {
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+    toolbar: 'align lineheight fontsizeselect fontselect'
+  };
+
+  TinyLoader.setup((editor: Editor, success, failure) => {
+    const container = SugarElement.fromDom(editor.getContainer());
+    const doc = SugarDocument.getDocument();
+
+    const sTestToolbar = (description: string, title: string, defaultValue: Optional<string>) => {
+      const defaultMessage = defaultValue.fold(Fun.constant('the first item'), Fun.identity);
+      const defaultSelector = defaultValue.fold(
+        () => ':nth-child(1)',
+        (value) => `:contains("${ value }")`
+      );
+
+      return Log.stepsAsStep('TINY-6399', `Does the ${ description } toolbar correctly focus on ${ defaultMessage }`, [
+        FocusTools.sSetFocus(`Selecting ${ description } toolbar button`, container, `button[title="${ title }"]`),
+        Keyboard.sKeystroke(doc, Keys.down(), {}),
+        FocusTools.sTryOnSelector(`Is ${ defaultMessage } selected`, doc, defaultSelector),
+        Keyboard.sKeystroke(doc, Keys.escape(), {})
+      ]);
+    };
+
+    const sTestNestedMenu = (description: string, topLevel: string, otherLevels: string[], defaultValue: Optional<string>) => {
+      const defaultMessage = defaultValue.fold(Fun.constant('the first item'), Fun.identity);
+      const defaultSelector = defaultValue.fold(
+        () => ':nth-child(1)',
+        (value) => `:contains("${ value }")`
+      );
+
+      return Log.stepsAsStep('TINY-6399', `Does the ${ description } menu correctly focus on ${ defaultMessage }`, [
+        FocusTools.sSetFocus(`Selecting ${ topLevel } menu`, container, `button[role="menuitem"]:contains("${ topLevel }")`),
+        Keyboard.sKeystroke(doc, Keys.down(), {}),
+        ...Arr.bind(otherLevels, (level) => [
+          Waiter.sTryUntil('Waiting for submenu to open',
+            FocusTools.sSetFocus(`Selecting ${ level } submenu`, doc, `div[title="${ level }"]`)
+          ),
+          Keyboard.sKeystroke(doc, Keys.right(), {})
+        ]),
+        FocusTools.sTryOnSelector(`Is ${ defaultMessage } selected`, doc, defaultSelector),
+        // escape out of the nested menus
+        ...Arr.map(otherLevels, Fun.constant(Keyboard.sKeystroke(doc, Keys.escape(), {}))),
+        Keyboard.sKeystroke(doc, Keys.escape(), {})
+      ]);
+    };
+
+    Pipeline.async({}, [
+      sTestToolbar('text align', 'Align', Optional.none()),
+      sTestToolbar('line height', 'Line height', Optional.some('1.4')),
+      sTestToolbar('font size', 'Font sizes', Optional.some('12pt')),
+      sTestToolbar('font select', 'Fonts', Optional.none()),
+      sTestNestedMenu('block format', 'Format', [ 'Formats', 'Blocks' ], Optional.some('Paragraph')),
+      sTestNestedMenu('font size', 'Format', [ 'Font sizes' ], Optional.some('12pt'))
+    ], success, failure);
+  }, settings, success, failure);
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/AccessibleMenuHighlightTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/AccessibleMenuHighlightTest.ts
@@ -1,4 +1,4 @@
-import { FocusTools, Keyboard, Keys, Log, Pipeline, Waiter } from '@ephox/agar';
+import { FocusTools, Keyboard, Keys, Log, Pipeline, Step, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { TinyLoader } from '@ephox/mcagar';
@@ -63,8 +63,18 @@ UnitTest.asyncTest('browser.tinymce.themes.silver.editor.AccessibleMenuHighlight
       sTestToolbar('line height', 'Line height', Optional.some('1.4')),
       sTestToolbar('font size', 'Font sizes', Optional.some('12pt')),
       sTestToolbar('font select', 'Fonts', Optional.none()),
+
       sTestNestedMenu('block format', 'Format', [ 'Formats', 'Blocks' ], Optional.some('Paragraph')),
-      sTestNestedMenu('font size', 'Format', [ 'Font sizes' ], Optional.some('12pt'))
+      sTestNestedMenu('font size', 'Format', [ 'Font sizes' ], Optional.some('12pt')),
+
+      Log.stepsAsStep('TINY-6399', 'Check that changing underlying content while menu is open does not break focus', [
+        FocusTools.sSetFocus('Selecting line height toolbar button', container, 'button[title="Line height"]'),
+        Keyboard.sKeystroke(doc, Keys.down(), {}),
+        FocusTools.sTryOnSelector(`Is 1.4 selected`, doc, ':contains("1.4")'),
+        Step.sync(() => editor.execCommand('LineHeight', false, '1.5', { skip_focus: true })),
+        FocusTools.sTryOnSelector(`Is 1.4 selected`, doc, ':contains("1.4")'),
+        Keyboard.sKeystroke(doc, Keys.escape(), {})
+      ])
     ], success, failure);
   }, settings, success, failure);
 });


### PR DESCRIPTION
Related Ticket: TINY-6399

Description of Changes:
* When navigating dropdown menus (either from toolbar buttons or from top menus) with the keyboard, we auto-focus an item whenever a menu opens. Previously this was always the first item in the list — now (if such an element exists) we will auto-focus the selected / active item in the list.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* ~[ ] Branch prefixed with `feature/` for new features (if applicable)~
* ~[ ] License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
