### PR TITLE
TINY-6870: Switch charmap plugin to use BDD style tests

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
@@ -75,6 +75,9 @@ const sTryOnSelector = <T>(label: string, doc: SugarElement<Document | ShadowRoo
     )
   );
 
+const pTryOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, selector: string): Promise<SugarElement<HTMLElement>> =>
+  Waiter.pTryUntil(label + '. Focus did not match: ' + selector, () => isOnSelector(label, doc, selector).getOrDie());
+
 const cSetFocus = <T extends Node, U extends Element>(label: string, selector: string): Chain<SugarElement<T>, SugarElement<U>> =>
   // Input: container
   Chain.control(
@@ -108,6 +111,8 @@ export {
   setFocus,
   isOn,
   isOnSelector,
+
+  pTryOnSelector,
 
   sSetActiveValue,
   sSetFocus,

--- a/modules/agar/src/main/ts/ephox/agar/api/UiFinder.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/UiFinder.ts
@@ -98,6 +98,9 @@ const pWaitForVisible = (message: string, container: SugarElement<Node>, selecto
 const pWaitForHidden = (message: string, container: SugarElement<Node>, selector: string): Promise<SugarElement<Element>> =>
   Chain.toPromise(cWaitForHidden(message, selector))(container);
 
+const pWaitForState = (message: string, container: SugarElement<Node>, selector: string, predicate: (element: SugarElement<any>) => boolean): Promise<SugarElement<Element>> =>
+  Chain.toPromise(cWaitForState(message, selector, predicate))(container);
+
 export {
   findIn,
   findAllIn,
@@ -124,5 +127,6 @@ export {
 
   pWaitFor,
   pWaitForVisible,
-  pWaitForHidden
+  pWaitForHidden,
+  pWaitForState
 };

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Api.ts
@@ -5,15 +5,16 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
 import * as Actions from '../core/Actions';
 import * as CharMap from '../core/CharMap';
 
-const get = (editor) => {
+const get = (editor: Editor) => {
   const getCharMap = () => {
     return CharMap.getCharMap(editor);
   };
 
-  const insertChar = (chr) => {
+  const insertChar = (chr: string) => {
     Actions.insertChar(editor, chr);
   };
 

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Events.ts
@@ -5,7 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const fireInsertCustomChar = (editor, chr) => {
+import Editor from 'tinymce/core/api/Editor';
+
+const fireInsertCustomChar = (editor: Editor, chr: string) => {
   return editor.fire('insertCustomChar', { chr });
 };
 

--- a/modules/tinymce/src/plugins/charmap/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/Actions.ts
@@ -5,9 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
 import * as Events from '../api/Events';
 
-const insertChar = (editor, chr) => {
+const insertChar = (editor: Editor, chr: string) => {
   const evtChr = Events.fireInsertCustomChar(editor, chr).chr;
   editor.execCommand('mceInsertContent', false, evtChr);
 };

--- a/modules/tinymce/src/plugins/charmap/test/ts/atomic/ScanTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/atomic/ScanTest.ts
@@ -1,9 +1,10 @@
-import { Assertions } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+
 import { CharMap } from 'tinymce/plugins/charmap/core/CharMap';
 import * as Scan from 'tinymce/plugins/charmap/core/Scan';
 
-UnitTest.test('atomic.tinymce.plugins.charmap.ScanTest', () => {
+describe('atomic.tinymce.plugins.charmap.ScanTest', () => {
   const charMap: CharMap = {
     name: 'All',
     characters: [
@@ -16,20 +17,17 @@ UnitTest.test('atomic.tinymce.plugins.charmap.ScanTest', () => {
     ]
   };
 
-  const testCharCode = () => {
-    Assertions.assertEq('$ should match the dollar sign', [{ value: '$', icon: '$', text: 'dollar sign' }], Scan.scan(charMap, '$'));
-    Assertions.assertEq('À should match the "A - grave" and "a - grave"', [{ value: 'À', icon: 'À', text: 'A - grave' }, { value: 'à', icon: 'à', text: 'a - grave' }], Scan.scan(charMap, 'À'));
-    Assertions.assertEq('𝅘𝅥𝅮 should match "Musical Symbol Eighth Note"', [{ value: '𝅘𝅥𝅮', icon: '𝅘𝅥𝅮', text: 'Musical Symbol Eighth Note' }], Scan.scan(charMap, '𝅘𝅥𝅮'));
-  };
+  it('scan by charcode', () => {
+    assert.deepEqual(Scan.scan(charMap, '$'), [{ value: '$', icon: '$', text: 'dollar sign' }], '$ should match the dollar sign');
+    assert.deepEqual(Scan.scan(charMap, 'À'), [{ value: 'À', icon: 'À', text: 'A - grave' }, { value: 'à', icon: 'à', text: 'a - grave' }], 'À should match the "A - grave" and "a - grave"');
+    assert.deepEqual(Scan.scan(charMap, '𝅘𝅥𝅮'), [{ value: '𝅘𝅥𝅮', icon: '𝅘𝅥𝅮', text: 'Musical Symbol Eighth Note' }], '𝅘𝅥𝅮 should match "Musical Symbol Eighth Note"');
+  });
 
-  const testNames = () => {
-    Assertions.assertEq('"dolla" should match the dollar sign', [{ value: '$', icon: '$', text: 'dollar sign' }], Scan.scan(charMap, 'dolla'));
-    Assertions.assertEq('"function" should match the function / florin sign', [{ value: 'ƒ', icon: 'ƒ', text: 'function / florin' }], Scan.scan(charMap, 'function'));
-    Assertions.assertEq('"A-" without spaces should match "A - grave" and "a - grave"', [{ value: 'À', icon: 'À', text: 'A - grave' }, { value: 'à', icon: 'à', text: 'a - grave' }], Scan.scan(charMap, 'A-'));
-    Assertions.assertEq('"A - " with spaces should match "A - grave" and "a - grave"', [{ value: 'À', icon: 'À', text: 'A - grave' }, { value: 'à', icon: 'à', text: 'a - grave' }], Scan.scan(charMap, 'A - '));
-    Assertions.assertEq('"grave" should match "A - grave" and "a - grave"', [{ value: 'À', icon: 'À', text: 'A - grave' }, { value: 'à', icon: 'à', text: 'a - grave' }], Scan.scan(charMap, 'grave'));
-  };
-
-  testCharCode();
-  testNames();
+  it('scan by name', () => {
+    assert.deepEqual(Scan.scan(charMap, 'dolla'), [{ value: '$', icon: '$', text: 'dollar sign' }], '"dolla" should match the dollar sign');
+    assert.deepEqual(Scan.scan(charMap, 'function'), [{ value: 'ƒ', icon: 'ƒ', text: 'function / florin' }], '"function" should match the function / florin sign');
+    assert.deepEqual(Scan.scan(charMap, 'A-'), [{ value: 'À', icon: 'À', text: 'A - grave' }, { value: 'à', icon: 'à', text: 'a - grave' }], '"A-" without spaces should match "A - grave" and "a - grave"');
+    assert.deepEqual(Scan.scan(charMap, 'A - '), [{ value: 'À', icon: 'À', text: 'A - grave' }, { value: 'à', icon: 'à', text: 'a - grave' }], '"A - " with spaces should match "A - grave" and "a - grave"');
+    assert.deepEqual(Scan.scan(charMap, 'grave'), [{ value: 'À', icon: 'À', text: 'A - grave' }, { value: 'à', icon: 'à', text: 'a - grave' }], '"grave" should match "A - grave" and "a - grave"');
+  });
 });

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapAutocompletionTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapAutocompletionTest.ts
@@ -1,37 +1,30 @@
-import { Keyboard, Keys, Log, PhantomSkipper, Pipeline, Step, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { SugarBody, SugarElement } from '@ephox/sugar';
-import CharmapPlugin from 'tinymce/plugins/charmap/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { Keyboard, Keys, PhantomSkipper } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 
-UnitTest.asynctest('browser.tinymce.plugins.charmap.AutocompletionTest', (success, failure) => {
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/charmap/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-  CharmapPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const eDoc = SugarElement.fromDom(editor.getDoc());
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Charmap: Autocomplete, trigger an autocomplete and check it appears', [
-        tinyApis.sFocus(),
-        tinyApis.sSetContent('<p>:co</p>'),
-        tinyApis.sSetCursor([ 0, 0 ], 3),
-        Keyboard.sKeypress(eDoc, 'o'.charCodeAt(0), { }),
-        UiFinder.sWaitForVisible('Waiting for autocomplete menu', SugarBody.body(), '.tox-autocompleter'),
-        Keyboard.sKeydown(eDoc, Keys.enter(), { }),
-
-        // This assertion does not pass on Phantom. The editor content
-        // is empty. Not sure if it's an encoding issue for entities.
-        PhantomSkipper.detect() ? Step.pass : tinyApis.sAssertContent('<p>₡</p>')
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.charmap.AutocompletionTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'charmap',
     toolbar: 'charmap',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  it('TBA: Autocomplete, trigger an autocomplete and check it appears', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>:co</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 3);
+    Keyboard.activeKeypress(TinyDom.document(editor), 'o'.charCodeAt(0), { });
+    await TinyUiActions.pWaitForPopup(editor, '.tox-autocompleter');
+    Keyboard.activeKeydown(TinyDom.document(editor), Keys.enter(), { });
+
+    // This assertion does not pass on Phantom. The editor content
+    // is empty. Not sure if it's an encoding issue for entities.
+    if (!PhantomSkipper.detect()) {
+      TinyAssertions.assertContent(editor, '<p>₡</p>');
+    }
+  });
 });

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
@@ -1,68 +1,39 @@
-import { Chain, FocusTools, Guard, Log, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { Result } from '@ephox/katamari';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import { Css, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
-import CharmapPlugin from 'tinymce/plugins/charmap/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { FocusTools, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { Css, SugarBody, SugarDocument, SugarElement, Traverse } from '@ephox/sugar';
+import { assert } from 'chai';
 
-UnitTest.asynctest('browser.tinymce.plugins.charmap.DialogHeightTest', (success, failure) => {
-  CharmapPlugin();
-  SilverTheme();
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/charmap/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { fakeEvent } from '../module/Helpers';
 
-  // Move into shared library
-  const cFakeEvent = (name) => {
-    return Chain.control(
-      Chain.op((elm: SugarElement) => {
-        const evt = document.createEvent('HTMLEvents');
-        evt.initEvent(name, true, true);
-        elm.dom.dispatchEvent(evt);
-      }),
-      Guard.addLogging('Fake event')
-    );
-  };
-
-  const cTabPanelHeight = Chain.binder<SugarElement, string, string>((tabpanel) => Css.getRaw(tabpanel, 'height').fold(() => Result.error('tabpanel has no height'), Result.value));
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-    const doc = SugarElement.fromDom(document);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Charmap: Search for items, dialog height should not change when fewer items returned', [
-        tinyApis.sFocus(),
-        tinyUi.sClickOnToolbar('click charmap', 'button[aria-label="Special character"]'),
-        Chain.asStep({}, [
-          tinyUi.cWaitForPopup('wait for popup', 'div[role="dialog"]')
-        ]),
-        FocusTools.sTryOnSelector('Focus should start on', doc, 'input'),
-        Chain.asStep(SugarBody.body(), [
-          NamedChain.asChain([
-            NamedChain.direct(NamedChain.inputName(), Chain.identity, 'body'),
-            NamedChain.writeValue('doc', doc),
-            NamedChain.direct('body', UiFinder.cFindIn('[role="dialog"] [role="tabpanel"]'), 'tabpanel'),
-            NamedChain.direct('tabpanel', cTabPanelHeight, 'oldheight'),
-            NamedChain.direct('body', FocusTools.cSetActiveValue('.'), '_'),
-            NamedChain.direct('doc', FocusTools.cGetFocused, 'input'),
-            NamedChain.direct('input', cFakeEvent('input'), '_'),
-            // need to wait until '.tox-collection__group' has no children
-            NamedChain.direct('body', UiFinder.cWaitForState('wait until ', '[role="dialog"] .tox-collection__group', (e) => Traverse.childNodesCount(e) === 0), '_'),
-            NamedChain.direct('tabpanel', cTabPanelHeight, 'newheight'),
-            NamedChain.bundle((bindings) =>
-              // TODO: Use round pixel numbers in DialogTabHeight.ts
-              parseInt(bindings.oldheight, 10) !== parseInt(bindings.newheight, 10) ?
-                Result.error(`Old height and new height differ. Old height: '${bindings.oldheight}' new height '${bindings.newheight}'`) :
-                Result.value({})
-            )
-          ])
-        ])
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.charmap.DialogHeightTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'charmap',
     toolbar: 'charmap',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  const tabPanelHeight = (tabpanel: SugarElement<Element>) => Css.getRaw(tabpanel, 'height').getOrDie('tabpanel has no height');
+
+  it('TBA: Search for items, dialog height should not change when fewer items returned', async () => {
+    const editor = hook.editor();
+    const body = SugarBody.body();
+    const doc = SugarDocument.getDocument();
+
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Special character"]');
+    await TinyUiActions.pWaitForPopup(editor, 'div[role="dialog"]');
+    await FocusTools.pTryOnSelector('Focus should start on', doc, 'input');
+
+    const tabPanel = UiFinder.findIn(body, '[role="dialog"] [role="tabpanel"]').getOrDie();
+    const oldHeight = tabPanelHeight(tabPanel);
+    const input = FocusTools.setActiveValue(doc, '.');
+    fakeEvent(input, 'input');
+    // need to wait until '.tox-collection__group' has no children
+    await UiFinder.pWaitForState('Wait for search to finish', body, '[role="dialog"] .tox-collection__group', (e) => Traverse.childNodesCount(e) === 0);
+    const newHeight = tabPanelHeight(tabPanel);
+    assert.equal(parseInt(newHeight, 10), parseInt(oldHeight, 10), 'New height and old height differ');
+  });
 });

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
@@ -1,23 +1,27 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
+import { assert } from 'chai';
+
 import Editor from 'tinymce/core/api/Editor';
-import CharmapPlugin from 'tinymce/plugins/charmap/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import Plugin from 'tinymce/plugins/charmap/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.charmap.CharMapPluginTest', (success, failure) => {
-  const suite = LegacyUnit.createSuite<Editor>();
+describe('browser.tinymce.plugins.charmap.CharMapPluginTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'charmap',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin, Theme ]);
 
-  CharmapPlugin();
-  SilverTheme();
-
-  suite.test('TestCase-TBA: Charmap: Replace characters by array', (editor) => {
+  it('TBA: Replace characters by array', () => {
+    const editor = hook.editor();
     editor.settings.charmap = [
       [ 65, 'Latin A' ],
       [ 66, 'Latin B' ]
     ];
 
-    LegacyUnit.deepEqual(editor.plugins.charmap.getCharMap(), [
+    assert.deepEqual(editor.plugins.charmap.getCharMap(), [
       {
         name: 'User Defined',
         characters: [
@@ -28,13 +32,14 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.CharMapPluginTest', (success
     ]);
   });
 
-  suite.test('TestCase-TBA: Charmap: Replace characters by function', (editor) => {
+  it('TBA: Replace characters by function', () => {
+    const editor = hook.editor();
     editor.settings.charmap = () => [
       [ 65, 'Latin A fun' ],
       [ 66, 'Latin B fun' ]
     ];
 
-    LegacyUnit.deepEqual(editor.plugins.charmap.getCharMap(), [
+    assert.deepEqual(editor.plugins.charmap.getCharMap(), [
       {
         name: 'User Defined',
         characters: [
@@ -45,7 +50,8 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.CharMapPluginTest', (success
     ]);
   });
 
-  suite.test('TestCase-TBA: Charmap: Append characters by array', (editor) => {
+  it('TBA: Append characters by array', () => {
+    const editor = hook.editor();
     editor.settings.charmap = [
       [ 67, 'Latin C' ]
     ];
@@ -55,7 +61,7 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.CharMapPluginTest', (success
       [ 66, 'Latin B' ]
     ];
 
-    LegacyUnit.deepEqual(editor.plugins.charmap.getCharMap(), [
+    assert.deepEqual(editor.plugins.charmap.getCharMap(), [
       {
         name: 'User Defined',
         characters: [
@@ -67,7 +73,8 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.CharMapPluginTest', (success
     ]);
   });
 
-  suite.test('TestCase-TBA: Charmap: Append characters by function', (editor) => {
+  it('TBA: Append characters by function', () => {
+    const editor = hook.editor();
     editor.settings.charmap = [
       [ 67, 'Latin C' ]
     ];
@@ -77,7 +84,7 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.CharMapPluginTest', (success
       [ 66, 'Latin B fun' ]
     ];
 
-    LegacyUnit.deepEqual(editor.plugins.charmap.getCharMap(), [
+    assert.deepEqual(editor.plugins.charmap.getCharMap(), [
       {
         name: 'User Defined',
         characters: [
@@ -88,23 +95,15 @@ UnitTest.asynctest('browser.tinymce.plugins.charmap.CharMapPluginTest', (success
     ]);
   });
 
-  suite.test('TestCase-TBA: Charmap: Insert character', (editor) => {
-    let lastEvt;
+  it('TBA: Insert character', () => {
+    const editor = hook.editor();
+    let lastEvt: EditorEvent<{ chr: string }>;
 
     editor.on('InsertCustomChar', (e) => {
       lastEvt = e;
     });
 
     editor.plugins.charmap.insertChar('A');
-    LegacyUnit.equal(lastEvt.chr, 'A');
+    assert.equal(lastEvt.chr, 'A');
   });
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    Pipeline.async({}, Log.steps('TBA', 'Charmap: Test replacing, appending and inserting characters', suite.toSteps(editor)), onSuccess, onFailure);
-  }, {
-    theme: 'silver',
-    plugins: 'charmap',
-    indent: false,
-    base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
 });

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
@@ -1,73 +1,55 @@
-import { Assertions, Chain, FocusTools, Guard, Keyboard, Keys, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { FocusTools, Keyboard, Keys, UiFinder, Waiter } from '@ephox/agar';
+import { before, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
-import { Attribute, SugarBody, SugarElement } from '@ephox/sugar';
-import CharmapPlugin from 'tinymce/plugins/charmap/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
+import { assert } from 'chai';
 
-UnitTest.asynctest('browser.tinymce.plugins.charmap.SearchTest', (success, failure) => {
-  // TODO: TINY-6598: Test is broken on Chromium Edge 86, so we need to investigate
-  const platform = PlatformDetection.detect();
-  if (platform.browser.isChrome() && platform.os.isWindows()) {
-    return success();
-  }
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/charmap/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { fakeEvent } from '../module/Helpers';
 
-  // TODO: Replicate this test with only one category of characters.
-  CharmapPlugin();
-  SilverTheme();
+describe('browser.tinymce.plugins.charmap.SearchTest', () => {
+  before(function () {
+    // TODO: TINY-6598: Test is broken on Chromium Edge 86, so we need to investigate
+    const platform = PlatformDetection.detect();
+    if (platform.browser.isChrome() && platform.os.isWindows()) {
+      this.skip();
+    }
+  });
 
-  // Move into shared library
-  const cFakeEvent = (name) => {
-    return Chain.control(
-      Chain.op((elm: SugarElement) => {
-        const evt = document.createEvent('HTMLEvents');
-        evt.initEvent(name, true, true);
-        elm.dom.dispatchEvent(evt);
-      }),
-      Guard.addLogging('Fake event')
-    );
-  };
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-    const doc = SugarElement.fromDom(document);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Charmap: Open dialog, Search for "euro", Euro should be first option', [
-        tinyApis.sFocus(),
-        tinyUi.sClickOnToolbar('click charmap', 'button[aria-label="Special character"]'),
-        Chain.asStep({}, [
-          tinyUi.cWaitForPopup('wait for popup', 'div[role="dialog"]')
-        ]),
-        FocusTools.sTryOnSelector('Focus should start on', doc, 'input'), // TODO: Remove duped startup of these tests
-        FocusTools.sSetActiveValue(doc, 'euro'),
-        Chain.asStep(doc, [
-          FocusTools.cGetFocused,
-          cFakeEvent('input')
-        ]),
-        Waiter.sTryUntil(
-          'Wait until Euro is the first choice (search should filter)',
-          Chain.asStep(SugarBody.body(), [
-            UiFinder.cFindIn('.tox-collection__item:first'),
-            Chain.mapper((item) => Attribute.get(item, 'data-collection-item-value')),
-            Assertions.cAssertEq('Search should show euro', '€')
-          ])
-        ),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sTryOnSelector('Focus should have moved to collection', doc, '.tox-collection__item'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        Waiter.sTryUntil(
-          'Waiting for content update',
-          tinyApis.sAssertContent('<p>&euro;</p>')
-        )
-      ])
-      , onSuccess, onFailure);
-  }, {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'charmap',
     toolbar: 'charmap',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  // TODO: Replicate this test with only one category of characters.
+  it('TBA: Open dialog, Search for "euro", Euro should be first option', async () => {
+    const editor = hook.editor();
+    const body = SugarBody.body();
+    const doc = SugarDocument.getDocument();
+
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Special character"]');
+    await TinyUiActions.pWaitForPopup(editor, 'div[role="dialog"]');
+    await FocusTools.pTryOnSelector('Focus should start on', doc, 'input'); // TODO: Remove duped startup of these tests
+    const input = FocusTools.setActiveValue(doc, 'euro');
+    fakeEvent(input, 'input');
+    await Waiter.pTryUntil(
+      'Wait until Euro is the first choice (search should filter)',
+      () => {
+        const item = UiFinder.findIn(body, '.tox-collection__item:first').getOrDie();
+        const value = Attribute.get(item, 'data-collection-item-value');
+        assert.equal(value, '€', 'Search should show euro');
+      }
+    );
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    await FocusTools.pTryOnSelector('Focus should have moved to collection', doc, '.tox-collection__item');
+    Keyboard.activeKeydown(doc, Keys.enter(), { });
+    await Waiter.pTryUntil(
+      'Waiting for content update',
+      () => TinyAssertions.assertContent(editor, '<p>&euro;</p>')
+    );
+  });
 });

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/InsertQuotationMarkTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/InsertQuotationMarkTest.ts
@@ -1,39 +1,25 @@
-import { Chain, Log, Mouse, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import CharmapPlugin from 'tinymce/plugins/charmap/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { Mouse } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
-UnitTest.asynctest('browser.tinymce.plugins.charmap.InsertQuotationMarkTest', (success, failure) => {
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/charmap/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-  CharmapPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Charmap: Open dialog, click on the All tab and click on Quotation Mark and then assert Quotation Mark is inserted', [
-        tinyApis.sFocus(),
-        tinyUi.sClickOnToolbar('click charmap', 'button[aria-label="Special character"]'),
-        Chain.asStep({}, [
-          Chain.fromParent(
-            tinyUi.cWaitForPopup('wait for popup', 'div[role="dialog"]'),
-            [
-              Mouse.cClickOn('.tox-dialog__body-nav-item:contains(All)'),
-              Mouse.cClickOn('.tox-collection .tox-collection__item-icon:contains(")') // Could not get span[data-glyph="\"""] or similar to work...
-            ]
-          )
-        ]),
-        tinyApis.sAssertContent('<p>"</p>')
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.charmap.InsertQuotationMarkTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'charmap',
     charmap_append: [[ 34, 'quotation mark' ]],
     toolbar: 'charmap',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  it('TBA: Open dialog, click on the All tab and click on Quotation Mark and then assert Quotation Mark is inserted', async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Special character"]');
+    const dialog = await TinyUiActions.pWaitForPopup(editor, 'div[role="dialog"]');
+    Mouse.clickOn(dialog, '.tox-dialog__body-nav-item:contains(All)');
+    Mouse.clickOn(dialog, '.tox-collection .tox-collection__item-icon:contains(")');
+    TinyAssertions.assertContent(editor, '<p>"</p>');
+  });
 });

--- a/modules/tinymce/src/plugins/charmap/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/module/Helpers.ts
@@ -1,0 +1,12 @@
+import { SugarElement } from '@ephox/sugar';
+
+// TODO: Move into shared library
+const fakeEvent = (elm: SugarElement<Node>, name: string) => {
+  const evt = document.createEvent('HTMLEvents');
+  evt.initEvent(name, true, true);
+  elm.dom.dispatchEvent(evt);
+};
+
+export {
+  fakeEvent
+};


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `charmap` plugin to use BDD style tests
* Adds some additional agar helpers needed to convert the `charmap` tests.
* Sprinkled some editor types (needed to find the `InsertCustomChar` event type)

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
