### PR TITLE
TINY-6770: redirect more of the undo manager to rtc

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -43,6 +43,10 @@ interface RtcRuntimeApi {
   hasUndo: () => boolean;
   hasRedo: () => boolean;
   transact: (fn: () => void) => void;
+  reset: () => void;
+  clear: () => void;
+  ignore: (fn: () => void) => void;
+  extra: (fn1: () => void, fn2: () => void) => void;
   canApplyFormat: (format: string) => boolean;
   matchFormat: (format: string, vars: Record<string, string>) => boolean;
   closestFormat: (formats: string) => string;
@@ -194,16 +198,16 @@ const makeRtcAdaptor = (tinymceEditor: Editor, rtcEditor: RtcRuntimeApi): RtcAda
         rtcEditor.redo();
         return createDummyUndoLevel();
       },
-      clear: unsupported,
-      reset: unsupported,
+      clear: () => rtcEditor.clear(),
+      reset: () => rtcEditor.reset(),
       hasUndo: () => rtcEditor.hasUndo(),
       hasRedo: () => rtcEditor.hasRedo(),
       transact: (_undoManager, _locks, fn) => {
         rtcEditor.transact(fn);
         return createDummyUndoLevel();
       },
-      ignore: unsupported,
-      extra: unsupported
+      ignore: (_locks, callback) => rtcEditor.ignore(callback),
+      extra: (_undoManager, _index, callback1, callback2) => rtcEditor.extra(callback1, callback2)
     },
     formatter: {
       match: (name, vars?, _node?) => rtcEditor.matchFormat(name, defaultVars(vars)),


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This redirects more of the undo manager to rtc when enabled.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
