### PR TITLE
TINY-6504: Enabled the `prefer-arrow/prefer-arrow-functions` ESLint rule for TinyMCE plugins & themes

### DIFF
--- a/modules/tinymce/.eslintrc.json
+++ b/modules/tinymce/.eslintrc.json
@@ -1,7 +1,5 @@
 {
   "rules": {
-    "@typescript-eslint/explicit-module-boundary-types": "off",
-    "prefer-arrow-callback": "error",
-    "prefer-arrow/prefer-arrow-functions": "off"
+    "@typescript-eslint/explicit-module-boundary-types": "off"
   }
 }

--- a/modules/tinymce/src/plugins/advlist/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import * as Actions from '../core/Actions';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('ApplyUnorderedListStyle', (ui, value) => {
     Actions.applyListFormat(editor, 'UL', value['list-style-type']);
   });

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/Actions.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const applyListFormat = function (editor, listName, styleValue) {
+const applyListFormat = (editor, listName, styleValue) => {
   const cmd = listName === 'UL' ? 'InsertUnorderedList' : 'InsertOrderedList';
   editor.execCommand(cmd, false, styleValue === false ? null : { 'list-style-type': styleValue });
 };

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -7,21 +7,21 @@
 
 import { Optional } from '@ephox/katamari';
 
-const isChildOfBody = function (editor, elm) {
+const isChildOfBody = (editor, elm) => {
   return editor.$.contains(editor.getBody(), elm);
 };
 
-const isTableCellNode = function (node) {
+const isTableCellNode = (node) => {
   return node && /^(TH|TD)$/.test(node.nodeName);
 };
 
-const isListNode = function (editor) {
-  return function (node) {
+const isListNode = (editor) => {
+  return (node) => {
     return node && (/^(OL|UL|DL)$/).test(node.nodeName) && isChildOfBody(editor, node);
   };
 };
 
-const getSelectedStyleType = function (editor): Optional<string> {
+const getSelectedStyleType = (editor): Optional<string> => {
   const listElm = editor.dom.getParent(editor.selection.getNode(), 'ol,ul');
   const style = editor.dom.getStyle(listElm, 'listStyleType');
   return Optional.from(style);

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -17,7 +17,7 @@ const enum ListType {
   UnorderedList = 'UL'
 }
 
-const findIndex = function (list, predicate) {
+const findIndex = (list, predicate) => {
   for (let index = 0; index < list.length; index++) {
     const element = list[index];
 
@@ -29,7 +29,7 @@ const findIndex = function (list, predicate) {
 };
 
 // <ListStyles>
-const styleValueToText = function (styleValue) {
+const styleValueToText = (styleValue) => {
   return styleValue.replace(/\-/g, ' ').replace(/\b\w/g, (chr) => {
     return chr.toUpperCase();
   });
@@ -42,7 +42,7 @@ const isWithinList = (editor: Editor, e, nodeName) => {
   return lists.length > 0 && lists[0].nodeName === nodeName;
 };
 
-const addSplitButton = function (editor: Editor, id: string, tooltip: string, cmd: string, nodeName: ListType, styles: string[]) {
+const addSplitButton = (editor: Editor, id: string, tooltip: string, cmd: string, nodeName: ListType, styles: string[]) => {
   editor.ui.registry.addSplitButton(id, {
     tooltip,
     icon: nodeName === ListType.OrderedList ? 'ordered-list' : 'unordered-list',
@@ -82,7 +82,7 @@ const addSplitButton = function (editor: Editor, id: string, tooltip: string, cm
   });
 };
 
-const addButton = function (editor: Editor, id, tooltip, cmd, nodeName, _styles) {
+const addButton = (editor: Editor, id, tooltip, cmd, nodeName, _styles) => {
   editor.ui.registry.addToggleButton(id, {
     active: false,
     tooltip,
@@ -99,7 +99,7 @@ const addButton = function (editor: Editor, id, tooltip, cmd, nodeName, _styles)
   });
 };
 
-const addControl = function (editor: Editor, id: string, tooltip: string, cmd: string, nodeName: ListType, styles: string[]) {
+const addControl = (editor: Editor, id: string, tooltip: string, cmd: string, nodeName: ListType, styles: string[]) => {
   if (styles.length > 1) {
     addSplitButton(editor, id, tooltip, cmd, nodeName, styles);
   } else {
@@ -107,7 +107,7 @@ const addControl = function (editor: Editor, id: string, tooltip: string, cmd: s
   }
 };
 
-const register = function (editor) {
+const register = (editor) => {
   addControl(editor, 'numlist', 'Numbered list', 'InsertOrderedList', ListType.OrderedList, Settings.getNumberStyles(editor));
   addControl(editor, 'bullist', 'Bullet list', 'InsertUnorderedList', ListType.UnorderedList, Settings.getBulletStyles(editor));
 };

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
@@ -13,7 +13,7 @@ UnitTest.asynctest('browser.tinymce.plugins.advlist.AdvlistPluginTest', (success
   ListsPlugin();
   Theme();
 
-  const listStyleTest = function (title: string, definition) {
+  const listStyleTest = (title: string, definition) => {
     suite.test(title, (editor) => {
       editor.getBody().innerHTML = definition.inputContent;
       LegacyUnit.setSelection(editor, definition.inputSelection[0], definition.inputSelection[1]);

--- a/modules/tinymce/src/plugins/anchor/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/Plugin.ts
@@ -11,7 +11,7 @@ import * as FilterContent from './core/FilterContent';
 import * as Formats from './core/Formats';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('anchor', (editor) => {
     FilterContent.setup(editor);
     Commands.register(editor);
@@ -21,4 +21,4 @@ export default function () {
       Formats.registerFormats(editor);
     });
   });
-}
+};

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Formats.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Formats.ts
@@ -18,7 +18,7 @@ const registerFormats = (editor: Editor) => {
     attributes: {
       id: '%value'
     },
-    onmatch(node: Node, _fmt, _itemName: string) {
+    onmatch: (node: Node, _fmt, _itemName: string) => {
       return Utils.isNamedAnchor(node);
     }
   });

--- a/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
@@ -53,7 +53,7 @@ const open = (editor: Editor) => {
     initialData: {
       id: currentId
     },
-    onSubmit(api) {
+    onSubmit: (api) => {
       if (insertAnchor(editor, api.getData().id)) { // TODO we need a better way to do validation
         api.close();
       }

--- a/modules/tinymce/src/plugins/autolink/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/Plugin.ts
@@ -8,8 +8,8 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Keys from './core/Keys';
 
-export default function () {
+export default () => {
   PluginManager.add('autolink', (editor) => {
     Keys.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/autolink/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/api/Settings.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 const getAutoLinkPattern = (editor: Editor) => editor.getParam('autolink_pattern', /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+\-]+@(?!.*@))(.+)$/i);
 
-const getDefaultLinkTarget = function (editor: Editor) {
+const getDefaultLinkTarget = (editor: Editor) => {
   return editor.getParam('default_link_target', false);
 };
 

--- a/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
@@ -9,23 +9,23 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import * as Settings from '../api/Settings';
 
-const rangeEqualsDelimiterOrSpace = function (rangeString, delimiter) {
+const rangeEqualsDelimiterOrSpace = (rangeString, delimiter) => {
   return rangeString === delimiter || rangeString === ' ' || rangeString.charCodeAt(0) === 160;
 };
 
-const handleEclipse = function (editor) {
+const handleEclipse = (editor) => {
   parseCurrentLine(editor, -1, '(');
 };
 
-const handleSpacebar = function (editor) {
+const handleSpacebar = (editor) => {
   parseCurrentLine(editor, 0, '');
 };
 
-const handleEnter = function (editor) {
+const handleEnter = (editor) => {
   parseCurrentLine(editor, -1, '');
 };
 
-const scopeIndex = function (container, index) {
+const scopeIndex = (container, index) => {
   if (index < 0) {
     index = 0;
   }
@@ -41,7 +41,7 @@ const scopeIndex = function (container, index) {
   return index;
 };
 
-const setStart = function (rng, container, offset) {
+const setStart = (rng, container, offset) => {
   if (container.nodeType !== 1 || container.hasChildNodes()) {
     rng.setStart(container, scopeIndex(container, offset));
   } else {
@@ -49,7 +49,7 @@ const setStart = function (rng, container, offset) {
   }
 };
 
-const setEnd = function (rng, container, offset) {
+const setEnd = (rng, container, offset) => {
   if (container.nodeType !== 1 || container.hasChildNodes()) {
     rng.setEnd(container, scopeIndex(container, offset));
   } else {
@@ -57,7 +57,7 @@ const setEnd = function (rng, container, offset) {
   }
 };
 
-const parseCurrentLine = function (editor: Editor, endOffset, delimiter) {
+const parseCurrentLine = (editor: Editor, endOffset, delimiter) => {
   let end, endContainer, bookmark, text, prev, len, rngText;
   const autoLinkPattern = Settings.getAutoLinkPattern(editor);
   const defaultLinkTarget = Settings.getDefaultLinkTarget(editor);
@@ -171,7 +171,7 @@ const parseCurrentLine = function (editor: Editor, endOffset, delimiter) {
   }
 };
 
-const setup = function (editor: Editor) {
+const setup = (editor: Editor) => {
   let autoUrlDetectState;
 
   editor.on('keydown', (e) => {

--- a/modules/tinymce/src/plugins/autolink/test/ts/module/test/KeyUtils.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/module/test/KeyUtils.ts
@@ -1,7 +1,7 @@
 import { Arr, Fun, Unicode } from '@ephox/katamari';
 import * as NodeType from 'tinymce/core/dom/NodeType';
 
-const charCodeToKeyCode = function (charCode) {
+const charCodeToKeyCode = (charCode) => {
   const lookup = {
     '0': 48, '1': 49, '2': 50, '3': 51, '4': 52, '5': 53, '6': 54, '7': 55, '8': 56, '9': 57, 'a': 65, 'b': 66, 'c': 67,
     'd': 68, 'e': 69, 'f': 70, 'g': 71, 'h': 72, 'i': 73, 'j': 74, 'k': 75, 'l': 76, 'm': 77, 'n': 78, 'o': 79, 'p': 80, 'q': 81,
@@ -25,10 +25,10 @@ const needsNbsp = (rng: Range, chr: string) => {
   return false;
 };
 
-const type = function (editor, chr) {
+const type = (editor, chr) => {
   let keyCode, charCode, evt, rng, offset;
 
-  const fakeEvent = function (target, type, evt) {
+  const fakeEvent = (target, type, evt) => {
     editor.dom.fire(target, type, evt);
   };
 
@@ -123,7 +123,7 @@ const type = function (editor, chr) {
   fakeEvent(startElm, 'keyup', evt);
 };
 
-const typeString = function (editor, str) {
+const typeString = (editor, str) => {
   Arr.each(str.split(''), Fun.curry(type, editor));
 };
 

--- a/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
@@ -17,7 +17,7 @@ import * as Resize from './core/Resize';
  * @private
  */
 
-export default function () {
+export default () => {
   PluginManager.add('autoresize', (editor) => {
     // If autoresize is enabled, disable resize if the user hasn't explicitly enabled it
     if (!editor.settings.hasOwnProperty('resize')) {
@@ -29,4 +29,4 @@ export default function () {
       Resize.setup(editor, oldSize);
     }
   });
-}
+};

--- a/modules/tinymce/src/plugins/autosave/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/Plugin.ts
@@ -19,7 +19,7 @@ import * as Buttons from './ui/Buttons';
  * @private
  */
 
-export default function () {
+export default () => {
   PluginManager.add('autosave', (editor) => {
     BeforeUnload.setup(editor);
     Buttons.register(editor);
@@ -32,4 +32,4 @@ export default function () {
 
     return Api.get(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
@@ -8,7 +8,7 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Convert from './core/Convert';
 
-export default function () {
+export default () => {
   PluginManager.add('bbcode', (editor) => {
     editor.on('BeforeSetContent', (e) => {
       e.content = Convert.bbcode2html(e.content);
@@ -24,4 +24,4 @@ export default function () {
       }
     });
   });
-}
+};

--- a/modules/tinymce/src/plugins/bbcode/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/api/Settings.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const getDialect = function (editor) {
+const getDialect = (editor) => {
   // Note: This option isn't even used since we only support one dialect
   return editor.getParam('bbcode_dialect', 'punbb').toLowerCase();
 };

--- a/modules/tinymce/src/plugins/bbcode/main/ts/core/Convert.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/core/Convert.ts
@@ -7,10 +7,10 @@
 
 import Tools from 'tinymce/core/api/util/Tools';
 
-const html2bbcode = function (s) {
+const html2bbcode = (s) => {
   s = Tools.trim(s);
 
-  const rep = function (re, str) {
+  const rep = (re, str) => {
     s = s.replace(re, str);
   };
 
@@ -56,10 +56,10 @@ const html2bbcode = function (s) {
   return s;
 };
 
-const bbcode2html = function (s) {
+const bbcode2html = (s) => {
   s = Tools.trim(s);
 
-  const rep = function (re, str) {
+  const rep = (re, str) => {
     s = s.replace(re, str);
   };
 

--- a/modules/tinymce/src/plugins/charmap/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/Plugin.ts
@@ -13,7 +13,7 @@ import * as CharMap from './core/CharMap';
 import * as Autocompletion from './ui/Autocompletion';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('charmap', (editor) => {
     const charMap = CharMap.getCharMap(editor);
     Commands.register(editor, charMap);
@@ -23,4 +23,4 @@ export default function () {
 
     return Api.get(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Api.ts
@@ -8,12 +8,12 @@
 import * as Actions from '../core/Actions';
 import * as CharMap from '../core/CharMap';
 
-const get = function (editor) {
-  const getCharMap = function () {
+const get = (editor) => {
+  const getCharMap = () => {
     return CharMap.getCharMap(editor);
   };
 
-  const insertChar = function (chr) {
+  const insertChar = (chr) => {
     Actions.insertChar(editor, chr);
   };
 

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Commands.ts
@@ -11,7 +11,7 @@ import * as Dialog from '../ui/Dialog';
 
 type CharMap = CharMap.CharMap;
 
-const register = function (editor: Editor, charMap: CharMap[]) {
+const register = (editor: Editor, charMap: CharMap[]) => {
   editor.addCommand('mceShowCharmap', () => {
     Dialog.open(editor, charMap);
   });

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Events.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const fireInsertCustomChar = function (editor, chr) {
+const fireInsertCustomChar = (editor, chr) => {
   return editor.fire('insertCustomChar', { chr });
 };
 

--- a/modules/tinymce/src/plugins/charmap/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/Actions.ts
@@ -7,7 +7,7 @@
 
 import * as Events from '../api/Events';
 
-const insertChar = function (editor, chr) {
+const insertChar = (editor, chr) => {
   const evtChr = Events.fireInsertCustomChar(editor, chr).chr;
   editor.execCommand('mceInsertContent', false, evtChr);
 };

--- a/modules/tinymce/src/plugins/charmap/main/ts/core/CharMap.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/CharMap.ts
@@ -19,7 +19,7 @@ export interface CharMap {
   characters: [number, string][];
 }
 
-const getDefaultCharMap = function (): CharMap[] {
+const getDefaultCharMap = (): CharMap[] => {
   return [
     // TODO: Merge categories with TBIO
     // {
@@ -365,13 +365,13 @@ const getDefaultCharMap = function (): CharMap[] {
   ];
 };
 
-const charmapFilter = function (charmap) {
+const charmapFilter = (charmap) => {
   return Tools.grep(charmap, (item) => {
     return isArray(item) && item.length === 2;
   });
 };
 
-const getCharsFromSetting = function (settingValue) {
+const getCharsFromSetting = (settingValue) => {
   if (isArray(settingValue)) {
     return [].concat(charmapFilter(settingValue));
   }
@@ -383,7 +383,7 @@ const getCharsFromSetting = function (settingValue) {
   return [];
 };
 
-const extendCharMap = function (editor: Editor, charmap: CharMap[]) {
+const extendCharMap = (editor: Editor, charmap: CharMap[]) => {
   const userCharMap = Settings.getCharMap(editor);
   if (userCharMap) {
     charmap = [{ name: UserDefined, characters: getCharsFromSetting(userCharMap) }];
@@ -402,7 +402,7 @@ const extendCharMap = function (editor: Editor, charmap: CharMap[]) {
   return charmap;
 };
 
-const getCharMap = function (editor: Editor): CharMap[] {
+const getCharMap = (editor: Editor): CharMap[] => {
   const groups = extendCharMap(editor, getDefaultCharMap());
   return groups.length > 1 ? [
     {

--- a/modules/tinymce/src/plugins/charmap/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('charmap', {
     icon: 'insert-character',
     tooltip: 'Special character',

--- a/modules/tinymce/src/plugins/charmap/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/ui/Dialog.ts
@@ -14,7 +14,7 @@ import * as Scan from '../core/Scan';
 
 const patternName = 'pattern';
 
-const open = function (editor: Editor, charMap: CharMap[]) {
+const open = (editor: Editor, charMap: CharMap[]) => {
   const makeGroupItems = (): Dialog.BodyComponentSpec[] => [
     {
       label: 'Search',
@@ -77,7 +77,7 @@ const open = function (editor: Editor, charMap: CharMap[]) {
       }
     ],
     initialData,
-    onAction(api, details) {
+    onAction: (api, details) => {
       if (details.name === 'results') {
         Actions.insertChar(editor, details.value);
         api.close();

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
@@ -11,7 +11,7 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.DialogHeightTest', (success,
   SilverTheme();
 
   // Move into shared library
-  const cFakeEvent = function (name) {
+  const cFakeEvent = (name) => {
     return Chain.control(
       Chain.op((elm: SugarElement) => {
         const evt = document.createEvent('HTMLEvents');

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
@@ -29,12 +29,10 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.CharMapPluginTest', (success
   });
 
   suite.test('TestCase-TBA: Charmap: Replace characters by function', (editor) => {
-    editor.settings.charmap = function () {
-      return [
-        [ 65, 'Latin A fun' ],
-        [ 66, 'Latin B fun' ]
-      ];
-    };
+    editor.settings.charmap = () => [
+      [ 65, 'Latin A fun' ],
+      [ 66, 'Latin B fun' ]
+    ];
 
     LegacyUnit.deepEqual(editor.plugins.charmap.getCharMap(), [
       {
@@ -74,12 +72,10 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.CharMapPluginTest', (success
       [ 67, 'Latin C' ]
     ];
 
-    editor.settings.charmap_append = function () {
-      return [
-        [ 65, 'Latin A fun' ],
-        [ 66, 'Latin B fun' ]
-      ];
-    };
+    editor.settings.charmap_append = () => [
+      [ 65, 'Latin A fun' ],
+      [ 66, 'Latin B fun' ]
+    ];
 
     LegacyUnit.deepEqual(editor.plugins.charmap.getCharMap(), [
       {

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
@@ -18,7 +18,7 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.SearchTest', (success, failu
   SilverTheme();
 
   // Move into shared library
-  const cFakeEvent = function (name) {
+  const cFakeEvent = (name) => {
     return Chain.control(
       Chain.op((elm: SugarElement) => {
         const evt = document.createEvent('HTMLEvents');

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapUserDefinedTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapUserDefinedTest.ts
@@ -5,7 +5,7 @@ import { SugarElement } from '@ephox/sugar';
 import CharmapPlugin from 'tinymce/plugins/charmap/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';
 
-const cFakeEvent = function (name) {
+const cFakeEvent = (name) => {
   return Chain.control(
     Chain.op((elm: SugarElement) => {
       const evt = document.createEvent('HTMLEvents');

--- a/modules/tinymce/src/plugins/code/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/Plugin.ts
@@ -9,11 +9,11 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('code', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
 
     return {};
   });
-}
+};

--- a/modules/tinymce/src/plugins/code/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import * as Dialog from '../ui/Dialog';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('mceCodeEditor', () => {
     Dialog.open(editor);
   });

--- a/modules/tinymce/src/plugins/code/main/ts/core/Content.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/core/Content.ts
@@ -5,10 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const setContent = function (editor, html) {
+const setContent = (editor, html) => {
   // We get a lovely "Wrong document" error in IE 11 if we
   // don't move the focus to the editor before creating an undo
-  // transation since it tries to make a bookmark for the current selection
+  // transaction since it tries to make a bookmark for the current selection
   editor.focus();
 
   editor.undoManager.transact(() => {
@@ -19,7 +19,7 @@ const setContent = function (editor, html) {
   editor.nodeChanged();
 };
 
-const getContent = function (editor) {
+const getContent = (editor) => {
   return editor.getContent({ source_view: true });
 };
 

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Buttons.ts
@@ -8,7 +8,7 @@
 import Editor from 'tinymce/core/api/Editor';
 import * as Dialog from './Dialog';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('code', {
     icon: 'sourcecode',
     tooltip: 'Source code',

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
@@ -8,7 +8,7 @@
 import Editor from 'tinymce/core/api/Editor';
 import * as Content from '../core/Content';
 
-const open = function (editor: Editor) {
+const open = (editor: Editor) => {
   const editorContent: string = Content.getContent(editor);
 
   editor.windowManager.open({

--- a/modules/tinymce/src/plugins/codesample/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/Plugin.ts
@@ -12,7 +12,7 @@ import * as Buttons from './ui/Buttons';
 import * as Dialog from './ui/Dialog';
 import * as Utils from './util/Utils';
 
-export default function () {
+export default () => {
   PluginManager.add('codesample', (editor) => {
     FilterContent.setup(editor);
     Buttons.register(editor);
@@ -24,4 +24,4 @@ export default function () {
       }
     });
   });
-}
+};

--- a/modules/tinymce/src/plugins/codesample/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/api/Commands.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Dialog from '../ui/Dialog';
 import * as Utils from '../util/Utils';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.addCommand('codesample', () => {
     const node = editor.selection.getNode();
     if (editor.selection.isCollapsed() || Utils.isCodeSample(node)) {

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Utils from '../util/Utils';
 import * as Prism from './Prism';
 
-const setup = function (editor: Editor) {
+const setup = (editor: Editor) => {
   const $ = editor.$;
 
   editor.on('PreProcess', (e) => {

--- a/modules/tinymce/src/plugins/codesample/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/ui/Buttons.ts
@@ -13,7 +13,7 @@ const isCodeSampleSelection = (editor: Editor) => {
   return editor.dom.is(node, 'pre[class*="language-"]');
 };
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addToggleButton('codesample', {
     icon: 'code-sample',
     tooltip: 'Insert/edit code sample',

--- a/modules/tinymce/src/plugins/codesample/main/ts/util/Utils.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/util/Utils.ts
@@ -5,15 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-function isCodeSample(elm: Element) {
+const isCodeSample = (elm: Element) => {
   return elm && elm.nodeName === 'PRE' && elm.className.indexOf('language-') !== -1;
-}
+};
 
-function trimArg<T>(predicateFn: (a: T) => boolean) {
-  return function (arg1: any, arg2: T) {
+const trimArg = <T>(predicateFn: (a: T) => boolean) => {
+  return (arg1: any, arg2: T) => {
     return predicateFn(arg2);
   };
-}
+};
 
 export {
   isCodeSample,

--- a/modules/tinymce/src/plugins/colorpicker/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/colorpicker/main/ts/Plugin.ts
@@ -7,9 +7,9 @@
 
 import PluginManager from 'tinymce/core/api/PluginManager';
 
-export default function () {
+export default () => {
   PluginManager.add('colorpicker', () => {
     // eslint-disable-next-line no-console
     console.warn('Color picker plugin is now built in to the core editor, please remove it from your editor configuration');
   });
-}
+};

--- a/modules/tinymce/src/plugins/contextmenu/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/contextmenu/main/ts/Plugin.ts
@@ -7,9 +7,9 @@
 
 import PluginManager from 'tinymce/core/api/PluginManager';
 
-export default function () {
+export default () => {
   PluginManager.add('contextmenu', () => {
     // eslint-disable-next-line no-console
     console.warn('Context menu plugin is now built in to the core editor, please remove it from your editor configuration');
   });
-}
+};

--- a/modules/tinymce/src/plugins/directionality/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/Plugin.ts
@@ -9,9 +9,9 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('directionality', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/directionality/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import * as Direction from '../core/Direction';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('mceDirectionLTR', () => {
     Direction.setDir(editor, 'ltr');
   });

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -8,7 +8,7 @@
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 
-const setDir = function (editor: Editor, dir: string) {
+const setDir = (editor: Editor, dir: string) => {
   const dom = editor.dom;
   let curDir;
   const blocks = editor.selection.getSelectedBlocks();

--- a/modules/tinymce/src/plugins/directionality/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/ui/Buttons.ts
@@ -18,7 +18,7 @@ const getNodeChangeHandler = (editor: Editor, dir: 'ltr' | 'rtl') => (api) => {
   return () => editor.off('NodeChange', nodeChangeHandler);
 };
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addToggleButton('ltr', {
     tooltip: 'Left to right',
     icon: 'ltr',

--- a/modules/tinymce/src/plugins/emoticons/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/Plugin.ts
@@ -20,7 +20,7 @@ import * as Buttons from './ui/Buttons';
  * @private
  */
 
-export default function () {
+export default () => {
   PluginManager.add('emoticons', (editor, pluginUrl) => {
     const databaseUrl = Settings.getEmoticonDatabaseUrl(editor, pluginUrl);
     const databaseId = Settings.getEmoticonDatabaseId(editor);
@@ -31,4 +31,4 @@ export default function () {
     Autocompletion.init(editor, database);
     Filters.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/emoticons/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/core/Actions.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const insertEmoticon = function (editor: Editor, ch: string): void {
+const insertEmoticon = (editor: Editor, ch: string): void => {
   editor.insertContent(ch);
 };
 

--- a/modules/tinymce/src/plugins/emoticons/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/ui/Buttons.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { EmojiDatabase } from '../core/EmojiDatabase';
 import * as Dialog from './Dialog';
 
-const register = function (editor: Editor, database: EmojiDatabase): void {
+const register = (editor: Editor, database: EmojiDatabase): void => {
   const onAction = () => Dialog.open(editor, database);
 
   editor.ui.registry.addButton('emoticons', {

--- a/modules/tinymce/src/plugins/emoticons/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/ui/Dialog.ts
@@ -14,7 +14,7 @@ import { emojisFrom } from '../core/Lookup';
 
 const patternName = 'pattern';
 
-const open = function (editor: Editor, database: EmojiDatabase) {
+const open = (editor: Editor, database: EmojiDatabase) => {
 
   const initialState = {
     pattern: '',

--- a/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
@@ -11,7 +11,7 @@ import * as Commands from './api/Commands';
 import * as FilterContent from './core/FilterContent';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('fullpage', (editor) => {
     const headState = Cell(''), footState = Cell('');
 
@@ -19,4 +19,4 @@ export default function () {
     Buttons.register(editor);
     FilterContent.setup(editor, headState, footState);
   });
-}
+};

--- a/modules/tinymce/src/plugins/fullpage/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import * as Dialog from '../ui/Dialog';
 
-const register = function (editor, headState) {
+const register = (editor, headState) => {
   editor.addCommand('mceFullPageProperties', () => {
     Dialog.open(editor, headState);
   });

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/FilterContent.ts
@@ -17,7 +17,7 @@ const each = Tools.each;
 const low = (s: string) =>
   s.replace(/<\/?[A-Z]+/g, (a: string) => a.toLowerCase());
 
-const handleSetContent = function (editor: Editor, headState, footState, evt) {
+const handleSetContent = (editor: Editor, headState, footState, evt) => {
   let startPos, endPos, content, styles = '';
   const dom = editor.dom;
 
@@ -121,7 +121,7 @@ const handleSetContent = function (editor: Editor, headState, footState, evt) {
   });
 };
 
-const getDefaultHeader = function (editor) {
+const getDefaultHeader = (editor) => {
   let header = '', value, styles = '';
 
   if (Settings.getDefaultXmlPi(editor)) {
@@ -157,13 +157,13 @@ const getDefaultHeader = function (editor) {
   return header;
 };
 
-const handleGetContent = function (editor: Editor, head, foot, evt: GetContentEvent) {
+const handleGetContent = (editor: Editor, head, foot, evt: GetContentEvent) => {
   if (evt.format === 'html' && !evt.selection && (!evt.source_view || !Settings.shouldHideInSourceView(editor))) {
     evt.content = Protect.unprotectHtml(Tools.trim(head) + '\n' + Tools.trim(evt.content) + '\n' + Tools.trim(foot));
   }
 };
 
-const setup = function (editor: Editor, headState, footState) {
+const setup = (editor: Editor, headState, footState) => {
   editor.on('BeforeSetContent', (evt) => {
     handleSetContent(editor, headState, footState, evt);
   });

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
@@ -29,7 +29,7 @@ interface Data {
   active_color?: string;
 }
 
-const parseHeader = function (head: string) {
+const parseHeader = (head: string) => {
   // Parse the contents with a DOM parser
   return DomParser({
     validate: false,
@@ -38,16 +38,16 @@ const parseHeader = function (head: string) {
   }).parse(head, { format: 'xhtml' });
 };
 
-const htmlToData = function (editor: Editor, head: string) {
+const htmlToData = (editor: Editor, head: string) => {
   const headerFragment = parseHeader(head);
   const data: Data = {};
   let elm, matches;
 
-  function getAttr(elm, name) {
+  const getAttr = (elm, name) => {
     const value = elm.attr(name);
 
     return value || '';
-  }
+  };
 
   // Default some values
   // TODO: Not sure these are used anymore
@@ -120,21 +120,21 @@ const htmlToData = function (editor: Editor, head: string) {
   return data;
 };
 
-const dataToHtml = function (editor: Editor, data: Data, head) {
+const dataToHtml = (editor: Editor, data: Data, head) => {
   let headElement, elm, value;
   const dom = editor.dom;
 
-  function setAttr(elm, name, value) {
+  const setAttr = (elm, name, value) => {
     elm.attr(name, value ? value : undefined);
-  }
+  };
 
-  function addHeadNode(node) {
+  const addHeadNode = (node) => {
     if (headElement.firstChild) {
       headElement.insert(node, headElement.firstChild);
     } else {
       headElement.append(node);
     }
-  }
+  };
 
   const headerFragment = parseHeader(head);
   headElement = headerFragment.getAll('head')[0];

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/Protect.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/Protect.ts
@@ -10,7 +10,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 declare const escape: any;
 declare const unescape: any;
 
-const protectHtml = function (protect, html) {
+const protectHtml = (protect, html) => {
   Tools.each(protect, (pattern) => {
     html = html.replace(pattern, (str) => {
       return '<!--mce:protected ' + escape(str) + '-->';
@@ -20,7 +20,7 @@ const protectHtml = function (protect, html) {
   return html;
 };
 
-const unprotectHtml = function (html) {
+const unprotectHtml = (html) => {
   return html.replace(/<!--mce:protected ([\s\S]*?)-->/g, (a, m) => {
     return unescape(m);
   });

--- a/modules/tinymce/src/plugins/fullpage/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('fullpage', {
     // TODO: This should be title or text, with no icon?
     tooltip: 'Metadata and document properties',

--- a/modules/tinymce/src/plugins/fullpage/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/ui/Dialog.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Parser from '../core/Parser';
 
-const open = function (editor: Editor, headState: Cell<string>) {
+const open = (editor: Editor, headState: Cell<string>) => {
   const data = Parser.htmlToData(editor, headState.get());
 
   const defaultData = {

--- a/modules/tinymce/src/plugins/fullpage/test/ts/atomic/ProtectTest.ts
+++ b/modules/tinymce/src/plugins/fullpage/test/ts/atomic/ProtectTest.ts
@@ -3,13 +3,13 @@ import { UnitTest } from '@ephox/bedrock-client';
 import * as Protect from 'tinymce/plugins/fullpage/core/Protect';
 
 UnitTest.test('atomic.tinymce.plugins.fullpage.ProtectTest', () => {
-  const testProtect = function () {
+  const testProtect = () => {
     Assertions.assertEq('', 'a<!--mce:protected b-->c', Protect.protectHtml([ /b/g ], 'abc'));
     Assertions.assertEq('', 'a<!--mce:protected b-->cde<!--mce:protected f-->', Protect.protectHtml([ /b/g, /f/g ], 'abcdef'));
     Assertions.assertEq('', 'a<!--mce:protected %3Cb%3E-->c', Protect.protectHtml([ /<b>/g ], 'a<b>c'));
   };
 
-  const testUnprotect = function () {
+  const testUnprotect = () => {
     Assertions.assertEq('', 'abc', Protect.unprotectHtml('a<!--mce:protected b-->c'));
     Assertions.assertEq('', 'abcdef', Protect.unprotectHtml('a<!--mce:protected b-->cde<!--mce:protected f-->'));
     Assertions.assertEq('', 'a<b>c', Protect.unprotectHtml('a<!--mce:protected %3Cb%3E-->c'));

--- a/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
+++ b/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
@@ -12,12 +12,12 @@ UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPagePluginTest', (succe
   Plugin();
   Theme();
 
-  const teardown = function (editor) {
+  const teardown = (editor) => {
     editor.getBody().rtl = '';
   };
 
   suite.test('TestCase-TBA: FullPage: Keep header/footer intact', (editor) => {
-    const normalizeHTML = function (html) {
+    const normalizeHTML = (html) => {
       return html.replace(/\s/g, '');
     };
 
@@ -76,7 +76,7 @@ UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPagePluginTest', (succe
   });
 
   suite.test('TestCase-TBA: FullPage: add/remove stylesheets', (editor) => {
-    const hasLink = function hasink(href) {
+    const hasLink = (href) => {
       const links = editor.getDoc().getElementsByTagName('link');
 
       for (let i = 0; i < links.length; i++) {
@@ -123,7 +123,7 @@ UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPagePluginTest', (succe
     LegacyUnit.equal(hasLink('c.css'), false);
   });
 
-  const sParseStyles = function (editor) {
+  const sParseStyles = (editor) => {
     return Logger.t('Parse styles', GeneralSteps.sequence([
       Step.sync(() => {
         editor.setContent('<html><head><style>p {text-transform: uppercase}</style></head><body dir="rtl"><p>Test</p></body></html>');
@@ -138,7 +138,7 @@ UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPagePluginTest', (succe
     ]));
   };
 
-  const sProtectConditionalCommentsInHeadFoot = function (editor) {
+  const sProtectConditionalCommentsInHeadFoot = (editor) => {
     return Logger.t('Set and assert styles were added to iframe document', GeneralSteps.sequence([
       Step.sync(() => {
         editor.setContent([

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/Plugin.ts
@@ -12,7 +12,7 @@ import * as Commands from './api/Commands';
 import { ScrollInfo } from './core/Actions';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('fullscreen', (editor) => {
     const fullscreenState = Cell<ScrollInfo | null>(null);
 
@@ -27,4 +27,4 @@ export default function () {
 
     return Api.get(fullscreenState);
   });
-}
+};

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Api.ts
@@ -8,11 +8,9 @@
 import { Cell } from '@ephox/katamari';
 import { ScrollInfo } from '../core/Actions';
 
-const get = function (fullscreenState: Cell<ScrollInfo | null>) {
+const get = (fullscreenState: Cell<ScrollInfo | null>) => {
   return {
-    isFullscreen() {
-      return fullscreenState.get() !== null;
-    }
+    isFullscreen: () => fullscreenState.get() !== null
   };
 };
 

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Events.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const fireFullscreenStateChanged = function (editor, state) {
+const fireFullscreenStateChanged = (editor, state) => {
   editor.fire('FullscreenStateChanged', { state });
 };
 

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Thor.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Thor.ts
@@ -18,7 +18,7 @@ const bgFallback = 'background-color:rgb(255,255,255)!important;';
 
 const isAndroid = Env.os.isAndroid();
 
-const matchColor = function (editorBody: SugarElement) {
+const matchColor = (editorBody: SugarElement) => {
   // in iOS you can overscroll, sometimes when you overscroll you can reveal the bgcolor of an element beneath,
   // by matching the bg color and clobbering ensures any reveals are 'camouflaged' the same color
   const color = Css.get(editorBody, 'background-color');
@@ -26,13 +26,13 @@ const matchColor = function (editorBody: SugarElement) {
 };
 
 // We clobber all tags, direct ancestors to the editorBody get ancestorStyles, everything else gets siblingStyles
-const clobberStyles = function (dom: DOMUtils, container: SugarElement, editorBody: SugarElement) {
-  const gatherSiblings = function (element) {
+const clobberStyles = (dom: DOMUtils, container: SugarElement, editorBody: SugarElement) => {
+  const gatherSiblings = (element) => {
     return SelectorFilter.siblings(element, '*:not(.tox-silver-sink)');
   };
 
-  const clobber = function (clobberStyle: string) {
-    return function (element) {
+  const clobber = (clobberStyle: string) => {
+    return (element) => {
       const styles = Attribute.get(element, 'style');
       const backup = styles === undefined ? 'no-styles' : styles.trim();
       if (backup === clobberStyle) {
@@ -56,7 +56,7 @@ const clobberStyles = function (dom: DOMUtils, container: SugarElement, editorBo
   clobber(containerStyles + ancestorStyles + bgColor)(container);
 };
 
-const restoreStyles = function (dom: DOMUtils) {
+const restoreStyles = (dom: DOMUtils) => {
   const clobberedEls = SelectorFilter.all('[' + attr + ']');
   Arr.each(clobberedEls, (element) => {
     const restore = Attribute.get(element, attr);

--- a/modules/tinymce/src/plugins/help/test/ts/module/PluginAssert.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/PluginAssert.ts
@@ -1,7 +1,7 @@
 import { Assertions, Chain, Guard, Logger, Mouse, UiFinder } from '@ephox/agar';
 import { TinyDom } from '@ephox/mcagar';
 
-export const sAssert = function (errString, objStruc, waitOn, clickOn) {
+export const sAssert = (errString, objStruc, waitOn, clickOn) => {
   return Logger.t('Assert structure in dialog', Chain.asStep(TinyDom.fromDom(document.body), [
     UiFinder.cWaitFor('Could not find notification', waitOn),
     Mouse.cClickOn(clickOn),

--- a/modules/tinymce/src/plugins/help/test/ts/module/test/FakePlugin.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/test/FakePlugin.ts
@@ -1,8 +1,8 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 
-const Plugin = function (_editor, _url) {
+const Plugin = (_editor, _url) => {
   return {
-    getMetadata() {
+    getMetadata: () => {
       return {
         name: 'Fake',
         url: 'http://www.fake.com'
@@ -13,4 +13,4 @@ const Plugin = function (_editor, _url) {
 
 PluginManager.add('fake', Plugin);
 
-export default function () {}
+export default () => {};

--- a/modules/tinymce/src/plugins/help/test/ts/module/test/NoMetaFakePlugin.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/test/NoMetaFakePlugin.ts
@@ -3,4 +3,4 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 
 PluginManager.add('nometafake', Fun.noop);
 
-export default function () {}
+export default () => {};

--- a/modules/tinymce/src/plugins/hr/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/hr/main/ts/Plugin.ts
@@ -9,9 +9,9 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('hr', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/hr/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/hr/main/ts/api/Commands.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('InsertHorizontalRule', () => {
     editor.execCommand('mceInsertContent', false, '<hr />');
   });

--- a/modules/tinymce/src/plugins/hr/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/hr/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('hr', {
     icon: 'horizontal-rule',
     tooltip: 'Horizontal line',

--- a/modules/tinymce/src/plugins/image/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/image/demo/ts/demo/Demo.ts
@@ -18,7 +18,7 @@ tinymce.init({
     { title: 'Class2', value: 'class2' }
   ],
   images_upload_url: 'postAcceptor.php',
-  file_picker_callback(callback, _value, _meta) {
+  file_picker_callback: (callback, _value, _meta) => {
     callback('https://www.google.com/logos/google.jpg', { alt: 'My alt text', caption: true });
   },
   images_upload_handler: (blobInfo, success, _failure, _progress) => {

--- a/modules/tinymce/src/plugins/image/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/Plugin.ts
@@ -10,10 +10,10 @@ import * as Commands from './api/Commands';
 import * as FilterContent from './core/FilterContent';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('image', (editor) => {
     FilterContent.setup(editor);
     Buttons.register(editor);
     Commands.register(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/image/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/Utils.ts
@@ -109,7 +109,7 @@ const createImageList = (editor: Editor, callback: (imageList: any) => void) => 
   if (typeof imageList === 'string') {
     XHR.send({
       url: imageList,
-      success(text) {
+      success: (text) => {
         callback(JSON.parse(text));
       }
     });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -76,7 +76,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.DialogUpdateTest', (success, f
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_title: true,
-    file_picker_callback(callback, _value, _meta) {
+    file_picker_callback: (callback, _value, _meta) => {
       callback('https://www.google.com/logos/google.jpg', { width: '200' });
     },
   }, success, failure);

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
@@ -28,7 +28,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.FigureResizeTest', (success, f
     Guard.addLogging('Get element size')
   );
 
-  const cDragHandleRight = function (px) {
+  const cDragHandleRight = (px: number) => {
     return Chain.control(
       Chain.op((input: any) => {
         const dom = input.editor.dom;

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
@@ -46,7 +46,7 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImageResizeTest', (success, fa
     plugins: 'image',
     toolbar: 'image',
     base_url: '/project/tinymce/js/tinymce',
-    file_picker_callback(callback) {
+    file_picker_callback: (callback) => {
       // eslint-disable-next-line no-console
       console.log('file picker pressed');
       callback('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');

--- a/modules/tinymce/src/plugins/imagetools/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/imagetools/demo/ts/demo/Demo.ts
@@ -43,7 +43,7 @@ tinymce.init({
   // imagetools_credentials_hosts: ['localhost'],
   // rtl_ui: true,
   toolbar: 'editimage undo redo | styleselect | alignleft aligncenter alignright alignjustify | link image | media | emoticons',
-  images_upload_handler(data, success, failure, progress) {
+  images_upload_handler: (data, success, failure, progress) => {
     console.log('blob upload [started]', 'id:', data.id(), 'filename:', data.filename());
     progress(0);
 
@@ -55,26 +55,26 @@ tinymce.init({
   }
 });
 
-function send() {
+const send = () => {
   tinymce.activeEditor.uploadImages(() => {
     console.log('saving:', tinymce.activeEditor.getContent());
   });
-}
+};
 
-function upload() {
+const upload = () => {
   console.log('upload [started]');
 
   tinymce.activeEditor.uploadImages((success) => {
     console.log('upload [ended]', success);
   });
-}
+};
 
-function dump() {
+const dump = () => {
   const content = tinymce.activeEditor.getContent();
 
   $('#view').html(content);
   console.log(content);
-}
+};
 
 $('<button>send()</button>').appendTo('#ephox-ui').on('click', send);
 $('<button>upload()</button>').appendTo('#ephox-ui').on('click', upload);

--- a/modules/tinymce/src/plugins/imagetools/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/Plugin.ts
@@ -12,7 +12,7 @@ import * as UploadSelectedImage from './core/UploadSelectedImage';
 import * as Buttons from './ui/Buttons';
 import * as ContextToolbar from './ui/ContextToolbar';
 
-export default function () {
+export default () => {
   PluginManager.add('imagetools', (editor) => {
     const imageUploadTimerState = Cell(0);
     const lastSelectedImageState = Cell(null);
@@ -23,4 +23,4 @@ export default function () {
 
     UploadSelectedImage.setup(editor, imageUploadTimerState, lastSelectedImageState);
   });
-}
+};

--- a/modules/tinymce/src/plugins/imagetools/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/api/Commands.ts
@@ -11,7 +11,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 import * as Actions from '../core/Actions';
 import * as Dialog from '../ui/Dialog';
 
-const register = function (editor: Editor, imageUploadTimerState: Cell<number>) {
+const register = (editor: Editor, imageUploadTimerState: Cell<number>) => {
   Tools.each({
     mceImageRotateLeft: Actions.rotate(editor, imageUploadTimerState, -90),
     mceImageRotateRight: Actions.rotate(editor, imageUploadTimerState, 90),

--- a/modules/tinymce/src/plugins/imagetools/main/ts/core/ImageSize.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/core/ImageSize.ts
@@ -10,12 +10,12 @@ export interface ImageSize {
   readonly h: number;
 }
 
-function getImageSize(img: HTMLImageElement): ImageSize | null {
+const getImageSize = (img: HTMLImageElement): ImageSize | null => {
   let width, height;
 
-  function isPxValue(value) {
+  const isPxValue = (value) => {
     return /^[0-9\.]+px$/.test(value);
-  }
+  };
 
   width = img.style.width;
   height = img.style.height;
@@ -41,9 +41,9 @@ function getImageSize(img: HTMLImageElement): ImageSize | null {
   }
 
   return null;
-}
+};
 
-function setImageSize(img: HTMLImageElement, size: ImageSize) {
+const setImageSize = (img: HTMLImageElement, size: ImageSize) => {
   let width, height;
 
   if (size) {
@@ -64,14 +64,14 @@ function setImageSize(img: HTMLImageElement, size: ImageSize) {
       img.setAttribute('height', String(size.h));
     }
   }
-}
+};
 
-function getNaturalImageSize(img: HTMLImageElement) {
+const getNaturalImageSize = (img: HTMLImageElement) => {
   return {
     w: img.naturalWidth,
     h: img.naturalHeight
   };
-}
+};
 
 export {
   getImageSize,

--- a/modules/tinymce/src/plugins/imagetools/main/ts/core/LoadImage.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/core/LoadImage.ts
@@ -7,9 +7,9 @@
 
 import Promise from 'tinymce/core/api/util/Promise';
 
-const loadImage = function (image: HTMLImageElement): Promise<HTMLImageElement> {
+const loadImage = (image: HTMLImageElement): Promise<HTMLImageElement> => {
   return new Promise((resolve) => {
-    const loaded = function () {
+    const loaded = () => {
       image.removeEventListener('load', loaded);
       resolve(image);
     };

--- a/modules/tinymce/src/plugins/imagetools/main/ts/core/UndoStack.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/core/UndoStack.ts
@@ -5,11 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-export default function () {
+export default () => {
   const data = [];
   let index = -1;
 
-  function add(state) {
+  const add = (state) => {
     const removed = data.splice(++index);
     data.push(state);
 
@@ -17,27 +17,27 @@ export default function () {
       state,
       removed
     };
-  }
+  };
 
-  function undo() {
+  const undo = () => {
     if (canUndo()) {
       return data[--index];
     }
-  }
+  };
 
-  function redo() {
+  const redo = () => {
     if (canRedo()) {
       return data[++index];
     }
-  }
+  };
 
-  function canUndo() {
+  const canUndo = () => {
     return index > 0;
-  }
+  };
 
-  function canRedo() {
+  const canRedo = () => {
     return index !== -1 && index < data.length - 1;
-  }
+  };
 
   return {
     data,
@@ -47,4 +47,4 @@ export default function () {
     canUndo,
     canRedo
   };
-}
+};

--- a/modules/tinymce/src/plugins/imagetools/main/ts/core/UploadSelectedImage.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/core/UploadSelectedImage.ts
@@ -9,7 +9,7 @@ import { Cell } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as Actions from './Actions';
 
-const setup = function (editor: Editor, imageUploadTimerState: Cell<number>, lastSelectedImageState: Cell<HTMLImageElement | null>) {
+const setup = (editor: Editor, imageUploadTimerState: Cell<number>, lastSelectedImageState: Cell<HTMLImageElement | null>) => {
   editor.on('NodeChange', (e) => {
     const lastSelectedImage = lastSelectedImageState.get();
     const selectedImage = Actions.getEditableImage(editor, e.element);

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
@@ -8,7 +8,7 @@
 import Editor from 'tinymce/core/api/Editor';
 import * as Actions from '../core/Actions';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   const cmd = (command: string) => () => editor.execCommand(command);
 
   editor.ui.registry.addButton('rotateleft', {

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/ContextToolbar.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/ContextToolbar.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../api/Settings';
 import * as Actions from '../core/Actions';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addContextToolbar('imagetools', {
     items: Settings.getToolbarItems(editor),
     predicate: (elem) => Actions.getEditableImage(editor, elem).isSome(),

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
@@ -16,7 +16,7 @@ UnitTest.asynctest('browser.tinymce.plugins.imagetools.ImageToolsErrorTest', (su
   ImagetoolsPlugin();
   SilverTheme();
 
-  const sAssertErrorMessage = function (html) {
+  const sAssertErrorMessage = (html) => {
     return Step.label('Check notification message', Chain.asStep(TinyDom.fromDom(document.body), [
       UiFinder.cWaitFor('Find notification', '.tox-notification__body > p'),
       Chain.label('Get notification HTML', Chain.mapper(Html.get)),

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/SequenceTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/SequenceTest.ts
@@ -25,7 +25,7 @@ UnitTest.asynctest('browser.tinymce.plugins.imagetools.SequenceTest', (success, 
     const tinyApis = TinyApis(editor);
     const imgOps = ImageOps(editor);
 
-    const sManipulateImage = function (message, url) {
+    const sManipulateImage = (message, url) => {
       return Log.stepsAsStep('TBA', `ImageTools: ${message}`, [
         ImageUtils.sLoadImage(editor, url),
         tinyApis.sSelect('img', []),

--- a/modules/tinymce/src/plugins/imagetools/test/ts/module/test/ImageOps.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/module/test/ImageOps.ts
@@ -3,10 +3,10 @@ import { Fun, Result } from '@ephox/katamari';
 import { TinyDom, TinyUi } from '@ephox/mcagar';
 import { Attribute } from '@ephox/sugar';
 
-export default function (editor) {
+export default (editor) => {
   const ui = TinyUi(editor);
 
-  const cHasState = function (predicate) {
+  const cHasState = (predicate) => {
     return Chain.control(
       Chain.binder((element) => {
         return predicate(element) ? Result.value(element) : Result.error(`Predicate didn't match.`);
@@ -15,7 +15,7 @@ export default function (editor) {
     );
   };
 
-  const cWaitForState = function (predicate) {
+  const cWaitForState = (predicate) => {
     return Chain.control(
       cHasState(predicate),
       Guard.tryUntil('Predicate has failed.', 10, 3000)
@@ -32,7 +32,7 @@ export default function (editor) {
     Guard.addLogging('Drag and drop')
   );
 
-  const cExecCommandFromDialog = function (label) {
+  const cExecCommandFromDialog = (label) => {
     let cInteractWithUi;
 
     switch (label) {
@@ -74,7 +74,7 @@ export default function (editor) {
     );
   };
 
-  const cWaitForUi = function (label, selector) {
+  const cWaitForUi = (label, selector) => {
     return Chain.control(
       UiFinder.cWaitForState(label, selector, Fun.always),
       Guard.addLogging('Wait for UI')
@@ -86,7 +86,7 @@ export default function (editor) {
     Guard.tryUntil('Waiting for dialog to go away', 10, 3000)
   );
 
-  const cClickButton = function (text) {
+  const cClickButton = (text) => {
     return Chain.control(
       Chain.fromChains([
         cWaitForUi('wait for ' + text + ' button', 'button:contains(' + text + ')'),
@@ -99,7 +99,7 @@ export default function (editor) {
     );
   };
 
-  const cClickToolbarButton = function (label) {
+  const cClickToolbarButton = (label) => {
     return Chain.control(
       Chain.fromChains([
         UiFinder.cFindIn('button[aria-label="' + label + '"]'),
@@ -112,7 +112,7 @@ export default function (editor) {
     );
   };
 
-  const sWaitForUrlChange = function (imgEl, origUrl) {
+  const sWaitForUrlChange = (imgEl, origUrl) => {
     return Logger.t('Wait for url change', Chain.asStep(imgEl, [
       cWaitForState((el) => {
         return Attribute.get(el, 'src') !== origUrl;
@@ -120,7 +120,7 @@ export default function (editor) {
     ]));
   };
 
-  const sExec = function (execFromToolbar, label) {
+  const sExec = (execFromToolbar, label) => {
     return Logger.t(`Execute ${label}`, Step.async((next, die) => {
       const imgEl = TinyDom.fromDom(editor.selection.getNode());
       const origUrl = Attribute.get(imgEl, 'src');
@@ -143,4 +143,4 @@ export default function (editor) {
     sExecDialog: Fun.curry(sExec, false),
     cClickToolbarButton
   };
-}
+};

--- a/modules/tinymce/src/plugins/imagetools/test/ts/module/test/ImageUtils.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/module/test/ImageUtils.ts
@@ -3,17 +3,17 @@ import { Assert } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
-const sExecCommand = function (editor: Editor, cmd: string, value?: string) {
+const sExecCommand = (editor: Editor, cmd: string, value?: string) => {
   return Logger.t(`Execute ${cmd}`, Step.sync(() => {
     editor.execCommand(cmd, false, value);
   }));
 };
 
-const sLoadImage = function (editor: Editor, url: string, size?: { width: number; height: number }) {
+const sLoadImage = (editor: Editor, url: string, size?: { width: number; height: number }) => {
   return Logger.t(`Load image ${url}`, Step.async((done, die) => {
     const img = new Image();
 
-    img.onload = function () {
+    img.onload = () => {
       editor.setContent(`<p><img src="${url}" ${size ? `width="${size.width}" height="${size.height}"` : ''} /></p>`);
       editor.focus();
       done();
@@ -25,23 +25,23 @@ const sLoadImage = function (editor: Editor, url: string, size?: { width: number
   }));
 };
 
-const sUploadImages = function (editor: Editor) {
+const sUploadImages = (editor: Editor) => {
   return Logger.t('Upload images', Step.async((done) => {
     editor.uploadImages(done);
   }));
 };
 
-const sWaitForBlobImage = function (editor: Editor) {
+const sWaitForBlobImage = (editor: Editor) => {
   return Waiter.sTryUntil('Did not find a blobimage', Step.sync(() => {
     Assert.eq('Should be one blob image', true, editor.dom.select('img[src^=blob]').length === 1);
   }), 10, 3000);
 };
 
-const createStateContainer = function () {
+const createStateContainer = () => {
   const state = Cell(null);
 
-  const handler = function (url: string) {
-    return function (blobInfo, success) {
+  const handler = (url: string) => {
+    return (blobInfo, success) => {
       state.set({
         blobInfo
       });

--- a/modules/tinymce/src/plugins/importcss/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/Plugin.ts
@@ -9,9 +9,9 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Api from './api/Api';
 import * as ImportCss from './core/ImportCss';
 
-export default function () {
+export default () => {
   PluginManager.add('importcss', (editor) => {
     ImportCss.setup(editor);
     return Api.get(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/importcss/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/api/Api.ts
@@ -7,8 +7,8 @@
 
 import * as ImportCss from '../core/ImportCss';
 
-const get = function (editor) {
-  const convertSelectorToFormat = function (selectorText) {
+const get = (editor) => {
+  const convertSelectorToFormat = (selectorText) => {
     return ImportCss.defaultConvertSelectorToFormat(editor, selectorText);
   };
 

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -28,7 +28,7 @@ interface UserDefinedGroup extends Partial<Group> {
   title: string;
 }
 
-const removeCacheSuffix = function (url: string) {
+const removeCacheSuffix = (url: string) => {
   const cacheSuffix = Env.cacheSuffix;
 
   if (typeof url === 'string') {
@@ -51,13 +51,13 @@ const isSkinContentCss = (editor: Editor, href: string) => {
   return false;
 };
 
-const compileFilter = function (filter: string | RegExp | ((value: string) => boolean)) {
+const compileFilter = (filter: string | RegExp | ((value: string) => boolean)) => {
   if (typeof filter === 'string') {
-    return function (value) {
+    return (value) => {
       return value.indexOf(filter) !== -1;
     };
   } else if (filter instanceof RegExp) {
-    return function (value) {
+    return (value) => {
       return filter.test(value);
     };
   }
@@ -68,10 +68,10 @@ const compileFilter = function (filter: string | RegExp | ((value: string) => bo
 const isCssImportRule = (rule: CSSRule): rule is CSSImportRule => (rule as any).styleSheet;
 const isCssPageRule = (rule: CSSRule): rule is CSSPageRule => (rule as any).selectorText;
 
-const getSelectors = function (editor: Editor, doc, fileFilter) {
+const getSelectors = (editor: Editor, doc, fileFilter) => {
   const selectors = [], contentCSSUrls = {};
 
-  function append(styleSheet, imported?) {
+  const append = (styleSheet, imported?) => {
     let href = styleSheet.href, rules: CSSRule[];
 
     href = removeCacheSuffix(href);
@@ -100,14 +100,14 @@ const getSelectors = function (editor: Editor, doc, fileFilter) {
         });
       }
     });
-  }
+  };
 
   Tools.each(editor.contentCSS, (url) => {
     contentCSSUrls[url] = true;
   });
 
   if (!fileFilter) {
-    fileFilter = function (href: string, imported: string) {
+    fileFilter = (href: string, imported: string) => {
       return imported || contentCSSUrls[href];
     };
   }
@@ -123,7 +123,7 @@ const getSelectors = function (editor: Editor, doc, fileFilter) {
   return selectors;
 };
 
-const defaultConvertSelectorToFormat = function (editor: Editor, selectorText: string) {
+const defaultConvertSelectorToFormat = (editor: Editor, selectorText: string) => {
   let format;
 
   // Parse simple element.class1, .class1
@@ -171,13 +171,13 @@ const defaultConvertSelectorToFormat = function (editor: Editor, selectorText: s
   return format;
 };
 
-const getGroupsBySelector = function (groups: Group[], selector: string): Group[] {
+const getGroupsBySelector = (groups: Group[], selector: string): Group[] => {
   return Tools.grep(groups, (group) => {
     return !group.filter || group.filter(selector);
   });
 };
 
-const compileUserDefinedGroups = function (groups: UserDefinedGroup[]): Group[] {
+const compileUserDefinedGroups = (groups: UserDefinedGroup[]): Group[] => {
   return Tools.map(groups, (group) => {
     return Tools.extend({}, group, {
       original: group,
@@ -197,16 +197,16 @@ interface StyleGroup {
   filter: string | RegExp | Function;
 }
 
-const isExclusiveMode = function (editor: Editor, group: StyleGroup) {
+const isExclusiveMode = (editor: Editor, group: StyleGroup) => {
   // Exclusive mode can only be disabled when there are groups allowing the same style to be present in multiple groups
   return group === null || Settings.shouldImportExclusive(editor) !== false;
 };
 
-const isUniqueSelector = function (editor: Editor, selector: string, group: StyleGroup, globallyUniqueSelectors: Record<string, any>) {
+const isUniqueSelector = (editor: Editor, selector: string, group: StyleGroup, globallyUniqueSelectors: Record<string, any>) => {
   return !(isExclusiveMode(editor, group) ? selector in globallyUniqueSelectors : selector in group.selectors);
 };
 
-const markUniqueSelector = function (editor: Editor, selector: string, group: StyleGroup, globallyUniqueSelectors: Record<string, any>) {
+const markUniqueSelector = (editor: Editor, selector: string, group: StyleGroup, globallyUniqueSelectors: Record<string, any>) => {
   if (isExclusiveMode(editor, group)) {
     globallyUniqueSelectors[selector] = true;
   } else {
@@ -214,7 +214,7 @@ const markUniqueSelector = function (editor: Editor, selector: string, group: St
   }
 };
 
-const convertSelectorToFormat = function (editor, plugin, selector, group) {
+const convertSelectorToFormat = (editor, plugin, selector, group) => {
   let selectorConverter;
 
   if (group && group.selector_converter) {
@@ -222,7 +222,7 @@ const convertSelectorToFormat = function (editor, plugin, selector, group) {
   } else if (Settings.getSelectorConverter(editor)) {
     selectorConverter = Settings.getSelectorConverter(editor);
   } else {
-    selectorConverter = function () {
+    selectorConverter = () => {
       return defaultConvertSelectorToFormat(editor, selector);
     };
   }
@@ -230,7 +230,7 @@ const convertSelectorToFormat = function (editor, plugin, selector, group) {
   return selectorConverter.call(plugin, selector, group);
 };
 
-const setup = function (editor: Editor) {
+const setup = (editor: Editor) => {
   editor.on('init', (_e) => {
     const model = generate();
 
@@ -238,7 +238,7 @@ const setup = function (editor: Editor) {
     const selectorFilter = compileFilter(Settings.getSelectorFilter(editor));
     const groups = compileUserDefinedGroups(Settings.getCssGroups(editor));
 
-    const processSelector = function (selector: string, group: StyleGroup) {
+    const processSelector = (selector: string, group: StyleGroup) => {
       if (isUniqueSelector(editor, selector, group, globallyUniqueSelectors)) {
         markUniqueSelector(editor, selector, group, globallyUniqueSelectors);
 

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/Plugin.ts
@@ -9,9 +9,9 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('insertdatetime', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Commands.ts
@@ -8,7 +8,7 @@
 import * as Actions from '../core/Actions';
 import * as Settings from './Settings';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('mceInsertDate', () => {
     Actions.insertDateTime(editor, Settings.getDateFormat(editor));
   });

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Settings.ts
@@ -5,24 +5,24 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const getDateFormat = function (editor) {
+const getDateFormat = (editor) => {
   return editor.getParam('insertdatetime_dateformat', editor.translate('%Y-%m-%d'));
 };
 
-const getTimeFormat = function (editor) {
+const getTimeFormat = (editor) => {
   return editor.getParam('insertdatetime_timeformat', editor.translate('%H:%M:%S'));
 };
 
-const getFormats = function (editor): string[] {
+const getFormats = (editor): string[] => {
   return editor.getParam('insertdatetime_formats', [ '%H:%M:%S', '%Y-%m-%d', '%I:%M:%S %p', '%D' ]);
 };
 
-const getDefaultDateTime = function (editor) {
+const getDefaultDateTime = (editor) => {
   const formats = getFormats(editor);
   return formats.length > 0 ? formats[0] : getTimeFormat(editor);
 };
 
-const shouldInsertTimeElement = function (editor) {
+const shouldInsertTimeElement = (editor) => {
   return editor.getParam('insertdatetime_element', false);
 };
 

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/core/Actions.ts
@@ -12,7 +12,7 @@ const daysLong = 'Sunday Monday Tuesday Wednesday Thursday Friday Saturday Sunda
 const monthsShort = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ');
 const monthsLong = 'January February March April May June July August September October November December'.split(' ');
 
-const addZeros = function (value, len) {
+const addZeros = (value, len) => {
   value = '' + value;
 
   if (value.length < len) {
@@ -24,7 +24,7 @@ const addZeros = function (value, len) {
   return value;
 };
 
-const getDateTime = function (editor, fmt, date?) {
+const getDateTime = (editor, fmt, date?) => {
   date = date || new Date();
 
   fmt = fmt.replace('%D', '%m/%d/%Y');
@@ -47,7 +47,7 @@ const getDateTime = function (editor, fmt, date?) {
   return fmt;
 };
 
-const updateElement = function (editor, timeElm, computerTime, userTime) {
+const updateElement = (editor, timeElm, computerTime, userTime) => {
   const newTimeElm = editor.dom.create('time', { datetime: computerTime }, userTime);
   timeElm.parentNode.insertBefore(newTimeElm, timeElm);
   editor.dom.remove(timeElm);
@@ -55,7 +55,7 @@ const updateElement = function (editor, timeElm, computerTime, userTime) {
   editor.selection.collapse(false);
 };
 
-const insertDateTime = function (editor, format) {
+const insertDateTime = (editor, format) => {
   if (Settings.shouldInsertTimeElement(editor)) {
     const userTime = getDateTime(editor, format);
     let computerTime;

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
@@ -12,7 +12,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 import * as Actions from '../core/Actions';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   const formats = Settings.getFormats(editor);
   const defaultFormat = Cell(Settings.getDefaultDateTime(editor));
 

--- a/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
@@ -15,8 +15,8 @@ import * as Formats from './core/Formats';
  * @private
  */
 
-export default function () {
+export default () => {
   PluginManager.add('legacyoutput', (editor) => {
     Formats.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/legacyoutput/main/ts/core/Formats.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/main/ts/core/Formats.ts
@@ -48,7 +48,7 @@ const overrideFormats = (editor: Editor) => {
       inline: 'font',
       toggle: false,
       attributes: {
-        size(vars) {
+        size: (vars) => {
           return String(Tools.inArray(fontSizes, vars.value) + 1);
         }
       }

--- a/modules/tinymce/src/plugins/link/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/Plugin.ts
@@ -11,7 +11,7 @@ import * as Actions from './core/Actions';
 import * as Keyboard from './core/Keyboard';
 import * as Controls from './ui/Controls';
 
-export default function () {
+export default () => {
   PluginManager.add('link', (editor) => {
     Controls.setupButtons(editor);
     Controls.setupMenuItems(editor);
@@ -21,4 +21,4 @@ export default function () {
     Commands.register(editor);
     Keyboard.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/link/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/api/Commands.ts
@@ -8,7 +8,7 @@
 import * as Actions from '../core/Actions';
 import * as Settings from './Settings';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('mceLink', () => {
     if (Settings.useQuickLink(editor)) {
       // Taken from ContextEditorEvents in silver. Find a better way.

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -18,7 +18,7 @@ const getLink = (editor: Editor, elm: Node) => editor.dom.getParent<HTMLAnchorEl
 
 const getSelectedLink = (editor: Editor) => getLink(editor, editor.selection.getStart());
 
-const hasOnlyAltModifier = function (e) {
+const hasOnlyAltModifier = (e) => {
   return e.altKey === true && e.shiftKey === false && e.ctrlKey === false && e.metaKey === false;
 };
 
@@ -36,15 +36,15 @@ const gotoLink = (editor: Editor, a: HTMLAnchorElement | null) => {
   }
 };
 
-const openDialog = (editor: Editor) => function () {
+const openDialog = (editor: Editor) => () => {
   Dialog.open(editor);
 };
 
-const gotoSelectedLink = (editor: Editor) => function () {
+const gotoSelectedLink = (editor: Editor) => () => {
   gotoLink(editor, getSelectedLink(editor));
 };
 
-const leftClickedOnAHref = (editor: Editor) => function (elm) {
+const leftClickedOnAHref = (editor: Editor) => (elm) => {
   let sel, rng, node;
   // TODO: this used to query the context menu plugin directly. Is that a good idea?
   //  && !isContextMenuVisible(editor)

--- a/modules/tinymce/src/plugins/link/main/ts/core/Keyboard.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Keyboard.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const setup = function (editor) {
+const setup = (editor) => {
   editor.addShortcut('Meta+K', '', () => {
     editor.execCommand('mceLink');
   });

--- a/modules/tinymce/src/plugins/link/main/ts/core/OpenUrl.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/OpenUrl.ts
@@ -5,13 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const appendClickRemove = function (link, evt) {
+const appendClickRemove = (link, evt) => {
   document.body.appendChild(link);
   link.dispatchEvent(evt);
   document.body.removeChild(link);
 };
 
-const open = function (url) {
+const open = (url) => {
   // Chrome and Webkit has implemented noopener and works correctly with/without popup blocker
   // Firefox has it implemented noopener but when the popup blocker is activated it doesn't work
   // Edge has only implemented noreferrer and it seems to remove opener as well

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -13,7 +13,7 @@ import * as Settings from '../api/Settings';
 import * as Actions from '../core/Actions';
 import * as Utils from '../core/Utils';
 
-const setupButtons = function (editor: Editor) {
+const setupButtons = (editor: Editor) => {
   editor.ui.registry.addToggleButton('link', {
     icon: 'link',
     tooltip: 'Insert/edit link',
@@ -36,7 +36,7 @@ const setupButtons = function (editor: Editor) {
   });
 };
 
-const setupMenuItems = function (editor: Editor) {
+const setupMenuItems = (editor: Editor) => {
   editor.ui.registry.addMenuItem('openlink', {
     text: 'Open link',
     icon: 'new-tab',
@@ -59,7 +59,7 @@ const setupMenuItems = function (editor: Editor) {
   });
 };
 
-const setupContextMenu = function (editor: Editor) {
+const setupContextMenu = (editor: Editor) => {
   const inLink = 'link unlink openlink';
   const noLink = 'link';
   editor.ui.registry.addContextMenu('link', {
@@ -67,8 +67,8 @@ const setupContextMenu = function (editor: Editor) {
   });
 };
 
-const setupContextToolbars = function (editor: Editor) {
-  const collapseSelectionToEnd = function (editor: Editor) {
+const setupContextToolbars = (editor: Editor) => {
+  const collapseSelectionToEnd = (editor: Editor) => {
     editor.selection.collapse(false);
   };
 

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
@@ -155,7 +155,7 @@ const makeDialog = (settings: LinkDialogInfo, onSubmit, editor: Editor): Dialog.
   };
 };
 
-const open = function (editor: Editor) {
+const open = (editor: Editor) => {
   const data = collectData(editor);
   data.then((info) => {
     const onSubmit = handleSubmit(editor, info);

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogConfirms.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogConfirms.ts
@@ -16,7 +16,7 @@ import * as Utils from '../core/Utils';
 import { LinkDialogOutput } from './DialogTypes';
 
 // Delay confirm since onSubmit will move focus
-const delayedConfirm = function (editor: Editor, message: string, callback: (state: boolean) => void) {
+const delayedConfirm = (editor: Editor, message: string, callback: (state: boolean) => void) => {
   const rng = editor.selection.getRng();
 
   Delay.setEditorTimeout(editor, () => {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
@@ -15,17 +15,17 @@ UnitTest.asynctest('browser.tinymce.plugins.link.ImageFigureLinkTest', (success,
     const api = TinyApis(editor);
     const ui = TinyUi(editor);
 
-    const sLinkTheSelection = function () {
+    const sLinkTheSelection = () => {
       return Logger.t('Link the selection', TestLinkUi.sInsertLink(ui, 'http://google.com'));
     };
 
-    const sUnlinkSelection = function () {
+    const sUnlinkSelection = () => {
       return Logger.t('Unlink the selection', Step.sync(() => {
         LinkPluginUtils.unlink(editor);
       }));
     };
 
-    const sAssertPresence = function (selector: Record<string, number>) {
+    const sAssertPresence = (selector: Record<string, number>) => {
       return Waiter.sTryUntil('Assert element is present',
         Assertions.sAssertPresence('Detect presence of the element', selector, TinyDom.fromDom(editor.getBody()))
       );

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlInputTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlInputTest.ts
@@ -6,7 +6,7 @@ import { Attribute, SugarElement } from '@ephox/sugar';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-const cFakeEvent = function (name) {
+const cFakeEvent = (name) => {
   return Chain.label('Fake event',
     Chain.op((elm: SugarElement) => {
       const evt = document.createEvent('HTMLEvents');

--- a/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
@@ -94,7 +94,7 @@ const sWaitForUi = (label: string, selector: string) => Logger.t('Wait for UI', 
   1000
 ));
 
-const sInsertLink = function (ui: TinyUi, url: string) {
+const sInsertLink = (ui: TinyUi, url: string) => {
   return Logger.t('Insert link', GeneralSteps.sequence([
     sOpenLinkDialog(ui),
     FocusTools.sSetActiveValue(doc, url),

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -17,25 +17,25 @@ import * as Selection from '../core/Selection';
 import { isCustomList } from '../core/Util';
 import { flattenListSelection } from './Indendation';
 
-const updateListStyle = function (dom, el, detail) {
+const updateListStyle = (dom, el, detail) => {
   const type = detail['list-style-type'] ? detail['list-style-type'] : null;
   dom.setStyle(el, 'list-style-type', type);
 };
 
-const setAttribs = function (elm, attrs) {
+const setAttribs = (elm, attrs) => {
   Tools.each(attrs, (value, key) => {
     elm.setAttribute(key, value);
   });
 };
 
-const updateListAttrs = function (dom, el, detail) {
+const updateListAttrs = (dom, el, detail) => {
   setAttribs(el, detail['list-attributes']);
   Tools.each(dom.select('li', el), (li) => {
     setAttribs(li, detail['list-item-attributes']);
   });
 };
 
-const updateListWithDetails = function (dom, el, detail) {
+const updateListWithDetails = (dom, el, detail) => {
   updateListStyle(dom, el, detail);
   updateListAttrs(dom, el, detail);
 };
@@ -44,7 +44,7 @@ const removeStyles = (dom, element: HTMLElement, styles: string[]) => {
   Tools.each(styles, (style) => dom.setStyle(element, { [style]: '' }));
 };
 
-const getEndPointNode = function (editor, rng, start, root) {
+const getEndPointNode = (editor, rng, start, root) => {
   let container = rng[start ? 'startContainer' : 'endContainer'];
   const offset = rng[start ? 'startOffset' : 'endOffset'];
 
@@ -72,7 +72,7 @@ const getEndPointNode = function (editor, rng, start, root) {
   return container;
 };
 
-const getSelectedTextBlocks = function (editor: Editor, rng, root) {
+const getSelectedTextBlocks = (editor: Editor, rng, root) => {
   const textBlocks = [], dom = editor.dom;
 
   const startNode = getEndPointNode(editor, rng, true, root);
@@ -124,7 +124,7 @@ const getSelectedTextBlocks = function (editor: Editor, rng, root) {
   return textBlocks;
 };
 
-const hasCompatibleStyle = function (dom: DOMUtils, sib, detail) {
+const hasCompatibleStyle = (dom: DOMUtils, sib, detail) => {
   const sibStyle = dom.getStyle(sib, 'list-style-type');
   let detailStyle = detail ? detail['list-style-type'] : '';
 
@@ -133,7 +133,7 @@ const hasCompatibleStyle = function (dom: DOMUtils, sib, detail) {
   return sibStyle === detailStyle;
 };
 
-const applyList = function (editor: Editor, listName: string, detail = {}) {
+const applyList = (editor: Editor, listName: string, detail = {}) => {
   const rng = editor.selection.getRng();
   let listItemName = 'LI';
   const root = Selection.getClosestListRootElm(editor, editor.selection.getStart(true));
@@ -183,25 +183,25 @@ const applyList = function (editor: Editor, listName: string, detail = {}) {
   editor.selection.setRng(Bookmark.resolveBookmark(bookmark));
 };
 
-const isValidLists = function (list1, list2) {
+const isValidLists = (list1, list2) => {
   return list1 && list2 && NodeType.isListNode(list1) && list1.nodeName === list2.nodeName;
 };
 
-const hasSameListStyle = function (dom, list1, list2) {
+const hasSameListStyle = (dom, list1, list2) => {
   const targetStyle = dom.getStyle(list1, 'list-style-type', true);
   const style = dom.getStyle(list2, 'list-style-type', true);
   return targetStyle === style;
 };
 
-const hasSameClasses = function (elm1, elm2) {
+const hasSameClasses = (elm1, elm2) => {
   return elm1.className === elm2.className;
 };
 
-const shouldMerge = function (dom, list1, list2) {
+const shouldMerge = (dom, list1, list2) => {
   return isValidLists(list1, list2) && hasSameListStyle(dom, list1, list2) && hasSameClasses(list1, list2);
 };
 
-const mergeWithAdjacentLists = function (dom, listBlock) {
+const mergeWithAdjacentLists = (dom, listBlock) => {
   let sibling, node;
 
   sibling = listBlock.nextSibling;
@@ -223,7 +223,7 @@ const mergeWithAdjacentLists = function (dom, listBlock) {
   }
 };
 
-const updateList = function (editor: Editor, list, listName, detail) {
+const updateList = (editor: Editor, list, listName, detail) => {
   if (list.nodeName !== listName) {
     const newList = editor.dom.rename(list, listName);
     updateListWithDetails(editor.dom, newList, detail);
@@ -234,7 +234,7 @@ const updateList = function (editor: Editor, list, listName, detail) {
   }
 };
 
-const toggleMultipleLists = function (editor, parentList, lists, listName, detail) {
+const toggleMultipleLists = (editor, parentList, lists, listName, detail) => {
   const parentIsList = NodeType.isListNode(parentList);
   if (parentIsList && parentList.nodeName === listName && !hasListStyleDetail(detail)) {
     flattenListSelection(editor);
@@ -251,11 +251,11 @@ const toggleMultipleLists = function (editor, parentList, lists, listName, detai
   }
 };
 
-const hasListStyleDetail = function (detail) {
+const hasListStyleDetail = (detail) => {
   return 'list-style-type' in detail;
 };
 
-const toggleSingleList = function (editor, parentList, listName, detail) {
+const toggleSingleList = (editor, parentList, listName, detail) => {
   if (parentList === editor.getBody()) {
     return;
   }
@@ -278,7 +278,7 @@ const toggleSingleList = function (editor, parentList, listName, detail) {
   }
 };
 
-const toggleList = function (editor, listName, detail) {
+const toggleList = (editor, listName, detail) => {
   const parentList = Selection.getParentList(editor);
   const selectedSubLists = Selection.getSelectedSubLists(editor);
 

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Api.ts
@@ -8,9 +8,9 @@
 import Editor from 'tinymce/core/api/Editor';
 import * as Delete from '../core/Delete';
 
-const get = function (editor: Editor) {
+const get = (editor: Editor) => {
   return {
-    backspaceDelete(isForward: boolean) {
+    backspaceDelete: (isForward: boolean) => {
       Delete.backspaceDelete(editor, isForward);
     }
   };

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
@@ -9,14 +9,14 @@ import { flattenListSelection, indentListSelection, outdentListSelection } from 
 import * as ToggleList from '../actions/ToggleList';
 import * as Dialog from '../ui/Dialog';
 
-const queryListCommandState = function (editor, listName) {
-  return function () {
+const queryListCommandState = (editor, listName) => {
+  return () => {
     const parentList = editor.dom.getParent(editor.selection.getStart(), 'UL,OL,DL');
     return parentList && parentList.nodeName === listName;
   };
 };
 
-const register = function (editor) {
+const register = (editor) => {
   editor.on('BeforeExecCommand', (e) => {
     const cmd = e.command.toLowerCase();
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Bookmark.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Bookmark.ts
@@ -21,10 +21,10 @@ const DOM = DOMUtils.DOM;
  * @param  {DOMRange} rng DOM Range to get bookmark on.
  * @return {Object} Bookmark object.
  */
-const createBookmark = function (rng) {
+const createBookmark = (rng) => {
   const bookmark = {};
 
-  const setupEndPoint = function (start?) {
+  const setupEndPoint = (start?) => {
     let offsetNode, container, offset;
 
     container = rng[start ? 'startContainer' : 'endContainer'];
@@ -62,11 +62,11 @@ const createBookmark = function (rng) {
   return bookmark;
 };
 
-const resolveBookmark = function (bookmark) {
-  function restoreEndPoint(start?) {
+const resolveBookmark = (bookmark) => {
+  const restoreEndPoint = (start?) => {
     let container, offset, node;
 
-    const nodeIndex = function (container) {
+    const nodeIndex = (container) => {
       let node = container.parentNode.firstChild, idx = 0;
 
       while (node) {
@@ -104,7 +104,7 @@ const resolveBookmark = function (bookmark) {
 
     bookmark[start ? 'startContainer' : 'endContainer'] = container;
     bookmark[start ? 'startOffset' : 'endOffset'] = offset;
-  }
+  };
 
   restoreEndPoint(true);
   restoreEndPoint();

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -20,7 +20,7 @@ import * as NormalizeLists from './NormalizeLists';
 import * as ListRangeUtils from './RangeUtils';
 import * as Selection from './Selection';
 
-const findNextCaretContainer = function (editor: Editor, rng: Range, isForward: Boolean, root: Node): Node {
+const findNextCaretContainer = (editor: Editor, rng: Range, isForward: Boolean, root: Node): Node => {
   let node = rng.startContainer;
   const offset = rng.startOffset;
 
@@ -57,18 +57,18 @@ const findNextCaretContainer = function (editor: Editor, rng: Range, isForward: 
   }
 };
 
-const hasOnlyOneBlockChild = function (dom: DOMUtils, elm: Element): boolean {
+const hasOnlyOneBlockChild = (dom: DOMUtils, elm: Element): boolean => {
   const childNodes = elm.childNodes;
   return childNodes.length === 1 && !NodeType.isListNode(childNodes[0]) && dom.isBlock(childNodes[0]);
 };
 
-const unwrapSingleBlockChild = function (dom: DOMUtils, elm: Element) {
+const unwrapSingleBlockChild = (dom: DOMUtils, elm: Element) => {
   if (hasOnlyOneBlockChild(dom, elm)) {
     dom.remove(elm.firstChild, true);
   }
 };
 
-const moveChildren = function (dom: DOMUtils, fromElm: Element, toElm: Element) {
+const moveChildren = (dom: DOMUtils, fromElm: Element, toElm: Element) => {
   let node;
 
   const targetElm = hasOnlyOneBlockChild(dom, toElm) ? toElm.firstChild : toElm;
@@ -81,7 +81,7 @@ const moveChildren = function (dom: DOMUtils, fromElm: Element, toElm: Element) 
   }
 };
 
-const mergeLiElements = function (dom: DOMUtils, fromElm: Element, toElm: Element) {
+const mergeLiElements = (dom: DOMUtils, fromElm: Element, toElm: Element) => {
   let listNode;
   const ul: Node = fromElm.parentNode;
 
@@ -127,13 +127,13 @@ const mergeLiElements = function (dom: DOMUtils, fromElm: Element, toElm: Elemen
   });
 };
 
-const mergeIntoEmptyLi = function (editor: Editor, fromLi: HTMLLIElement, toLi: HTMLLIElement) {
+const mergeIntoEmptyLi = (editor: Editor, fromLi: HTMLLIElement, toLi: HTMLLIElement) => {
   editor.dom.$(toLi).empty();
   mergeLiElements(editor.dom, fromLi, toLi);
   editor.selection.setCursorLocation(toLi);
 };
 
-const mergeForward = function (editor: Editor, rng: Range, fromLi: HTMLLIElement, toLi: HTMLLIElement) {
+const mergeForward = (editor: Editor, rng: Range, fromLi: HTMLLIElement, toLi: HTMLLIElement) => {
   const dom = editor.dom;
 
   if (dom.isEmpty(toLi)) {
@@ -145,14 +145,14 @@ const mergeForward = function (editor: Editor, rng: Range, fromLi: HTMLLIElement
   }
 };
 
-const mergeBackward = function (editor: Editor, rng: Range, fromLi: HTMLLIElement, toLi: HTMLLIElement) {
+const mergeBackward = (editor: Editor, rng: Range, fromLi: HTMLLIElement, toLi: HTMLLIElement) => {
   const bookmark = Bookmark.createBookmark(rng);
   mergeLiElements(editor.dom, fromLi, toLi);
   const resolvedBookmark = Bookmark.resolveBookmark(bookmark);
   editor.selection.setRng(resolvedBookmark);
 };
 
-const backspaceDeleteFromListToListCaret = function (editor: Editor, isForward: boolean) {
+const backspaceDeleteFromListToListCaret = (editor: Editor, isForward: boolean) => {
   const dom = editor.dom, selection = editor.selection;
   const selectionStartElm = selection.getStart();
   const root = Selection.getClosestListRootElm(editor, selectionStartElm);
@@ -195,7 +195,7 @@ const backspaceDeleteFromListToListCaret = function (editor: Editor, isForward: 
   return false;
 };
 
-const removeBlock = function (dom: DOMUtils, block: Element, root: Node) {
+const removeBlock = (dom: DOMUtils, block: Element, root: Node) => {
   const parentBlock = dom.getParent(block.parentNode, dom.isBlock, root);
 
   dom.remove(block);
@@ -204,7 +204,7 @@ const removeBlock = function (dom: DOMUtils, block: Element, root: Node) {
   }
 };
 
-const backspaceDeleteIntoListCaret = function (editor: Editor, isForward: boolean) {
+const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean) => {
   const dom = editor.dom;
   const selectionStartElm = editor.selection.getStart();
   const root = Selection.getClosestListRootElm(editor, selectionStartElm);
@@ -229,11 +229,11 @@ const backspaceDeleteIntoListCaret = function (editor: Editor, isForward: boolea
   return false;
 };
 
-const backspaceDeleteCaret = function (editor: Editor, isForward: boolean): boolean {
+const backspaceDeleteCaret = (editor: Editor, isForward: boolean): boolean => {
   return backspaceDeleteFromListToListCaret(editor, isForward) || backspaceDeleteIntoListCaret(editor, isForward);
 };
 
-const backspaceDeleteRange = function (editor: Editor): boolean {
+const backspaceDeleteRange = (editor: Editor): boolean => {
   const selectionStartElm = editor.selection.getStart();
   const root = Selection.getClosestListRootElm(editor, selectionStartElm);
   const startListParent = editor.dom.getParent(selectionStartElm, 'LI,DT,DD', root);
@@ -250,11 +250,11 @@ const backspaceDeleteRange = function (editor: Editor): boolean {
   return false;
 };
 
-const backspaceDelete = function (editor: Editor, isForward: boolean): boolean {
+const backspaceDelete = (editor: Editor, isForward: boolean): boolean => {
   return editor.selection.isCollapsed() ? backspaceDeleteCaret(editor, isForward) : backspaceDeleteRange(editor);
 };
 
-const setup = function (editor: Editor) {
+const setup = (editor: Editor) => {
   editor.on('keydown', (e) => {
     if (e.keyCode === VK.BACKSPACE) {
       if (backspaceDelete(editor, false)) {

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Keyboard.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Keyboard.ts
@@ -10,7 +10,7 @@ import { indentListSelection, outdentListSelection } from '../actions/Indendatio
 import * as Settings from '../api/Settings';
 import * as Delete from './Delete';
 
-const setupTabKey = function (editor) {
+const setupTabKey = (editor) => {
   editor.on('keydown', (e) => {
     // Check for tab but not ctrl/cmd+tab since it switches browser tabs
     if (e.keyCode !== VK.TAB || VK.metaKeyPressed(e)) {
@@ -25,7 +25,7 @@ const setupTabKey = function (editor) {
   });
 };
 
-const setup = function (editor) {
+const setup = (editor) => {
   if (Settings.shouldIndentOnTab(editor)) {
     setupTabKey(editor);
   }

--- a/modules/tinymce/src/plugins/lists/main/ts/core/NormalizeLists.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/NormalizeLists.ts
@@ -11,7 +11,7 @@ import * as NodeType from './NodeType';
 
 const DOM = DOMUtils.DOM;
 
-const normalizeList = function (dom, ul) {
+const normalizeList = (dom, ul) => {
   let sibling;
   const parentNode = ul.parentNode;
 
@@ -38,7 +38,7 @@ const normalizeList = function (dom, ul) {
   }
 };
 
-const normalizeLists = function (dom, element) {
+const normalizeLists = (dom, element) => {
   Tools.each(Tools.grep(dom.select('ol,ul', element)), (ul) => {
     normalizeList(dom, ul);
   });

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
@@ -18,17 +18,17 @@ const getParentList = (editor: Editor, node?: Node) => {
   return editor.dom.getParent(selectionStart, 'OL,UL,DL', getClosestListRootElm(editor, selectionStart));
 };
 
-const isParentListSelected = function (parentList, selectedBlocks) {
+const isParentListSelected = (parentList, selectedBlocks) => {
   return parentList && selectedBlocks.length === 1 && selectedBlocks[0] === parentList;
 };
 
-const findSubLists = function (parentList) {
+const findSubLists = (parentList) => {
   return Tools.grep(parentList.querySelectorAll('ol,ul,dl'), (elm: Node) => {
     return NodeType.isListNode(elm);
   });
 };
 
-const getSelectedSubLists = function (editor) {
+const getSelectedSubLists = (editor) => {
   const parentList = getParentList(editor);
   const selectedBlocks = editor.selection.getSelectedBlocks();
 
@@ -41,7 +41,7 @@ const getSelectedSubLists = function (editor) {
   }
 };
 
-const findParentListItemsNodes = function (editor, elms) {
+const findParentListItemsNodes = (editor, elms) => {
   const listItemsElms = Tools.map(elms, (elm) => {
     const parentLi = editor.dom.getParent(elm, 'li,dd,dt', getClosestListRootElm(editor, elm));
 
@@ -51,7 +51,7 @@ const findParentListItemsNodes = function (editor, elms) {
   return DomQuery.unique(listItemsElms);
 };
 
-const getSelectedListItems = function (editor) {
+const getSelectedListItems = (editor) => {
   const selectedBlocks = editor.selection.getSelectedBlocks();
   return Tools.grep(findParentListItemsNodes(editor, selectedBlocks), (block) => {
     return NodeType.isListItemNode(block);
@@ -60,7 +60,7 @@ const getSelectedListItems = function (editor) {
 
 const getSelectedDlItems = (editor: Editor): Node[] => Arr.filter(getSelectedListItems(editor), NodeType.isDlItemNode);
 
-const getClosestListRootElm = function (editor, elm) {
+const getClosestListRootElm = (editor, elm) => {
   const parentTableCell = editor.dom.getParents(elm, 'TD,TH');
   const root = parentTableCell.length > 0 ? parentTableCell[0] : editor.getBody();
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/SplitList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/SplitList.ts
@@ -12,8 +12,8 @@ import { createTextBlock } from './TextBlock';
 
 const DOM = DOMUtils.DOM;
 
-const splitList = function (editor, ul, li) {
-  const removeAndKeepBookmarks = function (targetNode) {
+const splitList = (editor, ul, li) => {
+  const removeAndKeepBookmarks = (targetNode) => {
     Tools.each(bookmarks, (node) => {
       targetNode.parentNode.insertBefore(node, li.parentNode);
     });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
@@ -29,12 +29,12 @@ UnitTest.asynctest('browser.tinymce.plugins.lists.BackspaceDeleteInlineTest', (s
     LegacyUnit.equal(DomQuery('#lists li').length, 3);
   });
 
-  const teardown = function (editor, div) {
+  const teardown = (editor, div) => {
     editor.remove();
     div.parentNode.removeChild(div);
   };
 
-  const setup = function (success, failure) {
+  const setup = (success, failure) => {
     const div = document.createElement('div');
 
     div.innerHTML = (
@@ -54,7 +54,7 @@ UnitTest.asynctest('browser.tinymce.plugins.lists.BackspaceDeleteInlineTest', (s
       skin: false,
       plugins: 'lists',
       disable_nodechange: true,
-      init_instance_callback(editor) {
+      init_instance_callback: (editor) => {
         Pipeline.async({}, Log.steps('TBA', 'Lists: Backspace delete inline tests', suite.toSteps(editor)), () => {
           teardown(editor, div);
           success();

--- a/modules/tinymce/src/plugins/media/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/media/demo/ts/demo/Demo.ts
@@ -6,7 +6,7 @@ tinymce.init({
   toolbar: 'undo redo | media',
   // media_dimensions: false,
   // media_live_embeds: false,
-  file_picker_callback(callback, value, meta) {
+  file_picker_callback: (callback, value, meta) => {
     // Provide alternative source and posted for the media dialog
     if (meta.filetype === 'media') {
       callback('https://youtu.be/a4tNU2jgTZU');

--- a/modules/tinymce/src/plugins/media/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/Plugin.ts
@@ -13,7 +13,7 @@ import * as ResolveName from './core/ResolveName';
 import * as Selection from './core/Selection';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('media', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
@@ -22,4 +22,4 @@ export default function () {
     Selection.setup(editor);
     return Api.get(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/media/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/api/Api.ts
@@ -7,8 +7,8 @@
 
 import * as Dialog from '../ui/Dialog';
 
-const get = function (editor) {
-  const showDialog = function () {
+const get = (editor) => {
+  const showDialog = () => {
     Dialog.showDialog(editor);
   };
 

--- a/modules/tinymce/src/plugins/media/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/api/Commands.ts
@@ -7,8 +7,8 @@
 
 import * as Dialog from '../ui/Dialog';
 
-const register = function (editor) {
-  const showDialog = function () {
+const register = (editor) => {
+  const showDialog = () => {
     Dialog.showDialog(editor);
   };
 

--- a/modules/tinymce/src/plugins/media/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/api/Settings.ts
@@ -5,39 +5,39 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const getScripts = function (editor) {
+const getScripts = (editor) => {
   return editor.getParam('media_scripts');
 };
 
-const getAudioTemplateCallback = function (editor) {
+const getAudioTemplateCallback = (editor) => {
   return editor.getParam('audio_template_callback');
 };
 
-const getVideoTemplateCallback = function (editor) {
+const getVideoTemplateCallback = (editor) => {
   return editor.getParam('video_template_callback');
 };
 
-const hasLiveEmbeds = function (editor) {
+const hasLiveEmbeds = (editor) => {
   return editor.getParam('media_live_embeds', true);
 };
 
-const shouldFilterHtml = function (editor) {
+const shouldFilterHtml = (editor) => {
   return editor.getParam('media_filter_html', true);
 };
 
-const getUrlResolver = function (editor) {
+const getUrlResolver = (editor) => {
   return editor.getParam('media_url_resolver');
 };
 
-const hasAltSource = function (editor) {
+const hasAltSource = (editor) => {
   return editor.getParam('media_alt_source', true);
 };
 
-const hasPoster = function (editor) {
+const hasPoster = (editor) => {
   return editor.getParam('media_poster', true);
 };
 
-const hasDimensions = function (editor) {
+const hasDimensions = (editor) => {
   return editor.getParam('media_dimensions', true);
 };
 

--- a/modules/tinymce/src/plugins/media/main/ts/core/DataToHtml.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/DataToHtml.ts
@@ -17,12 +17,12 @@ import * as VideoScript from './VideoScript';
 
 export type DataToHtmlCallback = (data: MediaData) => string;
 
-const getIframeHtml = function (data: MediaData) {
+const getIframeHtml = (data: MediaData) => {
   const allowFullscreen = data.allowFullscreen ? ' allowFullscreen="1"' : '';
   return '<iframe src="' + data.source + '" width="' + data.width + '" height="' + data.height + '"' + allowFullscreen + '></iframe>';
 };
 
-const getFlashHtml = function (data: MediaData) {
+const getFlashHtml = (data: MediaData) => {
   let html = '<object data="' + data.source + '" width="' + data.width + '" height="' + data.height + '" type="application/x-shockwave-flash">';
 
   if (data.poster) {
@@ -34,7 +34,7 @@ const getFlashHtml = function (data: MediaData) {
   return html;
 };
 
-const getAudioHtml = function (data: MediaData, audioTemplateCallback: DataToHtmlCallback) {
+const getAudioHtml = (data: MediaData, audioTemplateCallback: DataToHtmlCallback) => {
   if (audioTemplateCallback) {
     return audioTemplateCallback(data);
   } else {
@@ -50,7 +50,7 @@ const getAudioHtml = function (data: MediaData, audioTemplateCallback: DataToHtm
   }
 };
 
-const getVideoHtml = function (data: MediaData, videoTemplateCallback: DataToHtmlCallback) {
+const getVideoHtml = (data: MediaData, videoTemplateCallback: DataToHtmlCallback) => {
   if (videoTemplateCallback) {
     return videoTemplateCallback(data);
   } else {
@@ -67,11 +67,11 @@ const getVideoHtml = function (data: MediaData, videoTemplateCallback: DataToHtm
   }
 };
 
-const getScriptHtml = function (data: MediaData) {
+const getScriptHtml = (data: MediaData) => {
   return '<script src="' + data.source + '"></script>';
 };
 
-const dataToHtml = function (editor: Editor, dataIn: MediaData) {
+const dataToHtml = (editor: Editor, dataIn: MediaData) => {
   const data: MediaData = Tools.extend({}, dataIn);
 
   if (!data.source) {

--- a/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
@@ -13,7 +13,7 @@ import * as Sanitize from './Sanitize';
 
 declare let unescape: any;
 
-const setup = function (editor: Editor) {
+const setup = (editor: Editor) => {
   editor.on('preInit', () => {
     // Make sure that any messy HTML is retained inside these
     const specialElements = editor.schema.getSpecialElements();

--- a/modules/tinymce/src/plugins/media/main/ts/core/HtmlToData.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/HtmlToData.ts
@@ -38,7 +38,7 @@ const htmlToData = (prefixes: VideoScript[], html: string): MediaData => {
   SaxParser({
     validate: false,
     allow_conditional_comments: true,
-    start(name, attrs) {
+    start: (name, attrs) => {
       if (isEphoxEmbed.get()) {
         // Ignore any child elements if handling an EME embed
       } else if (Obj.has(attrs.map, 'data-ephox-embed-iri')) {

--- a/modules/tinymce/src/plugins/media/main/ts/core/Mime.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Mime.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const guess = function (url: string): string {
+const guess = (url: string): string => {
   const mimes = {
     mp3: 'audio/mpeg',
     m4a: 'audio/x-m4a',

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -126,7 +126,7 @@ const createPreviewNode = (editor: Editor, node: AstNode) => {
   return previewWrapper;
 };
 
-const retainAttributesAndInnerHtml = function (editor: Editor, sourceNode: AstNode, targetNode: AstNode) {
+const retainAttributesAndInnerHtml = (editor: Editor, sourceNode: AstNode, targetNode: AstNode) => {
   // Prefix all attributes except width, height and style since we
   // will add these to the placeholder
   const attribs = sourceNode.attributes;
@@ -158,7 +158,7 @@ const isPageEmbedWrapper = (node: AstNode) => {
   return nodeClass && /\btiny-pageembed\b/.test(nodeClass);
 };
 
-const isWithinEmbedWrapper = function (node: AstNode) {
+const isWithinEmbedWrapper = (node: AstNode) => {
   while ((node = node.parent)) {
     if (node.attr('data-ephox-embed-iri') || isPageEmbedWrapper(node)) {
       return true;
@@ -168,8 +168,8 @@ const isWithinEmbedWrapper = function (node: AstNode) {
   return false;
 };
 
-const placeHolderConverter = function (editor: Editor) {
-  return function (nodes) {
+const placeHolderConverter = (editor: Editor) => {
+  return (nodes) => {
     let i = nodes.length;
     let node;
     let videoScript;

--- a/modules/tinymce/src/plugins/media/main/ts/core/ResolveName.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/ResolveName.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const setup = function (editor: Editor) {
+const setup = (editor: Editor) => {
   editor.on('ResolveName', (e) => {
     let name;
 

--- a/modules/tinymce/src/plugins/media/main/ts/core/Sanitize.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Sanitize.ts
@@ -11,7 +11,7 @@ import Schema from 'tinymce/core/api/html/Schema';
 import Writer from 'tinymce/core/api/html/Writer';
 import * as Settings from '../api/Settings';
 
-const sanitize = function (editor: Editor, html: string) {
+const sanitize = (editor: Editor, html: string) => {
   if (Settings.shouldFilterHtml(editor) === false) {
     return html;
   }
@@ -23,25 +23,25 @@ const sanitize = function (editor: Editor, html: string) {
     validate: false,
     allow_conditional_comments: false,
 
-    comment(text) {
+    comment: (text) => {
       if (!blocked) {
         writer.comment(text);
       }
     },
 
-    cdata(text) {
+    cdata: (text) => {
       if (!blocked) {
         writer.cdata(text);
       }
     },
 
-    text(text, raw) {
+    text: (text, raw) => {
       if (!blocked) {
         writer.text(text, raw);
       }
     },
 
-    start(name, attrs, empty) {
+    start: (name, attrs, empty) => {
       blocked = true;
 
       if (name === 'script' || name === 'noscript' || name === 'svg') {
@@ -65,7 +65,7 @@ const sanitize = function (editor: Editor, html: string) {
       blocked = false;
     },
 
-    end(name) {
+    end: (name) => {
       if (blocked) {
         return;
       }

--- a/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
@@ -12,9 +12,9 @@ import * as DataToHtml from './DataToHtml';
 import { MediaData } from './Types';
 
 const cache = {};
-const embedPromise = function (data: MediaData, dataToHtml: DataToHtml.DataToHtmlCallback, handler) {
+const embedPromise = (data: MediaData, dataToHtml: DataToHtml.DataToHtmlCallback, handler) => {
   return new Promise<{url: string; html: string}>((res, rej) => {
-    const wrappedResolve = function (response) {
+    const wrappedResolve = (response) => {
       if (response.html) {
         cache[data.source] = response;
       }
@@ -31,25 +31,25 @@ const embedPromise = function (data: MediaData, dataToHtml: DataToHtml.DataToHtm
   });
 };
 
-const defaultPromise = function (data: MediaData, dataToHtml: DataToHtml.DataToHtmlCallback) {
+const defaultPromise = (data: MediaData, dataToHtml: DataToHtml.DataToHtmlCallback) => {
   return new Promise<{url: string; html: string}>((res) => {
     res({ html: dataToHtml(data), url: data.source });
   });
 };
 
-const loadedData = function (editor: Editor) {
-  return function (data: MediaData) {
+const loadedData = (editor: Editor) => {
+  return (data: MediaData) => {
     return DataToHtml.dataToHtml(editor, data);
   };
 };
 
-const getEmbedHtml = function (editor: Editor, data: MediaData) {
+const getEmbedHtml = (editor: Editor, data: MediaData) => {
   const embedHandler = Settings.getUrlResolver(editor);
 
   return embedHandler ? embedPromise(data, loadedData(editor), embedHandler) : defaultPromise(data, loadedData(editor));
 };
 
-const isCached = function (url: string) {
+const isCached = (url: string) => {
   return cache.hasOwnProperty(url);
 };
 

--- a/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
@@ -70,19 +70,19 @@ const updateHtml = (html: string, data: Partial<MediaData>, updateAll?: boolean)
     validate: false,
     allow_conditional_comments: true,
 
-    comment(text) {
+    comment: (text) => {
       writer.comment(text);
     },
 
-    cdata(text) {
+    cdata: (text) => {
       writer.cdata(text);
     },
 
-    text(text, raw) {
+    text: (text, raw) => {
       writer.text(text, raw);
     },
 
-    start(name, attrs, empty) {
+    start: (name, attrs, empty) => {
       if (isEphoxEmbed.get()) {
         // Don't make any changes to children of an EME embed
       } else if (Obj.has(attrs.map, 'data-ephox-embed-iri')) {
@@ -153,7 +153,7 @@ const updateHtml = (html: string, data: Partial<MediaData>, updateAll?: boolean)
       writer.start(name, attrs, empty);
     },
 
-    end(name) {
+    end: (name) => {
       if (!isEphoxEmbed.get()) {
         if (name === 'video' && updateAll) {
           for (let index = 0; index < 2; index++) {

--- a/modules/tinymce/src/plugins/media/main/ts/core/VideoScript.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/VideoScript.ts
@@ -11,7 +11,7 @@ export interface VideoScript {
   height?: number;
 }
 
-const getVideoScriptMatch = function (prefixes: VideoScript[], src: string): VideoScript {
+const getVideoScriptMatch = (prefixes: VideoScript[], src: string): VideoScript => {
   // var prefixes = Settings.getScripts(editor);
   if (prefixes) {
     for (let i = 0; i < prefixes.length; i++) {

--- a/modules/tinymce/src/plugins/media/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/ui/Buttons.ts
@@ -11,7 +11,7 @@ import { Toolbar } from 'tinymce/core/api/ui/Ui';
 const stateSelectorAdapter = (editor: Editor, selector: string[]) => (buttonApi: Toolbar.ToolbarToggleButtonInstanceApi) =>
   editor.selection.selectorChangedWithUnbind(selector.join(','), buttonApi.setActive).unbind;
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addToggleButton('media', {
     tooltip: 'Insert/edit media',
     icon: 'embed',

--- a/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
@@ -81,8 +81,8 @@ const wrap = (data: MediaData): MediaDialogData => {
   return wrapped;
 };
 
-const handleError = function (editor: Editor): (error?: { msg: string }) => void {
-  return function (error) {
+const handleError = (editor: Editor): (error?: { msg: string }) => void => {
+  return (error) => {
     const errorMessage = error && error.msg ?
       'Media embed handler error: ' + error.msg :
       'Media embed handler threw unknown error.';
@@ -94,7 +94,7 @@ const snippetToData = (editor: Editor, embedSnippet: string): MediaData => HtmlT
 
 const isMediaElement = (element: Element) => element.getAttribute('data-mce-object') || element.getAttribute('data-ephox-embed-iri');
 
-const getEditorData = function (editor: Editor): MediaData {
+const getEditorData = (editor: Editor): MediaData => {
   const element = editor.selection.getNode();
   const snippet = isMediaElement(element) ? editor.serializer.serialize(element, { selection: true }) : '';
   return {
@@ -103,8 +103,8 @@ const getEditorData = function (editor: Editor): MediaData {
   };
 };
 
-const addEmbedHtml = function (api: Dialog.DialogInstanceApi<MediaDialogData>, editor: Editor) {
-  return function (response: { url: string; html: string }) {
+const addEmbedHtml = (api: Dialog.DialogInstanceApi<MediaDialogData>, editor: Editor) => {
+  return (response: { url: string; html: string }) => {
     // Only set values if a URL has been defined
     if (Type.isString(response.url) && response.url.trim().length > 0) {
       const html = response.html;
@@ -120,7 +120,7 @@ const addEmbedHtml = function (api: Dialog.DialogInstanceApi<MediaDialogData>, e
   };
 };
 
-const selectPlaceholder = function (editor: Editor, beforeObjects: HTMLElement[]) {
+const selectPlaceholder = (editor: Editor, beforeObjects: HTMLElement[]) => {
   const afterObjects = editor.dom.select('*[data-mce-object]');
 
   // Find new image placeholder so we can select it
@@ -135,7 +135,7 @@ const selectPlaceholder = function (editor: Editor, beforeObjects: HTMLElement[]
   editor.selection.select(afterObjects[0]);
 };
 
-const handleInsert = function (editor: Editor, html: string) {
+const handleInsert = (editor: Editor, html: string) => {
   const beforeObjects = editor.dom.select('*[data-mce-object]');
 
   editor.insertContent(html);
@@ -143,7 +143,7 @@ const handleInsert = function (editor: Editor, html: string) {
   editor.nodeChanged();
 };
 
-const submitForm = function (prevData: MediaData, newData: MediaData, editor: Editor) {
+const submitForm = (prevData: MediaData, newData: MediaData, editor: Editor) => {
   newData.embed = UpdateHtml.updateHtml(newData.embed, newData);
 
   // Only fetch the embed HTML content if the URL has changed from what it previously was
@@ -157,7 +157,7 @@ const submitForm = function (prevData: MediaData, newData: MediaData, editor: Ed
   }
 };
 
-const showDialog = function (editor: Editor) {
+const showDialog = (editor: Editor) => {
   const editorData = getEditorData(editor);
   const currentData = Cell<MediaData>(editorData);
   const initialData = wrap(editorData);
@@ -279,12 +279,12 @@ const showDialog = function (editor: Editor) {
         primary: true
       }
     ],
-    onSubmit(api) {
+    onSubmit: (api) => {
       const serviceData = unwrap(api.getData());
       submitForm(currentData.get(), serviceData, editor);
       api.close();
     },
-    onChange(api, detail) {
+    onChange: (api, detail) => {
       switch (detail.name) {
         case 'source':
           handleSource(currentData.get(), api);

--- a/modules/tinymce/src/plugins/media/test/ts/atomic/HtmlToDataTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/atomic/HtmlToDataTest.ts
@@ -2,7 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import * as HtmlToData from 'tinymce/plugins/media/core/HtmlToData';
 
 UnitTest.test('atomic.tinymce.plugins.media.core.HtmlToDataTest', () => {
-  const testHtmlToData = function (html, expected) {
+  const testHtmlToData = (html, expected) => {
     const actual = HtmlToData.htmlToData([], html);
     Assert.eq('Assert equal', expected, actual);
   };

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -144,10 +144,10 @@ UnitTest.asynctest('browser.tinymce.plugins.media.ContentFormatsTest', (success,
   });
 
   suite.test('TestCase-TBA: Media: XSS content', (editor) => {
-    function testXss(input, expectedOutput) {
+    const testXss = (input, expectedOutput) => {
       editor.setContent(input);
       LegacyUnit.equal(editor.getContent(), expectedOutput);
-    }
+    };
 
     testXss('<video><a href="javascript:alert(1);">a</a></video>', '<p><video width="300" height="150"><a>a</a></video></p>');
     testXss('<video><img src="x" onload="alert(1)"></video>', '<p><video width="300" height=\"150\"><img src="x" /></video></p>');

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
@@ -12,7 +12,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.DataAttributeTest', (success, 
   Plugin();
   Theme();
 
-  const sTestEmbedContentFromUrlWithAttribute = function (editor: Editor, api: TinyApis, ui: TinyUi, url: string, content: string) {
+  const sTestEmbedContentFromUrlWithAttribute = (editor: Editor, api: TinyApis, ui: TinyUi, url: string, content: string) => {
     return Logger.t(`Assert embeded ${content} from ${url} with attribute`, GeneralSteps.sequence([
       api.sSetContent(''),
       Utils.sOpenDialog(ui),
@@ -24,7 +24,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.DataAttributeTest', (success, 
       Utils.sCloseDialog(ui)
     ]));
   };
-  const sTestEmbedContentFromUrl2 = function (editor: Editor, api: TinyApis, ui: TinyUi, url: string, url2: string, content: string, content2: string) {
+  const sTestEmbedContentFromUrl2 = (editor: Editor, api: TinyApis, ui: TinyUi, url: string, url2: string, content: string, content2: string) => {
     return Logger.t(`Assert embeded ${content} from ${url} and ${content2} from ${url2}`, GeneralSteps.sequence([
       api.sSetContent(''),
       Utils.sOpenDialog(ui),
@@ -65,7 +65,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.DataAttributeTest', (success, 
     plugins: [ 'media' ],
     toolbar: 'media',
     theme: 'silver',
-    media_url_resolver(data, resolve) {
+    media_url_resolver: (data, resolve) => {
       resolve({ html: '<div data-ephox-embed-iri="' + data.url + '" style="max-width: 300px; max-height: 150px"></div>' });
     },
     base_url: '/project/tinymce/js/tinymce'

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
@@ -11,7 +11,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.core.DataToHtmlTest', (success
   Plugin();
   Theme();
 
-  const sTestDataToHtml = function (editor, data, expected) {
+  const sTestDataToHtml = (editor, data, expected) => {
     const actual = SugarElement.fromHtml(DataToHtml.dataToHtml(editor, data));
 
     return Logger.t(`Test html data ${expected}`, Waiter.sTryUntil('Wait for structure check',

--- a/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
@@ -33,7 +33,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.core.EphoxEmbedTest', (success
     });
   });
 
-  const sAssertDivStructure = function (editor: Editor, expected: StructAssert) {
+  const sAssertDivStructure = (editor: Editor, expected: StructAssert) => {
     return Logger.t(`Assert div structure ${expected}`, Step.sync(() => {
       const div = editor.dom.select('div')[0];
       const actual = div ? SugarElement.fromHtml(div.outerHTML) : SugarElement.fromHtml('');
@@ -64,7 +64,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.core.EphoxEmbedTest', (success
     plugins: 'media',
     toolbar: 'media',
     theme: 'silver',
-    media_url_resolver(data, resolve) {
+    media_url_resolver: (data, resolve) => {
       resolve({
         html: '<video width="300" height="150" ' +
           'controls="controls">\n<source src="' + data.url + '" />\n</video>'

--- a/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
@@ -12,7 +12,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.IsCachedResponseTest', (succes
   Theme();
   MediaPlugin();
 
-  const sWaitForAndAssertNotification = function (expected: string) {
+  const sWaitForAndAssertNotification = (expected: string) => {
     return Chain.asStep(TinyDom.fromDom(document.body), [
       UiFinder.cWaitFor('Could not find notification', 'div.tox-notification__body'),
       Chain.mapper(Html.get),
@@ -57,7 +57,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.IsCachedResponseTest', (succes
     toolbar: 'media',
     theme: 'silver',
     base_url: '/project/tinymce/js/tinymce',
-    media_url_resolver(data, resolve, reject) {
+    media_url_resolver: (data, resolve, reject) => {
       if (data.url === 'test') {
         resolve({
           html: '<div>x</div>' });

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
@@ -38,7 +38,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.core.MediaEmbedTest', (success
     plugins: [ 'media' ],
     toolbar: 'media',
     theme: 'silver',
-    media_url_resolver(data, resolve) {
+    media_url_resolver: (data, resolve) => {
       resolve({
         html: '<video width="300" height="150" ' +
           'controls="controls">\n<source src="' + data.url + '" />\n</video>'

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ReopenResizeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ReopenResizeTest.ts
@@ -12,13 +12,13 @@ UnitTest.asynctest('browser.tinymce.plugins.media.ReopenResizeTest', (success, f
   Plugin();
   Theme();
 
-  const sWaitForResizeHandles = function (editor: Editor) {
+  const sWaitForResizeHandles = (editor: Editor) => {
     return Waiter.sTryUntil('Wait for new width value', Step.sync(() => {
       Assert.eq('Resize handle should exist', editor.dom.select('#mceResizeHandlenw').length, 1);
     }));
   };
 
-  const sRawAssertImagePresence = function (editor: Editor) {
+  const sRawAssertImagePresence = (editor: Editor) => {
     // Hacky way to assert that the placeholder image is in
     // the correct place that works cross browser
     // assertContentStructure did not work because some

--- a/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
@@ -70,7 +70,7 @@ UnitTest.asynctest('browser.tinymce.plugins.media.core.SubmitTest', (success, fa
     plugins: [ 'media' ],
     toolbar: 'media',
     theme: 'silver',
-    media_url_resolver(data, resolve) {
+    media_url_resolver: (data, resolve) => {
       Delay.setTimeout(() => {
         resolve({
           html: '<span id="fake">' + data.url + '</span>'

--- a/modules/tinymce/src/plugins/media/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/module/test/Utils.ts
@@ -17,7 +17,7 @@ const selectors = {
   poster: 'label:contains(Media poster (Image URL)) + div.tox-form__controls-h-stack input.tox-textfield'
 };
 
-const sOpenDialog = function (ui: TinyUi) {
+const sOpenDialog = (ui: TinyUi) => {
   return Logger.t('Open dialog', GeneralSteps.sequence([
     ui.sClickOnToolbar('Click on media button, there should be only 1 button in the toolbar', 'div.tox-toolbar__group > button'),
     ui.sWaitForPopup('wait for popup', 'div.tox-dialog-wrap')
@@ -69,21 +69,21 @@ const sSetValueAndTrigger = (selector: string, value: string, events: string[]) 
   ])
 ]));
 
-const sPasteSourceValue = function (ui: TinyUi, value: string) {
+const sPasteSourceValue = (ui: TinyUi, value: string) => {
   return sSetValueAndTrigger(selectors.source, value, [ 'paste' ])(ui);
 };
 
 const sPastePosterValue = (ui: TinyUi, value: string) => sSetValueAndTrigger(selectors.poster, value, [ 'paste' ])(ui);
 
-const sChangeWidthValue = function (ui: TinyUi, value: string) {
+const sChangeWidthValue = (ui: TinyUi, value: string) => {
   return sSetValueAndTrigger(selectors.width, value, [ 'input', 'change' ])(ui);
 };
 
-const sChangeHeightValue = function (ui: TinyUi, value: string) {
+const sChangeHeightValue = (ui: TinyUi, value: string) => {
   return sSetValueAndTrigger(selectors.height, value, [ 'input', 'change' ])(ui);
 };
 
-const sAssertSizeRecalcConstrained = function (ui: TinyUi) {
+const sAssertSizeRecalcConstrained = (ui: TinyUi) => {
   return Logger.t('Asset constrained size recalculation', GeneralSteps.sequence([
     sOpenDialog(ui),
     sPasteSourceValue(ui, 'http://test.se'),
@@ -96,7 +96,7 @@ const sAssertSizeRecalcConstrained = function (ui: TinyUi) {
   ]));
 };
 
-const sAssertSizeRecalcConstrainedReopen = function (ui: TinyUi) {
+const sAssertSizeRecalcConstrainedReopen = (ui: TinyUi) => {
   return Logger.t('Assert constrained size recalculation on dialog reopen', GeneralSteps.sequence([
     sOpenDialog(ui),
     sPasteSourceValue(ui, 'http://test.se'),
@@ -113,7 +113,7 @@ const sAssertSizeRecalcConstrainedReopen = function (ui: TinyUi) {
   ]));
 };
 
-const sAssertSizeRecalcUnconstrained = function (ui: TinyUi) {
+const sAssertSizeRecalcUnconstrained = (ui: TinyUi) => {
   return Logger.t('Assert unconstrained size recalculation', GeneralSteps.sequence([
     sOpenDialog(ui),
     sPasteSourceValue(ui, 'http://test.se'),
@@ -127,11 +127,11 @@ const sAssertSizeRecalcUnconstrained = function (ui: TinyUi) {
   ]));
 };
 
-const sCloseDialog = function (ui: TinyUi) {
+const sCloseDialog = (ui: TinyUi) => {
   return Logger.t('Close dialog', ui.sClickOnUi('Click cancel button', selectors.xClose));
 };
 
-const cFakeEvent = function (name: string) {
+const cFakeEvent = (name: string) => {
   return Chain.control(
     Chain.op((elm: SugarElement) => {
       const element: HTMLElement = elm.dom;
@@ -156,7 +156,7 @@ const cFindFilepickerInput = cFindInDialog(selectors.source);
 
 const cFindTextarea = cFindInDialog(selectors.embed);
 
-const cSetSourceInput = function (ui: TinyUi, value: string) {
+const cSetSourceInput = (ui: TinyUi, value: string) => {
   return Chain.control(
     Chain.fromChains([
       cFindFilepickerInput(ui),
@@ -166,7 +166,7 @@ const cSetSourceInput = function (ui: TinyUi, value: string) {
   );
 };
 
-const sPasteTextareaValue = function (ui: TinyUi, value: string) {
+const sPasteTextareaValue = (ui: TinyUi, value: string) => {
   return Logger.t(`Paste text area ${value}`, Chain.asStep({}, [
     Chain.fromChains([
       cFindInDialog(selectors.embedButton)(ui),
@@ -180,7 +180,7 @@ const sPasteTextareaValue = function (ui: TinyUi, value: string) {
   ]));
 };
 
-const sAssertEmbedData = function (ui: TinyUi, content: string) {
+const sAssertEmbedData = (ui: TinyUi, content: string) => {
   return GeneralSteps.sequence([
     ui.sClickOnUi('Switch to Embed tab', '.tox-tab:contains("Embed")'),
     Waiter.sTryUntil('Textarea should have a proper value',
@@ -193,7 +193,7 @@ const sAssertEmbedData = function (ui: TinyUi, content: string) {
   ]);
 };
 
-const sTestEmbedContentFromUrl = function (apis: TinyApis, ui: TinyUi, url: string, content: string) {
+const sTestEmbedContentFromUrl = (apis: TinyApis, ui: TinyUi, url: string, content: string) => {
   return Logger.t(`Assert embed ${content} from ${url}`, GeneralSteps.sequence([
     apis.sSetContent(''),
     sOpenDialog(ui),
@@ -203,13 +203,13 @@ const sTestEmbedContentFromUrl = function (apis: TinyApis, ui: TinyUi, url: stri
   ]));
 };
 
-const sSetFormItemNoEvent = function (ui: TinyUi, value: string) {
+const sSetFormItemNoEvent = (ui: TinyUi, value: string) => {
   return Logger.t(`Set form item ${value}`, Chain.asStep({}, [
     cSetSourceInput(ui, value)
   ]));
 };
 
-const sAssertEditorContent = function (apis: TinyApis, editor: Editor, expected: string) {
+const sAssertEditorContent = (apis: TinyApis, editor: Editor, expected: string) => {
   return Waiter.sTryUntil('Wait for editor value',
     Chain.asStep({}, [
       apis.cGetContent(),
@@ -218,18 +218,18 @@ const sAssertEditorContent = function (apis: TinyApis, editor: Editor, expected:
   );
 };
 
-const sSubmitDialog = function (ui: TinyUi) {
+const sSubmitDialog = (ui: TinyUi) => {
   return Logger.t('Submit dialog', ui.sClickOnUi('Click submit button', selectors.saveButton));
 };
 
-const sSubmitAndReopen = function (ui: TinyUi) {
+const sSubmitAndReopen = (ui: TinyUi) => {
   return Logger.t('Submit and reopen dialog', GeneralSteps.sequence([
     sSubmitDialog(ui),
     sOpenDialog(ui)
   ]));
 };
 
-const sSetSetting = function (editorSetting: Record<string, any>, key: string, value: any) {
+const sSetSetting = (editorSetting: Record<string, any>, key: string, value: any) => {
   return Logger.t(`Set setting ${key}: ${value}`, Step.sync(() => {
     editorSetting[key] = value;
   }));

--- a/modules/tinymce/src/plugins/nonbreaking/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/main/ts/Plugin.ts
@@ -17,10 +17,10 @@ import * as Buttons from './ui/Buttons';
  * @private
  */
 
-export default function () {
+export default () => {
   PluginManager.add('nonbreaking', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
     Keyboard.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/nonbreaking/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import * as Actions from '../core/Actions';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('mceNonBreaking', () => {
     Actions.insertNbsp(editor, 1);
   });

--- a/modules/tinymce/src/plugins/nonbreaking/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/main/ts/api/Settings.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getKeyboardSpaces = function (editor: Editor) {
+const getKeyboardSpaces = (editor: Editor) => {
   const spaces = editor.getParam('nonbreaking_force_tab', 0);
 
   if (typeof spaces === 'boolean') {
@@ -17,7 +17,7 @@ const getKeyboardSpaces = function (editor: Editor) {
   }
 };
 
-const wrapNbsps = function (editor: Editor) {
+const wrapNbsps = (editor: Editor) => {
   return editor.getParam('nonbreaking_wrap', true, 'boolean');
 };
 

--- a/modules/tinymce/src/plugins/nonbreaking/main/ts/core/Keyboard.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/main/ts/core/Keyboard.ts
@@ -9,7 +9,7 @@ import VK from 'tinymce/core/api/util/VK';
 import * as Settings from '../api/Settings';
 import * as Actions from './Actions';
 
-const setup = function (editor) {
+const setup = (editor) => {
   const spaces = Settings.getKeyboardSpaces(editor);
 
   if (spaces > 0) {

--- a/modules/tinymce/src/plugins/nonbreaking/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('nonbreaking', {
     icon: 'non-breaking',
     tooltip: 'Nonbreaking space',

--- a/modules/tinymce/src/plugins/noneditable/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/noneditable/main/ts/Plugin.ts
@@ -8,8 +8,8 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 import * as FilterContent from './core/FilterContent';
 
-export default function () {
+export default () => {
   PluginManager.add('noneditable', (editor) => {
     FilterContent.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/Plugin.ts
@@ -11,11 +11,11 @@ import * as FilterContent from './core/FilterContent';
 import * as ResolveName from './core/ResolveName';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('pagebreak', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
     FilterContent.setup(editor);
     ResolveName.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
@@ -8,15 +8,13 @@
 import Env from 'tinymce/core/api/Env';
 import * as Settings from '../api/Settings';
 
-const getPageBreakClass = function () {
-  return 'mce-pagebreak';
-};
+const getPageBreakClass = () => 'mce-pagebreak';
 
-const getPlaceholderHtml = function () {
+const getPlaceholderHtml = () => {
   return '<img src="' + Env.transparentSrc + '" class="' + getPageBreakClass() + '" data-mce-resize="false" data-mce-placeholder />';
 };
 
-const setup = function (editor) {
+const setup = (editor) => {
   const separatorHtml = Settings.getSeparatorHtml(editor);
 
   const pageBreakSeparatorRegExp = new RegExp(separatorHtml.replace(/[\?\.\*\[\]\(\)\{\}\+\^\$\:]/g, (a) => {

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/core/ResolveName.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/core/ResolveName.ts
@@ -7,7 +7,7 @@
 
 import * as FilterContent from './FilterContent';
 
-const setup = function (editor) {
+const setup = (editor) => {
   editor.on('ResolveName', (e) => {
     if (e.target.nodeName === 'IMG' && editor.dom.hasClass(e.target, FilterContent.getPageBreakClass())) {
       e.name = 'pagebreak';

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('pagebreak', {
     icon: 'page-break',
     tooltip: 'Page break',

--- a/modules/tinymce/src/plugins/paste/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/paste/demo/ts/demo/Demo.ts
@@ -7,7 +7,7 @@ tinymce.init({
   skin_url: '../../../../../js/tinymce/skins/ui/oxide',
   plugins: 'paste code',
   toolbar: 'undo redo | pastetext code',
-  init_instance_callback(editor) {
+  init_instance_callback: (editor) => {
     editor.on('PastePreProcess', (evt) => {
       console.log(evt);
     });

--- a/modules/tinymce/src/plugins/paste/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/Plugin.ts
@@ -18,7 +18,7 @@ import * as PrePostProcess from './core/PrePostProcess';
 import * as Quirks from './core/Quirks';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('paste', (editor) => {
     if (DetectProPlugin.hasProPlugin(editor) === false) {
       const draggingInternallyState = Cell(false);
@@ -35,4 +35,4 @@ export default function () {
       return Api.get(clipboard, quirks);
     }
   });
-}
+};

--- a/modules/tinymce/src/plugins/paste/main/ts/alien/DetectProPlugin.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/alien/DetectProPlugin.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const hasProPlugin = function (editor: Editor) {
+const hasProPlugin = (editor: Editor) => {
   // draw back if power version is requested and registered
   if (editor.hasPlugin('powerpaste', true)) {
     if (typeof window.console !== 'undefined' && window.console.log) {

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Api.ts
@@ -7,7 +7,7 @@
 
 import { Clipboard } from './Clipboard';
 
-const get = function (clipboard: Clipboard, quirks) {
+const get = (clipboard: Clipboard, quirks) => {
   return {
     clipboard,
     quirks

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Commands.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Actions from '../core/Actions';
 import { Clipboard } from './Clipboard';
 
-const register = function (editor: Editor, clipboard: Clipboard) {
+const register = (editor: Editor, clipboard: Clipboard) => {
   editor.addCommand('mceTogglePlainTextPaste', () => {
     Actions.togglePlainTextPaste(editor, clipboard);
   });

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Events.ts
@@ -7,19 +7,19 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const firePastePreProcess = function (editor: Editor, html: string, internal: boolean, isWordHtml: boolean) {
+const firePastePreProcess = (editor: Editor, html: string, internal: boolean, isWordHtml: boolean) => {
   return editor.fire('PastePreProcess', { content: html, internal, wordContent: isWordHtml });
 };
 
-const firePastePostProcess = function (editor: Editor, node: HTMLElement, internal: boolean, isWordHtml: boolean) {
+const firePastePostProcess = (editor: Editor, node: HTMLElement, internal: boolean, isWordHtml: boolean) => {
   return editor.fire('PastePostProcess', { node, internal, wordContent: isWordHtml });
 };
 
-const firePastePlainTextToggle = function (editor: Editor, state: boolean) {
+const firePastePlainTextToggle = (editor: Editor, state: boolean) => {
   return editor.fire('PastePlainTextToggle', { state });
 };
 
-const firePaste = function (editor: Editor, ieFake: boolean) {
+const firePaste = (editor: Editor, ieFake: boolean) => {
   // Casting this as it only exists for IE compatibility
   return editor.fire('paste', { ieFake } as any as ClipboardEvent);
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Actions.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { Clipboard } from '../api/Clipboard';
 import * as Events from '../api/Events';
 
-const togglePlainTextPaste = function (editor: Editor, clipboard: Clipboard) {
+const togglePlainTextPaste = (editor: Editor, clipboard: Clipboard) => {
   if (clipboard.pasteFormat.get() === 'text') {
     clipboard.pasteFormat.set('html');
     Events.firePastePlainTextToggle(editor, false);

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -302,7 +302,7 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
     }
   });
 
-  function insertClipboardContent(editor: Editor, clipboardContent: ClipboardContents, isKeyBoardPaste: boolean, plainTextMode: boolean, internal: boolean) {
+  const insertClipboardContent = (editor: Editor, clipboardContent: ClipboardContents, isKeyBoardPaste: boolean, plainTextMode: boolean, internal: boolean) => {
     let content;
 
     // Grab HTML from Clipboard API or paste bin as a fallback
@@ -358,9 +358,9 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
     } else {
       pasteHtml(editor, content, internal);
     }
-  }
+  };
 
-  const getLastRng = function () {
+  const getLastRng = () => {
     return pasteBin.getLastRng() || editor.selection.getRng();
   };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/DragDrop.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/DragDrop.ts
@@ -14,21 +14,21 @@ import { ClipboardContents } from './Clipboard';
 import * as InternalHtml from './InternalHtml';
 import * as Utils from './Utils';
 
-const getCaretRangeFromEvent = function (editor: Editor, e: MouseEvent) {
+const getCaretRangeFromEvent = (editor: Editor, e: MouseEvent) => {
   return RangeUtils.getCaretRangeFromPoint(e.clientX, e.clientY, editor.getDoc());
 };
 
-const isPlainTextFileUrl = function (content: ClipboardContents) {
+const isPlainTextFileUrl = (content: ClipboardContents) => {
   const plainTextContent = content['text/plain'];
   return plainTextContent ? plainTextContent.indexOf('file://') === 0 : false;
 };
 
-const setFocusedRange = function (editor: Editor, rng: Range) {
+const setFocusedRange = (editor: Editor, rng: Range) => {
   editor.focus();
   editor.selection.setRng(rng);
 };
 
-const setup = function (editor: Editor, clipboard: Clipboard, draggingInternallyState) {
+const setup = (editor: Editor, clipboard: Clipboard, draggingInternallyState) => {
   // Block all drag/drop events
   if (Settings.shouldBlockDrop(editor)) {
     editor.on('dragend dragover draggesture dragdrop drop drag', (e) => {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/FragmentParser.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/FragmentParser.ts
@@ -7,28 +7,28 @@
 
 const validContext = /^(p|h[1-6]|li)$/;
 
-const findStartTokenIndex = function (regexp: RegExp, html: string) {
+const findStartTokenIndex = (regexp: RegExp, html: string) => {
   const matches = regexp.exec(html);
   return matches ? matches.index + matches[0].length : -1;
 };
 
-const findEndTokenIndex = function (regexp: RegExp, html: string) {
+const findEndTokenIndex = (regexp: RegExp, html: string) => {
   const matches = regexp.exec(html);
   return matches ? matches.index : -1;
 };
 
-const unwrap = function (startRe: RegExp, endRe: RegExp, html: string) {
+const unwrap = (startRe: RegExp, endRe: RegExp, html: string) => {
   const startIndex = findStartTokenIndex(startRe, html);
   const endIndex = findEndTokenIndex(endRe, html);
   return startIndex !== -1 && endIndex !== -1 ? html.substring(startIndex, endIndex) : html;
 };
 
-const parseContext = function (html: string) {
+const parseContext = (html: string) => {
   const matches = /<\/([^>]+)>/g.exec(html);
   return matches ? matches[1].toLowerCase() : 'body';
 };
 
-const getFragmentInfo = function (html: string) {
+const getFragmentInfo = (html: string) => {
   const startIndex = findStartTokenIndex(/<!--\s*StartFragment\s*-->/g, html);
   const endIndex = findEndTokenIndex(/<!--\s*EndFragment\s*-->/g, html);
 
@@ -42,13 +42,13 @@ const getFragmentInfo = function (html: string) {
   }
 };
 
-const unwrapHtml = function (html: string) {
+const unwrapHtml = (html: string) => {
   return unwrap(/<body[^>]*>/gi, /<\/body>/gi,
     unwrap(/<!--\s*StartFragment\s*-->/g, /<!--\s*EndFragment\s*-->/g, html)
   );
 };
 
-const getFragmentHtml = function (html: string) {
+const getFragmentHtml = (html: string) => {
   const fragmentInfo = getFragmentInfo(html);
   return validContext.test(fragmentInfo.context) ? unwrapHtml(fragmentInfo.html) : unwrapHtml(html);
 };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/InternalHtml.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/InternalHtml.ts
@@ -8,15 +8,15 @@
 const internalMimeType = 'x-tinymce/html';
 const internalMark = '<!-- ' + internalMimeType + ' -->';
 
-const mark = function (html: string) {
+const mark = (html: string) => {
   return internalMark + html;
 };
 
-const unmark = function (html: string) {
+const unmark = (html: string) => {
   return html.replace(internalMark, '');
 };
 
-const isMarked = function (html: string) {
+const isMarked = (html: string) => {
   return html.indexOf(internalMark) !== -1;
 };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Newlines.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Newlines.ts
@@ -17,18 +17,18 @@ export interface RootAttrs {[key: string]: string }
  * @private
  */
 
-const isPlainText = function (text: string) {
+const isPlainText = (text: string) => {
   // so basically any tag that is not one of the "p, div, span, br", or is one of them, but is followed
   // by some additional characters qualifies the text as not a plain text (having some HTML tags)
   // <span style="white-space:pre"> and <br /> are added as separate exceptions to the rule
   return !/<(?:\/?(?!(?:div|p|br|span)>)\w+|(?:(?!(?:span style="white-space:\s?pre;?">)|br\s?\/>))\w+\s[^>]+)>/i.test(text);
 };
 
-const toBRs = function (text: string) {
+const toBRs = (text: string) => {
   return text.replace(/\r?\n/g, '<br>');
 };
 
-const openContainer = function (rootTag: string, rootAttrs: RootAttrs) {
+const openContainer = (rootTag: string, rootAttrs: RootAttrs) => {
   let key;
   const attrs = [];
   let tag = '<' + rootTag;
@@ -47,7 +47,7 @@ const openContainer = function (rootTag: string, rootAttrs: RootAttrs) {
   return tag + '>';
 };
 
-const toBlockElements = function (text: string, rootTag: string, rootAttrs: RootAttrs) {
+const toBlockElements = (text: string, rootTag: string, rootAttrs: RootAttrs) => {
   const blocks = text.split(/\n\n/);
   const tagOpen = openContainer(rootTag, rootAttrs);
   const tagClose = '</' + rootTag + '>';
@@ -56,14 +56,14 @@ const toBlockElements = function (text: string, rootTag: string, rootAttrs: Root
     return p.split(/\n/).join('<br />');
   });
 
-  const stitch = function (p) {
+  const stitch = (p) => {
     return tagOpen + p + tagClose;
   };
 
   return paragraphs.length === 1 ? paragraphs[0] : Tools.map(paragraphs, stitch).join('');
 };
 
-const convert = function (text: string, rootTag: string | boolean, rootAttrs: RootAttrs) {
+const convert = (text: string, rootTag: string | boolean, rootAttrs: RootAttrs) => {
   return rootTag ? toBlockElements(text, rootTag === true ? 'p' : rootTag, rootAttrs) : toBRs(text);
 };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/PasteBin.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/PasteBin.ts
@@ -97,7 +97,7 @@ const getHtml = (editor: Editor): string => {
   // for example: <img style="float: right"> we need to check if any of them contains some useful html.
   // TODO: Man o man is this ugly. WebKit is the new IE! Remove this if they ever fix it!
 
-  const copyAndRemove = function (toElm: HTMLElement, fromElm: HTMLElement) {
+  const copyAndRemove = (toElm: HTMLElement, fromElm: HTMLElement) => {
     toElm.appendChild(fromElm);
     editor.dom.remove(fromElm, true); // remove, but keep children
   };

--- a/modules/tinymce/src/plugins/paste/main/ts/core/PrePostProcess.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/PrePostProcess.ts
@@ -8,7 +8,7 @@
 import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../api/Settings';
 
-const setup = function (editor: Editor) {
+const setup = (editor: Editor) => {
   const plugin = editor.plugins.paste;
 
   const preProcess = Settings.getPreProcess(editor);

--- a/modules/tinymce/src/plugins/paste/main/ts/core/ProcessFilters.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/ProcessFilters.ts
@@ -27,17 +27,15 @@ const preProcess = (editor: Editor, html: string) => {
   return HtmlSerializer({ validate: Settings.getValidate(editor) }, editor.schema).serialize(fragment);
 };
 
-const processResult = function (content: string, cancelled: boolean) {
-  return { content, cancelled };
-};
+const processResult = (content: string, cancelled: boolean) => ({ content, cancelled });
 
-const postProcessFilter = function (editor: Editor, html: string, internal: boolean, isWordHtml: boolean) {
+const postProcessFilter = (editor: Editor, html: string, internal: boolean, isWordHtml: boolean) => {
   const tempBody = editor.dom.create('div', { style: 'display:none' }, html);
   const postProcessArgs = Events.firePastePostProcess(editor, tempBody, internal, isWordHtml);
   return processResult(postProcessArgs.node.innerHTML, postProcessArgs.isDefaultPrevented());
 };
 
-const filterContent = function (editor: Editor, content: string, internal: boolean, isWordHtml: boolean) {
+const filterContent = (editor: Editor, content: string, internal: boolean, isWordHtml: boolean) => {
   const preProcessArgs = Events.firePastePreProcess(editor, content, internal, isWordHtml);
 
   // Filter the content to remove potentially dangerous content (eg scripts)
@@ -50,7 +48,7 @@ const filterContent = function (editor: Editor, content: string, internal: boole
   }
 };
 
-const process = function (editor: Editor, html: string, internal: boolean) {
+const process = (editor: Editor, html: string, internal: boolean) => {
   const isWordHtml = WordFilter.isWordContent(html);
   const content = isWordHtml ? WordFilter.preProcess(editor, html) : html;
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Quirks.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Quirks.ts
@@ -21,17 +21,17 @@ import * as WordFilter from './WordFilter';
  * @private
  */
 
-function addPreProcessFilter(editor: Editor, filterFunc) {
+const addPreProcessFilter = (editor: Editor, filterFunc) => {
   editor.on('PastePreProcess', (e) => {
     e.content = filterFunc(editor, e.content, e.internal, e.wordContent);
   });
-}
+};
 
-function addPostProcessFilter(editor: Editor, filterFunc) {
+const addPostProcessFilter = (editor: Editor, filterFunc) => {
   editor.on('PastePostProcess', (e) => {
     filterFunc(editor, e.node);
   });
-}
+};
 
 /**
  * Removes BR elements after block elements. IE9 has a nasty bug where it puts a BR element after each
@@ -43,7 +43,7 @@ function addPostProcessFilter(editor: Editor, filterFunc) {
  * Becomes:
  *  <p>a</p><p>b</p>
  */
-function removeExplorerBrElementsAfterBlocks(editor: Editor, html: string) {
+const removeExplorerBrElementsAfterBlocks = (editor: Editor, html: string) => {
   // Only filter word specific content
   if (!WordFilter.isWordContent(html)) {
     return html;
@@ -74,7 +74,7 @@ function removeExplorerBrElementsAfterBlocks(editor: Editor, html: string) {
   ]);
 
   return html;
-}
+};
 
 /**
  * WebKit has a nasty bug where the all computed styles gets added to style attributes when copy/pasting contents.
@@ -85,7 +85,7 @@ function removeExplorerBrElementsAfterBlocks(editor: Editor, html: string) {
  *  paste_webkit_styles: "all", // Keep all of them
  *  paste_webkit_styles: "font-weight color" // Keep specific ones
  */
-function removeWebKitStyles(editor: Editor, content: string, internal: boolean, isWordHtml: boolean) {
+const removeWebKitStyles = (editor: Editor, content: string, internal: boolean, isWordHtml: boolean) => {
   // WordFilter has already processed styles at this point and internal doesn't need any processing
   if (isWordHtml || internal) {
     return content;
@@ -146,15 +146,15 @@ function removeWebKitStyles(editor: Editor, content: string, internal: boolean, 
   });
 
   return content;
-}
+};
 
-function removeUnderlineAndFontInAnchor(editor: Editor, root: Element) {
+const removeUnderlineAndFontInAnchor = (editor: Editor, root: Element) => {
   editor.$('a', root).find('font,u').each((i, node) => {
     editor.dom.remove(node, true);
   });
-}
+};
 
-const setup = function (editor: Editor) {
+const setup = (editor: Editor) => {
   if (Env.webkit) {
     addPreProcessFilter(editor, removeWebKitStyles);
   }

--- a/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
@@ -28,15 +28,15 @@ const pasteHtml = (editor: Editor, html: string) => {
  * @private
  */
 
-const isAbsoluteUrl = function (url: string) {
+const isAbsoluteUrl = (url: string) => {
   return /^https?:\/\/[\w\?\-\/+=.&%@~#]+$/i.test(url);
 };
 
-const isImageUrl = function (editor: Editor, url: string) {
+const isImageUrl = (editor: Editor, url: string) => {
   return isAbsoluteUrl(url) && Arr.exists(Settings.getAllowedImageFileTypes(editor), (type) => Strings.endsWith(url, `.${type}`));
 };
 
-const createImage = function (editor: Editor, url: string, pasteHtmlFn: typeof pasteHtml) {
+const createImage = (editor: Editor, url: string, pasteHtmlFn: typeof pasteHtml) => {
   editor.undoManager.extra(() => {
     pasteHtmlFn(editor, url);
   }, () => {
@@ -46,7 +46,7 @@ const createImage = function (editor: Editor, url: string, pasteHtmlFn: typeof p
   return true;
 };
 
-const createLink = function (editor: Editor, url: string, pasteHtmlFn: typeof pasteHtml) {
+const createLink = (editor: Editor, url: string, pasteHtmlFn: typeof pasteHtml) => {
   editor.undoManager.extra(() => {
     pasteHtmlFn(editor, url);
   }, () => {
@@ -56,15 +56,15 @@ const createLink = function (editor: Editor, url: string, pasteHtmlFn: typeof pa
   return true;
 };
 
-const linkSelection = function (editor: Editor, html: string, pasteHtmlFn: typeof pasteHtml) {
+const linkSelection = (editor: Editor, html: string, pasteHtmlFn: typeof pasteHtml) => {
   return editor.selection.isCollapsed() === false && isAbsoluteUrl(html) ? createLink(editor, html, pasteHtmlFn) : false;
 };
 
-const insertImage = function (editor: Editor, html: string, pasteHtmlFn: typeof pasteHtml) {
+const insertImage = (editor: Editor, html: string, pasteHtmlFn: typeof pasteHtml) => {
   return isImageUrl(editor, html) ? createImage(editor, html, pasteHtmlFn) : false;
 };
 
-const smartInsertContent = function (editor: Editor, html: string) {
+const smartInsertContent = (editor: Editor, html: string) => {
   Tools.each([
     linkSelection,
     insertImage,
@@ -74,7 +74,7 @@ const smartInsertContent = function (editor: Editor, html: string) {
   });
 };
 
-const insertContent = function (editor: Editor, html: string, pasteAsText: boolean) {
+const insertContent = (editor: Editor, html: string, pasteAsText: boolean) => {
   if (pasteAsText || Settings.isSmartPasteEnabled(editor) === false) {
     pasteHtml(editor, html);
   } else {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
@@ -16,7 +16,7 @@ import Tools from 'tinymce/core/api/util/Tools';
  * @class tinymce.pasteplugin.Utils
  */
 
-function filter(content, items) {
+const filter = (content, items) => {
   Tools.each(items, (v) => {
     if (v.constructor === RegExp) {
       content = content.replace(v, '');
@@ -26,7 +26,7 @@ function filter(content, items) {
   });
 
   return content;
-}
+};
 
 /**
  * Gets the innerText of the specified element. It will handle edge cases
@@ -35,7 +35,7 @@ function filter(content, items) {
  * @param {String} html HTML string to get text from.
  * @return {String} String of text with line feeds.
  */
-function innerText(html: string) {
+const innerText = (html: string) => {
   const schema = Schema();
   const domParser = DomParser({}, schema);
   let text = '';
@@ -43,7 +43,7 @@ function innerText(html: string) {
   const ignoreElements = Tools.makeMap('script noscript style textarea video audio iframe object', ' ');
   const blockElements = schema.getBlockElements();
 
-  function walk(node) {
+  const walk = (node) => {
     const name = node.name, currentNode = node;
 
     if (name === 'br') {
@@ -88,7 +88,7 @@ function innerText(html: string) {
         text += '\n';
       }
     }
-  }
+  };
 
   html = filter(html, [
     /<!\[[^\]]+\]>/g // Conditional comments
@@ -97,7 +97,7 @@ function innerText(html: string) {
   walk(domParser.parse(html));
 
   return text;
-}
+};
 
 /**
  * Trims the specified HTML by removing all WebKit fragments, all elements wrapping the body trailing BR elements etc.
@@ -105,8 +105,8 @@ function innerText(html: string) {
  * @param {String} html Html string to trim contents on.
  * @return {String} Html contents that got trimmed.
  */
-function trimHtml(html: string) {
-  function trimSpaces(all, s1, s2) {
+const trimHtml = (html: string) => {
+  const trimSpaces = (all, s1, s2) => {
     // WebKit &nbsp; meant to preserve multiple spaces but instead inserted around all inline tags,
     // including the spans with inline styles created on paste
     if (!s1 && !s2) {
@@ -114,7 +114,7 @@ function trimHtml(html: string) {
     }
 
     return Unicode.nbsp;
-  }
+  };
 
   html = filter(html, [
     /^[\s\S]*<body[^>]*>\s*|\s*<\/body[^>]*>[\s\S]*$/ig, // Remove anything but the contents within the BODY element
@@ -125,16 +125,16 @@ function trimHtml(html: string) {
   ]);
 
   return html;
-}
+};
 
 // TODO: Should be in some global class
-function createIdGenerator(prefix: string) {
+const createIdGenerator = (prefix: string) => {
   let count = 0;
 
-  return function () {
+  return () => {
     return prefix + (count++);
   };
-}
+};
 
 const getImageMimeType = (ext: string): string => {
   const mimeOverrides = {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/WordFilter.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/WordFilter.ts
@@ -25,18 +25,18 @@ import * as Utils from './Utils';
 /**
  * Checks if the specified content is from any of the following sources: MS Word/Office 365/Google docs.
  */
-function isWordContent(content) {
+const isWordContent = (content) => {
   return (
     (/<font face="Times New Roman"|class="?Mso|style="[^"]*\bmso-|style='[^']*\bmso-|w:WordDocument/i).test(content) ||
     (/class="OutlineElement/).test(content) ||
     (/id="?docs\-internal\-guid\-/.test(content))
   );
-}
+};
 
 /**
  * Checks if the specified text starts with "1. " or "a. " etc.
  */
-function isNumericList(text) {
+const isNumericList = (text) => {
   let found;
 
   const patterns = [
@@ -59,21 +59,21 @@ function isNumericList(text) {
   });
 
   return found;
-}
+};
 
-function isBulletList(text) {
+const isBulletList = (text) => {
   return /^[\s\u00a0]*[\u2022\u00b7\u00a7\u25CF]\s*/.test(text);
-}
+};
 
 /**
  * Converts fake bullet and numbered lists to real semantic OL/UL.
  *
  * @param {tinymce.html.Node} node Root node to convert children of.
  */
-function convertFakeListsToProperLists(node) {
+const convertFakeListsToProperLists = (node) => {
   let currentListNode, prevListNode, lastLevel = 1;
 
-  function getText(node) {
+  const getText = (node) => {
     let txt = '';
 
     if (node.type === 3) {
@@ -87,9 +87,9 @@ function convertFakeListsToProperLists(node) {
     }
 
     return txt;
-  }
+  };
 
-  function trimListStart(node, regExp) {
+  const trimListStart = (node, regExp) => {
     if (node.type === 3) {
       if (regExp.test(node.value)) {
         node.value = node.value.replace(regExp, '');
@@ -106,9 +106,9 @@ function convertFakeListsToProperLists(node) {
     }
 
     return true;
-  }
+  };
 
-  function removeIgnoredNodes(node) {
+  const removeIgnoredNodes = (node) => {
     if (node._listIgnore) {
       node.remove();
       return;
@@ -119,9 +119,9 @@ function convertFakeListsToProperLists(node) {
         removeIgnoredNodes(node);
       } while ((node = node.next));
     }
-  }
+  };
 
-  function convertParagraphToLi(paragraphNode, listName, start?) {
+  const convertParagraphToLi = (paragraphNode, listName, start?) => {
     const level = paragraphNode._listLevel || lastLevel;
 
     // Handle list nesting
@@ -165,7 +165,7 @@ function convertFakeListsToProperLists(node) {
     trimListStart(paragraphNode, /^\u00a0+/);
     trimListStart(paragraphNode, /^\s*([\u2022\u00b7\u00a7\u25CF]|\w+\.)/);
     trimListStart(paragraphNode, /^\u00a0+/);
-  }
+  };
 
   // Build a list of all root level elements before we start
   // altering them in the loop below.
@@ -224,9 +224,9 @@ function convertFakeListsToProperLists(node) {
       currentListNode = null;
     }
   }
-}
+};
 
-function filterStyles(editor: Editor, validStyles, node, styleValue) {
+const filterStyles = (editor: Editor, validStyles, node, styleValue) => {
   let outputStyles = {}, matches;
   const styles = editor.dom.parseStyle(styleValue);
 
@@ -319,9 +319,9 @@ function filterStyles(editor: Editor, validStyles, node, styleValue) {
   }
 
   return null;
-}
+};
 
-const filterWordContent = function (editor: Editor, content: string) {
+const filterWordContent = (editor: Editor, content: string) => {
   let validStyles;
 
   const retainStyleProperties = Settings.getRetainStyleProps(editor);
@@ -353,7 +353,7 @@ const filterWordContent = function (editor: Editor, content: string) {
     // Convert <span style="mso-spacerun:yes">___</span> to string of alternating
     // breaking/non-breaking spaces of same length
     [ /<span\s+style\s*=\s*"\s*mso-spacerun\s*:\s*yes\s*;?\s*"\s*>([\s\u00a0]*)<\/span>/gi,
-      function (str, spaces) {
+      (str, spaces) => {
         return (spaces.length > 0) ?
           spaces.replace(/./, ' ').slice(Math.floor(spaces.length / 2)).split('').join(Unicode.nbsp) : '';
       }
@@ -480,7 +480,7 @@ const filterWordContent = function (editor: Editor, content: string) {
   return content;
 };
 
-const preProcess = function (editor: Editor, content) {
+const preProcess = (editor: Editor, content) => {
   return Settings.shouldUseDefaultFilters(editor) ? filterWordContent(editor, content) : content;
 };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/ui/Buttons.ts
@@ -15,7 +15,7 @@ const makeSetupHandler = (editor: Editor, clipboard: Clipboard) => (api) => {
   return () => editor.off('PastePlainTextToggle', pastePlainTextToggleHandler);
 };
 
-const register = function (editor: Editor, clipboard: Clipboard) {
+const register = (editor: Editor, clipboard: Clipboard) => {
   editor.ui.registry.addToggleButton('pastetext', {
     active: false,
     icon: 'paste-text',

--- a/modules/tinymce/src/plugins/paste/test/ts/atomic/FragmentParserTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/atomic/FragmentParserTest.ts
@@ -2,7 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import * as FragmentParser from 'tinymce/plugins/paste/core/FragmentParser';
 
 UnitTest.test('atomic.tinymce.plugins.paste.FragmentParserTest', () => {
-  const testGetFragmentInfo = function () {
+  const testGetFragmentInfo = () => {
     Assert.eq(
       'Should be the input string and context body',
       {
@@ -82,7 +82,7 @@ UnitTest.test('atomic.tinymce.plugins.paste.FragmentParserTest', () => {
     );
   };
 
-  const testGetFragmentHtml = function () {
+  const testGetFragmentHtml = () => {
     Assert.eq(
       'Should be the input string',
       'abc',

--- a/modules/tinymce/src/plugins/paste/test/ts/atomic/InternalHtmlTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/atomic/InternalHtmlTest.ts
@@ -2,22 +2,22 @@ import { assert, UnitTest } from '@ephox/bedrock-client';
 import * as InternalHtml from 'tinymce/plugins/paste/core/InternalHtml';
 
 UnitTest.test('atomic.tinymce.plugins.paste.InternalHtmlTest', () => {
-  const testMark = function () {
+  const testMark = () => {
     assert.eq('<!-- x-tinymce/html -->abc', InternalHtml.mark('abc'));
   };
 
-  const testUnmark = function () {
+  const testUnmark = () => {
     assert.eq('abc', InternalHtml.unmark('<!-- x-tinymce/html -->abc'));
     assert.eq('abc', InternalHtml.unmark('abc<!-- x-tinymce/html -->'));
   };
 
-  const testIsMarked = function () {
+  const testIsMarked = () => {
     assert.eq(true, InternalHtml.isMarked('<!-- x-tinymce/html -->abc'));
     assert.eq(true, InternalHtml.isMarked('abc<!-- x-tinymce/html -->'));
     assert.eq(false, InternalHtml.isMarked('abc'));
   };
 
-  const testInternalHtmlMime = function () {
+  const testInternalHtmlMime = () => {
     assert.eq('x-tinymce/html', InternalHtml.internalHtmlMime());
   };
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
@@ -29,7 +29,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     'R0lGODlhAQABAPAAAP8REf///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=='
   ].join('');
 
-  const sTeardown = function (editor: Editor) {
+  const sTeardown = (editor: Editor) => {
     return Logger.t('Delete editor settings', Step.sync(() => {
       delete editor.settings.paste_data_images;
       delete editor.settings.images_dataimg_filter;
@@ -37,13 +37,13 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     }));
   };
 
-  const appendTeardown = function (editor: Editor, steps: Step<any, any>[]) {
+  const appendTeardown = (editor: Editor, steps: Step<any, any>[]) => {
     return Arr.bind(steps, (step) => {
       return [ step, sTeardown(editor) ];
     });
   };
 
-  const base64ToBlob = function (base64: string, type: string, filename: string): File {
+  const base64ToBlob = (base64: string, type: string, filename: string): File => {
     const buff = atob(base64);
     const bytes = new Uint8Array(buff.length);
 
@@ -57,7 +57,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     return file;
   };
 
-  const mockEvent = function (type: string, files) {
+  const mockEvent = (type: string, files) => {
     const event = {
       type,
       preventDefault: Fun.noop
@@ -71,15 +71,15 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     return event;
   };
 
-  const setupContent = function (editor: Editor) {
+  const setupContent = (editor: Editor) => {
     editor.setContent('<p>a</p>');
     LegacyUnit.setSelection(editor, 'p', 0);
     return editor.selection.getRng();
   };
 
-  const waitFor = function (predicate: () => boolean) {
+  const waitFor = (predicate: () => boolean) => {
     return new Promise((resolve, reject) => {
-      const check = function (time, count) {
+      const check = (time, count) => {
         if (predicate()) {
           resolve();
         } else {
@@ -97,7 +97,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     });
   };
 
-  const waitForSelector = function (editor: Editor, selector: string) {
+  const waitForSelector = (editor: Editor, selector: string) => {
     return waitFor(() => editor.dom.select(selector).length > 0);
   };
 
@@ -214,7 +214,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     const clipboard = Clipboard(editor, Cell('html'));
 
     editor.settings.paste_data_images = true;
-    editor.settings.images_dataimg_filter = function (img) {
+    editor.settings.images_dataimg_filter = (img) => {
       LegacyUnit.strictEqual(img.src, 'data:image/gif;base64,' + base64ImgSrc);
       return false;
     };
@@ -237,7 +237,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ImagePasteTest', (success, fai
     const clipboard = Clipboard(editor, Cell('html'));
 
     editor.settings.paste_data_images = true;
-    editor.settings.images_dataimg_filter = function (img) {
+    editor.settings.images_dataimg_filter = (img) => {
       LegacyUnit.strictEqual(img.src, 'data:image/gif;base64,' + base64ImgSrc);
       return false;
     };

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/InternalClipboardTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/InternalClipboardTest.ts
@@ -24,28 +24,28 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.InternalClipboardTest', (succe
     lastPostProcessEvent = null;
   }));
 
-  const sCutCopyDataTransferEvent = function (editor: Editor, type: string) {
+  const sCutCopyDataTransferEvent = (editor: Editor, type: string) => {
     return Logger.t('Cut copy data transfer event', Step.sync(() => {
       dataTransfer = MockDataTransfer.create({});
       editor.fire(type, { clipboardData: dataTransfer });
     }));
   };
 
-  const sPasteDataTransferEvent = function (editor: Editor, data: Record<string, string>) {
+  const sPasteDataTransferEvent = (editor: Editor, data: Record<string, string>) => {
     return Logger.t('Paste data transfer event', Step.sync(() => {
       dataTransfer = MockDataTransfer.create(data);
       editor.fire('paste', { clipboardData: dataTransfer } as ClipboardEvent);
     }));
   };
 
-  const sAssertClipboardData = function (expectedHtml: string, expectedText: string) {
+  const sAssertClipboardData = (expectedHtml: string, expectedText: string) => {
     return Logger.t(`Assert clipboard data ${expectedHtml}, ${expectedText}`, Step.sync(() => {
       Assert.eq('text/html data should match', expectedHtml, dataTransfer.getData('text/html'));
       Assert.eq('text/plain data should match', expectedText, dataTransfer.getData('text/plain'));
     }));
   };
 
-  const sCopy = function (editor: Editor, tinyApis: TinyApis, html: string, spath: number[], soffset: number, fpath: number[], foffset: number) {
+  const sCopy = (editor: Editor, tinyApis: TinyApis, html: string, spath: number[], soffset: number, fpath: number[], foffset: number) => {
     return Logger.t('Copy', GeneralSteps.sequence([
       tinyApis.sSetContent(html),
       tinyApis.sSetSelection(spath, soffset, fpath, foffset),
@@ -53,7 +53,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.InternalClipboardTest', (succe
     ]));
   };
 
-  const sCut = function (editor: Editor, tinyApis: TinyApis, html: string, spath: number[], soffset: number, fpath: number[], foffset: number) {
+  const sCut = (editor: Editor, tinyApis: TinyApis, html: string, spath: number[], soffset: number, fpath: number[], foffset: number) => {
     return Logger.t('Cut', GeneralSteps.sequence([
       tinyApis.sSetContent(html),
       tinyApis.sSetSelection(spath, soffset, fpath, foffset),
@@ -61,7 +61,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.InternalClipboardTest', (succe
     ]));
   };
 
-  const sPaste = function (editor: Editor, tinyApis: TinyApis, startHtml: string, pasteData: Record<string, string>, spath: number[], soffset: number, fpath: number[], foffset: number) {
+  const sPaste = (editor: Editor, tinyApis: TinyApis, startHtml: string, pasteData: Record<string, string>, spath: number[], soffset: number, fpath: number[], foffset: number) => {
     return Logger.t('Paste', GeneralSteps.sequence([
       tinyApis.sSetContent(startHtml),
       tinyApis.sSetSelection(spath, soffset, fpath, foffset),
@@ -70,7 +70,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.InternalClipboardTest', (succe
     ]));
   };
 
-  const sTestCopy = function (editor: Editor, tinyApis: TinyApis) {
+  const sTestCopy = (editor: Editor, tinyApis: TinyApis) => {
     return GeneralSteps.sequence([
       Log.stepsAsStep('TBA', 'Paste: Copy simple text', [
         sCopy(editor, tinyApis, '<p>text</p>', [ 0, 0 ], 0, [ 0, 0 ], 4),
@@ -125,8 +125,8 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.InternalClipboardTest', (succe
     ]);
   };
 
-  const sTestCut = function (editor: Editor, tinyApis: TinyApis) {
-    const sWaitUntilAssertContent = function (expected: string) {
+  const sTestCut = (editor: Editor, tinyApis: TinyApis) => {
+    const sWaitUntilAssertContent = (expected: string) => {
       return Waiter.sTryUntil('Cut is async now, so need to wait for content', tinyApis.sAssertContent(expected));
     };
 
@@ -162,14 +162,14 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.InternalClipboardTest', (succe
     ]);
   };
 
-  const sAssertLastPreProcessEvent = function (expectedData) {
+  const sAssertLastPreProcessEvent = (expectedData) => {
     return Logger.t('Assert last preprocess event', Step.sync(() => {
       Assert.eq('Internal property should be equal', expectedData.internal, lastPreProcessEvent.internal);
       Assert.eq('Content property should be equal', expectedData.content, lastPreProcessEvent.content);
     }));
   };
 
-  const sAssertLastPostProcessEvent = function (expectedData) {
+  const sAssertLastPostProcessEvent = (expectedData) => {
     return Logger.t('Assert last postprocess event', Step.sync(() => {
       Assert.eq('Internal property should be equal', expectedData.internal, lastPostProcessEvent.internal);
       Assert.eq('Content property should be equal', expectedData.content, lastPostProcessEvent.node.innerHTML);
@@ -181,7 +181,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.InternalClipboardTest', (succe
     Assert.eq('PastePostProcess event object', lastPostProcessEvent !== null, true);
   }));
 
-  const sTestPaste = function (editor: Editor, tinyApis: TinyApis) {
+  const sTestPaste = (editor: Editor, tinyApis: TinyApis) => {
     return GeneralSteps.sequence([
       Log.stepsAsStep('TBA', 'Paste: Paste external content', [
         sPaste(editor, tinyApis, '<p>abc</p>', { 'text/plain': 'X', 'text/html': '<p>X</p>' }, [ 0, 0 ], 0, [ 0, 0 ], 3),
@@ -226,7 +226,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.InternalClipboardTest', (succe
     ], onSuccess, onFailure);
   }, {
     plugins: 'paste table',
-    init_instance_callback(editor) {
+    init_instance_callback: (editor) => {
       editor.on('PastePreProcess', (evt) => {
         lastPreProcessEvent = evt;
       });

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
@@ -54,7 +54,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteBin', (success, failure) 
     }
   ];
 
-  const cCreateEditorFromSettings = function (settings = {}, html?) {
+  const cCreateEditorFromSettings = (settings = {}, html?) => {
     return Chain.control(
       McEditor.cFromHtml(html, {
         ...settings,
@@ -67,21 +67,21 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteBin', (success, failure) 
     );
   };
 
-  const cCreateEditorFromHtml = function (html, settings) {
+  const cCreateEditorFromHtml = (html, settings) => {
     return Chain.control(
       cCreateEditorFromSettings(settings, html),
       Guard.addLogging(`Create editor using ${html}`)
     );
   };
 
-  const cRemoveEditor = function () {
+  const cRemoveEditor = () => {
     return Chain.control(
       McEditor.cRemove,
       Guard.addLogging('Remove Editor')
     );
   };
 
-  const cAssertCases = function (cases) {
+  const cAssertCases = (cases) => {
     return Chain.control(
       Chain.op((editor: any) => {
         const pasteBin = PasteBin(editor);

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
@@ -9,7 +9,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteSettingsTest', (success, 
   Theme();
   Plugin();
 
-  const cCreateInlineEditor = function (settings) {
+  const cCreateInlineEditor = (settings) => {
     return Chain.control(
       McEditor.cFromSettings({
         ...settings,

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
@@ -19,7 +19,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteTest', (success, failure)
 
   /* eslint-disable max-len */
 
-  const sTeardown = function (editor: Editor) {
+  const sTeardown = (editor: Editor) => {
     return Logger.t('Delete settings', Step.sync(() => {
       delete editor.settings.paste_remove_styles_if_webkit;
       delete editor.settings.paste_retain_style_properties;
@@ -29,13 +29,13 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteTest', (success, failure)
     }));
   };
 
-  const appendTeardown = function (editor: Editor, steps: Step<any, any>[]) {
+  const appendTeardown = (editor: Editor, steps: Step<any, any>[]) => {
     return Arr.bind(steps, (step) => {
       return [ step, sTeardown(editor) ];
     });
   };
 
-  const trimContent = function (content: string) {
+  const trimContent = (content: string) => {
     return content.replace(/^<p>&nbsp;<\/p>\n?/, '').replace(/\n?<p>&nbsp;<\/p>$/, '');
   };
 
@@ -611,9 +611,9 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteTest', (success, failure)
   });
 
   suite.test('TestCase-TBA: Paste: paste pre process text (event)', (editor) => {
-    function callback(e) {
+    const callback = (e) => {
       e.content = 'PRE:' + e.content;
-    }
+    };
 
     editor.setContent('<p>a</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
@@ -629,9 +629,9 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteTest', (success, failure)
   });
 
   suite.test('TestCase-TBA: Paste: paste pre process html (event)', (editor) => {
-    function callback(e) {
+    const callback = (e) => {
       e.content = 'PRE:' + e.content;
-    }
+    };
 
     editor.setContent('<p>a</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
@@ -647,9 +647,9 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteTest', (success, failure)
   });
 
   suite.test('TestCase-TBA: Paste: paste post process (event)', (editor) => {
-    function callback(e) {
+    const callback = (e) => {
       e.node.innerHTML += ':POST';
-    }
+    };
 
     editor.setContent('<p>a</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
@@ -12,7 +12,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PlainTextPaste', (success, fai
   Theme();
   PastePlugin();
 
-  const cCreateEditorFromSettings = function (settings, _html?) {
+  const cCreateEditorFromSettings = (settings, _html?) => {
     return Chain.control(
       McEditor.cFromSettings({
         ...settings,
@@ -23,14 +23,14 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PlainTextPaste', (success, fai
     );
   };
 
-  const cRemoveEditor = function () {
+  const cRemoveEditor = () => {
     return Chain.control(
       McEditor.cRemove,
       Guard.addLogging('Remove editor')
     );
   };
 
-  const cClearEditor = function () {
+  const cClearEditor = () => {
     return Chain.control(
       Chain.async((editor: any, next, _die) => {
         editor.setContent('');
@@ -40,7 +40,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PlainTextPaste', (success, fai
     );
   };
 
-  const cFireFakePasteEvent = function (data) {
+  const cFireFakePasteEvent = (data) => {
     return Chain.control(
       Chain.async((editor: any, next, _die) => {
         editor.fire('paste', { clipboardData: MockDataTransfer.create(data) });
@@ -50,7 +50,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PlainTextPaste', (success, fai
     );
   };
 
-  const cAssertEditorContent = function (label, expected) {
+  const cAssertEditorContent = (label, expected) => {
     return Chain.control(
       Chain.async((editor: any, next, _die) => {
         Assertions.assertHtml(label || 'Asserting editors content', expected, editor.getContent());
@@ -60,7 +60,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PlainTextPaste', (success, fai
     );
   };
 
-  const cAssertClipboardPaste = function (expected, data) {
+  const cAssertClipboardPaste = (expected, data) => {
     const chains = [];
 
     Obj.each(data, (data, label) => {

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ProcessFiltersTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ProcessFiltersTest.ts
@@ -12,7 +12,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ProcessFiltersTest', (success,
   Theme();
   PastePlugin();
 
-  const cProcessPre = function (html, internal, preProcess) {
+  const cProcessPre = (html, internal, preProcess) => {
     return Chain.control(
       Chain.mapper((editor: any) => {
         editor.on('PastePreProcess', preProcess);
@@ -27,7 +27,7 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ProcessFiltersTest', (success,
     );
   };
 
-  const cProcessPrePost = function (html, internal, preProcess, postProcess) {
+  const cProcessPrePost = (html, internal, preProcess, postProcess) => {
     return Chain.control(
       Chain.mapper((editor: any) => {
         editor.on('PastePreProcess', preProcess);
@@ -44,22 +44,22 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.ProcessFiltersTest', (success,
     );
   };
 
-  const preventHandler = function (e) {
+  const preventHandler = (e) => {
     e.preventDefault();
   };
 
-  const preProcessHandler = function (e) {
+  const preProcessHandler = (e) => {
     e.content += 'X';
   };
 
-  const postProcessHandler = function (editor) {
-    return function (e) {
+  const postProcessHandler = (editor) => {
+    return (e) => {
       editor.dom.remove(editor.dom.select('b', e.node), true);
     };
   };
 
-  const assertInternal = function (expectedFlag) {
-    return function (e) {
+  const assertInternal = (expectedFlag) => {
+    return (e) => {
       Assertions.assertEq('Should be expected internal flag', expectedFlag, e.internal);
     };
   };

--- a/modules/tinymce/src/plugins/paste/test/ts/module/test/MockDataTransfer.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/module/test/MockDataTransfer.ts
@@ -1,34 +1,32 @@
-import { Arr, Obj } from '@ephox/katamari';
+import { Arr, Fun, Obj } from '@ephox/katamari';
 
-const notImplemented = function () {
+const notImplemented = () => {
   throw new Error('Mockup function is not implemented.');
 };
 
-const createDataTransferItem = function (mime, content) {
+const createDataTransferItem = (mime, content) => {
   return {
     kind: 'string',
     type: mime,
     getAsFile: notImplemented,
-    getAsString() {
-      return content;
-    }
+    getAsString: Fun.constant(content)
   };
 };
 
-const create = function (inputData) {
+const create = (inputData) => {
   let data = {};
 
-  const clearData = function () {
+  const clearData = () => {
     data = {};
     result.items = [];
     result.types = [];
   };
 
-  const getData = function (mime) {
+  const getData = (mime) => {
     return mime in data ? data[mime] : '';
   };
 
-  const setData = function (mime, content) {
+  const setData = (mime, content) => {
     data[mime] = content;
     result.types = Obj.keys(data);
     result.items = Arr.map(result.types, (type) => {

--- a/modules/tinymce/src/plugins/paste/test/ts/module/test/Paste.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/module/test/Paste.ts
@@ -1,7 +1,7 @@
 import { Logger, Step } from '@ephox/agar';
 import * as MockDataTransfer from './MockDataTransfer';
 
-const sPaste = function (editor, data) {
+const sPaste = (editor, data) => {
   return Logger.t(`Paste ${data}`, Step.sync(() => {
     const dataTransfer = MockDataTransfer.create(data);
     editor.fire('paste', { clipboardData: dataTransfer });

--- a/modules/tinymce/src/plugins/preview/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/Plugin.ts
@@ -9,9 +9,9 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('preview', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/preview/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import { open } from '../ui/Dialog';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('mcePreview', () => {
     open(editor);
   });

--- a/modules/tinymce/src/plugins/preview/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('preview', {
     icon: 'preview',
     tooltip: 'Preview',

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
@@ -18,11 +18,11 @@ UnitTest.asynctest('browser.tinymce.plugins.preview.PreviewContentStyleTest', (s
     Assert.eq('Should be same html', expected, regexp.test(actual));
   });
 
-  const sAssertIframeHtmlContains = function (editor, text) {
+  const sAssertIframeHtmlContains = (editor, text) => {
     return Logger.t('Assert Iframe Html contains ' + text, sAssertIframeContains(editor, text, true));
   };
 
-  const sAssertIframeHtmlNotContains = function (editor, text) {
+  const sAssertIframeHtmlNotContains = (editor, text) => {
     return Logger.t('Assert Iframe Html does not contain ' + text, sAssertIframeContains(editor, text, false));
   };
 

--- a/modules/tinymce/src/plugins/print/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/print/main/ts/Plugin.ts
@@ -9,10 +9,10 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('print', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
     editor.addShortcut('Meta+P', '', 'mcePrint');
   });
-}
+};

--- a/modules/tinymce/src/plugins/print/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/print/main/ts/api/Commands.ts
@@ -8,7 +8,7 @@
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.addCommand('mcePrint', () => {
     // TINY-3762 IE will print the current window instead of the iframe window
     // however using execCommand appears to make it print from the correct window

--- a/modules/tinymce/src/plugins/print/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/print/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('print', {
     icon: 'print',
     tooltip: 'Print',

--- a/modules/tinymce/src/plugins/quickbars/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/Plugin.ts
@@ -11,11 +11,11 @@ import * as InsertToolbars from './insert/Toolbars';
 
 import * as SelectionToolbars from './selection/Toolbars';
 
-export default function () {
+export default () => {
   PluginManager.add('quickbars', (editor) => {
     InsertButtons.setupButtons(editor);
     InsertToolbars.addToEditor(editor);
 
     SelectionToolbars.addToEditor(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/quickbars/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/api/Settings.ts
@@ -9,15 +9,15 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as EditorSettings from '../alien/EditorSettings';
 
-const getTextSelectionToolbarItems = function (editor: Editor): string {
+const getTextSelectionToolbarItems = (editor: Editor): string => {
   return EditorSettings.getToolbarItemsOr(editor, 'quickbars_selection_toolbar', 'bold italic | quicklink h2 h3 blockquote');
 };
 
-const getInsertToolbarItems = function (editor: Editor): string {
+const getInsertToolbarItems = (editor: Editor): string => {
   return EditorSettings.getToolbarItemsOr(editor, 'quickbars_insert_toolbar', 'quickimage quicktable');
 };
 
-const getImageToolbarItems = function (editor: Editor): string {
+const getImageToolbarItems = (editor: Editor): string => {
   return EditorSettings.getToolbarItemsOr(editor, 'quickbars_image_toolbar', 'alignleft aligncenter alignright');
 };
 

--- a/modules/tinymce/src/plugins/quickbars/main/ts/insert/Actions.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/insert/Actions.ts
@@ -8,7 +8,7 @@
 import { Id } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
-const createTableHtml = function (cols: number, rows: number) {
+const createTableHtml = (cols: number, rows: number) => {
   let x, y, html;
 
   html = '<table data-mce-id="mce" style="width: 100%">';
@@ -30,7 +30,7 @@ const createTableHtml = function (cols: number, rows: number) {
   return html;
 };
 
-const getInsertedElement = function (editor: Editor) {
+const getInsertedElement = (editor: Editor) => {
   const elms = editor.dom.select('*[data-mce-id]');
   return elms[0];
 };
@@ -46,11 +46,11 @@ const insertTableHtml = (editor: Editor, cols: number, rows: number) => {
   });
 };
 
-const insertTable = function (editor: Editor, cols: number, rows: number) {
+const insertTable = (editor: Editor, cols: number, rows: number) => {
   editor.plugins.table ? editor.plugins.table.insertTable(cols, rows) : insertTableHtml(editor, cols, rows);
 };
 
-const insertBlob = function (editor: Editor, base64: string, blob: Blob) {
+const insertBlob = (editor: Editor, base64: string, blob: Blob) => {
   const blobCache = editor.editorUpload.blobCache;
   const blobInfo = blobCache.create(Id.generate('mceu'), blob, base64);
   blobCache.add(blobInfo);

--- a/modules/tinymce/src/plugins/quickbars/main/ts/insert/Buttons.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/insert/Buttons.ts
@@ -10,11 +10,11 @@ import * as Actions from './Actions';
 import * as Conversions from './Conversions';
 import * as Picker from './Picker';
 
-const setupButtons = function (editor: Editor) {
+const setupButtons = (editor: Editor) => {
   editor.ui.registry.addButton('quickimage', {
     icon: 'image',
     tooltip: 'Insert image',
-    onAction() {
+    onAction: () => {
       Picker.pickFile(editor).then((files) => {
         if (files.length > 0) {
           const blob = files[0];
@@ -30,7 +30,7 @@ const setupButtons = function (editor: Editor) {
   editor.ui.registry.addButton('quicktable', {
     icon: 'table',
     tooltip: 'Insert table',
-    onAction() {
+    onAction: () => {
       // panel.hide();
       Actions.insertTable(editor, 2, 2);
     }

--- a/modules/tinymce/src/plugins/quickbars/main/ts/insert/Conversions.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/insert/Conversions.ts
@@ -7,11 +7,11 @@
 
 import Promise from 'tinymce/core/api/util/Promise';
 
-const blobToBase64 = function (blob: Blob) {
+const blobToBase64 = (blob: Blob) => {
   return new Promise<string>((resolve) => {
     const reader = new FileReader();
 
-    reader.onloadend = function () {
+    reader.onloadend = () => {
       resolve((reader.result as string).split(',')[1]);
     };
 

--- a/modules/tinymce/src/plugins/quickbars/main/ts/selection/Actions.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/selection/Actions.ts
@@ -9,33 +9,33 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Unlink from './Unlink';
 
-const collapseSelectionToEnd = function (editor: Editor) {
+const collapseSelectionToEnd = (editor: Editor) => {
   editor.selection.collapse(false);
 };
 
-const unlink = function (editor: Editor) {
+const unlink = (editor: Editor) => {
   editor.focus();
   Unlink.unlinkSelection(editor);
   collapseSelectionToEnd(editor);
 };
 
-const changeHref = function (editor: Editor, elm: Element, url: string) {
+const changeHref = (editor: Editor, elm: Element, url: string) => {
   editor.focus();
   editor.dom.setAttrib(elm, 'href', url);
   collapseSelectionToEnd(editor);
 };
 
-const insertLink = function (editor: Editor, url: string) {
+const insertLink = (editor: Editor, url: string) => {
   editor.execCommand('mceInsertLink', false, { href: url });
   collapseSelectionToEnd(editor);
 };
 
-const updateOrInsertLink = function (editor: Editor, url: string) {
+const updateOrInsertLink = (editor: Editor, url: string) => {
   const elm = editor.dom.getParent(editor.selection.getStart(), 'a[href]');
   elm ? changeHref(editor, elm, url) : insertLink(editor, url);
 };
 
-const createLink = function (editor: Editor, url: string) {
+const createLink = (editor: Editor, url: string) => {
   url.trim().length === 0 ? unlink(editor) : updateOrInsertLink(editor, url);
 };
 

--- a/modules/tinymce/src/plugins/quickbars/main/ts/selection/Bookmark.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/selection/Bookmark.ts
@@ -16,10 +16,10 @@
  * @param  {DOMRange} rng DOM Range to get bookmark on.
  * @return {Object} Bookmark object.
  */
-const create = function (dom, rng) {
+const create = (dom, rng) => {
   const bookmark = {};
 
-  function setupEndPoint(start?) {
+  const setupEndPoint = (start?) => {
     let offsetNode, container, offset;
 
     container = rng[start ? 'startContainer' : 'endContainer'];
@@ -46,7 +46,7 @@ const create = function (dom, rng) {
 
     bookmark[start ? 'startContainer' : 'endContainer'] = container;
     bookmark[start ? 'startOffset' : 'endOffset'] = offset;
-  }
+  };
 
   setupEndPoint(true);
 
@@ -62,11 +62,11 @@ const create = function (dom, rng) {
  *
  * @param {Object} bookmark Bookmark object to move selection to.
  */
-const resolve = function (dom, bookmark) {
-  function restoreEndPoint(start?) {
+const resolve = (dom, bookmark) => {
+  const restoreEndPoint = (start?) => {
     let container, offset, node;
 
-    function nodeIndex(container) {
+    const nodeIndex = (container) => {
       let node = container.parentNode.firstChild, idx = 0;
 
       while (node) {
@@ -83,7 +83,7 @@ const resolve = function (dom, bookmark) {
       }
 
       return -1;
-    }
+    };
 
     container = node = bookmark[start ? 'startContainer' : 'endContainer'];
     offset = bookmark[start ? 'startOffset' : 'endOffset'];
@@ -100,7 +100,7 @@ const resolve = function (dom, bookmark) {
 
     bookmark[start ? 'startContainer' : 'endContainer'] = container;
     bookmark[start ? 'startOffset' : 'endOffset'] = offset;
-  }
+  };
 
   restoreEndPoint(true);
   restoreEndPoint();

--- a/modules/tinymce/src/plugins/quickbars/main/ts/selection/Unlink.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/selection/Unlink.ts
@@ -18,7 +18,7 @@ import * as Bookmark from './Bookmark';
  *  a[b<a href="x">c]d</a>e -> a[bc]<a href="x">d</a>e
  */
 
-const getSelectedElements = function (rootElm: HTMLElement, startNode: Node, endNode: Node) {
+const getSelectedElements = (rootElm: HTMLElement, startNode: Node, endNode: Node) => {
   let node;
   const elms = [];
 
@@ -36,7 +36,7 @@ const getSelectedElements = function (rootElm: HTMLElement, startNode: Node, end
   return elms;
 };
 
-const unwrapElements = function (editor: Editor, elms: HTMLElement[]) {
+const unwrapElements = (editor: Editor, elms: HTMLElement[]) => {
   const dom = editor.dom;
   const selection = editor.selection;
   const bookmark = Bookmark.create(dom, selection.getRng());
@@ -48,16 +48,16 @@ const unwrapElements = function (editor: Editor, elms: HTMLElement[]) {
   selection.setRng(Bookmark.resolve(dom, bookmark));
 };
 
-const isLink = function (elm: HTMLElement) {
+const isLink = (elm: HTMLElement) => {
   return elm.nodeName === 'A' && elm.hasAttribute('href');
 };
 
-const getParentAnchorOrSelf = function (dom, elm: Node) {
+const getParentAnchorOrSelf = (dom, elm: Node) => {
   const anchorElm = dom.getParent(elm, isLink);
   return anchorElm ? anchorElm : elm;
 };
 
-const getSelectedAnchors = function (editor: Editor) {
+const getSelectedAnchors = (editor: Editor) => {
   const selection = editor.selection;
   const dom = editor.dom;
   const rng = selection.getRng();
@@ -68,7 +68,7 @@ const getSelectedAnchors = function (editor: Editor) {
   return Tools.grep(getSelectedElements(rootElm, startElm, endElm), isLink);
 };
 
-const unlinkSelection = function (editor: Editor) {
+const unlinkSelection = (editor: Editor) => {
   unwrapElements(editor, getSelectedAnchors(editor));
 };
 

--- a/modules/tinymce/src/plugins/save/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/Plugin.ts
@@ -9,9 +9,9 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('save', (editor) => {
     Buttons.register(editor);
     Commands.register(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/save/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import * as Actions from '../core/Actions';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('mceSave', () => {
     Actions.save(editor);
   });

--- a/modules/tinymce/src/plugins/save/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/api/Settings.ts
@@ -5,15 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const enableWhenDirty = function (editor) {
+const enableWhenDirty = (editor) => {
   return editor.getParam('save_enablewhendirty', true);
 };
 
-const hasOnSaveCallback = function (editor) {
+const hasOnSaveCallback = (editor) => {
   return !!editor.getParam('save_onsavecallback');
 };
 
-const hasOnCancelCallback = function (editor) {
+const hasOnCancelCallback = (editor) => {
   return !!editor.getParam('save_oncancelcallback');
 };
 

--- a/modules/tinymce/src/plugins/save/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/core/Actions.ts
@@ -9,14 +9,14 @@ import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 
-const displayErrorMessage = function (editor, message) {
+const displayErrorMessage = (editor, message) => {
   editor.notificationManager.open({
     text: message,
     type: 'error'
   });
 };
 
-const save = function (editor) {
+const save = (editor) => {
   const formObj = DOMUtils.DOM.getParent(editor.id, 'form') as HTMLFormElement;
 
   if (Settings.enableWhenDirty(editor) && !editor.isDirty()) {
@@ -51,7 +51,7 @@ const save = function (editor) {
   }
 };
 
-const cancel = function (editor) {
+const cancel = (editor) => {
   const h = Tools.trim(editor.startContent);
 
   // Use callback instead

--- a/modules/tinymce/src/plugins/save/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/ui/Buttons.ts
@@ -8,8 +8,8 @@
 import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../api/Settings';
 
-const stateToggle = function (editor: Editor) {
-  return function (api) {
+const stateToggle = (editor: Editor) => {
+  return (api) => {
     const handler = () => {
       api.setDisabled(Settings.enableWhenDirty(editor) && !editor.isDirty());
     };
@@ -19,7 +19,7 @@ const stateToggle = function (editor: Editor) {
   };
 };
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('save', {
     icon: 'save',
     tooltip: 'Save',

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/Plugin.ts
@@ -12,7 +12,7 @@ import * as Commands from './api/Commands';
 import { SearchState } from './core/Actions';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('searchreplace', (editor) => {
     const currentSearchState = Cell<SearchState>({
       index: -1,
@@ -28,4 +28,4 @@ export default function () {
 
     return Api.get(editor, currentSearchState);
   });
-}
+};

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/api/Api.ts
@@ -9,24 +9,24 @@ import { Cell } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as Actions from '../core/Actions';
 
-const get = function (editor: Editor, currentState: Cell<Actions.SearchState>) {
-  const done = function (keepEditorSelection?: boolean) {
+const get = (editor: Editor, currentState: Cell<Actions.SearchState>) => {
+  const done = (keepEditorSelection?: boolean) => {
     return Actions.done(editor, currentState, keepEditorSelection);
   };
 
-  const find = function (text: string, matchCase: boolean, wholeWord: boolean, inSelection: boolean = false) {
+  const find = (text: string, matchCase: boolean, wholeWord: boolean, inSelection: boolean = false) => {
     return Actions.find(editor, currentState, text, matchCase, wholeWord, inSelection);
   };
 
-  const next = function () {
+  const next = () => {
     return Actions.next(editor, currentState);
   };
 
-  const prev = function () {
+  const prev = () => {
     return Actions.prev(editor, currentState);
   };
 
-  const replace = function (text: string, forward?: boolean, all?: boolean) {
+  const replace = (text: string, forward?: boolean, all?: boolean) => {
     return Actions.replace(editor, currentState, text, forward, all);
   };
 

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/api/Commands.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { SearchState } from '../core/Actions';
 import * as Dialog from '../ui/Dialog';
 
-const register = function (editor: Editor, currentSearchState: Cell<SearchState>) {
+const register = (editor: Editor, currentSearchState: Cell<SearchState>) => {
   editor.addCommand('SearchReplace', () => {
     Dialog.open(editor, currentSearchState);
   });

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/Actions.ts
@@ -22,7 +22,7 @@ export interface SearchState {
   inSelection: boolean;
 }
 
-const getElmIndex = function (elm: Element) {
+const getElmIndex = (elm: Element) => {
   const value = elm.getAttribute('data-mce-index');
 
   if (typeof value === 'number') {
@@ -32,7 +32,7 @@ const getElmIndex = function (elm: Element) {
   return value;
 };
 
-const markAllMatches = function (editor: Editor, currentSearchState: Cell<SearchState>, pattern: Pattern, inSelection: boolean) {
+const markAllMatches = (editor: Editor, currentSearchState: Cell<SearchState>, pattern: Pattern, inSelection: boolean) => {
   const marker = editor.dom.create('span', {
     'data-mce-bogus': 1
   });
@@ -49,7 +49,7 @@ const markAllMatches = function (editor: Editor, currentSearchState: Cell<Search
   }
 };
 
-const unwrap = function (node: Node) {
+const unwrap = (node: Node) => {
   const parentNode = node.parentNode;
 
   if (node.firstChild) {
@@ -59,7 +59,7 @@ const unwrap = function (node: Node) {
   node.parentNode.removeChild(node);
 };
 
-const findSpansByIndex = function (editor: Editor, index: number) {
+const findSpansByIndex = (editor: Editor, index: number) => {
   const spans = [];
 
   const nodes = Tools.toArray(editor.getBody().getElementsByTagName('span'));
@@ -80,7 +80,7 @@ const findSpansByIndex = function (editor: Editor, index: number) {
   return spans;
 };
 
-const moveSelection = function (editor: Editor, currentSearchState: Cell<SearchState>, forward: boolean) {
+const moveSelection = (editor: Editor, currentSearchState: Cell<SearchState>, forward: boolean) => {
   const searchState = currentSearchState.get();
   let testIndex = searchState.index;
   const dom = editor.dom;
@@ -113,7 +113,7 @@ const moveSelection = function (editor: Editor, currentSearchState: Cell<SearchS
   return -1;
 };
 
-const removeNode = function (dom: DOMUtils, node: Node) {
+const removeNode = (dom: DOMUtils, node: Node) => {
   const parent = node.parentNode;
 
   dom.remove(node);
@@ -129,7 +129,7 @@ const escapeSearchText = (text: string, wholeWord: boolean) => {
   return wholeWord ? `(?:^|\\s|${PolarisPattern.punctuation()})` + wordRegex + `(?=$|\\s|${PolarisPattern.punctuation()})` : wordRegex;
 };
 
-const find = function (editor: Editor, currentSearchState: Cell<SearchState>, text: string, matchCase: boolean, wholeWord: boolean, inSelection: boolean) {
+const find = (editor: Editor, currentSearchState: Cell<SearchState>, text: string, matchCase: boolean, wholeWord: boolean, inSelection: boolean) => {
   const escapedText = escapeSearchText(text, wholeWord);
 
   const pattern = {
@@ -153,23 +153,23 @@ const find = function (editor: Editor, currentSearchState: Cell<SearchState>, te
   return count;
 };
 
-const next = function (editor: Editor, currentSearchState: Cell<SearchState>) {
+const next = (editor: Editor, currentSearchState: Cell<SearchState>) => {
   const index = moveSelection(editor, currentSearchState, true);
   currentSearchState.set({ ...currentSearchState.get(), index });
 };
 
-const prev = function (editor: Editor, currentSearchState: Cell<SearchState>) {
+const prev = (editor: Editor, currentSearchState: Cell<SearchState>) => {
   const index = moveSelection(editor, currentSearchState, false);
   currentSearchState.set({ ...currentSearchState.get(), index });
 };
 
-const isMatchSpan = function (node: Element) {
+const isMatchSpan = (node: Element) => {
   const matchIndex = getElmIndex(node);
 
   return matchIndex !== null && matchIndex.length > 0;
 };
 
-const replace = function (editor: Editor, currentSearchState: Cell<SearchState>, text: string, forward?: boolean, all?: boolean) {
+const replace = (editor: Editor, currentSearchState: Cell<SearchState>, text: string, forward?: boolean, all?: boolean) => {
   const searchState = currentSearchState.get();
   const currentIndex = searchState.index;
   let currentMatchIndex, nextIndex = currentIndex;
@@ -224,7 +224,7 @@ const replace = function (editor: Editor, currentSearchState: Cell<SearchState>,
   return !all && currentSearchState.get().count > 0;
 };
 
-const done = function (editor: Editor, currentSearchState: Cell<SearchState>, keepEditorSelection?: boolean) {
+const done = (editor: Editor, currentSearchState: Cell<SearchState>, keepEditorSelection?: boolean) => {
   let i, startContainer, endContainer;
   const searchState = currentSearchState.get();
 

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Buttons.ts
@@ -10,13 +10,13 @@ import Editor from 'tinymce/core/api/Editor';
 import { SearchState } from '../core/Actions';
 import * as Dialog from './Dialog';
 
-const showDialog = function (editor: Editor, currentSearchState: Cell<SearchState>) {
-  return function () {
+const showDialog = (editor: Editor, currentSearchState: Cell<SearchState>) => {
+  return () => {
     Dialog.open(editor, currentSearchState);
   };
 };
 
-const register = function (editor: Editor, currentSearchState: Cell<SearchState>) {
+const register = (editor: Editor, currentSearchState: Cell<SearchState>) => {
   editor.ui.registry.addMenuItem('searchreplace', {
     text: 'Find and replace...',
     shortcut: 'Meta+F',

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
@@ -21,18 +21,18 @@ export interface DialogData {
   inselection: boolean;
 }
 
-const open = function (editor: Editor, currentSearchState: Cell<Actions.SearchState>) {
+const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>) => {
   const dialogApi = Singleton.value<Dialog.DialogInstanceApi<DialogData>>();
   editor.undoManager.add();
 
   const selectedText = Tools.trim(editor.selection.getContent({ format: 'text' }));
 
-  function updateButtonStates(api: Dialog.DialogInstanceApi<DialogData>) {
+  const updateButtonStates = (api: Dialog.DialogInstanceApi<DialogData>) => {
     const updateNext = Actions.hasNext(editor, currentSearchState) ? api.enable : api.disable;
     updateNext('next');
     const updatePrev = Actions.hasPrev(editor, currentSearchState) ? api.enable : api.disable;
     updatePrev('prev');
-  }
+  };
 
   const updateSearchState = (api: Dialog.DialogInstanceApi<DialogData>) => {
     const data = api.getData();
@@ -46,17 +46,17 @@ const open = function (editor: Editor, currentSearchState: Cell<Actions.SearchSt
     });
   };
 
-  const disableAll = function (api: Dialog.DialogInstanceApi<DialogData>, disable: boolean) {
+  const disableAll = (api: Dialog.DialogInstanceApi<DialogData>, disable: boolean) => {
     const buttons = [ 'replace', 'replaceall', 'prev', 'next' ];
     const toggle = disable ? api.disable : api.enable;
     Arr.each(buttons, toggle);
   };
 
-  function notFoundAlert(api: Dialog.DialogInstanceApi<DialogData>) {
+  const notFoundAlert = (api: Dialog.DialogInstanceApi<DialogData>) => {
     editor.windowManager.alert('Could not find the specified string.', () => {
       api.focus('findtext');
     });
-  }
+  };
 
   // Temporarily workaround for iOS/iPadOS dialog placement to hide the keyboard
   // TODO: Remove in 5.2 once iOS fixed positioning is fixed. See TINY-4441

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/HtmlUtils.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/HtmlUtils.ts
@@ -1,7 +1,7 @@
 import SaxParser from 'tinymce/core/api/html/SaxParser';
 import Writer from 'tinymce/core/api/html/Writer';
 
-const cleanHtml = function (html) {
+const cleanHtml = (html) => {
   return html.toLowerCase().replace(/[\r\n]+/gi, '')
     .replace(/ (sizcache[0-9]+|sizcache|nodeindex|sizset[0-9]+|sizset|data\-mce\-expando|data\-mce\-selected)="[^"]*"/gi, '')
     .replace(/<span[^>]+data-mce-bogus[^>]+>[\u200B\uFEFF]+<\/span>|<div[^>]+data-mce-bogus[^>]+><\/div>/gi, '')
@@ -11,7 +11,7 @@ const cleanHtml = function (html) {
     });
 };
 
-const normalizeHtml = function (html) {
+const normalizeHtml = (html) => {
   const writer = Writer();
 
   SaxParser({
@@ -23,7 +23,7 @@ const normalizeHtml = function (html) {
     pi: writer.pi,
     doctype: writer.doctype,
 
-    start(name, attrs, empty) {
+    start: (name, attrs, empty) => {
       attrs.sort((a, b) => {
         if (a.name === b.name) {
           return 0;

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
@@ -15,7 +15,7 @@ import { LastSuggestion } from './core/Actions';
 import * as Buttons from './ui/Buttons';
 import * as SuggestionsMenu from './ui/SuggestionsMenu';
 
-export default function () {
+export default () => {
   PluginManager.add('spellchecker', (editor, pluginUrl) => {
     if (DetectProPlugin.hasProPlugin(editor) === false) {
       const startedState = Cell(false);
@@ -30,4 +30,4 @@ export default function () {
       return Api.get(editor, startedState, lastSuggestionsState, textMatcherState, currentLanguageState, pluginUrl);
     }
   });
-}
+};

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/alien/DetectProPlugin.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/alien/DetectProPlugin.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const hasProPlugin = function (editor: Editor) {
+const hasProPlugin = (editor: Editor) => {
   // draw back if power version is requested and registered
   if (editor.hasPlugin('tinymcespellchecker', true)) {
 

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/api/Api.ts
@@ -14,28 +14,20 @@ import * as Settings from './Settings';
 type LastSuggestion = Actions.LastSuggestion;
 type Data = Actions.Data;
 
-const get = function (editor: Editor, startedState: Cell<boolean>, lastSuggestionsState: Cell<LastSuggestion>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, _url: string) {
-  const getLanguage = function () {
-    return currentLanguageState.get();
-  };
-
-  const getWordCharPattern = function () {
+const get = (editor: Editor, startedState: Cell<boolean>, lastSuggestionsState: Cell<LastSuggestion>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, _url: string) => {
+  const getWordCharPattern = () => {
     return Settings.getSpellcheckerWordcharPattern(editor);
   };
 
-  const markErrors = function (data: Data) {
+  const markErrors = (data: Data) => {
     Actions.markErrors(editor, startedState, textMatcherState, lastSuggestionsState, data);
   };
 
-  const getTextMatcher = function () {
-    return textMatcherState.get();
-  };
-
   return {
-    getTextMatcher,
+    getTextMatcher: textMatcherState.get,
     getWordCharPattern,
     markErrors,
-    getLanguage
+    getLanguage: currentLanguageState.get
   };
 };
 

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/api/Commands.ts
@@ -12,7 +12,7 @@ import { DomTextMatcher } from '../core/DomTextMatcher';
 
 type LastSuggestion = Actions.LastSuggestion;
 
-const register = function (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, currentLanguageState: Cell<string>) {
+const register = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, currentLanguageState: Cell<string>) => {
   editor.addCommand('mceSpellCheck', () => {
     Actions.spellcheck(editor, pluginUrl, startedState, textMatcherState, lastSuggestionsState, currentLanguageState);
   });

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/api/Events.ts
@@ -7,11 +7,11 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const fireSpellcheckStart = function (editor: Editor) {
+const fireSpellcheckStart = (editor: Editor) => {
   return editor.fire('SpellcheckStart');
 };
 
-const fireSpellcheckEnd = function (editor: Editor) {
+const fireSpellcheckEnd = (editor: Editor) => {
   return editor.fire('SpellcheckEnd');
 };
 

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/api/Settings.ts
@@ -7,25 +7,25 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getLanguages = function (editor: Editor): string {
+const getLanguages = (editor: Editor): string => {
   const defaultLanguages = 'English=en,Danish=da,Dutch=nl,Finnish=fi,French=fr_FR,German=de,Italian=it,Polish=pl,Portuguese=pt_BR,Spanish=es,Swedish=sv';
   return editor.getParam('spellchecker_languages', defaultLanguages);
 };
 
-const getLanguage = function (editor: Editor) {
+const getLanguage = (editor: Editor) => {
   const defaultLanguage = editor.getParam('language', 'en');
   return editor.getParam('spellchecker_language', defaultLanguage);
 };
 
-const getRpcUrl = function (editor: Editor) {
+const getRpcUrl = (editor: Editor) => {
   return editor.getParam('spellchecker_rpc_url');
 };
 
-const getSpellcheckerCallback = function (editor: Editor) {
+const getSpellcheckerCallback = (editor: Editor) => {
   return editor.getParam('spellchecker_callback');
 };
 
-const getSpellcheckerWordcharPattern = function (editor: Editor) {
+const getSpellcheckerWordcharPattern = (editor: Editor) => {
   const defaultPattern = new RegExp('[^' +
   '\\s!"#$%&()*+,-./:;<=>?@[\\]^_{|}`' +
   '\u00a7\u00a9\u00ab\u00ae\u00b1\u00b6\u00b7\u00b8\u00bb' +

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/core/Actions.ts
@@ -19,7 +19,7 @@ export interface Data {
   dictionary?: any;
 }
 
-const getTextMatcher = function (editor, textMatcherState) {
+const getTextMatcher = (editor, textMatcherState) => {
   if (!textMatcherState.get()) {
     const textMatcher = DomTextMatcher(editor.getBody(), editor);
     textMatcherState.set(textMatcher);
@@ -28,8 +28,8 @@ const getTextMatcher = function (editor, textMatcherState) {
   return textMatcherState.get();
 };
 
-const defaultSpellcheckCallback = function (editor: Editor, pluginUrl: string, currentLanguageState: Cell<string>) {
-  return function (method: string, text: string, doneCallback: Function, errorCallback: Function) {
+const defaultSpellcheckCallback = (editor: Editor, pluginUrl: string, currentLanguageState: Cell<string>) => {
+  return (method: string, text: string, doneCallback: Function, errorCallback: Function) => {
     const data = { method, lang: currentLanguageState.get() };
     let postData = '';
 
@@ -47,7 +47,7 @@ const defaultSpellcheckCallback = function (editor: Editor, pluginUrl: string, c
       type: 'post',
       content_type: 'application/x-www-form-urlencoded',
       data: postData,
-      success(result) {
+      success: (result) => {
         const parseResult = JSON.parse(result);
 
         if (!parseResult) {
@@ -59,7 +59,7 @@ const defaultSpellcheckCallback = function (editor: Editor, pluginUrl: string, c
           doneCallback(parseResult);
         }
       },
-      error() {
+      error: () => {
         const message = editor.translate('The spelling service was not found: (') +
           Settings.getRpcUrl(editor) +
           editor.translate(')');
@@ -69,24 +69,24 @@ const defaultSpellcheckCallback = function (editor: Editor, pluginUrl: string, c
   };
 };
 
-const sendRpcCall = function (editor: Editor, pluginUrl: string, currentLanguageState: Cell<string>, name: string, data: string, successCallback: Function, errorCallback?: Function) {
+const sendRpcCall = (editor: Editor, pluginUrl: string, currentLanguageState: Cell<string>, name: string, data: string, successCallback: Function, errorCallback?: Function) => {
   const userSpellcheckCallback = Settings.getSpellcheckerCallback(editor);
   const spellCheckCallback = userSpellcheckCallback ? userSpellcheckCallback : defaultSpellcheckCallback(editor, pluginUrl, currentLanguageState);
   spellCheckCallback.call(editor.plugins.spellchecker, name, data, successCallback, errorCallback);
 };
 
-const spellcheck = function (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, currentLanguageState: Cell<string>) {
+const spellcheck = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, currentLanguageState: Cell<string>) => {
   if (finish(editor, startedState, textMatcherState)) {
     return;
   }
 
-  const errorCallback = function (message: string) {
+  const errorCallback = (message: string) => {
     editor.notificationManager.open({ text: message, type: 'error' });
     editor.setProgressState(false);
     finish(editor, startedState, textMatcherState);
   };
 
-  const successCallback = function (data: Data) {
+  const successCallback = (data: Data) => {
     markErrors(editor, startedState, textMatcherState, lastSuggestionsState, data);
   };
 
@@ -95,13 +95,13 @@ const spellcheck = function (editor: Editor, pluginUrl: string, startedState: Ce
   editor.focus();
 };
 
-const checkIfFinished = function (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>) {
+const checkIfFinished = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>) => {
   if (!editor.dom.select('span.mce-spellchecker-word').length) {
     finish(editor, startedState, textMatcherState);
   }
 };
 
-const addToDictionary = function (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, word: string, spans: Element[]) {
+const addToDictionary = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, word: string, spans: Element[]) => {
   editor.setProgressState(true);
 
   sendRpcCall(editor, pluginUrl, currentLanguageState, 'addToDictionary', word, () => {
@@ -114,7 +114,7 @@ const addToDictionary = function (editor: Editor, pluginUrl: string, startedStat
   });
 };
 
-const ignoreWord = function (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, word: string, spans: Element[], all?: boolean) {
+const ignoreWord = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, word: string, spans: Element[], all?: boolean) => {
   editor.selection.collapse();
 
   if (all) {
@@ -130,7 +130,7 @@ const ignoreWord = function (editor: Editor, startedState: Cell<boolean>, textMa
   checkIfFinished(editor, startedState, textMatcherState);
 };
 
-const finish = function (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>) {
+const finish = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>) => {
   const bookmark = editor.selection.getBookmark();
   getTextMatcher(editor, textMatcherState).reset();
   editor.selection.moveToBookmark(bookmark);
@@ -144,7 +144,7 @@ const finish = function (editor: Editor, startedState: Cell<boolean>, textMatche
   }
 };
 
-const getElmIndex = function (elm: HTMLElement) {
+const getElmIndex = (elm: HTMLElement) => {
   const value = elm.getAttribute('data-mce-index');
 
   if (typeof value === 'number') {
@@ -154,7 +154,7 @@ const getElmIndex = function (elm: HTMLElement) {
   return value;
 };
 
-const findSpansByIndex = function (editor: Editor, index: string): HTMLSpanElement[] {
+const findSpansByIndex = (editor: Editor, index: string): HTMLSpanElement[] => {
   const spans: HTMLSpanElement[] = [];
 
   const nodes = Tools.toArray(editor.getBody().getElementsByTagName('span'));
@@ -180,7 +180,7 @@ export interface LastSuggestion {
   hasDictionarySupport: boolean;
 }
 
-const markErrors = function (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, data: Data) {
+const markErrors = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, data: Data) => {
   const hasDictionarySupport = !!data.dictionary;
   const suggestions = data.words;
 

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/core/DomTextMatcher.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/core/DomTextMatcher.ts
@@ -5,9 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-function isContentEditableFalse(node) {
+const isContentEditableFalse = (node) => {
   return node && node.nodeType === 1 && node.contentEditable === 'false';
-}
+};
 
 export type Match = Record<string, string>;
 
@@ -28,7 +28,7 @@ export interface DomTextMatcher {
   indexOf: (match: Match) => number;
 }
 
-export const DomTextMatcher = function (node, editor): DomTextMatcher {
+export const DomTextMatcher = (node, editor): DomTextMatcher => {
   let m, matches = [];
   const dom = editor.dom;
 
@@ -36,7 +36,7 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
   const hiddenTextElementsMap = editor.schema.getWhiteSpaceElements(); // TEXTAREA, PRE, STYLE, SCRIPT
   const shortEndedElementsMap = editor.schema.getShortEndedElements(); // BR, IMG, INPUT
 
-  function createMatch(m, data) {
+  const createMatch = (m, data) => {
     if (!m[0]) {
       throw new Error('findAndReplaceDOMText cannot handle zero-length matches');
     }
@@ -47,9 +47,9 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
       text: m[0],
       data
     };
-  }
+  };
 
-  function getText(node) {
+  const getText = (node) => {
     let txt;
 
     if (node.nodeType === 3) {
@@ -77,9 +77,9 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
     }
 
     return txt;
-  }
+  };
 
-  function stepThroughMatches(node, matches, replaceFn) {
+  const stepThroughMatches = (node, matches, replaceFn) => {
     let startNode, endNode, startNodeIndex,
       endNodeIndex, innerNodes = [], atIndex = 0, curNode = node,
       matchLocation, matchIndex = 0;
@@ -163,14 +163,14 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
         }
       }
     }
-  }
+  };
 
   /**
   * Generates the actual replaceFn which splits up text nodes
   * and inserts the replacement element.
   */
-  function genReplacer(callback) {
-    function makeReplacementNode(fill, matchIndex) {
+  const genReplacer = (callback) => {
+    const makeReplacementNode = (fill, matchIndex) => {
       const match = matches[matchIndex];
 
       if (!match.stencil) {
@@ -185,9 +185,9 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
       }
 
       return clone;
-    }
+    };
 
-    return function (range) {
+    return (range) => {
       let before;
       let after;
       let parentNode;
@@ -247,21 +247,21 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
 
       return elB;
     };
-  }
+  };
 
-  function unwrapElement(element) {
+  const unwrapElement = (element) => {
     const parentNode = element.parentNode;
     while (element.childNodes.length > 0) {
       parentNode.insertBefore(element.childNodes[0], element);
     }
     parentNode.removeChild(element);
-  }
+  };
 
-  function hasClass(elm) {
+  const hasClass = (elm) => {
     return elm.className.indexOf('mce-spellchecker-word') !== -1;
-  }
+  };
 
-  function getWrappersByIndex(index) {
+  const getWrappersByIndex = (index) => {
     const elements = node.getElementsByTagName('*'), wrappers = [];
 
     index = typeof index === 'number' ? '' + index : null;
@@ -277,7 +277,7 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
     }
 
     return wrappers;
-  }
+  };
 
   /**
   * Returns the index of a specific match object or -1 if it isn't found.
@@ -285,7 +285,7 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
   * @param  {Match} match Text match object.
   * @return {Number} Index of match or -1 if it isn't found.
   */
-  function indexOf(match) {
+  const indexOf = (match) => {
     let i = matches.length;
     while (i--) {
       if (matches[i] === match) {
@@ -294,7 +294,7 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
     }
 
     return -1;
-  }
+  };
 
   /**
   * Filters the matches. If the callback returns true it stays if not it gets removed.
@@ -391,9 +391,9 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
   * @param {DOMElement} element Element to return match object for.
   * @return {Object} Match object for the specified element.
   */
-  function matchFromElement(element) {
+  const matchFromElement = (element) => {
     return matches[element.getAttribute('data-mce-index')];
-  }
+  };
 
   /**
   * Returns a DOM element from the specified match element. This will be the first element if it's split
@@ -402,9 +402,9 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
   * @param {Object} match Match element to get first element of.
   * @return {DOMElement} DOM element for the specified match object.
   */
-  function elementFromMatch(match) {
+  const elementFromMatch = (match) => {
     return getWrappersByIndex(indexOf(match))[0];
-  }
+  };
 
   /**
   * Adds match the specified range for example a grammar line.
@@ -431,7 +431,7 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
   * @param  {Object} match Match object to get range for.
   * @return {DOMRange} DOM Range for the specified match.
   */
-  function rangeFromMatch(match) {
+  const rangeFromMatch = (match) => {
     const wrappers = getWrappersByIndex(indexOf(match));
 
     const rng = editor.dom.createRng();
@@ -439,7 +439,7 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
     rng.setEndAfter(wrappers[wrappers.length - 1]);
 
     return rng;
-  }
+  };
 
   /**
   * Replaces the specified match with the specified text.
@@ -448,7 +448,7 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
   * @param {String} text Text to replace the match with.
   * @return {DOMRange} DOM range produced after the replace.
   */
-  function replace(match, text) {
+  const replace = (match, text) => {
     const rng = rangeFromMatch(match);
 
     rng.deleteContents();
@@ -458,7 +458,7 @@ export const DomTextMatcher = function (node, editor): DomTextMatcher {
     }
 
     return rng;
-  }
+  };
 
   /**
   * Resets the DomTextMatcher instance. This will remove any wrapped nodes and remove any matches.

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/ui/Buttons.ts
@@ -22,7 +22,7 @@ interface LanguageValue {
 
 const spellcheckerEvents = 'SpellcheckStart SpellcheckEnd';
 
-const buildMenuItems = function (listName: string, languageValues: LanguageValue[]) {
+const buildMenuItems = (listName: string, languageValues: LanguageValue[]) => {
   const items = [];
 
   Tools.each(languageValues, (languageValue) => {
@@ -36,7 +36,7 @@ const buildMenuItems = function (listName: string, languageValues: LanguageValue
   return items;
 };
 
-const getItems = function (editor: Editor): LanguageValue[] {
+const getItems = (editor: Editor): LanguageValue[] => {
   return Tools.map(Settings.getLanguages(editor).split(','), (langPair) => {
     const langPairs = langPair.split('=');
 
@@ -47,9 +47,9 @@ const getItems = function (editor: Editor): LanguageValue[] {
   });
 };
 
-const register = function (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, lastSuggestionsState: Cell<LastSuggestion>) {
+const register = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, lastSuggestionsState: Cell<LastSuggestion>) => {
   const languageMenuItems = buildMenuItems('Language', getItems(editor));
-  const startSpellchecking = function () {
+  const startSpellchecking = () => {
     Actions.spellcheck(editor, pluginUrl, startedState, textMatcherState, lastSuggestionsState, currentLanguageState);
   };
 

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
@@ -63,8 +63,8 @@ const getSuggestions = (editor: Editor, pluginUrl: string, lastSuggestionsState:
   return items;
 };
 
-const setup = function (editor: Editor, pluginUrl: string, lastSuggestionsState: Cell<LastSuggestion>, startedState: Cell<boolean>,
-                        textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>) {
+const setup = (editor: Editor, pluginUrl: string, lastSuggestionsState: Cell<LastSuggestion>, startedState: Cell<boolean>,
+               textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>) => {
   const update = (element: HTMLElement) => {
     const target = element;
     if (target.className === 'mce-spellchecker-word') {

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/AddToDictionaryTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/AddToDictionaryTest.ts
@@ -39,7 +39,7 @@ UnitTest.asynctest('browser.tinymce.plugins.spellchecker.AddToDictionaryTest', (
     toolbar: 'spellchecker',
     spellchecker_languages: 'English=en,French=fr,German=de',
     base_url: '/project/tinymce/js/tinymce',
-    spellchecker_callback(method, text, success, _failure) {
+    spellchecker_callback: (method, text, success, _failure) => {
       if (method === 'spellcheck') {
         success({ dictionary: dict, words: { hello: [ 'word1' ], world: [ 'word2' ] }});
       } else if (method === 'addToDictionary') {

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerKeyboardNavigationTest.ts
@@ -13,7 +13,7 @@ UnitTest.asynctest('browser.tinymce.plugins.spellchecker.SpellcheckerTest', (suc
   SilverTheme();
   SpellcheckerPlugin();
 
-  const sTestDefaultLanguage = function (editor) {
+  const sTestDefaultLanguage = (editor) => {
     return Step.sync(() => {
       Assert.eq('should be same', Settings.getLanguage(editor), 'en');
     });
@@ -65,7 +65,7 @@ UnitTest.asynctest('browser.tinymce.plugins.spellchecker.SpellcheckerTest', (suc
     toolbar: 'spellchecker',
     base_url: '/project/tinymce/js/tinymce',
     statusbar: false,
-    spellchecker_callback(method, _text, success, _failure) {
+    spellchecker_callback: (method, _text, success, _failure) => {
       if (method === 'spellcheck') {
         success({ words: {
           helo: [ 'hello' ],

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerSpanClassTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerSpanClassTest.ts
@@ -71,7 +71,7 @@ UnitTest.asynctest('browser.tinymce.plugins.spellchecker.SpellcheckerSpanClassTe
     toolbar: 'spellchecker',
     spellchecker_languages: 'English=en,French=fr,German=de',
     base_url: '/project/tinymce/js/tinymce',
-    spellchecker_callback(method, text, success, _failure) {
+    spellchecker_callback: (method, text, success, _failure) => {
       if (method === 'spellcheck') {
         success({ dictionary: dict, words: { hello: [ 'word1' ], world: [ 'word2' ], bold: [ 'word3' ] }});
       } else if (method === 'addToDictionary') {

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerTest.ts
@@ -11,7 +11,7 @@ UnitTest.asynctest('browser.tinymce.plugins.spellchecker.SpellcheckerTest', (suc
   SilverTheme();
   SpellcheckerPlugin();
 
-  const sTestDefaultLanguage = function (editor) {
+  const sTestDefaultLanguage = (editor) => {
     return Step.sync(() => {
       Assert.eq('should be same', Settings.getLanguage(editor), 'en');
     });

--- a/modules/tinymce/src/plugins/tabfocus/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/tabfocus/main/ts/Plugin.ts
@@ -8,8 +8,8 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Keyboard from './core/Keyboard';
 
-export default function () {
+export default () => {
   PluginManager.add('tabfocus', (editor) => {
     Keyboard.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/tabfocus/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/tabfocus/main/ts/api/Settings.ts
@@ -5,11 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const getTabFocusElements = function (editor) {
+const getTabFocusElements = (editor) => {
   return editor.getParam('tabfocus_elements', ':prev,:next');
 };
 
-const getTabFocus = function (editor) {
+const getTabFocus = (editor) => {
   return editor.getParam('tab_focus', getTabFocusElements(editor));
 };
 

--- a/modules/tinymce/src/plugins/tabfocus/main/ts/core/Keyboard.ts
+++ b/modules/tinymce/src/plugins/tabfocus/main/ts/core/Keyboard.ts
@@ -16,32 +16,32 @@ import * as Settings from '../api/Settings';
 
 const DOM = DOMUtils.DOM;
 
-const tabCancel = function (e) {
+const tabCancel = (e) => {
   if (e.keyCode === VK.TAB && !e.ctrlKey && !e.altKey && !e.metaKey) {
     e.preventDefault();
   }
 };
 
-const setup = function (editor: Editor) {
-  function tabHandler(e) {
+const setup = (editor: Editor) => {
+  const tabHandler = (e) => {
     let x: number, i: number;
 
     if (e.keyCode !== VK.TAB || e.ctrlKey || e.altKey || e.metaKey || e.isDefaultPrevented()) {
       return;
     }
 
-    function find(direction) {
+    const find = (direction) => {
       const el = DOM.select(':input:enabled,*[tabindex]:not(iframe)');
 
-      function canSelectRecursive(e) {
+      const canSelectRecursive = (e) => {
         return e.nodeName === 'BODY' || (e.type !== 'hidden' &&
           e.style.display !== 'none' &&
           e.style.visibility !== 'hidden' && canSelectRecursive(e.parentNode));
-      }
+      };
 
-      function canSelect(el) {
+      const canSelect = (el) => {
         return /INPUT|TEXTAREA|BUTTON/.test(el.tagName) && EditorManager.get(e.id) && el.tabIndex !== -1 && canSelectRecursive(el);
-      }
+      };
 
       Tools.each(el, (e, i) => {
         if (e.id === editor.id) {
@@ -64,7 +64,7 @@ const setup = function (editor: Editor) {
       }
 
       return null;
-    }
+    };
 
     const v = Tools.explode(Settings.getTabFocus(editor));
 
@@ -106,7 +106,7 @@ const setup = function (editor: Editor) {
 
       e.preventDefault();
     }
-  }
+  };
 
   editor.on('init', () => {
     if (editor.inline) {

--- a/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
+++ b/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
@@ -10,7 +10,7 @@ UnitTest.asynctest('browser.tinymce.plugins.tabfocus.TabfocusSanityTest', (succe
   Theme();
   TabfocusPlugin();
 
-  const sAddInputs = function (editor) {
+  const sAddInputs = (editor) => {
     return Logger.t('Add inputs', Step.sync(() => {
       const container = editor.getContainer();
       const input1 = document.createElement('input');

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -26,7 +26,7 @@ import { getSelectionStartCellOrCaption } from './selection/TableSelection';
 import * as Buttons from './ui/Buttons';
 import * as MenuItems from './ui/MenuItems';
 
-function Plugin(editor: Editor) {
+const Plugin = (editor: Editor) => {
   const selections = Selections(() => Util.getBody(editor), () => getSelectionStartCellOrCaption(Util.getSelectionStart(editor)), ephemera.selectedSelector);
   const selectionTargets = getSelectionTargets(editor, selections);
   const resizeHandler = getResizeHandler(editor);
@@ -59,8 +59,8 @@ function Plugin(editor: Editor) {
   });
 
   return getApi(editor, clipboard, resizeHandler, selectionTargets);
-}
+};
 
-export default function () {
+export default () => {
   PluginManager.add('table', Plugin);
-}
+};

--- a/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
@@ -14,7 +14,7 @@ import * as TableTargets from '../queries/TableTargets';
 import * as Ephemera from '../selection/Ephemera';
 import { TableActions } from './TableActions';
 
-const extractSelected = function (cells) {
+const extractSelected = (cells) => {
   // Assume for now that we only have one table (also handles the case where we multi select outside a table)
   return TableLookup.table(cells[0]).map(Replication.deep).map((replica) => {
     return [ CopySelected.extract(replica, Ephemera.attributeSelector) ];
@@ -25,9 +25,9 @@ const serializeElements = (editor: Editor, elements: SugarElement[]): string => 
 
 const getTextContent = (elements: SugarElement[]): string => Arr.map(elements, (element) => element.dom.innerText).join('');
 
-const registerEvents = function (editor: Editor, selections: Selections, actions: TableActions, cellSelection) {
+const registerEvents = (editor: Editor, selections: Selections, actions: TableActions, cellSelection) => {
   editor.on('BeforeGetContent', (e) => {
-    const multiCellContext = function (cells) {
+    const multiCellContext = (cells) => {
       e.preventDefault();
       extractSelected(cells).each((elements) => {
         e.content = e.format === 'text' ? getTextContent(elements) : serializeElements(editor, elements);

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -25,14 +25,14 @@ export interface ResizeHandler {
 const barResizerPrefix = 'bar-';
 const isResizable = (elm: SugarElement<Element>) => Attribute.get(elm, 'data-mce-resize') !== 'false';
 
-export const getResizeHandler = function (editor: Editor): ResizeHandler {
+export const getResizeHandler = (editor: Editor): ResizeHandler => {
   let selectionRng = Optional.none<Range>();
   let resize = Optional.none<TableResize>();
   let wire = Optional.none<ResizeWire>();
   let startW: number;
   let startRawW: string;
 
-  const isTable = function (elm: Node): elm is HTMLTableElement {
+  const isTable = (elm: Node): elm is HTMLTableElement => {
     return elm.nodeName === 'TABLE';
   };
 
@@ -87,7 +87,7 @@ export const getResizeHandler = function (editor: Editor): ResizeHandler {
     }
   };
 
-  const destroy = function () {
+  const destroy = () => {
     resize.each((sz) => {
       sz.destroy();
     });

--- a/modules/tinymce/src/plugins/table/main/ts/actions/Styles.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/Styles.ts
@@ -9,11 +9,11 @@ import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 
-const getTDTHOverallStyle = function (dom: DOMUtils, elm: Element, name: string): string {
+const getTDTHOverallStyle = (dom: DOMUtils, elm: Element, name: string): string => {
   const cells = dom.select('td,th', elm);
   let firstChildStyle: string;
 
-  const checkChildren = function (firstChildStyle: string, elms: Element[]) {
+  const checkChildren = (firstChildStyle: string, elms: Element[]) => {
     for (let i = 0; i < elms.length; i++) {
       const currentStyle = dom.getStyle(elms[i], name);
       if (typeof firstChildStyle === 'undefined') {
@@ -29,25 +29,25 @@ const getTDTHOverallStyle = function (dom: DOMUtils, elm: Element, name: string)
   return checkChildren(firstChildStyle, cells);
 };
 
-const applyAlign = function (editor: Editor, elm: Element, name: string) {
+const applyAlign = (editor: Editor, elm: Element, name: string) => {
   if (name) {
     editor.formatter.apply('align' + name, {}, elm);
   }
 };
 
-const applyVAlign = function (editor: Editor, elm: Element, name: string) {
+const applyVAlign = (editor: Editor, elm: Element, name: string) => {
   if (name) {
     editor.formatter.apply('valign' + name, {}, elm);
   }
 };
 
-const unApplyAlign = function (editor: Editor, elm: Element) {
+const unApplyAlign = (editor: Editor, elm: Element) => {
   Tools.each('left center right'.split(' '), (name) => {
     editor.formatter.remove('align' + name, {}, elm);
   });
 };
 
-const unApplyVAlign = function (editor: Editor, elm: Element) {
+const unApplyVAlign = (editor: Editor, elm: Element) => {
   Tools.each('top middle bottom'.split(' '), (name) => {
     editor.formatter.remove('valign' + name, {}, elm);
   });

--- a/modules/tinymce/src/plugins/table/main/ts/actions/TableWire.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/TableWire.ts
@@ -11,7 +11,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Util from '../core/Util';
 
-const createContainer = function () {
+const createContainer = () => {
   const container = SugarElement.fromTag('div');
 
   Css.setAll(container, {
@@ -28,11 +28,11 @@ const createContainer = function () {
   return container;
 };
 
-const get = function (editor: Editor, isResizable: (elm: SugarElement<Element>) => boolean) {
+const get = (editor: Editor, isResizable: (elm: SugarElement<Element>) => boolean) => {
   return editor.inline ? ResizeWire.body(Util.getBody(editor), createContainer(), isResizable) : ResizeWire.only(SugarElement.fromDom(editor.getDoc()), isResizable);
 };
 
-const remove = function (editor: Editor, wire: ResizeWire) {
+const remove = (editor: Editor, wire: ResizeWire) => {
   if (editor.inline) {
     Remove.remove(wire.parent());
   }

--- a/modules/tinymce/src/plugins/table/main/ts/queries/TabContext.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/TabContext.ts
@@ -16,20 +16,20 @@ import { TableActions } from '../actions/TableActions';
 import * as Util from '../core/Util';
 import * as TableTargets from './TableTargets';
 
-const forward = function (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: SugarElement<HTMLTableCellElement>, actions: TableActions) {
+const forward = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: SugarElement<HTMLTableCellElement>, actions: TableActions) => {
   return go(editor, isRoot, CellNavigation.next(cell), actions);
 };
 
-const backward = function (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: SugarElement<HTMLTableCellElement>, actions: TableActions) {
+const backward = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: SugarElement<HTMLTableCellElement>, actions: TableActions) => {
   return go(editor, isRoot, CellNavigation.prev(cell), actions);
 };
 
-const getCellFirstCursorPosition = function (editor: Editor, cell: SugarElement<Node>): Range {
+const getCellFirstCursorPosition = (editor: Editor, cell: SugarElement<Node>): Range => {
   const selection = SimSelection.exact(cell, 0, cell, 0);
   return WindowSelection.toNative(selection);
 };
 
-const getNewRowCursorPosition = function (editor: Editor, table: SugarElement<HTMLTableElement>): Optional<Range> {
+const getNewRowCursorPosition = (editor: Editor, table: SugarElement<HTMLTableElement>): Optional<Range> => {
   const rows = SelectorFilter.descendants<HTMLTableRowElement>(table, 'tr');
   return Arr.last(rows).bind((last) => {
     return SelectorFind.descendant<HTMLTableCellElement>(last, 'td,th').map((first) => {
@@ -38,7 +38,7 @@ const getNewRowCursorPosition = function (editor: Editor, table: SugarElement<HT
   });
 };
 
-const go = function (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: CellLocation, actions: TableActions): Optional<Range> {
+const go = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: CellLocation, actions: TableActions): Optional<Range> => {
   return cell.fold<Optional<Range>>(Optional.none, Optional.none, (current, next) => {
     return CursorPosition.first(next).map((cell) => {
       return getCellFirstCursorPosition(editor, cell);
@@ -56,10 +56,10 @@ const go = function (editor: Editor, isRoot: (e: SugarElement) => boolean, cell:
 
 const rootElements = [ 'table', 'li', 'dl' ];
 
-const handle = function (event: KeyboardEvent, editor: Editor, actions: TableActions) {
+const handle = (event: KeyboardEvent, editor: Editor, actions: TableActions) => {
   if (event.keyCode === VK.TAB) {
     const body = Util.getBody(editor);
-    const isRoot = function (element) {
+    const isRoot = (element) => {
       const name = SugarNode.name(element);
       return Compare.eq(element, body) || Arr.contains(rootElements, name);
     };

--- a/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
@@ -25,7 +25,7 @@ export interface CellSelectionApi {
   clear: (container: SugarElement) => void;
 }
 
-export default function (editor: Editor, lazyResize: () => Optional<TableResize>, selectionTargets: SelectionTargets): CellSelectionApi {
+export default (editor: Editor, lazyResize: () => Optional<TableResize>, selectionTargets: SelectionTargets): CellSelectionApi => {
   const onSelection = (cells: SugarElement[], start: SugarElement, finish: SugarElement) => {
     selectionTargets.targets().each((targets) => {
       const tableOpt = TableLookup.table(start);
@@ -186,4 +186,4 @@ export default function (editor: Editor, lazyResize: () => Optional<TableResize>
   return {
     clear: annotations.clear
   };
-}
+};

--- a/modules/tinymce/src/plugins/table/test/ts/browser/GridSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/GridSelectionTest.ts
@@ -15,7 +15,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.GridSelectionTest', (success, 
   TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
     const tinyApis = TinyApis(editor);
 
-    const sAssertTableSelection = function (tableHtml: string, selectCells: string[], cellContents: string[]) {
+    const sAssertTableSelection = (tableHtml: string, selectCells: string[], cellContents: string[]) => {
       const selectRangeXY = (table, startTd, endTd) => {
         editor.fire('mousedown', { target: startTd, button: 0 } as MouseEvent);
         editor.fire('mouseover', { target: endTd, button: 0 } as MouseEvent);
@@ -75,7 +75,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.GridSelectionTest', (success, 
       )
     ];
 
-    const sAssertSelectionContent = function (editor, expectedHtml: string) {
+    const sAssertSelectionContent = (editor, expectedHtml: string) => {
       return Step.sync(() => {
         Assertions.assertHtml('Should be expected content', expectedHtml, editor.selection.getContent());
       });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
@@ -11,7 +11,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.IndentListsInTableTest', (succ
   TablePlugin();
   ListsPlugin();
 
-  const sAssertTableInnerHTML = function (editor, expected) {
+  const sAssertTableInnerHTML = (editor, expected) => {
     return Logger.t('Assert table InnerHTML ' + expected, Step.sync(() => {
       const actual = editor.getBody().firstChild.innerHTML;
       Assert.eq('Does not have correct html', expected, actual);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -22,7 +22,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.InlineEditorInsideTableTest', 
   '</tbody>' +
   '</table>';
 
-  const cOnSelector = function (selector: string) {
+  const cOnSelector = (selector: string) => {
     return Chain.control(
       Chain.async((_, next) => {
         EditorManager.init({
@@ -34,7 +34,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.InlineEditorInsideTableTest', 
           plugins: 'table',
           skin_url: '/project/tinymce/js/tinymce/skins/ui/oxide',
           content_css: '/project/tinymce/js/tinymce/skins/content/default',
-          setup(editor) {
+          setup: (editor) => {
             editor.on('SkinLoaded', () => {
               Delay.setTimeout(() => {
                 next(editor);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
@@ -33,7 +33,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.ResizeTableTest', (success, fa
     table_toolbar: ''
   };
 
-  const assertWithin = function (value, min, max) {
+  const assertWithin = (value, min, max) => {
     Assertions.assertEq('asserting if value falls within a certain range', true, value >= min && value <= max);
   };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertCommandsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertCommandsTest.ts
@@ -13,7 +13,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.command.InsertCommandsTest', (
   Plugin();
   SilverTheme();
 
-  const cleanTableHtml = function (html: string) {
+  const cleanTableHtml = (html: string) => {
     return html.replace(/<p>(&nbsp;|<br[^>]+>)<\/p>$/, '');
   };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
@@ -35,7 +35,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.command.MergeCellCommandTest',
   const clearEvents = () => modifiedEvents = [];
   const defaultEvent = { type: 'tablemodified', structure: true, style: false } as TableModifiedEvent;
 
-  const testCommand = function (editor: Editor, command: string, tests: MergeCellTest[]) {
+  const testCommand = (editor: Editor, command: string, tests: MergeCellTest[]) => {
     Tools.each(tests, (test) => {
       clearEvents();
       editor.getBody().innerHTML = test.before;
@@ -47,7 +47,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.command.MergeCellCommandTest',
     });
   };
 
-  const cleanTableHtml = function (html: string) {
+  const cleanTableHtml = (html: string) => {
     return html.replace(/<p>(&nbsp;|<br[^>]+>)<\/p>$/, '');
   };
 

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -50,7 +50,7 @@ const sAssertTableStructure = (editor: Editor, structure: StructAssert) => Logge
   Assertions.assertStructure('Should be a table the expected structure', structure, table);
 }));
 
-const sOpenToolbarOn = function (editor, selector, path) {
+const sOpenToolbarOn = (editor, selector, path) => {
   return Logger.t('Open dialog from toolbar', Chain.asStep(TinyDom.fromDom(editor.getBody()), [
     UiFinder.cFindIn(selector),
     Cursors.cFollow(path),
@@ -230,7 +230,7 @@ const cDeleteRow = Chain.control(
   Guard.addLogging('Delete row')
 );
 
-const cDragHandle = function (id, deltaH, deltaV) {
+const cDragHandle = (id, deltaH, deltaV) => {
   return Chain.control(
     NamedChain.asChain([
       NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),

--- a/modules/tinymce/src/plugins/template/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/Plugin.ts
@@ -10,10 +10,10 @@ import * as Commands from './api/Commands';
 import * as FilterContent from './core/FilterContent';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('template', (editor) => {
     Buttons.register(editor);
     Commands.register(editor);
     FilterContent.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
@@ -8,7 +8,7 @@
 import { Fun } from '@ephox/katamari';
 import * as Templates from '../core/Templates';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('mceInsertTemplate', Fun.curry(Templates.insertTemplate, editor));
 };
 

--- a/modules/tinymce/src/plugins/template/main/ts/core/DateTimeHelper.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/DateTimeHelper.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const addZeros = function (value, len) {
+const addZeros = (value, len) => {
   value = '' + value;
 
   if (value.length < len) {
@@ -17,7 +17,7 @@ const addZeros = function (value, len) {
   return value;
 };
 
-const getDateTime = function (editor, fmt, date?) {
+const getDateTime = (editor, fmt, date?) => {
   const daysShort = 'Sun Mon Tue Wed Thu Fri Sat Sun'.split(' ');
   const daysLong = 'Sunday Monday Tuesday Wednesday Thursday Friday Saturday Sunday'.split(' ');
   const monthsShort = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ');

--- a/modules/tinymce/src/plugins/template/main/ts/core/Templates.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/Templates.ts
@@ -11,8 +11,8 @@ import XHR from 'tinymce/core/api/util/XHR';
 import * as Settings from '../api/Settings';
 import * as DateTimeHelper from './DateTimeHelper';
 
-const createTemplateList = function (editor: Editor, callback) {
-  return function () {
+const createTemplateList = (editor: Editor, callback) => {
+  return () => {
     const templateList = Settings.getTemplates(editor);
 
     if (typeof templateList === 'function') {
@@ -23,7 +23,7 @@ const createTemplateList = function (editor: Editor, callback) {
     if (typeof templateList === 'string') {
       XHR.send({
         url: templateList,
-        success(text) {
+        success: (text) => {
           callback(JSON.parse(text));
         }
       });
@@ -33,7 +33,7 @@ const createTemplateList = function (editor: Editor, callback) {
   };
 };
 
-const replaceTemplateValues = function (html, templateValues) {
+const replaceTemplateValues = (html, templateValues) => {
   Tools.each(templateValues, (v, k) => {
     if (typeof v === 'function') {
       v = v(k);
@@ -45,7 +45,7 @@ const replaceTemplateValues = function (html, templateValues) {
   return html;
 };
 
-const replaceVals = function (editor, e) {
+const replaceVals = (editor, e) => {
   const dom = editor.dom, vl = Settings.getTemplateReplaceValues(editor);
 
   Tools.each(dom.select('*', e), (e) => {
@@ -59,11 +59,11 @@ const replaceVals = function (editor, e) {
   });
 };
 
-const hasClass = function (n, c) {
+const hasClass = (n, c) => {
   return new RegExp('\\b' + c + '\\b', 'g').test(n.className);
 };
 
-const insertTemplate = function (editor: Editor, _ui: boolean, html: string) {
+const insertTemplate = (editor: Editor, _ui: boolean, html: string) => {
   // Note: ui is unused here but is required since this can be called by execCommand
   let el;
   const dom = editor.dom;

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
@@ -9,13 +9,13 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Templates from '../core/Templates';
 import * as Dialog from './Dialog';
 
-const showDialog = function (editor: Editor) {
-  return function (templates) {
+const showDialog = (editor: Editor) => {
+  return (templates) => {
     Dialog.open(editor, templates);
   };
 };
 
-const register = function (editor: Editor) {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('template', {
     icon: 'template',
     tooltip: 'Insert template',

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
@@ -139,7 +139,7 @@ const open = (editor: Editor, templateList: ExternalTemplate[]) => {
   const getTemplateContent = (t: InternalTemplate) => new Promise<string>((resolve, reject) => {
     t.value.url.fold(() => resolve(t.value.content.getOr('')), (url) => XHR.send({
       url,
-      success(html: string) {
+      success: (html: string) => {
         resolve(html);
       },
       error: (e) => {

--- a/modules/tinymce/src/plugins/textcolor/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/textcolor/main/ts/Plugin.ts
@@ -7,9 +7,9 @@
 
 import PluginManager from 'tinymce/core/api/PluginManager';
 
-export default function () {
+export default () => {
   PluginManager.add('textcolor', () => {
     // eslint-disable-next-line no-console
     console.warn('Text color plugin is now built in to the core editor, please remove it from your editor configuration');
   });
-}
+};

--- a/modules/tinymce/src/plugins/textpattern/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/Plugin.ts
@@ -11,7 +11,7 @@ import * as Api from './api/Api';
 import * as Settings from './api/Settings';
 import * as Keyboard from './keyboard/Keyboard';
 
-export default function () {
+export default () => {
   PluginManager.add('textpattern', (editor) => {
     const patternsState = Cell(Settings.getPatternSet(editor));
 
@@ -19,4 +19,4 @@ export default function () {
 
     return Api.get(patternsState);
   });
-}
+};

--- a/modules/tinymce/src/plugins/textpattern/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/api/Settings.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { PatternSet } from '../core/PatternTypes';
 import { createPatternSet, normalizePattern } from './Pattern';
 
-const error = function (...args: Parameters<Console['error']>) {
+const error = (...args: Parameters<Console['error']>) => {
   const console: Console = Global.console;
   if (console) { // Skip test env
     if (console.error) { // tslint:disable-line:no-console

--- a/modules/tinymce/src/plugins/textpattern/main/ts/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/keyboard/Keyboard.ts
@@ -13,7 +13,7 @@ import VK from 'tinymce/core/api/util/VK';
 import { PatternSet } from '../core/PatternTypes';
 import * as KeyHandler from './KeyHandler';
 
-const setup = function (editor: Editor, patternsState: Cell<PatternSet>) {
+const setup = (editor: Editor, patternsState: Cell<PatternSet>) => {
   const charCodes = [ ',', '.', ';', ':', '!', '?' ];
   const keyCodes = [ 32 ];
 

--- a/modules/tinymce/src/plugins/textpattern/test/ts/atomic/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/atomic/FindBlockPatternsTest.ts
@@ -9,7 +9,7 @@ UnitTest.test('atomic.tinymce.plugins.textpattern.FindBlockPatternsTest', () => 
   const patternSet = getPatternSet(mockEditor as any);
   const defaultPatterns = patternSet.blockPatterns;
 
-  const testFindStartPattern = function (text: string, expectedPattern: string) {
+  const testFindStartPattern = (text: string, expectedPattern: string) => {
     const actual = findPattern(defaultPatterns, text).getOrNull();
 
     Assert.eq('Assert correct pattern', expectedPattern, actual.start);

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/FindInlinePatternTest.ts
@@ -27,7 +27,7 @@ UnitTest.asynctest('browser.tinymce.plugins.textpattern.FindInlinePatternTest', 
 
   const inlinePatterns = Settings.getPatternSet(mockEditor as any).inlinePatterns;
 
-  const cGetInlinePattern = function (patterns: InlinePattern[], space: boolean = false) {
+  const cGetInlinePattern = (patterns: InlinePattern[], space: boolean = false) => {
     const asStr = (p: InlinePattern) => {
       if (p.type === 'inline-format') {
         return p.start + 'TEXT' + p.end + ' = ' + JSON.stringify(p.format);
@@ -50,7 +50,7 @@ UnitTest.asynctest('browser.tinymce.plugins.textpattern.FindInlinePatternTest', 
     endRng: PathRange;
   }
 
-  const cAssertPatterns = function (expectedMatches: ExpectedPatternMatch[]) {
+  const cAssertPatterns = (expectedMatches: ExpectedPatternMatch[]) => {
     return Chain.op<InlinePatternMatch[]>((actualMatches) => {
       Assertions.assertEq('Pattern count does not match', expectedMatches.length, actualMatches.length);
       for (let i = 0; i < expectedMatches.length; i++) {
@@ -73,7 +73,7 @@ UnitTest.asynctest('browser.tinymce.plugins.textpattern.FindInlinePatternTest', 
     });
   };
 
-  const cAssertSimpleMatch = function (matchStart: string, matchEnd: string, formats: string[], startRng: PathRange, endRng: PathRange) {
+  const cAssertSimpleMatch = (matchStart: string, matchEnd: string, formats: string[], startRng: PathRange, endRng: PathRange) => {
     return cAssertPatterns([{ pattern: { start: matchStart, end: matchEnd, format: formats }, startRng, endRng }]);
   };
 

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TrailingPunctuationTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TrailingPunctuationTest.ts
@@ -12,15 +12,15 @@ UnitTest.asynctest(
     Theme();
     TextpatternPlugin();
 
-    const sTypeChar = function (editor: Editor, character: string) {
+    const sTypeChar = (editor: Editor, character: string) => {
       return Logger.t(`Type ${character}`, Step.sync(() => {
         const charCode = character.charCodeAt(0);
         editor.fire('keypress', { charCode } as KeyboardEvent);
       }));
     };
 
-    const sTypeAndTrigger = function (tinyApis: TinyApis, editor: Editor) {
-      return function (label, patternText, trigger, tag, rawText) {
+    const sTypeAndTrigger = (tinyApis: TinyApis, editor: Editor) => {
+      return (label, patternText, trigger, tag, rawText) => {
         return Logger.t(label, GeneralSteps.sequence([
           tinyApis.sSetContent('<p>' + patternText + trigger + '</p>'),
           tinyApis.sFocus(),

--- a/modules/tinymce/src/plugins/textpattern/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/module/test/Utils.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, GeneralSteps, Keys, Logger, Step, StructAssert } from 
 import { Arr, Unicode } from '@ephox/katamari';
 import { TinyActions, TinyApis } from '@ephox/mcagar';
 
-const sSetContentAndFireKeystroke = function (key: number) {
-  return function (tinyApis: TinyApis, tinyActions: TinyActions, content: string, offset = content.length, elementPath = [ 0, 0 ], wrapInP = true) {
+const sSetContentAndFireKeystroke = (key: number) => {
+  return (tinyApis: TinyApis, tinyActions: TinyActions, content: string, offset = content.length, elementPath = [ 0, 0 ], wrapInP = true) => {
     return Logger.t(`Set content and press ${key}`, GeneralSteps.sequence([
       tinyApis.sSetContent(wrapInP ? '<p>' + content + '</p>' : content),
       tinyApis.sFocus(),
@@ -27,13 +27,13 @@ const sSetContentAndPressSpace = (tinyApis: TinyApis, tinyActions: TinyActions, 
   tinyActions.sContentKeystroke(32, {})
 ]));
 
-const withTeardown = function (steps: Step<any, any>[], teardownStep: Step<any, any>) {
+const withTeardown = (steps: Step<any, any>[], teardownStep: Step<any, any>) => {
   return Arr.bind(steps, (step) => {
     return [ step, teardownStep ];
   });
 };
 
-const bodyStruct = function (children: StructAssert[]) {
+const bodyStruct = (children: StructAssert[]) => {
   return ApproxStructure.build((s, _str) => {
     return s.element('body', {
       children
@@ -41,7 +41,7 @@ const bodyStruct = function (children: StructAssert[]) {
   });
 };
 
-const inlineStructHelper = function (tag: string, content: string) {
+const inlineStructHelper = (tag: string, content: string) => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element('p', {
@@ -58,7 +58,7 @@ const inlineStructHelper = function (tag: string, content: string) {
   });
 };
 
-const inlineBlockStructHelper = function (tag: string, content: string) {
+const inlineBlockStructHelper = (tag: string, content: string) => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element('p', {
@@ -76,7 +76,7 @@ const inlineBlockStructHelper = function (tag: string, content: string) {
   });
 };
 
-const blockStructHelper = function (tag: string, content: string) {
+const blockStructHelper = (tag: string, content: string) => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element(tag, {
@@ -89,7 +89,7 @@ const blockStructHelper = function (tag: string, content: string) {
   });
 };
 
-const forcedRootBlockInlineStructHelper = function (tag: string, content: string) {
+const forcedRootBlockInlineStructHelper = (tag: string, content: string) => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element(tag, {
@@ -104,7 +104,7 @@ const forcedRootBlockInlineStructHelper = function (tag: string, content: string
   });
 };
 
-const forcedRootBlockStructHelper = function (tag: string, content: string) {
+const forcedRootBlockStructHelper = (tag: string, content: string) => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element(tag, {

--- a/modules/tinymce/src/plugins/toc/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/Plugin.ts
@@ -10,10 +10,10 @@ import * as Commands from './api/Commands';
 import * as FilterContent from './core/FilterContent';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('toc', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);
     FilterContent.setup(editor);
   });
-}
+};

--- a/modules/tinymce/src/plugins/toc/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import * as Toc from '../core/Toc';
 
-const register = function (editor) {
+const register = (editor) => {
   editor.addCommand('mceInsertToc', () => {
     Toc.insertToc(editor);
   });

--- a/modules/tinymce/src/plugins/toc/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/api/Settings.ts
@@ -5,16 +5,16 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const getTocClass = function (editor) {
+const getTocClass = (editor) => {
   return editor.getParam('toc_class', 'mce-toc');
 };
 
-const getTocHeader = function (editor) {
+const getTocHeader = (editor) => {
   const tagName = editor.getParam('toc_header', 'h2');
   return /^h[1-6]$/.test(tagName) ? tagName : 'h2';
 };
 
-const getTocDepth = function (editor) {
+const getTocDepth = (editor) => {
   const depth = parseInt(editor.getParam('toc_depth', '3'), 10);
   return depth >= 1 && depth <= 9 ? depth : 3;
 };

--- a/modules/tinymce/src/plugins/toc/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/core/FilterContent.ts
@@ -7,7 +7,7 @@
 
 import * as Settings from '../api/Settings';
 
-const setup = function (editor) {
+const setup = (editor) => {
   const $ = editor.$, tocClass = Settings.getTocClass(editor);
 
   editor.on('PreProcess', (e) => {

--- a/modules/tinymce/src/plugins/toc/main/ts/core/Guid.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/core/Guid.ts
@@ -5,10 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const create = function (prefix) {
+const create = (prefix) => {
   let counter = 0;
 
-  return function () {
+  return () => {
     const guid = new Date().getTime().toString(32);
     return prefix + guid + (counter++).toString(32);
   };

--- a/modules/tinymce/src/plugins/toc/main/ts/core/Toc.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/core/Toc.ts
@@ -14,7 +14,7 @@ import * as Guid from './Guid';
 
 const tocId = Guid.create('mcetoc_');
 
-const generateSelector = function (depth: number) {
+const generateSelector = (depth: number) => {
   let i;
   const selector = [];
   for (i = 1; i <= depth; i++) {
@@ -23,11 +23,11 @@ const generateSelector = function (depth: number) {
   return selector.join(',');
 };
 
-const hasHeaders = function (editor: Editor) {
+const hasHeaders = (editor: Editor) => {
   return readHeaders(editor).length > 0;
 };
 
-const readHeaders = function (editor: Editor) {
+const readHeaders = (editor: Editor) => {
   const tocClass = Settings.getTocClass(editor);
   const headerTag = Settings.getTocHeader(editor);
   const selector = generateSelector(Settings.getTocDepth(editor));
@@ -51,7 +51,7 @@ const readHeaders = function (editor: Editor) {
   });
 };
 
-const getMinLevel = function (headers) {
+const getMinLevel = (headers) => {
   let i, minLevel = 9;
 
   for (i = 0; i < headers.length; i++) {
@@ -67,18 +67,18 @@ const getMinLevel = function (headers) {
   return minLevel;
 };
 
-const generateTitle = function (tag, title) {
+const generateTitle = (tag, title) => {
   const openTag = '<' + tag + ' contenteditable="true">';
   const closeTag = '</' + tag + '>';
   return openTag + DOMUtils.DOM.encode(title) + closeTag;
 };
 
-const generateTocHtml = function (editor) {
+const generateTocHtml = (editor) => {
   const html = generateTocContentHtml(editor);
   return '<div class="' + editor.dom.encode(Settings.getTocClass(editor)) + '" contenteditable="false">' + html + '</div>';
 };
 
-const generateTocContentHtml = function (editor) {
+const generateTocContentHtml = (editor) => {
   let html = '';
   const headers = readHeaders(editor);
   let prevLevel = getMinLevel(headers) - 1;
@@ -123,11 +123,11 @@ const generateTocContentHtml = function (editor) {
   return html;
 };
 
-const isEmptyOrOffscren = function (editor, nodes) {
+const isEmptyOrOffscren = (editor, nodes) => {
   return !nodes.length || editor.dom.getParents(nodes[0], '.mce-offscreen-selection').length > 0;
 };
 
-const insertToc = function (editor) {
+const insertToc = (editor) => {
   const tocClass = Settings.getTocClass(editor);
   const $tocElm = editor.$('.' + tocClass);
 
@@ -138,7 +138,7 @@ const insertToc = function (editor) {
   }
 };
 
-const updateToc = function (editor) {
+const updateToc = (editor) => {
   const tocClass = Settings.getTocClass(editor);
   const $tocElm = editor.$('.' + tocClass);
 

--- a/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
+++ b/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
@@ -15,7 +15,7 @@ UnitTest.asynctest('browser.tinymce.plugins.toc.TocPluginTest', (success, failur
   Plugin();
   Theme();
 
-  const stripAttribs = function ($el, attr) {
+  const stripAttribs = ($el, attr) => {
     if (Tools.isArray(attr)) {
       Tools.each(attr, (attr) => {
         stripAttribs($el, attr);
@@ -27,7 +27,7 @@ UnitTest.asynctest('browser.tinymce.plugins.toc.TocPluginTest', (success, failur
     $el.find('[' + attr + ']').removeAttr(attr);
   };
 
-  const trimBr = function (html) {
+  const trimBr = (html) => {
     return html.replace(/<br data-mce-bogus="1" \/>/g, '');
   };
 

--- a/modules/tinymce/src/plugins/toc/test/ts/module/test/HtmlUtils.ts
+++ b/modules/tinymce/src/plugins/toc/test/ts/module/test/HtmlUtils.ts
@@ -1,7 +1,7 @@
 import SaxParser from 'tinymce/core/api/html/SaxParser';
 import Writer from 'tinymce/core/api/html/Writer';
 
-const cleanHtml = function (html) {
+const cleanHtml = (html) => {
   return html.toLowerCase().replace(/[\r\n]+/gi, '')
     .replace(/ (sizcache[0-9]+|sizcache|nodeindex|sizset[0-9]+|sizset|data\-mce\-expando|data\-mce\-selected)="[^"]*"/gi, '')
     .replace(/<span[^>]+data-mce-bogus[^>]+>[\u200B\uFEFF]+<\/span>|<div[^>]+data-mce-bogus[^>]+><\/div>/gi, '')
@@ -11,7 +11,7 @@ const cleanHtml = function (html) {
     });
 };
 
-const normalizeHtml = function (html) {
+const normalizeHtml = (html) => {
   const writer = Writer();
 
   SaxParser({
@@ -23,7 +23,7 @@ const normalizeHtml = function (html) {
     pi: writer.pi,
     doctype: writer.doctype,
 
-    start(name, attrs, empty) {
+    start: (name, attrs, empty) => {
       attrs.sort((a, b) => {
         if (a.name === b.name) {
           return 0;

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/Plugin.ts
@@ -11,7 +11,7 @@ import * as Commands from './api/Commands';
 import * as Bindings from './core/Bindings';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('visualblocks', (editor, pluginUrl) => {
     const enabledState = Cell(false);
 
@@ -19,4 +19,4 @@ export default function () {
     Buttons.register(editor, enabledState);
     Bindings.setup(editor, pluginUrl, enabledState);
   });
-}
+};

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/api/Commands.ts
@@ -9,7 +9,7 @@ import { Cell } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as VisualBlocks from '../core/VisualBlocks';
 
-const register = function (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>) {
+const register = (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>) => {
   editor.addCommand('mceVisualBlocks', () => {
     VisualBlocks.toggleVisualBlocks(editor, pluginUrl, enabledState);
   });

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/api/Events.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const fireVisualBlocks = function (editor: Editor, state: boolean) {
+const fireVisualBlocks = (editor: Editor, state: boolean) => {
   editor.fire('VisualBlocks', { state });
 };
 

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/api/Settings.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const isEnabledByDefault = function (editor: Editor) {
+const isEnabledByDefault = (editor: Editor) => {
   return editor.getParam('visualblocks_default_state', false, 'boolean');
 };
 

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/core/Bindings.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/core/Bindings.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../api/Settings';
 import * as VisualBlocks from './VisualBlocks';
 
-const setup = function (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>) {
+const setup = (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>) => {
   // Prevents the visualblocks from being presented in the preview of formats when that is computed
   editor.on('PreviewFormats AfterPreviewFormats', (e) => {
     if (enabledState.get()) {

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/core/VisualBlocks.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/core/VisualBlocks.ts
@@ -9,7 +9,7 @@ import { Cell } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as Events from '../api/Events';
 
-const toggleVisualBlocks = function (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>) {
+const toggleVisualBlocks = (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>) => {
   const dom = editor.dom;
 
   dom.toggleClass(editor.getBody(), 'mce-visualblocks');

--- a/modules/tinymce/src/plugins/visualblocks/test/ts/browser/PreviewFormatTest.ts
+++ b/modules/tinymce/src/plugins/visualblocks/test/ts/browser/PreviewFormatTest.ts
@@ -10,7 +10,7 @@ UnitTest.asynctest('browser.tinymce.plugins.visualblocks.PreviewFormatsTest', (s
   Theme();
   VisualBlocksPlugin();
 
-  const sWaitForVisualBlocks = function (editor) {
+  const sWaitForVisualBlocks = (editor) => {
     return Waiter.sTryUntil('Wait for background css to be applied to first element', Step.sync(() => {
       const p = SugarElement.fromDom(editor.getBody().firstChild);
       const background = Css.get(p, 'background-image');

--- a/modules/tinymce/src/plugins/visualchars/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/Plugin.ts
@@ -14,7 +14,7 @@ import * as Bindings from './core/Bindings';
 import * as Keyboard from './core/Keyboard';
 import * as Buttons from './ui/Buttons';
 
-export default function () {
+export default () => {
   PluginManager.add('visualchars', (editor) => {
     const toggleState = Cell(Settings.isEnabledByDefault(editor));
 
@@ -25,4 +25,4 @@ export default function () {
 
     return Api.get(toggleState);
   });
-}
+};

--- a/modules/tinymce/src/plugins/visualchars/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/api/Api.ts
@@ -5,8 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const get = function (toggleState) {
-  const isEnabled = function () {
+const get = (toggleState) => {
+  const isEnabled = () => {
     return toggleState.get();
   };
 

--- a/modules/tinymce/src/plugins/visualchars/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import * as Actions from '../core/Actions';
 
-const register = function (editor, toggleState) {
+const register = (editor, toggleState) => {
   editor.addCommand('mceVisualChars', () => {
     Actions.toggleVisualChars(editor, toggleState);
   });

--- a/modules/tinymce/src/plugins/visualchars/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/api/Events.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const fireVisualChars = function (editor, state) {
+const fireVisualChars = (editor, state) => {
   return editor.fire('VisualChars', { state });
 };
 

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Data.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Data.ts
@@ -12,7 +12,7 @@ export const charMap = {
   '\u00ad': 'shy'
 };
 
-export const charMapToRegExp = function (charMap, global?) {
+export const charMapToRegExp = (charMap, global?) => {
   let regExp = '';
 
   Obj.each(charMap, (_value, key) => {
@@ -22,7 +22,7 @@ export const charMapToRegExp = function (charMap, global?) {
   return new RegExp('[' + regExp + ']', global ? 'g' : '');
 };
 
-export const charMapToSelector = function (charMap) {
+export const charMapToSelector = (charMap) => {
   let selector = '';
   Obj.each(charMap, (value) => {
     if (selector) {

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Html.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Html.ts
@@ -7,7 +7,7 @@
 
 import * as Data from './Data';
 
-const wrapCharWithSpan = function (value) {
+const wrapCharWithSpan = (value) => {
   return '<span data-mce-bogus="1" class="mce-' + Data.charMap[value] + '">' + value + '</span>';
 };
 

--- a/modules/tinymce/src/plugins/visualchars/test/ts/atomic/NodesTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/atomic/NodesTest.ts
@@ -5,7 +5,7 @@ import { SugarElement } from '@ephox/sugar';
 import * as Nodes from 'tinymce/plugins/visualchars/core/Nodes';
 
 UnitTest.test('atomic.tinymce.plugins.visualchars.NodesTest', () => {
-  const testReplaceWithSpans = function () {
+  const testReplaceWithSpans = () => {
     Assertions.assertHtml(
       'should return span around shy and nbsp',
       'a<span data-mce-bogus="1" class="mce-nbsp">\u00a0</span>b<span data-mce-bogus="1" class="mce-shy">\u00AD</span>',
@@ -13,7 +13,7 @@ UnitTest.test('atomic.tinymce.plugins.visualchars.NodesTest', () => {
     );
   };
 
-  const testFilterDescendants = function () {
+  const testFilterDescendants = () => {
     const div = document.createElement('div');
     div.innerHTML = '<p>a</p>' +
                     '<p>b' + Unicode.nbsp + '</p>' +
@@ -27,7 +27,7 @@ UnitTest.test('atomic.tinymce.plugins.visualchars.NodesTest', () => {
     );
   };
 
-  const testFilterDescendants2 = function () {
+  const testFilterDescendants2 = () => {
     const div = document.createElement('div');
     div.innerHTML = '<p>a' + Unicode.nbsp + '</p>' +
                     '<p>b' + Unicode.nbsp + '</p>' +

--- a/modules/tinymce/src/plugins/wordcount/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/Plugin.ts
@@ -10,7 +10,7 @@ import * as Api from './api/Api';
 import * as Wordcounter from './core/WordCounter';
 import * as Buttons from './ui/Buttons';
 
-export default function (delay: number = 300) {
+export default (delay: number = 300) => {
   PluginManager.add('wordcount', (editor) => {
     const api = Api.get(editor);
 
@@ -18,4 +18,4 @@ export default function (delay: number = 300) {
     Wordcounter.setup(editor, api, delay);
     return api;
   });
-}
+};

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
@@ -12,14 +12,14 @@ UnitTest.asynctest('browser.tinymce.plugins.wordcount.PluginTest', (success, fai
   Plugin(2);
   Theme();
 
-  const sReset = function (tinyApis: TinyApis) {
+  const sReset = (tinyApis: TinyApis) => {
     return Logger.t('Reset content', GeneralSteps.sequence([
       tinyApis.sSetContent(''),
       sWaitForWordcount(0)
     ]));
   };
 
-  const sAssertWordcount = function (num: number) {
+  const sAssertWordcount = (num: number) => {
     return Logger.t(`Assert word count ${num}`, Step.sync(() => {
       const countEl = DOMUtils.DOM.select('.tox-statusbar__wordcount')[0];
       const value = countEl ? countEl.innerText : '';
@@ -31,18 +31,18 @@ UnitTest.asynctest('browser.tinymce.plugins.wordcount.PluginTest', (success, fai
     tinyApis.sAssertContent(expected)
   ]));
 
-  const sWaitForWordcount = function (num: number) {
+  const sWaitForWordcount = (num: number) => {
     return Waiter.sTryUntil('wordcount did not change', sAssertWordcount(num));
   };
 
-  const sFakeTyping = function (editor: Editor, str: string) {
+  const sFakeTyping = (editor: Editor, str: string) => {
     return Logger.t(`Fake typing ${str}`, Step.sync(() => {
       editor.getBody().innerHTML = '<p>' + str + '</p>';
       Keyboard.keystroke(Keys.space(), {}, TinyDom.fromDom(editor.getBody()));
     }));
   };
 
-  const sTestSetContent = function (tinyApis: TinyApis) {
+  const sTestSetContent = (tinyApis: TinyApis) => {
     return GeneralSteps.sequence(Log.steps('TBA', 'WordCount: Set test content and assert word count', [
       sReset(tinyApis),
       tinyApis.sSetContent('<p>hello world</p>'),
@@ -50,7 +50,7 @@ UnitTest.asynctest('browser.tinymce.plugins.wordcount.PluginTest', (success, fai
     ]));
   };
 
-  const sTestKeystroke = function (editor: Editor, tinyApis: TinyApis) {
+  const sTestKeystroke = (editor: Editor, tinyApis: TinyApis) => {
     return GeneralSteps.sequence(Log.steps('TBA', 'WordCount: Test keystroke and assert word count', [
       sReset(tinyApis),
       sFakeTyping(editor, 'a b c'),
@@ -58,13 +58,13 @@ UnitTest.asynctest('browser.tinymce.plugins.wordcount.PluginTest', (success, fai
     ]));
   };
 
-  const sExecCommand = function (editor: Editor, command: string) {
+  const sExecCommand = (editor: Editor, command: string) => {
     return Logger.t(`Execute ${command}`, Step.sync(() => {
       editor.execCommand(command);
     }));
   };
 
-  const sTestUndoRedo = function (editor: Editor, tinyApis: TinyApis) {
+  const sTestUndoRedo = (editor: Editor, tinyApis: TinyApis) => {
     return GeneralSteps.sequence(Log.steps('TBA', 'WordCount: Test undo and redo', [
       sReset(tinyApis),
       tinyApis.sSetContent('<p>a b c</p>'),

--- a/modules/tinymce/src/themes/mobile/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/themes/mobile/demo/ts/demo/Demo.ts
@@ -1,6 +1,6 @@
 declare let tinymce: any;
 
-export default function () {
+export default () => {
   tinymce.init({
     selector: '.tiny-text',
     theme: 'mobile',
@@ -12,7 +12,7 @@ export default function () {
     ],
     skin_url: '../../../../../js/tinymce/skins/ui/oxide',
 
-    setup(ed) {
+    setup: (ed) => {
       ed.on('skinLoaded', () => {
         // Notification fields for equality: type, text, progressBar, timeout
         ed.notificationManager.open({
@@ -74,4 +74,4 @@ export default function () {
       }
     ]
   });
-}
+};

--- a/modules/tinymce/src/themes/mobile/demo/ts/demo/FormDemo.ts
+++ b/modules/tinymce/src/themes/mobile/demo/ts/demo/FormDemo.ts
@@ -6,12 +6,12 @@ import * as Inputs from 'tinymce/themes/mobile/ui/Inputs';
 import * as SerialisedDialog from 'tinymce/themes/mobile/ui/SerialisedDialog';
 import * as UiDomFactory from 'tinymce/themes/mobile/util/UiDomFactory';
 
-export default function () {
+export default () => {
   const ephoxUi = SelectorFind.first('#ephox-ui').getOrDie();
 
   const form = SerialisedDialog.sketch({
     onExecute: Fun.noop,
-    getInitialValue() {
+    getInitialValue: () => {
       return Optional.some({
         alpha: 'Alpha',
         beta: '',
@@ -53,4 +53,4 @@ export default function () {
   });
 
   gui.add(container);
-}
+};

--- a/modules/tinymce/src/themes/mobile/demo/ts/demo/SlidersDemo.ts
+++ b/modules/tinymce/src/themes/mobile/demo/ts/demo/SlidersDemo.ts
@@ -6,7 +6,7 @@ import * as ColorSlider from 'tinymce/themes/mobile/ui/ColorSlider';
 import * as FontSizeSlider from 'tinymce/themes/mobile/ui/FontSizeSlider';
 import * as UiDomFactory from 'tinymce/themes/mobile/util/UiDomFactory';
 
-export default function () {
+export default () => {
   const ephoxUi = SelectorFind.first('#ephox-ui').getOrDie();
 
   const fontSlider = Container.sketch({
@@ -53,4 +53,4 @@ export default function () {
   });
 
   gui.add(container);
-}
+};

--- a/modules/tinymce/src/themes/mobile/demo/ts/demo/StylesMenuDemo.ts
+++ b/modules/tinymce/src/themes/mobile/demo/ts/demo/StylesMenuDemo.ts
@@ -5,7 +5,7 @@ import { SelectorFind } from '@ephox/sugar';
 import * as StylesMenu from 'tinymce/themes/mobile/ui/StylesMenu';
 import * as UiDomFactory from 'tinymce/themes/mobile/util/UiDomFactory';
 
-export default function () {
+export default () => {
   const ephoxUi = SelectorFind.first('#ephox-ui').getOrDie();
 
   const menu = StylesMenu.sketch({
@@ -26,7 +26,7 @@ export default function () {
         { title: 'Gamma', isSelected: Fun.never, getPreview: Fun.constant('') }
       ]
     },
-    handle(format) {
+    handle: (format) => {
       // eslint-disable-next-line no-console
       console.log('firing', format);
     }
@@ -48,4 +48,4 @@ export default function () {
   });
 
   gui.add(container);
-}
+};

--- a/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/Theme.ts
@@ -58,7 +58,7 @@ const renderMobileTheme = (editor: Editor) => {
 
     const outerWindow = targetNode.ownerDocument.defaultView;
     const orientation = Orientation.onChange(outerWindow, {
-      onChange() {
+      onChange: () => {
         const alloy = realm.system;
         alloy.broadcastOn([ TinyChannels.orientationChanged ], { width: Orientation.getActualWidth(outerWindow) });
       },
@@ -95,7 +95,7 @@ const renderMobileTheme = (editor: Editor) => {
     const bindHandler = (label: string, handler) => {
       editor.on(label, handler);
       return {
-        unbind() {
+        unbind: () => {
           editor.off(label);
         }
       };
@@ -104,25 +104,25 @@ const renderMobileTheme = (editor: Editor) => {
     editor.on('init', () => {
       realm.init({
         editor: {
-          getFrame() {
+          getFrame: () => {
             return SugarElement.fromDom(editor.contentAreaContainer.querySelector('iframe'));
           },
 
-          onDomChanged() {
+          onDomChanged: () => {
             return {
               unbind: Fun.noop
             };
           },
 
-          onToReading(handler) {
+          onToReading: (handler) => {
             return bindHandler(READING, handler);
           },
 
-          onToEditing(handler) {
+          onToEditing: (handler) => {
             return bindHandler(EDITING, handler);
           },
 
-          onScrollToCursor(handler) {
+          onScrollToCursor: (handler) => {
             editor.on('ScrollIntoView', (tinyEvent) => {
               handler(tinyEvent);
             });
@@ -137,11 +137,11 @@ const renderMobileTheme = (editor: Editor) => {
             };
           },
 
-          onTouchToolstrip() {
+          onTouchToolstrip: () => {
             hideDropup();
           },
 
-          onTouchContent() {
+          onTouchContent: () => {
             const toolbar = SugarElement.fromDom(editor.editorContainer.querySelector('.' + Styles.resolve('toolbar')));
             // If something in the toolbar had focus, fire an execute on it (execute on tap away)
             // Perhaps it will be clearer later what is a better way of doing this.
@@ -150,7 +150,7 @@ const renderMobileTheme = (editor: Editor) => {
             hideDropup();
           },
 
-          onTapContent(evt: EventArgs<TouchEvent>) {
+          onTapContent: (evt: EventArgs<TouchEvent>) => {
             const target = evt.target;
             // If the user has tapped (touchstart, touchend without movement) on an image, select it.
             if (SugarNode.name(target) === 'img') {
@@ -176,11 +176,11 @@ const renderMobileTheme = (editor: Editor) => {
         alloy: realm.system,
         translate: Fun.noop,
 
-        setReadOnly(ro) {
+        setReadOnly: (ro) => {
           setReadOnly(dynamicGroup, readOnlyGroups, mainGroups, ro);
         },
 
-        readOnlyOnInit() {
+        readOnlyOnInit: () => {
           return Settings.readOnlyOnInit(editor);
         }
       });
@@ -261,7 +261,7 @@ const renderMobileTheme = (editor: Editor) => {
   };
 
   return {
-    getNotificationManagerImpl() {
+    getNotificationManagerImpl: () => {
       return {
         open: Fun.constant({
           progressBar: { value: Fun.noop },

--- a/modules/tinymce/src/themes/mobile/main/ts/alien/TinyCodeDupe.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/alien/TinyCodeDupe.ts
@@ -6,7 +6,7 @@
  */
 
 // TODO this code is from the tinymce link plugin, deduplicate when we decide how to share it
-const openLink = function (target) {
+const openLink = (target) => {
   const link = document.createElement('a');
   link.target = '_blank';
   link.href = target.href;

--- a/modules/tinymce/src/themes/mobile/main/ts/android/core/AndroidEvents.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/android/core/AndroidEvents.ts
@@ -26,16 +26,16 @@ const isAndroid6 = PlatformDetection.detect().os.version.major >= 6;
   an input or textarea
 
 */
-const initEvents = function (editorApi: PlatformEditor, toolstrip, alloy) {
+const initEvents = (editorApi: PlatformEditor, toolstrip, alloy) => {
 
   const tapping = TappingEvent.monitor(editorApi);
   const outerDoc = Traverse.owner(toolstrip);
 
-  const isRanged = function (sel: SimRange) {
+  const isRanged = (sel: SimRange) => {
     return !Compare.eq(sel.start, sel.finish) || sel.soffset !== sel.foffset;
   };
 
-  const hasRangeInUi = function () {
+  const hasRangeInUi = () => {
     return Focus.active(outerDoc).filter((input) => {
       return SugarNode.name(input) === 'input';
     }).exists((input: SugarElement<HTMLInputElement>) => {
@@ -43,7 +43,7 @@ const initEvents = function (editorApi: PlatformEditor, toolstrip, alloy) {
     });
   };
 
-  const updateMargin = function () {
+  const updateMargin = () => {
     const rangeInContent = editorApi.doc.dom.hasFocus() && editorApi.getSelection().exists(isRanged);
     alloy.getByDom(toolstrip).each((rangeInContent || hasRangeInUi()) === true ? Toggling.on : Toggling.off);
   };
@@ -88,7 +88,7 @@ const initEvents = function (editorApi: PlatformEditor, toolstrip, alloy) {
     ]
   );
 
-  const destroy = function () {
+  const destroy = () => {
     Arr.each(listeners, (l) => {
       l.unbind();
     });

--- a/modules/tinymce/src/themes/mobile/main/ts/android/core/AndroidMode.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/android/core/AndroidMode.ts
@@ -14,14 +14,14 @@ import * as Thor from '../../util/Thor';
 import * as AndroidEvents from './AndroidEvents';
 import * as AndroidSetup from './AndroidSetup';
 
-const create = function (platform, mask) {
+const create = (platform, mask) => {
 
   const meta = MetaViewport.tag();
   const androidApi = Singleton.api();
 
   const androidEvents = Singleton.api();
 
-  const enter = function () {
+  const enter = () => {
     mask.hide();
 
     Class.add(platform.container, Styles.resolve('fullscreen-maximized'));
@@ -43,7 +43,7 @@ const create = function (platform, mask) {
     });
   };
 
-  const exit = function () {
+  const exit = () => {
     meta.restore();
     mask.show();
     Class.remove(platform.container, Styles.resolve('fullscreen-maximized'));

--- a/modules/tinymce/src/themes/mobile/main/ts/android/core/AndroidSetup.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/android/core/AndroidSetup.ts
@@ -19,42 +19,42 @@ const EXTRA_SPACING = 50;
 
 const data = 'data-' + Styles.resolve('last-outer-height');
 
-const setLastHeight = function (cBody, value) {
+const setLastHeight = (cBody, value) => {
   Attribute.set(cBody, data, value);
 };
 
-const getLastHeight = function (cBody) {
+const getLastHeight = (cBody) => {
   return DataAttributes.safeParse(cBody, data);
 };
 
-const getBoundsFrom = function (rect: RawRect) {
+const getBoundsFrom = (rect: RawRect) => {
   return {
     top: rect.top,
     bottom: rect.top + rect.height
   };
 };
 
-const getBounds = function (cWin) {
+const getBounds = (cWin) => {
   const rects = Rectangles.getRectangles(cWin);
   return rects.length > 0 ? Optional.some(rects[0]).map(getBoundsFrom) : Optional.none();
 };
 
-const findDelta = function (outerWindow, cBody) {
+const findDelta = (outerWindow, cBody) => {
   const last = getLastHeight(cBody);
   const current = outerWindow.innerHeight;
   return last > current ? Optional.some(last - current) : Optional.none();
 };
 
-const calculate = function (cWin, bounds, delta) {
+const calculate = (cWin, bounds, delta) => {
   // The goal here is to shift as little as required.
   const isOutside = bounds.top > cWin.innerHeight || bounds.bottom > cWin.innerHeight;
   return isOutside ? Math.min(delta, bounds.bottom - cWin.innerHeight + EXTRA_SPACING) : 0;
 };
 
-const setup = function (outerWindow, cWin) {
+const setup = (outerWindow, cWin) => {
   const cBody = SugarElement.fromDom(cWin.document.body);
 
-  const toEditing = function () {
+  const toEditing = () => {
     // TBIO-3816 throttling the resume was causing keyboard hide/show issues with undo/redo
     // throttling was introduced to work around a different keyboard hide/show issue, where
     // async uiChanged in Processor in polish was causing keyboard hide, which no longer seems to occur
@@ -77,7 +77,7 @@ const setup = function (outerWindow, cWin) {
 
   setLastHeight(cBody, outerWindow.innerHeight);
 
-  const destroy = function () {
+  const destroy = () => {
     onResize.unbind();
   };
 

--- a/modules/tinymce/src/themes/mobile/main/ts/android/focus/ResumeEditing.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/android/focus/ResumeEditing.ts
@@ -22,15 +22,15 @@ import Delay from 'tinymce/core/api/util/Delay';
 // Then we tried everyone's favourite setTimeout solution. This appears to work because it looks like the bug might
 // be caused by the fact that the autocomplete cache is maintained while in the same event queue. As soon as we
 // disconnect the stack, it looks like it is fixed. That makes some level of sense.
-const autocompleteHack = function (/* iBody */) {
-  return function (f) {
+const autocompleteHack = (/* iBody */) => {
+  return (f) => {
     Delay.setTimeout(() => {
       f();
     }, 0);
   };
 };
 
-const resume = function (cWin) {
+const resume = (cWin) => {
   cWin.focus();
   const iBody = SugarElement.fromDom(cWin.document.body);
 

--- a/modules/tinymce/src/themes/mobile/main/ts/api/AndroidWebapp.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/api/AndroidWebapp.ts
@@ -16,7 +16,7 @@ import * as TapToEditMask from '../touch/view/TapToEditMask';
 import MobileSchema from './MobileSchema';
 
 // TODO: Remove dupe with IosWebapp
-const produce = function (raw: {any}): MobileWebApp {
+const produce = (raw: {any}): MobileWebApp => {
   const mobile = ValueSchema.asRawOrDie(
     'Getting AndroidWebapp schema',
     MobileSchema,
@@ -27,7 +27,7 @@ const produce = function (raw: {any}): MobileWebApp {
   Css.set(mobile.toolstrip, 'width', '100%');
 
   // We do not make the Android container relative, because we aren't positioning the toolbar absolutely.
-  const onTap = function () {
+  const onTap = () => {
     mobile.setReadOnly(mobile.readOnlyOnInit());
     mode.enter();
   };
@@ -38,10 +38,10 @@ const produce = function (raw: {any}): MobileWebApp {
 
   mobile.alloy.add(mask);
   const maskApi = {
-    show() {
+    show: () => {
       mobile.alloy.add(mask);
     },
-    hide() {
+    hide: () => {
       mobile.alloy.remove(mask);
     }
   };

--- a/modules/tinymce/src/themes/mobile/main/ts/api/IosWebapp.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/api/IosWebapp.ts
@@ -21,7 +21,7 @@ export interface MobileWebApp {
   destroy(): void;
 }
 
-const produce = function (raw: {any}): MobileWebApp {
+const produce = (raw: {any}): MobileWebApp => {
   const mobile = ValueSchema.asRawOrDie(
     'Getting IosWebapp schema',
     MobileSchema,
@@ -32,7 +32,7 @@ const produce = function (raw: {any}): MobileWebApp {
   Css.set(mobile.toolstrip, 'width', '100%');
   Css.set(mobile.container, 'position', 'relative');
 
-  const onView = function () {
+  const onView = () => {
     mobile.setReadOnly(mobile.readOnlyOnInit());
     mode.enter();
   };
@@ -43,10 +43,10 @@ const produce = function (raw: {any}): MobileWebApp {
 
   mobile.alloy.add(mask);
   const maskApi = {
-    show() {
+    show: () => {
       mobile.alloy.add(mask);
     },
-    hide() {
+    hide: () => {
       mobile.alloy.remove(mask);
     }
   };

--- a/modules/tinymce/src/themes/mobile/main/ts/bridge/LinkBridge.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/bridge/LinkBridge.ts
@@ -8,15 +8,15 @@
 import { Fun, Optional } from '@ephox/katamari';
 import { Attribute, SelectorFind, SugarElement, TextContent } from '@ephox/sugar';
 
-const isNotEmpty = function (val) {
+const isNotEmpty = (val) => {
   return val.length > 0;
 };
 
-const defaultToEmpty = function (str) {
+const defaultToEmpty = (str) => {
   return str === undefined || str === null ? '' : str;
 };
 
-const noLink = function (editor) {
+const noLink = (editor) => {
   const text = editor.selection.getContent({ format: 'text' });
   return {
     url: '',
@@ -27,7 +27,7 @@ const noLink = function (editor) {
   };
 };
 
-const fromLink = function (link) {
+const fromLink = (link) => {
   const text = TextContent.get(link);
   const url = Attribute.get(link, 'href');
   const title = Attribute.get(link, 'title');
@@ -41,7 +41,7 @@ const fromLink = function (link) {
   };
 };
 
-const getInfo = function (editor) {
+const getInfo = (editor) => {
   // TODO: Improve with more of tiny's link logic?
   return query(editor).fold(
     () => {
@@ -53,26 +53,26 @@ const getInfo = function (editor) {
   );
 };
 
-const wasSimple = function (link) {
+const wasSimple = (link) => {
   const prevHref = Attribute.get(link, 'href');
   const prevText = TextContent.get(link);
   return prevHref === prevText;
 };
 
-const getTextToApply = function (link, url, info) {
+const getTextToApply = (link, url, info) => {
   return info.text.toOptional().filter(isNotEmpty).fold(() => {
     return wasSimple(link) ? Optional.some(url) : Optional.none();
   }, Optional.some);
 };
 
-const unlinkIfRequired = function (editor, info) {
+const unlinkIfRequired = (editor, info) => {
   const activeLink = info.link.bind(Fun.identity);
   activeLink.each((_link) => {
     editor.execCommand('unlink');
   });
 };
 
-const getAttrs = function (url, info) {
+const getAttrs = (url, info) => {
   const attrs: any = { };
   attrs.href = url;
 
@@ -85,7 +85,7 @@ const getAttrs = function (url, info) {
   return attrs;
 };
 
-const applyInfo = function (editor, info) {
+const applyInfo = (editor, info) => {
   info.url.toOptional().filter(isNotEmpty).fold(() => {
     // Unlink if there is something to unlink
     unlinkIfRequired(editor, info);
@@ -107,7 +107,7 @@ const applyInfo = function (editor, info) {
   });
 };
 
-const query = function (editor) {
+const query = (editor) => {
   const start = SugarElement.fromDom(editor.selection.getStart());
   return SelectorFind.closest(start, 'a');
 };

--- a/modules/tinymce/src/themes/mobile/main/ts/channels/Receivers.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/channels/Receivers.ts
@@ -9,12 +9,12 @@ import { Receiving } from '@ephox/alloy';
 import { Objects } from '@ephox/boulder';
 import * as TinyChannels from './TinyChannels';
 
-const format = function (command, update) {
+const format = (command, update) => {
   return Receiving.config({
     channels: Objects.wrap(
       TinyChannels.formatChanged,
       {
-        onReceive(button, data) {
+        onReceive: (button, data) => {
           if (data.command === command) {
             update(button, data.state);
           }
@@ -24,7 +24,7 @@ const format = function (command, update) {
   });
 };
 
-const orientation = function (onReceive) {
+const orientation = (onReceive) => {
   return Receiving.config({
     channels: Objects.wrap(
       TinyChannels.orientationChanged,
@@ -35,7 +35,7 @@ const orientation = function (onReceive) {
   });
 };
 
-const receive = function (channel: string, onReceive) {
+const receive = (channel: string, onReceive) => {
   return {
     key: channel,
     value: {

--- a/modules/tinymce/src/themes/mobile/main/ts/features/Features.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/features/Features.ts
@@ -40,21 +40,21 @@ const identify = (editor: Editor): string[] => {
   return Type.isArray(toolbar) ? identifyFromArray(toolbar) : extract(toolbar);
 };
 
-const setup = function (realm: MobileRealm, editor: Editor) {
-  const commandSketch = function (name) {
-    return function () {
+const setup = (realm: MobileRealm, editor: Editor) => {
+  const commandSketch = (name) => {
+    return () => {
       return Buttons.forToolbarCommand(editor, name);
     };
   };
 
-  const stateCommandSketch = function (name) {
-    return function () {
+  const stateCommandSketch = (name) => {
+    return () => {
       return Buttons.forToolbarStateCommand(editor, name);
     };
   };
 
-  const actionSketch = function (name, query, action) {
-    return function () {
+  const actionSketch = (name, query, action) => {
+    return () => {
       return Buttons.forToolbarStateAction(editor, name, query, action);
     };
   };
@@ -66,14 +66,14 @@ const setup = function (realm: MobileRealm, editor: Editor) {
   const underline = stateCommandSketch('underline');
   const removeformat = commandSketch('removeformat');
 
-  const link = function () {
+  const link = () => {
     return LinkButton.sketch(realm, editor);
   };
 
   const unlink = actionSketch('unlink', 'link', () => {
     editor.execCommand('unlink', null, false);
   });
-  const image = function () {
+  const image = () => {
     return ImagePicker.sketch(editor);
   };
 
@@ -85,23 +85,23 @@ const setup = function (realm: MobileRealm, editor: Editor) {
     editor.execCommand('InsertOrderedList', null, false);
   });
 
-  const fontsizeselect = function () {
+  const fontsizeselect = () => {
     return FontSizeSlider.sketch(realm, editor);
   };
 
-  const forecolor = function () {
+  const forecolor = () => {
     return ColorSlider.sketch(realm, editor);
   };
 
   const styleFormats = StyleFormats.register(editor);
 
-  const styleFormatsMenu = function () {
+  const styleFormatsMenu = () => {
     return StyleFormats.ui(editor, styleFormats, () => {
       editor.fire('scrollIntoView');
     });
   };
 
-  const styleselect = function () {
+  const styleselect = () => {
     return Buttons.forToolbar('style-formats', (button) => {
       editor.fire('toReading');
       realm.dropup.appear(styleFormatsMenu, Toggling.on, button);
@@ -122,9 +122,9 @@ const setup = function (realm: MobileRealm, editor: Editor) {
     ]), editor);
   };
 
-  const feature = function (prereq, sketch) {
+  const feature = (prereq, sketch) => {
     return {
-      isSupported() {
+      isSupported: () => {
         // NOTE: forall is true for none
         const buttons = editor.ui.registry.getAll().buttons;
         return prereq.forall((p) => {

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosHacks.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosHacks.ts
@@ -9,7 +9,7 @@ import { EventArgs, Focus, WindowSelection } from '@ephox/sugar';
 import Delay from 'tinymce/core/api/util/Delay';
 import { PlatformEditor } from './PlatformEditor';
 
-const setSelectionAtTouch = function (editorApi: PlatformEditor, touchEvent: EventArgs<TouchEvent>) {
+const setSelectionAtTouch = (editorApi: PlatformEditor, touchEvent: EventArgs<TouchEvent>) => {
   // shortTextFix, when text is short body height is short too, tapping at the bottom of the editor
   // should set a selection. We don't set body height to 100% because of side effects, so we resort
   // to a mousedown on the iDoc, it is a clean place, and very specific to this issue. On a vanilla
@@ -28,7 +28,7 @@ const setSelectionAtTouch = function (editorApi: PlatformEditor, touchEvent: Eve
 };
 
 // NOTE: NOT USED YET
-const onOrientationReady = function (outerWindow, refreshView) {
+const onOrientationReady = (outerWindow, refreshView) => {
   // When rotating into portrait, the page (and toolbar) is off the top of the screen (pageYOffset > 0)
   // when the view settles, the toolbar will readjust to be visible/fixed to the top (pageYOffset = 0)
   // wait for the toolbar to recover before refreshing the view and scrolling cursor into view

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosMode.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosMode.ts
@@ -20,7 +20,7 @@ import * as PlatformEditor from './PlatformEditor';
 
 type IosApi = IosSetup.IosApi;
 
-const create = function (platform, mask) {
+const create = (platform, mask) => {
   const meta = MetaViewport.tag();
 
   const priorState = Singleton.value();
@@ -29,7 +29,7 @@ const create = function (platform, mask) {
   const iosApi = Singleton.api<IosApi>();
   const iosEvents = Singleton.api();
 
-  const enter = function () {
+  const enter = () => {
     mask.hide();
     const doc = SugarElement.fromDom(document);
     PlatformEditor.getActiveApi(platform.editor).each((editorApi) => {
@@ -83,7 +83,7 @@ const create = function (platform, mask) {
     });
   };
 
-  const exit = function () {
+  const exit = () => {
     meta.restore();
     iosEvents.clear();
     iosApi.clear();
@@ -123,7 +123,7 @@ const create = function (platform, mask) {
   };
 
   // dropup
-  const refreshStructure = function () {
+  const refreshStructure = () => {
     iosApi.run((api) => {
       api.refreshStructure();
     });

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosSetup.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/core/IosSetup.ts
@@ -21,7 +21,7 @@ import * as IosViewport from '../view/IosViewport';
 
 const VIEW_MARGIN = 5;
 
-const register = function (toolstrip, socket, container, outerWindow, structure, cWin) {
+const register = (toolstrip, socket, container, outerWindow, structure, cWin) => {
   const scroller = BackgroundActivity((y) => {
     return IosScrolling.moveWindowScroll(toolstrip, socket, y);
   });
@@ -29,7 +29,7 @@ const register = function (toolstrip, socket, container, outerWindow, structure,
   // NOTE: This is a WebView specific way of scrolling when out of bounds. When we need to make
   // the webapp work again, we'll have to adjust this function. Essentially, it just jumps the scroll
   // back to show the current selection rectangle.
-  const scrollBounds = function () {
+  const scrollBounds = () => {
     const rects = Rectangles.getRectangles(cWin);
     return Optional.from(rects[0]).bind((rect) => {
       const viewTop = rect.top - socket.dom.scrollTop;
@@ -122,7 +122,7 @@ interface IosSetupOptions {
   readonly outerBody: SugarElement<Node>;
 }
 
-const setup = function (bag: IosSetupOptions) {
+const setup = (bag: IosSetupOptions) => {
   const cWin = bag.cWin;
   const ceBody = bag.ceBody;
   const socket = bag.socket;
@@ -136,17 +136,17 @@ const setup = function (bag: IosSetupOptions) {
   const structure = IosViewport.takeover(socket, ceBody, toolstrip, dropup);
   const keyboardModel = keyboardType(outerBody, cWin, SugarBody.body(), contentElement);
 
-  const toEditing = function () {
+  const toEditing = () => {
     // Consider inlining, though it will make it harder to follow the API
     keyboardModel.toEditing();
     clearSelection();
   };
 
-  const toReading = function () {
+  const toReading = () => {
     keyboardModel.toReading();
   };
 
-  const onToolbarTouch = function (_event) {
+  const onToolbarTouch = (_event) => {
     keyboardModel.onToolbarTouch();
   };
 
@@ -172,34 +172,34 @@ const setup = function (bag: IosSetupOptions) {
 
   const unfocusedSelection = FakeSelection(cWin, contentElement);
 
-  const refreshSelection = function () {
+  const refreshSelection = () => {
     if (unfocusedSelection.isActive()) {
       unfocusedSelection.update();
     }
   };
 
-  const highlightSelection = function () {
+  const highlightSelection = () => {
     unfocusedSelection.update();
   };
 
-  const clearSelection = function () {
+  const clearSelection = () => {
     unfocusedSelection.clear();
   };
 
-  const scrollIntoView = function (top, bottom) {
+  const scrollIntoView = (top, bottom) => {
     Greenzone.scrollIntoView(cWin, socket, dropup, top, bottom);
   };
 
-  const syncHeight = function () {
+  const syncHeight = () => {
     Css.set(contentElement, 'height', contentElement.dom.contentWindow.document.body.scrollHeight + 'px');
   };
 
-  const setViewportOffset = function (newYOffset) {
+  const setViewportOffset = (newYOffset) => {
     structure.setViewportOffset(newYOffset);
     IosScrolling.moveOnlyTop(socket, newYOffset).get(Fun.identity);
   };
 
-  const destroy = function () {
+  const destroy = () => {
     structure.restore();
     onOrientation.destroy();
     onScroll.unbind();

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/core/PlatformEditor.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/core/PlatformEditor.ts
@@ -37,32 +37,32 @@ export interface PlatformEditor {
   readonly getCursorBox: () => Optional<RawRect>;
 }
 
-const getBodyFromFrame = function (frame) {
+const getBodyFromFrame = (frame) => {
   return Optional.some(SugarElement.fromDom(frame.dom.contentWindow.document.body));
 };
 
-const getDocFromFrame = function (frame) {
+const getDocFromFrame = (frame) => {
   return Optional.some(SugarElement.fromDom(frame.dom.contentWindow.document));
 };
 
-const getWinFromFrame = function (frame) {
+const getWinFromFrame = (frame) => {
   return Optional.from(frame.dom.contentWindow);
 };
 
-const getSelectionFromFrame = function (frame) {
+const getSelectionFromFrame = (frame) => {
   const optWin = getWinFromFrame(frame);
   return optWin.bind(WindowSelection.getExact);
 };
 
-const getFrame = function (editor) {
+const getFrame = (editor) => {
   return editor.getFrame();
 };
 
-const getOrDerive = function (name, f) {
-  return function (editor) {
+const getOrDerive = (name, f) => {
+  return (editor) => {
     const g = editor[name].getOrThunk(() => {
       const frame = getFrame(editor);
-      return function () {
+      return () => {
         return f(frame);
       };
     });
@@ -71,25 +71,25 @@ const getOrDerive = function (name, f) {
   };
 };
 
-const getOrListen = function (editor, doc, name, type: string) {
+const getOrListen = (editor, doc, name, type: string) => {
   return editor[name].getOrThunk(() => {
-    return function (handler) {
+    return (handler) => {
       return DomEvent.bind(doc, type, handler);
     };
   });
 };
 
-const getActiveApi = function (editor): Optional<PlatformEditor> {
+const getActiveApi = (editor): Optional<PlatformEditor> => {
   const frame = getFrame(editor);
 
   // Empty paragraphs can have no rectangle size, so let's just use the start container
   // if it is collapsed;
-  const tryFallbackBox = function (win: Window) {
-    const isCollapsed = function (sel: SimRange) {
+  const tryFallbackBox = (win: Window) => {
+    const isCollapsed = (sel: SimRange) => {
       return Compare.eq(sel.start, sel.finish) && sel.soffset === sel.foffset;
     };
 
-    const toStartRect = function (sel): Optional<RawRect> {
+    const toStartRect = (sel): Optional<RawRect> => {
       const rect = sel.start.dom.getBoundingClientRect();
       return rect.width > 0 || rect.height > 0 ? Optional.some(rect) : Optional.none();
     };
@@ -104,7 +104,7 @@ const getActiveApi = function (editor): Optional<PlatformEditor> {
         const html = SugarElement.fromDom(doc.dom.documentElement);
 
         const getCursorBox: () => Optional<RawRect> = editor.getCursorBox.getOrThunk(() => {
-          return function () {
+          return () => {
             return WindowSelection.get(win).bind((sel) => {
               return WindowSelection.getFirstRect(win, sel).orThunk(() => {
                 return tryFallbackBox(win);
@@ -114,13 +114,13 @@ const getActiveApi = function (editor): Optional<PlatformEditor> {
         });
 
         const setSelection = editor.setSelection.getOrThunk(() => {
-          return function (start, soffset, finish, foffset) {
+          return (start, soffset, finish, foffset) => {
             WindowSelection.setExact(win, start, soffset, finish, foffset);
           };
         });
 
         const clearSelection = editor.clearSelection.getOrThunk(() => {
-          return function () {
+          return () => {
             WindowSelection.clear(win);
           };
         });

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/focus/FakeSelection.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/focus/FakeSelection.ts
@@ -12,7 +12,7 @@ import * as Styles from '../../style/Styles';
 import * as Rectangles from '../../util/Rectangles';
 import * as ResumeEditing from './ResumeEditing';
 
-export default function (win, frame) {
+export default (win, frame) => {
   // NOTE: This may be required for android also.
 
   /*
@@ -38,7 +38,7 @@ export default function (win, frame) {
     clear();
   });
 
-  const make = function (rectangle: RawRect) {
+  const make = (rectangle: RawRect) => {
     const span = SugarElement.fromTag('span');
     Classes.add(span, [ Styles.resolve('layer-editor'), Styles.resolve('unfocused-selection') ]);
     Css.setAll(span, {
@@ -50,23 +50,23 @@ export default function (win, frame) {
     return span;
   };
 
-  const update = function () {
+  const update = () => {
     clear();
     const rectangles = Rectangles.getRectangles(win);
     const spans = Arr.map(rectangles, make);
     InsertAll.append(container, spans);
   };
 
-  const clear = function () {
+  const clear = () => {
     Remove.empty(container);
   };
 
-  const destroy = function () {
+  const destroy = () => {
     onTouch.unbind();
     Remove.remove(container);
   };
 
-  const isActive = function () {
+  const isActive = () => {
     return Traverse.children(container).length > 0;
   };
 
@@ -76,4 +76,4 @@ export default function (win, frame) {
     destroy,
     clear
   };
-}
+};

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/scroll/IosScrolling.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/scroll/IosScrolling.ts
@@ -21,25 +21,25 @@ const ANIMATION_RATE = 10;
 
 const lastScroll = 'data-' + Styles.resolve('last-scroll-top');
 
-const getTop = function (element) {
+const getTop = (element) => {
   const raw = Css.getRaw(element, 'top').getOr('0');
   return parseInt(raw, 10);
 };
 
-const getScrollTop = function (element) {
+const getScrollTop = (element) => {
   return parseInt(element.dom.scrollTop, 10);
 };
 
-const moveScrollAndTop = function (element, destination, finalTop) {
+const moveScrollAndTop = (element, destination, finalTop) => {
   return Future.nu((callback) => {
     const getCurrent = Fun.curry(getScrollTop, element);
 
-    const update = function (newScroll) {
+    const update = (newScroll) => {
       element.dom.scrollTop = newScroll;
       Css.set(element, 'top', (getTop(element) + ANIMATION_STEP) + 'px');
     };
 
-    const finish = function (/* dest */) {
+    const finish = (/* dest */) => {
       element.dom.scrollTop = destination;
       Css.set(element, 'top', finalTop + 'px');
       callback(destination);
@@ -49,12 +49,12 @@ const moveScrollAndTop = function (element, destination, finalTop) {
   });
 };
 
-const moveOnlyScroll = function (element, destination) {
+const moveOnlyScroll = (element, destination) => {
   return Future.nu((callback) => {
     const getCurrent = Fun.curry(getScrollTop, element);
     Attribute.set(element, lastScroll, getCurrent());
 
-    const update = function (newScroll, abort) {
+    const update = (newScroll, abort) => {
       const previous = DataAttributes.safeParse(element, lastScroll);
       // As soon as we detect a scroll value that we didn't set, assume the user
       // is scrolling, and abort the scrolling.
@@ -66,7 +66,7 @@ const moveOnlyScroll = function (element, destination) {
       }
     };
 
-    const finish = function (/* dest */) {
+    const finish = (/* dest */) => {
       element.dom.scrollTop = destination;
       Attribute.set(element, lastScroll, destination);
       callback(destination);
@@ -79,15 +79,15 @@ const moveOnlyScroll = function (element, destination) {
   });
 };
 
-const moveOnlyTop = function (element, destination) {
+const moveOnlyTop = (element, destination) => {
   return Future.nu((callback) => {
     const getCurrent = Fun.curry(getTop, element);
 
-    const update = function (newTop) {
+    const update = (newTop) => {
       Css.set(element, 'top', newTop + 'px');
     };
 
-    const finish = function (/* dest */) {
+    const finish = (/* dest */) => {
       update(destination);
       callback(destination);
     };
@@ -98,7 +98,7 @@ const moveOnlyTop = function (element, destination) {
   });
 };
 
-const updateTop = function (element, amount) {
+const updateTop = (element, amount) => {
   const newTop = (amount + IosViewport.getYFixedData(element)) + 'px';
   Css.set(element, 'top', newTop);
 };
@@ -107,7 +107,7 @@ const updateTop = function (element, amount) {
 // However, on tinyMCE, we seemed to get a lot more cursor flickering as the window scroll
 // was changing. Therefore, until tests prove otherwise, we are just going to jump to the
 // destination in one go.
-const moveWindowScroll = function (toolbar, viewport, destY) {
+const moveWindowScroll = (toolbar, viewport, destY) => {
   const outerWindow = Traverse.owner(toolbar).dom.defaultView;
   return Future.nu((callback) => {
     updateTop(toolbar, destY);

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/scroll/Scrollables.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/scroll/Scrollables.ts
@@ -12,33 +12,33 @@ import * as Styles from '../../style/Styles';
 
 const dataHorizontal = 'data-' + Styles.resolve('horizontal-scroll');
 
-const canScrollVertically = function (container) {
+const canScrollVertically = (container) => {
   container.dom.scrollTop = 1;
   const result = container.dom.scrollTop !== 0;
   container.dom.scrollTop = 0;
   return result;
 };
 
-const canScrollHorizontally = function (container) {
+const canScrollHorizontally = (container) => {
   container.dom.scrollLeft = 1;
   const result = container.dom.scrollLeft !== 0;
   container.dom.scrollLeft = 0;
   return result;
 };
 
-const hasVerticalScroll = function (container) {
+const hasVerticalScroll = (container) => {
   return container.dom.scrollTop > 0 || canScrollVertically(container);
 };
 
-const hasHorizontalScroll = function (container) {
+const hasHorizontalScroll = (container) => {
   return container.dom.scrollLeft > 0 || canScrollHorizontally(container);
 };
 
-const markAsHorizontal = function (container) {
+const markAsHorizontal = (container) => {
   Attribute.set(container, dataHorizontal, 'true');
 };
 
-const hasScroll = function (container) {
+const hasScroll = (container) => {
   return Attribute.get(container, dataHorizontal) === 'true' ? hasHorizontalScroll(container) : hasVerticalScroll(container);
 };
 
@@ -46,7 +46,7 @@ const hasScroll = function (container) {
  * Prevents default on touchmove for anything that is not within a scrollable area. The
  * scrollable areas are defined by selector.
  */
-const exclusive = function (scope, selector) {
+const exclusive = (scope, selector) => {
   return DomEvent.bind(scope, 'touchmove', (event) => {
     SelectorFind.closest(event.target, selector).filter(hasScroll).fold(() => {
       event.prevent();

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/smooth/BackgroundActivity.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/smooth/BackgroundActivity.ts
@@ -7,13 +7,13 @@
 
 import { Cell, LazyValue } from '@ephox/katamari';
 
-export default function (doAction) {
+export default (doAction) => {
   // Start the activity in idle state.
   const action = Cell(
     LazyValue.pure({})
   );
 
-  const start = function (value) {
+  const start = (value) => {
     const future = LazyValue.nu((callback) => {
       return doAction(value).get(callback);
     });
@@ -23,7 +23,7 @@ export default function (doAction) {
   };
 
   // Idle will fire g once the current action is complete.
-  const idle = function (g) {
+  const idle = (g) => {
     action.get().get(() => {
       g();
     });
@@ -33,4 +33,4 @@ export default function (doAction) {
     start,
     idle
   };
-}
+};

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/smooth/SmoothAnimation.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/smooth/SmoothAnimation.ts
@@ -8,7 +8,7 @@
 import { Optional } from '@ephox/katamari';
 import Delay from 'tinymce/core/api/util/Delay';
 
-const adjust = function (value, destination, amount) {
+const adjust = (value, destination, amount) => {
   if (Math.abs(value - destination) <= amount) {
     return Optional.none();
   } else if (value < destination) {
@@ -18,20 +18,20 @@ const adjust = function (value, destination, amount) {
   }
 };
 
-const create = function () {
+const create = () => {
   let interval = null;
 
-  const animate = function (getCurrent, destination, amount, increment, doFinish, rate) {
+  const animate = (getCurrent, destination, amount, increment, doFinish, rate) => {
     let finished = false;
 
-    const finish = function (v) {
+    const finish = (v) => {
       finished = true;
       doFinish(v);
     };
 
     Delay.clearInterval(interval);
 
-    const abort = function (v) {
+    const abort = (v) => {
       Delay.clearInterval(interval);
       finish(v);
     };

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/view/Devices.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/view/Devices.ts
@@ -54,7 +54,7 @@ export interface Device {
   keyboard: Keyboard;
 }
 
-export const findDevice = function (deviceWidth, deviceHeight): Keyboard {
+export const findDevice = (deviceWidth, deviceHeight): Keyboard => {
   const devices: Device[] = [
     // iPhone 4 class
     { width: 320, height: 480, keyboard: { portrait: 300, landscape: 240 }},

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/view/Greenzone.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/view/Greenzone.ts
@@ -10,7 +10,7 @@ import * as CursorRefresh from '../../touch/focus/CursorRefresh';
 import * as IosScrolling from '../scroll/IosScrolling';
 import * as DeviceZones from './DeviceZones';
 
-const scrollIntoView = function (cWin, socket, dropup, top, bottom) {
+const scrollIntoView = (cWin, socket, dropup, top, bottom) => {
   const greenzone = DeviceZones.getGreenzone(socket, dropup);
   const refreshCursor = Fun.curry(CursorRefresh.refresh, cWin);
 

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosKeyboard.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosKeyboard.ts
@@ -50,11 +50,11 @@ export type IosKeyboardConstructor = (outerBody: SugarElement<Node>, cWin: Windo
  * needs to exclude the keyboard. This isn't a problem with timid, because the keyboard is dismissed.
  */
 const stubborn: IosKeyboardConstructor = (outerBody: SugarElement<Node>, cWin: Window, page: SugarElement<Node>, frame: SugarElement<HTMLElement>): IosKeyboard => {
-  const toEditing = function () {
+  const toEditing = () => {
     ResumeEditing.resume(cWin, frame);
   };
 
-  const toReading = function () {
+  const toReading = () => {
     CaptureBin.input(outerBody, Focus.blur);
   };
 
@@ -72,7 +72,7 @@ const stubborn: IosKeyboardConstructor = (outerBody: SugarElement<Node>, cWin: W
   // Do nothing
   const onToolbarTouch = Fun.noop;
 
-  const destroy = function () {
+  const destroy = () => {
     captureInput.unbind();
   };
 
@@ -103,19 +103,19 @@ const stubborn: IosKeyboardConstructor = (outerBody: SugarElement<Node>, cWin: W
  * dropdowns dismiss the keyboard, so they have all the height they require.
  */
 const timid: IosKeyboardConstructor = (outerBody: SugarElement<Node>, cWin: Window, page: SugarElement<Node>, frame: SugarElement<HTMLElement>): IosKeyboard => {
-  const dismissKeyboard = function () {
+  const dismissKeyboard = () => {
     Focus.blur(frame);
   };
 
-  const onToolbarTouch = function () {
+  const onToolbarTouch = () => {
     dismissKeyboard();
   };
 
-  const toReading = function () {
+  const toReading = () => {
     dismissKeyboard();
   };
 
-  const toEditing = function () {
+  const toEditing = () => {
     ResumeEditing.resume(cWin, frame);
   };
 

--- a/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosUpdates.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ios/view/IosUpdates.ts
@@ -11,13 +11,13 @@ import { Css } from '@ephox/sugar';
 import * as IosScrolling from '../scroll/IosScrolling';
 import * as IosViewport from './IosViewport';
 
-const updateFixed = function (element, property, winY, offsetY) {
+const updateFixed = (element, property, winY, offsetY) => {
   const destination = winY + offsetY;
   Css.set(element, property, destination + 'px');
   return Future.pure(offsetY);
 };
 
-const updateScrollingFixed = function (element, winY, offsetY) {
+const updateScrollingFixed = (element, winY, offsetY) => {
   const destTop = winY + offsetY;
   const oldProp = Css.getRaw(element, 'top').getOr(offsetY);
   // While we are changing top, aim to scroll by the same amount to keep the cursor in the same location.
@@ -26,7 +26,7 @@ const updateScrollingFixed = function (element, winY, offsetY) {
   return IosScrolling.moveScrollAndTop(element, destScroll, destTop);
 };
 
-const updateFixture = function (fixture, winY) {
+const updateFixture = (fixture, winY) => {
   return fixture.fold((element, property, offsetY) => {
     return updateFixed(element, property, winY, offsetY);
   }, (element, offsetY) => {
@@ -34,7 +34,7 @@ const updateFixture = function (fixture, winY) {
   });
 };
 
-const updatePositions = function (container, winY) {
+const updatePositions = (container, winY) => {
   const fixtures = IosViewport.findFixtures(container);
   const updates = Arr.map(fixtures, (fixture) => {
     return updateFixture(fixture, winY);

--- a/modules/tinymce/src/themes/mobile/main/ts/model/SwipingModel.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/model/SwipingModel.ts
@@ -13,14 +13,14 @@ const SWIPING_NONE = 0;
  * these points to identify whether or not the swipe was *consistent enough*
  */
 
-const init = function (xValue) {
+const init = (xValue) => {
   return {
     xValue,
     points: [ ]
   };
 };
 
-const move = function (model, xValue) {
+const move = (model, xValue) => {
   if (xValue === model.xValue) {
     return model; // do nothing.
   }
@@ -32,7 +32,7 @@ const move = function (model, xValue) {
 
   const newPoint = { direction: currentDirection, xValue };
 
-  const priorPoints = (function () {
+  const priorPoints = (() => {
     if (model.points.length === 0) {
       return [ ];
     } else {
@@ -47,7 +47,7 @@ const move = function (model, xValue) {
   };
 };
 
-const complete = function (model/* , snaps*/) {
+const complete = (model/* , snaps*/) => {
   if (model.points.length === 0) {
     return SWIPING_NONE;
   } else {

--- a/modules/tinymce/src/themes/mobile/main/ts/toolbar/ScrollingToolbar.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/toolbar/ScrollingToolbar.ts
@@ -27,8 +27,8 @@ export interface ScrollingToolbar {
   readonly focus: () => void;
 }
 
-export const ScrollingToolbar = function (): ScrollingToolbar {
-  const makeGroup = function (gSpec) {
+export const ScrollingToolbar = (): ScrollingToolbar => {
+  const makeGroup = (gSpec) => {
     const scrollClass = gSpec.scrollable === true ? '${prefix}-toolbar-scrollable-group' : '';
     return {
       dom: UiDomFactory.dom('<div aria-label="' + gSpec.label + '" class="${prefix}-toolbar-group ' + scrollClass + '"></div>'),
@@ -104,39 +104,39 @@ export const ScrollingToolbar = function (): ScrollingToolbar {
     })
   );
 
-  const resetGroups = function () {
+  const resetGroups = () => {
     Toolbar.setGroups(toolbar, initGroups.get());
     Toggling.off(toolbar);
   };
 
   const initGroups = Cell([ ]);
 
-  const setGroups = function (gs) {
+  const setGroups = (gs) => {
     initGroups.set(gs);
     resetGroups();
   };
 
-  const createGroups = function (gs) {
+  const createGroups = (gs) => {
     return Arr.map(gs, Fun.compose(ToolbarGroup.sketch, makeGroup));
   };
 
-  const refresh = function () {
+  const refresh = () => {
     // Toolbar.refresh is undefined
     // Toolbar.refresh(toolbar);
   };
 
-  const setContextToolbar = function (gs) {
+  const setContextToolbar = (gs) => {
     Toggling.on(toolbar);
     Toolbar.setGroups(toolbar, gs);
   };
 
-  const restoreToolbar = function () {
+  const restoreToolbar = () => {
     if (Toggling.isOn(toolbar)) {
       resetGroups();
     }
   };
 
-  const focus = function () {
+  const focus = () => {
     Keying.focusIn(toolbar);
   };
 

--- a/modules/tinymce/src/themes/mobile/main/ts/touch/focus/CursorRefresh.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/touch/focus/CursorRefresh.ts
@@ -8,7 +8,7 @@
 import { Focus } from '@ephox/sugar';
 import Delay from 'tinymce/core/api/util/Delay';
 
-const refreshInput = function (input) {
+const refreshInput = (input) => {
   // This is magic used to refresh the iOS cursor on an input field when input focus is
   // lost and then restored. The setTime out is important for consistency, a lower value
   // may not yield a successful reselection when the time out value is 10, 30% success
@@ -22,7 +22,7 @@ const refreshInput = function (input) {
   }, 50);
 };
 
-const refresh = function (winScope) {
+const refresh = (winScope) => {
   // Sometimes the cursor can get out of sync with the content, it looks weird and importantly
   // it causes the code that dismisses the keyboard to fail, Fussy has selection code, but since
   // this is fired often and confined to iOS, it's implemented with more native code. Note, you

--- a/modules/tinymce/src/themes/mobile/main/ts/touch/scroll/Scrollable.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/touch/scroll/Scrollable.ts
@@ -10,7 +10,7 @@ import * as Styles from '../../style/Styles';
 
 const scrollableStyle = Styles.resolve('scrollable');
 
-const register = function (element) {
+const register = (element) => {
 /*
  *  The reason this function exists is to have a
  *  central place where to set if an element can be explicitly
@@ -19,7 +19,7 @@ const register = function (element) {
   Class.add(element, scrollableStyle);
 };
 
-const deregister = function (element) {
+const deregister = (element) => {
   Class.remove(element, scrollableStyle);
 };
 

--- a/modules/tinymce/src/themes/mobile/main/ts/touch/view/MetaViewport.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/touch/view/MetaViewport.ts
@@ -11,10 +11,10 @@ import { Attribute, Insert, SelectorFind, SugarElement } from '@ephox/sugar';
  * The purpose of this fix is to toggle the presence of a meta tag which disables scrolling
  * for the user
  */
-const tag = function () {
+const tag = () => {
   const head = SelectorFind.first('head').getOrDie();
 
-  const nu = function () {
+  const nu = () => {
     const meta = SugarElement.fromTag('meta');
     Attribute.set(meta, 'name', 'viewport');
     Insert.append(head, meta);
@@ -24,11 +24,11 @@ const tag = function () {
   const element = SelectorFind.first('meta[name="viewport"]').getOrThunk(nu);
   const backup = Attribute.get(element, 'content');
 
-  const maximize = function () {
+  const maximize = () => {
     Attribute.set(element, 'content', 'width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0');
   };
 
-  const restore = function () {
+  const restore = () => {
     if (backup !== undefined && backup !== null && backup.length > 0) {
       Attribute.set(element, 'content', backup);
     } else {

--- a/modules/tinymce/src/themes/mobile/main/ts/touch/view/Orientation.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/touch/view/Orientation.ts
@@ -13,7 +13,7 @@ import Delay from 'tinymce/core/api/util/Delay';
 const INTERVAL = 50;
 const INSURANCE = 1000 / INTERVAL;
 
-const get = function (outerWindow) {
+const get = (outerWindow) => {
   // We need to use this because the window shrinks due to an app keyboard,
   // width > height is no longer reliable.
   const isPortrait = outerWindow.matchMedia('(orientation: portrait)').matches;
@@ -26,17 +26,17 @@ const get = function (outerWindow) {
 // rotated causing problems.
 // getActualWidth will return the actual width of the window accurated with the
 // orientation of the device.
-const getActualWidth = function (outerWindow) {
+const getActualWidth = (outerWindow) => {
   const isIos = PlatformDetection.detect().os.isiOS();
   const isPortrait = get(outerWindow).isPortrait();
   return isIos && !isPortrait ? outerWindow.screen.height : outerWindow.screen.width;
 };
 
-const onChange = function (outerWindow, listeners) {
+const onChange = (outerWindow, listeners) => {
   const win = SugarElement.fromDom(outerWindow);
   let poller = null;
 
-  const change = function () {
+  const change = () => {
     // If a developer is spamming orientation events in the simulator, clear our last check
     Delay.clearInterval(poller);
 
@@ -51,7 +51,7 @@ const onChange = function (outerWindow, listeners) {
 
   const orientationHandle = DomEvent.bind(win, 'orientationchange', change);
 
-  const onAdjustment = function (f) {
+  const onAdjustment = (f) => {
     // If a developer is spamming orientation events in the simulator, clear our last check
     Delay.clearInterval(poller);
 
@@ -69,7 +69,7 @@ const onChange = function (outerWindow, listeners) {
     }, INTERVAL);
   };
 
-  const destroy = function () {
+  const destroy = () => {
     orientationHandle.unbind();
   };
 

--- a/modules/tinymce/src/themes/mobile/main/ts/touch/view/TapToEditMask.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/touch/view/TapToEditMask.ts
@@ -11,7 +11,7 @@ import { Throttler } from '@ephox/katamari';
 import * as Styles from '../../style/Styles';
 import * as UiDomFactory from '../../util/UiDomFactory';
 
-const sketch = function (onView, _translate): SketchSpec {
+const sketch = (onView, _translate): SketchSpec => {
 
   const memIcon = Memento.record(
     Container.sketch({
@@ -38,7 +38,7 @@ const sketch = function (onView, _translate): SketchSpec {
             components: [
               memIcon.asSpec()
             ],
-            action(_button) {
+            action: (_button) => {
               onViewThrottle.throttle();
             },
 

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/ColorSlider.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/ColorSlider.ts
@@ -68,10 +68,10 @@ const makeSlider = (spec): SketchSpec => {
     ],
 
     onChange,
-    onDragStart(slider, thumb) {
+    onDragStart: (slider, thumb) => {
       Toggling.on(thumb);
     },
-    onDragEnd(slider, thumb) {
+    onDragEnd: (slider, thumb) => {
       Toggling.off(thumb);
     },
     onInit,
@@ -97,13 +97,13 @@ const makeItems = (spec): SketchSpec[] => [
 
 const sketch = (realm: MobileRealm, editor: Editor) => {
   const spec = {
-    onChange(slider, thumb, color) {
+    onChange: (slider, thumb, color) => {
       editor.undoManager.transact(() => {
         editor.formatter.apply('forecolor', { value: color });
         editor.nodeChanged();
       });
     },
-    getInitialValue(/* slider */) {
+    getInitialValue: (/* slider */) => {
       // Return black
       return BLACK;
     }

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/CommonRealm.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/CommonRealm.ts
@@ -12,7 +12,7 @@ import * as UiDomFactory from '../util/UiDomFactory';
 const makeEditSwitch = (webapp): AlloyComponent => GuiFactory.build(
   Button.sketch({
     dom: UiDomFactory.dom('<div class="${prefix}-mask-edit-icon ${prefix}-icon"></div>'),
-    action() {
+    action: () => {
       webapp.run((w) => {
         w.setReadOnly(false);
       });

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/Dropup.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/Dropup.ts
@@ -39,13 +39,13 @@ const build = (refresh, scrollIntoView): DropUp => {
           dimension: {
             property: 'height'
           },
-          onShrunk(component) {
+          onShrunk: (component) => {
             refresh();
             scrollIntoView();
 
             Replacing.set(component, [ ]);
           },
-          onGrown(_component) {
+          onGrown: (_component) => {
             refresh();
             scrollIntoView();
           }

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/FontSizeSlider.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/FontSizeSlider.ts
@@ -29,10 +29,10 @@ const makeItems = (spec) => [
 
 const sketch = (realm: MobileRealm, editor): SketchSpec => {
   const spec = {
-    onChange(value) {
+    onChange: (value) => {
       FontSizes.apply(editor, value);
     },
-    getInitialValue(/* slider */) {
+    getInitialValue: (/* slider */) => {
       return FontSizes.get(editor);
     }
   };

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/HeadingSlider.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/HeadingSlider.ts
@@ -25,10 +25,10 @@ const makeSlider = (spec): SketchSpec => SizeSlider.sketch({
 
 const sketch = (realm: MobileRealm, editor): SketchSpec => {
   const spec = {
-    onChange(value) {
+    onChange: (value) => {
       editor.execCommand('FormatBlock', null, headings[value].toLowerCase());
     },
-    getInitialValue() {
+    getInitialValue: () => {
       const node = editor.selection.getStart();
       const elem = SugarElement.fromDom(node);
       const heading = PredicateFind.closest(elem, (e) => {

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/ImagePicker.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/ImagePicker.ts
@@ -63,7 +63,7 @@ const sketch = (editor): SketchSpec => {
     components: [
       memPicker.asSpec()
     ],
-    action(button) {
+    action: (button) => {
       const picker = memPicker.get(button);
       // Trigger a dom click for the file input
       picker.element.dom.click();

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/Inputs.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/Inputs.ts
@@ -18,10 +18,10 @@ import * as UiDomFactory from '../util/UiDomFactory';
 
 const clearInputBehaviour = 'input-clearing';
 
-const field = function (name, placeholder) {
+const field = (name, placeholder) => {
   const inputSpec = Memento.record(Input.sketch({
     inputAttributes: { placeholder: I18n.translate(placeholder) },
-    onSetValue(input, _data) {
+    onSetValue: (input, _data) => {
       // If the value changes, inform the container so that it can update whether the "x" is visible
       AlloyTriggers.emit(input, NativeEvents.input());
     },
@@ -40,7 +40,7 @@ const field = function (name, placeholder) {
   const buttonSpec = Memento.record(
     Button.sketch({
       dom: UiDomFactory.dom('<button class="${prefix}-input-container-x ${prefix}-icon-cancel-circle ${prefix}-icon"></button>'),
-      action(button) {
+      action: (button) => {
         const input = inputSpec.get(button);
         Representing.setValue(input, '');
       }
@@ -60,7 +60,7 @@ const field = function (name, placeholder) {
           toggleClass: Styles.resolve('input-container-empty')
         }),
         Composing.config({
-          find(comp) {
+          find: (comp) => {
             return Optional.some(inputSpec.get(comp));
           }
         }),
@@ -88,7 +88,7 @@ const hidden = (name) => ({
         display: 'none'
       }
     },
-    getInitialValue() {
+    getInitialValue: () => {
       return Optional.none();
     }
   })

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/IosRealm.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/IosRealm.ts
@@ -55,38 +55,38 @@ export default (scrollIntoView: () => void): MobileRealm => {
   alloy.add(socket);
   alloy.add(dropup.component);
 
-  const setToolbarGroups = function (rawGroups) {
+  const setToolbarGroups = (rawGroups) => {
     const groups = toolbar.createGroups(rawGroups);
     toolbar.setGroups(groups);
   };
 
-  const setContextToolbar = function (rawGroups) {
+  const setContextToolbar = (rawGroups) => {
     const groups = toolbar.createGroups(rawGroups);
     toolbar.setContextToolbar(groups);
   };
 
-  const focusToolbar = function () {
+  const focusToolbar = () => {
     toolbar.focus();
   };
 
-  const restoreToolbar = function () {
+  const restoreToolbar = () => {
     toolbar.restoreToolbar();
   };
 
-  const init = function (spec) {
+  const init = (spec) => {
     webapp.set(
       IosWebapp.produce(spec)
     );
   };
 
-  const exit = function () {
+  const exit = () => {
     webapp.run((w) => {
       Replacing.remove(socket, switchToEdit);
       w.exit();
     });
   };
 
-  const updateMode = function (readOnly) {
+  const updateMode = (readOnly) => {
     CommonRealm.updateMode(socket, switchToEdit, readOnly, alloy.root);
   };
 

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/LinkButton.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/LinkButton.ts
@@ -30,13 +30,13 @@ const getGroups = Thunk.cached((realm, editor) => {
 
           // Do not include link
           maxFieldIndex: [ 'url', 'text', 'title', 'target' ].length - 1,
-          getInitialValue(/* dialog */) {
+          getInitialValue: (/* dialog */) => {
             return Optional.some(
               LinkBridge.getInfo(editor)
             );
           },
 
-          onExecute(dialog, _simulatedEvent) {
+          onExecute: (dialog, _simulatedEvent) => {
             const info = Representing.getValue(dialog);
             LinkBridge.applyInfo(editor, info);
             realm.restoreToolbar();
@@ -48,7 +48,7 @@ const getGroups = Thunk.cached((realm, editor) => {
   ];
 });
 
-const sketch = function (realm, editor): SketchSpec {
+const sketch = (realm, editor): SketchSpec => {
   return Buttons.forToolbarStateAction(editor, 'link', 'link', () => {
     const groups = getGroups(realm, editor);
 

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/OuterContainer.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/OuterContainer.ts
@@ -12,7 +12,7 @@ import * as Styles from '../style/Styles';
 const READ_ONLY_MODE_CLASS = Styles.resolve('readonly-mode');
 const EDIT_MODE_CLASS = Styles.resolve('edit-mode');
 
-export default function (spec) {
+export default (spec) => {
   const root = GuiFactory.build(
     Container.sketch({
       dom: {
@@ -29,4 +29,4 @@ export default function (spec) {
   );
 
   return Gui.takeover(root);
-}
+};

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/SerialisedDialog.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/SerialisedDialog.ts
@@ -22,7 +22,7 @@ interface NavigateEvent extends CustomEvent {
   readonly direction: number;
 }
 
-const sketch = function (rawSpec) {
+const sketch = (rawSpec) => {
   const navigateEvent = 'navigateEvent';
 
   const wrapperAdhocEvents = 'serializer-wrapper-events';
@@ -44,10 +44,10 @@ const sketch = function (rawSpec) {
 
   const spec = ValueSchema.asRawOrDie('SerialisedDialog', schema, rawSpec);
 
-  const navigationButton = function (direction, directionName, enabled) {
+  const navigationButton = (direction, directionName, enabled) => {
     return Button.sketch({
       dom: UiDomFactory.dom('<span class="${prefix}-icon-' + directionName + ' ${prefix}-icon"></span>'),
-      action(button) {
+      action: (button) => {
         AlloyTriggers.emitWith(button, navigateEvent, { direction });
       },
       buttonBehaviours: Behaviour.derive([
@@ -59,13 +59,13 @@ const sketch = function (rawSpec) {
     });
   };
 
-  const reposition = function (dialog, message) {
+  const reposition = (dialog, message) => {
     SelectorFind.descendant(dialog.element, '.' + Styles.resolve('serialised-dialog-chain')).each((parent) => {
       Css.set(parent, 'left', (-spec.state.currentScreen.get() * message.width) + 'px');
     });
   };
 
-  const navigate = function (dialog, direction) {
+  const navigate = (dialog, direction) => {
     const screens = SelectorFilter.descendants<HTMLElement>(dialog.element, '.' + Styles.resolve('serialised-dialog-screen'));
     SelectorFind.descendant(dialog.element, '.' + Styles.resolve('serialised-dialog-chain')).each((parent) => {
       if ((spec.state.currentScreen.get() + direction) >= 0 && (spec.state.currentScreen.get() + direction) < screens.length) {
@@ -80,7 +80,7 @@ const sketch = function (rawSpec) {
   };
 
   // Unfortunately we need to inspect the DOM to find the input that is currently on screen
-  const focusInput = function (dialog) {
+  const focusInput = (dialog) => {
     const inputs = SelectorFilter.descendants(dialog.element, 'input');
     const optInput = Optional.from(inputs[spec.state.currentScreen.get()]);
     optInput.each((input) => {
@@ -92,7 +92,7 @@ const sketch = function (rawSpec) {
     Highlighting.highlightAt(dotitems, spec.state.currentScreen.get());
   };
 
-  const resetState = function () {
+  const resetState = () => {
     spec.state.currentScreen.set(0);
     spec.state.dialogSwipeState.clear();
   };
@@ -123,14 +123,14 @@ const sketch = function (rawSpec) {
           }),
           Keying.config({
             mode: 'special',
-            focusIn(dialog, _specialInfo) {
+            focusIn: (dialog, _specialInfo) => {
               focusInput(dialog);
             },
-            onTab(dialog, _specialInfo) {
+            onTab: (dialog, _specialInfo) => {
               navigate(dialog, +1);
               return Optional.some(true);
             },
-            onShiftTab(dialog, _specialInfo) {
+            onShiftTab: (dialog, _specialInfo) => {
               navigate(dialog, -1);
               return Optional.some(true);
             }
@@ -192,7 +192,7 @@ const sketch = function (rawSpec) {
     behaviours: Behaviour.derive([
       Keying.config({
         mode: 'special',
-        focusIn(wrapper) {
+        focusIn: (wrapper) => {
           const form = memForm.get(wrapper);
           Keying.focusIn(form);
         }

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/SizeSlider.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/SizeSlider.ts
@@ -19,14 +19,14 @@ const schema = ValueSchema.objOfOnly([
   FieldSchema.strict('sizes')
 ]);
 
-const sketch = function (rawSpec): SketchSpec {
+const sketch = (rawSpec): SketchSpec => {
   const spec = ValueSchema.asRawOrDie('SizeSlider', schema, rawSpec);
 
-  const isValidValue = function (valueIndex) {
+  const isValidValue = (valueIndex) => {
     return valueIndex >= 0 && valueIndex < spec.sizes.length;
   };
 
-  const onChange = function (slider, thumb, valueIndex) {
+  const onChange = (slider, thumb, valueIndex) => {
     const index = valueIndex.x();
     if (isValidValue(index)) {
       spec.onChange(index);
@@ -42,10 +42,10 @@ const sketch = function (rawSpec): SketchSpec {
         Styles.resolve('slider-size-container') ]
     },
     onChange,
-    onDragStart(slider, thumb) {
+    onDragStart: (slider, thumb) => {
       Toggling.on(thumb);
     },
-    onDragEnd(slider, thumb) {
+    onDragEnd: (slider, thumb) => {
       Toggling.off(thumb);
     },
     model: {

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/StylesMenu.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/StylesMenu.ts
@@ -16,11 +16,11 @@ import * as Receivers from '../channels/Receivers';
 import * as Styles from '../style/Styles';
 import * as Scrollable from '../touch/scroll/Scrollable';
 
-const getValue = function (item): string {
+const getValue = (item): string => {
   return Obj.get(item, 'format').getOr(item.title);
 };
 
-const convert = function (formats, memMenuThunk) {
+const convert = (formats, memMenuThunk) => {
   const mainMenu = makeMenu('Styles', [
   ].concat(
     Arr.map(formats.items, (k) => {
@@ -50,7 +50,7 @@ const convert = function (formats, memMenuThunk) {
   };
 };
 
-const makeItem = function (value, text, selected, preview, isMenu) {
+const makeItem = (value, text, selected, preview, isMenu) => {
   return {
     data: {
       value,
@@ -86,7 +86,7 @@ const makeItem = function (value, text, selected, preview, isMenu) {
   };
 };
 
-const makeMenu = function (value, items, memMenuThunk, collapsable) {
+const makeMenu = (value, items, memMenuThunk, collapsable) => {
   return {
     value,
     dom: {
@@ -107,7 +107,7 @@ const makeMenu = function (value, items, memMenuThunk, collapsable) {
           },
           GuiFactory.text(value)
         ] : [ GuiFactory.text(value) ],
-        action(item) {
+        action: (item) => {
           if (collapsable) {
             const comp = memMenuThunk().get(item);
             TieredMenu.collapseMenu(comp);
@@ -155,7 +155,7 @@ const makeMenu = function (value, items, memMenuThunk, collapsable) {
   };
 };
 
-const sketch = function (settings) {
+const sketch = (settings) => {
   const dataset = convert(settings.formats, () => {
     return memMenu;
   });
@@ -173,20 +173,20 @@ const sketch = function (settings) {
     // For animations, need things to stay around in the DOM (at least until animation is done)
     stayInDom: true,
 
-    onExecute(_tmenu, item) {
+    onExecute: (_tmenu, item) => {
       const v = Representing.getValue(item);
       settings.handle(item, v.value);
       return Optional.none();
     },
-    onEscape() {
+    onEscape: () => {
       return Optional.none();
     },
-    onOpenMenu(container, menu) {
+    onOpenMenu: (container, menu) => {
       const w = Width.get(container.element);
       Width.set(menu.element, w);
       Transitioning.jumpTo(menu, 'current');
     },
-    onOpenSubmenu(container, item, submenu) {
+    onOpenSubmenu: (container, item, submenu) => {
       const w = Width.get(container.element);
       const menu = SelectorFind.ancestor(item.element, '[role="menu"]').getOrDie('hacky');
       const menuComp = container.getSystem().getByDom(menu).getOrDie();
@@ -198,7 +198,7 @@ const sketch = function (settings) {
       Transitioning.progressTo(submenu, 'current');
     },
 
-    onCollapseMenu(container, item, menu) {
+    onCollapseMenu: (container, item, menu) => {
       const submenu = SelectorFind.ancestor(item.element, '[role="menu"]').getOrDie('hacky');
       const submenuComp = container.getSystem().getByDom(submenu).getOrDie();
       Transitioning.progressTo(submenuComp, 'after');

--- a/modules/tinymce/src/themes/mobile/main/ts/util/StyleConversions.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/StyleConversions.ts
@@ -8,7 +8,7 @@
 import { Objects } from '@ephox/boulder';
 import { Arr, Merger, Obj } from '@ephox/katamari';
 
-const getFromExpandingItem = function (item) {
+const getFromExpandingItem = (item) => {
   const newItem = Merger.deepMerge(
     Objects.exclude(item, [ 'items' ]),
     {
@@ -37,7 +37,7 @@ const getFromExpandingItem = function (item) {
   };
 };
 
-const getFromItem = function (item) {
+const getFromItem = (item) => {
   return Obj.hasNonNullableKey(item, 'items') ? getFromExpandingItem(item) : {
     item,
     menus: { },
@@ -46,7 +46,7 @@ const getFromItem = function (item) {
 };
 
 // Takes items, and consolidates them into its return value
-const expand = function (items) {
+const expand = (items) => {
   return Arr.foldr(items, (acc, item) => {
     const newData = getFromItem(item);
     return {

--- a/modules/tinymce/src/themes/mobile/main/ts/util/StyleFormats.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/StyleFormats.ts
@@ -85,7 +85,7 @@ const ui = (editor, formats, onDone) => {
 
   return StylesMenu.sketch({
     formats: pruned,
-    handle(item, value) {
+    handle: (item, value) => {
       editor.undoManager.transact(() => {
         if (Toggling.isOn(item)) {
           editor.formatter.remove(value);

--- a/modules/tinymce/src/themes/mobile/main/ts/util/TappingEvent.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/TappingEvent.ts
@@ -12,7 +12,7 @@ import { PlatformEditor } from '../ios/core/PlatformEditor';
 // TODO: TapEvent needs to be exposed in alloy's API somehow
 const monitor = (editorApi: PlatformEditor) => {
   const tapEvent = TapEvent.monitor({
-    triggerEvent(type, evt) {
+    triggerEvent: (type, evt) => {
       editorApi.onTapContent(evt);
     }
   } as any);

--- a/modules/tinymce/src/themes/mobile/test/ts/atomic/smooth/AsyncSmoothAnimationTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/atomic/smooth/AsyncSmoothAnimationTest.ts
@@ -3,17 +3,15 @@ import { Fun, Future } from '@ephox/katamari';
 
 import * as SmoothAnimation from 'tinymce/themes/mobile/ios/smooth/SmoothAnimation';
 
-UnitTest.asynctest('SmoothAnimationTest', function () {
-  const success = arguments[arguments.length - 2];
-
+UnitTest.asynctest('SmoothAnimationTest', (success) => {
   const animator = SmoothAnimation.create();
 
-  const check = function (label, initial, destination, amount) {
+  const check = (label, initial, destination, amount) => {
     return Future.nu((callback) => {
       let current = initial;
       let values = [ current ];
 
-      const add = function (val, abort) {
+      const add = (val, abort) => {
         if (val > 100) {
           abort('abort');
         } else {
@@ -37,7 +35,7 @@ UnitTest.asynctest('SmoothAnimationTest', function () {
     });
   };
 
-  const assertInfo = function (label, expected, info) {
+  const assertInfo = (label, expected, info) => {
     assert.eq(
       expected.current,
       info.current,

--- a/modules/tinymce/src/themes/mobile/test/ts/atomic/smooth/SmoothAnimationTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/atomic/smooth/SmoothAnimationTest.ts
@@ -3,12 +3,12 @@ import { KAssert } from '@ephox/katamari-assertions';
 import * as SmoothAnimation from 'tinymce/themes/mobile/ios/smooth/SmoothAnimation';
 
 UnitTest.test('Smooth Animation AdjustTest', () => {
-  const checkNone = function (label, value, destination, amount) {
+  const checkNone = (label, value, destination, amount) => {
     const actual = SmoothAnimation.adjust(value, destination, amount);
     KAssert.eqNone(label, actual);
   };
 
-  const check = function (label, expected, value, destination, amount) {
+  const check = (label, expected, value, destination, amount) => {
     const actual = SmoothAnimation.adjust(value, destination, amount);
     KAssert.eqSome(label, expected, actual);
   };

--- a/modules/tinymce/src/themes/mobile/test/ts/atomic/styles/StyleConversionsTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/atomic/styles/StyleConversionsTest.ts
@@ -2,7 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import * as StyleConversions from 'tinymce/themes/mobile/util/StyleConversions';
 
 UnitTest.test('Atomic Test: styles.StyleConversionsTest', () => {
-  const check = function (label, expected, input) {
+  const check = (label, expected, input) => {
     const output = StyleConversions.expand(input);
     Assert.eq('StyleConversions.expand (' + label + ')', expected, output);
   };

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/features/BasicFormattingTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/features/BasicFormattingTest.ts
@@ -22,21 +22,21 @@ UnitTest.asynctest('Browser Test: features.BasicFormattingTest', (success, failu
       const sSetS1 = apis.sSetSelection([ 0, 0 ], 'n'.length, [ 0, 0 ], 'n'.length);
       const sSetS2 = apis.sSetSelection([ 0, 1, 0 ], 'for'.length, [ 0, 1, 0 ], 'for'.length);
 
-      const sCheckComponent = function (label, state) {
-        return function (memento) {
+      const sCheckComponent = (label, state) => {
+        return (memento) => {
           return TestUi.sWaitForToggledState(label, state, realm, memento);
         };
       };
 
-      const sTestFormatter = function (openTag, closeTag, name) {
-        const sCheckS1 = function (situation) {
+      const sTestFormatter = (openTag, closeTag, name) => {
+        const sCheckS1 = (situation) => {
           return GeneralSteps.sequence([
             sSetS1,
             sCheckComponent(situation, false)(buttons[name])
           ]);
         };
 
-        const sCheckS2 = function (situation) {
+        const sCheckS2 = (situation) => {
           return GeneralSteps.sequence([
             sSetS2,
             sCheckComponent(situation, true)(buttons[name])

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/features/ListTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/features/ListTest.ts
@@ -21,46 +21,46 @@ UnitTest.asynctest('Browser Test: features.ListTest', (success, failure) => {
       const sSetP2 = apis.sSetSelection([ 1, 0 ], 'Norma'.length, [ 1, 0 ], 'Norma'.length);
       const sSetP3 = apis.sSetSelection([ 2, 0, 0 ], 'Bu'.length, [ 2, 0, 0 ], 'Bu'.length);
 
-      const sCheckComponent = function (label, state) {
-        return function (memento) {
+      const sCheckComponent = (label, state) => {
+        return (memento) => {
           return TestUi.sWaitForToggledState(label, state, realm, memento);
         };
       };
 
-      const sCheckLists = function (situation, stateOfNumlist, stateOfBullist) {
+      const sCheckLists = (situation, stateOfNumlist, stateOfBullist) => {
         return GeneralSteps.sequence([
           sCheckComponent('checking numlist: ' + situation, stateOfNumlist)(buttons.numlist),
           sCheckComponent('checking bullist: ' + situation, stateOfBullist)(buttons.bullist)
         ]);
       };
 
-      const sCheckInNumlist = function (situation) {
+      const sCheckInNumlist = (situation) => {
         return sCheckLists(situation, true, false);
       };
 
-      const sCheckInBullist = function (situation) {
+      const sCheckInBullist = (situation) => {
         return sCheckLists(situation, false, true);
       };
 
-      const sCheckInNoList = function (situation) {
+      const sCheckInNoList = (situation) => {
         return sCheckLists(situation, false, false);
       };
 
-      const sCheckP1 = function (situation) {
+      const sCheckP1 = (situation) => {
         return GeneralSteps.sequence([
           sSetP1,
           sCheckInNumlist(situation)
         ]);
       };
 
-      const sCheckP2 = function (situation) {
+      const sCheckP2 = (situation) => {
         return GeneralSteps.sequence([
           sSetP2,
           sCheckInNoList(situation)
         ]);
       };
 
-      const sCheckP3 = function (situation) {
+      const sCheckP3 = (situation) => {
         return GeneralSteps.sequence([
           sSetP3,
           sCheckInBullist(situation)

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/features/UnlinkTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/features/UnlinkTest.ts
@@ -20,27 +20,27 @@ UnitTest.asynctest('Browser Test: features.UnlinkTest', (success, failure) => {
       const sSetS1 = apis.sSetSelection([ 0, 0 ], 'n'.length, [ 0, 0 ], 'n'.length);
       const sSetS2 = apis.sSetSelection([ 0, 1, 0 ], 'tin'.length, [ 0, 1, 0 ], 'tin'.length);
 
-      const sCheckComponent = function (label, state) {
-        return function (memento) {
+      const sCheckComponent = (label, state) => {
+        return (memento) => {
           return TestUi.sWaitForToggledState(label, state, realm, memento);
         };
       };
 
-      const sCheckS1 = function (situation) {
+      const sCheckS1 = (situation) => {
         return GeneralSteps.sequence([
           sSetS1,
           sCheckLink(situation, false)
         ]);
       };
 
-      const sCheckS2 = function (situation) {
+      const sCheckS2 = (situation) => {
         return GeneralSteps.sequence([
           sSetS2,
           sCheckLink(situation, true)
         ]);
       };
 
-      const sCheckLink = function (situation, expected) {
+      const sCheckLink = (situation, expected) => {
         return GeneralSteps.sequence([
           sCheckComponent(situation + ' (unlink state)', expected)(buttons.unlink),
           sCheckComponent(situation + ' (link state)', expected)(buttons.link)

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/ui/ButtonsTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/ui/ButtonsTest.ts
@@ -33,7 +33,7 @@ UnitTest.asynctest('Browser Test: ui.ButtonsTest', (success, failure) => {
 
   TestStyles.addStyles();
 
-  const unload = function () {
+  const unload = () => {
     TestStyles.removeStyles();
     Attachment.detachSystem(realm.system);
   };
@@ -59,8 +59,8 @@ UnitTest.asynctest('Browser Test: ui.ButtonsTest', (success, failure) => {
   const sClickBeta = TestUi.sClickComponent(realm, memBeta);
   const sClickGamma = TestUi.sClickComponent(realm, memGamma);
 
-  const sCheckComponent = function (label, state) {
-    return function (memento) {
+  const sCheckComponent = (label, state) => {
+    return (memento) => {
       return TestUi.sWaitForToggledState(label, state, realm, memento);
     };
   };

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/ui/FontSizeSliderTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/ui/FontSizeSliderTest.ts
@@ -24,7 +24,7 @@ UnitTest.asynctest('Browser Test: ui.FontSizeSliderTest', (success, failure) => 
 
   TestStyles.addStyles();
 
-  const unload = function () {
+  const unload = () => {
     TestStyles.removeStyles();
     Attachment.detachSystem(realm.system);
   };

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/ui/SerialisedLinkTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/ui/SerialisedLinkTest.ts
@@ -28,7 +28,7 @@ UnitTest.asynctest('Browser Test: ui.SerialisedLinkTest', (success, failure) => 
 
   TestStyles.addStyles();
 
-  const unload = function () {
+  const unload = () => {
     TestStyles.removeStyles();
     Attachment.detachSystem(realm.system);
   };
@@ -44,7 +44,7 @@ UnitTest.asynctest('Browser Test: ui.SerialisedLinkTest', (success, failure) => 
     }
   ]);
 
-  const sAssertNavigation = function (label, prevEnabled, nextEnabled) {
+  const sAssertNavigation = (label, prevEnabled, nextEnabled) => {
     return Logger.t(
       label,
       Step.sync(() => {
@@ -53,7 +53,7 @@ UnitTest.asynctest('Browser Test: ui.SerialisedLinkTest', (success, failure) => 
         const prev = Traverse.parent(active).bind(Traverse.prevSibling).getOrDie('Could not find button to left');
         const next = Traverse.parent(active).bind(Traverse.nextSibling).getOrDie('Could not find button to right');
 
-        const assertNavButton = function (buttonLabel, expected, button) {
+        const assertNavButton = (buttonLabel, expected, button) => {
           Assertions.assertStructure(
             'Checking ' + buttonLabel + ' button should be enabled = ' + expected,
             ApproxStructure.build((s, str, arr) => {
@@ -76,7 +76,7 @@ UnitTest.asynctest('Browser Test: ui.SerialisedLinkTest', (success, failure) => 
     );
   };
 
-  const sClickNavigation = function (selector) {
+  const sClickNavigation = (selector) => {
     return Chain.asStep({ }, [
       TestUi.cGetFocused,
       TestUi.cGetParent,
@@ -139,7 +139,7 @@ UnitTest.asynctest('Browser Test: ui.SerialisedLinkTest', (success, failure) => 
 
   const sClickLink = Mouse.sClickOn(realm.element, TestSelectors.link());
 
-  const sTestScenario = function (rawScenario) {
+  const sTestScenario = (rawScenario) => {
     const scenario = ValueSchema.asRawOrDie('Checking scenario', ValueSchema.objOf([
       FieldSchema.strict('label'),
       FieldSchema.defaulted('content', ''),
@@ -337,7 +337,7 @@ UnitTest.asynctest('Browser Test: ui.SerialisedLinkTest', (success, failure) => 
       node: SugarElement.fromHtml('<a href="http://prepared-url">Prepared</a>'),
       fields: { },
       expected: [ ],
-      mutations(node) {
+      mutations: (node) => {
         return Assertions.sAssertStructure('Checking mutated structure', ApproxStructure.build((s, str, _arr) => {
           return s.element('a', {
             attrs: {
@@ -356,7 +356,7 @@ UnitTest.asynctest('Browser Test: ui.SerialisedLinkTest', (success, failure) => 
         url: 'http://new-url'
       },
       expected: [ ],
-      mutations(node) {
+      mutations: (node) => {
         return Assertions.sAssertStructure('Checking mutated structure', ApproxStructure.build((s, str, _arr) => {
           return s.element('a', {
             attrs: {
@@ -375,7 +375,7 @@ UnitTest.asynctest('Browser Test: ui.SerialisedLinkTest', (success, failure) => 
         url: 'http://new-url'
       },
       expected: [ ],
-      mutations(node) {
+      mutations: (node) => {
         return Assertions.sAssertStructure('Checking mutated structure', ApproxStructure.build((s, str, _arr) => {
           return s.element('a', {
             attrs: {
@@ -395,7 +395,7 @@ UnitTest.asynctest('Browser Test: ui.SerialisedLinkTest', (success, failure) => 
         text: 'new-text'
       },
       expected: [ ],
-      mutations(node) {
+      mutations: (node) => {
         return Assertions.sAssertStructure('Checking mutated structure', ApproxStructure.build((s, str, _arr) => {
           return s.element('a', {
             attrs: {

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/theme/TestTheme.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/theme/TestTheme.ts
@@ -9,7 +9,7 @@ import * as FormatChangers from 'tinymce/themes/mobile/util/FormatChangers';
 
 const strName = 'test';
 
-const setup = function (info, onSuccess, onFailure) {
+const setup = (info, onSuccess, onFailure) => {
 
   /* This test is going to create a toolbar with both list items on it */
   const alloy = Gui.create();
@@ -52,7 +52,7 @@ const setup = function (info, onSuccess, onFailure) {
 
   ThemeManager.add(strName, (editor) => {
     return {
-      renderUI() {
+      renderUI: () => {
         editor.fire('SkinLoaded');
         return {
           iframeContainer: socket.element.dom,
@@ -63,7 +63,7 @@ const setup = function (info, onSuccess, onFailure) {
   });
 
   return {
-    use(f: (realm: MobileRealm, apis: TinyApis, toolbar: AlloyComponent, socket: AlloyComponent, buttons, onSuccess: () => void, onFailure: (err?: any) => void) => void) {
+    use: (f: (realm: MobileRealm, apis: TinyApis, toolbar: AlloyComponent, socket: AlloyComponent, buttons, onSuccess: () => void, onFailure: (err?: any) => void) => void) => {
       TinyLoader.setup((editor, onS, onF) => {
         const features = Features.setup(realm, editor);
 

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestEditor.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestEditor.ts
@@ -3,7 +3,7 @@ import { TestHelpers } from '@ephox/alloy';
 import { Objects } from '@ephox/boulder';
 import { Cell, Fun } from '@ephox/katamari';
 
-export default function () {
+export default () => {
   const store = TestHelpers.TestStore();
 
   const editorState = {
@@ -11,7 +11,7 @@ export default function () {
     content: Cell('')
   };
 
-  const sPrepareState = function (node, content) {
+  const sPrepareState = (node, content) => {
     return Step.sync(() => {
       editorState.start.set(node);
       editorState.content.set(content);
@@ -25,14 +25,14 @@ export default function () {
       select: Fun.noop
     },
 
-    insertContent(data) {
+    insertContent: (data) => {
       store.adder({ method: 'insertContent', data })();
     },
-    execCommand(name, ui, args) {
+    execCommand: (name, ui, args) => {
       store.adder({ method: 'execCommand', data: Objects.wrap(name, args) })();
     },
     dom: {
-      createHTML(tag, attributes, innerText) {
+      createHTML: (tag, attributes, innerText) => {
         return { tag, attributes, innerText };
       },
       encode: Fun.identity
@@ -55,4 +55,4 @@ export default function () {
     sClear: store.sClear,
     sPrepareState
   };
-}
+};

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestFrameEditor.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestFrameEditor.ts
@@ -5,7 +5,7 @@ import { Attribute, Focus, SugarElement, WindowSelection } from '@ephox/sugar';
 
 import TestEditor from './TestEditor';
 
-export default function () {
+export default () => {
   const frame = SugarElement.fromTag('iframe');
   Attribute.set(frame, 'src', '/project/tinymce/src/themes/mobile/test/html/editor.html');
 
@@ -19,10 +19,10 @@ export default function () {
   );
 
   const config = {
-    getFrame() {
+    getFrame: () => {
       return frame;
     },
-    onDomChanged() {
+    onDomChanged: () => {
       return { unbind: Fun.noop };
     }
   };
@@ -32,18 +32,18 @@ export default function () {
 
   const editor = {
     selection: {
-      getStart() {
+      getStart: () => {
         return WindowSelection.getExact(frame.dom.contentWindow).map((sel) => {
           return sel.start.dom;
         }).getOr(null);
       },
-      getContent() {
+      getContent: () => {
         return frame.dom.contentWindow.document.body.innerHTML;
       },
       select: Fun.noop
     },
 
-    getBody() {
+    getBody: () => {
       return frame.dom.contentWindow.document.body;
     },
 
@@ -51,7 +51,7 @@ export default function () {
     execCommand: dEditor.execCommand,
     dom: dEditor.dom,
     // Maybe this should be implemented
-    focus() {
+    focus: () => {
       Focus.focus(frame);
       const win = frame.dom.contentWindow;
       WindowSelection.getExact(win).orThunk(() => {
@@ -87,4 +87,4 @@ export default function () {
     sClear: delegate.sClear,
     sPrepareState: delegate.sPrepareState
   };
-}
+};

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestStyles.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestStyles.ts
@@ -4,7 +4,7 @@ import { Attribute, Class, Css, Insert, Remove, SelectorFind, SugarElement } fro
 
 const styleClass = Id.generate('ui-test-styles');
 
-const addStyles = function () {
+const addStyles = () => {
   const link = SugarElement.fromTag('link');
   Attribute.setAll(link, {
     rel: 'Stylesheet',
@@ -17,12 +17,12 @@ const addStyles = function () {
   Insert.append(head, link);
 };
 
-const removeStyles = function () {
+const removeStyles = () => {
   const head = SugarElement.fromDom(document.head);
   SelectorFind.descendant(head, '.' + styleClass).each(Remove.remove);
 };
 
-const sWaitForToolstrip = function (realm) {
+const sWaitForToolstrip = (realm) => {
   return Waiter.sTryUntil(
     'Waiting until CSS has loaded',
     Chain.asStep(realm.element, [

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestUi.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestUi.ts
@@ -16,20 +16,20 @@ const cGetParent = Chain.binder((elem: SugarElement) => {
   }, Result.value);
 });
 
-const sSetFieldValue = function (value: string) {
+const sSetFieldValue = (value: string) => {
   return Chain.asStep({ }, [
     cGetFocused,
     UiControls.cSetValue(value)
   ]);
 };
 
-const sSetFieldOptValue = function (optVal: Optional<string>) {
+const sSetFieldOptValue = (optVal: Optional<string>) => {
   return optVal.fold(() => {
     return Step.pass;
   }, sSetFieldValue);
 };
 
-const sStartEditor = function (alloy: Gui.GuiSystem) {
+const sStartEditor = (alloy: Gui.GuiSystem) => {
   return Step.sync(() => {
     const button = UiFinder.findIn(alloy.element, '[role="button"]').getOrDie();
     const x = alloy.getByDom(button).getOrDie();
@@ -37,7 +37,7 @@ const sStartEditor = function (alloy: Gui.GuiSystem) {
   });
 };
 
-const sClickComponent = function (realm: MobileRealm, memento: MementoRecord) {
+const sClickComponent = (realm: MobileRealm, memento: MementoRecord) => {
   return Chain.asStep({ }, [
     Chain.injectThunked(() => {
       return memento.get(realm.socket).element;
@@ -46,7 +46,7 @@ const sClickComponent = function (realm: MobileRealm, memento: MementoRecord) {
   ]);
 };
 
-const sWaitForToggledState = function (label: string, state: boolean, realm: MobileRealm, memento: MementoRecord) {
+const sWaitForToggledState = (label: string, state: boolean, realm: MobileRealm, memento: MementoRecord) => {
   return Waiter.sTryUntil(
     label,
     Step.sync(() => {
@@ -62,7 +62,7 @@ const sWaitForToggledState = function (label: string, state: boolean, realm: Mob
   );
 };
 
-const sBroadcastState = function (realm: MobileRealm, channels: string[], command: string, state: boolean) {
+const sBroadcastState = (realm: MobileRealm, channels: string[], command: string, state: boolean) => {
   return Step.sync(() => {
     realm.system.broadcastOn(channels, {
       command,

--- a/modules/tinymce/src/themes/mobile/test/ts/phantom/bridge/LinkBridgeTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/phantom/bridge/LinkBridgeTest.ts
@@ -22,14 +22,14 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
       getContent: editorState.content.get,
       select: Fun.noop
     },
-    insertContent(data) {
+    insertContent: (data) => {
       store.adder({ method: 'insertContent', data })();
     },
-    execCommand(name) {
+    execCommand: (name) => {
       store.adder({ method: 'execCommand', data: name })();
     },
     dom: {
-      createHTML(tag, attributes, innerText) {
+      createHTML: (tag, attributes, innerText) => {
         return { tag, attributes, innerText };
       },
       encode: Fun.identity
@@ -37,7 +37,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
     focus: Fun.noop
   };
 
-  const checkGetNoLink = function (rawScenario) {
+  const checkGetNoLink = (rawScenario) => {
     const schema = ValueSchema.objOfOnly([
       FieldSchema.strict('label'),
       FieldSchema.defaulted('nodeText', ''),
@@ -61,7 +61,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
     });
   };
 
-  const checkGetALink = function (rawScenario) {
+  const checkGetALink = (rawScenario) => {
     const schema = ValueSchema.objOfOnly([
       FieldSchema.strict('label'),
       FieldSchema.defaulted('linkHtml', ''),
@@ -80,7 +80,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
     });
   };
 
-  const checkApply = function (rawScenario) {
+  const checkApply = (rawScenario) => {
     const toResult = (info, param) => Optional.from(info[param]).fold(() => Result.error('Missing ' + param), Result.value);
     const scenario = {
       label: Optional.from(rawScenario.label).getOrDie('Missing label'),
@@ -175,7 +175,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
     info: {
       url: 'hi'
     },
-    mutations(_elem) {
+    mutations: (_elem) => {
 
     },
     expected: [
@@ -198,7 +198,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
       url: 'hi',
       text: 'hello'
     },
-    mutations(_elem) {
+    mutations: (_elem) => {
 
     },
     expected: [
@@ -222,7 +222,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
       text: 'hello',
       title: 'Title'
     },
-    mutations(_elem) {
+    mutations: (_elem) => {
 
     },
     expected: [
@@ -248,7 +248,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
       title: 'Title',
       target: 'new'
     },
-    mutations(_elem) {
+    mutations: (_elem) => {
 
     },
     expected: [
@@ -278,7 +278,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
         SugarElement.fromHtml('<a href="http://foo">http://foo</a>')
       )
     },
-    mutations(elem) {
+    mutations: (elem) => {
       Assertions.assertStructure('Checking structure', ApproxStructure.build((s, str, _arr) => {
         return s.element('a', {
           attrs: {
@@ -301,7 +301,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
         SugarElement.fromHtml('<a href="http://foo">Foo</a>')
       )
     },
-    mutations(elem) {
+    mutations: (elem) => {
       Assertions.assertStructure('Checking structure', ApproxStructure.build((s, str, _arr) => {
         return s.element('a', {
           attrs: {
@@ -324,7 +324,7 @@ UnitTest.test('Test: phantom.bridge.LinkBridgeTest', () => {
         SugarElement.fromHtml('<a href="http://foo">Foo</a>')
       )
     },
-    mutations(elem) {
+    mutations: (elem) => {
       Assertions.assertStructure('Checking structure', ApproxStructure.build((s, str, _arr) => {
         return s.element('a', {
           attrs: {

--- a/modules/tinymce/src/themes/mobile/test/ts/phantom/features/IdentifyToolbarTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/phantom/features/IdentifyToolbarTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock-client';
 import * as Features from 'tinymce/themes/mobile/features/Features';
 
 UnitTest.test('features.IdentifyToolbarTest', () => {
-  const check = function (label: string, expected: string[], input: string | string[] | string[][] | undefined) {
+  const check = (label: string, expected: string[], input: string | string[] | string[][] | undefined) => {
     const dummyEditor = {
       getParam: (_name: string, defaultValue: any) => input !== undefined ? input : defaultValue
     };

--- a/modules/tinymce/src/themes/silver/demo/ts/components/notification/NotificationDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/components/notification/NotificationDemo.ts
@@ -5,8 +5,8 @@ import Delay from 'tinymce/core/api/util/Delay';
 
 declare let tinymce: any;
 
-export default function () {
-  const notifyShort = function (type) {
+export default () => {
+  const notifyShort = (type) => {
     const notification = tinymce.activeEditor.notificationManager.open({
       type,
       text: 'This is an example ' + (type ? type : 'blank') + ' message.'
@@ -18,7 +18,7 @@ export default function () {
     console.log(notification);
   };
 
-  const notifyLong = function (len) {
+  const notifyLong = (len) => {
     const longTextMessage = [];
 
     for (let i = 0; i < len; i++) {
@@ -31,7 +31,7 @@ export default function () {
     console.log(notification);
   };
 
-  const notifyExtraLong = function (len) {
+  const notifyExtraLong = (len) => {
     const longTextMessage = [ 'this is text ' ];
 
     for (let i = 0; i < len; i++) {
@@ -44,7 +44,7 @@ export default function () {
     console.log(notification);
   };
 
-  const notifyProgress = function (percent) {
+  const notifyProgress = (percent) => {
     const notification = tinymce.activeEditor.notificationManager.open({
       text: 'Progress text',
       progressBar: true
@@ -57,7 +57,7 @@ export default function () {
     console.log(notification);
   };
 
-  const notifyTimeout = function (time) {
+  const notifyTimeout = (time) => {
     const notification = tinymce.activeEditor.notificationManager.open({
       text: 'Timeout: ' + time,
       timeout: time
@@ -65,7 +65,7 @@ export default function () {
     console.log(notification);
   };
 
-  const notifyIcon = function () {
+  const notifyIcon = () => {
     const notification = tinymce.activeEditor.notificationManager.open({
       text: 'Text',
       icon: 'bold'
@@ -87,7 +87,7 @@ export default function () {
   ], (notification) => {
     const btn = document.createElement('button');
     btn.innerHTML = notification.title;
-    btn.onclick = function () {
+    btn.onclick = () => {
       notification.action(notification.value);
     };
     document.querySelector('#ephox-ui').appendChild(btn);
@@ -105,4 +105,4 @@ export default function () {
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     theme: 'silver'
   });
-}
+};

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
@@ -5,7 +5,7 @@ export default {
   setup: (ed: Editor) => {
     ed.ui.registry.addButton('basic-button-1', {
       text: 'basic-button-1',
-      onAction() {
+      onAction: () => {
         console.log('basic-button-1 click');
       }
     });
@@ -13,7 +13,7 @@ export default {
     ed.ui.registry.addButton('basic-button-2', {
       icon: 'basic-icon',
       text: 'aria-label-icon-button',
-      onAction() {
+      onAction: () => {
         console.log('basic-button-2 click, basic-icon');
       }
     });
@@ -40,7 +40,7 @@ export default {
     ed.ui.registry.addButton('dialog-button', {
       type: 'button',
       text: 'Launch Dialog',
-      onAction() {
+      onAction: () => {
         ed.windowManager.open({
           title: 'Dialog title',
           body: {
@@ -81,31 +81,31 @@ export default {
 
     ed.ui.registry.addMenuItem('menu-button-item-1', {
       text: 'menu-button-item-1',
-      onAction() {
+      onAction: () => {
         console.log('menu-button-item-1 click');
       }
     });
 
     ed.ui.registry.addNestedMenuItem('menu-button-item-2', {
       text: 'menu-button-item-2',
-      getSubmenuItems() {
+      getSubmenuItems: () => {
         return [
           {
             type: 'menuitem',
             text: 'submenu-1',
-            onAction() {
+            onAction: () => {
               console.log('submenu1');
             }
           },
           {
             type: 'menuitem',
             text: 'submenu-2',
-            getSubmenuItems() {
+            getSubmenuItems: () => {
               return [
                 {
                   type: 'menuitem',
                   text: 'submenu-2-a',
-                  onAction() {
+                  onAction: () => {
                     console.log('submenu2a');
                   }
                 }

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/FormatSelectDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/FormatSelectDemo.ts
@@ -1,7 +1,7 @@
 
 declare let tinymce: any;
 
-export default function () {
+export default () => {
 
   tinymce.init({
     selector: 'textarea.tiny-text',
@@ -66,4 +66,4 @@ export default function () {
     block_formats: 'Paragraph=p;Heading 1=h1;Heading 2=h2;Separator Name=|;Heading 3=h3',
     plugins: [ 'lists', 'autolink', 'autosave', 'insertdatetime' ]
   });
-}
+};

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
@@ -6,7 +6,7 @@ declare let tinymce: any;
 
 /* eslint-disable no-console */
 
-export default function () {
+export default () => {
   const DemoState = MockDemo.mockFeatureState();
   const DemoState2 = MockDemo.mockFeatureState();
 
@@ -24,11 +24,11 @@ export default function () {
       File: [ 'x1', 'x2', 'x3', '|', 't1', '|', 'd1' ]
     },
 
-    setup(ed: Editor) {
+    setup: (ed: Editor) => {
       ed.ui.registry.addMenuItem('x1', {
         icon: 'drop',
         text: 'Text with icon',
-        onAction() {
+        onAction: () => {
           console.log('Just Text click');
         }
       });
@@ -36,7 +36,7 @@ export default function () {
       ed.ui.registry.addMenuItem('x2', {
         // icon: Icons.getOr('bold', () => 'oh no'),
         text: 'Just Text',
-        onAction() {
+        onAction: () => {
           console.log('Just Text click');
         }
       });
@@ -45,7 +45,7 @@ export default function () {
         // icon: Icons.getOr('bold', () => 'oh no'),
         text: 'Just Text with shortcut',
         shortcut: 'Ctrl+Alt+Delete',
-        onAction() {
+        onAction: () => {
           console.log('Just Text click');
         }
       });
@@ -53,18 +53,18 @@ export default function () {
       ed.ui.registry.addToggleMenuItem('t1', {
         text: 'button with Toggle',
         shortcut: '⌘+C',
-        onSetup: (comp) => {
+        onSetup: (api) => {
           // debugger;
           // TODO: TS narrowing, when config toggling = true
           // then the comp interface should include comp.toggleOn otherwise it should complain
           const state = DemoState.get();
           console.log(state);
-          comp.setActive(state);
+          api.setActive(state);
           return Fun.noop;
         },
-        onAction(comp) {
+        onAction: (api) => {
           DemoState.toggle();
-          comp.setActive(DemoState.get());
+          api.setActive(DemoState.get());
           console.log('button with Toggle click - current state is: ' + DemoState.get());
         }
       });
@@ -76,7 +76,7 @@ export default function () {
           {
             type: 'menuitem',
             text: 'Nested 1',
-            onAction() {
+            onAction: () => {
               console.log('clicked nested 1');
             }
           },
@@ -84,7 +84,7 @@ export default function () {
             type: 'menuitem',
             text: 'Nested 2',
             icon: 'drop',
-            onAction() {
+            onAction: () => {
               console.log('clicked nested 1');
             }
           },
@@ -92,25 +92,25 @@ export default function () {
             type: 'menuitem',
             text: 'Nested 3',
             shortcut: 'X',
-            onAction() {
+            onAction: () => {
               console.log('clicked nested 1');
             }
           },
           {
             type: 'togglemenuitem',
             text: 'nested Toggle',
-            onSetup: (comp) => {
+            onSetup: (api) => {
               // debugger;
               // TODO: TS narrowing, when config toggling = true
               // then the comp interface should include comp.toggleOn otherwise it should complain
               const state = DemoState2.get();
               console.log(state);
-              comp.setActive(state);
+              api.setActive(state);
               return Fun.noop;
             },
-            onAction(comp) {
+            onAction: (api) => {
               DemoState2.toggle();
-              comp.setActive(DemoState2.get());
+              api.setActive(DemoState2.get());
               console.log('button with Toggle click - current state is: ' + DemoState2.get());
             }
           },
@@ -130,4 +130,4 @@ export default function () {
       });
     }
   });
-}
+};

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
@@ -5,7 +5,7 @@ import ButtonSetupDemo from './ButtonSetupDemo';
 
 declare let tinymce: any;
 
-export default function () {
+export default () => {
   tinymce.init({
     // TODO: Investigate. Should thisget the styles (e.g. margin) of the div/textarea?
     selector: 'div.tiny-text',
@@ -98,7 +98,7 @@ export default function () {
       // }
     ],
 
-    setup(ed: Editor) {
+    setup: (ed: Editor) => {
       ButtonSetupDemo.setup(ed);
 
       ed.on('skinLoaded', () => {
@@ -147,4 +147,4 @@ export default function () {
 
     }
   });
-}
+};

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/SidebarDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/SidebarDemo.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 // import ButtonSetupDemo from './ButtonSetupDemo';
 declare let tinymce: any;
 
-export default function () {
+export default () => {
   const makeSidebar = (ed: Editor, name: string, background: string, width: number) => {
     ed.ui.registry.addSidebar(name, {
       icon: 'comment',
@@ -40,10 +40,10 @@ export default function () {
     // statusbar: false,
     resize: 'both',
 
-    setup(ed: Editor) {
+    setup: (ed: Editor) => {
       makeSidebar(ed, 'sidebar1', 'green', 200);
       makeSidebar(ed, 'sidebar2', 'red', 300);
       makeSidebar(ed, 'sidebar3', 'blue', 150);
     }
   });
-}
+};

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
@@ -6,7 +6,7 @@ import * as MockDemo from './MockDemo';
 
 declare let tinymce: any;
 
-export default function () {
+export default () => {
   const DemoState2 = MockDemo.mockFeatureState();
   const generateButton = (editor: Editor, buttonType: 'button', name, num) => {
     const names = [];
@@ -15,7 +15,7 @@ export default function () {
       editor.ui.registry.addButton(`${name}-${i}`, {
         type: buttonType,
         icon: `*-${i}-*`,
-        onAction(_comp) {
+        onAction: (_api) => {
           console.log(`${name} ${i} button clicked`);
         }
       });
@@ -39,7 +39,7 @@ export default function () {
       'autosave' // Required to prevent users losing content when they press back
     ],
 
-    setup(ed: Editor) {
+    setup: (ed: Editor) => {
       ed.on('skinLoaded', () => {
         // Notification fields for equality: type, text, progressBar, timeout
         ed.notificationManager.open({
@@ -55,7 +55,7 @@ export default function () {
         icon: 'bold',
         // ariaLabel: 'aria says icon button',
         disabled: true,
-        onAction(_comp) {
+        onAction: (_api) => {
           console.log('basic-button-2 click, basic-icon');
         }
       });
@@ -64,7 +64,7 @@ export default function () {
         type: 'button',
         icon: 'checkmark',
         // ariaLabel: 'aria says icon button',
-        onAction(_comp) {
+        onAction: (_api) => {
           console.log('basic-button-2 click, basic-icon');
         }
       });
@@ -73,18 +73,18 @@ export default function () {
         type: 'togglebutton',
         icon: 'italic',
         // ariaLabel: 'aria speaks icon button toggle',
-        onSetup: (comp) => {
+        onSetup: (api) => {
           // debugger;
           // TODO: TS narrowing, when config toggling = true
           // then the comp interface should include comp.toggleOn otherwise it should complain
           const state = DemoState2.get();
           console.log(state);
-          comp.setActive(state);
+          api.setActive(state);
           return Fun.noop;
         },
-        onAction(comp) {
+        onAction: (api) => {
           DemoState2.toggle();
-          comp.setActive(DemoState2.get());
+          api.setActive(DemoState2.get());
           console.log('button with Toggle click - current state is: ' + DemoState2.get());
         }
       });
@@ -93,4 +93,4 @@ export default function () {
 
     }
   });
-}
+};

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarComponentsDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarComponentsDemo.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { identifyButtons } from 'tinymce/themes/silver/ui/toolbar/Integration';
 import { setupDemo } from '../components/DemoHelpers';
 
-export default function () {
+export default () => {
 
   const buttons = {
     'alpha': {
@@ -145,4 +145,4 @@ export default function () {
   });
 
   helpers.uiMothership.add(toolbar);
-}
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ReadOnly.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ReadOnly.ts
@@ -53,7 +53,7 @@ const receivingConfig = (): Behaviour.NamedConfiguredBehaviour<any, any> => Rece
   channels: {
     [ReadOnlyChannel]: {
       schema: ReadOnlyDataSchema,
-      onReceive(comp, data: ReadOnlyData) {
+      onReceive: (comp, data: ReadOnlyData) => {
         Disabling.set(comp, data.readonly);
       }
     }

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -168,7 +168,7 @@ const setup = (editor: Editor): RenderInfo => {
       classes: [ 'tox-menubar' ]
     },
     backstage,
-    onEscape() {
+    onEscape: () => {
       editor.focus();
     }
   });
@@ -182,7 +182,7 @@ const setup = (editor: Editor): RenderInfo => {
     },
     getSink: lazySink,
     providers: backstage.shared.providers,
-    onEscape() {
+    onEscape: () => {
       editor.focus();
     },
     type: toolbarMode,
@@ -392,7 +392,7 @@ const setup = (editor: Editor): RenderInfo => {
     return parsedHeight;
   };
 
-  const renderUI = function (): ModeRenderInfo {
+  const renderUI = (): ModeRenderInfo => {
     header.setup(editor, backstage.shared, lazyHeader);
     FormatControls.setup(editor, backstage);
     SilverContextMenu.setup(editor, lazySink, backstage);

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -14,7 +14,7 @@ import * as WindowManager from './ui/dialog/WindowManager';
 
 type RenderInfo = Render.RenderInfo;
 
-export default function () {
+export default () => {
   ThemeManager.add('silver', (editor): Theme => {
     const { uiMothership, backstage, renderUI, getUi }: RenderInfo = Render.setup(editor);
 
@@ -30,4 +30,4 @@ export default function () {
       ui: getUi()
     };
   });
-}
+};

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -14,7 +14,7 @@ import Delay from 'tinymce/core/api/util/Delay';
 import { UiFactoryBackstage } from '../backstage/Backstage';
 import { Notification } from '../ui/general/Notification';
 
-export default function (editor: Editor, extras, uiMothership: Gui.GuiSystem): NotificationManagerImpl {
+export default (editor: Editor, extras, uiMothership: Gui.GuiSystem): NotificationManagerImpl => {
   const backstage: UiFactoryBackstage = extras.backstage;
 
   const getLayoutDirection = (rel: 'tc-tc' | 'bc-bc' | 'bc-tc' | 'tc-bc') => {
@@ -134,11 +134,11 @@ export default function (editor: Editor, extras, uiMothership: Gui.GuiSystem): N
     };
   };
 
-  const close = function (notification: NotificationApi) {
+  const close = (notification: NotificationApi) => {
     notification.close();
   };
 
-  const getArgs = function (notification: NotificationApi) {
+  const getArgs = (notification: NotificationApi) => {
     return notification.settings;
   };
 
@@ -148,4 +148,4 @@ export default function (editor: Editor, extras, uiMothership: Gui.GuiSystem): N
     reposition,
     getArgs
   };
-}
+};

--- a/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
@@ -17,7 +17,7 @@ export interface ToolbarGroupSetting {
   items: string[];
 }
 
-const getSkinUrl = function (editor: Editor): string {
+const getSkinUrl = (editor: Editor): string => {
   const skin = editor.getParam('skin');
   let skinUrl = editor.getParam('skin_url');
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputHistory.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputHistory.ts
@@ -18,7 +18,7 @@ const isArrayOfUrl = (a: any): boolean => Type.isArray(a) && a.length <= HISTORY
 
 const isRecordOfUrlArray = (r: any): boolean => Type.isObject(r) && Obj.find(r, (value) => !isArrayOfUrl(value)).isNone();
 
-const getAllHistory = function (): Record<string, string[]> {
+const getAllHistory = (): Record<string, string[]> => {
   const unparsedHistory = LocalStorage.getItem(STORAGE_KEY);
   if (unparsedHistory === null) {
     return {};
@@ -44,19 +44,19 @@ const getAllHistory = function (): Record<string, string[]> {
   return history;
 };
 
-const setAllHistory = function (history: Record<string, string[]>) {
+const setAllHistory = (history: Record<string, string[]>) => {
   if (!isRecordOfUrlArray(history)) {
     throw new Error('Bad format for history:\n' + JSON.stringify(history));
   }
   LocalStorage.setItem(STORAGE_KEY, JSON.stringify(history));
 };
 
-const getHistory = function (fileType: string): string[] {
+const getHistory = (fileType: string): string[] => {
   const history = getAllHistory();
   return Object.prototype.hasOwnProperty.call(history, fileType) ? history[fileType] : [];
 };
 
-const addToHistory = function (url: string, fileType: string) {
+const addToHistory = (url: string, fileType: string) => {
   if (!isHttpUrl(url)) {
     return;
   }
@@ -67,7 +67,7 @@ const addToHistory = function (url: string, fileType: string) {
   setAllHistory(history);
 };
 
-const clearHistory = function () {
+const clearHistory = () => {
   LocalStorage.removeItem(STORAGE_KEY);
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/LinkTargets.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/LinkTargets.ts
@@ -29,8 +29,8 @@ export interface LinkTarget {
 const isElement = (node: Node): node is HTMLElement => Type.isNonNullable(node) && node.nodeType === 1;
 
 const trim = Tools.trim;
-const hasContentEditableState = function (value: string) {
-  return function (node: Node) {
+const hasContentEditableState = (value: string) => {
+  return (node: Node) => {
     if (isElement(node)) {
       if (node.contentEditable === value) {
         return true;
@@ -48,7 +48,7 @@ const hasContentEditableState = function (value: string) {
 const isContentEditableTrue = hasContentEditableState('true');
 const isContentEditableFalse = hasContentEditableState('false');
 
-const create = function (type: LinkTargetType, title: string, url: string, level: number, attach: () => void): LinkTarget {
+const create = (type: LinkTargetType, title: string, url: string, level: number, attach: () => void): LinkTarget => {
   return {
     type,
     title,
@@ -58,7 +58,7 @@ const create = function (type: LinkTargetType, title: string, url: string, level
   };
 };
 
-const isChildOfContentEditableTrue = function (node: Node) {
+const isChildOfContentEditableTrue = (node: Node) => {
   while ((node = node.parentNode)) {
     const value = (node as HTMLElement).contentEditable;
     if (value && value !== 'inherit') {
@@ -69,79 +69,79 @@ const isChildOfContentEditableTrue = function (node: Node) {
   return false;
 };
 
-const select = function (selector: string, root: HTMLElement) {
+const select = (selector: string, root: HTMLElement) => {
   return Arr.map(SelectorFilter.descendants<HTMLElement>(SugarElement.fromDom(root), selector), (element) => {
     return element.dom;
   });
 };
 
-const getElementText = function (elm: HTMLElement) {
+const getElementText = (elm: HTMLElement) => {
   return elm.innerText || elm.textContent;
 };
 
-const getOrGenerateId = function (elm: HTMLElement) {
+const getOrGenerateId = (elm: HTMLElement) => {
   return elm.id ? elm.id : Id.generate('h');
 };
 
-const isAnchor = function (elm: HTMLElement) {
+const isAnchor = (elm: HTMLElement) => {
   return elm && elm.nodeName === 'A' && (elm.id || (elm as HTMLAnchorElement).name) !== undefined;
 };
 
-const isValidAnchor = function (elm: HTMLElement) {
+const isValidAnchor = (elm: HTMLElement) => {
   return isAnchor(elm) && isEditable(elm);
 };
 
-const isHeader = function (elm: HTMLElement) {
+const isHeader = (elm: HTMLElement) => {
   return elm && /^(H[1-6])$/.test(elm.nodeName);
 };
 
-const isEditable = function (elm: HTMLElement) {
+const isEditable = (elm: HTMLElement) => {
   return isChildOfContentEditableTrue(elm) && !isContentEditableFalse(elm);
 };
 
-const isValidHeader = function (elm: HTMLElement) {
+const isValidHeader = (elm: HTMLElement) => {
   return isHeader(elm) && isEditable(elm);
 };
 
-const getLevel = function (elm: HTMLElement) {
+const getLevel = (elm: HTMLElement) => {
   return isHeader(elm) ? parseInt(elm.nodeName.substr(1), 10) : 0;
 };
 
-const headerTarget = function (elm: HTMLElement) {
+const headerTarget = (elm: HTMLElement) => {
   const headerId = getOrGenerateId(elm);
 
-  const attach = function () {
+  const attach = () => {
     elm.id = headerId;
   };
 
   return create('header', getElementText(elm), '#' + headerId, getLevel(elm), attach);
 };
 
-const anchorTarget = function (elm: HTMLAnchorElement) {
+const anchorTarget = (elm: HTMLAnchorElement) => {
   const anchorId = elm.id || elm.name;
   const anchorText = getElementText(elm);
 
   return create('anchor', anchorText ? anchorText : '#' + anchorId, '#' + anchorId, 0, Fun.noop);
 };
 
-const getHeaderTargets = function (elms: HTMLElement[]) {
+const getHeaderTargets = (elms: HTMLElement[]) => {
   return Arr.map(Arr.filter(elms, isValidHeader), headerTarget);
 };
 
-const getAnchorTargets = function (elms: HTMLElement[]) {
+const getAnchorTargets = (elms: HTMLElement[]) => {
   return Arr.map(Arr.filter(elms, isValidAnchor), anchorTarget);
 };
 
-const getTargetElements = function (elm: HTMLElement) {
+const getTargetElements = (elm: HTMLElement) => {
   const elms = select('h1,h2,h3,h4,h5,h6,a:not([href])', elm);
   return elms;
 };
 
-const hasTitle = function (target: LinkTarget) {
+const hasTitle = (target: LinkTarget) => {
   return trim(target.title).length > 0;
 };
 
-const find = function (elm: HTMLElement): LinkTarget[] {
+const find = (elm: HTMLElement): LinkTarget[] => {
   const elms = getTargetElements(elm);
   return Arr.filter(getHeaderTargets(elms).concat(getAnchorTargets(elms)), hasTitle);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -16,7 +16,7 @@ export interface ColorSwatchDialogData {
   colorpicker: string;
 }
 
-const getCurrentColor = function (editor: Editor, format) {
+const getCurrentColor = (editor: Editor, format) => {
   let color;
 
   editor.dom.getParents(editor.selection.getStart(), (elm) => {
@@ -30,7 +30,7 @@ const getCurrentColor = function (editor: Editor, format) {
   return color;
 };
 
-const applyFormat = function (editor: Editor, format, value) {
+const applyFormat = (editor: Editor, format, value) => {
   editor.undoManager.transact(() => {
     editor.focus();
     editor.formatter.apply(format, { value });
@@ -38,7 +38,7 @@ const applyFormat = function (editor: Editor, format, value) {
   });
 };
 
-const removeFormat = function (editor: Editor, format) {
+const removeFormat = (editor: Editor, format) => {
   editor.undoManager.transact(() => {
     editor.focus();
     editor.formatter.remove(format, { value: null }, null, true);
@@ -58,7 +58,7 @@ const registerCommands = (editor: Editor) => {
 
 const calcCols = (colors) => Math.max(5, Math.ceil(Math.sqrt(colors)));
 
-const getColorCols = function (editor: Editor) {
+const getColorCols = (editor: Editor) => {
   const colors = Settings.getColors(editor);
   const defaultCols = calcCols(colors.length);
   return Settings.getColorCols(editor, defaultCols);
@@ -84,7 +84,7 @@ const getAdditionalColors = (hasCustom: boolean): Menu.ChoiceMenuItemSpec[] => {
   ] : [ remove ];
 };
 
-const applyColor = function (editor: Editor, format, value, onChoice: (v: string) => void) {
+const applyColor = (editor: Editor, format, value, onChoice: (v: string) => void) => {
   if (value === 'custom') {
     const dialog = colorPickerDialog(editor);
     dialog((colorOpt) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Settings.ts
@@ -43,7 +43,7 @@ const defaultColors = [
 
 const colorCache = ColorCache(10);
 
-const mapColors = function (colorMap: string[]): Menu.ChoiceMenuItemSpec[] {
+const mapColors = (colorMap: string[]): Menu.ChoiceMenuItemSpec[] => {
   const colors = [];
 
   const canvas = document.createElement('canvas');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -38,11 +38,11 @@ const english = {
   'aria.input.invalid': 'Invalid input'
 };
 
-const getEnglishText = function (key) {
+const getEnglishText = (key) => {
   return english[key];
 };
 
-const translate = function (key) {
+const translate = (key) => {
   // TODO: use this: I18n.translate()
   return getEnglishText(key);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -26,7 +26,7 @@ import { formChangeEvent } from '../general/FormEvents';
 
 const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp';
 
-const filterByExtension = function (files: FileList, providersBackstage: UiFactoryBackstageProviders) {
+const filterByExtension = (files: FileList, providersBackstage: UiFactoryBackstageProviders) => {
   const allowedImageFileTypes = Tools.explode(providersBackstage.getSetting('images_file_types', defaultImageFileTypes, 'string'));
   const isFileInAllowedTypes = (file: File) => Arr.exists(allowedImageFileTypes, (type) => Strings.endsWith(file.name, `.${type}`));
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -136,7 +136,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     markers: {
       lockClass: 'tox-locked'
     },
-    onLockedChange(current: AlloyComponent, other: AlloyComponent, _lock: AlloyComponent) {
+    onLockedChange: (current: AlloyComponent, other: AlloyComponent, _lock: AlloyComponent) => {
       parseSize(Representing.getValue(current)).each((size) => {
         converter(size).each((newSize) => {
           Representing.setValue(other, formatSize(newSize));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
@@ -52,7 +52,7 @@ export const renderTabPanel = (spec: TabPanelSpec, backstage: UiFactoryBackstage
         classes: [ 'tox-dialog__body-nav-item' ],
         innerHtml: backstage.shared.providers.translate(tab.title)
       },
-      view() {
+      view: () => {
         return [
           // Dupe with SilverDialog
           AlloyForm.sketch((parts) => ({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -18,7 +18,7 @@ import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
 import { formChangeEvent, formSubmitEvent } from '../general/FormEvents';
 
-const renderTextField = function (spec: TextField, providersBackstage: UiFactoryBackstageProviders) {
+const renderTextField = (spec: TextField, providersBackstage: UiFactoryBackstageProviders) => {
   const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
 
   const baseInputBehaviours = [
@@ -47,12 +47,12 @@ const renderTextField = function (spec: TextField, providersBackstage: UiFactory
   ];
 
   const validatingBehaviours = spec.validation.map((vl) => Invalidating.config({
-    getRoot(input) {
+    getRoot: (input) => {
       return Traverse.parent(input.element);
     },
     invalidClass: 'tox-invalid',
     validator: {
-      validate(input) {
+      validate: (input) => {
         const v = Representing.getValue(input);
         const result = vl.validator(v);
         return Future.pure(result === true ? Result.value(v) : Result.error(result));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/CropRect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/CropRect.ts
@@ -56,7 +56,7 @@ const create = (currentRect, viewPortRect, clampRect, containerElm, action): Cro
 
   const getInnerRect = () => getRelativeRect(clampRect, currentRect);
 
-  function moveRect(handle, startRect, deltaX, deltaY) {
+  const moveRect = (handle, startRect, deltaX, deltaY) => {
     let x, y, w, h, rect;
 
     x = startRect.x;
@@ -82,24 +82,24 @@ const create = (currentRect, viewPortRect, clampRect, containerElm, action): Cro
 
     instance.fire('updateRect', { rect });
     setInnerRect(rect);
-  }
+  };
 
-  function render() {
-    function createDragHelper(handle) {
+  const render = () => {
+    const createDragHelper = (handle) => {
       let startRect;
-      return new DragHelper(id, {
+      return DragHelper(id, {
         document: containerElm.ownerDocument,
         handle: id + '-' + handle.name,
 
-        start() {
+        start: () => {
           startRect = currentRect;
         },
 
-        drag(e) {
+        drag: (e) => {
           moveRect(handle, startRect, e.deltaX, e.deltaY);
         }
       });
-    }
+    };
 
     DomQuery(
       '<div id="' + id + '" class="' + prefix + 'croprect-container"' +
@@ -139,12 +139,12 @@ const create = (currentRect, viewPortRect, clampRect, containerElm, action): Cro
         }
       });
 
-      function moveAndBlock(evt, handle, startRect, deltaX, deltaY) {
+      const moveAndBlock = (evt, handle, startRect, deltaX, deltaY) => {
         evt.stopPropagation();
         evt.preventDefault();
 
         moveRect(activeHandle, startRect, deltaX, deltaY);
-      }
+      };
 
       switch (e.keyCode) {
         case VK.LEFT:
@@ -170,9 +170,9 @@ const create = (currentRect, viewPortRect, clampRect, containerElm, action): Cro
           break;
       }
     });
-  }
+  };
 
-  function toggleVisibility(state: boolean) {
+  const toggleVisibility = (state: boolean) => {
     const selectors = Tools.map(handles, (handle) => {
       return '#' + id + '-' + handle.name;
     }).concat(Tools.map(blockers, (blocker) => {
@@ -184,10 +184,10 @@ const create = (currentRect, viewPortRect, clampRect, containerElm, action): Cro
     } else {
       DomQuery(selectors, containerElm).hide();
     }
-  }
+  };
 
-  function repaint(rect) {
-    function updateElementRect(name, rect) {
+  const repaint = (rect) => {
+    const updateElementRect = (name, rect) => {
       if (rect.h < 0) {
         rect.h = 0;
       }
@@ -202,7 +202,7 @@ const create = (currentRect, viewPortRect, clampRect, containerElm, action): Cro
         width: rect.w,
         height: rect.h
       });
-    }
+    };
 
     Tools.each(handles, (handle) => {
       DomQuery('#' + id + '-' + handle.name, containerElm).css({
@@ -221,34 +221,34 @@ const create = (currentRect, viewPortRect, clampRect, containerElm, action): Cro
     });
     updateElementRect('left', { x: viewPortRect.x, y: rect.y, w: rect.x - viewPortRect.x, h: rect.h });
     updateElementRect('move', rect);
-  }
+  };
 
-  function setRect(rect: GeomRect): void {
+  const setRect = (rect: GeomRect): void => {
     currentRect = rect;
     repaint(currentRect);
-  }
+  };
 
-  function setViewPortRect(rect: GeomRect): void {
+  const setViewPortRect = (rect: GeomRect): void => {
     viewPortRect = rect;
     repaint(currentRect);
-  }
+  };
 
-  function setInnerRect(rect: GeomRect): void {
+  const setInnerRect = (rect: GeomRect): void => {
     setRect(getAbsoluteRect(clampRect, rect));
-  }
+  };
 
-  function setClampRect(rect: GeomRect): void {
+  const setClampRect = (rect: GeomRect): void => {
     clampRect = rect;
     repaint(currentRect);
-  }
+  };
 
-  function destroy() {
+  const destroy = () => {
     Tools.each(dragHelpers, (helper) => {
       helper.destroy();
     });
 
     dragHelpers = [];
-  }
+  };
 
   render();
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/DragHelper.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/DragHelper.ts
@@ -33,7 +33,7 @@ interface DragHelperSettings {
   stop?: (e: MouseEvent | TouchEvent) => void;
 }
 
-function getDocumentSize(doc: Document) {
+const getDocumentSize = (doc: Document) => {
   const max = Math.max;
 
   const documentElement = doc.documentElement;
@@ -51,9 +51,9 @@ function getDocumentSize(doc: Document) {
     width: scrollWidth < offsetWidth ? clientWidth : scrollWidth,
     height: scrollHeight < offsetHeight ? clientHeight : scrollHeight
   };
-}
+};
 
-function updateWithTouchData(e) {
+const updateWithTouchData = (e) => {
   let keys, i;
 
   if (e.changedTouches) {
@@ -62,9 +62,9 @@ function updateWithTouchData(e) {
       e[keys[i]] = e.changedTouches[0][keys[i]];
     }
   }
-}
+};
 
-export default function (id: string, settings: DragHelperSettings) {
+export default (id: string, settings: DragHelperSettings) => {
   let $eventOverlay;
   const doc = settings.document || document;
   let downButton;
@@ -72,7 +72,7 @@ export default function (id: string, settings: DragHelperSettings) {
 
   const handleElement = doc.getElementById(settings.handle || id);
 
-  const start = function (e) {
+  const start = (e) => {
     const docSize = getDocumentSize(doc);
     let cursor;
 
@@ -107,7 +107,7 @@ export default function (id: string, settings: DragHelperSettings) {
     settings.start(e);
   };
 
-  const drag = function (e) {
+  const drag = (e) => {
     updateWithTouchData(e);
 
     if (e.button !== downButton) {
@@ -121,7 +121,7 @@ export default function (id: string, settings: DragHelperSettings) {
     settings.drag(e);
   };
 
-  const stop = function (e) {
+  const stop = (e) => {
     updateWithTouchData(e);
 
     DomQuery(doc).off('mousemove touchmove', drag).off('mouseup touchend', stop);
@@ -138,9 +138,13 @@ export default function (id: string, settings: DragHelperSettings) {
    *
    * @method destroy
    */
-  this.destroy = function () {
+  const destroy = () => {
     DomQuery(handleElement).off();
   };
 
   DomQuery(handleElement).on('mousedown touchstart', start);
-}
+
+  return {
+    destroy
+  };
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/Errors.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/Errors.ts
@@ -20,11 +20,11 @@ const friendlyServiceErrors = [
   { type: 'domain_not_trusted', message: 'The api key is not valid for the request origins.' }
 ];
 
-const isServiceErrorCode = function (code) {
+const isServiceErrorCode = (code) => {
   return code === 400 || code === 403 || code === 500;
 };
 
-const getHttpErrorMsg = function (status) {
+const getHttpErrorMsg = (status) => {
   const message = Arr.find(friendlyHttpErrors, (error) => {
     return status === error.code;
   }).fold(
@@ -37,13 +37,13 @@ const getHttpErrorMsg = function (status) {
   return 'ImageProxy HTTP error: ' + message;
 };
 
-const handleHttpError = function (status) {
+const handleHttpError = (status) => {
   const message = getHttpErrorMsg(status);
 
   return Promise.reject(message);
 };
 
-const getServiceErrorMsg = function (type) {
+const getServiceErrorMsg = (type) => {
   return Arr.find(friendlyServiceErrors, (error) => {
     return error.type === type;
   }).fold(
@@ -54,7 +54,7 @@ const getServiceErrorMsg = function (type) {
   );
 };
 
-const getServiceError = function (text) {
+const getServiceError = (text) => {
   const serviceError = Utils.parseJson(text);
   const errorType = Utils.traverse(serviceError, [ 'error', 'type' ]);
   const errorMsg = errorType ? getServiceErrorMsg(errorType) : 'Invalid JSON in service error message';
@@ -62,7 +62,7 @@ const getServiceError = function (text) {
   return 'ImageProxy Service error: ' + errorMsg;
 };
 
-const handleServiceError = function (status, blob) {
+const handleServiceError = (status, blob) => {
   return Utils.readBlob(blob).then((text) => {
     const serviceError = getServiceError(text);
 
@@ -70,7 +70,7 @@ const handleServiceError = function (status, blob) {
   });
 };
 
-const handleServiceErrorResponse = function (status, blob) {
+const handleServiceErrorResponse = (status, blob) => {
   return isServiceErrorCode(status) ? handleServiceError(status, blob) : handleHttpError(status);
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/ImagePanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/ImagePanel.ts
@@ -13,7 +13,7 @@ import Promise from 'tinymce/core/api/util/Promise';
 import { CropRect } from './CropRect';
 
 const loadImage = (image): Promise<SugarElement> => new Promise((resolve) => {
-  const loaded = function () {
+  const loaded = () => {
     image.removeEventListener('load', loaded);
     resolve(image);
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/UndoStack.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/UndoStack.ts
@@ -5,11 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-export default function () {
+export default () => {
   const data = [];
   let index = -1;
 
-  function add(state) {
+  const add = (state) => {
     const removed = data.splice(++index);
     data.push(state);
 
@@ -17,27 +17,27 @@ export default function () {
       state,
       removed
     };
-  }
+  };
 
-  function undo() {
+  const undo = () => {
     if (canUndo()) {
       return data[--index];
     }
-  }
+  };
 
-  function redo() {
+  const redo = () => {
     if (canRedo()) {
       return data[++index];
     }
-  }
+  };
 
-  function canUndo() {
+  const canUndo = () => {
     return index > 0;
-  }
+  };
 
-  function canRedo() {
+  const canRedo = () => {
     return index !== -1 && index < data.length - 1;
-  }
+  };
 
   return {
     data,
@@ -47,4 +47,4 @@ export default function () {
     canUndo,
     canRedo
   };
-}
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/Utils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/Utils.ts
@@ -8,11 +8,11 @@
 import Promise from 'tinymce/core/api/util/Promise';
 import Tools from 'tinymce/core/api/util/Tools';
 
-const isValue = function (obj) {
+const isValue = (obj) => {
   return obj !== null && obj !== undefined;
 };
 
-const traverse = function (json, path) {
+const traverse = (json, path) => {
   const value = path.reduce((result, key) => {
     return isValue(result) ? result[key] : undefined;
   }, json);
@@ -20,15 +20,15 @@ const traverse = function (json, path) {
   return isValue(value) ? value : null;
 };
 
-const requestUrlAsBlob = function (url: string, headers: Record<string, string>, withCredentials: boolean) {
+const requestUrlAsBlob = (url: string, headers: Record<string, string>, withCredentials: boolean) => {
   return new Promise<{status: number; blob: Blob}>((resolve) => {
     const xhr = new XMLHttpRequest();
 
-    xhr.onreadystatechange = function () {
+    xhr.onreadystatechange = () => {
       if (xhr.readyState === 4) {
         resolve({
           status: xhr.status,
-          blob: this.response
+          blob: xhr.response
         });
       }
     };
@@ -46,11 +46,11 @@ const requestUrlAsBlob = function (url: string, headers: Record<string, string>,
   });
 };
 
-const readBlob = function (blob) {
+const readBlob = (blob) => {
   return new Promise((resolve) => {
     const fr = new FileReader();
 
-    fr.onload = function (e) {
+    fr.onload = (e) => {
       const data = e.target;
       resolve(data.result);
     };
@@ -59,7 +59,7 @@ const readBlob = function (blob) {
   });
 };
 
-const parseJson = function (text) {
+const parseJson = (text) => {
   let json;
 
   try {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/FormValues.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/FormValues.ts
@@ -10,7 +10,7 @@ import { Arr, Future, Futures, Merger, Obj, Optional, Result, Results } from '@e
 
 export interface FormValidator { 'value': string | number; 'text': string }
 
-const toValidValues = function <T> (values: { [key: string]: Optional<T[keyof T]> }) {
+const toValidValues = <T> (values: { [key: string]: Optional<T[keyof T]> }) => {
   const errors: string[] = [];
   const result: { [key: string]: T[keyof T] } = {};
 
@@ -26,7 +26,7 @@ const toValidValues = function <T> (values: { [key: string]: Optional<T[keyof T]
     Result.value<{ [key: string]: T[keyof T] }, string[]>(result);
 };
 
-const toValuesOrDefaults = function (optionValues, defaults) {
+const toValuesOrDefaults = (optionValues, defaults) => {
   const r = {};
   Obj.each(optionValues, (v, k) => {
     v.each((someValue) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/NavigableObject.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/NavigableObject.ts
@@ -14,7 +14,7 @@ import { ComposingConfigs } from '../alien/ComposingConfigs';
 const beforeObject = Id.generate('alloy-fake-before-tabstop');
 const afterObject = Id.generate('alloy-fake-after-tabstop');
 
-const craftWithClasses = function (classes) {
+const craftWithClasses = (classes) => {
   return {
     dom: {
       tag: 'div',
@@ -35,7 +35,7 @@ const craftWithClasses = function (classes) {
   };
 };
 
-const craft = function (spec) {
+const craft = (spec) => {
   return {
     dom: {
       tag: 'div',
@@ -53,7 +53,7 @@ const craft = function (spec) {
 };
 
 // TODO: Create an API in alloy to do this.
-const triggerTab = function (placeholder, shiftKey) {
+const triggerTab = (placeholder, shiftKey) => {
   AlloyTriggers.emitWith(placeholder, NativeEvents.keydown(), {
     raw: {
       which: 9,
@@ -62,13 +62,13 @@ const triggerTab = function (placeholder, shiftKey) {
   });
 };
 
-const onFocus = function (container, targetComp) {
+const onFocus = (container, targetComp) => {
   const target = targetComp.element;
   // If focus has shifted naturally to a before object, the tab direction is backwards.
   if (Class.has(target, beforeObject)) { triggerTab(container, true); } else if (Class.has(target, afterObject)) { triggerTab(container, false); }
 };
 
-const isPseudoStop = function (element) {
+const isPseudoStop = (element) => {
   return SelectorExists.closest(element, [ '.' + beforeObject, '.' + afterObject ].join(','), Fun.never);
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -79,73 +79,73 @@ interface ToolbarApis {
   isOpen?: (toolbar: AlloyComponent) => boolean;
 }
 
-const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, OuterContainerSketchSpec> = function (detail, components, _spec) {
+const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, OuterContainerSketchSpec> = (detail, components, _spec) => {
   const apis: OuterContainerApis = {
-    getSocket(comp) {
+    getSocket: (comp) => {
       return Composite.parts.getPart(comp, detail, 'socket');
     },
-    setSidebar(comp, panelConfigs) {
+    setSidebar: (comp, panelConfigs) => {
       Composite.parts.getPart(comp, detail, 'sidebar').each(
         (sidebar) => Sidebar.setSidebar(sidebar, panelConfigs)
       );
     },
-    toggleSidebar(comp, name) {
+    toggleSidebar: (comp, name) => {
       Composite.parts.getPart(comp, detail, 'sidebar').each(
         (sidebar) => Sidebar.toggleSidebar(sidebar, name)
       );
     },
-    whichSidebar(comp) {
+    whichSidebar: (comp) => {
       return Composite.parts.getPart(comp, detail, 'sidebar').bind(
         Sidebar.whichSidebar
       ).getOrNull();
     },
-    getHeader(comp) {
+    getHeader: (comp) => {
       return Composite.parts.getPart(comp, detail, 'header');
     },
-    getToolbar(comp) {
+    getToolbar: (comp) => {
       return Composite.parts.getPart(comp, detail, 'toolbar');
     },
-    setToolbar(comp, groups) {
+    setToolbar: (comp, groups) => {
       Composite.parts.getPart(comp, detail, 'toolbar').each((toolbar) => {
         toolbar.getApis<ToolbarApis>().setGroups(toolbar, groups);
       });
     },
-    setToolbars(comp, toolbars) {
+    setToolbars: (comp, toolbars) => {
       Composite.parts.getPart(comp, detail, 'multiple-toolbar').each((mToolbar) => {
         CustomList.setItems(mToolbar, toolbars);
       });
     },
-    refreshToolbar(comp) {
+    refreshToolbar: (comp) => {
       const toolbar = Composite.parts.getPart(comp, detail, 'toolbar');
       toolbar.each((toolbar) => toolbar.getApis<ToolbarApis>().refresh(toolbar));
     },
-    toggleToolbarDrawer(comp) {
+    toggleToolbarDrawer: (comp) => {
       Composite.parts.getPart(comp, detail, 'toolbar').each((toolbar) => {
         Optionals.mapFrom(toolbar.getApis<ToolbarApis>().toggle, (toggle) => toggle(toolbar));
       });
     },
-    isToolbarDrawerToggled(comp) {
+    isToolbarDrawerToggled: (comp) => {
       // isOpen may not be defined on all toolbars e.g. 'scrolling' and 'wrap'
       return Composite.parts.getPart(comp, detail, 'toolbar')
         .bind((toolbar) => Optional.from(toolbar.getApis<ToolbarApis>().isOpen).map((isOpen) => isOpen(toolbar)))
         .getOr(false);
     },
-    getThrobber(comp) {
+    getThrobber: (comp) => {
       return Composite.parts.getPart(comp, detail, 'throbber');
     },
-    focusToolbar(comp) {
+    focusToolbar: (comp) => {
       const optToolbar = Composite.parts.getPart(comp, detail, 'toolbar').orThunk(() => Composite.parts.getPart(comp, detail, 'multiple-toolbar'));
 
       optToolbar.each((toolbar) => {
         Keying.focusIn(toolbar);
       });
     },
-    setMenubar(comp, menus) {
+    setMenubar: (comp, menus) => {
       Composite.parts.getPart(comp, detail, 'menubar').each((menubar) => {
         SilverMenubar.setMenus(menubar, menus);
       });
     },
-    focusMenubar(comp) {
+    focusMenubar: (comp) => {
       Composite.parts.getPart(comp, detail, 'menubar').each((menubar) => {
         SilverMenubar.focus(menubar);
       });
@@ -305,56 +305,56 @@ export default Sketcher.composite<OuterContainerSketchSpec, OuterContainerSketch
   ],
 
   apis: {
-    getSocket(apis, comp) {
+    getSocket: (apis, comp) => {
       return apis.getSocket(comp);
     },
-    setSidebar(apis, comp, panelConfigs) {
+    setSidebar: (apis, comp, panelConfigs) => {
       apis.setSidebar(comp, panelConfigs);
     },
-    toggleSidebar(apis, comp, name) {
+    toggleSidebar: (apis, comp, name) => {
       apis.toggleSidebar(comp, name);
     },
-    whichSidebar(apis, comp) {
+    whichSidebar: (apis, comp) => {
       return apis.whichSidebar(comp);
     },
-    getHeader(apis, comp) {
+    getHeader: (apis, comp) => {
       return apis.getHeader(comp);
     },
-    getToolbar(apis, comp) {
+    getToolbar: (apis, comp) => {
       return apis.getToolbar(comp);
     },
-    setToolbar(apis, comp, grps) {
+    setToolbar: (apis, comp, grps) => {
       const groups = Arr.map(grps, (grp) => {
         return renderToolbarGroup(grp);
       });
 
       apis.setToolbar(comp, groups);
     },
-    setToolbars(apis, comp, ts) {
+    setToolbars: (apis, comp, ts) => {
       const renderedToolbars = Arr.map(ts, (g) => Arr.map(g, renderToolbarGroup));
 
       apis.setToolbars(comp, renderedToolbars);
     },
-    refreshToolbar(apis, comp) {
+    refreshToolbar: (apis, comp) => {
       return apis.refreshToolbar(comp);
     },
-    toggleToolbarDrawer(apis, comp) {
+    toggleToolbarDrawer: (apis, comp) => {
       apis.toggleToolbarDrawer(comp);
     },
-    isToolbarDrawerToggled(apis, comp) {
+    isToolbarDrawerToggled: (apis, comp) => {
       return apis.isToolbarDrawerToggled(comp);
     },
-    getThrobber(apis, comp) {
+    getThrobber: (apis, comp) => {
       return apis.getThrobber(comp);
     },
     // FIX: Dupe
-    setMenubar(apis, comp, menus) {
+    setMenubar: (apis, comp, menus) => {
       apis.setMenubar(comp, menus);
     },
-    focusMenubar(apis, comp) {
+    focusMenubar: (apis, comp) => {
       apis.focusMenubar(comp);
     },
-    focusToolbar(apis, comp) {
+    focusToolbar: (apis, comp) => {
       apis.focusToolbar(comp);
     }
   }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
@@ -36,7 +36,7 @@ import { renderHtmlPanel } from './HtmlPanel';
 export type FormPartRenderer = (parts: FormTypes.FormParts, spec: BridgedType, backstage: UiFactoryBackstage) => AlloySpec;
 export type NoFormRenderer = (spec: BridgedType, backstage: UiFactoryBackstage) => AlloySpec;
 
-const make = function (render: NoFormRenderer): FormPartRenderer {
+const make = (render: NoFormRenderer): FormPartRenderer => {
   return (parts, spec, backstage) => Obj.get(spec, 'name').fold(
     () => render(spec, backstage),
     (fieldName) => parts.field(fieldName, render(spec, backstage) as SimpleOrSketchSpec)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
@@ -204,7 +204,7 @@ const getBehaviours = (editor: Editor, sharedBackstage: UiFactoryBackstageShared
     Focusing.config({ }),
     Docking.config({
       contextual: {
-        lazyContext(comp) {
+        lazyContext: (comp) => {
           const headerHeight = Height.getOuter(comp.element);
           const container = editor.inline ? editor.getContentAreaContainer() : editor.getContainer();
           const box = Boxes.box(SugarElement.fromDom(container));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Coords.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Coords.ts
@@ -16,7 +16,7 @@ interface Position {
   y: number;
 }
 
-const nu = function (x: number, y: number): MakeshiftAnchorSpec {
+const nu = (x: number, y: number): MakeshiftAnchorSpec => {
   return {
     anchor: 'makeshift',
     x,
@@ -24,13 +24,13 @@ const nu = function (x: number, y: number): MakeshiftAnchorSpec {
   };
 };
 
-const transpose = function (pos: Position, dx: number, dy: number) {
+const transpose = (pos: Position, dx: number, dy: number) => {
   return nu(pos.x + dx, pos.y + dy);
 };
 
 const isTouchEvent = (e: MouseEvent | TouchEvent): e is TouchEvent => e.type === 'longpress' || e.type.indexOf('touch') === 0;
 
-const fromPageXY = function (e: MouseEvent | TouchEvent) {
+const fromPageXY = (e: MouseEvent | TouchEvent) => {
   if (isTouchEvent(e)) {
     const touch = e.touches[0];
     return nu(touch.pageX, touch.pageY);
@@ -39,7 +39,7 @@ const fromPageXY = function (e: MouseEvent | TouchEvent) {
   }
 };
 
-const fromClientXY = function (e: MouseEvent | TouchEvent) {
+const fromClientXY = (e: MouseEvent | TouchEvent) => {
   if (isTouchEvent(e)) {
     const touch = e.touches[0];
     return nu(touch.clientX, touch.clientY);
@@ -48,12 +48,12 @@ const fromClientXY = function (e: MouseEvent | TouchEvent) {
   }
 };
 
-const transposeContentAreaContainer = function (element: HTMLElement, pos: Position) {
+const transposeContentAreaContainer = (element: HTMLElement, pos: Position) => {
   const containerPos = DOMUtils.DOM.getPos(element);
   return transpose(pos, containerPos.x, containerPos.y);
 };
 
-export const getPointAnchor = function (editor: Editor, e: MouseEvent | TouchEvent) {
+export const getPointAnchor = (editor: Editor, e: MouseEvent | TouchEvent) => {
   // If the contextmenu event is fired via the editor.fire() API or some other means, fall back to selection anchor
   if (e.type === 'contextmenu' || e.type === 'longpress') {
     if (editor.inline) {
@@ -66,7 +66,7 @@ export const getPointAnchor = function (editor: Editor, e: MouseEvent | TouchEve
   }
 };
 
-export const getSelectionAnchor = function (editor: Editor): SelectionAnchorSpec {
+export const getSelectionAnchor = (editor: Editor): SelectionAnchorSpec => {
   return {
     anchor: 'selection',
     root: SugarElement.fromDom(editor.selection.getNode())

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Settings.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 const patchPipeConfig = (config: string[] | string) => typeof config === 'string' ? config.split(/[ ,]/) : config;
 
-const shouldNeverUseNative = function (editor: Editor): boolean {
+const shouldNeverUseNative = (editor: Editor): boolean => {
   return editor.getParam('contextmenu_never_use_native', false, 'boolean');
 };
 
@@ -26,7 +26,7 @@ const getMenuItems = (editor: Editor, name: string, defaultItems: string): strin
 
 const isContextMenuDisabled = (editor: Editor): boolean => editor.getParam('contextmenu') === false;
 
-const getContextMenu = function (editor: Editor): string[] {
+const getContextMenu = (editor: Editor): string[] => {
   return getMenuItems(editor, 'contextmenu', 'link linkchecker image imagetools table spellchecker configurepermanentpen');
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
@@ -16,7 +16,7 @@ import { deriveMenuMovement } from '../../menu/MenuMovement';
 import * as MenuParts from '../../menu/MenuParts';
 import ItemResponse from '../ItemResponse';
 
-export function renderColorSwatchItem(spec: Menu.FancyMenuItem, backstage: UiFactoryBackstage): ItemTypes.WidgetItemSpec {
+export const renderColorSwatchItem = (spec: Menu.FancyMenuItem, backstage: UiFactoryBackstage): ItemTypes.WidgetItemSpec => {
   const items = ColorSwatch.getColors(backstage.colorinput.getColors(), backstage.colorinput.hasCustomColors());
   const columns = backstage.colorinput.getColorCols();
   const presets = 'color';
@@ -52,4 +52,4 @@ export function renderColorSwatchItem(spec: Menu.FancyMenuItem, backstage: UiFac
       ItemWidget.parts.widget(AlloyMenu.sketch(widgetSpec))
     ]
   };
-}
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
@@ -47,7 +47,7 @@ export interface MenubarItemSpec {
   getItems: () => Menu.NestedMenuItemContents[];
 }
 
-const factory: UiSketcher.SingleSketchFactory<SilverMenubarDetail, SilverMenubarSpec> = function (detail, spec) {
+const factory: UiSketcher.SingleSketchFactory<SilverMenubarDetail, SilverMenubarSpec> = (detail, spec) => {
   const setMenus = (comp: AlloyComponent, menus: MenubarItemSpec[]) => {
     const newMenus = Arr.map(menus, (m) => {
       const buttonSpec: Toolbar.ToolbarMenuButtonSpec = {
@@ -148,10 +148,10 @@ export default Sketcher.single<SilverMenubarSpec, SilverMenubarDetail, SilverMen
     FieldSchema.defaulted('onSetup', Fun.noop)
   ],
   apis: {
-    focus(apis, comp) {
+    focus: (apis, comp) => {
       apis.focus(comp);
     },
-    setMenus(apis, comp, menus) {
+    setMenus: (apis, comp, menus) => {
       apis.setMenus(comp, menus);
     }
   }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInputModel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInputModel.ts
@@ -14,11 +14,11 @@ export interface Size {
   unit: SizeUnit;
 }
 
-export const nuSize = function (value: number, unit: SizeUnit): Size {
+export const nuSize = (value: number, unit: SizeUnit): Size => {
   return { value, unit };
 };
 
-export const formatSize = function (size: Size): string {
+export const formatSize = (size: Size): string => {
   const unitDec = {
     '': 0,
     'px': 0,
@@ -41,7 +41,7 @@ export const formatSize = function (size: Size): string {
   return numText + size.unit;
 };
 
-export const parseSize = function (sizeText: string): Result<Size, string> {
+export const parseSize = (sizeText: string): Result<Size, string> => {
   const numPattern = /^\s*(\d+(?:\.\d+)?)\s*(|cm|mm|in|px|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax|%)\s*$/;
   const match = numPattern.exec(sizeText);
   if (match !== null) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -301,7 +301,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
       attributes: { 'aria-pressed': false, ...getTooltipAttributes(spec.tooltip, sharedBackstage.providers) }
     },
 
-    onExecute(button: AlloyComponent) {
+    onExecute: (button: AlloyComponent) => {
       spec.onAction(getApi(button));
     },
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/urlinput/Completions.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/urlinput/Completions.ts
@@ -55,14 +55,14 @@ const anchorTargetBottom = (linkInfo: LinkInformation) => Optional.from(linkInfo
 
 const historyTargets = (history: string[]) => Arr.map(history, (url) => staticMenuItem(url, url));
 
-const joinMenuLists = function (items: BridgeMenu.MenuItemSpec[][]) {
+const joinMenuLists = (items: BridgeMenu.MenuItemSpec[][]) => {
   return Arr.foldl(items, (a, b) => {
     const bothEmpty = a.length === 0 || b.length === 0;
     return bothEmpty ? a.concat(b) : a.concat(separator, b);
   }, [] as SingleMenuItemSpec[]);
 };
 
-const filterByQuery = function (term: string, menuItems: BridgeMenu.MenuItemSpec[]) {
+const filterByQuery = (term: string, menuItems: BridgeMenu.MenuItemSpec[]) => {
   const lowerCaseTerm = term.toLowerCase();
   return Arr.filter(menuItems, (item) => {
     const text = item.meta !== undefined && item.meta.text !== undefined ? item.meta.text : item.text;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -90,7 +90,7 @@ const renderInlineHeader = (
     Dragging.config({
       mode: 'mouse',
       blockerClass: 'blocker',
-      getTarget(handle) {
+      getTarget: (handle) => {
         return SelectorFind.closest(handle, '[role="dialog"]').getOrDie();
       },
       snaps: {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -427,7 +427,7 @@ UnitTest.asynctest('Editor (Silver) test', (success, failure) => {
           icon: 'italic',
           text: 'Text with icon',
           shortcut: 'Meta+M',
-          onAction() {
+          onAction: () => {
             console.log('Just Text click');
           }
         });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -426,7 +426,7 @@ UnitTest.asynctest('Inline Editor (Silver) test', (success, failure) => {
         icon: 'italic',
         text: 'Text with icon',
         shortcut: 'Meta+M',
-        onAction() {
+        onAction: () => {
           console.log('Just Text click');
         }
       });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -23,7 +23,7 @@ UnitTest.asynctest('ColorPickerSanityTest', (success, failure) => {
 
     const docBody = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement())));
 
-    const sAssertColor = function (expected) {
+    const sAssertColor = (expected) => {
       return Logger.t('Asserting color', Step.sync(() => {
         Assertions.assertEq('Asserting current colour is ' + expected, expected, currentColor);
       }));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
@@ -10,13 +10,13 @@ import * as Settings from 'tinymce/themes/silver/ui/core/color/Settings';
 UnitTest.asynctest('ColorSettingsTest', (success, failure) => {
   SilverTheme();
 
-  const sResetLocalStorage = function () {
+  const sResetLocalStorage = () => {
     return Logger.t('Reset local storage', Step.sync(() => {
       LocalStorage.removeItem('tinymce-custom-colors');
     }));
   };
 
-  const sAssertColors = function (input, expected) {
+  const sAssertColors = (input, expected) => {
     const extractColor = (color: string) => {
       const m = /^#([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/.exec(color);
       return [ parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16) ];
@@ -41,14 +41,14 @@ UnitTest.asynctest('ColorSettingsTest', (success, failure) => {
     }));
   };
 
-  const sAssertCols = function (editor, expected) {
+  const sAssertCols = (editor, expected) => {
     return Logger.t(`Assert color cols: ${expected}`, Step.sync(() => {
       const colors = ColorSwatch.getColorCols(editor);
       Assert.eq('should be same', expected, colors);
     }));
   };
 
-  const sAssertCalcCols = function (editor, colors, expected) {
+  const sAssertCalcCols = (editor, colors, expected) => {
     return Logger.t(`Assert calced cols: ${expected}`, Step.sync(() => {
       const sqrt = ColorSwatch.calcCols(colors);
       Assert.eq('should be same', expected, sqrt);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextcolorCommandsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextcolorCommandsTest.ts
@@ -13,7 +13,7 @@ UnitTest.asynctest('TextcolorCommandsTest', (success, failure) => {
 
   const state = Cell(null);
 
-  const sAssertState = function (expected) {
+  const sAssertState = (expected) => {
     return Logger.t(`Assert state ${expected}`, Step.sync(() => {
       Assert.eq('should be same', expected, state.get());
     }));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -19,7 +19,7 @@ UnitTest.asynctest('browser.tinymce.themes.silver.sidebar.SidebarTest', (success
   TinyLoader.setupLight((editor, onSuccess, onFailure) => {
     const tinyUi = TinyUi(editor);
 
-    const sClickAndAssertEvents = function (tooltip, expected: EventLog[]) {
+    const sClickAndAssertEvents = (tooltip, expected: EventLog[]) => {
       return GeneralSteps.sequence([
         store.sClear,
         tinyUi.sClickOnToolbar('Toggle sidebar', 'button[aria-label="' + tooltip + '"]'),
@@ -78,7 +78,7 @@ UnitTest.asynctest('browser.tinymce.themes.silver.sidebar.SidebarTest', (success
     theme: 'silver',
     base_url: '/project/tinymce/js/tinymce',
     toolbar: 'mysidebar1 mysidebar2 mysidebar3',
-    setup(editor) {
+    setup: (editor) => {
       const logEvent = (name: string) => (api: Sidebar.SidebarInstanceApi) => {
         const index = Traverse.findIndex(SugarElement.fromDom(api.element())).getOr(-1);
         const entry: EventLog = { name, index };

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
@@ -5,7 +5,7 @@ import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import { ApiUrlData } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
 import TestProviders from './TestProviders';
 
-export default function (sink?: AlloyComponent): UiFactoryBackstage {
+export default (sink?: AlloyComponent): UiFactoryBackstage => {
   // NOTE: Non-sensical anchor
   const hotspotAnchorFn = (): HotspotAnchorSpec => ({
     anchor: 'hotspot',
@@ -48,4 +48,4 @@ export default function (sink?: AlloyComponent): UiFactoryBackstage {
       isDraggableModal: Fun.never
     }
   };
-}
+};

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/customeditor/BasicCustomEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/customeditor/BasicCustomEditorTest.ts
@@ -35,8 +35,8 @@ UnitTest.asynctest('CustomEditor component Test', (success, failure) => {
         Delay.clearInterval(intervalId);
         Class.add(SugarElement.fromDom(e), 'my-custom-editor');
         resolve({
-          setValue(s: string) { customEditorValue.set(s); },
-          getValue() { return customEditorValue.get(); },
+          setValue: (s: string) => customEditorValue.set(s),
+          getValue: () => customEditorValue.get(),
           destroy: Fun.noop
         });
       }

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/customeditor/CustomEditorSchemaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/customeditor/CustomEditorSchemaTest.ts
@@ -35,7 +35,7 @@ UnitTest.test('Custom Editor Schema Test', () => {
 
   Assert.eq('Expect init be valid', true, ValueSchema.asRaw('.', schema, {
     ...base,
-    init(_el) {
+    init: (_el) => {
       return {
         setValue: Fun.noop,
         getValue: Fun.constant(''),
@@ -48,7 +48,7 @@ UnitTest.test('Custom Editor Schema Test', () => {
     ...base,
     scriptId: 'scriptId',
     scriptUrl: 'scriptUrl',
-    init(_el) {
+    init: (_el) => {
       return {
         setValue: Fun.noop,
         getValue: Fun.constant(''),


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
*  Enabled the `prefer-arrow/prefer-arrow-functions` ESLint rule for TinyMCE plugins and themes

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
