### PR TITLE
TINY-6828: Fixed base64 URLs not getting restored in style attributes during parsing

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -12,6 +12,7 @@ Version 5.7.0 (TBD)
     Changed the type signature for `editor.selection.getRng()` incorrectly returning `null` #TINY-6843
     Changed some `SaxParser` regular expressions to improve performance #TINY-6823
     Fixed table width style was removed when copying #TINY-6664
+    Fixed content containing corrupted base64 URLs in style attributes after parsing #TINY-6828
     Fixed the order of CSS precedence of `content_style` and `content_css` in the `preview` and `template` plugins. `content_style` now has precedence #TINY-6529
     Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL #TINY-6611
     Fixed an issue where `scope` attributes on table cells would not change as expected when merging or unmerging cells #TINY-6486

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -12,7 +12,7 @@ Version 5.7.0 (TBD)
     Changed the type signature for `editor.selection.getRng()` incorrectly returning `null` #TINY-6843
     Changed some `SaxParser` regular expressions to improve performance #TINY-6823
     Fixed table width style was removed when copying #TINY-6664
-    Fixed content containing corrupted base64 URLs in style attributes after parsing #TINY-6828
+    Fixed base64 URLs used in style attributes were corrupted when parsing HTML #TINY-6828
     Fixed the order of CSS precedence of `content_style` and `content_css` in the `preview` and `template` plugins. `content_style` now has precedence #TINY-6529
     Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL #TINY-6611
     Fixed an issue where `scope` attributes on table cells would not change as expected when merging or unmerging cells #TINY-6486

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Obj, Strings, Type } from '@ephox/katamari';
+import { Arr, Fun, Strings, Type } from '@ephox/katamari';
 import { Base64Extract, extractBase64DataUris, restoreDataUris } from '../../html/Base64Uris';
 import Tools from '../util/Tools';
 import Entities from './Entities';
@@ -273,7 +273,7 @@ const SaxParser = (settings?: SaxParserSettings, schema = Schema()): SaxParser =
       comment(restoreDataUris(value, base64Extract));
     };
 
-    const processAttr = (value: string) => Obj.get(base64Extract.uris, value).getOr(value);
+    const processAttr = (value: string) => restoreDataUris(value, base64Extract);
 
     const processMalformedComment = (value: string, startIndex: number) => {
       const startTag = value || '';

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -106,7 +106,8 @@ UnitTest.test('atomic.tinymce.core.html.Base64UrisTest', () => {
           img_123_0: 'data:image/gif;base64,R0/yw==',
           img_123_1: 'data:image/png;base64,R1/yw==',
           img_123_2: 'data:image/jpeg;base64,R2/yw=='
-        }
+        },
+        re: /img_123_[0-9]+/g
       },
       '<img src="img_123_0"><img src="img_123_1"><img src="img_123_2">',
       '<img src="data:image/gif;base64,R0/yw=="><img src="data:image/png;base64,R1/yw=="><img src="data:image/jpeg;base64,R2/yw==">'

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -1058,8 +1058,22 @@ UnitTest.asynctest('browser.tinymce.core.html.SaxParserTest', (success, failure)
     const parser = SaxParser(counter, schema);
 
     writer.reset();
-    parser.parse('a<img src="data:image/gif;base64,R0/yw==" /><img src="data:image/jpeg;base64,R1/yw==" /><!-- <img src="data:image/jpeg;base64,R1/yw==" /> -->b');
-    LegacyUnit.equal(writer.getContent(), 'a<img src="data:image/gif;base64,R0/yw==" /><img src="data:image/jpeg;base64,R1/yw==" /><!-- <img src="data:image/jpeg;base64,R1/yw==" /> -->b');
+    parser.parse(
+      'a' +
+      '<img src="data:image/gif;base64,R0/yw==" />' +
+      '<img src="data:image/jpeg;base64,R1/yw==" />' +
+      '<div style="background-image: url(\'data:image/png;base64,R2/yw==\')">b</div>' +
+      '<!-- <img src="data:image/jpeg;base64,R1/yw==" /> -->' +
+      'c'
+    );
+    LegacyUnit.equal(writer.getContent(),
+      'a' +
+      '<img src="data:image/gif;base64,R0/yw==" />' +
+      '<img src="data:image/jpeg;base64,R1/yw==" />' +
+      '<div style="background-image: url(\'data:image/png;base64,R2/yw==\')">b</div>' +
+      '<!-- <img src="data:image/jpeg;base64,R1/yw==" /> -->' +
+      'c'
+    );
   });
 
   Pipeline.async({}, suite.toSteps({}), success, failure);


### PR DESCRIPTION
Related Ticket: TINY-6828

Description of Changes:
This fixes a regression introduced in 5.3.0, as we now extract the base64 URLs before parsing as HTML and then restore them later. However, the replacement logic only looked for exact matches in the attribute value which meant if a base64 URL was used in say a style, then it wouldn't get replaced and would end up being corrupt.

Note: I've also made one minor performance improvement, as the base64 replacement logic used to compile the regex each time it was called (ie for every text or comment node and now attribute values as well). It will now instead only be compiled once and then is reused when restoring the base64 data.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
