### PR TITLE
TINY-6870: Switch help plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/help/test/ts/browser/CustomTabsTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/CustomTabsTest.ts
@@ -6,6 +6,7 @@ import { Html, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import Plugin from 'tinymce/plugins/help/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
@@ -24,129 +25,123 @@ describe('browser.tinymce.plugins.help.CustomTabsTest', () => {
     });
   };
 
-  Arr.each([
-    {
-      label: 'TINY-3535: Default help dialog',
-      expectedTabNames: [ 'Handy Shortcuts', 'Keyboard Navigation', 'Plugins', 'Version' ],
-      settings: { }
-    },
+  const pCreateEditor = (settings: RawEditorSettings) => McEditor.pFromSettings<Editor>({
+    plugins: 'help',
+    toolbar: 'help',
+    base_url: '/project/tinymce/js/tinymce',
+    ...settings
+  });
 
-    {
-      label: 'TINY-3535: help_tabs with pre-registered and new tabs',
-      expectedTabNames: [ 'Handy Shortcuts', 'Plugins', 'Version', 'Extra1' ],
-      settings: {
-        help_tabs: [
-          'shortcuts',
-          'plugins',
-          {
-            name: 'versions', // this will override the default versions tab
-            title: 'Version',
-            items: [{
-              type: 'htmlpanel',
-              html: '<p>This is a custom version panel...</p>'
-            }]
-          },
-          {
-            name: 'extraTab1',
-            title: 'Extra1',
-            items: [{
-              type: 'htmlpanel',
-              html: '<p>This is an extra tab</p>'
-            }]
-          }
-        ]
-      }
-    },
+  it('TINY-3535: Default help dialog', async () => {
+    const editor = await pCreateEditor({});
+    compareTabNames(editor, [ 'Handy Shortcuts', 'Keyboard Navigation', 'Plugins', 'Version' ]);
+    McEditor.remove(editor);
+  });
 
-    {
-      label: 'TINY-3535: addTab() with a new tab',
-      expectedTabNames: [ 'Handy Shortcuts', 'Keyboard Navigation', 'Plugins', 'Extra1', 'Version' ],
-      settings: {
-        setup: (editor: Editor) => {
-          editor.on('init', () => {
-            editor.plugins.help.addTab({
-              name: 'extraTab1',
-              title: 'Extra1',
-              items: [{
-                type: 'htmlpanel',
-                html: '<p>This is an extra tab</p>'
-              }]
-            });
-          });
+  it('TINY-3535: help_tabs with pre-registered and new tabs', async () => {
+    const editor = await pCreateEditor({
+      help_tabs: [
+        'shortcuts',
+        'plugins',
+        {
+          name: 'versions', // this will override the default versions tab
+          title: 'Version',
+          items: [{
+            type: 'htmlpanel',
+            html: '<p>This is a custom version panel...</p>'
+          }]
+        },
+        {
+          name: 'extraTab1',
+          title: 'Extra1',
+          items: [{
+            type: 'htmlpanel',
+            html: '<p>This is an extra tab</p>'
+          }]
         }
-      }
-    },
-
-    {
-      label: 'TINY-3535: help_tabs and addTab()',
-      expectedTabNames: [ 'Handy Shortcuts', 'Extra2', 'Plugins', 'Version', 'Extra1' ],
-      settings: {
-        help_tabs: [
-          'shortcuts',
-          'extraTab2',
-          'plugins',
-          {
-            name: 'versions', // this will override the default versions tab
-            title: 'Version',
-            items: [{
-              type: 'htmlpanel',
-              html: '<p>This is a custom version panel...</p>'
-            }]
-          },
-          {
-            name: 'extraTab1',
-            title: 'Extra1',
-            items: [{
-              type: 'htmlpanel',
-              html: '<p>This is an extra tab</p>'
-            }]
-          }
-        ],
-        setup: (editor: Editor) => {
-          editor.on('init', () => {
-            editor.plugins.help.addTab({
-              name: 'extraTab2',
-              title: 'Extra2',
-              items: [{
-                type: 'htmlpanel',
-                html: '<p>This is another extra tab</p>'
-              }]
-            });
-            editor.plugins.help.addTab({
-              name: 'extraTab3',
-              title: 'Extra3',
-              items: [{
-                type: 'htmlpanel',
-                html: '<p>This is yet another extra tab, but this one should not render</p>'
-              }]
-            });
-          });
-        }
-      }
-    },
-
-    {
-      label: 'TINY-3535: things do not break if a tab name does not have a spec',
-      expectedTabNames: [ 'Handy Shortcuts', 'Plugins', 'Version' ],
-      settings: {
-        help_tabs: [
-          'shortcuts',
-          'plugins',
-          'versions',
-          'unknown'
-        ]
-      }
-    }
-  ], (test) => {
-    it(test.label, async () => {
-      const editor = await McEditor.pFromSettings<Editor>({
-        plugins: 'help',
-        toolbar: 'help',
-        base_url: '/project/tinymce/js/tinymce',
-        ...test.settings
-      });
-      compareTabNames(editor, test.expectedTabNames);
-      McEditor.remove(editor);
+      ]
     });
+    compareTabNames(editor, [ 'Handy Shortcuts', 'Plugins', 'Version', 'Extra1' ]);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-3535: addTab() with a new tab', async () => {
+    const editor = await pCreateEditor({
+      setup: (editor) => {
+        editor.on('init', () => {
+          editor.plugins.help.addTab({
+            name: 'extraTab1',
+            title: 'Extra1',
+            items: [{
+              type: 'htmlpanel',
+              html: '<p>This is an extra tab</p>'
+            }]
+          });
+        });
+      }
+    });
+    compareTabNames(editor, [ 'Handy Shortcuts', 'Keyboard Navigation', 'Plugins', 'Extra1', 'Version' ]);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-3535: help_tabs and addTab()', async () => {
+    const editor = await pCreateEditor({
+      help_tabs: [
+        'shortcuts',
+        'extraTab2',
+        'plugins',
+        {
+          name: 'versions', // this will override the default versions tab
+          title: 'Version',
+          items: [{
+            type: 'htmlpanel',
+            html: '<p>This is a custom version panel...</p>'
+          }]
+        },
+        {
+          name: 'extraTab1',
+          title: 'Extra1',
+          items: [{
+            type: 'htmlpanel',
+            html: '<p>This is an extra tab</p>'
+          }]
+        }
+      ],
+      setup: (editor) => {
+        editor.on('init', () => {
+          editor.plugins.help.addTab({
+            name: 'extraTab2',
+            title: 'Extra2',
+            items: [{
+              type: 'htmlpanel',
+              html: '<p>This is another extra tab</p>'
+            }]
+          });
+          editor.plugins.help.addTab({
+            name: 'extraTab3',
+            title: 'Extra3',
+            items: [{
+              type: 'htmlpanel',
+              html: '<p>This is yet another extra tab, but this one should not render</p>'
+            }]
+          });
+        });
+      }
+    });
+    compareTabNames(editor, [ 'Handy Shortcuts', 'Extra2', 'Plugins', 'Version', 'Extra1' ]);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-3535: things do not break if a tab name does not have a spec', async () => {
+    const editor = await pCreateEditor({
+      help_tabs: [
+        'shortcuts',
+        'plugins',
+        'versions',
+        'unknown'
+      ]
+    });
+    compareTabNames(editor, [ 'Handy Shortcuts', 'Plugins', 'Version' ]);
+    McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
@@ -1,85 +1,82 @@
-import { FocusTools, Keyboard, Keys, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
-import HelpPlugin from 'tinymce/plugins/help/Plugin';
+import { FocusTools, Keyboard, Keys, Mouse } from '@ephox/agar';
+import { before, describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
+import { SugarBody, SugarDocument } from '@ephox/sugar';
+
+import Plugin from 'tinymce/plugins/help/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.help.DialogKeyboardNavTest', (success, failure) => {
-
-  HelpPlugin();
-  Theme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const doc = SugarElement.fromDom(document);
-
-    // Tab key press
-    const sPressTabKey = Keyboard.sKeydown(doc, Keys.tab(), { });
-
-    // Down arrow key press to nav between tabs
-    const sPressDownArrowKey = Keyboard.sKeydown(doc, Keys.down(), { });
-
-    // Assert focus is on the expected form element
-    const sAssertFocusOnItem = (label, selector) => FocusTools.sTryOnSelector(
-      `Focus should be on: ${label}`,
-      doc,
-      selector
-    );
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Help: Open dialog', [
-        tinyApis.sFocus(),
-        tinyApis.sExecCommand('mceHelp')
-      ]),
-
-      Log.stepsAsStep('TBA', 'Help: test the tab key navigation cycles through all focusable fields in Handy Shortcuts tab', [
-        sAssertFocusOnItem('Handy Shortcuts Tab', '.tox-dialog__body-nav-item:contains("Handy Shortcuts")'),
-        sPressTabKey,
-        sAssertFocusOnItem('Handy Shortcuts Items', '.tox-dialog__table'),
-        sPressTabKey,
-        sAssertFocusOnItem('Close Button', '.tox-button:contains("Close")'),
-        sPressTabKey,
-        sAssertFocusOnItem('Handy Shortcuts Tab', '.tox-dialog__body-nav-item:contains("Handy Shortcuts")'),
-        sPressDownArrowKey
-      ]),
-
-      Log.stepsAsStep('TBA', 'Help: test the tab key navigation cycles through all focusable fields in Keyboard Nav tab', [
-        sAssertFocusOnItem('Keyboard Nav Tab', '.tox-dialog__body-nav-item:contains("Keyboard Navigation")'),
-        sPressTabKey,
-        sAssertFocusOnItem('Installed Plugins', 'div[role="document"]'),
-        sPressTabKey,
-        sAssertFocusOnItem('Close Button', '.tox-button:contains("Close")'),
-        sPressTabKey,
-        sAssertFocusOnItem('Keyboard Nav Tab', '.tox-dialog__body-nav-item:contains("Keyboard Navigation")'),
-        sPressDownArrowKey
-      ]),
-
-      Log.stepsAsStep('TBA', 'Help: test the tab key navigation cycles through all focusable fields in Plugins tab', [
-        sAssertFocusOnItem('Plugins Tab', '.tox-dialog__body-nav-item:contains("Plugins")'),
-        sPressTabKey,
-        sAssertFocusOnItem('Installed Plugins', 'div[role="document"]'),
-        sPressTabKey,
-        sAssertFocusOnItem('Close Button', '.tox-button:contains("Close")'),
-        sPressTabKey,
-        sAssertFocusOnItem('Plugins Tab', '.tox-dialog__body-nav-item:contains("Plugins")'),
-        sPressDownArrowKey
-      ]),
-
-      Log.stepsAsStep('TBA', 'Help: test the tab key navigation cycles through all focusable fields in Version tab', [
-        sAssertFocusOnItem('Version Tab', '.tox-dialog__body-nav-item:contains("Version")'),
-        sPressTabKey,
-        sAssertFocusOnItem('TinyMCE Version', 'div[role="document"]'),
-        sPressTabKey,
-        sAssertFocusOnItem('Close Button', '.tox-button:contains("Close")'),
-        sPressTabKey,
-        sAssertFocusOnItem('Version Tab', '.tox-dialog__body-nav-item:contains("Version")')
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
+  const hook = TinyHooks.bddSetupLight({
     plugins: 'help',
     toolbar: 'help',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  // Tab key press
+  const pressTabKey = () => Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.tab(), { });
+
+  // Down arrow key press to nav between tabs
+  const pressDownArrowKey = () => Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down(), { });
+
+  // Assert focus is on the expected form element
+  const pAssertFocusOnItem = (label: string, selector: string) => FocusTools.pTryOnSelector(
+    `Focus should be on: ${label}`,
+    SugarDocument.getDocument(),
+    selector
+  );
+
+  const selectTab = (selector: string) => Mouse.trueClickOn(SugarBody.body(), selector);
+
+  before(() => {
+    // Open the help dialog
+    hook.editor().execCommand('mceHelp');
+  });
+
+  it('TBA: test the tab key navigation cycles through all focusable fields in Handy Shortcuts tab', async () => {
+    selectTab('.tox-dialog__body-nav-item:contains("Handy Shortcuts")');
+    await pAssertFocusOnItem('Handy Shortcuts Tab', '.tox-dialog__body-nav-item:contains("Handy Shortcuts")');
+    pressTabKey();
+    await pAssertFocusOnItem('Handy Shortcuts Items', '.tox-dialog__table');
+    pressTabKey();
+    await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
+    pressTabKey();
+    await pAssertFocusOnItem('Handy Shortcuts Tab', '.tox-dialog__body-nav-item:contains("Handy Shortcuts")');
+    pressDownArrowKey();
+  });
+
+  it('TBA: test the tab key navigation cycles through all focusable fields in Keyboard Nav tab', async () => {
+    selectTab('.tox-dialog__body-nav-item:contains("Keyboard Navigation")');
+    await pAssertFocusOnItem('Keyboard Nav Tab', '.tox-dialog__body-nav-item:contains("Keyboard Navigation")');
+    pressTabKey();
+    await pAssertFocusOnItem('Installed Plugins', 'div[role="document"]');
+    pressTabKey();
+    await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
+    pressTabKey();
+    await pAssertFocusOnItem('Keyboard Nav Tab', '.tox-dialog__body-nav-item:contains("Keyboard Navigation")');
+    pressDownArrowKey();
+  });
+
+  it('TBA: test the tab key navigation cycles through all focusable fields in Plugins tab', async () => {
+    selectTab('.tox-dialog__body-nav-item:contains("Plugins")');
+    await pAssertFocusOnItem('Plugins Tab', '.tox-dialog__body-nav-item:contains("Plugins")');
+    pressTabKey();
+    await pAssertFocusOnItem('Installed Plugins', 'div[role="document"]');
+    pressTabKey();
+    await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
+    pressTabKey();
+    await pAssertFocusOnItem('Plugins Tab', '.tox-dialog__body-nav-item:contains("Plugins")');
+    pressDownArrowKey();
+  });
+
+  it('TBA: test the tab key navigation cycles through all focusable fields in Version tab', async () => {
+    selectTab('.tox-dialog__body-nav-item:contains("Version")');
+    await pAssertFocusOnItem('Version Tab', '.tox-dialog__body-nav-item:contains("Version")');
+    pressTabKey();
+    await pAssertFocusOnItem('TinyMCE Version', 'div[role="document"]');
+    pressTabKey();
+    await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
+    pressTabKey();
+    await pAssertFocusOnItem('Version Tab', '.tox-dialog__body-nav-item:contains("Version")');
+  });
 });

--- a/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
@@ -1,41 +1,32 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
 import HelpPlugin from 'tinymce/plugins/help/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-import * as PluginAssert from '../module/PluginAssert';
+import Theme from 'tinymce/themes/silver/Theme';
 
+import * as PluginAssert from '../module/PluginAssert';
 import { selectors } from '../module/Selectors';
 
-UnitTest.asynctest('browser.tinymce.plugins.help.IgnoreForcedPluginsTest', (success, failure) => {
-  HelpPlugin();
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const ui = TinyUi(editor);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Help: Hide forced plugins from Help plugin list', [
-        ui.sClickOnToolbar('Click help button', selectors.toolbarHelpButton),
-        PluginAssert.sAssert(
-          'Could not ignore forced plugin: link',
-          {
-            'li a:contains("Help")': 1,
-            'li a:contains("Link")': 0
-          },
-          selectors.dialog,
-          selectors.pluginsTab
-        )
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.help.IgnoreForcedPluginsTest', () => {
+  const hook = TinyHooks.bddSetupLight({
     plugins: 'help',
     toolbar: 'help',
-    theme: 'silver',
     forced_plugins: [ 'link' ],
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ HelpPlugin, LinkPlugin, Theme ]);
+
+  it('TBA: Hide forced plugins from Help plugin list', async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, selectors.toolbarHelpButton);
+    await PluginAssert.pAssert(
+      'Could not ignore forced plugin: link',
+      {
+        'li a:contains("Help")': 1,
+        'li a:contains("Link")': 0
+      },
+      selectors.dialog,
+      selectors.pluginsTab
+    );
+  });
 });

--- a/modules/tinymce/src/plugins/help/test/ts/browser/MetadataTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/MetadataTest.ts
@@ -1,46 +1,34 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
 import HelpPlugin from 'tinymce/plugins/help/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
+
 import * as PluginAssert from '../module/PluginAssert';
-
 import { selectors } from '../module/Selectors';
-
 import FakePlugin from '../module/test/FakePlugin';
 import NoMetaFakePlugin from '../module/test/NoMetaFakePlugin';
 
-UnitTest.asynctest('Browser Test: .MetadataTest', (success, failure) => {
-
-  HelpPlugin();
-  FakePlugin();
-  NoMetaFakePlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const ui = TinyUi(editor);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Help: Assert Help Plugin list contains getMetadata functionality', [
-        ui.sClickOnToolbar('Click help button', selectors.toolbarHelpButton),
-        PluginAssert.sAssert(
-          'Failed to list fake plugins',
-          {
-            'li a:contains("Help")': 1,
-            'li a:contains("Fake")': 1,
-            'li:contains("nometafake")': 1,
-            'button:contains("Close")': 1
-          },
-          selectors.dialog,
-          selectors.pluginsTab
-        )
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('Browser Test: .MetadataTest', () => {
+  const hook = TinyHooks.bddSetupLight({
     plugins: 'help fake nometafake',
     toolbar: 'help',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ HelpPlugin, FakePlugin, NoMetaFakePlugin, Theme ]);
+
+  it('TBA: Assert Help Plugin list contains getMetadata functionality', async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, selectors.toolbarHelpButton);
+    await PluginAssert.pAssert(
+      'Failed to list fake plugins',
+      {
+        'li a:contains("Help")': 1,
+        'li a:contains("Fake")': 1,
+        'li:contains("nometafake")': 1,
+        'button:contains("Close")': 1
+      },
+      selectors.dialog,
+      selectors.pluginsTab
+    );
+  });
 });

--- a/modules/tinymce/src/plugins/help/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/PluginTest.ts
@@ -1,39 +1,29 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
-import HelpPlugin from 'tinymce/plugins/help/Plugin';
+import Plugin from 'tinymce/plugins/help/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
 import * as PluginAssert from '../module/PluginAssert';
 import { selectors } from '../module/Selectors';
 
-UnitTest.asynctest('browser.tinymce.plugins.help.PluginTest', (success, failure) => {
-
-  Theme();
-  HelpPlugin();
-
-  TinyLoader.setup((editor, onSuccess, onFailure) => {
-    const ui = TinyUi(editor);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Help: Assert Help Plugin list contains Help', [
-        ui.sClickOnToolbar('Click help button', selectors.toolbarHelpButton),
-        PluginAssert.sAssert(
-          'Failed to find `Help` plugin',
-          {
-            'a:contains("Help")': 1
-          },
-          selectors.dialog,
-          selectors.pluginsTab
-        )
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.help.PluginTest', () => {
+  const hook = TinyHooks.bddSetupLight({
     plugins: 'help',
     toolbar: 'help',
-    theme: 'silver',
-    statusbar: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  it('TBA: Assert Help Plugin list contains Help', async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, selectors.toolbarHelpButton);
+    await PluginAssert.pAssert(
+      'Failed to find `Help` plugin',
+      {
+        'a:contains("Help")': 1
+      },
+      selectors.dialog,
+      selectors.pluginsTab
+    );
+  });
 });

--- a/modules/tinymce/src/plugins/help/test/ts/module/PluginAssert.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/PluginAssert.ts
@@ -1,15 +1,11 @@
-import { Assertions, Chain, Guard, Logger, Mouse, UiFinder } from '@ephox/agar';
-import { TinyDom } from '@ephox/mcagar';
+import { Assertions, Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { SugarDocument } from '@ephox/sugar';
 
-export const sAssert = (errString, objStruc, waitOn, clickOn) => {
-  return Logger.t('Assert structure in dialog', Chain.asStep(TinyDom.fromDom(document.body), [
-    UiFinder.cWaitFor('Could not find notification', waitOn),
-    Mouse.cClickOn(clickOn),
-    Chain.control(
-      Chain.op((panel) => {
-        Assertions.assertPresence(errString, objStruc, panel);
-      }),
-      Guard.tryUntil('Keep waiting', 100, 4000)
-    )
-  ]));
+export const pAssert = async (message: string, expected: Record<string, number>, waitOnSelector: string, clickOnSelector: string) => {
+  const dialog = await UiFinder.pWaitFor('Could not find dialog', SugarDocument.getDocument(), waitOnSelector);
+  Mouse.clickOn(dialog, clickOnSelector);
+  await Waiter.pTryUntil(
+    'Waiting for expected structure',
+    () => Assertions.assertPresence(message, expected, dialog)
+  );
 };

--- a/modules/tinymce/src/plugins/help/test/ts/module/test/FakePlugin.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/test/FakePlugin.ts
@@ -1,7 +1,8 @@
+import Editor from 'tinymce/core/api/Editor';
 import PluginManager from 'tinymce/core/api/PluginManager';
 
 export default () => {
-  const Plugin = (_editor, _url) => {
+  const Plugin = (_editor: Editor, _url: string) => {
     return {
       getMetadata: () => {
         return {


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `help` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
