### PR TITLE
TINY-6834: Fixed an issue where event states weren't updated correctly

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -15,6 +15,7 @@ Version 5.7.0 (TBD)
     Fixed an issue where `scope` attributes on table cells would not change as expected when merging or unmerging cells #TINY-6486
     Fixed the plugin documentation links in the `help` plugin #DOC-703
     Fixed events bound using `DOMUtils` not returning the correct result for `isDefaultPrevented` in some cases #TINY-6834
+    Fixed the "Dropped file type is not supported" notification incorrectly showing when using an inline editor #TINY-6834
     Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
     Fixed incorrect return types on `editor.selection.moveToBookmark` #TINY-6504
 Version 5.6.2 (2020-12-08)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -14,6 +14,7 @@ Version 5.7.0 (TBD)
     Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL #TINY-6611
     Fixed an issue where `scope` attributes on table cells would not change as expected when merging or unmerging cells #TINY-6486
     Fixed the plugin documentation links in the `help` plugin #DOC-703
+    Fixed events bound using `DOMUtils` not returning the correct result for `isDefaultPrevented` in some cases #TINY-6834
     Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
     Fixed incorrect return types on `editor.selection.moveToBookmark` #TINY-6504
 Version 5.6.2 (2020-12-08)

--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -283,8 +283,8 @@ const blockIeDrop = (editor: Editor) => {
 // to run after the editor event handlers have run. We also bind to the document
 // so that it'll try to ensure it's the last thing that runs, as it bubbles up the dom.
 const blockUnsupportedFileDrop = (editor: Editor) => {
-  const preventFileDrop = (e: DragEvent) => {
-    if (!e.defaultPrevented) {
+  const preventFileDrop = (e: EditorEvent<DragEvent>) => {
+    if (!e.isDefaultPrevented()) {
       // Prevent file drop events within the editor, as they'll cause the browser to navigate away
       const dataTransfer = e.dataTransfer;
       if (dataTransfer && (Arr.contains(dataTransfer.types, 'Files') || dataTransfer.files.length > 0)) {
@@ -296,7 +296,7 @@ const blockUnsupportedFileDrop = (editor: Editor) => {
     }
   };
 
-  const preventFileDropIfUIElement = (e: DragEvent) => {
+  const preventFileDropIfUIElement = (e: EditorEvent<DragEvent>) => {
     if (isUIElement(editor, e.target as Element)) {
       preventFileDrop(e);
     }

--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -7,6 +7,7 @@
 
 import { Arr, Singleton } from '@ephox/katamari';
 import DOMUtils from './api/dom/DOMUtils';
+import { EventUtilsEvent } from './api/dom/EventUtils';
 import EditorSelection from './api/dom/Selection';
 import Editor from './api/Editor';
 import * as Settings from './api/Settings';
@@ -283,7 +284,7 @@ const blockIeDrop = (editor: Editor) => {
 // to run after the editor event handlers have run. We also bind to the document
 // so that it'll try to ensure it's the last thing that runs, as it bubbles up the dom.
 const blockUnsupportedFileDrop = (editor: Editor) => {
-  const preventFileDrop = (e: EditorEvent<DragEvent>) => {
+  const preventFileDrop = (e: EventUtilsEvent<DragEvent>) => {
     if (!e.isDefaultPrevented()) {
       // Prevent file drop events within the editor, as they'll cause the browser to navigate away
       const dataTransfer = e.dataTransfer;
@@ -296,7 +297,7 @@ const blockUnsupportedFileDrop = (editor: Editor) => {
     }
   };
 
-  const preventFileDropIfUIElement = (e: EditorEvent<DragEvent>) => {
+  const preventFileDropIfUIElement = (e: EventUtilsEvent<DragEvent>) => {
     if (isUIElement(editor, e.target as Element)) {
       preventFileDrop(e);
     }

--- a/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
@@ -19,6 +19,7 @@ interface PartialEvent {
   isImmediatePropagationStopped?: () => boolean;
   stopImmediatePropagation?: () => void;
   returnValue?: boolean;
+  defaultPrevented?: boolean;
   cancelBubble?: boolean;
   composedPath?: () => EventTarget[];
 }
@@ -121,6 +122,7 @@ const fix = <T extends PartialEvent> (originalEvent: T, data?): EventUtilsEvent<
 
   // Add preventDefault method
   event.preventDefault = () => {
+    event.defaultPrevented = true;
     event.isDefaultPrevented = returnTrue;
 
     // Execute preventDefault on the original event object
@@ -135,6 +137,7 @@ const fix = <T extends PartialEvent> (originalEvent: T, data?): EventUtilsEvent<
 
   // Add stopPropagation
   event.stopPropagation = () => {
+    event.cancelBubble = true;
     event.isPropagationStopped = returnTrue;
 
     // Execute stopPropagation on the original event object
@@ -155,8 +158,8 @@ const fix = <T extends PartialEvent> (originalEvent: T, data?): EventUtilsEvent<
 
   // Add event delegation states
   if (hasIsDefaultPrevented(event) === false) {
-    event.isDefaultPrevented = returnFalse;
-    event.isPropagationStopped = returnFalse;
+    event.isDefaultPrevented = event.defaultPrevented === true ? returnTrue : returnFalse;
+    event.isPropagationStopped = event.cancelBubble === true ? returnTrue : returnFalse;
     event.isImmediatePropagationStopped = returnFalse;
   }
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
@@ -168,6 +168,29 @@ UnitTest.asynctest('browser.tinymce.core.dom.EventUtilsTest', (success, failure)
     LegacyUnit.deepEqual(result, { inner: true, content: true, body: true, document: true, window: true });
   });
 
+  suite.test('bubbling with prevented default', () => {
+    let result;
+
+    eventUtils.bind(window, 'click', (e) => {
+      result.window = true;
+      result.windowPrevented = e.defaultPrevented;
+      result.windowIsPrevented = e.isDefaultPrevented();
+    });
+
+    eventUtils.bind(document.getElementById('inner'), 'click', (e) => {
+      result.inner = true;
+      e.preventDefault();
+    });
+
+    result = {};
+    eventUtils.fire(window, 'click', { defaultPrevented: false, cancelBubble: false });
+    LegacyUnit.deepEqual(result, { window: true, windowPrevented: false, windowIsPrevented: false });
+
+    result = {};
+    eventUtils.fire(document.getElementById('inner'), 'click', { defaultPrevented: false, cancelBubble: false });
+    LegacyUnit.deepEqual(result, { inner: true, window: true, windowPrevented: true, windowIsPrevented: true });
+  });
+
   suite.test('bind/fire stopImmediatePropagation', () => {
     eventUtils.bind(window, 'click', () => {
       result.click1 = true;


### PR DESCRIPTION
Related Ticket: TINY-6834

Description of Changes:
* Fixed the `EventUtils` fix function not setting the initial state correctly for `isDefaultPrevented` or `isPropagationStopped`.
* Fixed calling `preventDefault()` not updating the `defaultPrevented` state of the cloned event.

Note: This is the root cause of the `Dropped file type not supported` notification showing, since `defaultPrevented` was false since the original event was updated in the same callbacks handler.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
