### PR TITLE
TINY-6870: Switch advlist plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
@@ -64,7 +64,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistPluginTest', () => {
     expectedSelection: [ 'li:nth-child(1)', 0 ]
   });
 
-  listStyleTest('Apply ordered list style to an unordered list', {
+  listStyleTest('Apply unordered list style to an ordered list', {
     inputContent: '<ol><li>a</li></ol>',
     inputSelection: [ 'li:nth-child(1)', 0 ],
     command: 'ApplyUnorderedListStyle',

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -40,7 +40,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistPluginTest', () => {
       const rng = editor.selection.getRng();
       const expectedElm = editor.dom.select(definition.expectedSelection[0])[0];
 
-      assert.equal(editor.getContent(), definition.expectedContent, 'Editor content should be equal');
+      TinyAssertions.assertContent(editor, definition.expectedContent);
       LegacyUnit.equalDom(rng.startContainer.parentNode, expectedElm, 'Selection elements should be equal');
       assert.equal(rng.startOffset, definition.expectedSelection[1], 'Selection offset should be equal');
     });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/ChangeListStyleTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/ChangeListStyleTest.ts
@@ -1,97 +1,116 @@
-import { GeneralSteps, Logger, Pipeline, UiFinder, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { UiFinder, Waiter } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarElement, SugarShadowDom } from '@ephox/sugar';
-import AdvlistPlugin from 'tinymce/plugins/advlist/Plugin';
+
+import Editor from 'tinymce/core/api/Editor';
+import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.advlist.ChangeListStyleTest', (success, failure) => {
-  Theme();
-  ListsPlugin();
-  AdvlistPlugin();
+describe('browser.tinymce.plugins.advlist.ChangeListStyleTest', () => {
+  Arr.each([
+    { label: 'Iframe Editor', setup: TinyHooks.bddSetup },
+    { label: 'Shadow Dom Editor', setup: TinyHooks.bddSetupInShadowRoot }
+  ], (tester) => {
+    context(tester.label, () => {
+      const hook = tester.setup<Editor>({
+        indent: false,
+        plugins: 'lists advlist',
+        toolbar: 'numlist bullist',
+        menubar: false,
+        statusbar: false,
+        base_url: '/project/tinymce/js/tinymce'
+      }, [ AdvListPlugin, ListsPlugin, Theme ]);
 
-  TinyLoader.setupInBodyAndShadowRoot((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-    const contentContainer = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement())));
-    const sWaitForMenu = () => Waiter.sTryUntil(
-      'Waiting for menu to appear',
-      UiFinder.sExists(contentContainer, '.tox-menu.tox-selected-menu')
-    );
+      const pWaitForMenu = (editor: Editor) => Waiter.pTryUntil(
+        'Waiting for menu to appear',
+        () => {
+          const contentContainer = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement())));
+          UiFinder.exists(contentContainer, '.tox-menu.tox-selected-menu');
+        }
+      );
 
-    Pipeline.async({}, [
-      Logger.t('ul to alpha, cursor only in parent', GeneralSteps.sequence([
-        tinyApis.sSetContent('<ul><li>a</li><ul><li>b</li></ul></ul>'),
-        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
-        tinyUi.sClickOnToolbar('click numlist button', '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron'),
-        sWaitForMenu(),
-        tinyUi.sClickOnUi('click lower alpha item', 'div.tox-selected-menu[role="menu"] div[title="Lower Alpha"]'),
-        tinyApis.sAssertContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ul><li>b</li></ul></ol>'),
-        tinyApis.sAssertSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0)
-      ])),
-      Logger.t('ul to alpha, selection from parent to sublist', GeneralSteps.sequence([
-        tinyApis.sSetContent('<ul><li>a</li><ul><li>b</li></ul></ul>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1),
-        tinyUi.sClickOnToolbar('click numlist button', '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron'),
-        sWaitForMenu(),
-        tinyUi.sClickOnUi('click lower alpha item', 'div.tox-selected-menu[role="menu"] div[title="Lower Alpha"]'),
-        tinyApis.sAssertContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>'),
-        tinyApis.sAssertSelection([ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1)
-      ])),
-      Logger.t('ol to ul, cursor only in parent', GeneralSteps.sequence([
-        tinyApis.sSetContent('<ol><li>a</li><ol><li>b</li></ol></ol>'),
-        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
-        tinyUi.sClickOnToolbar('click bullist button', '[aria-label="Bullet list"] > .tox-tbtn'),
-        tinyApis.sAssertContent('<ul><li>a</li><ol><li>b</li></ol></ul>'),
-        tinyApis.sAssertSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0)
-      ])),
-      Logger.t('ol to ul, selection from parent to sublist', GeneralSteps.sequence([
-        tinyApis.sSetContent('<ol><li>a</li><ol><li>b</li></ol></ol>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1),
-        tinyUi.sClickOnToolbar('click bullist button', '[aria-label="Bullet list"] > .tox-tbtn'),
-        tinyApis.sAssertContent('<ul><li>a</li><ul><li>b</li></ul></ul>'),
-        tinyApis.sAssertSelection([ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1)
-      ])),
-      Logger.t('alpha to ol, cursor only in parent', GeneralSteps.sequence([
-        tinyApis.sSetContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>'),
-        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
-        tinyUi.sClickOnToolbar('click numlist button', '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron'),
-        sWaitForMenu(),
-        tinyUi.sClickOnUi('click lower alpha item', 'div.tox-selected-menu[role="menu"] div[title="Default"]'),
-        tinyApis.sAssertContent('<ol><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>'),
-        tinyApis.sAssertSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0)
-      ])),
-      Logger.t('alpha to ol, selection from parent to sublist', GeneralSteps.sequence([
-        tinyApis.sSetContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1),
-        tinyUi.sClickOnToolbar('click numlist button', '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron'),
-        sWaitForMenu(),
-        tinyUi.sClickOnUi('click lower alpha item', 'div.tox-selected-menu[role="menu"] div[title="Default"]'),
-        tinyApis.sAssertContent('<ol><li>a</li><ol><li>b</li></ol></ol>'),
-        tinyApis.sAssertSelection([ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1)
-      ])),
-      Logger.t('alpha to ul, cursor only in parent', GeneralSteps.sequence([
-        tinyApis.sSetContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>'),
-        tinyApis.sSetCursor([ 0, 0, 0 ], 0),
-        tinyUi.sClickOnToolbar('click numlist button', '[aria-label="Bullet list"] > .tox-tbtn'),
-        tinyApis.sAssertContent('<ul><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ul>'),
-        tinyApis.sAssertSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0)
-      ])),
-      Logger.t('alpha to ul, selection from parent to sublist', GeneralSteps.sequence([
-        tinyApis.sSetContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1),
-        tinyUi.sClickOnToolbar('click numlist button', '[aria-label="Bullet list"] > .tox-tbtn'),
-        tinyApis.sAssertContent('<ul><li>a</li><ul><li>b</li></ul></ul>'),
-        tinyApis.sAssertSelection([ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1)
-      ]))
-    ], onSuccess, onFailure);
-  }, {
-    indent: false,
-    plugins: 'lists advlist',
-    toolbar: 'numlist bullist',
-    menubar: false,
-    statusbar: false,
-    base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+      it('ul to alpha, cursor only in parent', async () => {
+        const editor = hook.editor();
+        editor.setContent('<ul><li>a</li><ul><li>b</li></ul></ul>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron');
+        await pWaitForMenu(editor);
+        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[title="Lower Alpha"]');
+        TinyAssertions.assertContent(editor, '<ol style="list-style-type: lower-alpha;"><li>a</li><ul><li>b</li></ul></ol>');
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+      });
+
+      it('ul to alpha, selection from parent to sublist', async () => {
+        const editor = hook.editor();
+        editor.setContent('<ul><li>a</li><ul><li>b</li></ul></ul>');
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron');
+        await pWaitForMenu(editor);
+        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[title="Lower Alpha"]');
+        TinyAssertions.assertContent(editor, '<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>');
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
+      });
+
+      it('ol to ul, cursor only in parent', () => {
+        const editor = hook.editor();
+        editor.setContent('<ol><li>a</li><ol><li>b</li></ol></ol>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Bullet list"] > .tox-tbtn');
+        TinyAssertions.assertContent(editor, '<ul><li>a</li><ol><li>b</li></ol></ul>');
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+      });
+
+      it('ol to ul, selection from parent to sublist', () => {
+        const editor = hook.editor();
+        editor.setContent('<ol><li>a</li><ol><li>b</li></ol></ol>');
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Bullet list"] > .tox-tbtn');
+        TinyAssertions.assertContent(editor, '<ul><li>a</li><ul><li>b</li></ul></ul>');
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
+      });
+
+      it('alpha to ol, cursor only in parent', async () => {
+        const editor = hook.editor();
+        editor.setContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron');
+        await pWaitForMenu(editor);
+        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[title="Default"]');
+        TinyAssertions.assertContent(editor, '<ol><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>');
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+      });
+
+      it('alpha to ol, selection from parent to sublist', async () => {
+        const editor = hook.editor();
+        editor.setContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>');
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron');
+        await pWaitForMenu(editor);
+        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[title="Default"]');
+        TinyAssertions.assertContent(editor, '<ol><li>a</li><ol><li>b</li></ol></ol>');
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
+      });
+
+      it('alpha to ul, cursor only in parent', () => {
+        const editor = hook.editor();
+        editor.setContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Bullet list"] > .tox-tbtn');
+        TinyAssertions.assertContent(editor, '<ul><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ul>');
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+      });
+
+      it('alpha to ul, selection from parent to sublist', () => {
+        const editor = hook.editor();
+        editor.setContent('<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>');
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Bullet list"] > .tox-tbtn');
+        TinyAssertions.assertContent(editor, '<ul><li>a</li><ul><li>b</li></ul></ul>');
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
+      });
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/ToolbarButtonStructureTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/ToolbarButtonStructureTest.ts
@@ -1,73 +1,53 @@
-import { ApproxStructure, Assertions, Chain, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { Editor } from '@ephox/mcagar';
+import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
+import { before, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Editor as McEditor } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.advlist.ToolbarButtonStructureTest', (success, failure) => {
-  AdvListPlugin();
-  ListsPlugin();
-  Theme();
+describe('browser.tinymce.plugins.advlist.ToolbarButtonStructureTest', () => {
+  before(() => {
+    AdvListPlugin();
+    ListsPlugin();
+    Theme();
+  });
 
-  Pipeline.async({}, [
-    Log.chainsAsStep('TBA', 'Test that one list type = toolbar button NOT splitbutton', [
-      Editor.cFromSettings({
-        theme: 'silver',
-        plugins: 'lists advlist',
-        toolbar: 'numlist',
-        advlist_number_styles: 'default',
-        menubar: false,
-        statusbar: false,
-        base_url: '/project/tinymce/js/tinymce'
-      }),
-      Chain.fromIsolatedChainsWith(SugarBody.body(), [
-        UiFinder.cFindIn('.tox-editor-header .tox-toolbar .tox-toolbar__group'),
-        Waiter.cTryUntil('', Assertions.cAssertStructure(
-          'Check lists toolbar button structure',
-          ApproxStructure.build((s, str, arr) => s.element('div', {
-            classes: [ arr.has('tox-toolbar__group') ],
-            children: [
-              s.element('button', {
-                classes: [ arr.has('tox-tbtn'), arr.not('tox-split-button') ],
-                attrs: {
-                  title: str.is('Numbered list')
-                }
-              })
-            ]
-          }))
-        ))
-      ]),
-      Editor.cRemove
-    ]),
-    Log.chainsAsStep('TBA', 'Test that one list type = toolbar button IS splitbutton', [
-      Editor.cFromSettings({
-        theme: 'silver',
+  Arr.each([
+    { label: 'TBA: Test that one list type = toolbar button NOT splitbutton', hasSplitBtn: false, settings: { advlist_number_styles: 'default' }},
+    { label: 'TBA: Test that no list type = toolbar button IS splitbutton', hasSplitBtn: true, settings: { }},
+  ], (test) => {
+    it(test.label, async () => {
+      const editor = await McEditor.pFromSettings<Editor>({
         plugins: 'lists advlist',
         toolbar: 'numlist',
         menubar: false,
         statusbar: false,
-        base_url: '/project/tinymce/js/tinymce'
-      }),
-      Chain.fromIsolatedChainsWith(SugarBody.body(), [
-        UiFinder.cFindIn('.tox-editor-header .tox-toolbar .tox-toolbar__group'),
-        Waiter.cTryUntil('', Assertions.cAssertStructure(
-          'Check lists toolbar button structure',
-          ApproxStructure.build((s, str, arr) => s.element('div', {
-            classes: [ arr.has('tox-toolbar__group') ],
-            children: [
-              s.element('div', {
-                classes: [ arr.not('tox-tbtn'), arr.has('tox-split-button') ],
-                attrs: {
-                  title: str.is('Numbered list')
-                }
-              })
-            ]
-          }))
-        ))
-      ]),
-      Editor.cRemove
-    ])
-  ], success, failure);
+        base_url: '/project/tinymce/js/tinymce',
+        ...test.settings
+      });
+      const toolbarGroup = UiFinder.findIn(SugarBody.body(), '.tox-editor-header .tox-toolbar .tox-toolbar__group').getOrDie();
+      await Waiter.pTryUntil('Wait for toolbar', () => Assertions.assertStructure(
+        'Check lists toolbar button structure',
+        ApproxStructure.build((s, str, arr) => s.element('div', {
+          classes: [ arr.has('tox-toolbar__group') ],
+          children: [
+            s.element(test.hasSplitBtn ? 'div' : 'button', {
+              classes: test.hasSplitBtn ?
+                [ arr.not('tox-tbtn'), arr.has('tox-split-button') ] :
+                [ arr.has('tox-tbtn'), arr.not('tox-split-button') ],
+              attrs: {
+                title: str.is('Numbered list')
+              }
+            })
+          ]
+        })),
+        toolbarGroup
+      ));
+      McEditor.remove(editor);
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `advlist` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
