### PR TITLE
TINY-6870: Switch emoticons plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAutocompletionTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAutocompletionTest.ts
@@ -1,39 +1,32 @@
-import { Keyboard, Keys, Log, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { SugarBody, SugarElement } from '@ephox/sugar';
-import EmoticonsPlugin from 'tinymce/plugins/emoticons/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { Keyboard, Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 
-UnitTest.asynctest('browser.tinymce.plugins.emoticons.AutocompletionTest', (success, failure) => {
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/emoticons/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-  EmoticonsPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const eDoc = SugarElement.fromDom(editor.getDoc());
-
-    // NOTE: This is almost identical to charmap
-    Pipeline.async({},
-      Log.steps('TBA', 'Emoticons: Autocomplete, trigger an autocomplete and check it appears', [
-        tinyApis.sFocus(),
-        tinyApis.sSetContent('<p>:ha</p>'),
-        tinyApis.sSetCursor([ 0, 0 ], 3),
-        Keyboard.sKeypress(eDoc, 'a'.charCodeAt(0), { }),
-        UiFinder.sWaitForVisible('Waiting for autocomplete menu', SugarBody.body(), '.tox-autocompleter .tox-collection__item'),
-        Keyboard.sKeydown(eDoc, Keys.right(), { }),
-        Keyboard.sKeydown(eDoc, Keys.right(), { }),
-        Keyboard.sKeydown(eDoc, Keys.enter(), { }),
-        tinyApis.sAssertContent('<p>😂</p>')
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.emoticons.AutocompletionTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'emoticons',
     toolbar: 'emoticons',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce',
     emoticons_database_url: '/project/tinymce/src/plugins/emoticons/test/js/test-emojis.js',
     emoticons_database_id: 'tinymce.plugins.emoticons.test-emojis.js'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  // NOTE: This is almost identical to charmap
+  it('TBA: Autocomplete, trigger an autocomplete and check it appears', async () => {
+    const editor = hook.editor();
+    const editorDoc = TinyDom.document(editor);
+
+    editor.setContent('<p>:ha</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 3);
+    Keyboard.activeKeypress(editorDoc, 'a'.charCodeAt(0), { });
+    await TinyUiActions.pWaitForPopup(editor, '.tox-autocompleter .tox-collection__item');
+    Keyboard.activeKeydown(editorDoc, Keys.right(), { });
+    Keyboard.activeKeydown(editorDoc, Keys.right(), { });
+    Keyboard.activeKeydown(editorDoc, Keys.enter(), { });
+    TinyAssertions.assertContent(editor, '<p>😂</p>');
+  });
 });

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonSearchTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonSearchTest.ts
@@ -1,54 +1,45 @@
-import { Assertions, Chain, FocusTools, Keyboard, Keys, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import { Attribute, SugarBody, SugarElement } from '@ephox/sugar';
+import { FocusTools, Keyboard, Keys, UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
+import { assert } from 'chai';
 
-import EmoticonsPlugin from 'tinymce/plugins/emoticons/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-import { cFakeEvent } from '../module/test/Utils';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/emoticons/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { fakeEvent } from '../module/test/Utils';
 
-UnitTest.asynctest('browser.tinymce.plugins.emoticons.SearchTest', (success, failure) => {
-  EmoticonsPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-    const doc = SugarElement.fromDom(document);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Emoticons: Open dialog, Search for "rainbow", Rainbow should be first option', [
-        tinyApis.sFocus(),
-        tinyUi.sClickOnToolbar('click emoticons', 'button'),
-        tinyUi.sWaitForPopup('wait for popup', 'div[role="dialog"]'),
-        FocusTools.sTryOnSelector('Focus should start on input', doc, 'input'),
-        FocusTools.sSetActiveValue(doc, 'rainbow'),
-        Chain.asStep(doc, [
-          FocusTools.cGetFocused,
-          cFakeEvent('input')
-        ]),
-        Waiter.sTryUntil(
-          'Wait until rainbow is the first choice (search should filter)',
-          Chain.asStep(SugarBody.body(), [
-            UiFinder.cFindIn('.tox-collection__item:first'),
-            Chain.mapper((item) => Attribute.get(item, 'data-collection-item-value')),
-            Assertions.cAssertEq('Search should show rainbow', '🌈')
-          ])
-        ),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sTryOnSelector('Focus should have moved to collection', doc, '.tox-collection__item'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        Waiter.sTryUntil(
-          'Waiting for content update',
-          tinyApis.sAssertContent('<p>🌈</p>')
-        )
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.emoticons.SearchTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'emoticons',
     toolbar: 'emoticons',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce',
     emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojis.js'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  it('TBA: Open dialog, Search for "rainbow", Rainbow should be first option', async () => {
+    const editor = hook.editor();
+    const doc = SugarDocument.getDocument();
+
+    TinyUiActions.clickOnToolbar(editor, 'button');
+    await TinyUiActions.pWaitForPopup(editor, 'div[role="dialog"]');
+    await FocusTools.pTryOnSelector('Focus should start on input', doc, 'input');
+    const input = FocusTools.setActiveValue(doc, 'rainbow');
+    fakeEvent(input, 'input');
+    await Waiter.pTryUntil(
+      'Wait until rainbow is the first choice (search should filter)',
+      () => {
+        const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item:first').getOrDie();
+        const value = Attribute.get(item, 'data-collection-item-value');
+        assert.equal(value, '🌈', 'Search should show rainbow');
+      }
+    );
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    await FocusTools.pTryOnSelector('Focus should have moved to collection', doc, '.tox-collection__item');
+    Keyboard.activeKeydown(doc, Keys.enter(), { });
+    await Waiter.pTryUntil(
+      'Waiting for content update',
+      () => TinyAssertions.assertContent(editor, '<p>🌈</p>')
+    );
+  });
 });

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmoticonTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmoticonTest.ts
@@ -1,64 +1,53 @@
-import { Assertions, Chain, FocusTools, Keyboard, Keys, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { FocusTools, Keyboard, Keys, UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
 
-import EmoticonsPlugin from 'tinymce/plugins/emoticons/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-import { cFakeEvent } from '../module/test/Utils';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/emoticons/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { fakeEvent } from '../module/test/Utils';
 
-UnitTest.asynctest('browser.tinymce.plugins.emoticons.ImageEmoticonTest', (success, failure) => {
-  EmoticonsPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-    const doc = SugarDocument.getDocument();
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Emoticons: Open dialog, Search for "dog", Dog should be first option', [
-        tinyApis.sFocus(),
-        tinyUi.sClickOnToolbar('click emoticons', 'button'),
-        tinyUi.sWaitForPopup('wait for popup', 'div[role="dialog"]'),
-        FocusTools.sTryOnSelector('Focus should start on input', doc, 'input'),
-        FocusTools.sSetActiveValue(doc, 'dog'),
-        Chain.asStep(doc, [
-          FocusTools.cGetFocused,
-          cFakeEvent('input')
-        ]),
-        Waiter.sTryUntil(
-          'Wait until dog is the first choice (search should filter)',
-          Chain.asStep(SugarBody.body(), [
-            UiFinder.cFindIn('.tox-collection__item:first'),
-            Chain.mapper((item) => {
-              const attr = Attribute.get(item, 'data-collection-item-value');
-              const img = SugarElement.fromHtml<HTMLImageElement>(attr);
-              return Attribute.get(img, 'src');
-            }),
-            Assertions.cAssertEq('Search should show a dog', 'https://twemoji.maxcdn.com/v/13.0.1/72x72/1f436.png')
-          ])
-        ),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sTryOnSelector('Focus should have moved to collection', doc, '.tox-collection__item'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        Waiter.sTryUntil(
-          'Waiting for content update',
-          tinyApis.sAssertContentPresence({
-            'img[data-emoticon]': 1,
-            'img[data-mce-resize="false"]': 1,
-            'img[data-mce-placeholder="1"]': 1,
-            'img[alt="\ud83d\udc36"]': 1,
-            'img[src="https://twemoji.maxcdn.com/v/13.0.1/72x72/1f436.png"]': 1
-          })
-        )
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.emoticons.ImageEmoticonTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'emoticons',
     toolbar: 'emoticons',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce',
     emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojiimages.js'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  it('TBA: Open dialog, Search for "dog", Dog should be first option', async () => {
+    const editor = hook.editor();
+    const doc = SugarDocument.getDocument();
+
+    TinyUiActions.clickOnToolbar(editor, 'button');
+    await TinyUiActions.pWaitForPopup(editor, 'div[role="dialog"]');
+    await FocusTools.pTryOnSelector('Focus should start on input', doc, 'input');
+    const input = FocusTools.setActiveValue(doc, 'dog');
+    fakeEvent(input, 'input');
+    await Waiter.pTryUntil(
+      'Wait until dog is the first choice (search should filter)',
+      () => {
+        const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item:first').getOrDie();
+        const attr = Attribute.get(item, 'data-collection-item-value');
+        const img = SugarElement.fromHtml<HTMLImageElement>(attr);
+        const src = Attribute.get(img, 'src');
+        assert.equal(src, 'https://twemoji.maxcdn.com/v/13.0.1/72x72/1f436.png', 'Search should show a dog');
+      }
+    );
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    await FocusTools.pTryOnSelector('Focus should have moved to collection', doc, '.tox-collection__item');
+    Keyboard.activeKeydown(doc, Keys.enter(), { });
+    await Waiter.pTryUntil(
+      'Waiting for content update',
+      () => TinyAssertions.assertContentPresence(editor, {
+        'img[data-emoticon]': 1,
+        'img[data-mce-resize="false"]': 1,
+        'img[data-mce-placeholder="1"]': 1,
+        'img[alt="\ud83d\udc36"]': 1,
+        'img[src="https://twemoji.maxcdn.com/v/13.0.1/72x72/1f436.png"]': 1
+      })
+    );
+  });
 });

--- a/modules/tinymce/src/plugins/emoticons/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/module/test/Utils.ts
@@ -1,16 +1,12 @@
-import { Chain, Guard } from '@ephox/agar';
 import { SugarElement } from '@ephox/sugar';
 
 // TODO: Move into shared library (eg agar)
-const cFakeEvent = (name: string) => Chain.control(
-  Chain.op((elm: SugarElement) => {
-    const evt = document.createEvent('HTMLEvents');
-    evt.initEvent(name, true, true);
-    elm.dom.dispatchEvent(evt);
-  }),
-  Guard.addLogging('Fake event')
-);
+const fakeEvent = (elm: SugarElement<Node>, name: string) => {
+  const evt = document.createEvent('HTMLEvents');
+  evt.initEvent(name, true, true);
+  elm.dom.dispatchEvent(evt);
+};
 
 export {
-  cFakeEvent
+  fakeEvent
 };


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `emoticons` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
