### PR TITLE
TINY-6504: Enabled the `brace-style` ESLint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "@typescript-eslint/prefer-for-of": "off",
     "@typescript-eslint/prefer-regexp-exec": "off",
     "@typescript-eslint/unbound-method": "off",
+    "brace-style": "error",
     "no-empty": "off",
     "no-underscore-dangle": "off",
     "one-var": "off",

--- a/modules/agar/src/test/ts/atomic/api/ChainTest.ts
+++ b/modules/agar/src/test/ts/atomic/api/ChainTest.ts
@@ -272,9 +272,7 @@ UnitTest.asynctest('ChainTest', (success, failure) => {
       '[Basic API: Chain.injectThunked\n',
       testChainInjectThunked
     )
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });
 
 UnitTest.asynctest('Chain.predicate true', (success, failure) => {

--- a/modules/agar/src/test/ts/atomic/api/NamedChainTest.ts
+++ b/modules/agar/src/test/ts/atomic/api/NamedChainTest.ts
@@ -131,7 +131,5 @@ UnitTest.asynctest('NamedChainTest', (success, failure) => {
         ])
       ])
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/agar/src/test/ts/atomic/api/WaiterChainTest.ts
+++ b/modules/agar/src/test/ts/atomic/api/WaiterChainTest.ts
@@ -81,7 +81,5 @@ UnitTest.asynctest('WaiterChainTest', (success, failure) => {
       makeDelayChain('not enough time', 50, 500)
     )
 
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/agar/src/test/ts/atomic/api/WaiterStepTest.ts
+++ b/modules/agar/src/test/ts/atomic/api/WaiterStepTest.ts
@@ -76,7 +76,5 @@ UnitTest.asynctest('WaiterTest', (success, failure) => {
       makeDelayStep('not enough time', 50, 500)
     )
 
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/agar/src/test/ts/browser/KeyboardTest.ts
+++ b/modules/agar/src/test/ts/browser/KeyboardTest.ts
@@ -87,7 +87,5 @@ UnitTest.asynctest('KeyboardTest', (success, failure) => {
 
     listenOnKeystroke(Keys.space(), {}),
     DomContainers.mTeardown
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/agar/src/test/ts/browser/PropertyStepsTest.ts
+++ b/modules/agar/src/test/ts/browser/PropertyStepsTest.ts
@@ -17,5 +17,5 @@ UnitTest.asynctest('PropertyStepsTest', (success, failure) => {
       }),
       {}
     )
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/agar/src/test/ts/browser/TouchTest.ts
+++ b/modules/agar/src/test/ts/browser/TouchTest.ts
@@ -115,11 +115,15 @@ UnitTest.asynctest('TouchTest', (success, failure) => {
     )
 
   ], () => {
-    Arr.each(handlers, (h) => { h.unbind(); });
+    Arr.each(handlers, (h) => {
+      h.unbind();
+    });
     Remove.remove(container);
     success();
   }, (err) => {
-    Arr.each(handlers, (h) => { h.unbind(); });
+    Arr.each(handlers, (h) => {
+      h.unbind();
+    });
     failure(err);
   });
 });

--- a/modules/agar/src/test/ts/browser/UiControlsTest.ts
+++ b/modules/agar/src/test/ts/browser/UiControlsTest.ts
@@ -32,5 +32,5 @@ UnitTest.asynctest('UiControlsTest', (success, failure) => {
       Assertions.cAssertEq('Checking that cSetValue sets the value and cGetValue reads it', 'chain.value.1')
     ])
 
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/agar/src/test/ts/browser/UiFinderTest.ts
+++ b/modules/agar/src/test/ts/browser/UiFinderTest.ts
@@ -99,5 +99,8 @@ UnitTest.asynctest('UiFinderTest', (success, failure) => {
       Chain.inject(container),
       UiFinder.cWaitFor('Waiting for the strong tag to gain class: changing-state-waitfor', 'strong.changing-state-waitfor')
     ])
-  ], () => { teardown(); success(); }, failure);
+  ], () => {
+    teardown();
+    success();
+  }, failure);
 });

--- a/modules/agar/src/test/ts/browser/datatransfer/DataTransferItemTest.ts
+++ b/modules/agar/src/test/ts/browser/datatransfer/DataTransferItemTest.ts
@@ -34,7 +34,5 @@ UnitTest.asynctest('DataTransferItemTest', (success, failure) => {
         }
       });
     }))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/SliderDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/SliderDemo.ts
@@ -247,6 +247,8 @@ export default (): void => {
   const isTouch = platform.deviceType.isTouch();
 
   DomEvent.bind(body, 'click', () => {
-    if (!isTouch) { Keying.focusIn(slider1); }
+    if (!isTouch) {
+      Keying.focusIn(slider1);
+    }
   });
 };

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/SlidingDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/SlidingDemo.ts
@@ -110,7 +110,11 @@ export default (): void => {
           },
           action: () => {
             const slider = gui.getByUid('width-slider').getOrDie();
-            if (Sliding.hasGrown(slider)) { Sliding.shrink(slider); } else { Sliding.grow(slider); }
+            if (Sliding.hasGrown(slider)) {
+              Sliding.shrink(slider);
+            } else {
+              Sliding.grow(slider);
+            }
           }
         })
       ]

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/forms/DemoRenders.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/forms/DemoRenders.ts
@@ -238,7 +238,9 @@ const menu = (menuSpec: DemoMenu): PartialMenuSpec => {
 
 const orb = (spec: DemoItem): ItemSpec => {
   const html = (() => {
-    if (spec.data && spec.data.meta && spec.data.meta.text) { return spec.data.meta.text; }
+    if (spec.data && spec.data.meta && spec.data.meta.text) {
+      return spec.data.meta.text;
+    }
     return 'No.Text.For.Orb';
   })();
 

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/frames/Frames.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/frames/Frames.ts
@@ -26,7 +26,9 @@ const readDoc = (element: SugarElement): SugarElement<Document> => {
 };
 
 const write = (element: SugarElement, content: string): void => {
-  if (!SugarBody.inBody(element)) { throw new Error('Internal error: attempted to write to an iframe that is not n the DOM'); }
+  if (!SugarBody.inBody(element)) {
+    throw new Error('Internal error: attempted to write to an iframe that is not n the DOM');
+  }
 
   const doc = readDoc(element);
   const dom = doc.dom;

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
@@ -13,7 +13,11 @@ const point = <T extends Node> (element: SugarElement<T>, offset: number): Eleme
 // NOTE: This only descends once.
 const descendOnce = (element: SugarElement<Node>, offset: number): ElementAndOffset<Node> => {
   const children: SugarElement[] = Traverse.children(element);
-  if (children.length === 0) { return point(element, offset); } else if (offset < children.length) { return point(children[offset], 0); } else {
+  if (children.length === 0) {
+    return point(element, offset);
+  } else if (offset < children.length) {
+    return point(children[offset], 0);
+  } else {
     const last = children[children.length - 1];
     const len = SugarNode.isText(last) ? SugarText.get(last).length : Traverse.children(last).length;
     return point(last, len);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyEvents.ts
@@ -95,7 +95,9 @@ const runOnSourceName = <T extends EventFormat> (name: string): RunOnSourceName<
     key: name,
     value: EventHandler.nu({
       run: (component: AlloyComponent, simulatedEvent: SimulatedEvent<T>) => {
-        if (EventRoot.isSource(component, simulatedEvent)) { handler(component, simulatedEvent); }
+        if (EventRoot.isSource(component, simulatedEvent)) {
+          handler(component, simulatedEvent);
+        }
       }
     })
   });

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/Attachment.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/Attachment.ts
@@ -12,7 +12,9 @@ const attach = (parent: AlloyComponent, child: AlloyComponent): void => {
 const attachWith = (parent: AlloyComponent, child: AlloyComponent, insertion: (parent: SugarElement, child: SugarElement) => void): void => {
   parent.getSystem().addToWorld(child);
   insertion(parent.element, child.element);
-  if (SugarBody.inBody(parent.element)) { InternalAttachment.fireAttaching(child); }
+  if (SugarBody.inBody(parent.element)) {
+    InternalAttachment.fireAttaching(child);
+  }
   parent.syncComponents();
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/ForeignGui.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/ForeignGui.ts
@@ -160,7 +160,9 @@ const engage = (spec: ForeignGuiSpec): ForeignGuiConnection => {
      * c) execute the event handler
      * d) remove it from the internal system and clear any DOM markers (alloy-ids etc)
      */
-    if (gui.element.dom.contains(event.target.dom)) { return; }
+    if (gui.element.dom.contains(event.target.dom)) {
+      return;
+    }
 
     // Find if the target has an assigned dispatcher
     findDispatcher(detail.dispatchers, event.target).each((mission) => {
@@ -170,7 +172,9 @@ const engage = (spec: ForeignGuiSpec): ForeignGuiConnection => {
       const events = data.evts;
 
       // if this dispatcher defines this event, proxy it and fire the handler
-      if (Obj.hasNonNullableKey(events, type)) { proxyFor(event, mission.target, events[type]); }
+      if (Obj.hasNonNullableKey(events, type)) {
+        proxyFor(event, mission.target, events[type]);
+      }
     });
   };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormChooser.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormChooser.ts
@@ -43,7 +43,7 @@ const factory: CompositeSketchFactory<FormChooserDetail, FormChooserSpec> = (det
             return chooser.getSystem().getByDom(focused).map((choice) => {
               Highlighting.highlight(chooser, choice);
               return true;
-            }).toOptional().map(Fun.constant<boolean>(true));
+            }).toOptional().map<boolean>(Fun.always);
           }
         }),
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormCoupledInputs.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormCoupledInputs.ts
@@ -36,8 +36,12 @@ const factory: CompositeSketchFactory<FormCoupledInputsDetail, FormCoupledInputs
           },
           setValue: (comp, value) => {
             const parts = AlloyParts.getPartsOrDie(comp, detail, [ 'field1', 'field2' ]);
-            if (Obj.hasNonNullableKey(value, detail.field1Name)) { Representing.setValue(parts.field1(), value[detail.field1Name]); }
-            if (Obj.hasNonNullableKey(value, detail.field2Name)) { Representing.setValue(parts.field2(), value[detail.field2Name]); }
+            if (Obj.hasNonNullableKey(value, detail.field1Name)) {
+              Representing.setValue(parts.field1(), value[detail.field1Name]);
+            }
+            if (Obj.hasNonNullableKey(value, detail.field2Name)) {
+              Representing.setValue(parts.field2(), value[detail.field2Name]);
+            }
           }
         }
       })

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/pinching/ActivePinching.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/pinching/ActivePinching.ts
@@ -10,7 +10,9 @@ const mode: DragModeDeltas<TouchEvent, PinchDragData> = {
   getData: (e: EventArgs<TouchEvent>) => {
     const raw = e.raw;
     const touches = raw.touches;
-    if (touches.length < 2) { return Optional.none(); }
+    if (touches.length < 2) {
+      return Optional.none();
+    }
 
     const deltaX = Math.abs(touches[0].clientX - touches[1].clientX);
     const deltaY = Math.abs(touches[0].clientY - touches[1].clientY);

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
@@ -82,7 +82,9 @@ const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningC
       Css.getRaw(placee.element, 'right').isNone() &&
       Css.getRaw(placee.element, 'bottom').isNone() &&
       Css.getRaw(placee.element, 'position').is('fixed')
-    ) { Css.remove(placee.element, 'position'); }
+    ) {
+      Css.remove(placee.element, 'position');
+    }
   }, placee.element);
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/MemoryStore.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/MemoryStore.ts
@@ -18,7 +18,9 @@ const getValue = (component: AlloyComponent, repConfig: MemoryRepresentingConfig
 
 const onLoad = (component: AlloyComponent, repConfig: MemoryRepresentingConfig, repState: MemoryRepresentingState) => {
   repConfig.store.initialValue.each((initVal) => {
-    if (repState.isNotSet()) { repState.set(initVal); }
+    if (repState.isNotSet()) {
+      repState.set(initVal);
+    }
   });
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/ActiveSliding.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/ActiveSliding.ts
@@ -27,7 +27,9 @@ const events = (slideConfig: SlidingConfig, slideState: SlidingState): AlloyEven
       // This will fire for all transitions, we're only interested in the dimension completion on source
       if (raw.propertyName === slideConfig.dimension.property) {
         SlidingApis.disableTransitions(component, slideConfig); // disable transitions immediately (Safari animates the dimension removal below)
-        if (slideState.isExpanded()) { Css.remove(component.element, slideConfig.dimension.property); } // when showing, remove the dimension so it is responsive
+        if (slideState.isExpanded()) {
+          Css.remove(component.element, slideConfig.dimension.property);
+        } // when showing, remove the dimension so it is responsive
         const notify = slideState.isExpanded() ? slideConfig.onGrown : slideConfig.onShrunk;
         notify(component);
       }

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingApis.ts
@@ -112,15 +112,21 @@ const refresh = (component: AlloyComponent, slideConfig: SlidingConfig, slideSta
 };
 
 const grow = (component: AlloyComponent, slideConfig: SlidingConfig, slideState: SlidingState): void => {
-  if (!slideState.isExpanded()) { doStartGrow(component, slideConfig, slideState); }
+  if (!slideState.isExpanded()) {
+    doStartGrow(component, slideConfig, slideState);
+  }
 };
 
 const shrink = (component: AlloyComponent, slideConfig: SlidingConfig, slideState: SlidingState): void => {
-  if (slideState.isExpanded()) { doStartSmartShrink(component, slideConfig, slideState); }
+  if (slideState.isExpanded()) {
+    doStartSmartShrink(component, slideConfig, slideState);
+  }
 };
 
 const immediateShrink = (component: AlloyComponent, slideConfig: SlidingConfig, slideState: SlidingState): void => {
-  if (slideState.isExpanded()) { doImmediateShrink(component, slideConfig, slideState, Optional.none()); }
+  if (slideState.isExpanded()) {
+    doImmediateShrink(component, slideConfig, slideState, Optional.none());
+  }
 };
 
 const hasGrown = (component: AlloyComponent, slideConfig: SlidingConfig, slideState: SlidingState): boolean =>

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/streaming/StreamingSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/streaming/StreamingSchema.ts
@@ -14,7 +14,9 @@ const setup = (streamInfo: StreamingConfig, streamState: StreamingStateType) => 
 
   return (component: AlloyComponent, simulatedEvent: SimulatedEvent<EventFormat>) => {
     throttler.throttle(component, simulatedEvent);
-    if (sInfo.stopEvent) { simulatedEvent.stop(); }
+    if (sInfo.stopEvent) {
+      simulatedEvent.stop();
+    }
   };
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleModes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleModes.ts
@@ -6,7 +6,9 @@ import { AriaTogglingConfig } from './TogglingTypes';
 
 const updatePressed = (component: AlloyComponent, ariaInfo: AriaTogglingConfig, status: boolean): void => {
   Attribute.set(component.element, 'aria-pressed', status);
-  if (ariaInfo.syncWithExpanded) { updateExpanded(component, ariaInfo, status); }
+  if (ariaInfo.syncWithExpanded) {
+    updateExpanded(component, ariaInfo, status);
+  }
 };
 
 const updateSelected = (component: AlloyComponent, ariaInfo: AriaTogglingConfig, status: boolean): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/TransitionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/TransitionApis.ts
@@ -62,7 +62,9 @@ const jumpTo = (comp: AlloyComponent, transConfig: TransitioningConfig, transSta
   // Remove the previous transition
   disableTransition(comp, transConfig, transState);
   // Only call finish if there was an original state
-  if (Attribute.has(comp.element, transConfig.stateAttr) && Attribute.get(comp.element, transConfig.stateAttr) !== destination) { transConfig.onFinish(comp, destination); }
+  if (Attribute.has(comp.element, transConfig.stateAttr) && Attribute.get(comp.element, transConfig.stateAttr) !== destination) {
+    transConfig.onFinish(comp, destination);
+  }
   Attribute.set(comp.element, transConfig.stateAttr, destination);
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/construct/EventHandler.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/construct/EventHandler.ts
@@ -5,9 +5,10 @@ import { AlloyEventHandler, EventRunHandler } from '../api/events/AlloyEvents';
 import { EventFormat, SimulatedEvent } from '../events/SimulatedEvent';
 
 const nu = <T extends EventFormat>(parts: Partial<AlloyEventHandler<T>>): AlloyEventHandler<T> => {
-  if (!Obj.hasNonNullableKey(parts, 'can') && !Obj.hasNonNullableKey(parts, 'abort') && !Obj.hasNonNullableKey(parts, 'run')) { throw new Error(
-    'EventHandler defined by: ' + JSON.stringify(parts, null, 2) + ' does not have can, abort, or run!'
-  );
+  if (!Obj.hasNonNullableKey(parts, 'can') && !Obj.hasNonNullableKey(parts, 'abort') && !Obj.hasNonNullableKey(parts, 'run')) {
+    throw new Error(
+      'EventHandler defined by: ' + JSON.stringify(parts, null, 2) + ' does not have can, abort, or run!'
+    );
   }
   return ValueSchema.asRawOrDie('Extracting event.handler', ValueSchema.objOfOnly([
     FieldSchema.defaulted('can', Fun.always),

--- a/modules/alloy/src/main/ts/ephox/alloy/construct/EventHandler.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/construct/EventHandler.ts
@@ -25,8 +25,8 @@ const any = <T extends EventFormat>(handlers: Array<AlloyEventHandler<T>>, f: (h
 
 const read = <T extends EventFormat>(handler: (() => SimulatedEvent<T>) | AlloyEventHandler<T>): AlloyEventHandler<T> =>
   Type.isFunction(handler) ? {
-    can: Fun.constant(true),
-    abort: Fun.constant(false),
+    can: Fun.always,
+    abort: Fun.never,
     run: handler
   } : handler;
 

--- a/modules/alloy/src/main/ts/ephox/alloy/debugging/Debugging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/debugging/Debugging.ts
@@ -87,14 +87,20 @@ const makeEventLogger = (eventName: string, initialTarget: SugarElement): Debugg
     },
     write: () => {
       const finishTime = new Date().getTime();
-      if (Arr.contains([ 'mousemove', 'mouseover', 'mouseout', SystemEvents.systemInit() ], eventName)) { return; }
+      if (Arr.contains([ 'mousemove', 'mouseover', 'mouseout', SystemEvents.systemInit() ], eventName)) {
+        return;
+      }
       // eslint-disable-next-line no-console
       console.log(eventName, {
         event: eventName,
         time: finishTime - startTime,
         target: initialTarget.dom,
         sequence: Arr.map(sequence, (s) => {
-          if (!Arr.contains([ 'cut', 'stopped', 'response' ], s.outcome)) { return s.outcome; } else { return '{' + s.purpose + '} ' + s.outcome + ' at (' + AlloyLogger.element(s.target) + ')'; }
+          if (!Arr.contains([ 'cut', 'stopped', 'response' ], s.outcome)) {
+            return s.outcome;
+          } else {
+            return '{' + s.purpose + '} ' + s.outcome + ' at (' + AlloyLogger.element(s.target) + ')';
+          }
         })
       });
     }
@@ -131,7 +137,9 @@ const path = [
 ];
 
 const getTrace = (): string => {
-  if (debugging === false) { return unknown; }
+  if (debugging === false) {
+    return unknown;
+  }
   const err = new Error();
   if (err.stack !== undefined) {
     const lines = err.stack.split('\n');

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/mouse/MouseDragging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/mouse/MouseDragging.ts
@@ -19,7 +19,9 @@ import { MouseDraggingConfig } from './MouseDraggingTypes';
 const events = <E>(dragConfig: MouseDraggingConfig<E>, dragState: DraggingState, updateStartState: (comp: AlloyComponent) => void): Array<AlloyEvents.AlloyEventKeyAndHandler<EventArgs<MouseEvent>>> => [
   AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousedown(), (component, simulatedEvent) => {
     const raw = simulatedEvent.event.raw;
-    if (raw.button !== 0) { return; }
+    if (raw.button !== 0) {
+      return;
+    }
     simulatedEvent.stop();
 
     const stop = () => DragUtils.stop(component, Optional.some(blocker), dragConfig, dragState);

--- a/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
@@ -77,7 +77,9 @@ export const EventRegistry = (): EventRegistry => {
   const unregisterId = (id: string): void => {
     // INVESTIGATE: Find a better way than mutation if we can.
     Obj.each(registry, (handlersById: Record<string, CurriedHandler>, _eventName) => {
-      if (handlersById.hasOwnProperty(id)) { delete handlersById[id]; }
+      if (handlersById.hasOwnProperty(id)) {
+        delete handlersById[id];
+      }
     });
   };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/events/GuiEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/GuiEvents.ts
@@ -84,21 +84,29 @@ const setup = (container: SugarElement, rawSettings: { }): { unbind: () => void 
     ]),
     (type) => DomEvent.bind(container, type, (event) => {
       tapEvent.fireIfReady(event, type).each((tapStopped) => {
-        if (tapStopped) { event.kill(); }
+        if (tapStopped) {
+          event.kill();
+        }
       });
 
       const stopped = settings.triggerEvent(type, event);
-      if (stopped) { event.kill(); }
+      if (stopped) {
+        event.kill();
+      }
     })
   );
   const pasteTimeout = Cell(Optional.none<number>());
   const onPaste = DomEvent.bind(container, 'paste', (event) => {
     tapEvent.fireIfReady(event, 'paste').each((tapStopped) => {
-      if (tapStopped) { event.kill(); }
+      if (tapStopped) {
+        event.kill();
+      }
     });
 
     const stopped = settings.triggerEvent('paste', event);
-    if (stopped) { event.kill(); }
+    if (stopped) {
+      event.kill();
+    }
     pasteTimeout.set(Optional.some(setTimeout(() => {
       settings.triggerEvent(SystemEvents.postPaste(), event);
     }, 0)));
@@ -116,13 +124,17 @@ const setup = (container: SugarElement, rawSettings: { }): { unbind: () => void 
 
   const onFocusIn = bindFocus(container, (event) => {
     const stopped = settings.triggerEvent('focusin', event);
-    if (stopped) { event.kill(); }
+    if (stopped) {
+      event.kill();
+    }
   });
 
   const focusoutTimeout = Cell(Optional.none<number>());
   const onFocusOut = bindBlur(container, (event) => {
     const stopped = settings.triggerEvent('focusout', event);
-    if (stopped) { event.kill(); }
+    if (stopped) {
+      event.kill();
+    }
 
     // INVESTIGATE: Come up with a better way of doing this. Related target can be used, but not on FF.
     // It allows the active element to change before firing the blur that we will listen to

--- a/modules/alloy/src/main/ts/ephox/alloy/events/TapEvent.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/TapEvent.ts
@@ -25,7 +25,9 @@ const LONGPRESS_DELAY = 400;
 
 const getTouch = (event: EventArgs<TouchEvent>): Optional<Touch> => {
   const raw = event.raw;
-  if (raw.touches === undefined || raw.touches.length !== 1) { return Optional.none(); }
+  if (raw.touches === undefined || raw.touches.length !== 1) {
+    return Optional.none();
+  }
   return Optional.some(raw.touches[0]);
 };
 
@@ -71,7 +73,9 @@ const monitor = (settings: GuiEventSettings): Monitor => {
     longpress.cancel();
     getTouch(event).each((touch) => {
       startData.get().each((data) => {
-        if (isFarEnough(touch, data)) { startData.set(Optional.none()); }
+        if (isFarEnough(touch, data)) {
+          startData.set(Optional.none());
+        }
       });
     });
     return Optional.none();

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/build/WidgetType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/build/WidgetType.ts
@@ -50,7 +50,11 @@ const builder = (detail: WidgetItemDetail) => {
       AlloyEvents.run(NativeEvents.mouseover(), ItemEvents.onHover),
 
       AlloyEvents.run(SystemEvents.focusItem(), (component, _simulatedEvent) => {
-        if (detail.autofocus) { focusWidget(component); } else { Focusing.focus(component); }
+        if (detail.autofocus) {
+          focusWidget(component);
+        } else {
+          Focusing.focus(component);
+        }
       })
     ]),
     behaviours: SketchBehaviours.augment(

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/util/ItemEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/util/ItemEvents.ts
@@ -15,7 +15,9 @@ const onHover = (item: AlloyComponent): void => {
   // want to lose focus on the widget. Note, that because this isn't API based
   // (i.e. we are manually searching for focus), it may not be that flexible.
   if (Focus.search(item.element).isNone() || Focusing.isFocused(item)) {
-    if (!Focusing.isFocused(item)) { Focusing.focus(item); }
+    if (!Focusing.isFocused(item)) {
+      Focusing.focus(item);
+    }
     AlloyTriggers.emitWith(item, hoverEvent, { item });
   }
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/registry/Registry.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/registry/Registry.ts
@@ -30,16 +30,21 @@ export const Registry = (): Registry => {
 
   const failOnDuplicate = (component: AlloyComponent, tagId: string): void => {
     const conflict = components[tagId];
-    if (conflict === component) { unregister(component); } else { throw new Error(
-      'The tagId "' + tagId + '" is already used by: ' + AlloyLogger.element(conflict.element) + '\nCannot use it for: ' + AlloyLogger.element(component.element) + '\n' +
+    if (conflict === component) {
+      unregister(component);
+    } else {
+      throw new Error(
+        'The tagId "' + tagId + '" is already used by: ' + AlloyLogger.element(conflict.element) + '\nCannot use it for: ' + AlloyLogger.element(component.element) + '\n' +
         'The conflicting element is' + (SugarBody.inBody(conflict.element) ? ' ' : ' not ') + 'already in the DOM'
-    );
+      );
     }
   };
 
   const register = (component: AlloyComponent): void => {
     const tagId = readOrTag(component);
-    if (Obj.hasNonNullableKey(components, tagId)) { failOnDuplicate(component, tagId); }
+    if (Obj.hasNonNullableKey(components, tagId)) {
+      failOnDuplicate(component, tagId);
+    }
     // Component is passed through an an extra argument to all events
     const extraArgs = [ component ];
     events.registerId(extraArgs, tagId, component.events);

--- a/modules/alloy/src/main/ts/ephox/alloy/spec/UiSubstitutes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/spec/UiSubstitutes.ts
@@ -40,7 +40,9 @@ const adt: {
 const isSubstituted = (spec: any): spec is ConfiguredPart => Obj.has(spec, 'uiType');
 
 const subPlaceholder = <D extends CompositeSketchDetail>(owner: Optional<string>, detail: D, compSpec: ConfiguredPart, placeholders: Record<string, Replacement>): UiSubstitutesAdt => {
-  if (owner.exists((o) => o !== compSpec.owner)) { return adt.single(true, Fun.constant(compSpec)); }
+  if (owner.exists((o) => o !== compSpec.owner)) {
+    return adt.single(true, Fun.constant(compSpec));
+  }
   // Ignore having to find something for the time being.
   return Obj.get(placeholders as any, compSpec.name).fold(() => {
     throw new Error('Unknown placeholder component: ' + compSpec.name + '\nKnown: [' +

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/composite/TypeaheadSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/composite/TypeaheadSpec.ts
@@ -123,7 +123,9 @@ const make: CompositeSketchFactory<TypeaheadDetail, TypeaheadSpec> = (detail, co
             const onOpenSync = (_sandbox: AlloyComponent) => {
               Composing.getCurrent(sandbox).each((menu) => {
                 previousValue.fold(() => {
-                  if (detail.model.selectsOver) { Highlighting.highlightFirst(menu); }
+                  if (detail.model.selectsOver) {
+                    Highlighting.highlightFirst(menu);
+                  }
                 }, (pv) => {
                   Highlighting.highlightBy(menu, (item) => {
                     const itemData = Representing.getValue(item) as TypeaheadData;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FormCoupledInputsSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FormCoupledInputsSchema.ts
@@ -41,7 +41,9 @@ const coupledPart = (selfName: string, otherName: string) => PartType.required<F
             getField(me, detail, otherName).each((other) => {
               AlloyParts.getPart(me, detail, 'lock').each((lock) => {
                 // TODO IMPROVEMENT: Allow locker to fire onLockedChange if it is turned on after being off.
-                if (Toggling.isOn(lock)) { detail.onLockedChange(me, other, lock); }
+                if (Toggling.isOn(lock)) {
+                  detail.onLockedChange(me, other, lock);
+                }
               });
             });
           })

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
@@ -78,7 +78,9 @@ const make: SingleSketchFactory<TieredMenuDetail, TieredMenuSpec> = (detail, _ra
   const getItemByValue = (_container: AlloyComponent, menus: AlloyComponent[], itemValue: string): Optional<AlloyComponent> =>
     // Can *greatly* improve the performance of this by calculating things up front.
     Arr.findMap(menus, (menu) => {
-      if (!menu.getSystem().isConnected()) { return Optional.none(); }
+      if (!menu.getSystem().isConnected()) {
+        return Optional.none();
+      }
       const candidates = Highlighting.getCandidates(menu);
       return Arr.find(candidates, (c) => getItemValue(c) === itemValue);
     });
@@ -102,7 +104,9 @@ const make: SingleSketchFactory<TieredMenuDetail, TieredMenuSpec> = (detail, _ra
 
       // May not need to do the active menu thing.
       Classes.remove(o.element, [ detail.markers.backgroundMenu ]);
-      if (!detail.stayInDom) { Replacing.remove(container, o); }
+      if (!detail.stayInDom) {
+        Replacing.remove(container, o);
+      }
     });
   };
 

--- a/modules/alloy/src/test/ts/atomic/alien/ObjIndexTest.ts
+++ b/modules/alloy/src/test/ts/atomic/alien/ObjIndexTest.ts
@@ -8,7 +8,13 @@ UnitTest.test('ObjIndexTest', () => {
   const tuple = <T>(k: string, v: T) => ({ country: k, value: v });
 
   const sortObjValue = (obj: Record<string, any[]>) => Obj.map(obj, (array, _k) => array.slice(0).sort((a, b) => {
-    if (a.country < b.country) { return -1; } else if (a.country > b.country) { return +1; } else { return 0; }
+    if (a.country < b.country) {
+      return -1;
+    } else if (a.country > b.country) {
+      return +1;
+    } else {
+      return 0;
+    }
   }));
 
   const assertSortedEq = (label: string, expected: Record<string, any[]>, actual: Record<string, any[]>) => {

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderCursorTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderCursorTest.ts
@@ -19,7 +19,9 @@ UnitTest.test('BounderCursorTest', () => {
     Assert.eq('label', expected.label, actual.label);
     Assert.eq('X', expected.x, actual.x);
     Assert.eq('Y', expected.y, actual.y);
-    if (expected.candidateYforTest !== undefined) { Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest); }
+    if (expected.candidateYforTest !== undefined) {
+      Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest);
+    }
   };
 
   // Layout is for boxes with a bubble pointing to a cursor position (vertically aligned to nearest side)

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderMenuTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderMenuTest.ts
@@ -19,7 +19,9 @@ UnitTest.test('BounderMenuTest', () => {
     assert.eq(expected.label, actual.label);
     assert.eq(expected.x, actual.x);
     assert.eq(expected.y, actual.y);
-    if (expected.candidateYforTest !== undefined) { assert.eq(expected.candidateYforTest, actual.candidateYforTest); }
+    if (expected.candidateYforTest !== undefined) {
+      assert.eq(expected.candidateYforTest, actual.candidateYforTest);
+    }
   };
 
   // LinkedLayout is for submenus (vertically aligned to opposite side of menu)

--- a/modules/alloy/src/test/ts/atomic/position/view/BounderToolbuttonTest.ts
+++ b/modules/alloy/src/test/ts/atomic/position/view/BounderToolbuttonTest.ts
@@ -20,7 +20,9 @@ UnitTest.test('BounderToolbuttonTest', () => {
     Assert.eq('label', expected.label, actual.label);
     Assert.eq('X', expected.x, actual.x);
     Assert.eq('Y', expected.y, actual.y);
-    if (expected.candidateYforTest !== undefined) { Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest); }
+    if (expected.candidateYforTest !== undefined) {
+      Assert.eq('Candidate Y', expected.candidateYforTest, actual.candidateYforTest);
+    }
   };
 
   // Layout is for boxes with a bubble pointing to a cursor position (vertically aligned to nearest side)

--- a/modules/alloy/src/test/ts/browser/api/ComponentConfiguredTest.ts
+++ b/modules/alloy/src/test/ts/browser/api/ComponentConfiguredTest.ts
@@ -60,5 +60,5 @@ UnitTest.asynctest('Browser Test: api.ComponentConfiguredTest', (success, failur
         Assertions.assertEq('hasConfigured', false, toggler.hasConfigured(Toggling));
       })
     )
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/api/ForeignGuiTest.ts
+++ b/modules/alloy/src/test/ts/browser/api/ForeignGuiTest.ts
@@ -124,5 +124,5 @@ UnitTest.asynctest('Browser Test: api.ForeignGuiTest', (success, failure) => {
       connection.disengage();
       Remove.remove(root);
     })
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/AllowBubblingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/AllowBubblingTest.ts
@@ -38,5 +38,5 @@ UnitTest.asynctest('AllowBubblingTest', (success, failure) => {
       sDispatchScrollEvent(component),
       store.sAssertEq('Should have fired simulated scroll event', [ 'bubbled.scroll' ])
     ])),
-  () => { success(); }, failure);
+  success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/CouplingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/CouplingTest.ts
@@ -66,5 +66,5 @@ UnitTest.asynctest('CouplingTest', (success, failure) => {
       'After clicking, store should have message',
       [ 'clicked on coupled button of: primary' ]
     )
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/DisablingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/DisablingTest.ts
@@ -158,5 +158,5 @@ UnitTest.asynctest('DisablingTest', (success, failure) => {
         disabledButton.element
       )
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/FocusingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/FocusingTest.ts
@@ -49,5 +49,5 @@ UnitTest.asynctest('FocusingTest', (success, failure) => {
     }),
     FocusTools.sTryOnSelector('Focusing after focus call', doc, '.focusable')
 
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/HighlightingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/HighlightingTest.ts
@@ -198,5 +198,5 @@ UnitTest.asynctest('HighlightingTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/InvalidatingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/InvalidatingTest.ts
@@ -276,5 +276,5 @@ UnitTest.asynctest('InvalidatingTest', (success, failure) => {
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/PinchingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/PinchingTest.ts
@@ -89,5 +89,5 @@ UnitTest.asynctest('Browser Test: behaviour.PinchingTest', (success, failure) =>
         { method: 'pinch', dx: (16 - 8) - (20 - 5), dy: (160 - 80) - (200 - 50) }
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/ReceivingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/ReceivingTest.ts
@@ -51,5 +51,5 @@ UnitTest.asynctest('ReceivingTest', (success, failure) => {
       gui.broadcast({ dummy: '2' });
     }),
     store.sAssertEq('After broadcast to all', [ 'received: 2' ])
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/ReplacingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/ReplacingTest.ts
@@ -245,5 +245,5 @@ UnitTest.asynctest('ReplacingTest', (success, failure) => {
         'replaceAt-2'
       )
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/SandboxingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/SandboxingTest.ts
@@ -133,5 +133,5 @@ UnitTest.asynctest('SandboxingTest', (success, failure) => {
 
       sCheckClosedState('After sending system close event', { store: [ 'onClose' ] })
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/StreamingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/StreamingTest.ts
@@ -56,5 +56,5 @@ UnitTest.asynctest('StreamingTest', (success, failure) => {
       AlloyTriggers.emit(component, 'cancel.stream');
     }),
     Waiter.sTryUntil('', store.sAssertEq('Event should have been cancelled, so nothing should be in store', [ ]))
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/TabstoppingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/TabstoppingTest.ts
@@ -25,5 +25,5 @@ UnitTest.asynctest('TabstoppingTest', (success, failure) => {
       })),
       component.element
     )
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/TooltippingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/TooltippingTest.ts
@@ -180,5 +180,5 @@ UnitTest.asynctest('Tooltipping Behaviour', (success, failure) => {
         ]
       )
     ]);
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/TransitioningTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/TransitioningTest.ts
@@ -10,7 +10,9 @@ import * as PhantomSkipper from 'ephox/alloy/test/PhantomSkipper';
 
 UnitTest.asynctest('TransitioningTest', (success, failure) => {
 
-  if (PhantomSkipper.skip()) { return success(); }
+  if (PhantomSkipper.skip()) {
+    return success();
+  }
 
   GuiSetup.setup((store, _doc, _body) => GuiFactory.build({
     dom: {
@@ -106,5 +108,5 @@ UnitTest.asynctest('TransitioningTest', (success, failure) => {
         'beta->alpha'
       ])
     )
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/UnselectingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/UnselectingTest.ts
@@ -34,5 +34,5 @@ UnitTest.asynctest('UnselectingTest', (success, failure) => {
       })),
       component.element
     )
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/dragging/MouseDragEventTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/dragging/MouseDragEventTest.ts
@@ -63,5 +63,5 @@ UnitTest.asynctest('MouseDragEventTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/dragging/MouseDraggingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/dragging/MouseDraggingTest.ts
@@ -220,5 +220,5 @@ UnitTest.asynctest('MouseDraggingTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/dragging/SnapToTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/dragging/SnapToTest.ts
@@ -103,5 +103,5 @@ UnitTest.asynctest('SnapToTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/AcyclicKeyingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/AcyclicKeyingTest.ts
@@ -142,7 +142,5 @@ UnitTest.asynctest('Browser Test: behaviour.keying.AcyclicKeyingTest', (success,
     store.sAssertEq('Enter on outer container', [ 'cycle.enter' ]),
     store.sClear,
     GuiSetup.mTeardownKeyLogger(body, [ ])
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/CyclicKeyingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/CyclicKeyingTest.ts
@@ -113,7 +113,5 @@ UnitTest.asynctest('Cyclic Keying Test', (success, failure) => {
       'button:contains("Button1")'
     ),
     GuiSetup.mTeardownKeyLogger(body, [ ])
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/ExecutingKeyingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/ExecutingKeyingTest.ts
@@ -93,5 +93,5 @@ UnitTest.asynctest('ExecutingKeyingTest', (success, failure) => {
   Pipeline.async({ }, [
     sTestDefault,
     sTestConfiguration
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/FlatgridKeyingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/FlatgridKeyingTest.ts
@@ -171,7 +171,5 @@ UnitTest.asynctest('Flat Grid Keying Test', (success, failure) => {
       ),
       GuiSetup.mTeardownKeyLogger(body, [ ])
     ];
-  }, () => {
-    success();
-  }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/FlowKeyingAllowVerticalTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/FlowKeyingAllowVerticalTest.ts
@@ -136,7 +136,5 @@ UnitTest.asynctest('Flow Keying Allow Vertical Test', (success, failure) => {
         'keydown.to.body: 40'
       ])
     ];
-  }, () => {
-    success();
-  }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/FlowKeyingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/FlowKeyingTest.ts
@@ -136,7 +136,5 @@ UnitTest.asynctest('Flow Keying Skip Element Test', (success, failure) => {
 
       GuiSetup.mTeardownKeyLogger(body, [ ])
     ];
-  }, () => {
-    success();
-  }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/FocusModesTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/FocusModesTest.ts
@@ -120,7 +120,5 @@ UnitTest.asynctest('Focus Modes Test', (success, failure) => {
         FocusTools.sTryOnSelector('Focus should move within container', doc, '.onFocus-button')
       ]))
     ];
-  }, () => {
-    success();
-  }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/MatrixKeyingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/MatrixKeyingTest.ts
@@ -175,7 +175,5 @@ UnitTest.asynctest('Matrix Keying Test', (success, failure) => {
 
       GuiSetup.mTeardownKeyLogger(body, [ ])
     ];
-  }, () => {
-    success();
-  }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/MenuKeyingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/MenuKeyingTest.ts
@@ -102,5 +102,5 @@ UnitTest.asynctest('MenuKeyingTest', (success, failure) => {
 
       GuiSetup.mTeardownKeyLogger(body, [ ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/SpecialKeyingFocusInTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/SpecialKeyingFocusInTest.ts
@@ -80,5 +80,5 @@ UnitTest.asynctest('SpecialKeyingFocusInTest', (success, failure) => {
 
       GuiSetup.mTeardownKeyLogger(body, [ ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/SpecialKeyingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/SpecialKeyingTest.ts
@@ -50,5 +50,5 @@ UnitTest.asynctest('SpecialKeyingTest', (success, failure) => {
       press('escape', Keys.escape(), { }),
       GuiSetup.mTeardownKeyLogger(body, [ ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/WidgetKeyingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/WidgetKeyingTest.ts
@@ -151,7 +151,5 @@ UnitTest.asynctest('Widget Keying Test', (success, failure) => {
 
     GuiSetup.mRemoveStyles,
     GuiSetup.mTeardownKeyLogger(body, [ ])
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/representing/RepresentingDatasetTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/representing/RepresentingDatasetTest.ts
@@ -98,5 +98,5 @@ UnitTest.asynctest('RepresentingTest (mode: dataset)', (success, failure) => {
         component.element
       )
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/representing/RepresentingManualTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/representing/RepresentingManualTest.ts
@@ -36,5 +36,5 @@ UnitTest.asynctest('RepresentingTest (mode: manual)', (success, failure) => {
     RepresentPipes.sSetValue(component, 'new-value'),
     store.sAssertEq('Should have called setValue on init', [ 'setValue(init-value)', 'getValue', 'setValue(new-value)' ]),
     RepresentPipes.sAssertValue('Checking 2nd value', 'new-value', component)
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/representing/RepresentingMemoryTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/representing/RepresentingMemoryTest.ts
@@ -23,5 +23,5 @@ UnitTest.asynctest('RepresentingTest (mode: memory)', (success, failure) => {
     RepresentPipes.sAssertValue('Checking initial value', '1', component),
     RepresentPipes.sSetValue(component, '2'),
     RepresentPipes.sAssertValue('Checking 2nd value', '2', component)
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/sliding/SlidingInterruptedTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/sliding/SlidingInterruptedTest.ts
@@ -12,7 +12,9 @@ import * as PhantomSkipper from 'ephox/alloy/test/PhantomSkipper';
 UnitTest.asynctest('SlidingInterruptedTest', (success, failure) => {
 
   // Seems to have stopped working on phantomjs
-  if (PhantomSkipper.skip()) { return success(); }
+  if (PhantomSkipper.skip()) {
+    return success();
+  }
 
   const slidingStyles = [
     '.test-sliding-width-growing { transition: width 5.0s ease; }',
@@ -113,5 +115,5 @@ UnitTest.asynctest('SlidingInterruptedTest', (success, failure) => {
         sIsNotShrinking
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/behaviour/sliding/SlidingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/sliding/SlidingTest.ts
@@ -12,7 +12,9 @@ import * as PhantomSkipper from 'ephox/alloy/test/PhantomSkipper';
 UnitTest.asynctest('SlidingTest', (success, failure) => {
 
   // Seems to have stopped working on phantomjs
-  if (PhantomSkipper.skip()) { return success(); }
+  if (PhantomSkipper.skip()) {
+    return success();
+  }
 
   const slidingStyles = [
     '.test-sliding-closed { visibility: hidden; opacity: 0; }',
@@ -242,5 +244,5 @@ UnitTest.asynctest('SlidingTest', (success, failure) => {
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/events/AttachingEventTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/AttachingEventTest.ts
@@ -112,5 +112,5 @@ UnitTest.asynctest('Browser Test: events.AttachingEventTest', (success, failure)
     }),
 
     store.sAssertEq('After detaching from the DOM, should have fired detached', [ 'detached-from:main-container' ])
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/events/EventRegistryTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/EventRegistryTest.ts
@@ -63,7 +63,13 @@ UnitTest.asynctest('EventRegistryTest', (success, failure) => {
       purpose: f.descHandler.purpose,
       id: f.id
     })).sort((f, g) => {
-      if (f.id < g.id) { return -1; } else if (f.id > g.id) { return +1; } else { return 0; }
+      if (f.id < g.id) {
+        return -1;
+      } else if (f.id > g.id) {
+        return +1;
+      } else {
+        return 0;
+      }
     });
 
     Assertions.assertEq(() => 'filter(' + type + ') = ' + JSON.stringify(expected), expected, raw);
@@ -149,5 +155,5 @@ UnitTest.asynctest('EventRegistryTest', (success, failure) => {
       { handler: 'event.only(extra-args)', target: 'comp-1' },
       'event.only', 'comp-5'
     )
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/events/TapEventsTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/TapEventsTest.ts
@@ -169,5 +169,5 @@ UnitTest.asynctest('browser events.TapEventsTest', (success, failure) => {
         store.sClear
       ])
     )
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/events/TriggersTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/TriggersTest.ts
@@ -11,7 +11,9 @@ UnitTest.asynctest('TriggersTest', (success, failure) => {
 
   const make = (stop: boolean, message: string) => (labEvent: EventArgs) => {
     log.push(message);
-    if (stop) { labEvent.stop(); }
+    if (stop) {
+      labEvent.stop();
+    }
   };
 
   // OK for this test, we need to start with a list of events which may or may not stop
@@ -124,5 +126,5 @@ UnitTest.asynctest('TriggersTest', (success, failure) => {
     c.type
   ));
 
-  Pipeline.async({}, steps, () => { success(); }, failure);
+  Pipeline.async({}, steps, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/position/HotspotCustomBoundsPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/HotspotCustomBoundsPositionTest.ts
@@ -88,5 +88,5 @@ UnitTest.asynctest('HotspotPositionTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/position/HotspotPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/HotspotPositionTest.ts
@@ -67,5 +67,5 @@ UnitTest.asynctest('HotspotPositionTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/position/MakeshiftPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/MakeshiftPositionTest.ts
@@ -75,5 +75,5 @@ UnitTest.asynctest('MakeshiftPositionTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/position/NodeInFramePositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/NodeInFramePositionTest.ts
@@ -142,5 +142,5 @@ UnitTest.asynctest('SelectionInFramePositionTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/position/SelectionInDocPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/SelectionInDocPositionTest.ts
@@ -137,5 +137,5 @@ UnitTest.asynctest('SelectionInDocPositionTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/position/SelectionInFramePositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/SelectionInFramePositionTest.ts
@@ -182,5 +182,5 @@ UnitTest.asynctest('SelectionInFramePositionTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/position/SubmenuPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/SubmenuPositionTest.ts
@@ -78,5 +78,5 @@ UnitTest.asynctest('SubmenuPositionTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
@@ -388,5 +388,5 @@ UnitTest.asynctest('ModalDialogTest', (success, failure) => {
         }))
       )
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownListTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownListTest.ts
@@ -327,5 +327,5 @@ UnitTest.asynctest('Dropdown List', (success, failure) => {
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownMenuTest.ts
@@ -447,5 +447,5 @@ UnitTest.asynctest('DropdownMenuTest', (success, failure) => {
         ]
       )
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/GridMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/GridMenuTest.ts
@@ -121,5 +121,5 @@ UnitTest.asynctest('GridMenuTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/MatrixMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/MatrixMenuTest.ts
@@ -135,5 +135,5 @@ UnitTest.asynctest('MatrixMenuTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/MenuFocusTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/MenuFocusTest.ts
@@ -138,5 +138,5 @@ UnitTest.asynctest('MenuFocusTest', (success, failure) => {
       sAssertFocusShift('Focusing on alpha-widget-2 (fakeFocus)', 'input', '.alpha-widget-2'),
       sAssertFocusShift('Focusing on beta-item-2 (fakeFocus)', 'input', '.beta-item-2')
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/MenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/MenuTest.ts
@@ -100,5 +100,5 @@ UnitTest.asynctest('MenuTest', (success, failure) => {
         ])
       ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/SplitDropdownTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/SplitDropdownTest.ts
@@ -237,5 +237,5 @@ UnitTest.asynctest('SplitDropdown List', (success, failure) => {
       FocusTools.sTryOnSelector('Focus should be on alpha', doc, 'li:contains("Alpha")'),
       store.sClear
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/TieredMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/TieredMenuTest.ts
@@ -188,5 +188,5 @@ UnitTest.asynctest('TieredMenuTest', (success, failure) => {
       )
       // TODO: Beef up tests
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/TieredMenuWithoutImmedateHighlightTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/TieredMenuWithoutImmedateHighlightTest.ts
@@ -151,5 +151,5 @@ UnitTest.asynctest('TieredMenuWithoutImmediateHighlightTest', (success, failure)
       })),
       component.element
     )
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/form/BasicFormTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/form/BasicFormTest.ts
@@ -155,5 +155,5 @@ UnitTest.asynctest('Basic Form', (success, failure) => {
         ])
       )
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/form/ExpandableFormTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/form/ExpandableFormTest.ts
@@ -21,7 +21,9 @@ import { FormParts } from 'ephox/alloy/ui/types/FormTypes';
 UnitTest.asynctest('ExpandableFormTest', (success, failure) => {
 
   // Seems to have stopped working on phantomjs
-  if (PhantomSkipper.skip()) { return success(); }
+  if (PhantomSkipper.skip()) {
+    return success();
+  }
 
   GuiSetup.setup((_store, _doc, _body) => {
 
@@ -311,5 +313,5 @@ UnitTest.asynctest('ExpandableFormTest', (success, failure) => {
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/form/FieldsTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/form/FieldsTest.ts
@@ -256,5 +256,5 @@ UnitTest.asynctest('FieldsTest', (success, failure) => {
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/form/HtmlSelectTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/form/HtmlSelectTest.ts
@@ -77,5 +77,5 @@ UnitTest.asynctest('HtmlSelectTest', (success, failure) => {
   Pipeline.async({}, [
     Logger.t('Scenario: no initial value', sNoInitialValue),
     Logger.t('Scenario: has initial value gamma', sHasInitialValue)
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/inline/InlineViewDismissTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/inline/InlineViewDismissTest.ts
@@ -147,5 +147,5 @@ UnitTest.asynctest('InlineViewDismissTest', (success, failure) => {
       store.sAssertEq('Broadcasting on outer element SHOULD fire dismiss event', [ 'test-dismiss-fired' ])
 
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/inline/InlineViewTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/inline/InlineViewTest.ts
@@ -311,5 +311,5 @@ UnitTest.asynctest('InlineViewTest', (success, failure) => {
       sCheckClosed('Broadcasting dismiss on a external element should close inline toolbar')
 
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/slider/HorizontalSliderTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/slider/HorizontalSliderTest.ts
@@ -14,7 +14,9 @@ UnitTest.asynctest('Browser Test: ui.slider.HorizontalSliderTest', (success, fai
 
   // Tests requiring 'flex' do not currently work on phantom. Use the remote  to see how it is
   // viewed as an invalid value.
-  if (PhantomSkipper.skip()) { return success(); }
+  if (PhantomSkipper.skip()) {
+    return success();
+  }
   GuiSetup.setup((_store, _doc, _body) => GuiFactory.build(
     Slider.sketch({
       dom: {
@@ -249,5 +251,5 @@ UnitTest.asynctest('Browser Test: ui.slider.HorizontalSliderTest', (success, fai
       Keyboard.sKeydown(doc, Keys.right(), {}),
       sAssertValue('Checking that the thumb is now one step further right', 70)
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/slider/TwoDSliderTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/slider/TwoDSliderTest.ts
@@ -14,7 +14,9 @@ UnitTest.asynctest('Browser Test: ui.slider.TwoDSliderTest', (success, failure) 
 
   // Tests requiring 'flex' do not currently work on phantom. Use the remote  to see how it is
   // viewed as an invalid value.
-  if (PhantomSkipper.skip()) { return success(); }
+  if (PhantomSkipper.skip()) {
+    return success();
+  }
   GuiSetup.setup((_store, _doc, _body) => GuiFactory.build(
     Slider.sketch({
       dom: {
@@ -367,7 +369,7 @@ UnitTest.asynctest('Browser Test: ui.slider.TwoDSliderTest', (success, failure) 
       Keyboard.sKeydown(doc, Keys.down(), {}),
       sAssertValue('Checking that the thumb is now one step further right', { x: 49, y: 70 })
     ];
-  }, () => { success(); }, (err, logs) => {
+  }, success, (err, logs) => {
     failure(err, logs);
   });
 });

--- a/modules/alloy/src/test/ts/browser/ui/slider/VerticalSliderTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/slider/VerticalSliderTest.ts
@@ -14,7 +14,9 @@ UnitTest.asynctest('Browser Test: ui.slider.VerticalSliderTest', (success, failu
 
   // Tests requiring 'flex' do not currently work on phantom. Use the remote  to see how it is
   // viewed as an invalid value.
-  if (PhantomSkipper.skip()) { return success(); }
+  if (PhantomSkipper.skip()) {
+    return success();
+  }
   GuiSetup.setup((_store, _doc, _body) => GuiFactory.build(
     Slider.sketch({
       dom: {
@@ -250,5 +252,5 @@ UnitTest.asynctest('Browser Test: ui.slider.VerticalSliderTest', (success, failu
       Keyboard.sKeydown(doc, Keys.down(), {}),
       sAssertValue('Checking that the thumb is now one step further bottom', 70)
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/slotcontainer/SlotContainerTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/slotcontainer/SlotContainerTest.ts
@@ -180,5 +180,5 @@ UnitTest.asynctest('SlotContainerTest', (success, failure) => {
       sAssertButtonSlotHidden('After SlotContainer.hideAllSlots(_)'),
       sAssertGetSlotNames('checking the list slots', [ 'inputA', 'buttonB' ])
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/tabs/TabSectionSelectFirstTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/tabs/TabSectionSelectFirstTest.ts
@@ -123,5 +123,5 @@ UnitTest.asynctest('TabSectionSelectFirst Test', (success, failure) => {
     })), component.element),
 
     GuiSetup.mRemoveStyles
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/tabs/TabSectionTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/tabs/TabSectionTest.ts
@@ -257,5 +257,5 @@ UnitTest.asynctest('TabSection Test', (success, failure) => {
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/toolbar/BasicToolbarTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/toolbar/BasicToolbarTest.ts
@@ -184,5 +184,5 @@ UnitTest.asynctest('BasicToolbarTest', (success, failure) => {
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/toolbar/MultipleToolbarTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/toolbar/MultipleToolbarTest.ts
@@ -129,5 +129,5 @@ UnitTest.asynctest('MultipleToolbarTest', (success, failure) => {
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/toolbar/SplitFloatingToolbarTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/toolbar/SplitFloatingToolbarTest.ts
@@ -15,7 +15,9 @@ import * as TestPartialToolbarGroup from 'ephox/alloy/test/toolbar/TestPartialTo
 UnitTest.asynctest('SplitFloatingToolbarTest', (success, failure) => {
   // Tests requiring 'flex' do not currently work on phantom. Use the remote to see how it is
   // viewed as an invalid value.
-  if (PhantomSkipper.skip()) { return success(); }
+  if (PhantomSkipper.skip()) {
+    return success();
+  }
 
   const sinkComp = Sinks.relativeSink();
 
@@ -223,5 +225,5 @@ UnitTest.asynctest('SplitFloatingToolbarTest', (success, failure) => {
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/toolbar/SplitSlidingToolbarTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/toolbar/SplitSlidingToolbarTest.ts
@@ -13,7 +13,9 @@ import * as TestPartialToolbarGroup from 'ephox/alloy/test/toolbar/TestPartialTo
 UnitTest.asynctest('SplitSlidingToolbarTest', (success, failure) => {
   // Tests requiring 'flex' do not currently work on phantom. Use the remote to see how it is
   // viewed as an invalid value.
-  if (PhantomSkipper.skip()) { return success(); }
+  if (PhantomSkipper.skip()) {
+    return success();
+  }
 
   GuiSetup.setup((store, _doc, _body) => {
     const pPrimary = SplitSlidingToolbar.parts.primary({
@@ -205,5 +207,5 @@ UnitTest.asynctest('SplitSlidingToolbarTest', (success, failure) => {
       // TODO: Add testing for sliding?
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/toolbar/ToolbarGroupTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/toolbar/ToolbarGroupTest.ts
@@ -94,5 +94,5 @@ UnitTest.asynctest('ToolbarGroupTest', (success, failure) => {
       Keyboard.sKeydown(doc, Keys.right(), { }),
       FocusTools.sTryOnSelector('Focus should move to B', doc, 'button:contains("B")')
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadNoReopeningTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadNoReopeningTest.ts
@@ -170,5 +170,5 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadNoReopeningTest', (succ
 
       GuiSetup.mRemoveStyles
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadTest.ts
@@ -246,5 +246,5 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadTest', (success, failur
       GuiSetup.mRemoveStyles
 
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/StepUtils.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/StepUtils.ts
@@ -12,7 +12,9 @@ const sAssertFailIs = <T>(label: string, expected: string, f: () => void): Step<
         Assertions.assertEq('Checking exist error match', expected, err.message);
       }
 
-      if (passed) { throw new Error('Expected error: ' + expected + ' was not thrown'); }
+      if (passed) {
+        throw new Error('Expected error: ' + expected + ' was not thrown');
+      }
     }),
     Guard.addLogging(label)
   );
@@ -28,7 +30,9 @@ const sAssertFailContains = <T>(label: string, expected: string, f: () => void):
         Assertions.assertEq('Checking err message contains: ' + expected, true, err.message.indexOf(expected) > -1);
       }
 
-      if (passed) { throw new Error('Expected error: ' + expected + ' was not thrown'); }
+      if (passed) {
+        throw new Error('Expected error: ' + expected + ' was not thrown');
+      }
     }),
     Guard.addLogging(label)
   );

--- a/modules/alloy/src/test/ts/webdriver/spec/ButtonSpaceTest.ts
+++ b/modules/alloy/src/test/ts/webdriver/spec/ButtonSpaceTest.ts
@@ -48,5 +48,5 @@ UnitTest.asynctest('ButtonSpaceTest (webdriver)', (success, failure) => {
     ]),
     Step.wait(400),
     store.sAssertEq('Clicked should only have fired once', [ 'clicked.fake' ])
-  ], () => { success(); }, failure);
+  ], success, failure);
 });

--- a/modules/alloy/src/test/ts/webdriver/spec/TypeaheadTriggerTest.ts
+++ b/modules/alloy/src/test/ts/webdriver/spec/TypeaheadTriggerTest.ts
@@ -114,5 +114,5 @@ UnitTest.asynctest('TypeaheadTriggerTest (webdriver)', (success, failure) => {
       // Focus should still be in the typeahead.
       steps.sAssertFocusOnTypeahead('Focus after <down>')
     ];
-  }, () => { success(); }, failure);
+  }, success, failure);
 });

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Query.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Query.ts
@@ -16,8 +16,12 @@ const comparePosition = (item: Gene, other: Gene): number => {
   const top = Up.top(item);
   const all = extract(top);
 
-  const itemIndex = Arr.findIndex(all, (x) => { return item.id === x; });
-  const otherIndex = Arr.findIndex(all, (x) => { return other.id === x; });
+  const itemIndex = Arr.findIndex(all, (x) => {
+    return item.id === x;
+  });
+  const otherIndex = Arr.findIndex(all, (x) => {
+    return other.id === x;
+  });
   return itemIndex.bind((iIndex) => {
     return otherIndex.map((oIndex): number => {
       if (iIndex < oIndex) {
@@ -32,7 +36,9 @@ const comparePosition = (item: Gene, other: Gene): number => {
 const prevSibling = (item: Gene): Optional<Gene> => {
   const parent = Properties.parent(item);
   const kin = parent.map(Properties.children).getOr([]);
-  const itemIndex = Arr.findIndex(kin, (x) => { return item.id === x.id; });
+  const itemIndex = Arr.findIndex(kin, (x) => {
+    return item.id === x.id;
+  });
   return itemIndex.bind((iIndex) => {
     return iIndex > 0 ? Optional.some(kin[iIndex - 1]) : Optional.none();
   });
@@ -41,7 +47,9 @@ const prevSibling = (item: Gene): Optional<Gene> => {
 const nextSibling = (item: Gene): Optional<Gene> => {
   const parent = Properties.parent(item);
   const kin = parent.map(Properties.children).getOr([]);
-  const itemIndex = Arr.findIndex(kin, (x) => { return item.id === x.id; });
+  const itemIndex = Arr.findIndex(kin, (x) => {
+    return item.id === x.id;
+  });
   return itemIndex.bind((iIndex) => {
     return iIndex < kin.length - 1 ? Optional.some(kin[iIndex + 1]) : Optional.none();
   });

--- a/modules/boulder/src/main/ts/ephox/boulder/core/ObjChanger.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/ObjChanger.ts
@@ -4,7 +4,9 @@ const narrow = <T extends Record<string, any>, F extends Array<keyof T>>(obj: T,
   const r = { } as Pick<T, F[number]>;
   Arr.each(fields, (field) => {
     // TODO: Investigate if the undefined check is relied upon by something
-    if (obj[field] !== undefined && Obj.has(obj, field)) { r[field] = obj[field]; }
+    if (obj[field] !== undefined && Obj.has(obj, field)) {
+      r[field] = obj[field];
+    }
   });
 
   return r;

--- a/modules/boulder/src/main/ts/ephox/boulder/core/SchemaError.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/SchemaError.ts
@@ -39,7 +39,9 @@ const unsupportedFields = <T>(path: string[], unsupported: string[]): SimpleResu
 };
 
 const custom = <T>(path: string[], err: string): SimpleResult<SchemaError[], T> => {
-  return nu(path, () => { return err; });
+  return nu(path, () => {
+    return err;
+  });
 };
 
 const toString = (error: SchemaError): string => {

--- a/modules/boulder/src/test/ts/atomic/api/FieldSchemaTest.ts
+++ b/modules/boulder/src/test/ts/atomic/api/FieldSchemaTest.ts
@@ -12,7 +12,9 @@ UnitTest.test('Atomic Test: api.FieldSchemaTest', () => {
     ]);
 
     ValueSchema.asRaw('spec', schema, input).fold(
-      (err) => { throw err; },
+      (err) => {
+        throw err;
+      },
       (value) => Assert.eq(label, expected, value)
     );
   };

--- a/modules/boulder/src/test/ts/atomic/api/ValueSchemaFuncTest.ts
+++ b/modules/boulder/src/test/ts/atomic/api/ValueSchemaFuncTest.ts
@@ -29,7 +29,9 @@ UnitTest.test('Atomic Test: api.ValueSchemaFuncTest', () => {
         Assert.eq(label + '. Was looking to see if contained: ' + expectedPart + '.\nWas: ' + message, true, message.indexOf(expectedPart) > -1);
       }
 
-      if (passed !== null) { assert.fail(label + '\nExpected error: ' + expectedPart + '\nWas success(' + JSON.stringify(passed, null, 2) + ')'); }
+      if (passed !== null) {
+        assert.fail(label + '\nExpected error: ' + expectedPart + '\nWas success(' + JSON.stringify(passed, null, 2) + ')');
+      }
     });
   };
 

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
@@ -28,7 +28,9 @@ const findSpot = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, di
 };
 
 const scan = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, element: SugarElement, offset: number, direction: KeyDirection, numRetries: number): Optional<Situs> => {
-  if (numRetries === 0) { return Optional.none(); }
+  if (numRetries === 0) {
+    return Optional.none();
+  }
   // Firstly, move the (x, y) and see what element we end up on.
   return tryCursor(bridge, isRoot, element, offset, direction).bind((situs) => {
     const range = bridge.fromSitus(situs);

--- a/modules/imagetools/src/main/ts/ephox/imagetools/util/Conversions.ts
+++ b/modules/imagetools/src/main/ts/ephox/imagetools/util/Conversions.ts
@@ -84,7 +84,9 @@ const dataUriToBlobSync = (uri: string): Optional<Blob> => {
   const data = uri.split(',');
 
   const matches = /data:([^;]+)/.exec(data[0]);
-  if (!matches) { return Optional.none(); }
+  if (!matches) {
+    return Optional.none();
+  }
 
   const mimetype = matches[1];
   const base64 = data[1];

--- a/modules/imagetools/src/main/ts/ephox/imagetools/util/Promise.ts
+++ b/modules/imagetools/src/main/ts/ephox/imagetools/util/Promise.ts
@@ -107,7 +107,9 @@ const promise = <T>(): PromisePolyfillConstructor => {
       this._state = true;
       this._value = newValue;
       finale.call(this);
-    } catch (e) { reject.call(this, e); }
+    } catch (e) {
+      reject.call(this, e);
+    }
   }
 
   function reject(this: PromisePolyfill<T>, newValue: any) {
@@ -200,7 +202,9 @@ const promise = <T>(): PromisePolyfillConstructor => {
           if (val && (typeof val === 'object' || typeof val === 'function')) {
             const then = val.then;
             if (typeof then === 'function') {
-              then.call(val, (val: any) => { res(i, val); }, reject);
+              then.call(val, (val: any) => {
+                res(i, val);
+              }, reject);
               return;
             }
           }

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Results.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Results.ts
@@ -38,8 +38,12 @@ export const partition = <T, E>(results: Result<T, E>[]): { values: T[]; errors:
 
   Arr.each(results, (result: Result<T, E>) => {
     result.fold(
-      (err) => { errors.push(err); },
-      (value) => { values.push(value); }
+      (err) => {
+        errors.push(err);
+      },
+      (value) => {
+        values.push(value);
+      }
     );
   });
 

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
@@ -29,7 +29,9 @@ UnitTest.test('Arr.find: Unit tests', () => {
   };
 
   checkNone([], (x) => x > 0);
-  checkNone([], (_x) => { throw new Error('should not be called'); });
+  checkNone([], (_x) => {
+    throw new Error('should not be called');
+  });
   checkNone([ -1 ], (x) => x > 0);
   checkArr(1, [ 1 ], (x) => x > 0);
   checkArr(41, [ 4, 2, 10, 41, 3 ], (x) => x === 41);

--- a/modules/katamari/src/test/ts/atomic/api/arr/ContainsTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ContainsTest.ts
@@ -18,7 +18,9 @@ UnitTest.test('Arr.contains: unit test', () => {
 });
 
 UnitTest.test('Arr.contains: empty', () => {
-  Assert.eq('empty', false, Arr.contains([], () => { throw new Error('⊥'); }));
+  Assert.eq('empty', false, Arr.contains([], () => {
+    throw new Error('⊥');
+  }));
 });
 
 UnitTest.test('Arr.contains: array contains element', () => {

--- a/modules/katamari/src/test/ts/atomic/api/arr/ExistsTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ExistsTest.ts
@@ -6,7 +6,9 @@ import * as Fun from 'ephox/katamari/api/Fun';
 const eqc = (x) => (a) => x === a;
 const never = Fun.never;
 const always = Fun.always;
-const bottom = () => { throw new Error('error'); };
+const bottom = () => {
+  throw new Error('error');
+};
 
 UnitTest.test('Arr.exists: unit test', () => {
   const check = (expected, input: any[], f) => {

--- a/modules/katamari/src/test/ts/atomic/api/arr/ForallTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ForallTest.ts
@@ -20,7 +20,9 @@ UnitTest.test('Arr.forall: unit tests', () => {
 });
 
 UnitTest.test('forall of an empty array is true', () => {
-  Assert.eq('forall empty array', true, Arr.forall([], () => { throw new Error('⊥'); }));
+  Assert.eq('forall empty array', true, Arr.forall([], () => {
+    throw new Error('⊥');
+  }));
 });
 
 UnitTest.test('forall of a non-empty array with a predicate that always returns false is false', () => {

--- a/modules/katamari/src/test/ts/atomic/api/obj/ObjFindTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/obj/ObjFindTest.ts
@@ -15,14 +15,26 @@ UnitTest.test('ObjFindTest', () => {
     Assert.eq('eq', expected, actual);
   };
 
-  checkNone({}, (v, _k) => { return v > 0; });
-  checkObj(3, { test: 3 }, (_v, k) => { return k === 'test'; });
-  checkNone({ test: 0 }, (v, _k) => { return v > 0; });
-  checkObj(4, { blah: 4, test: 3 }, (v, _k) => { return v > 0; });
-  checkNone({ blah: 4, test: 3 }, (v, _k) => { return v === 12; });
+  checkNone({}, (v, _k) => {
+    return v > 0;
+  });
+  checkObj(3, { test: 3 }, (_v, k) => {
+    return k === 'test';
+  });
+  checkNone({ test: 0 }, (v, _k) => {
+    return v > 0;
+  });
+  checkObj(4, { blah: 4, test: 3 }, (v, _k) => {
+    return v > 0;
+  });
+  checkNone({ blah: 4, test: 3 }, (v, _k) => {
+    return v === 12;
+  });
 
   const obj = { blah: 4, test: 3 };
-  checkObj(4, obj, (v, k, o) => { return o === obj; });
+  checkObj(4, obj, (v, k, o) => {
+    return o === obj;
+  });
 });
 
 UnitTest.test('the value found by find always passes predicate', () => {

--- a/modules/katamari/src/test/ts/module/ephox/katamari/test/AsyncProps.ts
+++ b/modules/katamari/src/test/ts/module/ephox/katamari/test/AsyncProps.ts
@@ -24,9 +24,7 @@ type Testable<A> = Testable.Testable<A>;
  */
 export const promiseTest = <A>(name: string, f: () => Promise<A>): void => {
   UnitTest.asynctest(name, (success, failure) => {
-    f().then(() => {
-      success();
-    }, failure);
+    f().then(success, failure);
   });
 };
 

--- a/modules/mcagar/src/test/ts/browser/api/ActionsTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/ActionsTest.ts
@@ -61,7 +61,5 @@ UnitTest.asynctest('ActionTest', (success, failure) => {
   Pipeline.async({}, [
     sResetCount,
     sTestStep
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/mcagar/src/test/ts/browser/api/EditorTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/EditorTest.ts
@@ -15,7 +15,5 @@ UnitTest.asynctest('EditorTest', (success, failure) => {
       cAssertEditorExists,
       Editor.cRemove
     ])
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/mcagar/src/test/ts/browser/api/SelectionTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/SelectionTest.ts
@@ -39,7 +39,5 @@ UnitTest.asynctest('SelectionTest', (success, failure) => {
 
   Pipeline.async({}, [
     sTestStep
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/phoenix/src/main/ts/ephox/phoenix/extract/Extract.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/extract/Extract.ts
@@ -42,7 +42,9 @@ const typed = <E, D>(universe: Universe<E, D>, item: E, optimise?: (e: E) => boo
 const items = <E, D>(universe: Universe<E, D>, item: E, optimise?: (e: E) => boolean): E[] => {
   const typedItemList = typed(universe, item, optimise);
 
-  const raw = (item: E, _universe: Universe<E, D>) => { return item; };
+  const raw = (item: E, _universe: Universe<E, D>) => {
+    return item;
+  };
 
   return Arr.map(typedItemList, (typedItem: TypedItem<E, D>) => {
     return typedItem.fold(raw, raw, raw, raw);

--- a/modules/phoenix/src/main/ts/ephox/phoenix/extract/TypedList.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/extract/TypedList.ts
@@ -33,7 +33,9 @@ const empty = Fun.constant([]);
 
 const justText = <E, D>(parray: TypedItem<E, D>[]): E[] => {
   return Arr.bind(parray, (x): E[] => {
-    return x.fold(empty, empty, (i) => { return [ i ]; }, empty);
+    return x.fold(empty, empty, (i) => {
+      return [ i ];
+    }, empty);
   });
 };
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/family/Group.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/family/Group.ts
@@ -23,7 +23,9 @@ const group = <E, D>(universe: Universe<E, D>, items: E[], optimise?: (e: E) => 
     });
   });
 
-  return Arr.filter(segments, (x) => { return x.length > 0; });
+  return Arr.filter(segments, (x) => {
+    return x.length > 0;
+  });
 };
 
 export {

--- a/modules/phoenix/src/main/ts/ephox/phoenix/search/MatchSplitter.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/search/MatchSplitter.ts
@@ -23,7 +23,9 @@ const separate = <E, D, M extends PRange & { word: string }>(universe: Universe<
   const collate = (match: M): SearchResult<E> => {
     const sub = PositionArray.sublist(structure, match.start, match.finish);
 
-    const elements = Arr.map(sub, (unit) => { return unit.element; });
+    const elements = Arr.map(sub, (unit) => {
+      return unit.element;
+    });
 
     const exact = Arr.map(elements, universe.property().getText).join('');
     return {

--- a/modules/phoenix/src/main/ts/ephox/phoenix/search/Splitter.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/search/Splitter.ts
@@ -26,7 +26,9 @@ const subdivide = <E, D>(universe: Universe<E, D>, item: E, positions: number[])
     return Optional.some(result);
   }, pieces[0].length);
 
-  const otherElements = Arr.map(others, (a) => { return a.element; });
+  const otherElements = Arr.map(others, (a) => {
+    return a.element;
+  });
   universe.insert().afterAll(item, otherElements);
 
   return [ Spot.range(item, 0, pieces[0].length) ].concat(others);

--- a/modules/phoenix/src/main/ts/ephox/phoenix/split/Split.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/split/Split.ts
@@ -58,7 +58,9 @@ const splitByPair = <E, D>(universe: Universe<E, D>, item: E, start: number, end
   universe.property().setText(item, parts[0]);
 
   // Create new text nodes for the split text sections
-  const newText = Arr.map(parts.slice(1), (text) => { return universe.create().text(text); });
+  const newText = Arr.map(parts.slice(1), (text) => {
+    return universe.create().text(text);
+  });
   const middle = newText[0];
 
   // Append new items

--- a/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Navigation.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Navigation.ts
@@ -53,20 +53,26 @@ const scan = <E, D>(universe: Universe<E, D>, element: E, direction: (e: E) => O
 
 const freefallLtr = <E, D>(universe: Universe<E, D>, element: E): SpotPoint<E> => {
   const candidate = scan(universe, element, universe.query().nextSibling).getOr(element);
-  if (universe.property().isText(candidate)) { return Spot.point(candidate, 0); }
+  if (universe.property().isText(candidate)) {
+    return Spot.point(candidate, 0);
+  }
   const children = universe.property().children(candidate);
   return children.length > 0 ? freefallLtr(universe, children[0]) : Spot.point(candidate, 0);
 };
 
 const toEnd = <E, D>(universe: Universe<E, D>, element: E): number => {
-  if (universe.property().isText(element)) { return universe.property().getText(element).length; }
+  if (universe.property().isText(element)) {
+    return universe.property().getText(element).length;
+  }
   const children = universe.property().children(element);
   return children.length;
 };
 
 const freefallRtl = <E, D>(universe: Universe<E, D>, element: E): SpotPoint<E> => {
   const candidate = scan(universe, element, universe.query().prevSibling).getOr(element);
-  if (universe.property().isText(candidate)) { return Spot.point(candidate, toEnd(universe, candidate)); }
+  if (universe.property().isText(candidate)) {
+    return Spot.point(candidate, toEnd(universe, candidate));
+  }
   const children = universe.property().children(candidate);
   return children.length > 0 ? freefallRtl(universe, children[children.length - 1]) : Spot.point(candidate, toEnd(universe, candidate));
 };

--- a/modules/phoenix/src/test/ts/atomic/api/family/RangeTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/family/RangeTest.ts
@@ -41,7 +41,9 @@ UnitTest.test('RangeTest', () => {
     const start = Finder.get(doc, startId);
     const finish = Finder.get(doc, finishId);
     const actual = Family.range(doc, start, delta1, finish, delta2);
-    assert.eq(expected, Arr.map(actual, (x) => { return x.id; }));
+    assert.eq(expected, Arr.map(actual, (x) => {
+      return x.id;
+    }));
   };
 
   check([ 'a' ], 'a', 'a', 0, 0); // This doesn't check that it is a text node. Is that a problem?

--- a/modules/polaris/src/main/ts/ephox/polaris/array/Split.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/array/Split.ts
@@ -23,17 +23,23 @@ const splitbyAdv = <T>(xs: T[], pred: (x: T) => Splitting<T>): T[][] => {
       part.push(x);
     }, () => {
       // Stop the current sublist, create a new sublist containing just x, and then start the next sublist.
-      if (part.length > 0) { r.push(part); }
+      if (part.length > 0) {
+        r.push(part);
+      }
       r.push([ x ]);
       part = [];
     }, () => {
       // Stop the current sublist, and start the next sublist.
-      if (part.length > 0) { r.push(part); }
+      if (part.length > 0) {
+        r.push(part);
+      }
       part = [];
     });
   });
 
-  if (part.length > 0) { r.push(part); }
+  if (part.length > 0) {
+    r.push(part);
+  }
   return r;
 };
 

--- a/modules/polaris/src/main/ts/ephox/polaris/parray/Split.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/parray/Split.ts
@@ -15,7 +15,9 @@ const divide = <T extends PRange>(unit: T, positions: number[], subdivide: (unit
  * Adds extra split points into a PositionArray, using subdivide to split if necessary
  */
 const splits = <T extends PRange>(parray: T[], positions: number[], subdivide: (unit: T, positions: number[]) => T[]): T[] => {
-  if (positions.length === 0) { return parray; }
+  if (positions.length === 0) {
+    return parray;
+  }
 
   return Arr.bind(parray, (unit) => {
     const relevant = Arr.bind(positions, (pos) => {

--- a/modules/polaris/src/main/ts/ephox/polaris/string/Split.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/string/Split.ts
@@ -4,10 +4,14 @@ import { Arr } from '@ephox/katamari';
  * Splits a string into multiple chunks
  */
 const splits = (value: string, indices: number[]): string[] => {
-  if (indices.length === 0) { return [ value ]; }
+  if (indices.length === 0) {
+    return [ value ];
+  }
 
   const divisions = Arr.foldl(indices, (acc, x) => {
-    if (x === 0) { return acc; }
+    if (x === 0) {
+      return acc;
+    }
 
     const part = value.substring(acc.prev, x);
     return {

--- a/modules/polaris/src/test/ts/atomic/api/ParrayGenerateTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/ParrayGenerateTest.ts
@@ -6,7 +6,9 @@ import { PArrayTestItem } from '../../module/ephox/polaris/test/Parrays';
 UnitTest.test('api.PositionArray.generate', () => {
   const generator = (item: string, start: number): Optional<PArrayTestItem> => {
     const firstletter = item[0];
-    if (firstletter === 'a') { return Optional.none(); }
+    if (firstletter === 'a') {
+      return Optional.none();
+    }
     return Optional.some({
       start,
       finish: start + item.length,

--- a/modules/porkbun/src/test/ts/atomic/EventsTest.ts
+++ b/modules/porkbun/src/test/ts/atomic/EventsTest.ts
@@ -56,7 +56,9 @@ UnitTest.test('Events', () => {
     });
 
     assert.throwsError(
-      () => { events.registry.emptyEvent.bind(undefined as any); },
+      () => {
+        events.registry.emptyEvent.bind(undefined as any);
+      },
       'Event bind error: undefined handler'
     );
   })();

--- a/modules/robin/src/main/ts/ephox/robin/api/general/TextSearch.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/TextSearch.ts
@@ -82,7 +82,9 @@ const expandRight = <E, D>(universe: Universe<E, D>, item: E, offset: number, ra
 // have been fragmented.
 const scanRight = <E, D>(universe: Universe<E, D>, item: E, originalOffset: number): Optional<SpotPoint<E>> => {
   const isRoot = Fun.never;
-  if (!universe.property().isText(item)) { return Optional.none(); }
+  if (!universe.property().isText(item)) {
+    return Optional.none();
+  }
   const text = universe.property().getText(item);
   if (originalOffset <= text.length) {
     return Optional.some(Spot.point(item, originalOffset));

--- a/modules/robin/src/test/ts/atomic/leftblock/LeftBlockTest.ts
+++ b/modules/robin/src/test/ts/atomic/leftblock/LeftBlockTest.ts
@@ -19,7 +19,9 @@ UnitTest.test('LeftBlockTest', () => {
 
   const check = (expected: string[], id: string, method: (u: TestUniverse, i: Gene) => Gene[]) => {
     const actual = method(universe, universe.find(universe.get(), id).getOrDie());
-    assert.eq(expected, Arr.map(actual, (x) => { return x.id; }));
+    assert.eq(expected, Arr.map(actual, (x) => {
+      return x.id;
+    }));
   };
 
   check([ 's1-text', 's2-text', 't3' ], 't3', LeftBlock.all);

--- a/modules/robin/src/test/ts/atomic/pathway/SimplifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/pathway/SimplifyTest.ts
@@ -41,7 +41,9 @@ UnitTest.test('SimplifyTest', () => {
     });
 
     const actual = Simplify.simplify(doc, path);
-    assert.eq(expected, Arr.map(actual, (s) => { return s.id; }));
+    assert.eq(expected, Arr.map(actual, (s) => {
+      return s.id;
+    }));
   };
 
   check([], []);

--- a/modules/robin/src/test/ts/atomic/words/ClusteringTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/ClusteringTest.ts
@@ -186,7 +186,9 @@ UnitTest.test('ClusteringTest', () => {
 
   const checkProps = (universe: TestUniverse, textIds: string[], start: Gene, actual: ClusteringLangs) => {
     const checkGroup = (label: string, group: WordDecisionItem<Gene>[]) => {
-      const items = Arr.map(group, (g) => { return g.item; });
+      const items = Arr.map(group, (g) => {
+        return g.item;
+      });
       Arr.each(items, (x) => {
         Assert.eq('Checking everything in ' + label + ' has same language', LanguageZones.calculate(universe, x).getOr('none'), actual.lang.getOr('none'));
         Assert.eq(

--- a/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
@@ -19,7 +19,9 @@ UnitTest.test('words :: Identify', () => {
 
   const checkWords = (expected: string[], input: string) => {
     const actual = Identify.words(input);
-    assert.eq(expected, Arr.map(actual, (a) => { return a.word; }));
+    assert.eq(expected, Arr.map(actual, (a) => {
+      return a.word;
+    }));
   };
 
   check([], '');

--- a/modules/robin/src/test/ts/atomic/words/WordDecisionTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/WordDecisionTest.ts
@@ -26,7 +26,9 @@ UnitTest.test('WordDecisionTest', () => {
   const check = (items: string[], abort: boolean, id: string, slicer: (text: string) => Optional<[number, number]>, _currLanguage: Optional<string>) => {
     const isCustomBoundary = Fun.never;
     const actual = WordDecision.decide(universe, universe.find(universe.get(), id).getOrDie(), slicer, isCustomBoundary);
-    assert.eq(items, Arr.map(actual.items, (item) => { return item.item.id; }));
+    assert.eq(items, Arr.map(actual.items, (item) => {
+      return item.item.id;
+    }));
     assert.eq(abort, actual.abort);
   };
 

--- a/modules/robin/src/test/ts/module/ephox/robin/test/Arbitraries.ts
+++ b/modules/robin/src/test/ts/module/ephox/robin/test/Arbitraries.ts
@@ -21,7 +21,9 @@ export interface ArbRangeIds {
 }
 
 const getIds = (item: Gene, predicate: (g: Gene) => boolean): string[] => {
-  const rest = Arr.bind(item.children || [], (id) => { return getIds(id, predicate); });
+  const rest = Arr.bind(item.children || [], (id) => {
+    return getIds(id, predicate);
+  });
   const self = predicate(item) && item.id !== 'root' ? [ item.id ] : [];
   return self.concat(rest);
 };

--- a/modules/snooker/src/demo/ts/ephox/snooker/demo/DetectDemo.ts
+++ b/modules/snooker/src/demo/ts/ephox/snooker/demo/DetectDemo.ts
@@ -200,8 +200,12 @@ Ready.execute(() => {
   const newCell: Generators['cell'] = (prev) => {
     const td = SugarElement.fromTag('td');
     Insert.append(td, SugarElement.fromText('?'));
-    if (prev.colspan === 1) { Css.set(td, 'width', Css.get(prev.element, 'width')); }
-    if (prev.rowspan === 1) { Css.set(td, 'height', Css.get(prev.element, 'height')); }
+    if (prev.colspan === 1) {
+      Css.set(td, 'width', Css.get(prev.element, 'width'));
+    }
+    if (prev.rowspan === 1) {
+      Css.set(td, 'height', Css.get(prev.element, 'height'));
+    }
     return td;
   };
 
@@ -218,7 +222,9 @@ Ready.execute(() => {
   const replace: Generators['replace'] = (cell, tag, attrs) => {
     const replica = Replication.copy(cell, tag);
     Obj.each(attrs, (v, k) => {
-      if (v !== null) { Attribute.set(replica, k, v); }
+      if (v !== null) {
+        Attribute.set(replica, k, v);
+      }
     });
     return replica;
   };

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Warehouse.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Warehouse.ts
@@ -28,7 +28,9 @@ const findItem = <T> (warehouse: Warehouse, item: T, comparator: (a: T, b: Sugar
 };
 
 const filterItems = (warehouse: Warehouse, predicate: (x: Structs.DetailExt, i: number) => boolean): Structs.DetailExt[] => {
-  const all = Arr.bind(warehouse.all, (r) => { return r.cells; });
+  const all = Arr.bind(warehouse.all, (r) => {
+    return r.cells;
+  });
   return Arr.filter(all, predicate);
 };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/Render.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/Render.ts
@@ -29,8 +29,12 @@ const createRow = (columns: number, rowHeaders: number, columnHeaders: number, r
   for (let j = 0; j < columns; j++) {
 
     const td = rowIndex < rowHeaders || j < columnHeaders ? tableHeaderCell() : tableCell();
-    if (j < columnHeaders) { Attribute.set(td, 'scope', 'row'); }
-    if (rowIndex < rowHeaders) { Attribute.set(td, 'scope', 'col'); }
+    if (j < columnHeaders) {
+      Attribute.set(td, 'scope', 'row');
+    }
+    if (rowIndex < rowHeaders) {
+      Attribute.set(td, 'scope', 'col');
+    }
 
     // Note, this is a placeholder so that the cells have height. The unicode character didn't work in IE10.
     Insert.append(td, SugarElement.fromTag('br'));

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
@@ -57,7 +57,9 @@ const getBottomEdge = (index: number, cell: SugarElement): RowInfo => {
 };
 
 const findPositions = <T> (getInnerEdge: (idx: number, ele: SugarElement) => T, getOuterEdge: (idx: number, ele: SugarElement) => T, array: Optional<SugarElement>[]): Optional<T>[] => {
-  if (array.length === 0 ) { return []; }
+  if (array.length === 0 ) {
+    return [];
+  }
   const lines = Arr.map(array.slice(1), (cellOption, index) => {
     return cellOption.map((cell) => {
       return getInnerEdge(index, cell);

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
@@ -67,7 +67,9 @@ const getWidthFrom = <T>(warehouse: Warehouse, table: SugarElement<HTMLTableElem
 };
 
 const getDeduced = (deduced: Optional<number>): string => {
-  return deduced.map((d) => { return d + 'px'; }).getOr('');
+  return deduced.map((d) => {
+    return d + 'px';
+  }).getOr('');
 };
 
 const getRawWidths = (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, tableSize: TableSize): string[] => {

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Redistribution.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Redistribution.ts
@@ -58,7 +58,9 @@ const redistributeValues = (newWidthType: Size, widths: string[], totalWidth: nu
 
 const redistribute = (widths: string[], totalWidth: number, newWidth: string): string[] => {
   const newType = Size.from(newWidth);
-  const floats = Arr.forall(widths, (s) => { return s === '0px'; }) ? redistributeEmpty(newType, widths.length) : redistributeValues(newType, widths, totalWidth);
+  const floats = Arr.forall(widths, (s) => {
+    return s === '0px';
+  }) ? redistributeEmpty(newType, widths.length) : redistributeValues(newType, widths, totalWidth);
   return normalize(floats);
 };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/selection/CellFinder.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/selection/CellFinder.ts
@@ -9,7 +9,9 @@ const moveBy = (warehouse: Warehouse, cell: SugarElement, row: number, column: n
     const startRow = row > 0 ? detail.row + detail.rowspan - 1 : detail.row;
     const startCol = column > 0 ? detail.column + detail.colspan - 1 : detail.column;
     const dest = Warehouse.getAt(warehouse, startRow + row, startCol + column);
-    return dest.map((d) => { return d.element; });
+    return dest.map((d) => {
+      return d.element;
+    });
   });
 };
 

--- a/modules/snooker/src/test/ts/atomic/lookup/BlocksTest.ts
+++ b/modules/snooker/src/test/ts/atomic/lookup/BlocksTest.ts
@@ -14,5 +14,7 @@ UnitTest.test('BlocksTest', () => {
     f('r3', [ s('h', 1, 1), s('i', 1, 2) ], 'tfoot')
   ]);
 
-  assert.eq([ 'a', 'd', 'e' ], Blocks.columns(warehouse).map((c) => { return c.getOrDie(); }));
+  assert.eq([ 'a', 'd', 'e' ], Blocks.columns(warehouse).map((c) => {
+    return c.getOrDie();
+  }));
 });

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElement.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElement.ts
@@ -33,7 +33,9 @@ const fromText = (text: string, scope?: Document | null): SugarElement<Text> => 
 
 const fromDom = <T extends Node | Window> (node: T): SugarElement<T> => {
   // TODO: Consider removing this check, but left atm for safety
-  if (node === null || node === undefined) { throw new Error('Node cannot be null or undefined'); }
+  if (node === null || node === undefined) {
+    throw new Error('Node cannot be null or undefined');
+  }
   return {
     dom: node
   };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attribute.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attribute.ts
@@ -69,7 +69,9 @@ const transferOne = (source: SugarElement<Element>, destination: SugarElement<El
 
 // Transfer attributes(attrs) from source to destination, unless they are already present
 const transfer = (source: SugarElement<Element>, destination: SugarElement<Element>, attrs: string[]): void => {
-  if (!SugarNode.isElement(source) || !SugarNode.isElement(destination)) { return; }
+  if (!SugarNode.isElement(source) || !SugarNode.isElement(destination)) {
+    return;
+  }
   Arr.each(attrs, (attr) => {
     transferOne(source, destination, attr);
   });

--- a/modules/sugar/src/test/ts/browser/AttributeTransferTest.ts
+++ b/modules/sugar/src/test/ts/browser/AttributeTransferTest.ts
@@ -41,7 +41,9 @@ UnitTest.test('AttributeTransfer', () => {
 
     Obj.each(expectedPresent, (v, k) => {
       if (!Attribute.has(destination, k)) {
-        assert.fail('Result should have attribute: ' + k); } else { assert.eq(v, Attribute.get(destination, k));
+        assert.fail('Result should have attribute: ' + k);
+      } else {
+        assert.eq(v, Attribute.get(destination, k));
       }
     });
   };

--- a/modules/sugar/src/test/ts/browser/ReadyTest.ts
+++ b/modules/sugar/src/test/ts/browser/ReadyTest.ts
@@ -5,6 +5,8 @@ UnitTest.test('ReadyTest', () => {
   // This isn't really a test. By definition, tests are run after document load.
   // We can't easily test the actual Ready event, but we can verify it works after document load
   let called = 0;
-  Ready.execute(() => { called++; });
+  Ready.execute(() => {
+    called++;
+  });
   assert.eq(1, called);
 });

--- a/modules/sugar/src/test/ts/browser/RemoveTest.ts
+++ b/modules/sugar/src/test/ts/browser/RemoveTest.ts
@@ -29,7 +29,9 @@ UnitTest.test('RemoveTest', () => {
     Insert.append(container, p2);
     Insert.append(p, span);
 
-    if (connected) { Insert.append(SugarBody.body(), container); }
+    if (connected) {
+      Insert.append(SugarBody.body(), container);
+    }
 
     assert.eq('<p><span></span></p><p></p>', Html.get(container));
     Remove.remove(p2);

--- a/modules/sugar/src/test/ts/browser/SelectionTest.ts
+++ b/modules/sugar/src/test/ts/browser/SelectionTest.ts
@@ -50,7 +50,11 @@ UnitTest.test('Browser Test: SelectionTest', () => {
   assertSelection('(p1text, 1) -> (p2text, 2)', p1text, 1, p2text, 1);
 
   setSelection(p2text, 2, p1text, 3);
-  if (!PlatformDetection.detect().browser.isIE()) { assertSelection('(p2text, 2) -> (p1text, 3)', p2text, 2, p1text, 3); } else { assertSelection('reversed (p1text, 3) -> (p2text, 2)', p1text, 3, p2text, 2); }
+  if (!PlatformDetection.detect().browser.isIE()) {
+    assertSelection('(p2text, 2) -> (p1text, 3)', p2text, 2, p1text, 3);
+  } else {
+    assertSelection('reversed (p1text, 3) -> (p2text, 2)', p1text, 3, p2text, 2);
+  }
 
   const assertFragmentHtml = (expected: string, fragment: SugarElement<Node>) => {
     const div = SugarElement.fromTag('div');

--- a/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
@@ -1068,7 +1068,9 @@ Expr = Sizzle.selectors = {
     TAG(nodeNameSelector) {
       const nodeName = nodeNameSelector.replace(runescape, funescape).toLowerCase();
       return nodeNameSelector === '*' ?
-        function () { return true; } :
+        function () {
+          return true;
+        } :
         function (elem) {
           return elem.nodeName && elem.nodeName.toLowerCase() === nodeName;
         };

--- a/modules/tinymce/src/core/main/ts/api/util/Promise.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Promise.ts
@@ -27,8 +27,12 @@ const promise = function () {
   const isArray = Array.isArray || ((value) => Object.prototype.toString.call(value) === '[object Array]');
 
   const Promise: any = function (fn) {
-    if (typeof this !== 'object') { throw new TypeError('Promises must be constructed via new'); }
-    if (typeof fn !== 'function') { throw new TypeError('not a function'); }
+    if (typeof this !== 'object') {
+      throw new TypeError('Promises must be constructed via new');
+    }
+    if (typeof fn !== 'function') {
+      throw new TypeError('not a function');
+    }
     this._state = null;
     this._value = null;
     this._deferreds = [];
@@ -65,7 +69,9 @@ const promise = function () {
 
   function resolve(newValue) {
     try { // Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure
-      if (newValue === this) { throw new TypeError('A promise cannot be resolved with itself.'); }
+      if (newValue === this) {
+        throw new TypeError('A promise cannot be resolved with itself.');
+      }
       if (newValue && (typeof newValue === 'object' || typeof newValue === 'function')) {
         const then = newValue.then;
         if (typeof then === 'function') {
@@ -76,7 +82,9 @@ const promise = function () {
       this._state = true;
       this._value = newValue;
       finale.call(this);
-    } catch (e) { reject.call(this, e); }
+    } catch (e) {
+      reject.call(this, e);
+    }
   }
 
   function reject(newValue) {
@@ -109,16 +117,22 @@ const promise = function () {
     let done = false;
     try {
       fn((value) => {
-        if (done) { return; }
+        if (done) {
+          return;
+        }
         done = true;
         onFulfilled(value);
       }, (reason) => {
-        if (done) { return; }
+        if (done) {
+          return;
+        }
         done = true;
         onRejected(reason);
       });
     } catch (ex) {
-      if (done) { return; }
+      if (done) {
+        return;
+      }
       done = true;
       onRejected(ex);
     }
@@ -139,14 +153,18 @@ const promise = function () {
     const args = Array.prototype.slice.call(values.length === 1 && isArray(values[0]) ? values[0] : values);
 
     return new Promise((resolve, reject) => {
-      if (args.length === 0) { return resolve([]); }
+      if (args.length === 0) {
+        return resolve([]);
+      }
       let remaining = args.length;
       const res = (i, val) => {
         try {
           if (val && (typeof val === 'object' || typeof val === 'function')) {
             const then = val.then;
             if (typeof then === 'function') {
-              then.call(val, (val) => { res(i, val); }, reject);
+              then.call(val, (val) => {
+                res(i, val);
+              }, reject);
               return;
             }
           }

--- a/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
+++ b/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
@@ -36,7 +36,9 @@ const normalizeSelection = (editor: Editor, rng: Range): void => {
   getFocusInElement(SugarElement.fromDom(editor.getBody()), rng).bind((elm) => {
     return CaretFinder.firstPositionIn(elm.dom);
   }).fold(
-    () => { editor.selection.normalize(); return; },
+    () => {
+      editor.selection.normalize(); return;
+    },
     (caretPos: CaretPosition) => editor.selection.setRng(caretPos.toRange())
   );
 };

--- a/modules/tinymce/src/core/main/ts/mode/Readonly.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Readonly.ts
@@ -114,7 +114,9 @@ const registerReadOnlyContentFilters = (editor: Editor) => {
   if (editor.serializer) {
     registerFilters(editor);
   } else {
-    editor.on('PreInit', () => { registerFilters(editor); });
+    editor.on('PreInit', () => {
+      registerFilters(editor);
+    });
   }
 };
 

--- a/modules/tinymce/src/core/test/ts/atomic/keyboard/MatchKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/keyboard/MatchKeysTest.ts
@@ -95,7 +95,5 @@ UnitTest.asynctest('atomic.tinymce.core.keyboard.MatchKeysTest', (success, failu
 
       Assertions.assertEq('Should return the parameters passed in', [ 1, 2, 3 ], action());
     }))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/atomic/text/BidiTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/text/BidiTest.ts
@@ -12,7 +12,5 @@ UnitTest.asynctest('atomic.tinymce.core.text.BidiTest', (success, failure) => {
 
   Pipeline.async({}, [
     sTestHasStrongRtl
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/atomic/text/ExtendingCharTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/text/ExtendingCharTest.ts
@@ -11,7 +11,5 @@ UnitTest.asynctest('atomic.tinymce.core.text.ExtendingCharTest', (success, failu
     LegacyUnit.strictEqual(ExtendingChar.isExtendingChar('\u0301'), true);
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/atomic/util/LazyEvaluatorTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/util/LazyEvaluatorTest.ts
@@ -26,7 +26,5 @@ UnitTest.asynctest('atomic.tinymce.core.util.LazyEvaluatorTest', (success, failu
 
   Pipeline.async({}, [
     sTestEvaluateUntil
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -44,7 +44,9 @@ UnitTest.asynctest('browser.tinymce.core.EditorRemoveTest', (success, failure) =
       cAssertTextareaDisplayStyle('none'),
       cRemoveEditor,
       cAssertTextareaDisplayStyle(''),
-      Chain.op((_editor) => { EditorManager.init({ selector: '#tinymce' }); }),
+      Chain.op((_editor) => {
+        EditorManager.init({ selector: '#tinymce' });
+      }),
       cAssertTextareaDisplayStyle(''),
       McEditor.cRemove
     ])),
@@ -54,7 +56,9 @@ UnitTest.asynctest('browser.tinymce.core.EditorRemoveTest', (success, failure) =
       cAssertTextareaDisplayStyle('none'),
       cRemoveEditor,
       cAssertTextareaDisplayStyle('none'),
-      Chain.op((_editor) => { EditorManager.init({ selector: '#tinymce' }); }),
+      Chain.op((_editor) => {
+        EditorManager.init({ selector: '#tinymce' });
+      }),
       cAssertTextareaDisplayStyle('none'),
       McEditor.cRemove
     ])),
@@ -64,11 +68,11 @@ UnitTest.asynctest('browser.tinymce.core.EditorRemoveTest', (success, failure) =
       cAssertTextareaDisplayStyle('none'),
       cRemoveEditor,
       cAssertTextareaDisplayStyle('block'),
-      Chain.op((_editor) => { EditorManager.init({ selector: '#tinymce' }); }),
+      Chain.op((_editor) => {
+        EditorManager.init({ selector: '#tinymce' });
+      }),
       cAssertTextareaDisplayStyle('block'),
       McEditor.cRemove
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/InlineEditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/InlineEditorRemoveTest.ts
@@ -33,7 +33,5 @@ UnitTest.asynctest('browser.tinymce.core.InlineEditorRemoveTest', (success, fail
       cAssertBogusNotExist,
       McEditor.cRemove
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/InlineEditorSaveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/InlineEditorSaveTest.ts
@@ -34,7 +34,5 @@ UnitTest.asynctest('browser.tinymce.core.InlineEditorSaveTest', (success, failur
       cAssertBogusExist,
       McEditor.cRemove
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
@@ -277,7 +277,9 @@ UnitTest.asynctest('browser.tinymce.core.annotate.AnnotationChangedTest', (succe
           } else {
             const { uid, nodes } = obj;
             // In this test, gamma markers span multiple nodes
-            if (name === 'gamma') { Assertions.assertEq('Gamma annotations must have 2 nodes', 2, nodes.length); }
+            if (name === 'gamma') {
+              Assertions.assertEq('Gamma annotations must have 2 nodes', 2, nodes.length);
+            }
             assertMarker(ed, { uid, name }, nodes);
           }
 

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
@@ -84,7 +84,5 @@ UnitTest.asynctest('browser.tinymce.core.content.EditorContentNotInitializedTest
       cGetAndAssertContent(new AstNode('body', 11), true),
       McEditor.cRemove
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentWsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentWsTest.ts
@@ -17,7 +17,5 @@ UnitTest.asynctest('browser.tinymce.core.content.EditorContentWsTest', (success,
       ApiChains.cAssertContent('  b  '),
       Editor.cRemove
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertListTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertListTest.ts
@@ -47,7 +47,5 @@ UnitTest.asynctest('browser.tinymce.core.content.InsertListTest', (success, fail
     LegacyUnit.equal(InsertList.trimListItems(InsertList.listItems(list)).length, 2);
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
@@ -101,7 +101,5 @@ UnitTest.asynctest('browser.tinymce.core.dom.ElementTypeTest', (success, failure
       sCheckElement('textarea', ElementType.isWsPreserveElement, true),
       sCheckText(ElementType.isWsPreserveElement)
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/EmptyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/EmptyTest.ts
@@ -46,7 +46,5 @@ UnitTest.asynctest('browser.tinymce.core.dom.EmptyTest', (success, failure) => {
       sTestEmpty('<span contenteditable="false"></span>', false),
       sTestEmpty('<a id="anchor"></a>', false)
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
@@ -481,7 +481,5 @@ UnitTest.asynctest('browser.tinymce.core.dom.EventUtilsTest', (success, failure)
 
   steps = [ sAddTestDiv ].concat(steps).concat(sRemoveTestDiv);
 
-  Pipeline.async({}, steps, () => {
-    success();
-  }, failure);
+  Pipeline.async({}, steps, success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/NodeTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/NodeTypeTest.ts
@@ -102,7 +102,5 @@ UnitTest.asynctest('browser.tinymce.core.dom.NodeTypeTest', (success, failure) =
     LegacyUnit.strictEqual(NodeType.isTable(null), false);
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/PaddingBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/PaddingBrTest.ts
@@ -56,7 +56,5 @@ UnitTest.asynctest('browser.tinymce.core.dom.PaddingBrTest', (success, failure) 
       sTestTrimBlockTrailingBr('Should be untouched since it is br after a inline', '<div><b>a</b><br></div>', '<div><b>a</b><br></div>'),
       sTestTrimBlockTrailingBr('Should be untouched since it is br after inlide inline', '<span><b>a</b><br></span>', '<span><b>a</b><br></span>')
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/ParentsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ParentsTest.ts
@@ -116,7 +116,5 @@ UnitTest.asynctest('browser.tinymce.core.dom.ParentsTest', (success, failure) =>
         cAssertElementNames([ '#text', 'u', 'i' ])
       ]))
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
@@ -50,7 +50,5 @@ UnitTest.asynctest('browser.tinymce.core.dom.TrimNodeTest', (success, failure) =
     sTestTrim('<pre><strong>x</strong>\n<em>y</em></pre>', '<pre><strong>x</strong>\n<em>y</em></pre>'),
     sTestTrimFragmentedTextNode,
     sTestTrimDocumentNode
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/file/ConversionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/file/ConversionsTest.ts
@@ -33,7 +33,5 @@ UnitTest.asynctest('browser.tinymce.core.file.ConversionsTest', (success, failur
     });
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/file/UploadStatusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/file/UploadStatusTest.ts
@@ -33,7 +33,5 @@ UnitTest.asynctest('browser.tinymce.core.file.UploadStatusTest', (success, failu
     LegacyUnit.strictEqual(status.hasBlobUri('existing_uri'), false);
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FontInfoTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FontInfoTest.ts
@@ -154,7 +154,5 @@ UnitTest.asynctest('browser.tinymce.core.fmt.FontInfoTest', (success, failure) =
     LegacyUnit.equal('string', typeof actual, 'should return always string');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/focus/CefFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/CefFocusTest.ts
@@ -56,7 +56,5 @@ UnitTest.asynctest('browser.tinymce.core.focus.CefFocusTest', (success, failure)
       }),
       sRemoveEditors
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
@@ -114,7 +114,5 @@ UnitTest.asynctest('browser.tinymce.core.focus.EditorFocusTest', (success, failu
         McEditor.cRemove
       ]))
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/geom/ClientRectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/geom/ClientRectTest.ts
@@ -92,7 +92,5 @@ UnitTest.asynctest('browser.tinymce.core.geom.ClientRectTest', (success, failure
     LegacyUnit.equal(ClientRect.getOverflow(rect(10, 10, 10, 10), rect(10, 15, 10, 10)), { x: 0, y: 5 });
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/geom/RectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/geom/RectTest.ts
@@ -93,7 +93,5 @@ UnitTest.asynctest('browser.tinymce.core.geom.RectTest', (success, failure) => {
     LegacyUnit.deepEqual(Rect.fromClientRect({ left: 10, top: 20, width: 30, height: 40, bottom: 60, right: 40 }), { x: 10, y: 20, w: 30, h: 40 });
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -785,7 +785,5 @@ UnitTest.asynctest('browser.tinymce.core.html.DomParserTest', (success, failure)
     );
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/EntitiesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/EntitiesTest.ts
@@ -127,7 +127,5 @@ UnitTest.asynctest('browser.tinymce.core.html.EntitiesTest', (success, failure) 
     LegacyUnit.equal(Entities.encodeNumeric(Entities.decode('&#194564;')), '&#194564;', 'High byte non western character.');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/NodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/NodeTest.ts
@@ -396,7 +396,5 @@ UnitTest.asynctest('browser.tinymce.core.html.NodeTest', (success, failure) => {
     LegacyUnit.equal(root.isEmpty({ img: 1 }, {}, isSpan), true, 'Should be true since the predicate says false.');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -1054,7 +1054,5 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', (success, failure)
     LegacyUnit.equal(writer.getContent(), 'a<img src="data:image/gif;base64,R0/yw==" /><img src="data:image/jpeg;base64,R1/yw==" /><!-- <img src="data:image/jpeg;base64,R1/yw==" /> -->b');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -530,7 +530,5 @@ UnitTest.asynctest('browser.tinymce.core.html.SchemaTest', (success, failure) =>
     });
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
@@ -41,7 +41,5 @@ UnitTest.asynctest('browser.tinymce.core.html.SerializerTest', (success, failure
     );
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -220,7 +220,5 @@ UnitTest.asynctest('browser.tinymce.core.html.StylesTest', (success, failure) =>
     LegacyUnit.equal(styles.serialize(styles.parse('background:url(vbscript:alert(1)')), `background: url('vbscript:alert(1');`);
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/WriterTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/WriterTest.ts
@@ -155,7 +155,5 @@ UnitTest.asynctest('browser.tinymce.core.html.WriterTest', (success, failure) =>
     LegacyUnit.equal(writer.getContent(), `<p title="&lt;&gt;&quot;'&amp;&aring;&auml;&ouml;">&lt;&gt;"'&amp;&aring;&auml;&ouml;</p>`);
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorOnHiddenElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorOnHiddenElementTest.ts
@@ -14,7 +14,5 @@ UnitTest.asynctest('browser.tinymce.core.init.InitEditorOnHiddenElementTest', (s
     }),
     ApiChains.cFocus
   ],
-  () => {
-    success();
-  }, failure);
+  success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/BoundaryCaretTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/BoundaryCaretTest.ts
@@ -48,7 +48,5 @@ UnitTest.asynctest('browser.tinymce.core.keyboard.BoundaryCaretTest', (success, 
       sTestRenderCaret('<p><a href="#">a<img src="#"></a></p>', [ 0, 0 ], 2, '<p><a href="#">a<img src="#">' + ZWSP + '</a></p>', [ 0, 0, 2 ], 1),
       sTestRenderCaret('<p><a href="#">a</a><img src="#"></p>', [ 0 ], 1, '<p><a href="#">a</a>' + ZWSP + '<img src="#"></p>', [ 0, 1 ], 1)
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyInlineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyInlineTest.ts
@@ -21,7 +21,5 @@ UnitTest.asynctest('browser.tinymce.core.keyboard.EnterKeyInlineTest', (success,
       ApiChains.cAssertContent('a<br />b'),
       Editor.cRemove
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InlineUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InlineUtilsTest.ts
@@ -179,7 +179,5 @@ UnitTest.asynctest('browser.tinymce.core.keyboard.InlineUtilsTest', (success, fa
         cAssertPosition([], 2)
       ]))
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/selection/MultiClickSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/MultiClickSelectionTest.ts
@@ -44,8 +44,6 @@ UnitTest.asynctest('browser.tinymce.core.selection.MultiClickSelectionTest', (su
     plugins: '',
     toolbar: '',
     base_url: '/project/tinymce/js/tinymce'
-  }, () => {
-    success();
-  }, failure);
+  }, success, failure);
 }
 );

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkIframeEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkIframeEditorTest.ts
@@ -116,8 +116,6 @@ UnitTest.asynctest(
       plugins: '',
       toolbar: '',
       base_url: '/project/tinymce/js/tinymce'
-    }, () => {
-      success();
-    }, failure);
+    }, success, failure);
   }
 );

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
@@ -199,8 +199,6 @@ UnitTest.asynctest(
       plugins: '',
       toolbar: '',
       base_url: '/project/tinymce/js/tinymce'
-    }, () => {
-      success();
-    }, failure);
+    }, success, failure);
   }
 );

--- a/modules/tinymce/src/core/test/ts/browser/selection/SimpleTableModelTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SimpleTableModelTest.ts
@@ -132,7 +132,5 @@ UnitTest.asynctest('browser.tinymce.core.selection.SimpleTableModel', (success, 
         cAssertModelAsHtml('<table><tbody><tr><td>E</td><td>F</td></tr><tr><td>H</td><td>I</td></tr></tbody></table>')
       ]))
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/undo/DiffTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/DiffTest.ts
@@ -20,7 +20,5 @@ UnitTest.asynctest('browser.tinymce.core.undo.DiffTest', (success, failure) => {
     LegacyUnit.deepEqual(Diff.diff([ 1 ], [ 2, 3 ]), [[ INSERT, 2 ], [ INSERT, 3 ], [ DELETE, 1 ]]);
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/undo/FragmentsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/FragmentsTest.ts
@@ -41,7 +41,5 @@ UnitTest.asynctest('browser.tinymce.core.undo.FragmentsTest', (success, failure)
     LegacyUnit.deepEqual(html(Fragments.write([ '<b>c</b>', '<b>d</b>', '<!--e-->' ], div('a<b>b</b>'))), '<b>c</b><b>d</b><!--e-->');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/ColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ColorTest.ts
@@ -37,7 +37,5 @@ UnitTest.asynctest('browser.tinymce.core.util.ColorTest', (success, failure) => 
     LegacyUnit.equal(Color({ r: 255, g: 254, b: 253 }).toHex(), '#fffefd');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/DelayTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/DelayTest.ts
@@ -133,7 +133,5 @@ UnitTest.asynctest('browser.tinymce.core.util.DelayTest', (success, failure) => 
     ok(true, 'clearInterval works.');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/EventDispatcherTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/EventDispatcherTest.ts
@@ -328,7 +328,5 @@ UnitTest.asynctest('browser.tinymce.core.util.EventDispatcherTest', (success, fa
     LegacyUnit.equal(lastState, false);
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/FakeStorageTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/FakeStorageTest.ts
@@ -103,7 +103,5 @@ UnitTest.asynctest('browser.tinymce.core.util.LocalStorageTest', (success, failu
 
   LocalStorage.clear();
   const steps = appendTeardown(suite.toSteps({}));
-  Pipeline.async({}, steps, () => {
-    success();
-  }, failure);
+  Pipeline.async({}, steps, success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/I18nTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/I18nTest.ts
@@ -91,7 +91,5 @@ UnitTest.asynctest('browser.tinymce.core.util.I18nTest', (success, failure) => {
     I18n.setCode('en');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/JsonRequestTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/JsonRequestTest.ts
@@ -50,7 +50,5 @@ UnitTest.asynctest('browser.tinymce.core.util.JsonRequestTest', (success, failur
     });
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/JsonTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/JsonTest.ts
@@ -40,7 +40,5 @@ UnitTest.asynctest('browser.tinymce.core.util.JsonTest', (success, failure) => {
     LegacyUnit.equal(parsedValue.date1, '1970-01-01T00:00:00.000Z');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/ObservableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ObservableTest.ts
@@ -62,7 +62,5 @@ UnitTest.asynctest('browser.tinymce.core.util.ObservableTest', (success, failure
     LegacyUnit.strictEqual(data, 'cabcr');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/PromiseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/PromiseTest.ts
@@ -43,7 +43,5 @@ UnitTest.asynctest('browser.tinymce.core.util.PromiseTest', (success, failure) =
     });
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/ToolsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ToolsTest.ts
@@ -11,7 +11,5 @@ UnitTest.asynctest('browser.tinymce.core.util.ToolsTest', (success, failure) => 
     LegacyUnit.deepEqual({ a: 1, c: 3 }, Tools.extend({ a: 1 }, null, { c: 3 }));
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/UriTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/UriTest.ts
@@ -139,7 +139,5 @@ UnitTest.asynctest('browser.tinymce.core.util.UriTest', (success, failure) => {
     LegacyUnit.equal(getDocumentBaseUrl({ protocol: 'http:', host: '[::1]:8080', pathname: '/dir/path1/path2' }), 'http://[::1]:8080/dir/path1/');
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/XhrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/XhrTest.ts
@@ -40,7 +40,5 @@ UnitTest.asynctest('browser.tinymce.core.util.XhrTest', (success, failure) => {
     });
   });
 
-  Pipeline.async({}, suite.toSteps({}), () => {
-    success();
-  }, failure);
+  Pipeline.async({}, suite.toSteps({}), success, failure);
 });

--- a/modules/tinymce/src/plugins/emoticons/main/ts/core/EmojiDatabase.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/core/EmojiDatabase.ts
@@ -104,7 +104,9 @@ const initDatabase = (editor: Editor, databaseUrl: string, databaseId: string): 
   });
 
   const listCategory = (category: string): EmojiEntry[] => {
-    if (category === ALL_CATEGORY) { return listAll(); }
+    if (category === ALL_CATEGORY) {
+      return listAll();
+    }
     return categories.get().bind((cats) => Optional.from(cats[category])).getOr([]);
   };
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
@@ -90,7 +90,5 @@ UnitTest.asynctest('browser.tinymce.plugins.image.FigureResizeTest', (success, f
       ]),
       McEditor.cRemove
     ])
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageDataTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageDataTest.ts
@@ -717,7 +717,5 @@ UnitTest.asynctest('browser.tinymce.plugins.image.core.ImageDataTest', (success,
         });
       }))
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/plugins/importcss/test/ts/module/MenuNavigationTestUtils.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/module/MenuNavigationTestUtils.ts
@@ -10,7 +10,9 @@ const sAssertFocusOnItem = (doc, text) => FocusTools.sTryOnSelector(
 const sDelay = Step.wait(0);
 
 const generateNavigation = (doc, navigation) => {
-  if (navigation.length === 0) { return [ ]; }
+  if (navigation.length === 0) {
+    return [ ];
+  }
 
   return Arr.bind(navigation.concat(navigation.slice(0, 1)), (nav, i) => {
     const exploration = (nav.subitems.length > 0) ? [

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
@@ -108,7 +108,5 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteBin', (success, failure) 
       cAssertCases(cases),
       cRemoveEditor()
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
@@ -36,7 +36,5 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteSettingsTest', (success, 
       }),
       cRemoveEditor
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
@@ -133,7 +133,5 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PlainTextPaste', (success, fai
       cAssertClipboardPaste(expectedWithoutRootBlock, pasteData),
       cRemoveEditor()
     ]))
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
@@ -196,7 +196,5 @@ UnitTest.asynctest('browser.tinymce.plugins.table.InsertColumnTableResizeTest', 
 
     NamedChain.read('editor', Editor.cRemove)
   ]),
-  () => {
-    success();
-  }, failure, TestLogs.init());
+  success, failure, TestLogs.init());
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
@@ -319,7 +319,5 @@ UnitTest.asynctest('browser.tinymce.plugins.table.UnmergeCellTableResizeTest', (
     NamedChain.read('editor', cMergeResizeSplitAssertWidth('resized after merge and then split', mergeResizeSplit)),
 
     NamedChain.read('editor', Editor.cRemove)
-  ]), () => {
-    success();
-  }, failure, TestLogs.init());
+  ]), success, failure, TestLogs.init());
 });

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
@@ -68,8 +68,12 @@ export default {
           initialData: {
             preview: 'some html url'
           },
-          onSubmit: (_api) => { console.log('Preview Demo Submit'); },
-          onClose: () => { console.log('Preview Demo Close'); }
+          onSubmit: (_api) => {
+            console.log('Preview Demo Submit');
+          },
+          onClose: () => {
+            console.log('Preview Demo Close');
+          }
         });
       }
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/ComponentApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/ComponentApi.ts
@@ -17,9 +17,15 @@ const deriveToggling = (spec, component: AlloyComponent) => {
     return spec.toggle().bind((toggle) => {
       if (toggle === true) {
         return {
-          toggleOn: () => { Toggling.on(component); },
-          toggleOff: () => { Toggling.off(component); },
-          toggleIsOn: () => { Toggling.isOn(component); }
+          toggleOn: () => {
+            Toggling.on(component);
+          },
+          toggleOff: () => {
+            Toggling.off(component);
+          },
+          toggleIsOn: () => {
+            Toggling.isOn(component);
+          }
         };
       }
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -163,7 +163,9 @@ const registerTextColorButton = (editor: Editor, name: string, format: string, t
 
       editor.on('TextColorChange', handler);
 
-      return () => { editor.off('TextColorChange', handler); };
+      return () => {
+        editor.off('TextColorChange', handler);
+      };
     }
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/NavigableObject.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/NavigableObject.ts
@@ -65,7 +65,11 @@ const triggerTab = (placeholder, shiftKey) => {
 const onFocus = (container, targetComp) => {
   const target = targetComp.element;
   // If focus has shifted naturally to a before object, the tab direction is backwards.
-  if (Class.has(target, beforeObject)) { triggerTab(container, true); } else if (Class.has(target, afterObject)) { triggerTab(container, false); }
+  if (Class.has(target, beforeObject)) {
+    triggerTab(container, true);
+  } else if (Class.has(target, afterObject)) {
+    triggerTab(container, false);
+  }
 };
 
 const isPseudoStop = (element) => {

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputParsingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputParsingTest.ts
@@ -46,8 +46,12 @@ UnitTest.test('SizeInputParsingTest', () => {
   });
 
   const arbPad = Jsc.array(Jsc.elements(' \t'.split(''))).smap(
-    (arr) => { return arr.join(''); },
-    (s) => { return s.split(''); }
+    (arr) => {
+      return arr.join('');
+    },
+    (s) => {
+      return s.split('');
+    }
   );
 
   Jsc.property(

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/sizing/ResizeTest.ts
@@ -63,7 +63,5 @@ UnitTest.asynctest('Editor resizing tests', (success, failure) => {
   Pipeline.async({}, [
     cappedSizeTests,
     getDimensionsTests
-  ], () => {
-    success();
-  }, failure);
+  ], success, failure);
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
@@ -235,9 +235,7 @@ UnitTest.asynctest('Editor ContextForm test', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
@@ -63,9 +63,7 @@ UnitTest.asynctest('Menu group heading test', (success, failure) => {
         { title: 'Table row 1', selector: 'tr', classes: 'tablerow1' }
       ]
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCancelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCancelTest.ts
@@ -40,9 +40,7 @@ UnitTest.asynctest('Editor (Silver) Configuration Cancel test', (success, failur
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCloseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCloseTest.ts
@@ -40,9 +40,7 @@ UnitTest.asynctest('Editor (Silver) Configuration Close test', (success, failure
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogPopupsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogPopupsTest.ts
@@ -117,9 +117,7 @@ UnitTest.asynctest('Editor Dialog Popups Test', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -433,9 +433,7 @@ UnitTest.asynctest('Editor (Silver) test', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -432,9 +432,7 @@ UnitTest.asynctest('Inline Editor (Silver) test', (success, failure) => {
       });
     }
   },
-  () => {
-    success();
-  },
+  success,
   failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
@@ -28,9 +28,7 @@ UnitTest.asynctest('Editor (Silver) tox wrapping test', (success, failure) => {
       menubar: true,
       base_url: '/project/tinymce/js/tinymce'
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleterTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleterTest.ts
@@ -669,9 +669,7 @@ UnitTest.asynctest('Editor Autocompleter test', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -329,9 +329,7 @@ UnitTest.asynctest('Editor (Silver) bespoke toolbar buttons test', (success, fai
       base_url: '/project/tinymce/js/tinymce',
       content_css: '/project/tinymce/src/themes/silver/test/css/content.css'
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
@@ -125,9 +125,7 @@ UnitTest.asynctest('Distraction free editor ContextToolbar Position test', (succ
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -228,9 +228,7 @@ UnitTest.asynctest('IFrame editor ContextToolbar Position test', (success, failu
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
@@ -135,9 +135,7 @@ UnitTest.asynctest('Inline editor ContextToolbar Position test', (success, failu
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
@@ -167,9 +167,7 @@ UnitTest.asynctest('Inline editor Context Toolbar Lookup test', (success, failur
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -48,9 +48,7 @@ UnitTest.asynctest('Editor ContextToolbar test', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -166,9 +166,7 @@ UnitTest.asynctest('Toolbar with toolbar drawer readonly mode test', (success, f
       readonly: true,
       resize: 'both'
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
@@ -121,9 +121,7 @@ UnitTest.asynctest('OxideBlockedDialogTest', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
@@ -227,9 +227,7 @@ UnitTest.asynctest('OxideCollectionComponentTest', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -139,9 +139,7 @@ UnitTest.asynctest('OxideColorSwatchMenuTest', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
@@ -224,9 +224,7 @@ UnitTest.asynctest('OxideFontFormatMenuTest', (success, failure) => {
 
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
@@ -92,9 +92,7 @@ UnitTest.asynctest('OxideGridCollectionMenuTest', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
@@ -165,9 +165,7 @@ UnitTest.asynctest('OxideListCollectionMenuTest', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
@@ -167,9 +167,7 @@ UnitTest.asynctest('OxideToolbarCollectionMenuTest', (success, failure) => {
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -49,7 +49,9 @@ UnitTest.asyncTest('browser.tinymce.themes.silver.window.SilverDialogBlockTest',
     const ui = TinyUi(editor);
 
     const cOpen = (params: WindowParams) => DialogUtils.cOpen(editor, dialogSpec, params);
-    const cClose = Chain.mapper<Dialog.DialogInstanceApi<{ fred: string }>, void>((api) => { api.close(); });
+    const cClose = Chain.mapper<Dialog.DialogInstanceApi<{ fred: string }>, void>((api) => {
+      api.close();
+    });
     const cClick = Chain.fromIsolatedChains([
       ui.cWaitForUi('Fred button', 'button:contains("Clickable?")'),
       Chain.mapper<SugarElement<HTMLButtonElement>, SugarElement<Element>>((button) => {

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/AutocompleterDelayedResponseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/AutocompleterDelayedResponseTest.ts
@@ -127,9 +127,7 @@ UnitTest.asynctest('Editor Autocompleter delay response test', (success, failure
         });
       }
     },
-    () => {
-      success();
-    },
+    success,
     failure
   );
 });


### PR DESCRIPTION
Related Ticket: TINY-6504

Description of Changes:
* Enabled the `brace-style` ESLint rule. Note: Fixes were done using the automated fixer
* Fixed 3 places missed that used `Fun.constant(false)` or similar

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
