### PR TITLE
TINY-6859: Backported upstream Sizzle memory leak fix

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -11,6 +11,7 @@ Version 5.7.0 (TBD)
     Changed the z-index of the `setProgressState(true)` throbber so it does not hide notifications #TINY-6686
     Changed the type signature for `editor.selection.getRng()` incorrectly returning `null` #TINY-6843
     Changed some `SaxParser` regular expressions to improve performance #TINY-6823
+    Fixed a memory leak by backporting an upstream Sizzle fix #TINY-6859
     Fixed table width style was removed when copying #TINY-6664
     Fixed the order of CSS precedence of `content_style` and `content_css` in the `preview` and `template` plugins. `content_style` now has precedence #TINY-6529
     Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL #TINY-6611

--- a/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
@@ -1263,6 +1263,8 @@ Expr = Sizzle.selectors = {
         function (elem, context, xml) {
           input[0] = elem;
           matcher(input, null, xml, results);
+          // Don't keep the element (issue #299)
+          input[0] = null;
           return !results.pop();
         };
     }),
@@ -1738,10 +1740,13 @@ function matcherFromTokens(tokens) {
       return indexOf.call(checkContext, elem) > -1;
     }, implicitRelative, true),
     matchers = [ function (elem, context, xml) {
-      return (!leadingRelative && (xml || context !== outermostContext)) || (
+      const ret = (!leadingRelative && (xml || context !== outermostContext)) || (
         (checkContext = context).nodeType ?
           matchContext(elem, context, xml) :
           matchAnyContext(elem, context, xml));
+      // Avoid hanging onto element (issue #299)
+      checkContext = null;
+      return ret;
     } ];
 
   for (; i < len; i++) {


### PR DESCRIPTION
Related Ticket: TINY-6859

Description of Changes:
* Backports the Sizzle memory leak fixes mentioned in #6390. I do want to look at removing our forked version if possible and use a dependency instead, but I'll look at that separately (likely for 5.8 due to the risks involved).

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #6390