### PR TITLE
INT-2282: Avoid continuing to initialize destroyed editor

### DIFF
--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/Editor.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/Editor.ts
@@ -31,7 +31,7 @@ const cFromElement = <T extends EditorType = EditorType>(element: SugarElement, 
 
     const targetSettings = SugarShadowDom.isInShadowRoot(element) ? ({ target: element.dom }) : ({ selector: '#' + randomId });
 
-    const onRemove = (e: any) => {
+    const onRemove = (e: { editor: EditorType }) => {
       if (e.editor.id === randomId) {
         tinymce.off('RemoveEditor', onRemove);
         Selectors.one('#' + randomId).each(Remove.remove);

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/Editor.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/Editor.ts
@@ -41,7 +41,7 @@ const cFromElement = <T extends EditorType = EditorType>(element: SugarElement, 
         const onRemove = () => {
           Selectors.one('#' + randomId).each(Remove.remove);
           die(errorMessageEditorRemoved);
-        }
+        };
         editor.once('remove', onRemove);
 
         editor.once('SkinLoaded', () => {

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -18,6 +18,7 @@ Version 5.7.0 (TBD)
     Fixed the "Dropped file type is not supported" notification incorrectly showing when using an inline editor #TINY-6834
     Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
     Fixed incorrect return types on `editor.selection.moveToBookmark` #TINY-6504
+    Fixed attempting to continue initialization after the editor was destroyed while loading stylesheets #INT-2282
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -18,7 +18,7 @@ Version 5.7.0 (TBD)
     Fixed the "Dropped file type is not supported" notification incorrectly showing when using an inline editor #TINY-6834
     Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
     Fixed incorrect return types on `editor.selection.moveToBookmark` #TINY-6504
-    Fixed attempting to continue initialization after the editor was destroyed while loading stylesheets #INT-2282
+    Fixed incorrect behaviour when editor is destroyed while loading stylesheets #INT-2282
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -288,15 +288,21 @@ const loadContentCss = (editor: Editor, css: string[]) => {
   const styleSheetLoader = getStyleSheetLoader(editor);
   const fontCss = Settings.getFontCss(editor);
 
-  const loaded = () => {
-    editor.on('remove', () => {
-      styleSheetLoader.unloadAll(css);
+  const removeCss = () => {
+    styleSheetLoader.unloadAll(css);
 
-      if (!editor.inline) {
-        editor.ui.styleSheetLoader.unloadAll(fontCss);
-      }
-    });
-    initEditor(editor);
+    if (!editor.inline) {
+      editor.ui.styleSheetLoader.unloadAll(fontCss);
+    }
+  };
+
+  const loaded = () => {
+    if (editor.destroyed) {
+      removeCss();
+    } else {
+      editor.on('remove', removeCss);
+      initEditor(editor);
+    }
   };
 
   // Load all stylesheets

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -297,7 +297,7 @@ const loadContentCss = (editor: Editor, css: string[]) => {
   };
 
   const loaded = () => {
-    if (editor.destroyed) {
+    if (editor.removed) {
       removeCss();
     } else {
       editor.on('remove', removeCss);

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -68,23 +68,14 @@ UnitTest.asynctest('browser.tinymce.core.EditorRemoveTest', (success, failure) =
           }, logs);
         }
       ),
-      Chain.async((input, next, die) => {
-        const checker = setInterval(() => {
-          if (uncaughtErrors.length > 0) {
-            clearInterval(checker);
-            clearTimeout(timer);
-            die(uncaughtErrors[0].reason);
-          }
-        }, 5);
-        const timer = setTimeout(() => {
-          clearInterval(checker);
-          next(input);
-        }, 50);
-      }),
+      Chain.wait(50), // to allow the stylesheet loading to finish
       Chain.op(() => {
         // teardown monitoring for uncaught errors
         window.removeEventListener('unhandledrejection', recordError);
-        uncaughtErrors = [];
+        // check for uncaught promise errors
+        if (uncaughtErrors.length > 0) {
+          throw uncaughtErrors[0].reason;
+        }
       })
     ])),
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -46,11 +46,11 @@ UnitTest.asynctest('browser.tinymce.core.EditorRemoveTest', (success, failure) =
           setup: (editor: Editor) => {
             editor.on('LoadContent', () => {
               // Hook the function called when stylesheets are loaded
-              // so we can destroy the editor right after starting to load them.
+              // so we can remove the editor right after starting to load them.
               const realLoadAll = editor.ui.styleSheetLoader.loadAll;
               editor.ui.styleSheetLoader.loadAll = (...args) => {
                 realLoadAll.apply(editor.ui.styleSheetLoader, args);
-                editor.destroy();
+                editor.remove();
               };
             });
           }

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -61,7 +61,7 @@ UnitTest.asynctest('browser.tinymce.core.EditorRemoveTest', (success, failure) =
             // As we have deliberately removed the editor during the loading process
             // we have to intercept the error that is thrown by McEditor.cFromHtml.
             if (err === McEditor.errorMessageEditorRemoved) {
-              next({}, logs2);
+              next(value, logs2);
             } else {
               die(err, logs2);
             }

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -19,6 +19,11 @@ UnitTest.asynctest('browser.tinymce.core.EditorRemoveTest', (success, failure) =
     Assert.eq('element does not have the expected style', expected, textareaElement.style.display);
   });
 
+  let uncaughtErrors: PromiseRejectionEvent[] = [];
+  const recordError = (ev: PromiseRejectionEvent) => {
+    uncaughtErrors.push(ev);
+  };
+
   const cCreateEditor = Chain.injectThunked(() => new Editor('editor', {}, EditorManager));
 
   const cRemoveEditor = Chain.op((editor: any) => editor.remove());
@@ -27,6 +32,60 @@ UnitTest.asynctest('browser.tinymce.core.EditorRemoveTest', (success, failure) =
     Logger.t('remove editor without initializing it', Chain.asStep({}, [
       cCreateEditor,
       cRemoveEditor
+    ])),
+
+    Logger.t('remove editor after stylesheets load', Chain.asStep({}, [
+      Chain.op(() => {
+        // setup monitoring for uncaught errors
+        uncaughtErrors = [];
+        window.addEventListener('unhandledrejection', recordError);
+      }),
+      Chain.control(
+        McEditor.cFromHtml('<textarea></textarea>', {
+          ...settings,
+          setup: (editor: Editor) => {
+            editor.on('LoadContent', () => {
+              // Hook the function called when stylesheets are loaded
+              // so we can destroy the editor right after starting to load them.
+              const realLoadAll = editor.ui.styleSheetLoader.loadAll;
+              editor.ui.styleSheetLoader.loadAll = (...args) => {
+                realLoadAll.apply(editor.ui.styleSheetLoader, args);
+                editor.destroy();
+              };
+            });
+          }
+        }), (f, value, next, die, logs) => {
+          f(value, (value2, logs2) => {
+            die('Expected editor would not load completely', logs2);
+          }, (err, logs2) => {
+            // As we have deliberately removed the editor during the loading process
+            // we have to intercept the error that is thrown by McEditor.cFromHtml.
+            if (err === McEditor.errorMessageEditorRemoved) {
+              next({}, logs2);
+            } else {
+              die(err, logs2);
+            }
+          }, logs);
+        }
+      ),
+      Chain.async((input, next, die) => {
+        const checker = setInterval(() => {
+          if (uncaughtErrors.length > 0) {
+            clearInterval(checker);
+            clearTimeout(timer);
+            die(uncaughtErrors[0].reason);
+          }
+        }, 5);
+        const timer = setTimeout(() => {
+          clearInterval(checker);
+          next(input);
+        }, 50);
+      }),
+      Chain.op(() => {
+        // teardown monitoring for uncaught errors
+        window.removeEventListener('unhandledrejection', recordError);
+        uncaughtErrors = [];
+      })
     ])),
 
     Logger.t('remove editor where the body has been removed', Chain.asStep({}, [


### PR DESCRIPTION
Related Ticket:
This issue was originally discovered in the react integration. It probably doesn't come up in "normal" use of TinyMCE otherwise.
https://github.com/tinymce/tinymce-react/issues/191

It is probably possible to work around the issue in the react integration but I felt it would be better to fix it at the source in this case.

Description of Changes:
Currently TinyMCE will attempt to continue loading after the stylesheet has loaded even when the editor has been destroyed. This then fails when TinyMCE attempts to get the selection object on the editor which has been set to null by the destroy function.

The goal of this PR is to prevent TinyMCE from continuing to load in those circumstances.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable) - not applicable as is bugfix
* [x] License headers added on new files (if applicable) - not applicable, no new files

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
