### PR TITLE
TINY-6870: Switch codesample plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/ChangeCodeSampleTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/ChangeCodeSampleTest.ts
@@ -1,36 +1,28 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
-import CodePlugin from 'tinymce/plugins/codesample/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyDom, TinyHooks } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/codesample/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 import * as TestUtils from '../module/CodeSampleTestUtils';
 
-UnitTest.asynctest('browser.tinymce.plugins.codesample.ChangeLanguageCodeSampleTest', (success, failure) => {
-
-  CodePlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-
-    const docBody = SugarElement.fromDom(document.body);
-    const editorBody = editor.contentDocument.body;
-    const jsContent = 'var foo = "bar";';
-
-    Pipeline.async({},
-      Log.steps('TBA', 'CodeSample: Open the dialog and check it has the right initial values. Set the codesample content, submit and check the editor content changes correctly. Re-open the dialog and check the dialog language and content is correct.', [
-        TestUtils.sOpenDialogAndAssertInitial(editor, docBody, 'markup', ''),
-        TestUtils.sSetLanguage('javascript'),
-        TestUtils.sSetTextareaContent(jsContent),
-        TestUtils.sSubmitDialog(docBody),
-        TestUtils.sAssertEditorContents(editorBody, 'javascript', jsContent, 'pre.language-javascript'),
-        TestUtils.sOpenDialogAndAssertInitial(editor, docBody, 'javascript', jsContent)
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.codesample.ChangeLanguageCodeSampleTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'codesample',
-    theme: 'silver',
     toolbar: 'codesample',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const jsContent = 'var foo = "bar";';
+
+  it('TBA: Open the dialog and check it has the right initial values. Set the codesample content, submit and check the editor content changes correctly. Re-open the dialog and check the dialog language and content is correct.', async () => {
+    const editor = hook.editor();
+    await TestUtils.pOpenDialogAndAssertInitial(editor, 'markup', '');
+    TestUtils.setLanguage('javascript');
+    TestUtils.setTextareaContent(jsContent);
+    await TestUtils.pSubmitDialog(editor);
+    await TestUtils.pAssertEditorContents(TinyDom.body(editor), 'javascript', jsContent, 'pre.language-javascript');
+    await TestUtils.pOpenDialogAndAssertInitial(editor, 'javascript', jsContent);
+    await TestUtils.pCancelDialog(editor);
+  });
 });

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
@@ -1,48 +1,44 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
-import CodePlugin from 'tinymce/plugins/codesample/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/codesample/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 import * as TestUtils from '../module/CodeSampleTestUtils';
 
-UnitTest.asynctest('browser.tinymce.plugins.codesample.CodeSampleSanityTest', (success, failure) => {
-
-  CodePlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-
-    const docBody = SugarElement.fromDom(document.body);
-    const editorBody = editor.contentDocument.body;
-    const markupContent = '<p>hello world</p>';
-    const newContent = 'editor content should not change to this';
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'CodeSample: Open the dialog and check it has the right initial values', [
-        TestUtils.sOpenDialogAndAssertInitial(editor, docBody, 'markup', '')
-      ]),
-
-      Log.stepsAsStep('TBA', 'CodeSample: Set the codesample content, submit and check the editor content changes correctly', [
-        TestUtils.sSetTextareaContent(markupContent),
-        TestUtils.sSubmitDialog(docBody),
-        TestUtils.sAssertEditorContents(editorBody, 'markup', markupContent, 'pre.language-markup')
-      ]),
-
-      Log.stepsAsStep('TBA', 'CodeSample: Re-open the dialog and check the dialog language and content is correct - focus problems and make this fail', [
-        TestUtils.sOpenDialogAndAssertInitial(editor, docBody, 'markup', markupContent)
-      ]),
-
-      Log.stepsAsStep('TBA', 'CodeSample: Set the codesample content but CANCEL and check the editor content did not change', [
-        TestUtils.sSetTextareaContent(newContent),
-        TestUtils.sCancelDialog(docBody),
-        TestUtils.sAssertEditorContents(editorBody, 'markup', markupContent, 'pre.language-markup')
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.codesample.CodeSampleSanityTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'codesample',
-    theme: 'silver',
     toolbar: 'codesample',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const markupContent = '<p>hello world</p>';
+  const newContent = 'editor content should not change to this';
+
+  beforeEach(() => {
+    hook.editor().setContent('');
+  });
+
+  it('TBA: Open the dialog and check it has the right initial values', async () => {
+    const editor = hook.editor();
+    await TestUtils.pOpenDialogAndAssertInitial(editor, 'markup', '');
+    await TestUtils.pCancelDialog(editor);
+  });
+
+  it('TBA: Set the codesample content, submit and check the editor content changes correctly', async () => {
+    const editor = hook.editor();
+    await TestUtils.pOpenDialogAndAssertInitial(hook.editor(), 'markup', '');
+    TestUtils.setTextareaContent(markupContent);
+    await TestUtils.pSubmitDialog(editor);
+    await TestUtils.pAssertEditorContents(TinyDom.body(editor), 'markup', markupContent, 'pre.language-markup');
+  });
+
+  it('TBA: Set the codesample content but CANCEL and check the editor content did not change', async () => {
+    const editor = hook.editor();
+    await TestUtils.pOpenDialogAndAssertInitial(hook.editor(), 'markup', '');
+    TestUtils.setTextareaContent(newContent);
+    await TestUtils.pCancelDialog(editor);
+    TinyAssertions.assertContent(editor, '');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `codesample` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
