### PR TITLE
TINY-6870: Switch anchor plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
@@ -1,39 +1,32 @@
-import { Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
-import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
+import { UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/anchor/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
-import { sAddAnchor } from '../module/Helpers';
+import { pAddAnchor } from '../module/Helpers';
 
-UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorAlertTest', (success, failure) => {
-  AnchorPlugin();
-  Theme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-    const tinyApis = TinyApis(editor);
-
-    const docBody = SugarElement.fromDom(document.body);
-    const dialogSelector = 'div[role="dialog"].tox-dialog';
-    const alertDialogSelector = 'div[role="dialog"].tox-dialog.tox-alert-dialog';
-
-    Pipeline.async({},
-      Log.steps('TINY-2788', 'Anchor: Add anchor with invalid id, check alert appears', [
-        tinyApis.sSetContent(''),
-        sAddAnchor(tinyApis, tinyUi, ''),
-        tinyUi.sWaitForPopup('Wait for alert window', alertDialogSelector),
-        tinyUi.sClickOnUi('Click on OK button', 'button.tox-button:contains(OK)'),
-        Waiter.sTryUntil('Alert dialog should close', UiFinder.sNotExists(docBody, alertDialogSelector)),
-        Waiter.sTryUntil('Anchor Dialog should not close', UiFinder.sExists(docBody, dialogSelector)),
-        tinyUi.sClickOnUi('Click on Cancel button', 'button.tox-button:contains(Cancel)'),
-        Waiter.sTryUntil('Anchor Dialog should close', UiFinder.sNotExists(docBody, dialogSelector)),
-        tinyApis.sAssertContent('')
-      ]), onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.anchor.AnchorAlertTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'anchor',
     toolbar: 'anchor',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+  const dialogSelector = 'div[role="dialog"].tox-dialog';
+  const alertDialogSelector = 'div[role="dialog"].tox-dialog.tox-alert-dialog';
+
+  it('TINY-2788: Add anchor with invalid id, check alert appears', async () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    await pAddAnchor(editor, '');
+    await TinyUiActions.pWaitForPopup(editor, alertDialogSelector);
+    TinyUiActions.clickOnUi(editor, 'button.tox-button:contains(OK)');
+    await Waiter.pTryUntil('Alert dialog should close', () => UiFinder.notExists(SugarBody.body(), alertDialogSelector));
+    await Waiter.pTryUntil('Anchor Dialog should not close', () => UiFinder.exists(SugarBody.body(), dialogSelector));
+    TinyUiActions.clickOnUi(editor, 'button.tox-button:contains(Cancel)');
+    await Waiter.pTryUntil('Anchor Dialog should close', () => UiFinder.notExists(SugarBody.body(), dialogSelector));
+    TinyAssertions.assertContent(editor, '');
+  });
 });

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAllowHtmlTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAllowHtmlTest.ts
@@ -1,103 +1,110 @@
-import { ApproxStructure, Assertions, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
+import { ApproxStructure } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-import { sAddAnchor, sAssertAnchorPresence } from '../module/Helpers';
+import Plugin from 'tinymce/plugins/anchor/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { pAddAnchor, pAssertAnchorPresence } from '../module/Helpers';
 
-UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorAllowHtmlTest', (success, failure) => {
-  AnchorPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    const sAssertContentStructure = (id: string, isContentEditable: boolean, innerContent: string) =>
-      Assertions.sAssertStructure('Checking content structure',
-        ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.element('a', {
-                  html: str.is(innerContent),
-                  attrs: { contenteditable: isContentEditable ? str.none() : str.is('false'), id: str.is(id) },
-                  classes: [ arr.has('mce-item-anchor') ]
-                }),
-                s.theRest()
-              ]
-            })
-          ]
-        })),
-        SugarElement.fromDom(editor.getBody())
-      );
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TINY-2788', 'Anchor: Add anchor without inner html, check contenteditable is false', [
-        tinyApis.sSetContent('<p><a id="abc"></a></p>'),
-        sAssertContentStructure('abc', false, '')
-      ]),
-      // Note: The next step should pass because of the allow_html_in_named_anchor setting
-      Log.stepsAsStep('TINY-2788', 'Anchor: Add anchor with inner html, check contenteditable is not present and inner html is present', [
-        tinyApis.sSetContent('<p><a id="abc">abc</a></p>'),
-        sAssertContentStructure('abc', true, 'abc')
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Select text and insert anchor, check selected text is included within anchor', [
-        tinyApis.sSetContent('<p>abc</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 3),
-        sAddAnchor(tinyApis, tinyUi, 'abc'),
-        sAssertAnchorPresence(tinyApis, 1),
-        sAssertContentStructure('abc', true, 'abc')
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Check non-empty anchor can be inserted and updated', [
-        tinyApis.sSetContent('<p>abc</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 3),
-        sAddAnchor(tinyApis, tinyUi, 'abc'),
-        sAssertContentStructure('abc', true, 'abc'),
-        // Latest html: <p><a id="abc">abc</a></p>
-        // Note: Browser check since selection is unstable on IE11 due to TINY-3799
-        Env.browser.isIE() ? tinyApis.sSelect('a', []) : tinyApis.sSetSelection([ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1),
-        sAddAnchor(tinyApis, tinyUi, 'def'),
-        sAssertContentStructure('def', true, 'abc')
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Check bare anchor can be converted to a named anchor', [
-        tinyApis.sSetContent('<p><a>abc</a></p>'),
-        tinyApis.sFocus(),
-        tinyApis.sSetCursor([ 0, 0, 0 ], 1),
-        sAddAnchor(tinyApis, tinyUi, 'abc'),
-        sAssertAnchorPresence(tinyApis, 1),
-        sAssertContentStructure('abc', true, 'abc')
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Select over existing anchor and insert new anchor, check existing anchor is removed and new anchor is inserted', [
-        // Test for empty anchor
-        tinyApis.sSetContent('<p>ab<a id="abc"></a>cd</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 2 ], 2),
-        sAddAnchor(tinyApis, tinyUi, 'def'),
-        sAssertAnchorPresence(tinyApis, 1),
-        sAssertContentStructure('def', true, 'abcd'),
-        // Test for non-empty anchor
-        tinyApis.sSetContent('<p>ab<a id="abc">cd</a>ef</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 2 ], 2),
-        sAddAnchor(tinyApis, tinyUi, 'def'),
-        sAssertAnchorPresence(tinyApis, 1),
-        sAssertContentStructure('def', true, 'abcdef')
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Partially select non-empty anchor and insert new anchor, check existing anchor is truncated and new anchor is inserted', [
-        tinyApis.sSetContent('<p>ab<a id="abc">cdef</a>gh</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 1, 0 ], 2),
-        sAddAnchor(tinyApis, tinyUi, 'def'),
-        sAssertAnchorPresence(tinyApis, 2),
-        tinyApis.sAssertContent('<p><a id="def">abcd</a><a id="abc">ef</a>gh</p>')
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.anchor.AnchorAllowHtmlTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'anchor',
     toolbar: 'anchor',
     allow_html_in_named_anchor: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const assertContentStructure = (editor: Editor, id: string, isContentEditable: boolean, innerContent: string) =>
+    TinyAssertions.assertContentStructure(editor,
+      ApproxStructure.build((s, str, arr) => s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.element('a', {
+                html: str.is(innerContent),
+                attrs: { contenteditable: isContentEditable ? str.none() : str.is('false'), id: str.is(id) },
+                classes: [ arr.has('mce-item-anchor') ]
+              }),
+              s.theRest()
+            ]
+          })
+        ]
+      }))
+    );
+
+  it('TINY-2788: Add anchor without inner html, check contenteditable is false', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a id="abc"></a></p>');
+    assertContentStructure(editor, 'abc', false, '');
+  });
+
+  // Note: The next step should pass because of the allow_html_in_named_anchor setting
+  it('TINY-2788: Add anchor with inner html, check contenteditable is not present and inner html is present', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a id="abc">abc</a></p>');
+    assertContentStructure(editor, 'abc', true, 'abc');
+  });
+
+  it('TINY-6236: Select text and insert anchor, check selected text is included within anchor', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>abc</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+    await pAddAnchor(editor, 'abc');
+    await pAssertAnchorPresence(editor, 1);
+    assertContentStructure(editor, 'abc', true, 'abc');
+  });
+
+  it('TINY-6236: Check non-empty anchor can be inserted and updated', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>abc</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+    await pAddAnchor(editor, 'abc');
+    assertContentStructure(editor, 'abc', true, 'abc');
+    // Latest html: <p><a id="abc">abc</a></p>
+    // Note: Browser check since selection is unstable on IE11 due to TINY-3799
+    if (Env.browser.isIE()) {
+      TinySelections.select(editor, 'a', []);
+    } else {
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
+    }
+    await pAddAnchor(editor, 'def');
+    assertContentStructure(editor, 'def', true, 'abc');
+  });
+
+  it('TINY-6236: Check bare anchor can be converted to a named anchor', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a>abc</a></p>');
+    editor.focus();
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+    await pAddAnchor(editor, 'abc');
+    await pAssertAnchorPresence(editor, 1);
+    assertContentStructure(editor, 'abc', true, 'abc');
+  });
+
+  it('TINY-6236: Select over existing anchor and insert new anchor, check existing anchor is removed and new anchor is inserted', async () => {
+    const editor = hook.editor();
+    // Test for empty anchor
+    editor.setContent('<p>ab<a id="abc"></a>cd</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 2 ], 2);
+    await pAddAnchor(editor, 'def');
+    await pAssertAnchorPresence(editor, 1);
+    assertContentStructure(editor, 'def', true, 'abcd');
+    // Test for non-empty anchor
+    editor.setContent('<p>ab<a id="abc">cd</a>ef</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 2 ], 2);
+    await pAddAnchor(editor, 'def');
+    await pAssertAnchorPresence(editor, 1);
+    assertContentStructure(editor, 'def', true, 'abcdef');
+  });
+
+  it('TINY-6236: Partially select non-empty anchor and insert new anchor, check existing anchor is truncated and new anchor is inserted', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>ab<a id="abc">cdef</a>gh</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 1, 0 ], 2);
+    await pAddAnchor(editor, 'def');
+    await pAssertAnchorPresence(editor, 2);
+    TinyAssertions.assertContent(editor, '<p><a id="def">abcd</a><a id="abc">ef</a>gh</p>');
+  });
 });

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorFormatsTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorFormatsTest.ts
@@ -1,58 +1,64 @@
-import { Log, Step, Pipeline } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { assert } from 'chai';
+
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Plugin from 'tinymce/plugins/anchor/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorFormatsTest', (success, failure) => {
-  AnchorPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-
-    const sTestMatchFormat = (editor: Editor, expected: boolean) => Step.sync(() => {
-      const match = editor.formatter.match('namedAnchor');
-      Assert.eq(`Expected format match to be ${expected}`, expected, match);
-    });
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TINY-6236', 'Anchor: Check that namedAnchor format matches on empty named anchor', [
-        tinyApis.sSetContent('<p><a id="abc"></a></p>'),
-        tinyApis.sSelect('a', []),
-        sTestMatchFormat(editor, true)
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Check that namedAnchor format matches on non-empty named anchor', [
-        tinyApis.sSetContent('<p><a id="abc">abc</a></p>'),
-        // Note: Browser check since selection is unstable on IE11 due to TINY-3799
-        Env.browser.isIE() ? tinyApis.sSelect('a', []) : tinyApis.sSetSelection([ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1),
-        sTestMatchFormat(editor, true)
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Check that namedAnchor format does not match on normal text', [
-        tinyApis.sSetContent('<p>abc</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 1, [ 0, 0 ], 1),
-        sTestMatchFormat(editor, false)
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Check that namedAnchor format does not match on bare anchor', [
-        tinyApis.sSetContent('<p><a>abc</a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1),
-        sTestMatchFormat(editor, false)
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Check that namedAnchor format does not match on normal link', [
-        tinyApis.sSetContent('<p><a href="http://www.test.com">http://www.test.com</a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1),
-        sTestMatchFormat(editor, false),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 1, [ 0, 0, 0 ], 3),
-        sTestMatchFormat(editor, false)
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.anchor.AnchorFormatsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'anchor',
     toolbar: 'anchor',
     allow_html_in_named_anchor: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const testMatchFormat = (editor: Editor, expected: boolean) => {
+    const match = editor.formatter.match('namedAnchor');
+    assert.equal(match, expected, `Expected format match to be ${expected}`);
+  };
+
+  it('TINY-6236: Check that namedAnchor format matches on empty named anchor', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a id="abc"></a></p>');
+    TinySelections.select(editor, 'a', []);
+    testMatchFormat(editor, true);
+  });
+
+  it('TINY-6236: Check that namedAnchor format matches on non-empty named anchor', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a id="abc">abc</a></p>');
+    // Note: Browser check since selection is unstable on IE11 due to TINY-3799
+    if (Env.browser.isIE()) {
+      TinySelections.select(editor, 'a', []);
+    } else {
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
+    }
+    testMatchFormat(editor, true);
+  });
+
+  it('TINY-6236: Check that namedAnchor format does not match on normal text', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>abc</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
+    testMatchFormat(editor, false);
+  });
+
+  it('TINY-6236: Check that namedAnchor format does not match on bare anchor', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a>abc</a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
+    testMatchFormat(editor, false);
+  });
+
+  it('TINY-6236: Check that namedAnchor format does not match on normal link', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://www.test.com">http://www.test.com</a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
+    testMatchFormat(editor, false);
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 3);
+    testMatchFormat(editor, false);
+  });
 });

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
@@ -1,65 +1,61 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-import { sAddAnchor, sAssertAnchorPresence } from '../module/Helpers';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 
-UnitTest.asynctest('browser.tinymce.plugins.anchor.AnchorSanityTest', (success, failure) => {
-  AnchorPlugin();
-  SilverTheme();
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/anchor/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { pAddAnchor, pAssertAnchorPresence } from '../module/Helpers';
 
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-    const tinyApis = TinyApis(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Anchor: Add text and anchor, then check if that anchor is present in the editor', [
-        tinyApis.sSetContent('abc'),
-        tinyApis.sFocus(),
-        sAddAnchor(tinyApis, tinyUi, 'abc'),
-        sAssertAnchorPresence(tinyApis, 1),
-        tinyApis.sAssertContent('<p><a id="abc"></a>abc</p>')
-      ]),
-      Log.stepsAsStep('TINY-2788', 'Anchor: Add anchor to empty editor, then check if that anchor is present in the editor', [
-        tinyApis.sSetContent(''),
-        tinyApis.sFocus(),
-        sAddAnchor(tinyApis, tinyUi, 'abc'),
-        sAssertAnchorPresence(tinyApis, 1),
-        tinyApis.sAssertContent('<p><a id="abc"></a></p>')
-      ]),
-      Log.stepsAsStep('TINY-2788', 'Anchor: Add anchor to empty line, then check if that anchor is present in the editor', [
-        tinyApis.sSetContent('<p>abc</p><p></p><p>def</p>'),
-        tinyApis.sFocus(),
-        tinyApis.sSetCursor([ 1 ], 0),
-        sAddAnchor(tinyApis, tinyUi, 'abc'),
-        sAssertAnchorPresence(tinyApis, 1),
-        tinyApis.sAssertContent('<p>abc</p>\n<p><a id="abc"></a></p>\n<p>def</p>')
-      ]),
-      Log.stepsAsStep('TINY-2788', 'Anchor: Add two anchors side by side, then check if they are present in the editor', [
-        tinyApis.sSetContent(''),
-        tinyApis.sFocus(),
-        sAddAnchor(tinyApis, tinyUi, 'abc'),
-        sAssertAnchorPresence(tinyApis, 1),
-        tinyApis.sAssertContent('<p><a id="abc"></a></p>'),
-        sAddAnchor(tinyApis, tinyUi, 'def'),
-        sAssertAnchorPresence(tinyApis, 2),
-        tinyApis.sAssertContent('<p><a id="abc"></a><a id="def"></a></p>')
-      ]),
-      Log.stepsAsStep('TINY-6236', 'Anchor: Check bare anchor can be converted to a named anchor', [
-        tinyApis.sSetContent('<p><a>abc</a></p>'),
-        tinyApis.sFocus(),
-        tinyApis.sSetCursor([ 0, 0, 0 ], 1),
-        sAddAnchor(tinyApis, tinyUi, 'abc'),
-        sAssertAnchorPresence(tinyApis, 1),
-        // Text is shifted outside anchor since 'allow_html_in_named_anchor' setting is false by default
-        tinyApis.sAssertContent('<p><a id="abc"></a>abc</p>')
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.anchor.AnchorSanityTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'anchor',
     toolbar: 'anchor',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  it('TBA: Add text and anchor, then check if that anchor is present in the editor', async () => {
+    const editor = hook.editor();
+    editor.setContent('abc');
+    await pAddAnchor(editor, 'abc');
+    await pAssertAnchorPresence(editor, 1);
+    TinyAssertions.assertContent(editor, '<p><a id="abc"></a>abc</p>');
+  });
+
+  it('TINY-2788: Add anchor to empty editor, then check if that anchor is present in the editor', async () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    await pAddAnchor(editor, 'abc');
+    await pAssertAnchorPresence(editor, 1);
+    TinyAssertions.assertContent(editor, '<p><a id="abc"></a></p>');
+  });
+
+  it('TINY-2788: Add anchor to empty line, then check if that anchor is present in the editor', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>abc</p><p></p><p>def</p>');
+    TinySelections.setCursor(editor, [ 1 ], 0);
+    await pAddAnchor(editor, 'abc');
+    await pAssertAnchorPresence(editor, 1);
+    TinyAssertions.assertContent(editor, '<p>abc</p>\n<p><a id="abc"></a></p>\n<p>def</p>');
+  });
+
+  it('TINY-2788: Add two anchors side by side, then check if they are present in the editor', async () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    await pAddAnchor(editor, 'abc');
+    await pAssertAnchorPresence(editor, 1);
+    TinyAssertions.assertContent(editor, '<p><a id="abc"></a></p>');
+    await pAddAnchor(editor, 'def');
+    await pAssertAnchorPresence(editor, 2);
+    TinyAssertions.assertContent(editor, '<p><a id="abc"></a><a id="def"></a></p>');
+  });
+
+  it('TINY-6236: Check bare anchor can be converted to a named anchor', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a>abc</a></p>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+    await pAddAnchor(editor, 'abc');
+    await pAssertAnchorPresence(editor, 1);
+    // Text is shifted outside anchor since 'allow_html_in_named_anchor' setting is false by default
+    TinyAssertions.assertContent(editor, '<p><a id="abc"></a>abc</p>');
+  });
 });

--- a/modules/tinymce/src/plugins/anchor/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/module/Helpers.ts
@@ -1,30 +1,29 @@
-import { Log, Step, Waiter } from '@ephox/agar';
-import { TinyUi, TinyApis } from '@ephox/mcagar';
+import { Waiter } from '@ephox/agar';
+import { TinyAssertions, TinyUiActions } from '@ephox/mcagar';
 
-const sType = (text: string) =>
-  Log.step('TBA', 'Add anchor id', Step.sync(() => {
-    const elm: any = document.querySelector('div[role="dialog"].tox-dialog  input');
-    elm.value = text;
-  }));
+import Editor from 'tinymce/core/api/Editor';
 
-const sAddAnchor = (tinyApis: TinyApis, tinyUi: TinyUi, id: string, useCommand: boolean = false) =>
-  Log.stepsAsStep('TBA', 'Add anchor', [
-    useCommand ? tinyApis.sExecCommand('mceAnchor') : tinyUi.sClickOnToolbar('click anchor button', 'button[aria-label="Anchor"]'),
-    tinyUi.sWaitForPopup('wait for window', 'div[role="dialog"].tox-dialog  input'),
-    sType(id),
-    tinyUi.sClickOnUi('click on Save btn', 'div.tox-dialog__footer button.tox-button:not(.tox-button--secondary)')
-  ]);
+const type = (text: string): void => {
+  const elm: HTMLInputElement = document.querySelector('div[role="dialog"].tox-dialog  input');
+  elm.value = text;
+};
 
-const sAssertAnchorPresence = (tinyApis: TinyApis, numAnchors: number, selector: string = 'a.mce-item-anchor') => {
+const pAddAnchor = async (editor: Editor, id: string, useCommand: boolean = false): Promise<void> => {
+  useCommand ? editor.execCommand('mceAnchor') : TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Anchor"]');
+  await TinyUiActions.pWaitForPopup(editor, 'div[role="dialog"].tox-dialog  input');
+  type(id);
+  TinyUiActions.clickOnUi(editor, 'div.tox-dialog__footer button.tox-button:not(.tox-button--secondary)');
+};
+
+const pAssertAnchorPresence = (editor: Editor, numAnchors: number, selector: string = 'a.mce-item-anchor'): Promise<void> => {
   const expected = {};
   expected[selector] = numAnchors;
-  return Waiter.sTryUntil('wait for anchor',
-    tinyApis.sAssertContentPresence(expected)
+  return Waiter.pTryUntil('wait for anchor',
+    () => TinyAssertions.assertContentPresence(editor, expected)
   );
 };
 
 export {
-  sType,
-  sAddAnchor,
-  sAssertAnchorPresence
+  pAddAnchor,
+  pAssertAnchorPresence
 };


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `anchor` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
