### PR TITLE
TINY-6283: Make DOMUtils Constructor documentation private

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -296,6 +296,7 @@ interface DOMUtils {
 /**
  * Constructs a new DOMUtils instance. Consult the TinyMCE Documentation for more details on settings etc for this class.
  *
+ * @private
  * @constructor
  * @method DOMUtils
  * @param {Document} doc Document reference to bind the utility class to.


### PR DESCRIPTION
Related Ticket: TINY-6283

Description of Changes:
See ticket description and comments

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
