### PR TITLE
Button: text-transform default to none

### DIFF
--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -29,7 +29,7 @@
 @button-text-align: center;
 @button-text-color: contrast(@button-background-color, @color-black, @color-white);
 @button-text-decoration: none;
-@button-text-transform: capitalize;
+@button-text-transform: none;
 
 @button-disabled-background-color: @button-background-color;
 @button-disabled-background-image: @button-background-image;


### PR DESCRIPTION
Related Ticket: none

I have not seen capitalized button labels yet. Maybe in some languages it's usual, but even GitHub does not use it in English (see below) and in other languages (like Czech in my case) it looks pretty weird.

![image](https://user-images.githubusercontent.com/9862581/102096474-0a276c80-3e25-11eb-9b5d-dd234ebd97ea.png)


Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)
* [ ] License headers added on new files (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable): none
