### PR TITLE
TINY-6870: Switch fullscreen plugin to use BDD style tests

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/RealMouse.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RealMouse.ts
@@ -12,6 +12,12 @@ const sActionOn = <T>(selector: string, type: string): Step<T, T> =>
     type
   });
 
+const pActionOn = (selector: string, type: string): Promise<{}> =>
+  SeleniumAction.pPerform('/mouse', {
+    selector,
+    type
+  });
+
 const sMoveToOn = <T>(selector: string): Step<T, T> =>
   sActionOn<T>(selector, 'move');
 
@@ -48,11 +54,28 @@ const cClick = (): Chain<SugarElement<Element>, SugarElement<Element>> =>
     })
   ]);
 
+const pClickOn = (selector: string): Promise<{}> =>
+  pActionOn(selector, 'click');
+
+const pUpOn = (selector: string): Promise<{}> =>
+  pActionOn(selector, 'up');
+
+const pDownOn = (selector: string): Promise<{}> =>
+  pActionOn(selector, 'down');
+
+const pMoveToOn = (selector: string): Promise<{}> =>
+  pActionOn(selector, 'click');
+
 export {
   sMoveToOn,
   sDownOn,
   sUpOn,
   sClickOn,
   cClick,
-  BedrockIdAttribute
+  BedrockIdAttribute,
+
+  pClickOn,
+  pUpOn,
+  pDownOn,
+  pMoveToOn
 };

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -1,201 +1,119 @@
-import { Assertions, Chain, Log, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { Assertions, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Cell } from '@ephox/katamari';
-import { ApiChains, Editor as McEditor } from '@ephox/mcagar';
-import { Attribute, Classes, Css, Insert, Remove, Html, SelectorFind, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
-import Editor from 'tinymce/core/api/Editor';
+import { TinyHooks } from '@ephox/mcagar';
+import { Attribute, Classes, Css, Html, SelectorFind, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { assert } from 'chai';
 
+import Editor from 'tinymce/core/api/Editor';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
-interface Config {
-  label: string;
-  setupEditor: () => Chain<any, Editor>;
-  cleanupEditor: () => Chain<Editor, any>;
-}
-
-const getContentContainer = (editor: Editor) =>
-  SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement())));
-
-const cCloseOnlyWindow = Chain.label(
-  'Close window',
-  Chain.op((editor: Editor) => {
-    const dialogs = () => UiFinder.findAllIn(getContentContainer(editor), '[role="dialog"]');
-    Assertions.assertEq('One window exists', 1, dialogs().length);
-    editor.windowManager.close();
-    Assertions.assertEq('No windows exist', 0, dialogs().length);
-  })
-);
-
-const cWaitForDialog = (ariaLabel: string): Chain<Editor, Editor> =>
-  Chain.label(
-    'Looking for dialog with an aria-label: ' + ariaLabel,
-    Chain.fromIsolatedChains([
-      Chain.mapper(getContentContainer),
-      UiFinder.cWaitFor('Waiting for dialog', '[role="dialog"]'),
-      Chain.op((dialog) => {
-        if (Attribute.has(dialog, 'aria-labelledby')) {
-          const labelledby = Attribute.get(dialog, 'aria-labelledby');
-          const dialogLabel = SelectorFind.descendant<HTMLLabelElement>(dialog, '#' + labelledby).getOrDie('Could not find labelledby');
-          Assertions.assertEq('Checking label text', ariaLabel, Html.get(dialogLabel));
-        } else {
-          throw new Error('Dialog did not have an aria-labelledby');
-        }
-      })
-    ])
-  );
-
-const cAssertHtmlAndBodyState = (label: string, shouldExist: boolean) => {
-  const selector = shouldExist ? 'root:.tox-fullscreen' : 'root::not(.tox-fullscreen)';
-  return Chain.label(
-    `${label}: Body and Html should ${shouldExist ? 'have' : 'not have'} "tox-fullscreen" class`,
-    Chain.fromIsolatedChains([
-      Chain.inject(SugarBody.body()),
-      UiFinder.cFindIn(selector),
-      Chain.inject(SugarElement.fromDom(document.documentElement)),
-      UiFinder.cFindIn(selector)
-    ])
-  );
-};
-
-const cAsssertEditorContainerAndSinkState = (label: string, shouldExist: boolean): Chain<Editor, Editor> =>
-  Chain.label(
-    `${label}: Editor container and sink should ${shouldExist ? 'have' : 'not have'} "tox-fullscreen" class and z-index`,
-    NamedChain.asChain([
-      NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
-      NamedChain.direct('editor', Chain.mapper((editor: Editor) => SugarElement.fromDom(editor.getContainer())), 'editorContainer'),
-      NamedChain.read('editorContainer', UiFinder.cFindIn(shouldExist ? 'root:.tox-fullscreen' : 'root::not(.tox-fullscreen)')),
-      NamedChain.read('editorContainer',
-        Chain.op((container) => {
-          Assertions.assertEq('Editor container z-index', shouldExist ? '1200' : 'auto', Css.get(container, 'z-index'));
-        })
-      ),
-      NamedChain.direct('editor', Chain.mapper(getContentContainer), 'contentContainer'),
-      NamedChain.direct('contentContainer', UiFinder.cFindIn('.tox-silver-sink.tox-tinymce-aux'), 'sink'),
-      NamedChain.read('sink',
-        Chain.op((sink) => {
-          Assertions.assertEq('Editor sink z-index', shouldExist ? '1201' : '1300', Css.get(sink, 'z-index'));
-        })
-      ),
-      NamedChain.output('editor')
-    ])
-  );
-
-const cAssertShadowHostState = (label: string, shouldExist: boolean): Chain<Editor, Editor> =>
-  Chain.label(
-    `${label}: Shadow host should ${shouldExist ? 'have' : 'not have'} "tox-fullscreen" and "tox-shadowhost" classes and z-index`,
-    Chain.op((editor: Editor) => {
-      const elm = SugarElement.fromDom(editor.getElement());
-      if (SugarShadowDom.isInShadowRoot(elm)) {
-        const host = SugarShadowDom.getShadowRoot(elm)
-          .map(SugarShadowDom.getShadowHost)
-          .getOrDie('Expected shadow host');
-
-        Assertions.assertEq('Shadow host classes', shouldExist, Classes.hasAll(host, [ 'tox-fullscreen', 'tox-shadowhost' ]));
-        Assertions.assertEq('Shadow host z-index', shouldExist ? '1200' : 'auto', Css.get(host, 'z-index'));
-      }
-    })
-  );
-
-const cAssertPageState = (label: string, shouldExist: boolean): Chain<Editor, Editor> =>
-  Chain.fromChains([
-    cAssertHtmlAndBodyState(label, shouldExist),
-    cAsssertEditorContainerAndSinkState(label, shouldExist),
-    cAssertShadowHostState(label, shouldExist)
-  ]);
-
-UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', (success, failure) => {
-  LinkPlugin();
-  FullscreenPlugin();
-  SilverTheme();
-
+describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
   const lastEventArgs = Cell(null);
 
-  const cAssertApiAndLastEvent = (label: string, state: boolean): Chain<Editor, Editor> =>
-    Chain.label(
-      `${label}: fullscreen API and event state should return ${state}`,
-      Chain.fromChains([
-        Chain.op((editor) => {
-          Assertions.assertEq('Editor isFullscreen', state, editor.plugins.fullscreen.isFullscreen());
-        }),
-        Chain.op(() => Assertions.assertEq('FullscreenStateChanged event', state, lastEventArgs.get().state))
-      ])
-    );
+  const getContentContainer = (editor: Editor) =>
+    SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement())));
 
-  const settings = {
-    plugins: 'fullscreen link',
-    theme: 'silver',
-    base_url: '/project/tinymce/js/tinymce',
-    setup: (editor: Editor) => {
-      lastEventArgs.set(null);
-      editor.on('FullscreenStateChanged', (e: Editor) => {
-        lastEventArgs.set(e);
-      });
+  const closeOnlyWindow = (editor: Editor) => {
+    const dialogs = () => UiFinder.findAllIn(getContentContainer(editor), '[role="dialog"]');
+    assert.lengthOf(dialogs(), 1, 'One window exists');
+    editor.windowManager.close();
+    assert.lengthOf(dialogs(), 0, 'No windows exist');
+  };
+
+  const pWaitForDialog = async (editor: Editor, ariaLabel: string) => {
+    const contentContainer = getContentContainer(editor);
+    const dialog = await UiFinder.pWaitFor('Waiting for dialog', contentContainer, '[role="dialog"]');
+    if (Attribute.has(dialog, 'aria-labelledby')) {
+      const labelledby = Attribute.get(dialog, 'aria-labelledby');
+      const dialogLabel = SelectorFind.descendant<HTMLLabelElement>(dialog, '#' + labelledby).getOrDie('Could not find labelledby');
+      Assertions.assertEq('Checking label text', ariaLabel, Html.get(dialogLabel));
+    } else {
+      throw new Error('Dialog did not have an aria-labelledby');
     }
   };
 
-  const standardConfig: Config = {
-    label: 'Standard',
-    setupEditor: () => McEditor.cFromSettings(settings),
-    cleanupEditor: () => McEditor.cRemove
+  const assertApiAndLastEvent = (editor: Editor, state: boolean) => {
+    assert.equal(editor.plugins.fullscreen.isFullscreen(), state, 'Editor isFullscreen state');
+    assert.equal(lastEventArgs.get().state, state, 'FullscreenStateChanged event state');
   };
 
-  const shadowRootConfig: Config = {
-    label: 'ShadowHost',
-    setupEditor: () => {
-      const shadowHost = SugarElement.fromTag('div');
-      Insert.append(SugarBody.body(), shadowHost);
-      const sr = SugarElement.fromDom(shadowHost.dom.attachShadow({ mode: 'open' }));
-      const editorDiv = SugarElement.fromTag('div');
-      Insert.append(sr, editorDiv);
-      return McEditor.cFromElement(editorDiv, settings);
-    },
-    cleanupEditor: () => Chain.fromChains([
-      Chain.op((editor: Editor) => {
-        const elm = SugarElement.fromDom(editor.getElement());
+  const assertHtmlAndBodyState = (editor: Editor, shouldExist: boolean) => {
+    const existsFn = shouldExist ? UiFinder.exists : UiFinder.notExists;
+    existsFn(SugarBody.body(), 'root:.tox-fullscreen');
+    existsFn(SugarElement.fromDom(document.documentElement), 'root:.tox-fullscreen');
+  };
+
+  const assertEditorContainerAndSinkState = (editor: Editor, shouldExist: boolean) => {
+    const editorContainer = SugarElement.fromDom(editor.getContainer());
+    const existsFn = shouldExist ? UiFinder.exists : UiFinder.notExists;
+    existsFn(editorContainer, 'root:.tox-fullscreen');
+    assert.equal(Css.get(editorContainer, 'z-index'), shouldExist ? '1200' : 'auto', 'Editor container z-index');
+
+    const contentContainer = getContentContainer(editor);
+    const sink = UiFinder.findIn(contentContainer, '.tox-silver-sink.tox-tinymce-aux').getOrDie();
+    assert.equal(Css.get(sink, 'z-index'), shouldExist ? '1201' : '1300', 'Editor sink z-index');
+  };
+
+  const assertShadowHostState = (editor: Editor, shouldExist: boolean) => {
+    const elm = SugarElement.fromDom(editor.getElement());
+    if (SugarShadowDom.isInShadowRoot(elm)) {
+      const host = SugarShadowDom.getShadowRoot(elm)
+        .map(SugarShadowDom.getShadowHost)
+        .getOrDie('Expected shadow host');
+
+      assert.equal(Classes.hasAll(host, [ 'tox-fullscreen', 'tox-shadowhost' ]), shouldExist, 'Shadow host classes');
+      assert.equal(Css.get(host, 'z-index'), shouldExist ? '1200' : 'auto', 'Shadow host z-index');
+    }
+  };
+
+  const assertPageState = (editor: Editor, shouldExist: boolean) => {
+    assertHtmlAndBodyState(editor, shouldExist);
+    assertEditorContainerAndSinkState(editor, shouldExist);
+    assertShadowHostState(editor, shouldExist);
+  };
+
+  Arr.each([
+    { label: 'Iframe Editor', setup: TinyHooks.bddSetup },
+    { label: 'Shadow Dom Editor', setup: TinyHooks.bddSetupInShadowRoot }
+  ], (tester) => {
+    context(tester.label, () => {
+      const hook = tester.setup<Editor>({
+        plugins: 'fullscreen link',
+        base_url: '/project/tinymce/js/tinymce',
+        setup: (editor: Editor) => {
+          lastEventArgs.set(null);
+          editor.on('FullscreenStateChanged', (e: Editor) => {
+            lastEventArgs.set(e);
+          });
+        }
+      }, [ FullscreenPlugin, LinkPlugin, Theme ]);
+
+      it('TBA: Toggle fullscreen on, open link dialog, insert link, close dialog and toggle fullscreen off', async () => {
+        const editor = hook.editor();
+        assertPageState(editor, false);
+        editor.execCommand('mceFullScreen');
+        assertApiAndLastEvent(editor, true);
+        assertPageState(editor, true);
+        editor.execCommand('mceLink');
+        await pWaitForDialog(editor, 'Insert/Edit Link');
+        closeOnlyWindow(editor);
+        assertPageState(editor, true);
+        editor.execCommand('mceFullScreen');
+        assertApiAndLastEvent(editor, false);
+        assertPageState(editor, false);
+      });
+
+      it('TBA: Toggle fullscreen and cleanup editor should clean up classes', () => {
+        const editor = hook.editor();
+        editor.execCommand('mceFullScreen');
+        assertApiAndLastEvent(editor, true);
+        assertPageState(editor, true);
         editor.remove();
-        SugarShadowDom.getShadowRoot(elm)
-          .map(SugarShadowDom.getShadowHost)
-          .each(Remove.remove);
-      })
-    ])
-  };
-
-  const configs = [ standardConfig, ...SugarShadowDom.isSupported() ? [ shadowRootConfig ] : [] ];
-
-  const steps = Arr.bind(configs, (config) => {
-    const { label, setupEditor, cleanupEditor } = config;
-    return [
-      Log.chainsAsStep('TBA', `FullScreen (${label}): Toggle fullscreen on, open link dialog, insert link, close dialog and toggle fullscreen off`, [
-        setupEditor(),
-        Chain.fromParent(Chain.identity, [
-          cAssertPageState('Before fullscreen command', false),
-          ApiChains.cExecCommand('mceFullScreen', true),
-          cAssertApiAndLastEvent('After fullscreen command', true),
-          cAssertPageState('After fullscreen command', true),
-          ApiChains.cExecCommand('mceLink', true),
-          cWaitForDialog('Insert/Edit Link'),
-          cCloseOnlyWindow,
-          cAssertPageState('After window is closed', true),
-          ApiChains.cExecCommand('mceFullScreen'),
-          cAssertApiAndLastEvent('After fullscreen toggled', false),
-          cAssertPageState('After fullscreen toggled', false)
-        ]),
-        cleanupEditor()
-      ]),
-      Log.chainsAsStep('TBA', `FullScreen (${label}): Toggle fullscreen and cleanup editor should clean up classes`, [
-        setupEditor(),
-        Chain.fromParent(Chain.identity, [
-          ApiChains.cExecCommand('mceFullScreen', true),
-          cAssertApiAndLastEvent('After fullscreen command', true),
-          cAssertPageState('After fullscreen command', true)
-        ]),
-        cleanupEditor(),
-        cAssertHtmlAndBodyState('After editor is closed', false)
-      ])
-    ];
+        assertHtmlAndBodyState(editor, false);
+      });
+    });
   });
-
-  Pipeline.async({}, steps, success, failure);
 });

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullscreenPluginInlineEditorTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullscreenPluginInlineEditorTest.ts
@@ -1,29 +1,23 @@
-import { Log, Pipeline, Step } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
+import { assert } from 'chai';
 
+import Editor from 'tinymce/core/api/Editor';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.fullscreen.FullScreenPluginInlineEditorTest', (success, failure) => {
-
-  FullscreenPlugin();
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    Pipeline.async({}, [ Log.step('TBA', 'FullScreen: Assert isFullscreen api function is present and fullscreen button is absent',
-      Step.sync(() => {
-        Assert.eq('should have isFullsceen api function', false, editor.plugins.fullscreen.isFullscreen());
-        Assert.eq('should not have the fullscreen button', 'undefined', typeof editor.ui.registry.getAll().buttons.fullscreen);
-      })
-    ) ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.fullscreen.FullScreenPluginInlineEditorTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     inline: true,
     plugins: 'fullscreen link',
     toolbar: 'fullscreen link',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ FullscreenPlugin, LinkPlugin, Theme ]);
+
+  it('TBA: Assert isFullscreen api function is present and fullscreen button is absent', () => {
+    const editor = hook.editor();
+    assert.isFalse(editor.plugins.fullscreen.isFullscreen(), 'should have isFullscreen api function');
+    assert.isUndefined(editor.ui.registry.getAll().buttons.fullscreen, 'should not have the fullscreen button');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `fullscreen` plugin to use BDD style tests
* Added new `RealMouse` helpers

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
