### PR TITLE
TINY-6843: Fix some type signatures in editor.selection

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -18,6 +18,7 @@ Version 5.7.0 (TBD)
     Fixed the "Dropped file type is not supported" notification incorrectly showing when using an inline editor #TINY-6834
     Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
     Fixed incorrect return types on `editor.selection.moveToBookmark` #TINY-6504
+    Fixed the type signature for `editor.selection.getRng` incorrectly returning null #TINY-6843
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -19,6 +19,7 @@ Version 5.7.0 (TBD)
     Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
     Fixed incorrect return types on `editor.selection.moveToBookmark` #TINY-6504
     Fixed the type signature for `editor.selection.getRng` incorrectly returning null #TINY-6843
+    Fixed the type signature for `editor.selection.setCursorLocation` incorrectly allowing a node with no offset #TINY-6843
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -9,6 +9,7 @@ Version 5.7.0 (TBD)
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
     Changed the z-index of the `setProgressState(true)` throbber so it does not hide notifications #TINY-6686
+    Changed the type signature for `editor.selection.getRng()` incorrectly returning `null` #TINY-6843
     Fixed table width style was removed when copying #TINY-6664
     Fixed the order of CSS precedence of `content_style` and `content_css` in the `preview` and `template` plugins. `content_style` now has precedence #TINY-6529
     Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL #TINY-6611
@@ -18,8 +19,7 @@ Version 5.7.0 (TBD)
     Fixed the "Dropped file type is not supported" notification incorrectly showing when using an inline editor #TINY-6834
     Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
     Fixed incorrect return types on `editor.selection.moveToBookmark` #TINY-6504
-    Fixed the type signature for `editor.selection.getRng` incorrectly returning null #TINY-6843
-    Fixed the type signature for `editor.selection.setCursorLocation` incorrectly allowing a node with no offset #TINY-6843
+    Fixed the type signature for `editor.selection.setCursorLocation()` incorrectly allowing a node with no `offset` #TINY-6843
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -130,7 +130,7 @@ const mergeLiElements = (dom: DOMUtils, fromElm: Element, toElm: Element) => {
 const mergeIntoEmptyLi = (editor: Editor, fromLi: HTMLLIElement, toLi: HTMLLIElement) => {
   editor.dom.$(toLi).empty();
   mergeLiElements(editor.dom, fromLi, toLi);
-  editor.selection.setCursorLocation(toLi);
+  editor.selection.setCursorLocation(toLi, 0);
 };
 
 const mergeForward = (editor: Editor, rng: Range, fromLi: HTMLLIElement, toLi: HTMLLIElement) => {


### PR DESCRIPTION
Related Ticket: TINY-6843

Description of Changes:
* editor.selection.getRng can no longer return null
* you can no longer pass a node to editor.selection.setCursorLocation without also passing an offset 

Pre-checks:
* [x] Changelog entry added
* ~[ ] Tests have been added (if applicable)~
* ~[ ] Branch prefixed with `feature/` for new features (if applicable)~
* ~[ ] License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
