### PR TITLE
TINY-6870: Switch fullpage plugin to use BDD style tests

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
@@ -29,21 +29,21 @@ const setActiveValue = (doc: SugarElement<Document | ShadowRoot>, newValue: stri
   return focused;
 };
 
-const isOn = (label: string, element: SugarElement<Node>): Result<SugarElement<HTMLElement>, string> => {
+const isOn = (label: string, element: SugarElement<Node>): SugarElement<HTMLElement> => {
   const doc = SugarShadowDom.getRootNode(element);
   return getFocused(doc).bind((active) => {
     return Compare.eq(element, active) ? Result.value(active) : Result.error(
       label + '\nExpected focus: ' + Truncate.getHtml(element) + '\nActual focus: ' + Truncate.getHtml(active)
     );
-  });
+  }).getOrDie();
 };
 
-const isOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, selector: string): Result<SugarElement<HTMLElement>, string> => {
+const isOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, selector: string): SugarElement<HTMLElement> => {
   return getFocused(doc).bind((active) => {
     return SizzleFind.matches(active, selector) ? Result.value(active) : Result.error(
       label + '\nExpected focus $("' + selector + '")]\nActual focus: ' + Truncate.getHtml(active)
     );
-  });
+  }).getOrDie();
 };
 
 const cGetFocused: Chain<SugarElement<Document | ShadowRoot>, SugarElement<HTMLElement>> =
@@ -52,16 +52,24 @@ const cGetFocused: Chain<SugarElement<Document | ShadowRoot>, SugarElement<HTMLE
 const cGetRootNode: Chain<SugarElement<Node>, SugarElement<Document | ShadowRoot>> =
   Chain.mapper(SugarShadowDom.getRootNode);
 
+const wrapInResult = <R>(f: () => R) => (): Result<R, string> => {
+  try {
+    return Result.value(f());
+  } catch (e) {
+    return Result.error(e.message);
+  }
+};
+
 const sIsOn = <T>(label: string, element: SugarElement<Node>): Step<T, T> =>
   Chain.asStep<T, SugarElement<Node>>(element, [
-    Chain.binder(() => isOn(label, element))
+    Chain.binder(wrapInResult(() => isOn(label, element)))
   ]);
 
 const sIsOnSelector = <T>(label: string, doc: SugarElement<Document | ShadowRoot>, selector: string): Step<T, T> =>
   Logger.t(
     `${label}: sIsOnSelector(${selector})`,
     Chain.asStep<T, SugarElement<Document | ShadowRoot>>(doc, [
-      Chain.binder(() => isOnSelector(label, doc, selector))
+      Chain.binder(wrapInResult(() => isOnSelector(label, doc, selector)))
     ])
   );
 
@@ -76,7 +84,7 @@ const sTryOnSelector = <T>(label: string, doc: SugarElement<Document | ShadowRoo
   );
 
 const pTryOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, selector: string): Promise<SugarElement<HTMLElement>> =>
-  Waiter.pTryUntil(label + '. Focus did not match: ' + selector, () => isOnSelector(label, doc, selector).getOrDie());
+  Waiter.pTryUntil(label + '. Focus did not match: ' + selector, () => isOnSelector(label, doc, selector));
 
 const cSetFocus = <T extends Node, U extends Element>(label: string, selector: string): Chain<SugarElement<T>, SugarElement<U>> =>
   // Input: container

--- a/modules/tinymce/src/plugins/fullpage/test/ts/atomic/ProtectTest.ts
+++ b/modules/tinymce/src/plugins/fullpage/test/ts/atomic/ProtectTest.ts
@@ -1,20 +1,18 @@
-import { Assertions } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+
 import * as Protect from 'tinymce/plugins/fullpage/core/Protect';
 
-UnitTest.test('atomic.tinymce.plugins.fullpage.ProtectTest', () => {
-  const testProtect = () => {
-    Assertions.assertEq('', 'a<!--mce:protected b-->c', Protect.protectHtml([ /b/g ], 'abc'));
-    Assertions.assertEq('', 'a<!--mce:protected b-->cde<!--mce:protected f-->', Protect.protectHtml([ /b/g, /f/g ], 'abcdef'));
-    Assertions.assertEq('', 'a<!--mce:protected %3Cb%3E-->c', Protect.protectHtml([ /<b>/g ], 'a<b>c'));
-  };
+describe('atomic.tinymce.plugins.fullpage.ProtectTest', () => {
+  it('protectHtml', () => {
+    assert.equal(Protect.protectHtml([ /b/g ], 'abc'), 'a<!--mce:protected b-->c');
+    assert.equal(Protect.protectHtml([ /b/g, /f/g ], 'abcdef'), 'a<!--mce:protected b-->cde<!--mce:protected f-->');
+    assert.equal(Protect.protectHtml([ /<b>/g ], 'a<b>c'), 'a<!--mce:protected %3Cb%3E-->c');
+  });
 
-  const testUnprotect = () => {
-    Assertions.assertEq('', 'abc', Protect.unprotectHtml('a<!--mce:protected b-->c'));
-    Assertions.assertEq('', 'abcdef', Protect.unprotectHtml('a<!--mce:protected b-->cde<!--mce:protected f-->'));
-    Assertions.assertEq('', 'a<b>c', Protect.unprotectHtml('a<!--mce:protected %3Cb%3E-->c'));
-  };
-
-  testProtect();
-  testUnprotect();
+  it('unprotectHtml', () => {
+    assert.equal(Protect.unprotectHtml('a<!--mce:protected b-->c'), 'abc');
+    assert.equal(Protect.unprotectHtml('a<!--mce:protected b-->cde<!--mce:protected f-->'), 'abcdef');
+    assert.equal(Protect.unprotectHtml('a<!--mce:protected %3Cb%3E-->c'), 'a<b>c');
+  });
 });

--- a/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPageDialogPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPageDialogPluginTest.ts
@@ -1,15 +1,24 @@
-import {
-  ApproxStructure, Assertions, Chain, FocusTools, GeneralSteps, Guard, Keyboard, Keys, Log, Logger, Pipeline, Step, UiFinder
-} from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader } from '@ephox/mcagar';
-import { SugarBody, SugarElement, Value } from '@ephox/sugar';
+import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
+import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/fullpage/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPageDialogPluginTest', (success, failure) => {
-  Plugin();
-  Theme();
+describe('browser.tinymce.plugins.fullpage.FullPageDialogPluginTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'fullpage',
+    base_url: '/project/tinymce/js/tinymce',
+    indent: false,
+    fullpage_default_title: 'Fullpage Dialog Test Title',
+    fullpage_default_langcode: 'en-US',
+    fullpage_default_xml_pi: true,
+    fullpage_default_text_color: 'blue',
+    fullpage_default_font_family: '"Times New Roman", Georgia, Serif'
+  }, [ Plugin, Theme ]);
 
   const selectors = {
     titleInput: 'label.tox-label:contains(Title) + input.tox-textfield',
@@ -20,211 +29,182 @@ UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPageDialogPluginTest', 
     encodingInput: 'label.tox-label:contains(Encoding) + input.tox-textfield'
   };
 
-  const sInitialState = (editor) => Logger.t(
-    'test inital data',
-    GeneralSteps.sequence([
-      sOpenDialog(editor),
-      UiFinder.sWaitFor('Waiting for dialog to appear', SugarBody.body(), '.tox-dialog-wrap'),
-      Chain.asStep(SugarBody.body(), [
-        UiFinder.cFindIn('div.tox-dialog'),
-        Chain.op((dialog) => {
-          Assertions.assertStructure(
-            'Full page properties should have this structure',
-            ApproxStructure.build((s, str, arr) => s.element('div', {
-              classes: [ arr.has('tox-dialog') ],
-              children: [
-                s.element('div', {
-                  classes: [ arr.has('tox-dialog__header') ],
-                  children: [
-                    s.element('div', {
-                      html: str.is('Metadata and Document Properties')
-                    }),
-                    s.element('button', {
-                      classes: [ arr.has('tox-button--icon'), arr.has('tox-button--naked') ]
-                    })
-                  ]
-                }),
-                s.element('div', {
-                  classes: [ arr.has('tox-dialog__content-js') ],
-                  children: [
-                    s.element('div', {
-                      classes: [ arr.has('tox-dialog__body') ],
-                      children: [
-                        s.element('div', {
-                          classes: [ arr.has('tox-dialog__body-content') ],
-                          children: [
-                            s.element('div', {
-                              classes: [ arr.has('tox-form') ],
-                              children: [
-                                s.element('div', {
-                                  classes: [ arr.has('tox-form__group') ],
-                                  children: [
-                                    s.element('label', {
-                                      classes: [ arr.has('tox-label') ],
-                                      html: str.is('Title')
-                                    }),
-                                    s.element('input', {
-                                      classes: [ arr.has('tox-textfield') ]
-                                    })
-                                  ]
-                                }),
-                                s.element('div', {
-                                  classes: [ arr.has('tox-form__group') ],
-                                  children: [
-                                    s.element('label', {
-                                      classes: [ arr.has('tox-label') ],
-                                      html: str.is('Keywords')
-                                    }),
-                                    s.element('input', {
-                                      classes: [ arr.has('tox-textfield') ]
-                                    })
-                                  ]
-                                }),
-                                s.element('div', {
-                                  classes: [ arr.has('tox-form__group') ],
-                                  children: [
-                                    s.element('label', {
-                                      classes: [ arr.has('tox-label') ],
-                                      html: str.is('Description')
-                                    }),
-                                    s.element('input', {
-                                      classes: [ arr.has('tox-textfield') ]
-                                    })
-                                  ]
-                                }),
-                                s.element('div', {
-                                  classes: [ arr.has('tox-form__group') ],
-                                  children: [
-                                    s.element('label', {
-                                      classes: [ arr.has('tox-label') ],
-                                      html: str.is('Robots')
-                                    }),
-                                    s.element('input', {
-                                      classes: [ arr.has('tox-textfield') ]
-                                    })
-                                  ]
-                                }),
-                                s.element('div', {
-                                  classes: [ arr.has('tox-form__group') ],
-                                  children: [
-                                    s.element('label', {
-                                      classes: [ arr.has('tox-label') ],
-                                      html: str.is('Author')
-                                    }),
-                                    s.element('input', {
-                                      classes: [ arr.has('tox-textfield') ]
-                                    })
-                                  ]
-                                }),
-                                s.element('div', {
-                                  classes: [ arr.has('tox-form__group') ],
-                                  children: [
-                                    s.element('label', {
-                                      classes: [ arr.has('tox-label') ],
-                                      html: str.is('Encoding')
-                                    }),
-                                    s.element('input', {
-                                      classes: [ arr.has('tox-textfield') ]
-                                    })
-                                  ]
-                                })
-                              ]
-                            })
-                          ]
-                        })
-                      ]
-                    })
-                  ]
-                }),
-                s.element('div', {
-                  classes: [ arr.has('tox-dialog__footer') ]
-                })
-              ]
-            })),
-            dialog
-          );
-        })
-      ])
-    ])
-  );
+  const pInitialState = async (editor: Editor) => {
+    openDialog(editor);
+    await UiFinder.pWaitFor('Waiting for dialog to appear', SugarBody.body(), '.tox-dialog-wrap');
+    const dialog = UiFinder.findIn(SugarBody.body(), 'div.tox-dialog').getOrDie();
+    Assertions.assertStructure(
+      'Full page properties should have this structure',
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-dialog') ],
+        children: [
+          s.element('div', {
+            classes: [ arr.has('tox-dialog__header') ],
+            children: [
+              s.element('div', {
+                html: str.is('Metadata and Document Properties')
+              }),
+              s.element('button', {
+                classes: [ arr.has('tox-button--icon'), arr.has('tox-button--naked') ]
+              })
+            ]
+          }),
+          s.element('div', {
+            classes: [ arr.has('tox-dialog__content-js') ],
+            children: [
+              s.element('div', {
+                classes: [ arr.has('tox-dialog__body') ],
+                children: [
+                  s.element('div', {
+                    classes: [ arr.has('tox-dialog__body-content') ],
+                    children: [
+                      s.element('div', {
+                        classes: [ arr.has('tox-form') ],
+                        children: [
+                          s.element('div', {
+                            classes: [ arr.has('tox-form__group') ],
+                            children: [
+                              s.element('label', {
+                                classes: [ arr.has('tox-label') ],
+                                html: str.is('Title')
+                              }),
+                              s.element('input', {
+                                classes: [ arr.has('tox-textfield') ]
+                              })
+                            ]
+                          }),
+                          s.element('div', {
+                            classes: [ arr.has('tox-form__group') ],
+                            children: [
+                              s.element('label', {
+                                classes: [ arr.has('tox-label') ],
+                                html: str.is('Keywords')
+                              }),
+                              s.element('input', {
+                                classes: [ arr.has('tox-textfield') ]
+                              })
+                            ]
+                          }),
+                          s.element('div', {
+                            classes: [ arr.has('tox-form__group') ],
+                            children: [
+                              s.element('label', {
+                                classes: [ arr.has('tox-label') ],
+                                html: str.is('Description')
+                              }),
+                              s.element('input', {
+                                classes: [ arr.has('tox-textfield') ]
+                              })
+                            ]
+                          }),
+                          s.element('div', {
+                            classes: [ arr.has('tox-form__group') ],
+                            children: [
+                              s.element('label', {
+                                classes: [ arr.has('tox-label') ],
+                                html: str.is('Robots')
+                              }),
+                              s.element('input', {
+                                classes: [ arr.has('tox-textfield') ]
+                              })
+                            ]
+                          }),
+                          s.element('div', {
+                            classes: [ arr.has('tox-form__group') ],
+                            children: [
+                              s.element('label', {
+                                classes: [ arr.has('tox-label') ],
+                                html: str.is('Author')
+                              }),
+                              s.element('input', {
+                                classes: [ arr.has('tox-textfield') ]
+                              })
+                            ]
+                          }),
+                          s.element('div', {
+                            classes: [ arr.has('tox-form__group') ],
+                            children: [
+                              s.element('label', {
+                                classes: [ arr.has('tox-label') ],
+                                html: str.is('Encoding')
+                              }),
+                              s.element('input', {
+                                classes: [ arr.has('tox-textfield') ]
+                              })
+                            ]
+                          })
+                        ]
+                      })
+                    ]
+                  })
+                ]
+              })
+            ]
+          }),
+          s.element('div', {
+            classes: [ arr.has('tox-dialog__footer') ]
+          })
+        ]
+      })),
+      dialog
+    );
+  };
 
-  const sOpenDialog = (editor) => Logger.t('Open dialog', Step.sync(() => {
+  const openDialog = (editor: Editor) => {
     editor.execCommand('mceFullPageProperties');
-  }));
+  };
 
-  const cGetInput = (selector: string) => Chain.control(
-    Chain.fromChains([
-      Chain.inject(SugarBody.body()),
-      UiFinder.cFindIn(selector)
-    ]),
-    Guard.addLogging('Get input')
-  );
+  const getInput = (selector: string) =>
+    UiFinder.findIn(SugarBody.body(), selector).getOrDie();
 
-  const sCheckInputValue = (Label, selector, expected) => Logger.t(Label,
-    Chain.asStep({}, [
-      cGetInput(selector),
-      Chain.op((element) => {
-        Assertions.assertEq(`The input value for ${Label} should be: `, expected, Value.get(element));
-      })
-    ])
-  );
+  const checkInputValue = (label: string, selector: string, expected: string) => {
+    const input = getInput(selector);
+    assert.equal(Value.get(input), expected, `The input value for ${label} should be: ${expected}`);
+  };
 
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const doc = SugarElement.fromDom(document);
-    Pipeline.async({},
-      Log.steps('TBA', 'FullPage: Test initial data, set new input values, open dialog, verify that the dialog data matches the input values', [
+  it('TBA: Test initial data, set new input values, open dialog, verify that the dialog data matches the input values', async () => {
+    const editor = hook.editor();
+    const doc = SugarDocument.getDocument();
 
-        sInitialState(editor),
-        sCheckInputValue('Title', selectors.titleInput, 'Fullpage Dialog Test Title'),
-        sCheckInputValue('Keywords', selectors.keywordsInput, ''),
-        sCheckInputValue('Description', selectors.descriptionInput, ''),
-        sCheckInputValue('Robots', selectors.robotsInput, ''),
-        sCheckInputValue('Author', selectors.authorInput, ''),
-        sCheckInputValue('Encoding', selectors.encodingInput, 'ISO-8859-1'),
+    await pInitialState(editor);
+    checkInputValue('Title', selectors.titleInput, 'Fullpage Dialog Test Title');
+    checkInputValue('Keywords', selectors.keywordsInput, '');
+    checkInputValue('Description', selectors.descriptionInput, '');
+    checkInputValue('Robots', selectors.robotsInput, '');
+    checkInputValue('Author', selectors.authorInput, '');
+    checkInputValue('Encoding', selectors.encodingInput, 'ISO-8859-1');
 
-        FocusTools.sTryOnSelector(
-          'Focus should start on first input',
-          doc,
-          selectors.titleInput
-        ),
-        FocusTools.sSetActiveValue(doc, 'the nu title'),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sSetActiveValue(doc, 'the nu keywords'),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sSetActiveValue(doc, 'the nu description'),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sSetActiveValue(doc, 'the nu robots'),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sSetActiveValue(doc, 'the nu author'),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sSetActiveValue(doc, 'the nu encoding'),
-        FocusTools.sIsOnSelector('last', doc, selectors.encodingInput),
+    await FocusTools.pTryOnSelector(
+      'Focus should start on first input',
+      doc,
+      selectors.titleInput
+    );
+    FocusTools.setActiveValue(doc, 'the nu title');
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    FocusTools.setActiveValue(doc, 'the nu keywords');
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    FocusTools.setActiveValue(doc, 'the nu description');
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    FocusTools.setActiveValue(doc, 'the nu robots');
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    FocusTools.setActiveValue(doc, 'the nu author');
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    FocusTools.setActiveValue(doc, 'the nu encoding');
+    FocusTools.isOnSelector('last', doc, selectors.encodingInput);
 
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sIsOnSelector('The cancel button should be focused', doc, 'button:contains("Cancel")'),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sIsOnSelector('The save button should be focused', doc, 'button:contains("Save")'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        UiFinder.sNotExists(SugarBody.body(), 'div.tox-dialog'),
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    FocusTools.isOnSelector('The cancel button should be focused', doc, 'button:contains("Cancel")');
+    Keyboard.activeKeydown(doc, Keys.tab(), { });
+    FocusTools.isOnSelector('The save button should be focused', doc, 'button:contains("Save")');
+    Keyboard.activeKeydown(doc, Keys.enter(), { });
+    UiFinder.notExists(SugarBody.body(), 'div.tox-dialog');
 
-        sOpenDialog(editor),
-        sCheckInputValue('Title', selectors.titleInput, 'the nu title'),
-        sCheckInputValue('Keywords', selectors.keywordsInput, 'the nu keywords'),
-        sCheckInputValue('Description', selectors.descriptionInput, 'the nu description'),
-        sCheckInputValue('Robots', selectors.robotsInput, 'the nu robots'),
-        sCheckInputValue('Author', selectors.authorInput, 'the nu author'),
-        sCheckInputValue('Encoding', selectors.encodingInput, 'the nu encoding')
-      ]), onSuccess, onFailure);
-
-  }, {
-    plugins: 'fullpage',
-    base_url: '/project/tinymce/js/tinymce',
-    indent: false,
-    theme: 'silver',
-    fullpage_default_title: 'Fullpage Dialog Test Title',
-    fullpage_default_langcode: 'en-US',
-    fullpage_default_xml_pi: true,
-    fullpage_default_text_color: 'blue',
-    fullpage_default_font_family: '"Times New Roman", Georgia, Serif'
-  }, success, failure);
+    openDialog(editor);
+    checkInputValue('Title', selectors.titleInput, 'the nu title');
+    checkInputValue('Keywords', selectors.keywordsInput, 'the nu keywords');
+    checkInputValue('Description', selectors.descriptionInput, 'the nu description');
+    checkInputValue('Robots', selectors.robotsInput, 'the nu robots');
+    checkInputValue('Author', selectors.authorInput, 'the nu author');
+    checkInputValue('Encoding', selectors.encodingInput, 'the nu encoding');
+  });
 });

--- a/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
+++ b/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
@@ -1,82 +1,96 @@
-import { Assertions, GeneralSteps, Log, Logger, Pipeline, Step, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+import { Waiter } from '@ephox/agar';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/fullpage/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPagePluginTest', (success, failure) => {
-  const suite = LegacyUnit.createSuite<Editor>();
+describe('browser.tinymce.plugins.fullpage.FullPagePluginTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'fullpage',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    theme: 'silver',
+    protect: [
+      /<!--([\s\S]*?)-->/g
+    ]
+  }, [ Plugin, Theme ]);
 
-  Plugin();
-  Theme();
+  afterEach(() => {
+    const editor = hook.editor();
+    editor.getBody().removeAttribute('dir');
+  });
 
-  const teardown = (editor) => {
-    editor.getBody().rtl = '';
-  };
-
-  suite.test('TestCase-TBA: FullPage: Keep header/footer intact', (editor) => {
-    const normalizeHTML = (html) => {
+  it('TBA: Keep header/footer intact', () => {
+    const editor = hook.editor();
+    const normalizeHTML = (html: string) => {
       return html.replace(/\s/g, '');
     };
 
     editor.setContent('<html><body><p>Test</p>');
-    LegacyUnit.equal(normalizeHTML(editor.getContent()), '<html><body><p>Test</p>', 'Invalid HTML content is still editable.');
+    assert.equal(normalizeHTML(editor.getContent()), '<html><body><p>Test</p>', 'Invalid HTML content is still editable.');
 
     editor.setContent('<html><body><p>Test</p></body></html>');
-    LegacyUnit.equal(normalizeHTML(editor.getContent()), '<html><body><p>Test</p></body></html>', 'Header/footer is intact.');
+    assert.equal(normalizeHTML(editor.getContent()), '<html><body><p>Test</p></body></html>', 'Header/footer is intact.');
   });
 
-  suite.test('TestCase-TBA: FullPage: Default header/footer', (editor) => {
+  it('TBA: Default header/footer', () => {
+    const editor = hook.editor();
     editor.setContent('<p>Test</p>');
-    LegacyUnit.equal(
+    assert.equal(
       editor.getContent(),
       '<!DOCTYPE html>\n<html>\n<head>\n</head>\n<body>\n<p>Test</p>\n</body>\n</html>',
       'Invalid HTML content is still editable.'
     );
   });
 
-  suite.test('TestCase-TBA: FullPage: Parse body attributes', (editor) => {
+  it('TBA: Parse body attributes', () => {
+    const editor = hook.editor();
     editor.setContent('<html><body><p>Test</p></body></html>');
-    LegacyUnit.equal(editor.getBody().style.color, '', 'No color on body.');
-    LegacyUnit.equal(editor.getBody().dir, '', 'No dir on body.');
-    LegacyUnit.equal(editor.dom.getStyle(editor.getBody().firstChild, 'display', true), 'block', 'No styles added to iframe document');
+    assert.equal(editor.getBody().style.color, '', 'No color on body.');
+    assert.equal(editor.getBody().dir, '', 'No dir on body.');
+    assert.equal(editor.dom.getStyle(editor.getBody().firstChild, 'display', true), 'block', 'No styles added to iframe document');
 
     editor.setContent('<html><body style="color:#FF0000"><p>Test</p></body></html>');
-    LegacyUnit.equal(editor.getBody().style.color.length > 0, true, 'Color added to body');
+    assert.isAbove(editor.getBody().style.color.length, 0, 'Color added to body');
 
     editor.setContent('<html><body dir="rtl"><p>Test</p></body></html>');
-    LegacyUnit.equal(editor.getBody().dir, 'rtl', 'Dir added to body');
+    assert.equal(editor.getBody().dir, 'rtl', 'Dir added to body');
 
     editor.setContent('<html><body><p>Test</p></body></html>');
-    LegacyUnit.equal(editor.getBody().style.color, '', 'No color on body.');
-    LegacyUnit.equal(editor.getBody().dir, '', 'No dir on body.');
-    LegacyUnit.equal(editor.dom.getStyle(editor.getBody().firstChild, 'display', true), 'block', 'No styles added to iframe document');
+    assert.equal(editor.getBody().style.color, '', 'No color on body.');
+    assert.equal(editor.getBody().dir, '', 'No dir on body.');
+    assert.equal(editor.dom.getStyle(editor.getBody().firstChild, 'display', true), 'block', 'No styles added to iframe document');
   });
 
-  suite.test('TestCase-TBA: FullPage: fullpage_hide_in_source_view: false', (editor) => {
+  it('TBA: fullpage_hide_in_source_view: false', () => {
+    const editor = hook.editor();
     editor.settings.fullpage_hide_in_source_view = false;
     editor.setContent('<html><body><p>1</p></body></html>');
-    LegacyUnit.equal(editor.getContent({ source_view: true }), '<html><body>\n<p>1</p>\n</body></html>');
+    assert.equal(editor.getContent({ source_view: true }), '<html><body>\n<p>1</p>\n</body></html>');
   });
 
-  suite.test('TestCase-TBA: FullPage: fullpage_hide_in_source_view: false', (editor) => {
+  it('TBA: fullpage_hide_in_source_view: true', () => {
+    const editor = hook.editor();
     editor.settings.fullpage_hide_in_source_view = true;
     editor.setContent('<html><body><p>1</p></body></html>');
-    LegacyUnit.equal(editor.getContent({ source_view: true }), '<p>1</p>');
+    assert.equal(editor.getContent({ source_view: true }), '<p>1</p>');
   });
 
-  suite.test('TestCase-TBA: FullPage: link elements', (editor) => {
+  it('TBA: link elements', () => {
+    const editor = hook.editor();
     editor.setContent('<html><head><link rel="stylesheet" href="a.css"><link rel="something"></head><body><p>c</p></body></html>');
-    LegacyUnit.equal(
+    assert.equal(
       editor.getContent(),
       '<html><head><link rel="stylesheet" href="a.css"><link rel="something"></head><body>\n<p>c</p>\n</body></html>'
     );
   });
 
-  suite.test('TestCase-TBA: FullPage: add/remove stylesheets', (editor) => {
-    const hasLink = (href) => {
+  it('TBA: add/remove stylesheets', () => {
+    const editor = hook.editor();
+    const hasLink = (href: string) => {
       const links = editor.getDoc().getElementsByTagName('link');
 
       for (let i = 0; i < links.length; i++) {
@@ -89,16 +103,16 @@ UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPagePluginTest', (succe
     };
 
     editor.setContent('<html><head><link rel="stylesheet" href="a.css"></head><body><p>c</p></body></html>');
-    LegacyUnit.equal(hasLink('a.css'), true);
-    LegacyUnit.equal(hasLink('b.css'), false);
-    LegacyUnit.equal(hasLink('c.css'), false);
+    assert.isTrue(hasLink('a.css'));
+    assert.isFalse(hasLink('b.css'));
+    assert.isFalse(hasLink('c.css'));
 
     editor.setContent(
       '<html><head><link rel="stylesheet" href="a.css"><link rel="stylesheet" href="b.css"></head><body><p>c</p></body></html>'
     );
-    LegacyUnit.equal(hasLink('a.css'), true);
-    LegacyUnit.equal(hasLink('b.css'), true);
-    LegacyUnit.equal(hasLink('c.css'), false);
+    assert.isTrue(hasLink('a.css'));
+    assert.isTrue(hasLink('b.css'));
+    assert.isFalse(hasLink('c.css'));
 
     editor.setContent(
       '<html><head>' +
@@ -108,95 +122,67 @@ UnitTest.asynctest('browser.tinymce.plugins.fullpage.FullPagePluginTest', (succe
       '</head>' +
       '<body><p>c</p></body></html>'
     );
-    LegacyUnit.equal(hasLink('a.css'), true);
-    LegacyUnit.equal(hasLink('b.css'), true);
-    LegacyUnit.equal(hasLink('c.css'), true);
+    assert.isTrue(hasLink('a.css'));
+    assert.isTrue(hasLink('b.css'));
+    assert.isTrue(hasLink('c.css'));
 
     editor.setContent('<html><head><link rel="stylesheet" href="a.css"></head><body><p>c</p></body></html>');
-    LegacyUnit.equal(hasLink('a.css'), true);
-    LegacyUnit.equal(hasLink('b.css'), false);
-    LegacyUnit.equal(hasLink('c.css'), false);
+    assert.isTrue(hasLink('a.css'));
+    assert.isFalse(hasLink('b.css'));
+    assert.isFalse(hasLink('c.css'));
 
     editor.setContent('<html><head></head><body><p>c</p></body></html>');
-    LegacyUnit.equal(hasLink('a.css'), false);
-    LegacyUnit.equal(hasLink('b.css'), false);
-    LegacyUnit.equal(hasLink('c.css'), false);
+    assert.isFalse(hasLink('a.css'));
+    assert.isFalse(hasLink('b.css'));
+    assert.isFalse(hasLink('c.css'));
   });
 
-  const sParseStyles = (editor) => {
-    return Logger.t('Parse styles', GeneralSteps.sequence([
-      Step.sync(() => {
-        editor.setContent('<html><head><style>p {text-transform: uppercase}</style></head><body dir="rtl"><p>Test</p></body></html>');
-      }),
-      Waiter.sTryUntil(
-        'Expected styles were added',
-        Step.sync(() => {
-          Assertions.assertEq('Styles added to iframe document', 'uppercase', editor.dom.getStyle(editor.getBody().firstChild, 'text-transform', true));
-          Assertions.assertEq('Styles not added to actual element', '', editor.dom.getStyle(editor.getBody().firstChild, 'text-transform', false));
-        }
-        ), 10, 3000)
-    ]));
-  };
+  it('Parse styles', async () => {
+    const editor = hook.editor();
+    editor.setContent('<html><head><style>p {text-transform: uppercase}</style></head><body dir="rtl"><p>Test</p></body></html>');
+    await Waiter.pTryUntil(
+      'Expected styles were added',
+      () => {
+        assert.equal(editor.dom.getStyle(editor.getBody().firstChild, 'text-transform', true), 'uppercase', 'Styles added to iframe document');
+        assert.equal(editor.dom.getStyle(editor.getBody().firstChild, 'text-transform', false), '', 'Styles not added to actual element');
+      }
+    );
+  });
 
-  const sProtectConditionalCommentsInHeadFoot = (editor) => {
-    return Logger.t('Set and assert styles were added to iframe document', GeneralSteps.sequence([
-      Step.sync(() => {
-        editor.setContent([
-          '<!DOCTYPE html>',
-          '<html>',
-          '<!--[if mso]>',
-          '<body class="mso-container" style="background-color:#FFFFFF;">',
-          '<![endif]-->',
-          '<!--[if !mso]><!-->',
-          '<body class="clean-body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #FFFFFF">',
-          '<!--<![endif]--><p>text</p>',
-          '</body>',
-          '</html>'
-        ].join('\n'));
-      }),
-      Step.sync(() => {
-        const expectedContent = [
-          '<!DOCTYPE html>',
-          '<html>',
-          '<!--[if mso]>',
-          '<body class="mso-container" style="background-color:#FFFFFF;">',
-          '<![endif]-->',
-          '<!--[if !mso]><!-->',
-          '<body class="clean-body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #FFFFFF">',
-          '<!--<![endif]--><p>text</p>',
-          '</body>',
-          '</html>'
-        ].join('\n');
+  it('protect conditional comments in head and foot', () => {
+    const editor = hook.editor();
+    editor.setContent([
+      '<!DOCTYPE html>',
+      '<html>',
+      '<!--[if mso]>',
+      '<body class="mso-container" style="background-color:#FFFFFF;">',
+      '<![endif]-->',
+      '<!--[if !mso]><!-->',
+      '<body class="clean-body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #FFFFFF">',
+      '<!--<![endif]--><p>text</p>',
+      '</body>',
+      '</html>'
+    ].join('\n'));
 
-        Assertions.assertHtml('Styles added to iframe document', expectedContent, editor.getContent());
-      })
-    ]));
-  };
+    const expectedContent = [
+      '<!DOCTYPE html>',
+      '<html>',
+      '<!--[if mso]>',
+      '<body class="mso-container" style="background-color:#FFFFFF;">',
+      '<![endif]-->',
+      '<!--[if !mso]><!-->',
+      '<body class="clean-body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #FFFFFF">',
+      '<!--<![endif]--><p>text</p>',
+      '</body>',
+      '</html>'
+    ].join('\n');
 
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'FullPage: Test full page header, footer, body attributes, hide in source view and adding and removing stylesheets',
-        [
-          sParseStyles(editor),
-          sProtectConditionalCommentsInHeadFoot(editor)
-        ].concat(suite.toSteps(editor))
-      ),
-      Log.stepsAsStep('TINY-6541', 'FullPage: Text content should not be modified', [
-        Step.sync(() => {
-          editor.setContent('some plain text');
-          Assertions.assertEq('should return plain text content', 'some plain text', editor.getContent({ format: 'text' }));
-        })
-      ])
-    ], onSuccess, onFailure);
+    TinyAssertions.assertContent(editor, expectedContent);
+  });
 
-    teardown(editor);
-  }, {
-    plugins: 'fullpage',
-    indent: false,
-    base_url: '/project/tinymce/js/tinymce',
-    theme: 'silver',
-    protect: [
-      /<!--([\s\S]*?)-->/g
-    ]
-  }, success, failure);
+  it('TINY-6541: Text content should not be modified', () => {
+    const editor = hook.editor();
+    editor.setContent('some plain text');
+    assert.equal(editor.getContent({ format: 'text' }), 'some plain text', 'should return plain text content');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `fullpage` plugin to use BDD style tests
* Adds some additional agar helpers needed to convert the `fullpage` tests (this is a duplicate of the charmap changes).
* Changes the `FocusTools.isOn` and `FocusTools.isOnSelector` to die if not found, as all the places it was used we needed to do that anyways (it's generally used as an assertion).

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
