### PR TITLE
TINY-6864: Fixed parsing a malformed comment causing an infinite loop

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -17,6 +17,7 @@ Version 5.7.0 (TBD)
     Fixed events bound using `DOMUtils` not returning the correct result for `isDefaultPrevented` in some cases #TINY-6834
     Fixed the "Dropped file type is not supported" notification incorrectly showing when using an inline editor #TINY-6834
     Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
+    Fixed an issue where parsing malformed comments could cause an infinite loop #TINY-6864
     Fixed incorrect return types on `editor.selection.moveToBookmark` #TINY-6504
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -168,10 +168,8 @@ const findCommentEndIndex = (html: string, isBogus: boolean, startIndex: number 
       const endIndex = lcHtml.indexOf('>', startIndex);
       return endIndex !== -1 ? endIndex : lcHtml.length;
     } else {
-      const endCommentRegexp = /--!?>/;
-      endCommentRegexp.lastIndex = startIndex;
-      const match = endCommentRegexp.exec(html);
-      return match ? match.index + match[0].length : lcHtml.length;
+      const match = /--!?>/.exec(html.substr(startIndex));
+      return match ? startIndex + match.index + match[0].length : lcHtml.length;
     }
   }
 };

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -168,8 +168,10 @@ const findCommentEndIndex = (html: string, isBogus: boolean, startIndex: number 
       const endIndex = lcHtml.indexOf('>', startIndex);
       return endIndex !== -1 ? endIndex : lcHtml.length;
     } else {
-      const match = /--!?>/.exec(html.substr(startIndex));
-      return match ? startIndex + match.index + match[0].length : lcHtml.length;
+      const endCommentRegexp = /--!?>/g;
+      endCommentRegexp.lastIndex = startIndex;
+      const match = endCommentRegexp.exec(html);
+      return match ? match.index + match[0].length : lcHtml.length;
     }
   }
 };

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -514,6 +514,13 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', (success, failure)
     parser.parse('<! value --!>');
     LegacyUnit.equal(writer.getContent(), '<!-- value --!-->', 'Parse comment with exclamation and missing hyphens.');
     LegacyUnit.deepEqual(counter.counts, { comment: 1 }, 'Parse comment with exclamation and missing hyphens counts.');
+
+    counter = createCounter(writer);
+    parser = SaxParser(counter, schema);
+    writer.reset();
+    parser.parse('<!-- first --><p>&nbsp;</p><!-- second');
+    LegacyUnit.equal(writer.getContent(), '<!-- first --><p>\u00a0</p><!-- second-->', 'Parse comment with no end sequence.');
+    LegacyUnit.deepEqual(counter.counts, { start: 1, end: 1, text: 1, comment: 2 }, 'Parse comment with no end sequence counts.');
   });
 
   suite.test('Parse PI', () => {


### PR DESCRIPTION
Related Ticket: TINY-6864

Description of Changes:
* As reported in #6015 the regex being used here wasn't a global or sticky regex, meaning that `endCommentRegexp.lastIndex = startIndex;` wasn't working. We couldn't use the sticky flag, as it's not supported on IE 11. As such this splits the string so the regex only operates from the starting index.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
