### PR TITLE
TINY-6870: Switch bbcode plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/bbcode/test/ts/browser/BbcodeSanityTest.ts
+++ b/modules/tinymce/src/plugins/bbcode/test/ts/browser/BbcodeSanityTest.ts
@@ -1,39 +1,35 @@
-import { ApproxStructure, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import BbcodePlugin from 'tinymce/plugins/bbcode/Plugin';
+import { ApproxStructure } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+
+import Plugin from 'tinymce/plugins/bbcode/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.bbcode.BbcodeSanityTest', (success, failure) => {
-
-  BbcodePlugin();
-  Theme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-
-    Pipeline.async({}, Log.steps('TBA', 'BBCode: Set bbcode content and assert the equivalent html structure is present', [
-      tinyApis.sSetContent('[b]a[/b]'),
-      tinyApis.sAssertContentStructure(ApproxStructure.build((s, str) => {
-        return s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.element('strong', {
-                  children: [
-                    s.text(str.is('a'))
-                  ]
-                })
-              ]
-            })
-          ]
-        });
-      }))
-    ]), onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.bbcode.BbcodeSanityTest', () => {
+  const hook = TinyHooks.bddSetupLight({
     plugins: 'bbcode',
     toolbar: 'bbcode',
     base_url: '/project/tinymce/js/tinymce',
     bbcode_dialect: 'punbb'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  it('TBA: Set bbcode content and assert the equivalent html structure is present', () => {
+    const editor = hook.editor();
+    editor.setContent('[b]a[/b]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.element('strong', {
+                children: [
+                  s.text(str.is('a'))
+                ]
+              })
+            ]
+          })
+        ]
+      });
+    }));
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `bbcode` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
