### PR TITLE
TINY-6504: Enabled the `@typescript-eslint/unbound-method` ESLint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,6 @@
     "@typescript-eslint/no-this-alias": "off",
     "@typescript-eslint/prefer-for-of": "off",
     "@typescript-eslint/prefer-regexp-exec": "off",
-    "@typescript-eslint/unbound-method": "off",
     "brace-style": "error",
     "no-empty": "off",
     "no-underscore-dangle": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,6 @@
     "@typescript-eslint/no-this-alias": "off",
     "@typescript-eslint/prefer-for-of": "off",
     "@typescript-eslint/prefer-regexp-exec": "off",
-    "brace-style": "error",
     "no-empty": "off",
     "no-underscore-dangle": "off",
     "one-var": "off",

--- a/modules/agar/src/main/ts/ephox/agar/assertions/Differ.ts
+++ b/modules/agar/src/main/ts/ephox/agar/assertions/Differ.ts
@@ -13,6 +13,7 @@
  * QUnit.diff( "the quick brown fox jumped over", "the quick fox jumps over" ) == "the  quick <del>brown </del> fox <del>jumped </del><ins>jumps </ins> over"
  */
 const htmlDiff: (v1: string, v2: string) => string = (() => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const hasOwn = Object.prototype.hasOwnProperty;
 
   /* jshint eqeqeq:false, eqnull:true */

--- a/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
+++ b/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
@@ -31,6 +31,7 @@ const createChangeEvent = (win: Window): Event => {
 const cPatchInputElement = (files: File[]) => Chain.op<any>(() => {
   const currentProps = {
     files: Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'files'),
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     click: HTMLInputElement.prototype.click
   };
 

--- a/modules/agar/src/test/ts/browser/datatransfer/DataTransferItemTest.ts
+++ b/modules/agar/src/test/ts/browser/datatransfer/DataTransferItemTest.ts
@@ -12,6 +12,7 @@ UnitTest.asynctest('DataTransferItemTest', (success, failure) => {
       const fileItem = createDataTransferItemFromFile(createDataTransfer(), createFile('a.txt', 1234, new Blob([ '123' ], { type: 'text/plain' })));
 
       Assert.eq('Should be the expected kind', 'file', fileItem.kind);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       Assert.eq('Should be a noop', Fun.noop, fileItem.getAsString);
       Assert.eq('Should be expected file', 'a.txt', fileItem.getAsFile().name);
       Assert.eq('Should be expected file', 'text/plain', fileItem.getAsFile().type);

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DataTransfers.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DataTransfers.ts
@@ -45,7 +45,9 @@ const getData = (transfer: DataTransfer, type: string): string => {
   return Type.isNull(data) ? '' : data;
 };
 
-const hasDragImageSupport = (transfer: DataTransfer): boolean => !Type.isUndefined(transfer.setDragImage);
+const hasDragImageSupport = (transfer: DataTransfer): boolean =>
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  !Type.isUndefined(transfer.setDragImage);
 
 const setDragImage = (transfer: DataTransfer, image: Element, x: number, y: number): void => {
   // IE 11 and Edge doesn't have support for setting drag image we can't really

--- a/modules/imagetools/src/main/ts/ephox/imagetools/util/Conversions.ts
+++ b/modules/imagetools/src/main/ts/ephox/imagetools/util/Conversions.ts
@@ -136,7 +136,7 @@ const uriToBlob = (url: string): Promise<Blob> | null => {
 const canvasToBlob = (canvas: HTMLCanvasElement, type?: string, quality?: number): Promise<Blob> => {
   type = type || 'image/png';
 
-  // eslint-disable-next-line @tinymce/no-implicit-dom-globals
+  // eslint-disable-next-line @tinymce/no-implicit-dom-globals, @typescript-eslint/unbound-method
   if (Type.isFunction(HTMLCanvasElement.prototype.toBlob)) {
     return new Promise<Blob>((resolve, reject) => {
       canvas.toBlob((blob) => {

--- a/modules/imagetools/src/main/ts/ephox/imagetools/util/Promise.ts
+++ b/modules/imagetools/src/main/ts/ephox/imagetools/util/Promise.ts
@@ -34,7 +34,7 @@ interface PromisePolyfillConstructor extends PromiseConstructor {
 
   new <T>(executor: Executor<T>): PromisePolyfill<T>;
 
-  immediateFn? (handler: (...args: any[]) => void): void;
+  immediateFn?: (handler: (...args: any[]) => void) => void;
 }
 
 const promise = <T>(): PromisePolyfillConstructor => {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -7,9 +7,11 @@ type ArrayMorphism<T, U> = (x: T, i: number) => U;
 type ArrayPredicate<T> = ArrayMorphism<T, boolean>;
 type Comparator<T> = (a: T, b: T) => number;
 
+/* eslint-disable @typescript-eslint/unbound-method */
 const nativeSlice = Array.prototype.slice;
 const nativeIndexOf = Array.prototype.indexOf;
 const nativePush = Array.prototype.push;
+/* eslint-enable */
 
 const rawIndexOf = <T> (ts: ArrayLike<T>, t: T): number =>
   nativeIndexOf.call(ts, t);

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Merger.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Merger.ts
@@ -25,6 +25,7 @@ interface ShallowMergeFunc {
   (...objs: Array<Record<string, any>>): Record<string, any>;
 }
 
+// eslint-disable-next-line @typescript-eslint/unbound-method
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 const shallow = (old: Record<string, any>, nu: Record<string, any>) => {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
@@ -8,6 +8,7 @@ import { Optional } from './Optional';
 // Use the native keys if it is available (IE9+), otherwise fall back to manually filtering
 export const keys = Object.keys;
 
+// eslint-disable-next-line @typescript-eslint/unbound-method
 export const hasOwnProperty = Object.hasOwnProperty;
 
 export const each = <T>(obj: T, f: (value: T[keyof T], key: string) => void): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
@@ -15,10 +15,11 @@ export type RootNode = SugarElement<Document | ShadowRoot>;
 export const isShadowRoot = (dos: RootNode): dos is SugarElement<ShadowRoot> =>
   SugarNode.isDocumentFragment(dos);
 
+/* eslint-disable @tinymce/no-implicit-dom-globals, @typescript-eslint/unbound-method */
 const supported: boolean =
-  // eslint-disable-next-line @tinymce/no-implicit-dom-globals
   Type.isFunction(Element.prototype.attachShadow) &&
   Type.isFunction(Node.prototype.getRootNode);
+/* eslint-enable */
 
 /**
  * Does the browser support shadow DOM?

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/Style.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/Style.ts
@@ -3,6 +3,7 @@ import { Type } from '@ephox/katamari';
 // some elements, such as mathml, don't have style attributes
 // others, such as angular elements, have style attributes that aren't a CSSStyleDeclaration
 const isSupported = (dom: Node): dom is HTMLStyleElement =>
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   (dom as HTMLStyleElement).style !== undefined && Type.isFunction((dom as HTMLStyleElement).style.getPropertyValue);
 
 export { isSupported };

--- a/modules/tinymce/src/core/main/ts/EditorSettings.ts
+++ b/modules/tinymce/src/core/main/ts/EditorSettings.ts
@@ -118,6 +118,8 @@ const getDefaultSettings = (settings: RawEditorSettings, id: string, documentBas
     indent_after: 'p,h1,h2,h3,h4,h5,h6,blockquote,div,title,style,pre,script,td,th,ul,ol,li,dl,dt,dd,area,table,thead,' +
     'tfoot,tbody,tr,section,summary,article,hgroup,aside,figure,figcaption,option,optgroup,datalist',
     entity_encoding: 'named',
+    // Note: Don't bind here, as the binding is handled via the `url_converter_scope`
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     url_converter: editor.convertURL,
     url_converter_scope: editor
   };

--- a/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
@@ -111,15 +111,15 @@ interface AddOnManager<T> {
   urls: Record<string, string>;
   lookup: Record<string, { instance: AddOnConstructor<T>; dependencies?: string[] }>;
   _listeners: { name: string; state: WaitState; callback: () => void }[];
-  get (name: string): AddOnConstructor<T>;
-  dependencies (name: string): string[]; // TODO: deprecated in 5.7
-  requireLangPack (name: string, languages: string): void;
-  add (id: string, addOn: AddOnCallback<T>, dependencies?: string[]): AddOnConstructor<T>;
-  remove (name: string): void;
-  createUrl (baseUrl: UrlObject, dep: string | UrlObject): UrlObject;
-  addComponents (pluginName: string, scripts: string[]): void;
-  load (name: string, addOnUrl: string | UrlObject, success?: () => void, scope?: any, failure?: () => void): void;
-  waitFor (name: string, callback: () => void, state?: WaitState): void;
+  get: (name: string) => AddOnConstructor<T>;
+  dependencies: (name: string) => string[]; // TODO: deprecated in 5.7
+  requireLangPack: (name: string, languages: string) => void;
+  add: (id: string, addOn: AddOnCallback<T>, dependencies?: string[]) => AddOnConstructor<T>;
+  remove: (name: string) => void;
+  createUrl: (baseUrl: UrlObject, dep: string | UrlObject) => UrlObject;
+  addComponents: (pluginName: string, scripts: string[]) => void;
+  load: (name: string, addOnUrl: string | UrlObject, success?: () => void, scope?: any, failure?: () => void) => void;
+  waitFor: (name: string, callback: () => void, state?: WaitState) => void;
 }
 
 const AddOnManager = <T>(): AddOnManager<T> => {

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -131,21 +131,21 @@ interface EditorManager extends Observable<EditorManagerEventMap> {
   i18n: I18n;
   suffix: string;
 
-  add (editor: Editor): Editor;
-  addI18n (code: string, item: Record<string, string>): void;
-  createEditor (id: string, settings: RawEditorSettings): Editor;
-  execCommand (cmd: string, ui: boolean, value: any): boolean;
-  get (): Editor[];
-  get (id: number | string): Editor;
-  init (settings: RawEditorSettings): Promise<Editor[]>;
-  overrideDefaults (defaultSettings: Partial<RawEditorSettings>): void;
-  remove (): void;
-  remove (selector: string | Editor): Editor | void;
-  setActive (editor: Editor): void;
-  setup (): void;
-  translate (text: Untranslated): TranslatedString;
-  triggerSave (): void;
-  _setBaseUrl (baseUrl: string): void;
+  add (this: EditorManager, editor: Editor): Editor;
+  addI18n: (code: string, item: Record<string, string>) => void;
+  createEditor (this: EditorManager, id: string, settings: RawEditorSettings): Editor;
+  execCommand (this: EditorManager, cmd: string, ui: boolean, value: any): boolean;
+  get (this: EditorManager): Editor[];
+  get (this: EditorManager, id: number | string): Editor;
+  init (this: EditorManager, settings: RawEditorSettings): Promise<Editor[]>;
+  overrideDefaults (this: EditorManager, defaultSettings: Partial<RawEditorSettings>): void;
+  remove (this: EditorManager): void;
+  remove (this: EditorManager, selector: string | Editor): Editor | void;
+  setActive (this: EditorManager, editor: Editor): void;
+  setup (this: EditorManager): void;
+  translate: (text: Untranslated) => TranslatedString;
+  triggerSave: () => void;
+  _setBaseUrl (this: EditorManager, baseUrl: string): void;
 }
 
 const isQuirksMode = document.compatMode !== 'CSS1Compat';
@@ -753,7 +753,7 @@ const EditorManager: EditorManager = {
 
       case 'mceToggleEditor':
         if (!editor) {
-          self.execCommand('mceAddEditor', 0, value);
+          self.execCommand('mceAddEditor', false, value);
           return true;
         }
 

--- a/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
@@ -138,9 +138,9 @@ const bindEventDelegate = (editor: Editor, eventName: string) => {
 };
 
 interface EditorObservable extends Observable<EditorEventMap> {
-  bindPendingEventDelegates (): void;
-  toggleNativeEvent (name: string, state: boolean);
-  unbindAllNativeEvents (): void;
+  bindPendingEventDelegates (this: Editor): void;
+  toggleNativeEvent (this: Editor, name: string, state: boolean);
+  unbindAllNativeEvents (this: Editor): void;
 }
 
 const EditorObservable: EditorObservable = {
@@ -152,7 +152,7 @@ const EditorObservable: EditorObservable = {
    * @private
    */
   bindPendingEventDelegates() {
-    const self = (this as Editor);
+    const self = this;
 
     Tools.each(self._pendingNativeEvents, (name) => {
       bindEventDelegate(self, name);

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -37,11 +37,11 @@ export type UploadCallback = (results: UploadResult[]) => void;
 
 interface EditorUpload {
   blobCache: BlobCache;
-  addFilter (filter: (img: HTMLImageElement) => boolean): void;
-  uploadImages (callback?: UploadCallback): Promise<UploadResult[]>;
-  uploadImagesAuto (callback?: UploadCallback): void | Promise<UploadResult[]>;
-  scanForImages (): Promise<BlobInfoImagePair[]>;
-  destroy (): void;
+  addFilter: (filter: (img: HTMLImageElement) => boolean) => void;
+  uploadImages: (callback?: UploadCallback) => Promise<UploadResult[]>;
+  uploadImagesAuto: (callback?: UploadCallback) => void | Promise<UploadResult[]>;
+  scanForImages: () => Promise<BlobInfoImagePair[]>;
+  destroy: () => void;
 }
 
 const UploadChangeHandler = (editor: Editor) => {

--- a/modules/tinymce/src/core/main/ts/api/Formatter.ts
+++ b/modules/tinymce/src/core/main/ts/api/Formatter.ts
@@ -32,16 +32,16 @@ import Editor from './Editor';
  */
 
 interface Formatter extends FormatRegistry {
-  apply (name: string, vars?: FormatVars, node?: Node | RangeLikeObject): void;
-  remove (name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean): void;
-  toggle (name: string, vars?: FormatVars, node?: Node): void;
-  match (name: string, vars?: FormatVars, node?: Node): boolean;
-  closest (names): string | null;
-  matchAll (names: string[], vars?: FormatVars): string[];
-  matchNode (node: Node, name: string, vars?: FormatVars, similar?: boolean): boolean;
-  canApply (name: string): boolean;
-  formatChanged (names: string, callback: FormatChanged.FormatChangeCallback, similar?: boolean): { unbind: () => void };
-  getCssText (format: string | Format): string;
+  apply: (name: string, vars?: FormatVars, node?: Node | RangeLikeObject) => void;
+  remove: (name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean) => void;
+  toggle: (name: string, vars?: FormatVars, node?: Node) => void;
+  match: (name: string, vars?: FormatVars, node?: Node) => boolean;
+  closest: (names) => string | null;
+  matchAll: (names: string[], vars?: FormatVars) => string[];
+  matchNode: (node: Node, name: string, vars?: FormatVars, similar?: boolean) => boolean;
+  canApply: (name: string) => boolean;
+  formatChanged: (names: string, callback: FormatChanged.FormatChangeCallback, similar?: boolean) => { unbind: () => void };
+  getCssText: (format: string | Format) => string;
 }
 
 const Formatter = (editor: Editor): Formatter => {

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -14,10 +14,10 @@ import * as Settings from './Settings';
 import Delay from './util/Delay';
 
 export interface NotificationManagerImpl {
-  open (spec: NotificationSpec, closeCallback?: () => void): NotificationApi;
-  close <T extends NotificationApi>(notification: T): void;
-  reposition <T extends NotificationApi>(notifications: T[]): void;
-  getArgs <T extends NotificationApi>(notification: T): NotificationSpec;
+  open: (spec: NotificationSpec, closeCallback?: () => void) => NotificationApi;
+  close: <T extends NotificationApi>(notification: T) => void;
+  reposition: <T extends NotificationApi>(notifications: T[]) => void;
+  getArgs: <T extends NotificationApi>(notification: T) => NotificationSpec;
 }
 
 export interface NotificationSpec {

--- a/modules/tinymce/src/core/main/ts/api/PluginManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/PluginManager.ts
@@ -8,7 +8,7 @@
 import AddOnManager from './AddOnManager';
 
 export interface Plugin {
-  getMetadata? (): { name: string; url: string };
+  getMetadata?: () => { name: string; url: string };
 
   // Allow custom apis
   [key: string]: any;

--- a/modules/tinymce/src/core/main/ts/api/Resource.ts
+++ b/modules/tinymce/src/core/main/ts/api/Resource.ts
@@ -9,8 +9,8 @@ import ScriptLoader from './dom/ScriptLoader';
 import Promise from './util/Promise';
 
 interface Resource {
-  load <T = any>(id: string, url: string): Promise<T>;
-  add (id: string, data: any): void;
+  load: <T = any>(id: string, url: string) => Promise<T>;
+  add: (id: string, data: any) => void;
 }
 
 const awaiter = (resolveCb: (data: any) => void, rejectCb: (err?: any) => void, timeout = 1000) => {

--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -74,6 +74,60 @@ export interface ShortcutsConstructor {
 
 type CommandFunc = string | [string, boolean, any] | (() => void);
 
+const parseShortcut = (pattern: string): Shortcut => {
+  let key;
+  const shortcut: any = {};
+
+  // Parse modifiers and keys ctrl+alt+b for example
+  each(explode(pattern.toLowerCase(), '+'), (value) => {
+    if (value in modifierNames) {
+      shortcut[value] = true;
+    } else {
+      // Allow numeric keycodes like ctrl+219 for ctrl+[
+      if (/^[0-9]{2,}$/.test(value)) {
+        shortcut.keyCode = parseInt(value, 10);
+      } else {
+        shortcut.charCode = value.charCodeAt(0);
+        shortcut.keyCode = keyCodeLookup[value] || value.toUpperCase().charCodeAt(0);
+      }
+    }
+  });
+
+  // Generate unique id for modifier combination and set default state for unused modifiers
+  const id = [ shortcut.keyCode ];
+  for (key in modifierNames) {
+    if (shortcut[key]) {
+      id.push(key);
+    } else {
+      shortcut[key] = false;
+    }
+  }
+  shortcut.id = id.join(',');
+
+  // Handle special access modifier differently depending on Mac/Win
+  if (shortcut.access) {
+    shortcut.alt = true;
+
+    if (Env.mac) {
+      shortcut.ctrl = true;
+    } else {
+      shortcut.shift = true;
+    }
+  }
+
+  // Handle special meta modifier differently depending on Mac/Win
+  if (shortcut.meta) {
+    if (Env.mac) {
+      shortcut.meta = true;
+    } else {
+      shortcut.ctrl = true;
+      shortcut.meta = false;
+    }
+  }
+
+  return shortcut;
+};
+
 class Shortcuts {
   private readonly editor: Editor;
   private readonly shortcuts: Record<string, Shortcut> = {};
@@ -167,62 +221,8 @@ class Shortcuts {
     }
   }
 
-  private parseShortcut(pattern: string): Shortcut {
-    let key;
-    const shortcut: any = {};
-
-    // Parse modifiers and keys ctrl+alt+b for example
-    each(explode(pattern.toLowerCase(), '+'), (value) => {
-      if (value in modifierNames) {
-        shortcut[value] = true;
-      } else {
-        // Allow numeric keycodes like ctrl+219 for ctrl+[
-        if (/^[0-9]{2,}$/.test(value)) {
-          shortcut.keyCode = parseInt(value, 10);
-        } else {
-          shortcut.charCode = value.charCodeAt(0);
-          shortcut.keyCode = keyCodeLookup[value] || value.toUpperCase().charCodeAt(0);
-        }
-      }
-    });
-
-    // Generate unique id for modifier combination and set default state for unused modifiers
-    const id = [ shortcut.keyCode ];
-    for (key in modifierNames) {
-      if (shortcut[key]) {
-        id.push(key);
-      } else {
-        shortcut[key] = false;
-      }
-    }
-    shortcut.id = id.join(',');
-
-    // Handle special access modifier differently depending on Mac/Win
-    if (shortcut.access) {
-      shortcut.alt = true;
-
-      if (Env.mac) {
-        shortcut.ctrl = true;
-      } else {
-        shortcut.shift = true;
-      }
-    }
-
-    // Handle special meta modifier differently depending on Mac/Win
-    if (shortcut.meta) {
-      if (Env.mac) {
-        shortcut.meta = true;
-      } else {
-        shortcut.ctrl = true;
-        shortcut.meta = false;
-      }
-    }
-
-    return shortcut;
-  }
-
   private createShortcut(pattern: string, desc?: string, cmdFunc?: () => void, scope?): Shortcut {
-    const shortcuts = Tools.map(explode(pattern, '>'), this.parseShortcut);
+    const shortcuts = Tools.map(explode(pattern, '>'), parseShortcut);
     shortcuts[shortcuts.length - 1] = Tools.extend(shortcuts[shortcuts.length - 1], {
       func: cmdFunc,
       scope: scope || this.editor

--- a/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
@@ -15,12 +15,16 @@ import { WindowManagerImpl } from './WindowManager';
 export interface Theme {
   ui?: any;
   inline?: any;
-  execCommand? (command: string, ui?: boolean, value?: any): boolean;
-  destroy? (): void;
-  init? (editor: Editor, url: string, $: DomQueryConstructor);
-  renderUI? (): { iframeContainer?: HTMLIFrameElement; editorContainer: HTMLElement; api?: Partial<EditorUiApi> };
-  getNotificationManagerImpl? (): NotificationManagerImpl;
-  getWindowManagerImpl? (): WindowManagerImpl;
+  execCommand?: (command: string, ui?: boolean, value?: any) => boolean;
+  destroy?: () => void;
+  init?: (editor: Editor, url: string, $: DomQueryConstructor) => void;
+  renderUI?: () => {
+    iframeContainer?: HTMLIFrameElement;
+    editorContainer: HTMLElement;
+    api?: Partial<EditorUiApi>;
+  };
+  getNotificationManagerImpl?: () => NotificationManagerImpl;
+  getWindowManagerImpl?: () => WindowManagerImpl;
 }
 
 type ThemeManager = AddOnManager<Theme>;

--- a/modules/tinymce/src/core/main/ts/api/dom/BookmarkManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/BookmarkManager.ts
@@ -17,8 +17,8 @@ import EditorSelection from './Selection';
  */
 
 interface BookmarkManager {
-  getBookmark (type: number, normalized?: boolean): Bookmark;
-  moveToBookmark (bookmark: Bookmark): void;
+  getBookmark: (type: number, normalized?: boolean) => Bookmark;
+  moveToBookmark: (bookmark: Bookmark) => void;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -21,11 +21,11 @@ import VK from '../util/VK';
 import EditorSelection from './Selection';
 
 interface ControlSelection {
-  isResizable (elm: Element): boolean;
-  showResizeRect (elm: Element): void;
-  hideResizeRect (): void;
-  updateResizeRect (evt: EditorEvent<any>): void;
-  destroy (): void;
+  isResizable: (elm: Element) => boolean;
+  showResizeRect: (elm: Element) => void;
+  hideResizeRect: () => void;
+  updateResizeRect: (evt: EditorEvent<any>) => void;
+  destroy: () => void;
 }
 
 type ResizeHandle = [ number, number, number, number ] & { elm?: Element };

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -186,89 +186,111 @@ interface DOMUtils {
   root: Node;
   $: DomQueryConstructor;
 
-  $$ <T extends Node>(elm: T | T[] | DomQuery<T>): DomQuery<T>;
-  $$ (elm: string): DomQuery<Node>;
-  isBlock (node: string | Node): boolean;
-  clone (node: Node, deep: boolean): Node;
-  getRoot (): HTMLElement;
-  getViewPort (argWin?: Window): GeomRect;
-  getRect (elm: string | HTMLElement): GeomRect;
-  getSize (elm: string | HTMLElement): {
+  $$: {
+    <T extends Node>(elm: T | T[] | DomQuery<T>): DomQuery<T>;
+    (elm: string): DomQuery<Node>;
+  };
+  isBlock: (node: string | Node) => boolean;
+  clone: (node: Node, deep: boolean) => Node;
+  getRoot: () => HTMLElement;
+  getViewPort: (argWin?: Window) => GeomRect;
+  getRect: (elm: string | HTMLElement) => GeomRect;
+  getSize: (elm: string | HTMLElement) => {
     w: number;
     h: number;
   };
-  getParent <K extends keyof HTMLElementTagNameMap>(node: string | Node, selector: K, root?: Node): HTMLElementTagNameMap[K] | null;
-  getParent <T extends HTMLElement>(node: string | Node, selector: (node: HTMLElement) => node is T, root?: Node): T | null;
-  getParent <T extends Element = Element>(node: string | Node, selector?: string | ((node: HTMLElement) => boolean | void), root?: Node): T | null;
-  getParents <K extends keyof HTMLElementTagNameMap>(elm: string | Node, selector: K, root?: Node, collect?: boolean): Array<HTMLElementTagNameMap[K]>;
-  getParents <T extends HTMLElement>(node: string | Node, selector: (node: HTMLElement) => node is T, root?: Node): T[];
-  getParents <T extends Element = Element>(elm: string | Node, selector?: string | ((node: HTMLElement) => boolean | void), root?: Node, collect?: boolean): T[];
-  get (elm: string | Node): HTMLElement | null;
-  getNext (node: Node, selector: string | ((node: Node) => boolean)): Node | null;
-  getPrev (node: Node, selector: string | ((node: Node) => boolean)): Node | null;
-  select <K extends keyof HTMLElementTagNameMap>(selector: K, scope?: string | Node): Array<HTMLElementTagNameMap[K]>;
-  select <T extends HTMLElement = HTMLElement>(selector: string, scope?: string | Node): T[];
-  is (elm: Node | Node[], selector: string): boolean;
-  add (parentElm: RunArguments, name: string | Node, attrs?: Record<string, string | boolean | number>, html?: string | Node, create?: boolean): HTMLElement;
-  create (name: string, attrs?: Record<string, string | boolean | number>, html?: string | Node): HTMLElement;
-  createHTML (name: string, attrs?: Record<string, string>, html?: string): string;
-  createFragment (html?: string): DocumentFragment;
-  remove <T extends Node>(node: string | T | T[] | DomQuery<T>, keepChildren?: boolean): T | T[];
-  setStyle (elm: string | Node | Node[], name: string, value: string | number | null): void;
-  setStyle (elm: string | Node | Node[], styles: StyleMap): void;
-  getStyle (elm: string | Node, name: string, computed?: boolean): string;
-  setStyles (elm: string | Node | Node[], stylesArg: StyleMap): void;
-  removeAllAttribs (e: RunArguments<Element>): void;
-  setAttrib (elm: string | Node | Node[], name: string, value: string | boolean | number | null): void;
-  setAttribs (elm: string | Node | Node[], attrs: Record<string, string | boolean | number | null>): void;
-  getAttrib (elm: string | Node, name: string, defaultVal?: string): string;
-  getPos (elm: string | Node, rootElm?: Node): {
+  getParent: {
+    <K extends keyof HTMLElementTagNameMap>(node: string | Node, selector: K, root?: Node): HTMLElementTagNameMap[K] | null;
+    <T extends HTMLElement>(node: string | Node, selector: (node: HTMLElement) => node is T, root?: Node): T | null;
+    <T extends Element = Element>(node: string | Node, selector?: string | ((node: HTMLElement) => boolean | void), root?: Node): T | null;
+  };
+  getParents: {
+    <K extends keyof HTMLElementTagNameMap>(elm: string | Node, selector: K, root?: Node, collect?: boolean): Array<HTMLElementTagNameMap[K]>;
+    <T extends HTMLElement>(node: string | Node, selector: (node: HTMLElement) => node is T, root?: Node): T[];
+    <T extends Element = Element>(elm: string | Node, selector?: string | ((node: HTMLElement) => boolean | void), root?: Node, collect?: boolean): T[];
+  };
+  get: (elm: string | Node) => HTMLElement | null;
+  getNext: (node: Node, selector: string | ((node: Node) => boolean)) => Node | null;
+  getPrev: (node: Node, selector: string | ((node: Node) => boolean)) => Node | null;
+  select: {
+    <K extends keyof HTMLElementTagNameMap>(selector: K, scope?: string | Node): Array<HTMLElementTagNameMap[K]>;
+    <T extends HTMLElement = HTMLElement>(selector: string, scope?: string | Node): T[];
+  };
+  is: (elm: Node | Node[], selector: string) => boolean;
+  add: (parentElm: RunArguments, name: string | Node, attrs?: Record<string, string | boolean | number>, html?: string | Node, create?: boolean) => HTMLElement;
+  create: (name: string, attrs?: Record<string, string | boolean | number>, html?: string | Node) => HTMLElement;
+  createHTML: (name: string, attrs?: Record<string, string>, html?: string) => string;
+  createFragment: (html?: string) => DocumentFragment;
+  remove: <T extends Node>(node: string | T | T[] | DomQuery<T>, keepChildren?: boolean) => T | T[];
+  setStyle: {
+    (elm: string | Node | Node[], name: string, value: string | number | null): void;
+    (elm: string | Node | Node[], styles: StyleMap): void;
+  };
+  getStyle: (elm: string | Node, name: string, computed?: boolean) => string;
+  setStyles: (elm: string | Node | Node[], stylesArg: StyleMap) => void;
+  removeAllAttribs: (e: RunArguments<Element>) => void;
+  setAttrib: (elm: string | Node | Node[], name: string, value: string | boolean | number | null) => void;
+  setAttribs: (elm: string | Node | Node[], attrs: Record<string, string | boolean | number | null>) => void;
+  getAttrib: (elm: string | Node, name: string, defaultVal?: string) => string;
+  getPos: (elm: string | Node, rootElm?: Node) => {
     x: number;
     y: number;
   };
-  parseStyle (cssText: string): Record<string, string>;
-  serializeStyle (stylesArg: StyleMap, name?: string): string;
-  addStyle (cssText: string): void;
-  loadCSS (url: string): void;
-  addClass (elm: string | Node | Node[], cls: string): void;
-  removeClass (elm: string | Node | Node[], cls: string): void;
-  hasClass (elm: string | Node, cls: string): boolean;
-  toggleClass (elm: string | Node | Node[], cls: string, state?: boolean): void;
-  show (elm: string | Node | Node[]): void;
-  hide (elm: string | Node | Node[]): void;
-  isHidden (elm: string | Node): boolean;
-  uniqueId (prefix?: string): string;
-  setHTML (elm: string | Node | Node[], html: string): void;
-  getOuterHTML (elm: string | Node): string;
-  setOuterHTML (elm: string | Node | Node[], html: string): void;
-  decode (text: string): string;
-  encode (text: string): string;
-  insertAfter <T extends Node>(node: T | T[], reference: string | Node): T;
-  insertAfter <T extends Node>(node: RunArguments<T>, reference: string | Node): false | T;
-  replace <T extends Node>(newElm: Node, oldElm: T | T[], keepChildren?: boolean): T;
-  replace <T extends Node>(newElm: Node, oldElm: RunArguments<T>, keepChildren?: boolean): false | T;
-  rename <K extends keyof HTMLElementTagNameMap>(elm: Element, name: K): HTMLElementTagNameMap[K];
-  rename (elm: Element, name: string): Element;
-  findCommonAncestor (a: Node, b: Node): Node;
-  toHex (rgbVal: string): string;
-  run <R, T extends Node>(elm: T | T[], func: (node: T) => R, scope?: any): R;
-  run <R, T extends Node>(elm: RunArguments<T>, func: (node: T) => R, scope?: any): false | R;
-  getAttribs (elm: string | Node): NamedNodeMap | Attr[];
-  isEmpty (node: Node, elements?: Record<string, any>): boolean;
-  createRng (): Range;
-  nodeIndex (node: Node, normalized?: boolean): number;
-  split <T extends Node>(parentElm: Node, splitElm: Node, replacementElm: T): T;
-  split <T extends Node>(parentElm: Node, splitElm: T): T;
-  bind <K extends string>(target: Target, name: K, func: Callback<K>, scope?: any): Callback<K>;
-  bind <K extends string>(target: Target[], name: K, func: Callback<K>, scope?: any): Callback<K>[];
-  unbind <K extends string>(target: Target, name?: K, func?: EventUtilsCallback<MappedEvent<HTMLElementEventMap, K>>): EventUtils;
-  unbind <K extends string>(target: Target[], name?: K, func?: EventUtilsCallback<MappedEvent<HTMLElementEventMap, K>>): EventUtils[];
-  fire (target: Node | Window, name: string, evt?: {}): EventUtils;
-  getContentEditable (node: Node): string | null;
-  getContentEditableParent (node: Node): string | null;
-  destroy (): void;
-  isChildOf (node: Node, parent: Node): boolean;
-  dumpRng (r: Range): string;
+  parseStyle: (cssText: string) => Record<string, string>;
+  serializeStyle: (stylesArg: StyleMap, name?: string) => string;
+  addStyle: (cssText: string) => void;
+  loadCSS: (url: string) => void;
+  addClass: (elm: string | Node | Node[], cls: string) => void;
+  removeClass: (elm: string | Node | Node[], cls: string) => void;
+  hasClass: (elm: string | Node, cls: string) => boolean;
+  toggleClass: (elm: string | Node | Node[], cls: string, state?: boolean) => void;
+  show: (elm: string | Node | Node[]) => void;
+  hide: (elm: string | Node | Node[]) => void;
+  isHidden: (elm: string | Node) => boolean;
+  uniqueId: (prefix?: string) => string;
+  setHTML: (elm: string | Node | Node[], html: string) => void;
+  getOuterHTML: (elm: string | Node) => string;
+  setOuterHTML: (elm: string | Node | Node[], html: string) => void;
+  decode: (text: string) => string;
+  encode: (text: string) => string;
+  insertAfter: {
+    <T extends Node>(node: T | T[], reference: string | Node): T;
+    <T extends Node>(node: RunArguments<T>, reference: string | Node): false | T;
+  };
+  replace: {
+    <T extends Node>(newElm: Node, oldElm: T | T[], keepChildren?: boolean): T;
+    <T extends Node>(newElm: Node, oldElm: RunArguments<T>, keepChildren?: boolean): false | T;
+  };
+  rename: {
+    <K extends keyof HTMLElementTagNameMap>(elm: Element, name: K): HTMLElementTagNameMap[K];
+    (elm: Element, name: string): Element;
+  };
+  findCommonAncestor: (a: Node, b: Node) => Node;
+  toHex: (rgbVal: string) => string;
+  run <R, T extends Node>(this: DOMUtils, elm: T | T[], func: (node: T) => R, scope?: any): R;
+  run <R, T extends Node>(this: DOMUtils, elm: RunArguments<T>, func: (node: T) => R, scope?: any): false | R;
+  getAttribs: (elm: string | Node) => NamedNodeMap | Attr[];
+  isEmpty: (node: Node, elements?: Record<string, any>) => boolean;
+  createRng: () => Range;
+  nodeIndex: (node: Node, normalized?: boolean) => number;
+  split: {
+    <T extends Node>(parentElm: Node, splitElm: Node, replacementElm: T): T;
+    <T extends Node>(parentElm: Node, splitElm: T): T;
+  };
+  bind: {
+    <K extends string>(target: Target, name: K, func: Callback<K>, scope?: any): Callback<K>;
+    <K extends string>(target: Target[], name: K, func: Callback<K>, scope?: any): Callback<K>[];
+  };
+  unbind: {
+    <K extends string>(target: Target, name?: K, func?: EventUtilsCallback<MappedEvent<HTMLElementEventMap, K>>): EventUtils;
+    <K extends string>(target: Target[], name?: K, func?: EventUtilsCallback<MappedEvent<HTMLElementEventMap, K>>): EventUtils[];
+  };
+  fire: (target: Node | Window, name: string, evt?: {}) => EventUtils;
+  getContentEditable: (node: Node) => string | null;
+  getContentEditableParent: (node: Node) => string | null;
+  destroy: () => void;
+  isChildOf: (node: Node, parent: Node) => boolean;
+  dumpRng: (r: Range) => string;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/dom/DomQuery.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DomQuery.ts
@@ -153,7 +153,11 @@ interface DomQuery<T extends Node = Node> extends ArrayLike<T> {
   wrapInner (content: string): this;
 }
 
-const doc = document, push = Array.prototype.push, slice = Array.prototype.slice;
+const doc = document;
+/* eslint-disable @typescript-eslint/unbound-method */
+const push = Array.prototype.push;
+const slice = Array.prototype.slice;
+/* eslint-enable */
 const rquickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w\-]*)$)/;
 const Event = EventUtils.Event;
 const skipUniques = Tools.makeMap('children,contents,next,prev');
@@ -1229,8 +1233,10 @@ DomQueryConstructor.fn = (DomQueryConstructor as any).prototype = {
   },
 
   push,
+  /* eslint-disable @typescript-eslint/unbound-method */
   sort: Array.prototype.sort,
   splice: Array.prototype.splice
+  /* eslint-enable */
 };
 
 // Static members

--- a/modules/tinymce/src/core/main/ts/api/dom/RangeUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/RangeUtils.ts
@@ -16,9 +16,9 @@ import * as SplitRange from '../../selection/SplitRange';
 import DOMUtils from './DOMUtils';
 
 interface RangeUtils {
-  walk (rng: Range, callback: (nodes: Node[]) => void): void;
-  split (rng: Range): RangeLikeObject;
-  normalize (rng: Range): boolean;
+  walk: (rng: Range, callback: (nodes: Node[]) => void) => void;
+  split: (rng: Range) => RangeLikeObject;
+  normalize: (rng: Range) => boolean;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -64,8 +64,10 @@ interface EditorSelection {
   editor: Editor;
   collapse: (toStart?: boolean) => void;
   setCursorLocation: (node?: Node, offset?: number) => void;
-  getContent (args: { format: 'tree' } & GetSelectionContent.GetSelectionContentArgs): AstNode;
-  getContent (args?: GetSelectionContent.GetSelectionContentArgs): string;
+  getContent: {
+    (args: { format: 'tree' } & GetSelectionContent.GetSelectionContentArgs): AstNode;
+    (args?: GetSelectionContent.GetSelectionContentArgs): string;
+  };
   setContent: (content: string, args?: SetSelectionContent.SelectionSetContentArgs) => void;
   getBookmark: (type?: number, normalized?: boolean) => Bookmark;
   moveToBookmark: (bookmark: Bookmark) => void;

--- a/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
@@ -24,7 +24,7 @@ import { Arr } from '@ephox/katamari';
 
 /* eslint-enable */
 
-/* eslint-disable no-bitwise, prefer-const, no-nested-ternary, @typescript-eslint/consistent-type-assertions, prefer-arrow/prefer-arrow-functions, @tinymce/prefer-fun */
+/* eslint-disable no-bitwise, prefer-const, no-nested-ternary, @typescript-eslint/consistent-type-assertions, prefer-arrow/prefer-arrow-functions, @tinymce/prefer-fun, @typescript-eslint/unbound-method */
 
 let support,
   Expr,

--- a/modules/tinymce/src/core/main/ts/api/geom/Rect.ts
+++ b/modules/tinymce/src/core/main/ts/api/geom/Rect.ts
@@ -19,13 +19,13 @@ export interface GeomRect {
 }
 
 interface Rect {
-  inflate (rect: GeomRect, w: number, h: number): GeomRect;
-  relativePosition (rect: GeomRect, targetRect: GeomRect, rel: string): GeomRect;
-  findBestRelativePosition (rect: GeomRect, targetRect: GeomRect, constrainRect: GeomRect, rels: string[]): string | null;
-  intersect (rect: GeomRect, cropRect: GeomRect): GeomRect | null;
-  clamp (rect: GeomRect, clampRect: GeomRect, fixedSize?: boolean): GeomRect;
-  create (x: number, y: number, w: number, h: number): GeomRect;
-  fromClientRect (clientRect: ClientRect): GeomRect;
+  inflate: (rect: GeomRect, w: number, h: number) => GeomRect;
+  relativePosition: (rect: GeomRect, targetRect: GeomRect, rel: string) => GeomRect;
+  findBestRelativePosition: (rect: GeomRect, targetRect: GeomRect, constrainRect: GeomRect, rels: string[]) => string | null;
+  intersect: (rect: GeomRect, cropRect: GeomRect) => GeomRect | null;
+  clamp: (rect: GeomRect, clampRect: GeomRect, fixedSize?: boolean) => GeomRect;
+  create: (x: number, y: number, w: number, h: number) => GeomRect;
+  fromClientRect: (clientRect: ClientRect) => GeomRect;
 }
 
 const min = Math.min, max = Math.max, round = Math.round;

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -71,12 +71,12 @@ export interface DomParserSettings {
 
 interface DomParser {
   schema: Schema;
-  addAttributeFilter (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void): void;
-  getAttributeFilters (): ParserFilter[];
-  addNodeFilter (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void): void;
-  getNodeFilters (): ParserFilter[];
-  filterNode (node: AstNode): AstNode;
-  parse (html: string, args?: ParserArgs): AstNode;
+  addAttributeFilter: (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => void;
+  getAttributeFilters: () => ParserFilter[];
+  addNodeFilter: (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => void;
+  getNodeFilters: () => ParserFilter[];
+  filterNode: (node: AstNode) => AstNode;
+  parse: (html: string, args?: ParserArgs) => AstNode;
 }
 
 const DomParser = (settings?: DomParserSettings, schema = Schema()): DomParser => {

--- a/modules/tinymce/src/core/main/ts/api/html/Entities.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Entities.ts
@@ -11,12 +11,12 @@ import Tools from '../util/Tools';
 export interface EntitiesMap { [name: string]: string }
 
 interface Entities {
-  encodeRaw (text: string, attr?: boolean): string;
-  encodeAllRaw (text: string): string;
-  encodeNumeric (text: string, attr?: boolean): string;
-  encodeNamed (text: string, attr?: boolean, entities?: EntitiesMap): string;
-  getEncodeFunc (name: string, entities?: EntitiesMap | string): (text: string, attr?: boolean) => string;
-  decode (text: string): string;
+  encodeRaw: (text: string, attr?: boolean) => string;
+  encodeAllRaw: (text: string) => string;
+  encodeNumeric: (text: string, attr?: boolean) => string;
+  encodeNamed: (text: string, attr?: boolean, entities?: EntitiesMap) => string;
+  getEncodeFunc: (name: string, entities?: EntitiesMap | string) => (text: string, attr?: boolean) => string;
+  decode: (text: string) => string;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -65,19 +65,19 @@ export interface SaxParserSettings {
   self_closing_elements?: Record<string, {}>;
   validate?: boolean;
 
-  cdata? (text: string): void;
-  comment? (text: string): void;
-  doctype? (text: string): void;
-  end? (name: string): void;
-  pi? (name: string, text: string): void;
-  start? (name: string, attrs: AttrList, empty: boolean): void;
-  text? (text: string, raw?: boolean): void;
+  cdata?: (text: string) => void;
+  comment?: (text: string) => void;
+  doctype?: (text: string) => void;
+  end?: (name: string) => void;
+  pi?: (name: string, text: string) => void;
+  start?: (name: string, attrs: AttrList, empty: boolean) => void;
+  text?: (text: string, raw?: boolean) => void;
 }
 
 export type ParserFormat = 'html' | 'xhtml' | 'xml';
 
 interface SaxParser {
-  parse (html: string, format?: ParserFormat): void;
+  parse: (html: string, format?: ParserFormat) => void;
 }
 
 const enum ParsingMode {

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -77,27 +77,27 @@ export interface SchemaRegExpMap { [name: string]: RegExp }
 interface Schema {
   children: Record<string, {}>;
   elements: Record<string, SchemaElement>;
-  getValidStyles (): SchemaMap;
-  getValidClasses (): SchemaMap;
-  getBlockElements (): SchemaMap;
-  getInvalidStyles (): SchemaMap;
-  getShortEndedElements (): SchemaMap;
-  getTextBlockElements (): SchemaMap;
-  getTextInlineElements (): SchemaMap;
-  getBoolAttrs (): SchemaMap;
-  getElementRule (name: string): SchemaElement;
-  getSelfClosingElements (): SchemaMap;
-  getNonEmptyElements (): SchemaMap;
-  getMoveCaretBeforeOnEnterElements (): SchemaMap;
-  getWhiteSpaceElements (): SchemaMap;
-  getSpecialElements (): SchemaRegExpMap;
-  isValidChild (name: string, child: string): boolean;
-  isValid (name: string, attr?: string): boolean;
-  getCustomElements (): SchemaMap;
-  addValidElements (validElements: string): void;
-  setValidElements (validElements: string): void;
-  addCustomElements (customElements: string): void;
-  addValidChildren (validChildren: any): void;
+  getValidStyles: () => SchemaMap;
+  getValidClasses: () => SchemaMap;
+  getBlockElements: () => SchemaMap;
+  getInvalidStyles: () => SchemaMap;
+  getShortEndedElements: () => SchemaMap;
+  getTextBlockElements: () => SchemaMap;
+  getTextInlineElements: () => SchemaMap;
+  getBoolAttrs: () => SchemaMap;
+  getElementRule: (name: string) => SchemaElement;
+  getSelfClosingElements: () => SchemaMap;
+  getNonEmptyElements: () => SchemaMap;
+  getMoveCaretBeforeOnEnterElements: () => SchemaMap;
+  getWhiteSpaceElements: () => SchemaMap;
+  getSpecialElements: () => SchemaRegExpMap;
+  isValidChild: (name: string, child: string) => boolean;
+  isValid: (name: string, attr?: string) => boolean;
+  getCustomElements: () => SchemaMap;
+  addValidElements: (validElements: string) => void;
+  setValidElements: (validElements: string) => void;
+  addCustomElements: (customElements: string) => void;
+  addValidChildren: (validChildren: any) => void;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
@@ -15,7 +15,7 @@ export interface HtmlSerializerSettings extends WriterSettings {
 }
 
 interface HtmlSerializer {
-  serialize (node: AstNode): string;
+  serialize: (node: AstNode) => string;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -38,9 +38,9 @@ export interface StylesSettings {
 }
 
 interface Styles {
-  toHex(color: string): string;
-  parse(css: string): Record<string, string>;
-  serialize(styles: StyleMap, elementName?: string): string;
+  toHex: (color: string) => string;
+  parse: (css: string) => Record<string, string>;
+  serialize: (styles: StyleMap, elementName?: string) => string;
 }
 
 const toHex = (match: string, r: string, g: string, b: string) => {

--- a/modules/tinymce/src/core/main/ts/api/html/Writer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Writer.ts
@@ -35,15 +35,15 @@ export interface WriterSettings {
 }
 
 interface Writer {
-  cdata (text: string): void;
-  comment (text: string): void;
-  doctype (text: string): void;
-  end (name: string): void;
-  getContent (): string;
-  pi (name: string, text: string): void;
-  reset (): void;
-  start (name: string, attrs?: Attributes, empty?: boolean): void;
-  text (text: string, raw?: boolean): void;
+  cdata: (text: string) => void;
+  comment: (text: string) => void;
+  doctype: (text: string) => void;
+  end: (name: string) => void;
+  getContent: () => string;
+  pi: (name: string, text: string) => void;
+  reset: () => void;
+  start: (name: string, attrs?: Attributes, empty?: boolean) => void;
+  text: (text: string, raw?: boolean) => void;
 }
 
 const Writer = (settings?: WriterSettings): Writer => {

--- a/modules/tinymce/src/core/main/ts/api/util/Color.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Color.ts
@@ -32,10 +32,10 @@ interface HSV {
 }
 
 interface Color {
-  toRgb (): RGB;
-  toHsv (): HSV;
-  toHex (): string;
-  parse (value: string | RGB | HSV): Color;
+  toRgb: () => RGB;
+  toHsv: () => HSV;
+  toHex: () => string;
+  parse: (value: string | RGB | HSV) => Color;
 }
 
 export type ColorConstructor = new (value?: string | RGB | HSV) => Color;

--- a/modules/tinymce/src/core/main/ts/api/util/Delay.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Delay.ts
@@ -14,15 +14,15 @@ interface DebounceFunc<T extends (...args: any[]) => void> {
 }
 
 interface Delay {
-  requestAnimationFrame (callback: () => void, element?: HTMLElement): void;
-  setEditorInterval (editor: Editor, callback: () => void, time?: number): number;
-  setEditorTimeout (editor: Editor, callback: () => void, time?: number): number;
-  setInterval (callback: () => void, time?: number): number;
-  setTimeout (callback: () => void, time?: number): number;
-  clearInterval (id?: number): void;
-  clearTimeout (id?: number): void;
-  debounce <T extends (...args: any[]) => any>(callback: T, time?: number): DebounceFunc<T>;
-  throttle <T extends (...args: any[]) => any>(callback: T, time?: number): DebounceFunc<T>;
+  requestAnimationFrame: (callback: () => void, element?: HTMLElement) => void;
+  setEditorInterval: (editor: Editor, callback: () => void, time?: number) => number;
+  setEditorTimeout: (editor: Editor, callback: () => void, time?: number) => number;
+  setInterval: (callback: () => void, time?: number) => number;
+  setTimeout: (callback: () => void, time?: number) => number;
+  clearInterval: (id?: number) => void;
+  clearTimeout: (id?: number) => void;
+  debounce: <T extends (...args: any[]) => any>(callback: T, time?: number) => DebounceFunc<T>;
+  throttle: <T extends (...args: any[]) => any>(callback: T, time?: number) => DebounceFunc<T>;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
@@ -56,12 +56,12 @@ export interface NativeEventMap {
 export type EditorEvent<T> = T & {
   target: any;
   type: string;
-  preventDefault (): void;
-  isDefaultPrevented (): boolean;
-  stopPropagation (): void;
-  isPropagationStopped (): boolean;
-  stopImmediatePropagation (): void;
-  isImmediatePropagationStopped (): boolean;
+  preventDefault: () => void;
+  isDefaultPrevented: () => boolean;
+  stopPropagation: () => void;
+  isPropagationStopped: () => boolean;
+  stopImmediatePropagation: () => void;
+  isImmediatePropagationStopped: () => boolean;
 };
 
 export interface EventDispatcherSettings {
@@ -75,7 +75,7 @@ export interface EventDispatcherConstructor<T extends NativeEventMap> {
 
   new (settings?: EventDispatcherSettings): EventDispatcher<T>;
 
-  isNative (name: string): boolean;
+  isNative: (name: string) => boolean;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/util/I18n.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/I18n.ts
@@ -159,13 +159,13 @@ const isRtl = () => getLanguageData()
 const hasCode = (code: string) => Obj.has(data, code);
 
 interface I18n {
-  getData (): Record<string, Record<string, string>>;
-  setCode (newCode: string): void;
-  getCode (): string;
-  add (code: string, items: Record<string, string>): void;
-  translate (text: Untranslated): TranslatedString;
-  isRtl (): boolean;
-  hasCode (code: string): boolean;
+  getData: () => Record<string, Record<string, string>>;
+  setCode: (newCode: string) => void;
+  getCode: () => string;
+  add: (code: string, items: Record<string, string>) => void;
+  translate: (text: Untranslated) => TranslatedString;
+  isRtl: () => boolean;
+  hasCode: (code: string) => boolean;
 }
 
 const I18n: I18n = {

--- a/modules/tinymce/src/core/main/ts/api/util/ImageUploader.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/ImageUploader.ts
@@ -15,7 +15,7 @@ import * as Settings from '../Settings';
 export type UploadResult = Uploader.UploadResult;
 
 interface ImageUploader {
-  upload (blobInfos: BlobInfo[], showNotification?: boolean): Promise<UploadResult[]>;
+  upload: (blobInfos: BlobInfo[], showNotification?: boolean) => Promise<UploadResult[]>;
 }
 
 export const openNotification = (editor: Editor) => (): NotificationApi => editor.notificationManager.open({

--- a/modules/tinymce/src/core/main/ts/api/util/JSON.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/JSON.ts
@@ -35,8 +35,8 @@ const serialize = (obj: any) => {
 };
 
 interface JSONUtils {
-  serialize (obj: any): string;
-  parse (text: string): any;
+  serialize: (obj: any) => string;
+  parse: (text: string) => any;
 }
 
 const JSONUtils: JSONUtils = {

--- a/modules/tinymce/src/core/main/ts/api/util/JSONP.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/JSONP.ts
@@ -10,20 +10,20 @@ import DOMUtils from '../dom/DOMUtils';
 export interface JSONPSettings {
   count?: number;
   url: string;
-  callback (json: string): void;
+  callback: (json: string) => void;
 }
 
 interface JSONP {
   callbacks: {};
   count: number;
-  send (settings: JSONPSettings): void;
+  send (this: JSONP, settings: JSONPSettings): void;
 }
 
 const JSONP: JSONP = {
   callbacks: {},
   count: 0,
 
-  send(settings: JSONPSettings) {
+  send(this: JSONP, settings: JSONPSettings) {
     const self = this, dom = DOMUtils.DOM, count = settings.count !== undefined ? settings.count : self.count;
     const id = 'tinymce_jsonp_' + count;
 

--- a/modules/tinymce/src/core/main/ts/api/util/JSONRequest.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/JSONRequest.ts
@@ -46,8 +46,8 @@ export interface JSONRequestSettings {
   url?: string;
   error_scope?: any;
   success_scope?: any;
-  success? (data: any): void;
-  error? (error: any, xhr: XMLHttpRequest): void;
+  success?: (data: any) => void;
+  error?: (error: any, xhr: XMLHttpRequest) => void;
 }
 
 export interface JSONRequestArgs extends JSONRequestSettings {
@@ -61,7 +61,7 @@ export interface JSONRequestConstructor {
 
   new (settings?: JSONRequestSettings): JSONRequest;
 
-  sendRPC (o: JSONRequestArgs): void;
+  sendRPC: (o: JSONRequestArgs) => void;
 }
 
 class JSONRequest {

--- a/modules/tinymce/src/core/main/ts/api/util/Tools.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Tools.ts
@@ -13,26 +13,32 @@ type ArrayCallback<T, R> = ArrUtils.ArrayCallback<T, R>;
 type ObjCallback<T, R> = ArrUtils.ObjCallback<T, R>;
 
 interface Tools {
-  is (obj: any, type: string): boolean;
-  isArray <T>(arr: any): arr is Array<T>;
-  inArray <T>(arr: ArrayLike<T>, value: T): number;
-  grep <T>(arr: ArrayLike<T> | null | undefined, pred?: ArrayCallback<T, boolean>): T[];
-  grep <T>(arr: Record<string, T> | null | undefined, pred?: ObjCallback<T, boolean>): T[];
-  trim (str: string): string;
-  toArray <T>(obj: ArrayLike<T>): T[];
-  hasOwn (obj: any, name: string): boolean;
-  makeMap <T>(items: ArrayLike<T> | string, delim?: string | RegExp, map?: Record<string, T | string>): Record<string, T | string>;
-  each <T>(arr: ArrayLike<T> | null | undefined, cb: ArrayCallback<T, void | boolean>, scope?: any): boolean;
-  each <T>(obj: Record<string, T> | null | undefined, cb: ObjCallback<T, void | boolean>, scope?: any): boolean;
-  map <T, R>(arr: ArrayLike<T> | null | undefined, cb: ArrayCallback<T, R>): R[];
-  map <T, R>(obj: Record<string, T> | null | undefined, cb: ObjCallback<T, R>): R[];
-  extend (obj: Object, ext: Object, ...objs: Object[]): any;
-  create (name: string, p: Object, root?: Object);
-  walk <T = any>(obj: T, f: Function, n?: keyof T, scope?: any): void;
-  createNS (name: string, o?: Object): any;
-  resolve (path: string, o?: Object): any;
-  explode (s: string, d?: string | RegExp): string[];
-  _addCacheSuffix (url: string): string;
+  is: (obj: any, type: string) => boolean;
+  isArray: <T>(arr: any) => arr is Array<T>;
+  inArray: <T>(arr: ArrayLike<T>, value: T) => number;
+  grep: {
+    <T>(arr: ArrayLike<T> | null | undefined, pred?: ArrayCallback<T, boolean>): T[];
+    <T>(arr: Record<string, T> | null | undefined, pred?: ObjCallback<T, boolean>): T[];
+  };
+  trim: (str: string) => string;
+  toArray: <T>(obj: ArrayLike<T>) => T[];
+  hasOwn: (obj: any, name: string) => boolean;
+  makeMap: <T>(items: ArrayLike<T> | string, delim?: string | RegExp, map?: Record<string, T | string>) => Record<string, T | string>;
+  each: {
+    <T>(arr: ArrayLike<T> | null | undefined, cb: ArrayCallback<T, void | boolean>, scope?: any): boolean;
+    <T>(obj: Record<string, T> | null | undefined, cb: ObjCallback<T, void | boolean>, scope?: any): boolean;
+  };
+  map: {
+    <T, R>(arr: ArrayLike<T> | null | undefined, cb: ArrayCallback<T, R>): R[];
+    <T, R>(obj: Record<string, T> | null | undefined, cb: ObjCallback<T, R>): R[];
+  };
+  extend: (obj: Object, ext: Object, ...objs: Object[]) => any;
+  create: (name: string, p: Object, root?: Object) => void;
+  walk: <T = any>(obj: T, f: Function, n?: keyof T, scope?: any) => void;
+  createNS: (name: string, o?: Object) => any;
+  resolve: (path: string, o?: Object) => any;
+  explode: (s: string, d?: string | RegExp) => string[];
+  _addCacheSuffix: (url: string) => string;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/util/URI.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/URI.ts
@@ -31,8 +31,8 @@ export interface URIConstructor {
 
   new (url: string, settings?: URISettings): URI;
 
-  getDocumentBaseUrl (loc: { protocol: string; host?: string; href?: string; pathname?: string }): string;
-  parseDataUri (uri: string): { type: string; data: string };
+  getDocumentBaseUrl: (loc: { protocol: string; host?: string; href?: string; pathname?: string }) => string;
+  parseDataUri: (uri: string) => { type: string; data: string };
 }
 
 class URI {

--- a/modules/tinymce/src/core/main/ts/api/util/VK.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/VK.ts
@@ -27,8 +27,8 @@ interface VK {
   END: number;
   HOME: number;
 
-  modifierPressed (e: KeyboardLikeEvent): boolean;
-  metaKeyPressed (e: KeyboardLikeEvent): boolean;
+  modifierPressed: (e: KeyboardLikeEvent) => boolean;
+  metaKeyPressed: (e: KeyboardLikeEvent) => boolean;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/util/XHR.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/XHR.ts
@@ -20,8 +20,8 @@ export interface XHRSettings {
   url: string;
   error_scope?: any;
   success_scope?: any;
-  error? (message: 'TIMED_OUT' | 'GENERAL', xhr: XMLHttpRequest, settings: XHRSettings): void;
-  success? (text: string, xhr: XMLHttpRequest, settings: XHRSettings): void;
+  error?: (message: 'TIMED_OUT' | 'GENERAL', xhr: XMLHttpRequest, settings: XHRSettings) => void;
+  success?: (text: string, xhr: XMLHttpRequest, settings: XHRSettings) => void;
 }
 
 export interface XHREventMap {
@@ -30,7 +30,7 @@ export interface XHREventMap {
 }
 
 interface XHR extends Observable<XHREventMap> {
-  send (settings: XHRSettings): void;
+  send (this: XHR, settings: XHRSettings): void;
 }
 
 /**
@@ -230,7 +230,7 @@ const XHR: XHR = {
    * </table>
    * </div>
    */
-  send(settings: XHRSettings) {
+  send(this: XHR, settings: XHRSettings) {
     let xhr, count = 0;
 
     const ready = () => {

--- a/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
@@ -44,13 +44,13 @@ const findNode = (node: Node, direction: number, predicateFn: (node: Node) => bo
 
   if (isBackwards(direction)) {
     if (isCefOrCaretContainer) {
-      node = skipCaretContainers(walker.prev, true);
+      node = skipCaretContainers(walker.prev.bind(walker), true);
       if (predicateFn(node)) {
         return node;
       }
     }
 
-    while ((node = skipCaretContainers(walker.prev, shallow))) {
+    while ((node = skipCaretContainers(walker.prev.bind(walker), shallow))) {
       if (predicateFn(node)) {
         return node;
       }
@@ -59,13 +59,13 @@ const findNode = (node: Node, direction: number, predicateFn: (node: Node) => bo
 
   if (isForwards(direction)) {
     if (isCefOrCaretContainer) {
-      node = skipCaretContainers(walker.next, true);
+      node = skipCaretContainers(walker.next.bind(walker), true);
       if (predicateFn(node)) {
         return node;
       }
     }
 
-    while ((node = skipCaretContainers(walker.next, shallow))) {
+    while ((node = skipCaretContainers(walker.next.bind(walker), shallow))) {
       if (predicateFn(node)) {
         return node;
       }

--- a/modules/tinymce/src/core/main/ts/caret/CaretWalker.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretWalker.ts
@@ -13,8 +13,8 @@ import CaretPosition from './CaretPosition';
 import { findNode, isBackwards, isForwards } from './CaretUtils';
 
 export interface CaretWalker {
-  next(caretPosition: CaretPosition): CaretPosition;
-  prev(caretPosition: CaretPosition): CaretPosition;
+  next: (caretPosition: CaretPosition) => CaretPosition;
+  prev: (caretPosition: CaretPosition) => CaretPosition;
 }
 
 /**

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerImpl.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerImpl.ts
@@ -33,16 +33,18 @@ interface DomSerializerSettings extends DomParserSettings, WriterSettings, Schem
 
 interface DomSerializerImpl {
   schema: Schema;
-  addNodeFilter (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void): void;
-  addAttributeFilter (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void): void;
-  getNodeFilters (): ParserFilter[];
-  getAttributeFilters (): ParserFilter[];
-  serialize (node: Element, parserArgs: { format: 'tree' } & DomSerializerArgs): AstNode;
-  serialize (node: Element, parserArgs?: DomSerializerArgs): string;
-  addRules (rules: string): void;
-  setRules (rules: string): void;
-  addTempAttr (name: string): void;
-  getTempAttrs (): string[];
+  addNodeFilter: (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => void;
+  addAttributeFilter: (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => void;
+  getNodeFilters: () => ParserFilter[];
+  getAttributeFilters: () => ParserFilter[];
+  serialize: {
+    (node: Element, parserArgs: { format: 'tree' } & DomSerializerArgs): AstNode;
+    (node: Element, parserArgs?: DomSerializerArgs): string;
+  };
+  addRules: (rules: string) => void;
+  setRules: (rules: string) => void;
+  addTempAttr: (name: string) => void;
+  getTempAttrs: () => string[];
 }
 
 const addTempAttr = (htmlParser: DomParser, tempAttrs: string[], name: string) => {

--- a/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
@@ -13,11 +13,13 @@ import * as DefaultFormats from './DefaultFormats';
 import { Format, Formats } from './FormatTypes';
 
 export interface FormatRegistry {
-  get (name: string): Format[];
-  get (): Record<string, Format[]>;
-  has (name: string): boolean;
-  register (name: string | Formats, format?: Format[] | Format): void;
-  unregister (name: string): Formats;
+  get: {
+    (name: string): Format[];
+    (): Record<string, Format[]>;
+  };
+  has: (name: string) => boolean;
+  register: (name: string | Formats, format?: Format[] | Format) => void;
+  unregister: (name: string) => Formats;
 }
 
 export const FormatRegistry = (editor: Editor): FormatRegistry => {

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -410,6 +410,8 @@ const initContentBody = (editor: Editor, skipWrite?: boolean) => {
   editor.schema = Schema(settings);
   editor.dom = DOMUtils(doc, {
     keep_values: true,
+    // Note: Don't bind here, as the binding is handled via the `url_converter_scope`
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     url_converter: editor.convertURL,
     url_converter_scope: editor,
     hex_colors: settings.force_hex_style_colors,

--- a/modules/tinymce/src/core/test/ts/browser/util/UriTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/UriTest.ts
@@ -124,6 +124,7 @@ UnitTest.asynctest('browser.tinymce.core.util.UriTest', (success, failure) => {
   });
 
   suite.test('getDocumentBaseUrl', () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     const getDocumentBaseUrl = URI.getDocumentBaseUrl;
 
     LegacyUnit.equal(getDocumentBaseUrl({ protocol: 'file:', host: '', pathname: '/dir/path1/path2' }), 'file:///dir/path1/');

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -172,7 +172,9 @@ const pasteImage = (editor: Editor, imageItem: FileResult) => {
 
 const isClipboardEvent = (event: Event): event is ClipboardEvent => event.type === 'paste';
 
-const isDataTransferItem = (item: DataTransferItem | File): item is DataTransferItem => Type.isNonNullable((item as DataTransferItem).getAsFile);
+const isDataTransferItem = (item: DataTransferItem | File): item is DataTransferItem =>
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  Type.isNonNullable((item as DataTransferItem).getAsFile);
 
 const readFilesAsDataUris = (items: Array<File | DataTransferItem>) => Promise.all(Arr.map(items, (item) => new Promise<FileResult>((resolve) => {
   const blob = isDataTransferItem(item) ? item.getAsFile() : item;

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
@@ -75,7 +75,7 @@ const collectTextToBoundary = (dom: DOMUtils, section: TextSection, node: Node, 
 
   const rootBlock = dom.getParent(rootNode, dom.isBlock);
   const walker = new DomTreeWalker(node, rootBlock);
-  const walkerFn = forwards ? walker.next : walker.prev;
+  const walkerFn = forwards ? walker.next.bind(walker) : walker.prev.bind(walker);
 
   // Walk over and add text nodes to the section and increase the offsets
   // so we know to ignore the additional text when matching
@@ -111,7 +111,7 @@ const collect = (dom: DOMUtils, rootNode: Node, startNode: Node, endNode?: Node,
 
   // Collect all the text nodes in the specified range and create sections from the
   // boundaries within the range
-  walk(dom, walker.next, startNode, {
+  walk(dom, walker.next.bind(walker), startNode, {
     boundary: finishSection,
     cef: (node) => {
       finishSection();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@ephox/swag": "^4.3.0",
     "@ephox/wrap-jsverify": "^2.0.1",
     "@ephox/wrap-prismjs": "^1.19.0",
-    "@tinymce/eslint-plugin": "^1.6.1",
+    "@tinymce/eslint-plugin": "^1.7.1",
     "awesome-typescript-loader": "^5.2.0",
     "chalk": "^4.1.0",
     "emojilib": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,10 +1260,10 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tinymce/eslint-plugin@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@tinymce/eslint-plugin/-/eslint-plugin-1.6.1.tgz#fc37f96f3804196e968615f10e48548f7ebb8e28"
-  integrity sha512-DFGi/Tyq+e3xR5+HSxe9/buzPRJsONVBRfh7u5cNbxyLfANOehtf+XULYioxy51mAKsMLXYDH17hgRc11BQXpA==
+"@tinymce/eslint-plugin@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@tinymce/eslint-plugin/-/eslint-plugin-1.7.1.tgz#5e3685a6ab4e613636fd79f8126058f33ca0fe71"
+  integrity sha512-Y45sApqyWZ799CNyI+TgtrhtDT4MQ9bGd7qrZvA62YkpTqcZMNkeSKTpYwaYg0owiegAc6v3fWL7M6G6Bs7uVg==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.0.0"
     "@typescript-eslint/parser" "^4.0.0"


### PR DESCRIPTION
Related Ticket: TINY-6504

Description of Changes:
Enabled the `@typescript-eslint/unbound-method` ESLint rule. This required changing how a number of interfaces were declared, as if we use `func (args): returnType` then the `unbound-method` check assumes it's an old function declaration and maybe using `this` or similar. As such I've gone through and cleaned them up and added the `this` types where we do use `this`.

Note: The rule isn't smart enough to figure out all we do in `Type` is use `typeof` so I've just disabled the rule in the few cases it's flagged.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
