### PR TITLE
TINY-6870: Switch code plugin to use BDD style tests

### DIFF
--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyUiActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyUiActions.ts
@@ -38,11 +38,17 @@ const clickOnUi = <T extends Element>(editor: Editor, selector: string): SugarEl
   return elem;
 };
 
-const submitDialog = (editor: Editor, selector: string): void => {
+const clickDialogButton = (editor: Editor, selector: string, buttonSelector: string) => {
   const dialog = UiFinder.findIn(getUiRoot(editor), selector).getOrDie();
-  const button = UiFinder.findIn(dialog, getThemeSelectors().dialogSubmitSelector).getOrDie();
+  const button = UiFinder.findIn(dialog, buttonSelector).getOrDie();
   Mouse.click(button);
 };
+
+const submitDialog = (editor: Editor, selector: string): void =>
+  clickDialogButton(editor, selector, getThemeSelectors().dialogSubmitSelector);
+
+const closeDialog = (editor: Editor, selector: string): void =>
+  clickDialogButton(editor, selector, getThemeSelectors().dialogCloseSelector);
 
 const pWaitForUi = (editor: Editor, selector: string): Promise<SugarElement<Element>> =>
   UiFinder.pWaitFor(`Waiting for a UI element matching '${selector}' to exist`, getUiRoot(editor), selector);
@@ -55,6 +61,7 @@ export {
   clickOnMenu,
   clickOnUi,
   submitDialog,
+  closeDialog,
 
   pWaitForPopup,
   pWaitForUi

--- a/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
+++ b/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
@@ -1,66 +1,53 @@
-import { FocusTools, GeneralSteps, Log, Logger, Mouse, Pipeline, Step, UiFinder, Waiter } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { assert } from 'chai';
+
 import Editor from 'tinymce/core/api/Editor';
-import CodePlugin from 'tinymce/plugins/code/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Plugin from 'tinymce/plugins/code/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.code.CodeSanityTest', (success, failure) => {
-
-  CodePlugin();
-  SilverTheme();
-
-  const dialogSelector = 'div.tox-dialog';
-  const toolbarButtonSelector = '[role="toolbar"] button[aria-label="Source code"]';
-
-  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-
-    const docBody = SugarElement.fromDom(document.body);
-
-    const sSetTextareaContent = (content) => Logger.t('Changing textarea content to ' + content, Step.sync(() => {
-      const textarea: any = document.querySelector('div[role="dialog"] textarea');
-      textarea.value = content;
-    }));
-
-    const sAssertTextareaContent = (expected) => Logger.t('Asserting textarea content is ' + expected, Step.sync(() => {
-      const textarea: any = document.querySelector('div[role="dialog"] textarea');
-      Assert.eq('Should have correct value', expected, textarea.value);
-    }));
-
-    const sSubmitDialog = (docBody) => GeneralSteps.sequence(Logger.ts('Clicking on the Save button to close dialog', [
-      FocusTools.sSetFocus('Focus dialog', docBody, dialogSelector),
-      Mouse.sClickOn(docBody, 'button.tox-button:contains(Save)'),
-      Waiter.sTryUntil('Dialog should close', UiFinder.sNotExists(docBody, dialogSelector))
-    ]));
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Code: Set content in empty editor and assert values', [
-        Mouse.sClickOn(SugarElement.fromDom(editor.getContainer()), toolbarButtonSelector),
-        UiFinder.sWaitForVisible('Waited for dialog to be visible', docBody, dialogSelector),
-        sAssertTextareaContent(''),
-        sSetTextareaContent('<em>a</em>'),
-        sSubmitDialog(docBody),
-        tinyApis.sAssertContent('<p><em>a</em></p>')
-      ]),
-
-      Log.stepsAsStep('TBA', 'Code: Reopen dialog and check textarea content is correct', [
-        Mouse.sClickOn(SugarElement.fromDom(editor.getContainer()), toolbarButtonSelector),
-        UiFinder.sWaitForVisible('Waited for dialog to be visible', docBody, dialogSelector),
-        sAssertTextareaContent('<p><em>a</em></p>')
-      ]),
-
-      Log.stepsAsStep('TBA', 'Code: Change source code and assert editor content changes', [
-        sSetTextareaContent('<strong>b</strong>'),
-        sSubmitDialog(docBody),
-        tinyApis.sAssertContent('<p><strong>b</strong></p>')
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.code.CodeSanityTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'code',
-    theme: 'silver',
     toolbar: 'code',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const dialogSelector = 'div[role="dialog"]';
+  const toolbarButtonSelector = '[role="toolbar"] button[aria-label="Source code"]';
+
+  const setTextareaContent = (content: string) => {
+    const textarea: HTMLTextAreaElement = document.querySelector('div[role="dialog"] textarea');
+    textarea.value = content;
+  };
+
+  const assertTextareaContent = (expected: string) => {
+    const textarea: HTMLTextAreaElement = document.querySelector('div[role="dialog"] textarea');
+    assert.equal(textarea.value, expected, 'Should have correct value');
+  };
+
+  it('TBA: Set content in empty editor and assert values', async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+    await TinyUiActions.pWaitForPopup(editor, dialogSelector);
+    assertTextareaContent('');
+    setTextareaContent('<em>a</em>');
+    TinyUiActions.submitDialog(editor, dialogSelector);
+    TinyAssertions.assertContent(editor, '<p><em>a</em></p>');
+
+    // Reopen dialog and check textarea content is correct
+    TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+    await TinyUiActions.pWaitForPopup(editor, dialogSelector);
+    assertTextareaContent('<p><em>a</em></p>');
+    TinyUiActions.closeDialog(editor, dialogSelector);
+  });
+
+  it('TBA: Change source code and assert editor content changes', async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+    await TinyUiActions.pWaitForPopup(editor, dialogSelector);
+    setTextareaContent('<strong>b</strong>');
+    TinyUiActions.submitDialog(editor, dialogSelector);
+    TinyAssertions.assertContent(editor, '<p><strong>b</strong></p>');
+  });
 });

--- a/modules/tinymce/src/plugins/code/test/ts/browser/CodeTextareaTest.ts
+++ b/modules/tinymce/src/plugins/code/test/ts/browser/CodeTextareaTest.ts
@@ -1,52 +1,37 @@
-import { Assertions, Chain, Log, NamedChain, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi, UiChains } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { assert } from 'chai';
+
 import Editor from 'tinymce/core/api/Editor';
-import CodePlugin from 'tinymce/plugins/code/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Plugin from 'tinymce/plugins/code/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.code.CodeTextareaTest', (success, failure) => {
-
-  CodePlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-
-    const cOpenDialog = Chain.fromChains([
-      Chain.op(() => editor.execCommand('mceCodeEditor')),
-      tinyUi.cWaitForPopup('wait for dialog', 'div[role="dialog"]')
-    ]);
-
-    const cGetWhiteSpace = Chain.injectThunked(() => {
-      const element = editor.getElement();
-      return editor.dom.getStyle(element, 'white-space', true);
-    });
-
-    const cAssertWhiteSpace = () => NamedChain.asChain([
-      NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
-      NamedChain.direct('editor', cOpenDialog, 'element'),
-      NamedChain.direct('element', cGetWhiteSpace, 'whitespace'),
-      NamedChain.read('whitespace', Chain.op((whitespace) => {
-        Assertions.assertEq('Textarea should have "white-space: pre-wrap"', 'pre-wrap', whitespace);
-      }))
-    ]);
-
-    const sAssertStyleExits = Chain.asStep({ editor }, [
-      cAssertWhiteSpace(),
-      UiChains.cCloseDialog('div[role="dialog"]')
-    ]);
-
-    // Test verifies that new lines and whitespaces are allowed within the textarea in Firefox and IE
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Code: Verify if "white-space: pre-wrap" style is set on the textarea', [
-        sAssertStyleExits
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.code.CodeTextareaTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'code',
-    theme: 'silver',
     toolbar: 'code',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const pOpenDialog = async (editor: Editor) => {
+    editor.execCommand('mceCodeEditor');
+    await TinyUiActions.pWaitForPopup(editor, 'div[role="dialog"]');
+  };
+
+  const getWhiteSpace = (editor: Editor) => {
+    const element = editor.getElement();
+    return editor.dom.getStyle(element, 'white-space', true);
+  };
+
+  const pAssertWhiteSpace = async (editor: Editor) => {
+    await pOpenDialog(editor);
+    const whitespace = getWhiteSpace(editor);
+    assert.equal(whitespace, 'pre-wrap', 'Textarea should have "white-space: pre-wrap"');
+  };
+
+  it('TBA: Verify if "white-space: pre-wrap" style is set on the textarea', async () => {
+    const editor = hook.editor();
+    await pAssertWhiteSpace(editor);
+    TinyUiActions.closeDialog(editor, 'div[role="dialog"]');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `code` plugin to use BDD style tests
* Added new `closeDialog` helper to `TinyUiActions`

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
