### PR TITLE
TINY-6870: Switch image plugin to use BDD style tests

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/FileInput.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FileInput.ts
@@ -1,6 +1,7 @@
-import { cRunOnPatchedFileInput, sRunOnPatchedFileInput } from '../file/PatchInputFiles';
+import { cRunOnPatchedFileInput, sRunOnPatchedFileInput, pRunOnPatchedFileInput } from '../file/PatchInputFiles';
 
 export {
   sRunOnPatchedFileInput,
-  cRunOnPatchedFileInput
+  cRunOnPatchedFileInput,
+  pRunOnPatchedFileInput
 };

--- a/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
+++ b/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
@@ -65,7 +65,11 @@ const cRunOnPatchedFileInput = (files: File[], chain: Chain<any, any>): Chain<an
   cUnpatchInputElement
 ]);
 
+const pRunOnPatchedFileInput = (files: File[], action: () => Promise<void>): Promise<void > =>
+  Chain.toPromise(cRunOnPatchedFileInput(files, Chain.fromPromise(action)))(undefined);
+
 export {
   sRunOnPatchedFileInput,
-  cRunOnPatchedFileInput
+  cRunOnPatchedFileInput,
+  pRunOnPatchedFileInput
 };

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyUiActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyUiActions.ts
@@ -2,6 +2,7 @@ import { Mouse, UiFinder } from '@ephox/agar';
 import { SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { Editor } from '../alien/EditorTypes';
 import { getThemeSelectors } from './ThemeSelectors';
+import { TinyDom } from './TinyDom';
 
 const getUiRoot = (editor: Editor) =>
   SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement())));
@@ -56,6 +57,11 @@ const pWaitForUi = (editor: Editor, selector: string): Promise<SugarElement<Elem
 const pWaitForPopup = (editor: Editor, selector: string): Promise<SugarElement<Element>> =>
   UiFinder.pWaitForVisible(`Waiting for a popup matching '${selector}' to be visible`, getUiRoot(editor), selector);
 
+const pTriggerContextMenu = async (editor: Editor, target: string, menu: string): Promise<void> => {
+  Mouse.contextMenuOn(TinyDom.body(editor), target);
+  await pWaitForPopup(editor, menu);
+};
+
 export {
   clickOnToolbar,
   clickOnMenu,
@@ -64,5 +70,6 @@ export {
   closeDialog,
 
   pWaitForPopup,
-  pWaitForUi
+  pWaitForUi,
+  pTriggerContextMenu
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Checked.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Checked.ts
@@ -6,12 +6,16 @@ const set = (element: SugarElement<HTMLInputElement>, status: boolean): void => 
   element.dom.checked = status;
 };
 
+const get = (element: SugarElement<HTMLInputElement>): boolean =>
+  element.dom.checked;
+
 // :checked selector requires IE9
 // http://www.quirksmode.org/css/selectors/#t60
 const find = (parent: SugarElement<Node>): Optional<SugarElement<HTMLInputElement>> =>
   SelectorFind.descendant<HTMLInputElement>(parent, 'input:checked');
 
 export {
+  get,
   set,
   find
 };

--- a/modules/sugar/src/test/ts/browser/CheckedTest.ts
+++ b/modules/sugar/src/test/ts/browser/CheckedTest.ts
@@ -1,4 +1,4 @@
-import { UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { KAssert } from '@ephox/katamari-assertions';
 import * as InsertAll from 'ephox/sugar/api/dom/InsertAll';
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
@@ -15,8 +15,11 @@ UnitTest.test('CheckedTest', () => {
   InsertAll.append(container, [ alpha, beta, gamma ]);
 
   KAssert.eqNone('eq', Checked.find(container));
+  Assert.eq('Alpha checked value should be false', false, Checked.get(alpha));
   Checked.set(beta, true);
+  Assert.eq('Beta checked value should be true', true, Checked.get(beta));
   KAssert.eqSome('eq', 'beta', Checked.find(container).map(Value.get));
   Checked.set(alpha, true);
+  Assert.eq('Alpha checked value should be true', true, Checked.get(alpha));
   KAssert.eqSome('eq', 'alpha', Checked.find(container).map(Value.get));
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ContextMenuTest.ts
@@ -1,73 +1,72 @@
-import { Chain, Keyboard, Keys, Log, Mouse, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
+import { Keyboard, Keys, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { SugarDocument } from '@ephox/sugar';
 
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { pWaitForDialog, submitDialog } from '../module/Helpers';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.ContextMenuTest', (success, failure) => {
-  SilverTheme();
-  ImagePlugin();
-
-  TinyLoader.setup((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    const rootDoc = SugarElement.fromDom(document);
-
-    const sOpenContextMenu = (target) => Chain.asStep(editor, [
-      tinyUi.cTriggerContextMenu('trigger image context menu', target, '.tox-silver-sink [role="menuitem"]'),
-      // Not sure why this is needed, but without the browser deselects the contextmenu target
-      Chain.wait(0)
-    ]);
-
-    const sWaitForAndSubmitDialog = Chain.asStep(editor, [
-      tinyUi.cWaitForPopup('wait for dialog', 'div[role="dialog"]'),
-      Mouse.cClickOn('.tox-button:contains("Save")')
-    ]);
-
-    Pipeline.async({}, [
-      tinyApis.sFocus(),
-      Log.stepsAsStep('TBA', 'Opening context menus on a selected figure', [
-        tinyApis.sSetRawContent('<figure class="image" contenteditable="false"><img src="image.png"><figcaption contenteditable="true">Caption</figcaption></figure><p>Second paragraph</p>'),
-        tinyApis.sSetSelection([], 0, [], 1),
-        sOpenContextMenu('figure.image'),
-        Keyboard.sKeydown(rootDoc, Keys.enter(), {}),
-        sWaitForAndSubmitDialog,
-        tinyApis.sAssertSelection([], 0, [], 1)
-      ]),
-      Log.stepsAsStep('TBA', 'Opening context menus on an unselected figure', [
-        tinyApis.sSetRawContent('<figure class="image" contenteditable="false"><img src="image.png"><figcaption contenteditable="true">Caption</figcaption></figure><p>Second paragraph</p>'),
-        tinyApis.sSetSelection([ 1, 0 ], 1, [ 1, 0 ], 1),
-        sOpenContextMenu('figure.image'),
-        Keyboard.sKeydown(rootDoc, Keys.enter(), {}),
-        sWaitForAndSubmitDialog,
-        tinyApis.sAssertSelection([], 0, [], 1)
-      ]),
-      Log.stepsAsStep('TBA', 'Opening context menus on a selected image', [
-        tinyApis.sSetRawContent('<p><img src="image.png" /></p><p>Second paragraph</p>'),
-        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
-        sOpenContextMenu('img'),
-        Keyboard.sKeydown(rootDoc, Keys.enter(), {}),
-        sWaitForAndSubmitDialog,
-        tinyApis.sAssertSelection([ 0 ], 0, [ 0 ], 1)
-      ]),
-      Log.stepsAsStep('TBA', 'Opening context menus on an unselected image', [
-        tinyApis.sSetRawContent('<p><img src="image.png" /></p><p>Second paragraph</p>'),
-        tinyApis.sSetSelection([ 1, 0 ], 1, [ 1, 0 ], 1),
-        sOpenContextMenu('img'),
-        Keyboard.sKeydown(rootDoc, Keys.enter(), {}),
-        sWaitForAndSubmitDialog,
-        tinyApis.sAssertSelection([ 0 ], 0, [ 0 ], 1)
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.image.ContextMenuTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'image',
     toolbar: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_caption: true
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  const pOpenContextMenu = async (editor: Editor, target: string) => {
+    // Not sure why this is needed, but without the browser deselects the contextmenu target
+    await Waiter.pWait(0);
+    await TinyUiActions.pTriggerContextMenu(editor, target, '.tox-silver-sink [role="menuitem"]');
+  };
+
+  const pWaitForAndSubmitDialog = async (editor: Editor) => {
+    await pWaitForDialog(editor);
+    submitDialog(editor);
+  };
+
+  it('TBA: Opening context menus on a selected figure', async () => {
+    const editor = hook.editor();
+    editor.setContent('<figure class="image" contenteditable="false"><img src="image.png"><figcaption contenteditable="true">Caption</figcaption></figure><p>Second paragraph</p>', { format: 'raw' });
+    // Note: A fake caret will be the first element in the dom
+    TinySelections.setSelection(editor, [], 1, [], 2);
+    await pOpenContextMenu(editor, 'figure.image');
+    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter(), {});
+    await pWaitForAndSubmitDialog(editor);
+    TinyAssertions.assertSelection(editor, [], 0, [], 1);
+  });
+
+  it('TBA: Opening context menus on an unselected figure', async () => {
+    const editor = hook.editor();
+    editor.setContent('<figure class="image" contenteditable="false"><img src="image.png"><figcaption contenteditable="true">Caption</figcaption></figure><p>Second paragraph</p>', { format: 'raw' });
+    // Note: A fake caret will be the first element in the dom
+    TinySelections.setCursor(editor, [ 2, 0 ], 1);
+    await pOpenContextMenu(editor, 'figure.image');
+    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter(), {});
+    await pWaitForAndSubmitDialog(editor);
+    TinyAssertions.assertSelection(editor, [], 0, [], 1);
+  });
+
+  it('TBA: Opening context menus on a selected image', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="image.png" /></p><p>Second paragraph</p>', { format: 'raw' });
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    await pOpenContextMenu(editor, 'img');
+    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter(), {});
+    await pWaitForAndSubmitDialog(editor);
+    TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 1);
+  });
+
+  it('TBA: Opening context menus on an unselected image', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="image.png" /></p><p>Second paragraph</p>', { format: 'raw' });
+    TinySelections.setSelection(editor, [ 1, 0 ], 1, [ 1, 0 ], 1);
+    await pOpenContextMenu(editor, 'img');
+    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter(), {});
+    await pWaitForAndSubmitDialog(editor);
+    TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 1);
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
@@ -1,107 +1,98 @@
-import { Chain, FocusTools, Keyboard, Keys, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { ApiChains, TinyApis, TinyLoader } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
+import { FocusTools, Keyboard, Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { SugarDocument } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
+
 import {
-  cAssertCleanHtml, cAssertInputCheckbox, cAssertInputValue, cFillActiveDialog, cSubmitDialog, cWaitForDialog, generalTabSelectors
+  assertCleanHtml, assertInputCheckbox, assertInputValue, fillActiveDialog, generalTabSelectors, pWaitForDialog, submitDialog
 } from '../module/Helpers';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.DescriptiveImageDialogTest', (success, failure) => {
-
-  SilverTheme();
-  Plugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const api = TinyApis(editor);
-    const doc = SugarElement.fromDom(document);
-
-    const sPressTab = Keyboard.sKeydown(doc, Keys.tab(), {});
-    const sPressEsc = Keyboard.sKeydown(doc, Keys.escape(), {});
-
-    const sAssertFocused = (name, selector) => FocusTools.sTryOnSelector(name, doc, selector);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Insert Image Dialog basic keyboard navigation cycle ', [
-        api.sExecCommand('mceImage'),
-        sAssertFocused('Source', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Descriptive', '.tox-checkbox__input'),
-        sPressTab,
-        sAssertFocused('Description', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Width', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Height', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Constraint proportions', 'button.tox-lock'),
-        sPressTab,
-        sAssertFocused('Cancel', 'button.tox-button:contains("Cancel")'),
-        sPressTab,
-        sAssertFocused('Save', 'button.tox-button:contains("Save")'),
-        sPressEsc
-      ]),
-      Log.chainsAsStep('TBA', 'Image update with empty alt should remove the existing alt attribute', [
-        Chain.inject(editor),
-        ApiChains.cSetContent('<p><img src="#1" alt="alt1" /></p>'),
-        ApiChains.cSetSelection([ 0 ], 0, [ 0 ], 1),
-        ApiChains.cExecCommand('mceImage', true),
-        cWaitForDialog(),
-        Chain.fromParent(Chain.identity, [
-          cAssertInputValue(generalTabSelectors.src, '#1'),
-          cAssertInputValue(generalTabSelectors.alt, 'alt1')
-        ]),
-        cFillActiveDialog({
-          src: {
-            value: 'src'
-          },
-          alt: ''
-        }),
-        cSubmitDialog(),
-        cAssertCleanHtml('Checking output', '<p><img src="src" /></p>')
-      ]),
-      Log.chainsAsStep('TBA', 'Image update with decorative toggled on should produce empty alt and role=presentation', [
-        Chain.inject(editor),
-        ApiChains.cSetContent('<p><img src="#1" alt="alt1" /></p>'),
-        ApiChains.cSetSelection([ 0 ], 0, [ 0 ], 1),
-        ApiChains.cExecCommand('mceImage', true),
-        cWaitForDialog(),
-        Chain.fromParent(Chain.identity, [
-          cAssertInputValue(generalTabSelectors.src, '#1'),
-          cAssertInputValue(generalTabSelectors.alt, 'alt1'),
-          cAssertInputCheckbox(generalTabSelectors.decorative, false)
-        ]),
-        cFillActiveDialog({
-          decorative: true
-        }),
-        cSubmitDialog(),
-        cAssertCleanHtml('Checking output', '<p><img role="presentation" src="#1" alt="" /></p>')
-      ]),
-      Log.chainsAsStep('TBA', 'Image update with decorative toggled off should produce empty alt and role=presentation', [
-        Chain.inject(editor),
-        ApiChains.cSetContent('<p><img role="presentation" src="#1" alt="" /></p>'),
-        ApiChains.cSetSelection([ 0 ], 0, [ 0 ], 1),
-        ApiChains.cExecCommand('mceImage', true),
-        cWaitForDialog(),
-        Chain.fromParent(Chain.identity, [
-          cAssertInputValue(generalTabSelectors.src, '#1'),
-          cAssertInputValue(generalTabSelectors.alt, ''),
-          cAssertInputCheckbox(generalTabSelectors.decorative, true)
-        ]),
-        cFillActiveDialog({
-          decorative: false
-        }),
-        cSubmitDialog(),
-        cAssertCleanHtml('Checking output', '<p><img src="#1" /></p>')
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.image.DescriptiveImageDialogTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'image',
     toolbar: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     a11y_advanced_options: true
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const pressTab = () => Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.tab(), { });
+  const pressEsc = () => Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.escape(), { });
+
+  const pAssertFocused = (name: string, selector: string) => FocusTools.pTryOnSelector(name, SugarDocument.getDocument(), selector);
+
+  it('TBA: Insert Image Dialog basic keyboard navigation cycle', async () => {
+    const editor = hook.editor();
+    editor.execCommand('mceImage');
+    await pAssertFocused('Source', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Descriptive', '.tox-checkbox__input');
+    pressTab();
+    await pAssertFocused('Description', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Width', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Height', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Constraint proportions', 'button.tox-lock');
+    pressTab();
+    await pAssertFocused('Cancel', 'button.tox-button:contains("Cancel")');
+    pressTab();
+    await pAssertFocused('Save', 'button.tox-button:contains("Save")');
+    pressEsc();
+  });
+
+  it('TBA: Image update with empty alt should remove the existing alt attribute', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="#1" alt="alt1" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+    assertInputValue(generalTabSelectors.src, '#1');
+    assertInputValue(generalTabSelectors.alt, 'alt1');
+    fillActiveDialog({
+      src: {
+        value: 'src'
+      },
+      alt: ''
+    });
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="src" /></p>');
+  });
+
+  it('TBA: Image update with decorative toggled on should produce empty alt and role=presentation', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="#1" alt="alt1" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+    assertInputValue(generalTabSelectors.src, '#1');
+    assertInputValue(generalTabSelectors.alt, 'alt1');
+    assertInputCheckbox(generalTabSelectors.decorative, false);
+    fillActiveDialog({
+      decorative: true
+    });
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img role="presentation" src="#1" alt="" /></p>');
+  });
+
+  it('TBA: Image update with decorative toggled off should produce empty alt and role=presentation', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img role="presentation" src="#1" alt="" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+    assertInputValue(generalTabSelectors.src, '#1');
+    assertInputValue(generalTabSelectors.alt, '');
+    assertInputCheckbox(generalTabSelectors.decorative, true);
+    fillActiveDialog({
+      decorative: false
+    });
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="#1" /></p>');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
@@ -1,143 +1,142 @@
-import { FocusTools, Keyboard, Keys, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { FocusTools, Keyboard, Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/mcagar';
+import { SugarDocument } from '@ephox/sugar';
 
+import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.DialogTest', (success, failure) => {
-
-  SilverTheme();
-  Plugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const api = TinyApis(editor);
-    const doc = SugarElement.fromDom(document);
-
-    const sPressTab = Keyboard.sKeydown(doc, Keys.tab(), {});
-    const sPressEsc = Keyboard.sKeydown(doc, Keys.escape(), {});
-    const sPressDown = Keyboard.sKeydown(doc, Keys.down(), {});
-
-    const sAssertFocused = (name, selector) => FocusTools.sTryOnSelector(name, doc, selector);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Insert Image Dialog basic cycle ', [
-        api.sExecCommand('mceImage'),
-        sAssertFocused('Source', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Description', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Width', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Height', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Constraint proportions', 'button.tox-lock'),
-        sPressTab,
-        sAssertFocused('Cancel', 'button.tox-button:contains("Cancel")'),
-        sPressTab,
-        sAssertFocused('Save', 'button.tox-button:contains("Save")'),
-        sPressEsc
-      ]),
-
-      Log.stepsAsStep('TBA', 'Insert Image Dialog with filepicker cycle', [
-        api.sSetSetting('image_advtab', true),
-        api.sExecCommand('mceImage'),
-        sAssertFocused('Tab', '.tox-dialog__body-nav-item:contains("General")'),
-        sPressTab,
-        sAssertFocused('Source', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Description', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Width', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Height', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Constraint proportions', 'button.tox-lock'),
-        sPressTab,
-        sAssertFocused('Cancel', 'button.tox-button:contains("Cancel")'),
-        sPressTab,
-        sAssertFocused('Save', 'button.tox-button:contains("Save")'),
-        sPressEsc
-      ]),
-
-      Log.stepsAsStep('TBA', 'Insert Image Dialog with all options', [
-        api.sSetSetting('file_picker_callback', Fun.noop),
-        api.sSetSetting('image_class_list', [{ title: 'sample', value: 'sample' }]),
-        api.sSetSetting('image_list', [{ title: 'sample', value: 'sample' }]),
-        api.sSetSetting('image_caption', true),
-        api.sExecCommand('mceImage'),
-        sAssertFocused('Tab', '.tox-dialog__body-nav-item:contains("General")'),
-        sPressTab,
-        sAssertFocused('Source', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Source button', '.tox-browse-url'),
-        sPressTab,
-        sAssertFocused('Image list', '.tox-listbox'),
-        sPressTab,
-        sAssertFocused('Description', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Width', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Height', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Constraint proportions', 'button.tox-lock'),
-        sPressTab,
-        sAssertFocused('Class', '.tox-listbox'),
-        sPressTab,
-        sAssertFocused('Caption', 'input.tox-checkbox__input'),
-        sPressTab,
-        sAssertFocused('Cancel', 'button.tox-button:contains("Cancel")'),
-        sPressTab,
-        sAssertFocused('Save', 'button.tox-button:contains("Save")'),
-        sPressEsc
-      ]),
-
-      Log.stepsAsStep('TBA', 'Insert Image Dialog with advanced tab', [
-        api.sExecCommand('mceImage'),
-        sAssertFocused('Tab', '.tox-dialog__body-nav-item:contains("General")'),
-        sPressDown,
-        sAssertFocused('Tab', '.tox-dialog__body-nav-item:contains("Advanced")'),
-        sPressTab,
-        sAssertFocused('Style', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Vertical space', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Horizontal space', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Border width', '.tox-textfield'),
-        sPressTab,
-        sAssertFocused('Border style', '.tox-listbox'),
-        sPressTab,
-        sAssertFocused('Cancel', 'button.tox-button:contains("Cancel")'),
-        sPressTab,
-        sAssertFocused('Save', 'button.tox-button:contains("Save")'),
-        sPressEsc
-      ]),
-
-      Log.stepsAsStep('TBA', 'Insert Image Dialog with upload tab', [
-        api.sSetSetting('images_upload_url', '/custom/imageUpload'),
-        api.sExecCommand('mceImage'),
-        sAssertFocused('General tab', '.tox-dialog__body-nav-item:contains("General")'),
-        sPressDown,
-        sAssertFocused('Advanced tab', '.tox-dialog__body-nav-item:contains("Advanced")'),
-        sPressDown,
-        sAssertFocused('Upload tab', '.tox-dialog__body-nav-item:contains("Upload")'),
-        sPressTab,
-        sAssertFocused('Browse for an image', '.tox-dropzone button.tox-button'),
-        sPressTab,
-        sAssertFocused('Cancel', 'button.tox-button:contains("Cancel")'),
-        sPressTab,
-        sAssertFocused('Save', 'button.tox-button:contains("Save")'),
-        sPressEsc
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.image.DialogTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'image',
     toolbar: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const pressTab = () => Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.tab(), { });
+  const pressEsc = () => Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.escape(), { });
+  const pressDown = () => Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down(), { });
+
+  const pAssertFocused = (name: string, selector: string) => FocusTools.pTryOnSelector(name, SugarDocument.getDocument(), selector);
+
+  it('TBA: Insert Image Dialog basic cycle', async () => {
+    const editor = hook.editor();
+    editor.execCommand('mceImage');
+    await pAssertFocused('Source', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Description', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Width', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Height', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Constraint proportions', 'button.tox-lock');
+    pressTab();
+    await pAssertFocused('Cancel', 'button.tox-button:contains("Cancel")');
+    pressTab();
+    await pAssertFocused('Save', 'button.tox-button:contains("Save")');
+    pressEsc();
+  });
+
+  it('TBA: Insert Image Dialog with filepicker cycle', async () => {
+    const editor = hook.editor();
+    editor.settings.image_advtab = true;
+    editor.execCommand('mceImage');
+    await pAssertFocused('General tab', '.tox-dialog__body-nav-item:contains("General")');
+    pressTab();
+    await pAssertFocused('Source', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Description', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Width', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Height', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Constraint proportions', 'button.tox-lock');
+    pressTab();
+    await pAssertFocused('Cancel', 'button.tox-button:contains("Cancel")');
+    pressTab();
+    await pAssertFocused('Save', 'button.tox-button:contains("Save")');
+    pressEsc();
+  });
+
+  it('TBA: Insert Image Dialog with all options', async () => {
+    const editor = hook.editor();
+    editor.settings.file_picker_callback = Fun.noop;
+    editor.settings.image_advtab = true;
+    editor.settings.image_class_list = [{ title: 'sample', value: 'sample' }];
+    editor.settings.image_list = [{ title: 'sample', value: 'sample' }];
+    editor.settings.image_caption = true;
+    editor.execCommand('mceImage');
+    await pAssertFocused('General tab', '.tox-dialog__body-nav-item:contains("General")');
+    pressTab();
+    await pAssertFocused('Source', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Source button', '.tox-browse-url');
+    pressTab();
+    await pAssertFocused('Image list', '.tox-listbox');
+    pressTab();
+    await pAssertFocused('Description', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Width', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Height', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Constraint proportions', 'button.tox-lock');
+    pressTab();
+    await pAssertFocused('Class', '.tox-listbox');
+    pressTab();
+    await pAssertFocused('Caption', 'input.tox-checkbox__input');
+    pressTab();
+    await pAssertFocused('Cancel', 'button.tox-button:contains("Cancel")');
+    pressTab();
+    await pAssertFocused('Save', 'button.tox-button:contains("Save")');
+    pressEsc();
+  });
+
+  it('TBA: Insert Image Dialog with advanced tab', async () => {
+    const editor = hook.editor();
+    editor.settings.image_advtab = true;
+    editor.execCommand('mceImage');
+    await pAssertFocused('General tab', '.tox-dialog__body-nav-item:contains("General")');
+    pressDown();
+    await pAssertFocused('Advanced tab', '.tox-dialog__body-nav-item:contains("Advanced")');
+    pressTab();
+    await pAssertFocused('Style', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Vertical space', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Horizontal space', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Border width', '.tox-textfield');
+    pressTab();
+    await pAssertFocused('Border style', '.tox-listbox');
+    pressTab();
+    await pAssertFocused('Cancel', 'button.tox-button:contains("Cancel")');
+    pressTab();
+    await pAssertFocused('Save', 'button.tox-button:contains("Save")');
+    pressEsc();
+  });
+
+  it('TBA: Insert Image Dialog with upload tab', async () => {
+    const editor = hook.editor();
+    editor.settings.image_advtab = true;
+    editor.settings.images_upload_url = '/custom/imageUpload';
+    editor.execCommand('mceImage');
+    await pAssertFocused('General tab', '.tox-dialog__body-nav-item:contains("General")');
+    pressDown();
+    await pAssertFocused('Advanced tab', '.tox-dialog__body-nav-item:contains("Advanced")');
+    pressDown();
+    await pAssertFocused('Upload tab', '.tox-dialog__body-nav-item:contains("Upload")');
+    pressTab();
+    await pAssertFocused('Browse for an image', '.tox-dropzone button.tox-button');
+    pressTab();
+    await pAssertFocused('Cancel', 'button.tox-button:contains("Cancel")');
+    pressTab();
+    await pAssertFocused('Save', 'button.tox-button:contains("Save")');
+    pressEsc();
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -1,76 +1,18 @@
-import { Chain, Log, Pipeline, Mouse } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { ApiChains, TinyLoader } from '@ephox/mcagar';
+import { Mouse, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-import { cAssertCleanHtml, cAssertInputValue, cFillActiveDialog, cSubmitDialog, cWaitForDialog, generalTabSelectors, cSetInputValue, cFakeEvent } from '../module/Helpers';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.DialogUpdateTest', (success, failure) => {
-  SilverTheme();
-  Plugin();
+import {
+  assertCleanHtml, assertInputValue, fakeEvent, fillActiveDialog, generalTabSelectors, pWaitForDialog, setInputValue, submitDialog
+} from '../module/Helpers';
 
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-
-    Pipeline.async({}, [
-      Log.chainsAsStep('TBA', 'Update an image by setting title to empty should remove the existing title attribute', [
-        Chain.inject(editor),
-        ApiChains.cSetContent('<p><img src="#1" title="title" /></p>'),
-        ApiChains.cSetSelection([ 0 ], 0, [ 0 ], 1),
-        ApiChains.cExecCommand('mceImage', true),
-        cWaitForDialog(),
-        Chain.fromParent(Chain.identity, [
-          cAssertInputValue(generalTabSelectors.src, '#1'),
-          cAssertInputValue(generalTabSelectors.title, 'title')
-        ]),
-        cFillActiveDialog({
-          src: { value: '#2' },
-          title: ''
-        }),
-        cSubmitDialog(),
-        cAssertCleanHtml('Checking output', '<p><img src="#2" /></p>')
-      ]),
-
-      Log.chainsAsStep('TINY-6611', 'Setting src to empty should remove the existing dimensions settings', [
-        Chain.inject(editor),
-        ApiChains.cSetContent('<p><img src="https://www.google.com/logos/google.jpg"  width="200" height="200"/></p>'),
-        ApiChains.cSetSelection([ 0 ], 0, [ 0 ], 1),
-        ApiChains.cExecCommand('mceImage', true),
-        cWaitForDialog(),
-        Chain.fromParent(Chain.identity, [
-          cAssertInputValue(generalTabSelectors.src, 'https://www.google.com/logos/google.jpg'),
-          cAssertInputValue(generalTabSelectors.height, '200'),
-          cAssertInputValue(generalTabSelectors.width, '200')
-        ]),
-        Chain.fromIsolatedChains([
-          cSetInputValue(generalTabSelectors.src, ''),
-          cFakeEvent('change'),
-        ]),
-        Chain.fromParent(Chain.identity, [
-          cAssertInputValue(generalTabSelectors.height, ''),
-          cAssertInputValue(generalTabSelectors.width, '')
-        ]),
-        cSubmitDialog(),
-        cAssertCleanHtml('Checking output', '')
-      ]),
-
-      Log.chainsAsStep('TINY-6611', 'Clicking on Source button should bring expected dimension values from the image', [
-        Chain.inject(editor),
-        ApiChains.cSetSelection([ 0 ], 0, [ 0 ], 1),
-        ApiChains.cExecCommand('mceImage', true),
-        cWaitForDialog(),
-        Chain.fromIsolatedChainsWith(SugarBody.body(), [
-          Mouse.cClickOn('button[title="Source"]')
-        ]),
-        Chain.fromParent(Chain.identity, [
-          cAssertInputValue(generalTabSelectors.width, '200')
-        ]),
-        cSubmitDialog(),
-        cAssertCleanHtml('Checking output', '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200" /></p>')
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'image',
     toolbar: 'image',
     indent: false,
@@ -78,6 +20,51 @@ UnitTest.asynctest('browser.tinymce.plugins.image.DialogUpdateTest', (success, f
     image_title: true,
     file_picker_callback: (callback, _value, _meta) => {
       callback('https://www.google.com/logos/google.jpg', { width: '200' });
-    },
-  }, success, failure);
+    }
+  }, [ Plugin, Theme ]);
+
+  it('TBA: Update an image by setting title to empty should remove the existing title attribute', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="#1" title="title" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+    assertInputValue(generalTabSelectors.src, '#1');
+    assertInputValue(generalTabSelectors.title, 'title');
+    fillActiveDialog({
+      src: { value: '#2' },
+      title: ''
+    });
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="#2" /></p>');
+  });
+
+  it('TINY-6611: Setting src to empty should remove the existing dimensions settings', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="https://www.google.com/logos/google.jpg"  width="200" height="200"/></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+    assertInputValue(generalTabSelectors.src, 'https://www.google.com/logos/google.jpg');
+    assertInputValue(generalTabSelectors.height, '200');
+    assertInputValue(generalTabSelectors.width, '200');
+
+    const input = setInputValue(generalTabSelectors.src, '');
+    fakeEvent(input, 'change');
+    assertInputValue(generalTabSelectors.height, '');
+    assertInputValue(generalTabSelectors.width, '');
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '');
+  });
+
+  it('TINY-6611: Clicking on Source button should bring expected dimension values from the image', async () => {
+    const editor = hook.editor();
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+    Mouse.clickOn(SugarBody.body(), 'button[title="Source"]');
+    await Waiter.pTryUntil('Wait for width to be populated', () => assertInputValue(generalTabSelectors.width, '200'));
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200" /></p>');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
@@ -1,94 +1,66 @@
-import { Assertions, Chain, Guard, Log, Mouse, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { ApiChains, Editor as McEditor, TinyDom, UiChains } from '@ephox/mcagar';
+import { Mouse, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Css, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
 
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-import { cFillActiveDialog } from '../module/Helpers';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+import { fillActiveDialog, pWaitForDialog, submitDialog } from '../module/Helpers';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.FigureResizeTest', (success, failure) => {
+describe('browser.tinymce.plugins.image.FigureResizeTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'image',
+    toolbar: 'image',
+    indent: false,
+    image_caption: true,
+    height: 400,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin, Theme ]);
 
-  SilverTheme();
-  ImagePlugin();
-
-  const cGetBody = Chain.control(
-    Chain.mapper((editor: any) => {
-      return TinyDom.fromDom(editor.getBody());
-    }),
-    Guard.addLogging('Get body')
-  );
-
-  const cGetElementSize = Chain.control(
-    Chain.mapper((elm: SugarElement<HTMLImageElement>) => {
-      const width = Css.get(elm, 'width');
-      const height = Css.get(elm, 'height');
-      return { width, height };
-    }),
-    Guard.addLogging('Get element size')
-  );
-
-  const cDragHandleRight = (px: number) => {
-    return Chain.control(
-      Chain.op((input: any) => {
-        const dom = input.editor.dom;
-        const target = input.resizeSE.dom;
-        const pos = dom.getPos(target);
-
-        dom.fire(target, 'mousedown', { screenX: pos.x, screenY: pos.y });
-        dom.fire(target, 'mousemove', { screenX: pos.x + px, screenY: pos.y });
-        dom.fire(target, 'mouseup');
-      }),
-      Guard.addLogging('Drag handle right')
-    );
+  const getElementSize = (elm: SugarElement<HTMLImageElement>) => {
+    const width = Css.get(elm, 'width');
+    const height = Css.get(elm, 'height');
+    return { width, height };
   };
 
-  Pipeline.async({}, [
-    Log.chainsAsStep('TBA', 'Image: resizing image in figure', [
-      McEditor.cFromSettings({
-        theme: 'silver',
-        plugins: 'image',
-        toolbar: 'image',
-        indent: false,
-        image_caption: true,
-        height: 400,
-        base_url: '/project/tinymce/js/tinymce'
-      }),
-      UiChains.cClickOnToolbar('click image button', 'button[aria-label="Insert/edit image"]'),
+  const dragHandleRight = (editor: Editor, resizeHandle: SugarElement<Element>, px: number) => {
+    const dom = editor.dom;
+    const target = resizeHandle.dom;
+    const pos = dom.getPos(target);
 
-      Chain.control(
-        cFillActiveDialog({
-          src: {
-            value: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-          },
-          dimensions: {
-            width: '100px',
-            height: '100px'
-          },
-          caption: true
-        }),
-        Guard.tryUntil('Waiting for fill active dialog')
-      ),
-      UiChains.cSubmitDialog(),
-      NamedChain.asChain([
-        NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
-        NamedChain.direct('editor', cGetBody, 'editorBody'),
-        // click the image, but expect the handles on the figure
-        NamedChain.direct('editorBody', UiFinder.cFindIn('figure > img'), 'img'),
-        NamedChain.direct('img', Mouse.cTrueClick, '_'),
-        NamedChain.direct(NamedChain.inputName(), ApiChains.cAssertSelection([], 0, [], 1), '_'),
-        NamedChain.direct('editorBody', Chain.control(
-          UiFinder.cFindIn('#mceResizeHandlese'),
-          Guard.tryUntil('wait for resize handlers')
-        ), '_'),
-        // actually drag the handle to the right
-        NamedChain.direct('editorBody', UiFinder.cFindIn('#mceResizeHandlese'), 'resizeSE'),
-        NamedChain.write('_', cDragHandleRight(100)),
-        NamedChain.direct('img', cGetElementSize, 'imgSize'),
-        NamedChain.direct('imgSize', Assertions.cAssertEq('asserting image size after resize', { width: '200px', height: '200px' }), '_'),
-        NamedChain.output('editor')
-      ]),
-      McEditor.cRemove
-    ])
-  ], success, failure);
+    dom.fire(target, 'mousedown', { screenX: pos.x, screenY: pos.y });
+    dom.fire(target, 'mousemove', { screenX: pos.x + px, screenY: pos.y });
+    dom.fire(target, 'mouseup');
+  };
+
+  it('TBA: resizing image in figure', async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
+    await pWaitForDialog(editor);
+
+    fillActiveDialog({
+      src: {
+        value: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+      },
+      dimensions: {
+        width: '100px',
+        height: '100px'
+      },
+      caption: true
+    });
+    submitDialog(editor);
+
+    const body = TinyDom.body(editor);
+    const img = UiFinder.findIn(body, 'figure > img').getOrDie();
+    Mouse.trueClick(img);
+    TinyAssertions.assertSelection(editor, [], 0, [], 1);
+
+    const resizeHandle = await UiFinder.pWaitFor('Wait for resize handlers', body, '#mceResizeHandlese');
+    // actually drag the handle to the right
+    dragHandleRight(editor, resizeHandle, 100);
+    const imgSize = getElementSize(img);
+    assert.deepEqual(imgSize, { width: '200px', height: '200px' }, 'asserting image size after resize');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageListTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageListTest.ts
@@ -1,42 +1,30 @@
-import { Chain, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
-import { cAssertInputValue, cSetInputValue, cSetListBoxItem, generalTabSelectors } from '../module/Helpers';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.ImageListTest', (success, failure) => {
+import { assertInputValue, generalTabSelectors, pSetListBoxItem, pWaitForDialog, setInputValue } from '../module/Helpers';
 
-  SilverTheme();
-  ImagePlugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Image: click image list, check that source changes, change source and check that image list changes', [
-        tinyApis.sSetSetting('image_list', [
-          { title: 'Dog', value: 'mydog.jpg' },
-          { title: 'Cat', value: 'mycat.jpg' }
-        ]),
-        tinyUi.sClickOnToolbar('click image button', 'button[aria-label="Insert/edit image"]'),
-        tinyUi.sWaitForPopup('wait for dialog', 'div[role="dialog"]'),
-        Chain.asStep({}, [
-          cSetListBoxItem(generalTabSelectors.images, 'Dog')
-        ]),
-        Chain.asStep({}, [
-          cAssertInputValue(generalTabSelectors.src, 'mydog.jpg'),
-          cSetInputValue(generalTabSelectors.src, 'mycat.jpg'),
-          cAssertInputValue(generalTabSelectors.src, 'mycat.jpg')
-        ])
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.image.ImageListTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'image',
     toolbar: 'image',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  it('TBA: click image list, check that source changes, change source and check that image list changes', async () => {
+    const editor = hook.editor();
+    editor.settings.image_list = [
+      { title: 'Dog', value: 'mydog.jpg' },
+      { title: 'Cat', value: 'mycat.jpg' }
+    ];
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
+    await pWaitForDialog(editor);
+    await pSetListBoxItem(generalTabSelectors.images, 'Dog');
+    assertInputValue(generalTabSelectors.src, 'mydog.jpg');
+    setInputValue(generalTabSelectors.src, 'mycat.jpg');
+    assertInputValue(generalTabSelectors.src, 'mycat.jpg');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -1,196 +1,223 @@
-import { Chain, GeneralSteps, Log, Pipeline, Step } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import { SugarBody } from '@ephox/sugar';
+import { Cursors } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
-import { advancedTabSelectors, cAssertInputValue, cFillActiveDialog, cSetInputValue, ImageDialogData } from '../module/Helpers';
+import {
+  advancedTabSelectors, assertInputValue, fillActiveDialog, ImageDialogData, pWaitForDialog, setInputValue, submitDialog
+} from '../module/Helpers';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.ImagePluginTest', (success, failure) => {
-  SilverTheme();
-  Plugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const api = TinyApis(editor);
-    const ui = TinyUi(editor);
-
-    const sInitAndOpenDialog = (content: string, cursorPos: any) => GeneralSteps.sequence([
-      api.sSetSetting('image_advtab', true),
-      api.sSetSetting('image_dimensions', false),
-      api.sSetContent(content),
-      // api.sSetCursor([0], 1),
-      api.sSetCursor(cursorPos.elementPath, cursorPos.offset),
-      api.sExecCommand('mceImage', true),
-      ui.sWaitForPopup('Wait for Image dialog', 'div[role="dialog"]')
-    ]);
-
-    const createTestWithContent = (name: string, content: string, cursorPos: any, data: Partial<ImageDialogData>, expectedContent: string) => Log.stepsAsStep('TBA', 'Image: ' + name, [
-      sInitAndOpenDialog(content, cursorPos),
-      Chain.asStep({}, [
-        cFillActiveDialog(data, true)
-      ]),
-      ui.sClickOnUi('click save', 'div[role="dialog"] button:contains("Save")'),
-      api.sAssertContent(expectedContent)
-    ]);
-
-    const createTestOnEmptyEditor = (name: string, data: Partial<ImageDialogData>, expectedContent: string) => createTestWithContent(name, '', { elementPath: [ 0 ], offset: 0 }, data, expectedContent);
-
-    const createTestUpdatedStyle = (name: string, style: string, assertion: Step<any, any>) => Log.stepsAsStep('TBA', 'Image: ' + name, [
-      sInitAndOpenDialog('', { elementPath: [ 0 ], offset: 0 }),
-      ui.sClickOnUi('Switch to Advanced tab', '.tox-tab:contains("Advanced")'),
-      Chain.asStep(SugarBody.body(), [
-        cSetInputValue(advancedTabSelectors.style, style)
-      ]),
-      assertion,
-      ui.sClickOnUi('click save', 'div[role="dialog"] button:contains("Save")')
-    ]);
-
-    const suiteArr = [
-      createTestOnEmptyEditor(
-        'Advanced image dialog margin space options on empty editor',
-        {
-          alt: 'alt',
-          hspace: '10',
-          src: {
-            value: 'src'
-          },
-          vspace: '10'
-        },
-        '<p><img style="margin: 10px;" src="src" alt="alt" /></p>'
-      ),
-      createTestOnEmptyEditor(
-        'Advanced image dialog border style only options on empty editor',
-        {
-          alt: 'alt',
-          src: {
-            value: 'src'
-          },
-          style: 'border-width: 10px; border-style: solid;'
-        },
-        '<p><img style="border-width: 10px; border-style: solid;" src="src" alt="alt" /></p>'
-      ),
-      createTestOnEmptyEditor(
-        'Advanced image dialog margin style only options on empty editor',
-        {
-          alt: 'alt',
-          src: {
-            value: 'src'
-          },
-          style: 'margin: 10px;'
-        },
-        '<p><img style="margin: 10px;" src="src" alt="alt" /></p>'
-      ),
-      createTestOnEmptyEditor(
-        'Advanced image dialog overriden border style options on empty editor',
-        {
-          alt: 'alt',
-          border: '10',
-          src: {
-            value: 'src'
-          },
-          style: 'border-width: 15px;'
-        },
-        '<p><img style="border-width: 10px;" src="src" alt="alt" /></p>'
-      ),
-      createTestOnEmptyEditor(
-        'Advanced image dialog overriden margin style options on empty editor',
-        {
-          alt: 'alt',
-          hspace: '10',
-          src: {
-            value: 'src'
-          },
-          style: 'margin-left: 15px; margin-top: 20px;',
-          vspace: '10'
-        },
-        '<p><img style="margin: 10px;" src="src" alt="alt" /></p>'
-      ),
-      createTestWithContent(
-        'Advanced image dialog border option on editor with content',
-        '<p>a</p>',
-        {
-          elementPath: [ 0 ],
-          offset: 1
-        },
-        {
-          alt: 'alt',
-          border: '10',
-          borderstyle: 'dashed',
-          src: {
-            value: 'src'
-          }
-        },
-        '<p>a<img style="border-width: 10px; border-style: dashed;" src="src" alt="alt" /></p>'),
-      createTestUpdatedStyle(
-        'Advanced image dialog non-shorthand horizontal margin style change test',
-        'margin-left: 15px; margin-right: 15px;',
-        Chain.asStep({}, [
-          cAssertInputValue(advancedTabSelectors.vspace, ''),
-          cAssertInputValue(advancedTabSelectors.hspace, '15'),
-          cAssertInputValue(advancedTabSelectors.style, 'margin-left: 15px; margin-right: 15px;')
-        ])
-      ),
-      createTestUpdatedStyle(
-        'Advanced image dialog non-shorthand vertical margin style change test',
-        'margin-top: 15px; margin-bottom: 15px;',
-        Chain.asStep({}, [
-          cAssertInputValue(advancedTabSelectors.vspace, '15'),
-          cAssertInputValue(advancedTabSelectors.hspace, ''),
-          cAssertInputValue(advancedTabSelectors.style, 'margin-top: 15px; margin-bottom: 15px;')
-        ])
-      ),
-      createTestUpdatedStyle(
-        'Advanced image dialog shorthand margin 1 value style change test',
-        'margin: 5px;',
-        Chain.asStep({}, [
-          cAssertInputValue(advancedTabSelectors.vspace, '5'),
-          cAssertInputValue(advancedTabSelectors.hspace, '5'),
-          cAssertInputValue(advancedTabSelectors.style, 'margin: 5px;')
-        ])
-      ),
-      createTestUpdatedStyle(
-        'Advanced image dialog shorthand margin 2 value style change test',
-        'margin: 5px 10px;',
-        Chain.asStep({}, [
-          cAssertInputValue(advancedTabSelectors.vspace, '5'),
-          cAssertInputValue(advancedTabSelectors.hspace, '10'),
-          cAssertInputValue(advancedTabSelectors.style, 'margin: 5px 10px 5px 10px;')
-        ])
-      ),
-      createTestUpdatedStyle(
-        'Advanced image dialog shorthand margin 3 value style change test',
-        'margin: 5px 10px 15px;',
-        Chain.asStep({}, [
-          cAssertInputValue(advancedTabSelectors.vspace, ''),
-          cAssertInputValue(advancedTabSelectors.hspace, '10'),
-          cAssertInputValue(advancedTabSelectors.style, 'margin: 5px 10px 15px 10px;')
-        ])
-      ),
-      createTestUpdatedStyle(
-        'Advanced image dialog shorthand margin 4 value style change test',
-        'margin: 5px 10px 15px 20px;',
-        Chain.asStep({}, [
-          cAssertInputValue(advancedTabSelectors.vspace, ''),
-          cAssertInputValue(advancedTabSelectors.hspace, ''),
-          cAssertInputValue(advancedTabSelectors.style, 'margin: 5px 10px 15px 20px;')
-        ])
-      ),
-      createTestUpdatedStyle(
-        'Advanced image dialog shorthand margin 4 value style change test',
-        'margin: 5px 10px 15px 20px; margin-top: 15px;',
-        Chain.asStep({}, [
-          cAssertInputValue(advancedTabSelectors.vspace, '15'),
-          cAssertInputValue(advancedTabSelectors.hspace, ''),
-          cAssertInputValue(advancedTabSelectors.style, 'margin: 15px 10px 15px 20px;')
-        ])
-      )
-    ];
-    Pipeline.async({}, suiteArr, onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const pInitAndOpenDialog = async (editor: Editor, content: string, cursorPos: Cursors.CursorSpec | Cursors.RangeSpec) => {
+    editor.settings.image_advtab = true;
+    editor.settings.image_dimensions = false;
+    editor.setContent(content);
+    TinySelections.setSelectionFrom(editor, cursorPos);
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+  };
+
+  const pCreateTestWithContent = async (editor: Editor, content: string, cursorPos: Cursors.CursorSpec | Cursors.RangeSpec, data: Partial<ImageDialogData>, expectedContent: string) => {
+    await pInitAndOpenDialog(editor, content, cursorPos);
+    fillActiveDialog(data, true);
+    submitDialog(editor);
+    TinyAssertions.assertContent(editor, expectedContent);
+  };
+
+  const pCreateTestOnEmptyEditor = (editor: Editor, data: Partial<ImageDialogData>, expectedContent: string) =>
+    pCreateTestWithContent(editor, '', { element: [ 0 ], offset: 0 }, data, expectedContent);
+
+  const pCreateTestUpdatedStyle = async (editor: Editor, style: string, assertion: () => void) => {
+    await pInitAndOpenDialog(editor, '', { element: [ 0 ], offset: 0 });
+    TinyUiActions.clickOnUi(editor, '.tox-tab:contains("Advanced")');
+    setInputValue(advancedTabSelectors.style, style);
+    assertion();
+    submitDialog(editor);
+  };
+
+  it('TBA: Advanced image dialog margin space options on empty editor', () =>
+    pCreateTestOnEmptyEditor(
+      hook.editor(),
+      {
+        alt: 'alt',
+        hspace: '10',
+        src: {
+          value: 'src'
+        },
+        vspace: '10'
+      },
+      '<p><img style="margin: 10px;" src="src" alt="alt" /></p>'
+    )
+  );
+
+  it('TBA: Advanced image dialog border style only options on empty editor', () =>
+    pCreateTestOnEmptyEditor(
+      hook.editor(),
+      {
+        alt: 'alt',
+        src: {
+          value: 'src'
+        },
+        style: 'border-width: 10px; border-style: solid;'
+      },
+      '<p><img style="border-width: 10px; border-style: solid;" src="src" alt="alt" /></p>'
+    )
+  );
+
+  it('TBA: Advanced image dialog margin style only options on empty editor', () =>
+    pCreateTestOnEmptyEditor(
+      hook.editor(),
+      {
+        alt: 'alt',
+        src: {
+          value: 'src'
+        },
+        style: 'margin: 10px;'
+      },
+      '<p><img style="margin: 10px;" src="src" alt="alt" /></p>'
+    )
+  );
+
+  it('TBA: Advanced image dialog overridden border style options on empty editor', () =>
+    pCreateTestOnEmptyEditor(
+      hook.editor(),
+      {
+        alt: 'alt',
+        border: '10',
+        src: {
+          value: 'src'
+        },
+        style: 'border-width: 15px;'
+      },
+      '<p><img style="border-width: 10px;" src="src" alt="alt" /></p>'
+    )
+  );
+
+  it('TBA: Advanced image dialog overridden margin style options on empty editor', () =>
+    pCreateTestOnEmptyEditor(
+      hook.editor(),
+      {
+        alt: 'alt',
+        hspace: '10',
+        src: {
+          value: 'src'
+        },
+        style: 'margin-left: 15px; margin-top: 20px;',
+        vspace: '10'
+      },
+      '<p><img style="margin: 10px;" src="src" alt="alt" /></p>'
+    )
+  );
+
+  it('TBA: Advanced image dialog border option on editor with content', () =>
+    pCreateTestWithContent(
+      hook.editor(),
+      '<p>a</p>',
+      {
+        element: [ 0 ],
+        offset: 1
+      },
+      {
+        alt: 'alt',
+        border: '10',
+        borderstyle: 'dashed',
+        src: {
+          value: 'src'
+        }
+      },
+      '<p>a<img style="border-width: 10px; border-style: dashed;" src="src" alt="alt" /></p>')
+  );
+
+  it('TBA: Advanced image dialog non-shorthand horizontal margin style change test', () =>
+    pCreateTestUpdatedStyle(
+      hook.editor(),
+      'margin-left: 15px; margin-right: 15px;',
+      () => {
+        assertInputValue(advancedTabSelectors.vspace, '');
+        assertInputValue(advancedTabSelectors.hspace, '15');
+        assertInputValue(advancedTabSelectors.style, 'margin-left: 15px; margin-right: 15px;');
+      }
+    )
+  );
+
+  it('TBA: Advanced image dialog non-shorthand vertical margin style change test', () =>
+    pCreateTestUpdatedStyle(
+      hook.editor(),
+      'margin-top: 15px; margin-bottom: 15px;',
+      () => {
+        assertInputValue(advancedTabSelectors.vspace, '15');
+        assertInputValue(advancedTabSelectors.hspace, '');
+        assertInputValue(advancedTabSelectors.style, 'margin-top: 15px; margin-bottom: 15px;');
+      }
+    )
+  );
+
+  it('TBA: Advanced image dialog shorthand margin 1 value style change test', () =>
+    pCreateTestUpdatedStyle(
+      hook.editor(),
+      'margin: 5px;',
+      () => {
+        assertInputValue(advancedTabSelectors.vspace, '5');
+        assertInputValue(advancedTabSelectors.hspace, '5');
+        assertInputValue(advancedTabSelectors.style, 'margin: 5px;');
+      }
+    )
+  );
+
+  it('TBA: Advanced image dialog shorthand margin 2 value style change test', () =>
+    pCreateTestUpdatedStyle(
+      hook.editor(),
+      'margin: 5px 10px;',
+      () => {
+        assertInputValue(advancedTabSelectors.vspace, '5');
+        assertInputValue(advancedTabSelectors.hspace, '10');
+        assertInputValue(advancedTabSelectors.style, 'margin: 5px 10px 5px 10px;');
+      }
+    )
+  );
+
+  it('TBA: Advanced image dialog shorthand margin 3 value style change test', () =>
+    pCreateTestUpdatedStyle(
+      hook.editor(),
+      'margin: 5px 10px 15px;',
+      () => {
+        assertInputValue(advancedTabSelectors.vspace, '');
+        assertInputValue(advancedTabSelectors.hspace, '10');
+        assertInputValue(advancedTabSelectors.style, 'margin: 5px 10px 15px 10px;');
+      }
+    )
+  );
+
+  it('TBA: Advanced image dialog shorthand margin 4 value style change test', () =>
+    pCreateTestUpdatedStyle(
+      hook.editor(),
+      'margin: 5px 10px 15px 20px;',
+      () => {
+        assertInputValue(advancedTabSelectors.vspace, '');
+        assertInputValue(advancedTabSelectors.hspace, '');
+        assertInputValue(advancedTabSelectors.style, 'margin: 5px 10px 15px 20px;');
+      }
+    )
+  );
+
+  it('TBA: Advanced image dialog shorthand margin 4 value style with single value override change test', () =>
+    pCreateTestUpdatedStyle(
+      hook.editor(),
+      'margin: 5px 10px 15px 20px; margin-top: 15px;',
+      () => {
+        assertInputValue(advancedTabSelectors.vspace, '15');
+        assertInputValue(advancedTabSelectors.hspace, '');
+        assertInputValue(advancedTabSelectors.style, 'margin: 15px 10px 15px 20px;');
+      }
+    )
+  );
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
@@ -1,48 +1,15 @@
-import { Chain, Guard, Log, Mouse, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { Mouse, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
-import { cAssertCleanHtml, cAssertInputValue, cSetInputValue, generalTabSelectors } from '../module/Helpers';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.ImageResizeTest', (success, failure) => {
-  SilverTheme();
-  ImagePlugin();
+import { assertCleanHtml, assertInputValue, generalTabSelectors, pWaitForDialog, setInputValue, submitDialog } from '../module/Helpers';
 
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Image: image proportion constrains should work directly', [
-        tinyUi.sClickOnToolbar('click image button', 'button[aria-label="Insert/edit image"]'),
-        Chain.asStep({}, [
-          Chain.fromParent(tinyUi.cWaitForPopup('Wait for dialog', 'div[role="dialog"]'),
-            [
-              Chain.fromChains([
-                UiFinder.cFindIn('button.tox-browse-url'),
-                Mouse.cClick
-              ]),
-              Chain.control(
-                cAssertInputValue(generalTabSelectors.width, '1'),
-                Guard.tryUntil('did not find width input with value 1')
-              ),
-              cSetInputValue(generalTabSelectors.height, '5'),
-              Chain.control(
-                cAssertInputValue(generalTabSelectors.width, '5'),
-                Guard.tryUntil('did not find width input with value 5')
-              )
-            ]
-          ),
-          tinyUi.cSubmitDialog(),
-          Chain.inject(editor),
-          cAssertCleanHtml('Checking output', '<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" width="5" height="5" /></p>')
-        ])
-      ])
-
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.image.ImageResizeTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'image',
     toolbar: 'image',
     base_url: '/project/tinymce/js/tinymce',
@@ -51,5 +18,17 @@ UnitTest.asynctest('browser.tinymce.plugins.image.ImageResizeTest', (success, fa
       console.log('file picker pressed');
       callback('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
     }
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  it('TBA: image proportion constrains should work directly', async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
+    const dialog = await pWaitForDialog(editor);
+    Mouse.clickOn(dialog, 'button.tox-browse-url');
+    await Waiter.pTryUntil('did not find width input with value 1', () => assertInputValue(generalTabSelectors.width, '1'));
+    setInputValue(generalTabSelectors.height, '5');
+    await Waiter.pTryUntil('did not find width input with value 5', () => assertInputValue(generalTabSelectors.width, '5'));
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" width="5" height="5" /></p>');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
@@ -1,145 +1,147 @@
-import { ApproxStructure, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { ApproxStructure } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
 import { ImageData } from 'tinymce/plugins/image/core/ImageData';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.api.CommandsTest', (success, failure) => {
-  SilverTheme();
-  Plugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const api = TinyApis(editor);
-
-    const sUpdateImage = (data: Partial<ImageData>) => api.sExecCommand('mceUpdateImage', data);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Insert image with all data specified except caption and isDecorative', [
-        api.sSetContent('<p>a</a>'),
-        api.sSetCursor([ 0, 0 ], 1),
-        sUpdateImage({
-          src: '#2',
-          alt: 'alt',
-          title: 'title',
-          width: '100',
-          height: '200',
-          class: 'cls1',
-          style: 'color: red',
-          caption: false,
-          hspace: '1',
-          vspace: '2',
-          border: '3',
-          borderStyle: 'solid',
-          isDecorative: false
-        }),
-        api.sSetCursor([ 0, 0 ], 1),
-        api.sAssertContentStructure(
-          ApproxStructure.build((s, str, _arr) => s.element('body', {
-            children: [
-              s.element('p', {
-                children: [
-                  s.text(str.is('a')),
-                  s.element('img', {
-                    attrs: {
-                      class: str.is('cls1'),
-                      title: str.is('title'),
-                      src: str.is('#2'),
-                      alt: str.is('alt'),
-                      width: str.is('100'),
-                      height: str.is('200')
-                    },
-                    styles: {
-                      'color': str.is('red'),
-                      'border-width': str.is('3px'),
-                      'border-style': str.is('solid'),
-                      'margin': str.is('2px 1px')
-                    }
-                  })
-                ]
-              })
-            ]
-          }))
-        )
-      ]),
-      Log.stepsAsStep('TBA', 'Update image with all data specified except caption and isDecorative', [
-        api.sSetContent('<p><img src="#1" /></p>'),
-        api.sSetSelection([ 0 ], 0, [ 0 ], 1),
-        sUpdateImage({
-          src: '#2',
-          alt: 'alt',
-          title: 'title',
-          width: '100',
-          height: '200',
-          class: 'cls1',
-          style: 'color: red',
-          caption: false,
-          hspace: '1',
-          vspace: '2',
-          border: '3',
-          borderStyle: 'solid',
-          isDecorative: false
-        }),
-        api.sSetCursor([ 0 ], 1),
-        api.sAssertContentStructure(
-          ApproxStructure.build((s, str, _arr) => s.element('body', {
-            children: [
-              s.element('p', {
-                children: [
-                  s.element('img', {
-                    attrs: {
-                      class: str.is('cls1'),
-                      title: str.is('title'),
-                      src: str.is('#2'),
-                      alt: str.is('alt'),
-                      width: str.is('100'),
-                      height: str.is('200')
-                    },
-                    styles: {
-                      'color': str.is('red'),
-                      'border-width': str.is('3px'),
-                      'border-style': str.is('solid'),
-                      'margin': str.is('2px 1px')
-                    }
-                  })
-                ]
-              })
-            ]
-          }))
-        )
-      ]),
-      Log.stepsAsStep('TBA', 'Update image with null alt value', [
-        api.sSetContent('<p><img src="#1" alt="alt1" /></p>'),
-        api.sSetSelection([ 0 ], 0, [ 0 ], 1),
-        sUpdateImage({
-          alt: null
-        }),
-        api.sAssertContent('<p><img src="#1" /></p>')
-      ]),
-      Log.stepsAsStep('TBA', 'Update image with empty alt value', [
-        api.sSetContent('<p><img src="#1" alt="alt1" /></p>'),
-        api.sSetSelection([ 0 ], 0, [ 0 ], 1),
-        sUpdateImage({
-          alt: ''
-        }),
-        api.sAssertContent('<p><img src="#1" alt="" /></p>')
-      ]),
-      Log.stepsAsStep('TBA', 'Update image with empty title, width, height should not produce empty attributes', [
-        api.sSetContent('<p><img src="#1" title="title" width="100" height="200" /></p>'),
-        api.sSetSelection([ 0 ], 0, [ 0 ], 1),
-        sUpdateImage({
-          title: '',
-          width: '',
-          height: ''
-        }),
-        api.sAssertContent('<p><img src="#1" /></p>')
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.image.api.CommandsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'image',
     toolbar: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const updateImage = (editor: Editor, data: Partial<ImageData>) => editor.execCommand('mceUpdateImage', false, data);
+
+  it('TBA: Insert image with all data specified except caption and isDecorative', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>a</a>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    updateImage(editor, {
+      src: '#2',
+      alt: 'alt',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'cls1',
+      style: 'color: red',
+      caption: false,
+      hspace: '1',
+      vspace: '2',
+      border: '3',
+      borderStyle: 'solid',
+      isDecorative: false
+    });
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    TinyAssertions.assertContentStructure(editor,
+      ApproxStructure.build((s, str, _arr) => s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.text(str.is('a')),
+              s.element('img', {
+                attrs: {
+                  class: str.is('cls1'),
+                  title: str.is('title'),
+                  src: str.is('#2'),
+                  alt: str.is('alt'),
+                  width: str.is('100'),
+                  height: str.is('200')
+                },
+                styles: {
+                  'color': str.is('red'),
+                  'border-width': str.is('3px'),
+                  'border-style': str.is('solid'),
+                  'margin': str.is('2px 1px')
+                }
+              })
+            ]
+          })
+        ]
+      }))
+    );
+  });
+
+  it('TBA: Update image with all data specified except caption and isDecorative', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="#1" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    updateImage(editor, {
+      src: '#2',
+      alt: 'alt',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'cls1',
+      style: 'color: red',
+      caption: false,
+      hspace: '1',
+      vspace: '2',
+      border: '3',
+      borderStyle: 'solid',
+      isDecorative: false
+    });
+    TinySelections.setCursor(editor, [ 0 ], 1);
+    TinyAssertions.assertContentStructure(editor,
+      ApproxStructure.build((s, str, _arr) => s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.element('img', {
+                attrs: {
+                  class: str.is('cls1'),
+                  title: str.is('title'),
+                  src: str.is('#2'),
+                  alt: str.is('alt'),
+                  width: str.is('100'),
+                  height: str.is('200')
+                },
+                styles: {
+                  'color': str.is('red'),
+                  'border-width': str.is('3px'),
+                  'border-style': str.is('solid'),
+                  'margin': str.is('2px 1px')
+                }
+              })
+            ]
+          })
+        ]
+      }))
+    );
+  });
+
+  it('TBA: Update image with null alt value', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="#1" alt="alt1" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    updateImage(editor, {
+      alt: null
+    });
+    TinyAssertions.assertContent(editor, '<p><img src="#1" /></p>');
+  });
+
+  it('TBA: Update image with empty alt value', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="#1" alt="alt1" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    updateImage(editor, {
+      alt: ''
+    });
+    TinyAssertions.assertContent(editor, '<p><img src="#1" alt="" /></p>');
+  });
+
+  it('TBA: Update image with empty title, width, height should not produce empty attributes', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="#1" title="title" width="100" height="200" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    updateImage(editor, {
+      title: '',
+      width: '',
+      height: ''
+    });
+    TinyAssertions.assertContent(editor, '<p><img src="#1" /></p>');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
@@ -1,14 +1,17 @@
-import { ApproxStructure, Log, Pipeline, Step } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { ApproxStructure } from '@ephox/agar';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import PromisePolyfill from 'tinymce/core/api/util/Promise';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
 type Alignment = 'left' | 'center' | 'right' | 'justify';
 
 const figureImageApproxStructure = (alignment: Alignment) => {
-  const alignClasses = (arr) => ({
+  const alignClasses = (arr: ApproxStructure.ArrayApi) => ({
     left: arr.has('align-left'),
     center: arr.has('align-center'),
     right: arr.has('align-right'),
@@ -37,7 +40,7 @@ const figureImageApproxStructure = (alignment: Alignment) => {
 };
 
 const imageApproxStructure = (alignment: Alignment) => {
-  const alignStyles = (str) => ({
+  const alignStyles = (str: ApproxStructure.StringApi) => ({
     left: { float: str.is('left') },
     center: { 'display': str.is('block'), 'margin-left': str.is('auto'), 'margin-right': str.is('auto') },
     right: { float: str.is('right') },
@@ -62,100 +65,96 @@ const imageApproxStructure = (alignment: Alignment) => {
   }));
 };
 
-UnitTest.asynctest('browser.tinymce.plugins.image.ImageAlignTest', (success, failure) => {
-  SilverTheme();
-  ImagePlugin();
-
-  TinyLoader.setup((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    const sCheckToolbarHighlighting = (alignment: Alignment, isFigure: boolean) => {
-      const ariaLabels = {
-        left: 'Align left',
-        center: 'Align center',
-        right: 'Align right',
-        justify: 'Justify'
-      };
-      const ariaLabel = ariaLabels[alignment];
-      const otherLabels = Obj.values(Obj.filter(ariaLabels, (_, key) => key !== alignment));
-      // Justify is the default for figures so it never gets highlighted
-      const ariaPressed = isFigure && alignment === 'justify' ? 'false' : 'true';
-
-      return Log.stepsAsStep('TINY-4057', 'Verify only one align toolbar button is highlighted', [
-        tinyUi.sWaitForUi(`Check ${alignment} align toolbar button is highlighted`, `button[aria-label="${ariaLabel}"][aria-pressed="${ariaPressed}"]`),
-        ...Arr.map(otherLabels, (label) => tinyUi.sWaitForUi(`Check ${alignment} align toolbar button is not highlighted`, `button[aria-label="${label}"][aria-pressed="false"]`))
-      ]);
-    };
-
-    const sApplyAlignmentFromMenu = (alignment: Alignment) => {
-      const ariaLabels = {
-        left: 'Left',
-        center: 'Center',
-        right: 'Right',
-        justify: 'Justify'
-      };
-      const ariaLabel = ariaLabels[alignment];
-
-      return Log.stepsAsStep('TINY-4057', `Click ${ariaLabel} align menu button`, [
-        tinyUi.sClickOnToolbar(`Open align menu`, `button[aria-label="Align"]`),
-        tinyUi.sWaitForUi('Wait for align menu', `div[title="${ariaLabel}"]`),
-        tinyUi.sClickOnUi(`Click ${alignment} align menu button`, `div[title="${ariaLabel}"]`)
-      ]);
-    };
-
-    const sApplyAlignmentFromToolbar = (alignment: Alignment) => {
-      const ariaLabels = {
-        left: 'Align left',
-        center: 'Align center',
-        right: 'Align right',
-        justify: 'Justify'
-      };
-      const ariaLabel = ariaLabels[alignment];
-      return tinyUi.sClickOnToolbar(`Click ${alignment} align toolbar button`, `button[aria-label="${ariaLabel}"]`);
-    };
-
-    const sTestConsecutiveAlignments = (label: string, sAlignImage: (alignment: Alignment) => Step<unknown, unknown>, alignments: Alignment[]) => {
-      const alignmentSteps = (isFigure: boolean) => Arr.map(alignments, (alignment) => Log.stepsAsStep('TINY-4057', `Apply ${alignment} alignment to ${isFigure ? 'figure' : ''} image`, [
-        sAlignImage(alignment),
-        sCheckToolbarHighlighting(alignment, isFigure),
-        tinyApis.sAssertContentStructure(isFigure ? figureImageApproxStructure(alignment) : imageApproxStructure(alignment))
-      ]));
-
-      return Log.stepsAsStep('TINY-4057', label, [
-        tinyApis.sFocus(),
-        tinyApis.sSetContent('<p><img src="image.png" /></p>'),
-        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
-        ...alignmentSteps(false),
-        tinyApis.sFocus(),
-        tinyApis.sSetContent('<figure class="image"><img src="image.png" /><figcaption>Caption</figcaption></figure>'),
-        tinyApis.sSetSelection([], 1, [], 2),
-        ...alignmentSteps(true)
-      ]);
-    };
-
-    const sTestImageAlignment = (alignmentType: 'toolbar' | 'menu', sAlignImage: (alignment: Alignment) => Step<unknown, unknown>) =>
-      Log.stepsAsStep('TINY-4057', `Testing image alignment using the ${alignmentType}`, [
-        sTestConsecutiveAlignments('Align: left -> center -> left', sAlignImage, [ 'left', 'center', 'left' ]),
-        sTestConsecutiveAlignments('Align: left -> right -> left', sAlignImage, [ 'left', 'right', 'left' ]),
-        sTestConsecutiveAlignments('Align: left -> justify -> left', sAlignImage, [ 'left', 'justify', 'left' ]),
-        sTestConsecutiveAlignments('Align: right -> center -> right', sAlignImage, [ 'right', 'center', 'right' ]),
-        sTestConsecutiveAlignments('Align: right -> justify -> right', sAlignImage, [ 'right', 'justify', 'right' ]),
-        sTestConsecutiveAlignments('Align: center -> justify -> center', sAlignImage, [ 'center', 'justify', 'center' ]),
-        sTestConsecutiveAlignments('Align: left -> center -> right -> justify', sAlignImage, [ 'left', 'center', 'right', 'justify' ])
-      ]);
-
-    Pipeline.async({}, [
-      tinyApis.sFocus(),
-      sTestImageAlignment('toolbar', sApplyAlignmentFromToolbar),
-      sTestImageAlignment('menu', sApplyAlignmentFromMenu)
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.image.ImageAlignTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'image',
     toolbar: 'image align alignleft aligncenter alignright alignjustify',
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_caption: true
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  const pCheckToolbarHighlighting = async (editor: Editor, alignment: Alignment, isFigure: boolean) => {
+    const ariaLabels = {
+      left: 'Align left',
+      center: 'Align center',
+      right: 'Align right',
+      justify: 'Justify'
+    };
+    const ariaLabel = ariaLabels[alignment];
+    const otherLabels = Obj.values(Obj.filter(ariaLabels, (_, key) => key !== alignment));
+    // Justify is the default for figures so it never gets highlighted
+    const ariaPressed = isFigure && alignment === 'justify' ? 'false' : 'true';
+
+    await TinyUiActions.pWaitForUi(editor, `button[aria-label="${ariaLabel}"][aria-pressed="${ariaPressed}"]`);
+    await Arr.foldl(otherLabels, (p, label) => p.then(async () => {
+      await TinyUiActions.pWaitForUi(editor, `button[aria-label="${label}"][aria-pressed="false"]`);
+    }), PromisePolyfill.resolve());
+  };
+
+  const pApplyAlignmentFromMenu = async (editor: Editor, alignment: Alignment) => {
+    const ariaLabels = {
+      left: 'Left',
+      center: 'Center',
+      right: 'Right',
+      justify: 'Justify'
+    };
+    const ariaLabel = ariaLabels[alignment];
+
+    TinyUiActions.clickOnToolbar(editor, `button[aria-label="Align"]`);
+    await TinyUiActions.pWaitForUi(editor, `div[title="${ariaLabel}"]`);
+    TinyUiActions.clickOnUi(editor, `div[title="${ariaLabel}"]`);
+  };
+
+  const pApplyAlignmentFromToolbar = (editor: Editor, alignment: Alignment) => {
+    const ariaLabels = {
+      left: 'Align left',
+      center: 'Align center',
+      right: 'Align right',
+      justify: 'Justify'
+    };
+    const ariaLabel = ariaLabels[alignment];
+    TinyUiActions.clickOnToolbar(editor, `button[aria-label="${ariaLabel}"]`);
+    return PromisePolyfill.resolve();
+  };
+
+  beforeEach(() => {
+    hook.editor().focus();
+  });
+
+  const testConsecutiveAlignments = (label: string, pAlignImage: (editor: Editor, alignment: Alignment) => Promise<void>, alignments: Alignment[]) => {
+    it(label, async () => {
+      const editor = hook.editor();
+
+      const pAlignmentSteps = (isFigure: boolean) => Arr.foldl(alignments, (p, alignment) => p.then(async () => {
+        await pAlignImage(editor, alignment);
+        await pCheckToolbarHighlighting(editor, alignment, isFigure);
+        TinyAssertions.assertContentStructure(editor, isFigure ? figureImageApproxStructure(alignment) : imageApproxStructure(alignment));
+      }), PromisePolyfill.resolve());
+
+      editor.setContent('<p><img src="image.png" /></p>');
+      TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+      await pAlignmentSteps(false);
+
+      editor.focus();
+      editor.setContent('<figure class="image"><img src="image.png" /><figcaption>Caption</figcaption></figure>');
+      TinySelections.setSelection(editor, [], 1, [], 2);
+      await pAlignmentSteps(true);
+    });
+  };
+
+  Arr.each([
+    { label: 'TINY-4057: Testing image alignment using the toolbar', pAlignImage: pApplyAlignmentFromToolbar },
+    { label: 'TINY-4057: Testing image alignment using the menu', pAlignImage: pApplyAlignmentFromMenu }
+  ], (test) => {
+    context(test.label, () => {
+      testConsecutiveAlignments('Align: left -> center -> left', test.pAlignImage, [ 'left', 'center', 'left' ]);
+      testConsecutiveAlignments('Align: left -> right -> left', test.pAlignImage, [ 'left', 'right', 'left' ]);
+      testConsecutiveAlignments('Align: left -> justify -> left', test.pAlignImage, [ 'left', 'justify', 'left' ]);
+      testConsecutiveAlignments('Align: right -> center -> right', test.pAlignImage, [ 'right', 'center', 'right' ]);
+      testConsecutiveAlignments('Align: right -> justify -> right', test.pAlignImage, [ 'right', 'justify', 'right' ]);
+      testConsecutiveAlignments('Align: center -> justify -> center', test.pAlignImage, [ 'center', 'justify', 'center' ]);
+      testConsecutiveAlignments('Align: left -> center -> right -> justify', test.pAlignImage, [ 'left', 'center', 'right', 'justify' ]);
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageDataTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageDataTest.ts
@@ -1,18 +1,21 @@
-import { ApproxStructure, Assertions, Chain, Guard, Log, Pipeline, Step } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { ApproxStructure, Assertions, StructAssert } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
-import { Html, SelectorFind, SugarElement, SugarNode } from '@ephox/sugar';
+import { SelectorFind, SugarElement, SugarNode } from '@ephox/sugar';
+import { assert } from 'chai';
+
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
-import { create, defaultData, getStyleValue, ImageData, isFigure, isImage, read, write } from 'tinymce/plugins/image/core/ImageData';
+import * as ImageData from 'tinymce/plugins/image/core/ImageData';
 
-UnitTest.asynctest('browser.tinymce.plugins.image.core.ImageDataTest', (success, failure) => {
-  const cSetHtml = (html: string) => Chain.control(
-    Chain.op((elm: SugarElement) => {
-      Html.set(elm, html);
-    }),
-    Guard.addLogging('Set html')
-  );
+type ImageData = ImageData.ImageData;
 
+interface ImageDataExt {
+  readonly model: ImageData;
+  readonly image: SugarElement<HTMLImageElement>;
+  readonly parent: SugarElement<HTMLElement>;
+}
+
+describe('browser.tinymce.plugins.image.core.ImageDataTest', () => {
   const normalizeCss = (cssText: string) => {
     const css = DOMUtils.DOM.styles.parse(cssText);
     const newCss = {};
@@ -24,698 +27,662 @@ UnitTest.asynctest('browser.tinymce.plugins.image.core.ImageDataTest', (success,
     return DOMUtils.DOM.styles.serialize(newCss);
   };
 
-  const cCreate = (data: ImageData) => Chain.control(
-    Chain.inject(SugarElement.fromDom(create(normalizeCss, data))),
-    Guard.addLogging(`Create ${data}`)
-  );
-  const cReadFromImage = Chain.control(
-    Chain.mapper((elm: SugarElement) => {
-      const img = SugarNode.name(elm) === 'img' ? elm : SelectorFind.descendant(elm, 'img').getOrDie('failed to find image');
-      return { model: read(normalizeCss, img.dom), image: img, parent: elm };
-    }),
-    Guard.addLogging('Read from image')
-  );
+  const create = (data: ImageData) => SugarElement.fromDom(ImageData.create(normalizeCss, data));
 
-  const cWriteToImage = Chain.control(
-    Chain.op((data: any) => {
-      write(normalizeCss, data.model, data.image.dom);
-    }),
-    Guard.addLogging('Write to image')
-  );
+  const createHtml = (html: string) => SugarElement.fromHtml<HTMLElement>(html);
 
-  const cUpdateModel = (props) => Chain.control(
-    Chain.mapper((data: any) => {
-      return { model: { ...data.model, ...props }, image: data.image, parent: data.parent };
-    }),
-    Guard.addLogging('Update data model')
-  );
+  const readFromImage = (elm: SugarElement<HTMLElement>): ImageDataExt => {
+    const img = SugarNode.isTag('img')(elm) ? elm : SelectorFind.descendant<HTMLImageElement>(elm, 'img').getOrDie('failed to find image');
+    return { model: ImageData.read(normalizeCss, img.dom), image: img, parent: elm };
+  };
 
-  const cAssertModel = (model) => Chain.control(
-    Chain.op((data: any) => {
-      Assert.eq('', model, data.model);
-    }),
-    Guard.addLogging('Assert model')
-  );
+  const writeToImage = (data: ImageDataExt) => {
+    ImageData.write(normalizeCss, data.model, data.image.dom);
+  };
 
-  const cAssertStructure = (structure) => Chain.control(
-    Chain.op((data: any) => {
-      Assertions.assertStructure('', structure, data.parent);
-    }),
-    Guard.addLogging('Assert structure')
-  );
-
-  const cAssertImage = Chain.control(
-    Chain.op((data: any) => {
-      Assert.eq('Should be an image', true, isImage(data.image.dom));
-    }),
-    Guard.addLogging('Assert image')
-  );
-
-  const cAssertFigure = Chain.op((data: any) => {
-    Assert.eq('Parent should be a figure', true, isFigure(data.image.dom.parentNode));
+  const updateModel = (props: Partial<ImageData>, data: ImageDataExt) => ({
+    model: { ...data.model, ...props },
+    image: data.image,
+    parent: data.parent
   });
 
-  Pipeline.async({}, [
-    Log.step('TBA', 'Image: getStyleValue from image data', Step.sync(() => {
-      Assert.eq('Should not produce any styles', '', getStyleValue(normalizeCss, defaultData()));
-      Assert.eq('Should produce border width', 'border-width: 1px;', getStyleValue(normalizeCss, { ...defaultData(), border: '1' }));
-      Assert.eq('Should produce style', 'border-style: solid;', getStyleValue(normalizeCss, { ...defaultData(), borderStyle: 'solid' }));
-      Assert.eq('Should produce style & border', 'border-style: solid; border-width: 1px;', getStyleValue(normalizeCss, { ...defaultData(), border: '1', borderStyle: 'solid' }));
-      Assert.eq('Should produce compact border', 'border: 2px dotted red;', getStyleValue(normalizeCss, { ...defaultData(), style: 'border: 1px solid red', border: '2', borderStyle: 'dotted' }));
-    })),
-    Log.chainsAsStep('TBA', 'Image: Create image from data', [
-      cCreate({
-        src: 'some.gif',
-        alt: 'alt',
-        title: 'title',
-        width: '100',
-        height: '200',
-        class: 'class',
-        style: 'border: 1px solid red',
-        caption: false,
-        hspace: '2',
-        vspace: '3',
-        border: '4',
-        borderStyle: 'dotted',
-        isDecorative: false
-      }),
-      cReadFromImage,
-      cAssertModel({
-        src: 'some.gif',
-        alt: 'alt',
-        title: 'title',
-        width: '100',
-        height: '200',
-        class: 'class',
-        style: 'border: 4px dotted red; margin: 3px 2px;',
-        caption: false,
-        hspace: '2',
-        vspace: '3',
-        border: '4',
-        borderStyle: 'dotted',
-        isDecorative: false
-      }),
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('img', {
-          attrs: {
-            src: str.is('some.gif'),
-            alt: str.is('alt'),
-            title: str.is('title'),
-            width: str.is('100'),
-            height: str.is('200'),
-            class: str.is('class')
-          },
-          styles: {
-            'border-width': str.is('4px'),
-            'border-style': str.is('dotted'),
-            'border-color': str.is('red'),
-            'margin-top': str.is('3px'),
-            'margin-bottom': str.is('3px'),
-            'margin-left': str.is('2px'),
-            'margin-right': str.is('2px')
-          }
-        });
-      })),
-      cAssertImage
-    ]),
-    Log.chainsAsStep('TBA', 'Image: Create image with empty fields except src', [
-      cCreate({
-        src: 'some.gif',
-        alt: '',
-        title: '',
-        width: '',
-        height: '',
-        class: '',
-        style: '',
-        caption: false,
-        hspace: '',
-        vspace: '',
-        border: '',
-        borderStyle: '',
-        isDecorative: false
-      }),
-      cReadFromImage,
-      cAssertModel({
-        src: 'some.gif',
-        alt: '',
-        title: '',
-        width: '',
-        height: '',
-        class: '',
-        style: '',
-        caption: false,
-        hspace: '',
-        vspace: '',
-        border: '',
-        borderStyle: '',
-        isDecorative: false
-      }),
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('img', {
-          attrs: {
-            src: str.is('some.gif'),
-            alt: str.is(''),
-            title: str.none('no title'),
-            width: str.none('no width'),
-            height: str.none('no height'),
-            class: str.none('no class')
-          },
-          styles: {
-            'border-width': str.none('no style'),
-            'border-style': str.none('no style'),
-            'border-color': str.none('no style'),
-            'margin-top': str.none('no style'),
-            'margin-bottom': str.none('no style'),
-            'margin-left': str.none('no style'),
-            'margin-right': str.none('no style')
-          }
-        });
-      })),
-      cAssertImage
-    ]),
-    Log.chainsAsStep('TBA', 'Image: Create figure from data', [
-      cCreate({
-        src: 'some.gif',
-        alt: 'alt',
-        title: 'title',
-        width: '100',
-        height: '200',
-        class: 'class',
-        style: 'border: 1px solid red',
-        caption: true,
-        hspace: '2',
-        vspace: '3',
-        border: '4',
-        borderStyle: 'dotted',
-        isDecorative: false
-      }),
-      cReadFromImage,
-      cAssertModel({
-        src: 'some.gif',
-        alt: 'alt',
-        title: 'title',
-        width: '100',
-        height: '200',
-        class: 'class',
-        style: 'border: 4px dotted red; margin: 3px 2px;',
-        caption: true,
-        hspace: '2',
-        vspace: '3',
-        border: '4',
-        borderStyle: 'dotted',
-        isDecorative: false
-      }),
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('figure', {
-          attrs: {
-            contenteditable: str.is('false'),
-            class: str.is('image')
-          },
-          children: [
-            s.element('img', {
-              attrs: {
-                src: str.is('some.gif'),
-                alt: str.is('alt'),
-                title: str.is('title'),
-                width: str.is('100'),
-                height: str.is('200'),
-                class: str.is('class')
-              },
-              styles: {
-                'border-width': str.is('4px'),
-                'border-style': str.is('dotted'),
-                'border-color': str.is('red'),
-                'margin-top': str.is('3px'),
-                'margin-bottom': str.is('3px'),
-                'margin-left': str.is('2px'),
-                'margin-right': str.is('2px')
-              }
-            }),
-            s.element('figcaption', {
-              attrs: {
-                contenteditable: str.is('true')
-              },
-              children: [
-                s.text(str.is('Caption'))
-              ]
-            })
-          ]
-        });
-      })),
-      cAssertFigure
-    ]),
-    Log.chainsAsStep('TBA', 'Image: Create decorative image from data', [
-      cCreate({
-        src: 'some.gif',
-        alt: 'alt',
-        title: 'title',
-        width: '100',
-        height: '200',
-        class: 'class',
-        style: 'border: 1px solid red',
-        caption: false,
-        hspace: '2',
-        vspace: '3',
-        border: '4',
-        borderStyle: 'dotted',
-        isDecorative: true
-      }),
-      cReadFromImage,
-      cAssertModel({
-        src: 'some.gif',
-        alt: '',
-        title: 'title',
-        width: '100',
-        height: '200',
-        class: 'class',
-        style: 'border: 4px dotted red; margin: 3px 2px;',
-        caption: false,
-        hspace: '2',
-        vspace: '3',
-        border: '4',
-        borderStyle: 'dotted',
-        isDecorative: true
-      }),
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('img', {
-          attrs: {
-            src: str.is('some.gif'),
-            alt: str.is(''),
-            title: str.is('title'),
-            width: str.is('100'),
-            height: str.is('200'),
-            class: str.is('class'),
-            role: str.is('presentation')
-          },
-          styles: {
-            'border-width': str.is('4px'),
-            'border-style': str.is('dotted'),
-            'border-color': str.is('red'),
-            'margin-top': str.is('3px'),
-            'margin-bottom': str.is('3px'),
-            'margin-left': str.is('2px'),
-            'margin-right': str.is('2px')
-          }
-        });
-      })),
-      cAssertImage
-    ]),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: Read/write model to simple image without change', [
-      cSetHtml('<img src="some.gif">'),
-      cReadFromImage,
-      cAssertModel({
-        src: 'some.gif',
-        alt: '',
-        title: '',
-        width: '',
-        height: '',
-        class: '',
-        style: '',
-        caption: false,
-        hspace: '',
-        vspace: '',
-        border: '',
-        borderStyle: '',
-        isDecorative: false
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('img', {
-              attrs: {
-                src: str.is('some.gif'),
-                style: str.none('no style'),
-                width: str.none('no width'),
-                height: str.none('no height'),
-                alt: str.none('no alt'),
-                title: str.none('no title')
-              },
-              styles: {
-                'border-width': str.none('no width'),
-                'border-style': str.none('no style'),
-                'border-color': str.none('no color'),
-                'margin-top': str.none('no top'),
-                'margin-bottom': str.none('no bottom'),
-                'margin-left': str.none('no left'),
-                'margin-right': str.none('no right')
-              }
-            })
-          ]
-        });
-      }))
-    ])),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: Read/write model to complex image without change', [
-      cSetHtml('<img src="some.gif" class="class" width="100" height="200" style="margin: 1px 2px; border: 1px solid red" alt="alt" title="title">'),
-      cReadFromImage,
-      cAssertModel({
-        src: 'some.gif',
-        alt: 'alt',
-        title: 'title',
-        width: '100',
-        height: '200',
-        class: 'class',
-        style: 'border: 1px solid red; margin: 1px 2px;',
-        caption: false,
-        hspace: '2',
-        vspace: '1',
-        border: '1',
-        borderStyle: 'solid',
-        isDecorative: false
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('img', {
-              attrs: {
-                src: str.is('some.gif'),
-                alt: str.is('alt'),
-                title: str.is('title'),
-                width: str.is('100'),
-                height: str.is('200'),
-                class: str.is('class')
-              },
-              styles: {
-                'border-width': str.is('1px'),
-                'border-style': str.is('solid'),
-                'border-color': str.is('red'),
-                'margin-top': str.is('1px'),
-                'margin-bottom': str.is('1px'),
-                'margin-left': str.is('2px'),
-                'margin-right': str.is('2px')
-              }
-            })
-          ]
-        });
-      }))
-    ])),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: Read/write model to simple image with changes', [
-      cSetHtml('<img src="some.gif">'),
-      cReadFromImage,
-      cUpdateModel({
-        src: 'some2.gif',
-        alt: 'alt',
-        title: 'title',
-        width: '100',
-        height: '200',
-        class: 'class',
-        style: 'border: 1px solid red;',
-        caption: false,
-        hspace: '1',
-        vspace: '2',
-        border: '3',
-        borderStyle: 'dotted',
-        isDecorative: false
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('img', {
-              attrs: {
-                src: str.is('some2.gif'),
-                alt: str.is('alt'),
-                title: str.is('title'),
-                width: str.is('100'),
-                height: str.is('200'),
-                class: str.is('class')
-              },
-              styles: {
-                'border-width': str.is('3px'),
-                'border-style': str.is('dotted'),
-                'border-color': str.is('red'),
-                'margin-top': str.is('2px'),
-                'margin-bottom': str.is('2px'),
-                'margin-left': str.is('1px'),
-                'margin-right': str.is('1px')
-              }
-            })
-          ]
-        });
-      }))
-    ])),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: Read/write model to complex image with changes', [
-      cSetHtml('<img src="some.gif" class="class" width="100" height="200" style="margin: 1px 2px; border: 1px solid red" alt="alt" title="title">'),
-      cReadFromImage,
-      cUpdateModel({
-        src: 'some2.gif',
-        alt: 'alt2',
-        title: 'title2',
-        width: '101',
-        height: '201',
-        class: 'class2',
-        style: 'border: 1px solid blue;',
-        caption: false,
-        hspace: '3',
-        vspace: '4',
-        border: '4',
-        borderStyle: 'dotted',
-        isDecorative: false
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('img', {
-              attrs: {
-                src: str.is('some2.gif'),
-                alt: str.is('alt2'),
-                title: str.is('title2'),
-                width: str.is('101'),
-                height: str.is('201'),
-                class: str.is('class2')
-              },
-              styles: {
-                'border-width': str.is('4px'),
-                'border-style': str.is('dotted'),
-                'border-color': str.is('blue'),
-                'margin-top': str.is('4px'),
-                'margin-bottom': str.is('4px'),
-                'margin-left': str.is('3px'),
-                'margin-right': str.is('3px')
-              }
-            })
-          ]
-        });
-      }))
-    ])),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: write null as alt will remove the attribute', [
-      cSetHtml('<img src="some.gif" alt="alt">'),
-      cReadFromImage,
-      cUpdateModel({
-        src: 'some2.gif',
-        alt: null,
-        title: '',
-        width: '',
-        height: '',
-        class: '',
-        style: '',
-        caption: false,
-        hspace: '',
-        vspace: '',
-        border: '',
-        borderStyle: '',
-        isDecorative: false
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('img', {
-              attrs: {
-                src: str.is('some2.gif'),
-                alt: str.none('no alt')
-              }
-            })
-          ]
-        });
-      }))
-    ])),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: Toggle caption on', [
-      cSetHtml('<img src="some.gif">'),
-      cReadFromImage,
-      cUpdateModel({
-        caption: true
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('figure', {
-              attrs: {
-                contenteditable: str.is('false'),
-                class: str.is('image')
-              },
-              children: [
-                s.element('img', {
-                  attrs: {
-                    src: str.is('some.gif')
-                  }
-                }),
-                s.element('figcaption', {
-                  attrs: {
-                    contenteditable: str.is('true')
-                  },
-                  children: [
-                    s.text(str.is('Caption'))
-                  ]
-                })
-              ]
-            })
-          ]
-        });
-      }))
-    ])),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: Toggle caption off', [
-      cSetHtml('<figure class="image" contenteditable="false"><img src="some.gif"><figcaption contenteditable="true">Caption</figcaption></figure>'),
-      cReadFromImage,
-      cUpdateModel({
-        caption: false
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('img', {
-              attrs: {
-                src: str.is('some.gif')
-              }
-            })
-          ]
-        });
-      }))
-    ])),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: Update figure image data', [
-      cSetHtml('<figure class="image" contenteditable="false"><img src="some.gif"><figcaption contenteditable="true">Caption</figcaption></figure>'),
-      cReadFromImage,
-      cUpdateModel({
-        src: 'some2.gif'
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('figure', {
-              attrs: {
-                contenteditable: str.is('false'),
-                class: str.is('image')
-              },
-              children: [
-                s.element('img', {
-                  attrs: {
-                    src: str.is('some2.gif')
-                  }
-                }),
-                s.element('figcaption', {
-                  attrs: {
-                    contenteditable: str.is('true')
-                  },
-                  children: [
-                    s.text(str.is('Caption'))
-                  ]
-                })
-              ]
-            })
-          ]
-        });
-      }))
-    ])),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: Read/write model to image with style size without change', [
-      cSetHtml('<img src="some.gif" style="width: 100px; height: 200px">'),
-      cReadFromImage,
-      cAssertModel({
-        src: 'some.gif',
-        alt: '',
-        title: '',
-        width: '100',
-        height: '200',
-        class: '',
-        style: 'height: 200px; width: 100px;',
-        caption: false,
-        hspace: '',
-        vspace: '',
-        border: '',
-        borderStyle: '',
-        isDecorative: false
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('img', {
-              attrs: {
-                src: str.is('some.gif'),
-                width: str.none('no width'),
-                height: str.none('no height'),
-                alt: str.none('no alt'),
-                title: str.none('no title')
-              },
-              styles: {
-                'width': str.is('100px'),
-                'height': str.is('200px'),
-                'border-width': str.none('no width'),
-                'border-style': str.none('no style'),
-                'border-color': str.none('no color'),
-                'margin-top': str.none('no top'),
-                'margin-bottom': str.none('no bottom'),
-                'margin-left': str.none('no left'),
-                'margin-right': str.none('no right')
-              }
-            })
-          ]
-        });
-      }))
-    ])),
-    Chain.asStep(SugarElement.fromTag('div'), Log.chains('TBA', 'Image: Read/write model to image with style size with size change', [
-      cSetHtml('<img src="some.gif" style="width: 100px; height: 200px">'),
-      cReadFromImage,
-      cAssertModel({
-        src: 'some.gif',
-        alt: '',
-        title: '',
-        width: '100',
-        height: '200',
-        class: '',
-        style: 'height: 200px; width: 100px;',
-        caption: false,
-        hspace: '',
-        vspace: '',
-        border: '',
-        borderStyle: '',
-        isDecorative: false
-      }),
-      cUpdateModel({
-        width: '150',
-        height: '250'
-      }),
-      cWriteToImage,
-      cAssertStructure(ApproxStructure.build((s, str) => {
-        return s.element('div', {
-          children: [
-            s.element('img', {
-              attrs: {
-                src: str.is('some.gif'),
-                width: str.none('no width'),
-                height: str.none('no height'),
-                alt: str.none('no alt'),
-                title: str.none('no title')
-              },
-              styles: {
-                'width': str.is('150px'),
-                'height': str.is('250px'),
-                'border-width': str.none('no width'),
-                'border-style': str.none('no style'),
-                'border-color': str.none('no color'),
-                'margin-top': str.none('no top'),
-                'margin-bottom': str.none('no bottom'),
-                'margin-left': str.none('no left'),
-                'margin-right': str.none('no right')
-              }
-            })
-          ]
-        });
-      }))
-    ]))
-  ], success, failure);
+  const assertModel = (model: ImageData, data: ImageDataExt) => {
+    assert.deepEqual(data.model, model);
+  };
+
+  const assertStructure = (structure: StructAssert, data: any) => {
+    Assertions.assertStructure('', structure, data.parent);
+  };
+
+  const assertImage = (data: ImageDataExt) => {
+    assert.isTrue(ImageData.isImage(data.image.dom), 'Should be an image');
+  };
+
+  const assertFigure = (data: ImageDataExt) => {
+    assert.isTrue(ImageData.isFigure(data.image.dom.parentNode), 'Parent should be a figure');
+  };
+
+  it('TBA: getStyleValue from image data', () => {
+    assert.equal(ImageData.getStyleValue(normalizeCss, ImageData.defaultData()), '', 'Should not produce any styles');
+    assert.equal(ImageData.getStyleValue(normalizeCss, { ...ImageData.defaultData(), border: '1' }), 'border-width: 1px;', 'Should produce border width');
+    assert.equal(ImageData.getStyleValue(normalizeCss, { ...ImageData.defaultData(), borderStyle: 'solid' }), 'border-style: solid;', 'Should produce style');
+    assert.equal(ImageData.getStyleValue(normalizeCss, { ...ImageData.defaultData(), border: '1', borderStyle: 'solid' }), 'border-style: solid; border-width: 1px;', 'Should produce style & border');
+    assert.equal(ImageData.getStyleValue(normalizeCss, { ...ImageData.defaultData(), style: 'border: 1px solid red', border: '2', borderStyle: 'dotted' }), 'border: 2px dotted red;', 'Should produce compact border');
+  });
+
+  it('TBA: Create image from data', () => {
+    const image = create({
+      src: 'some.gif',
+      alt: 'alt',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'class',
+      style: 'border: 1px solid red',
+      caption: false,
+      hspace: '2',
+      vspace: '3',
+      border: '4',
+      borderStyle: 'dotted',
+      isDecorative: false
+    });
+    const data = readFromImage(image);
+    assertModel({
+      src: 'some.gif',
+      alt: 'alt',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'class',
+      style: 'border: 4px dotted red; margin: 3px 2px;',
+      caption: false,
+      hspace: '2',
+      vspace: '3',
+      border: '4',
+      borderStyle: 'dotted',
+      isDecorative: false
+    }, data);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some.gif'),
+          alt: str.is('alt'),
+          title: str.is('title'),
+          width: str.is('100'),
+          height: str.is('200'),
+          class: str.is('class')
+        },
+        styles: {
+          'border-width': str.is('4px'),
+          'border-style': str.is('dotted'),
+          'border-color': str.is('red'),
+          'margin-top': str.is('3px'),
+          'margin-bottom': str.is('3px'),
+          'margin-left': str.is('2px'),
+          'margin-right': str.is('2px')
+        }
+      });
+    }), data);
+    assertImage(data);
+  });
+
+  it('TBA: Create image with empty fields except src', () => {
+    const image = create({
+      src: 'some.gif',
+      alt: '',
+      title: '',
+      width: '',
+      height: '',
+      class: '',
+      style: '',
+      caption: false,
+      hspace: '',
+      vspace: '',
+      border: '',
+      borderStyle: '',
+      isDecorative: false
+    });
+    const data = readFromImage(image);
+    assertModel({
+      src: 'some.gif',
+      alt: '',
+      title: '',
+      width: '',
+      height: '',
+      class: '',
+      style: '',
+      caption: false,
+      hspace: '',
+      vspace: '',
+      border: '',
+      borderStyle: '',
+      isDecorative: false
+    }, data);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some.gif'),
+          alt: str.is(''),
+          title: str.none('no title'),
+          width: str.none('no width'),
+          height: str.none('no height'),
+          class: str.none('no class')
+        },
+        styles: {
+          'border-width': str.none('no style'),
+          'border-style': str.none('no style'),
+          'border-color': str.none('no style'),
+          'margin-top': str.none('no style'),
+          'margin-bottom': str.none('no style'),
+          'margin-left': str.none('no style'),
+          'margin-right': str.none('no style')
+        }
+      });
+    }), data);
+    assertImage(data);
+  });
+
+  it('TBA: Create figure from data', () => {
+    const image = create({
+      src: 'some.gif',
+      alt: 'alt',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'class',
+      style: 'border: 1px solid red',
+      caption: true,
+      hspace: '2',
+      vspace: '3',
+      border: '4',
+      borderStyle: 'dotted',
+      isDecorative: false
+    });
+    const data = readFromImage(image);
+    assertModel({
+      src: 'some.gif',
+      alt: 'alt',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'class',
+      style: 'border: 4px dotted red; margin: 3px 2px;',
+      caption: true,
+      hspace: '2',
+      vspace: '3',
+      border: '4',
+      borderStyle: 'dotted',
+      isDecorative: false
+    }, data);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('figure', {
+        attrs: {
+          contenteditable: str.is('false'),
+          class: str.is('image')
+        },
+        children: [
+          s.element('img', {
+            attrs: {
+              src: str.is('some.gif'),
+              alt: str.is('alt'),
+              title: str.is('title'),
+              width: str.is('100'),
+              height: str.is('200'),
+              class: str.is('class')
+            },
+            styles: {
+              'border-width': str.is('4px'),
+              'border-style': str.is('dotted'),
+              'border-color': str.is('red'),
+              'margin-top': str.is('3px'),
+              'margin-bottom': str.is('3px'),
+              'margin-left': str.is('2px'),
+              'margin-right': str.is('2px')
+            }
+          }),
+          s.element('figcaption', {
+            attrs: {
+              contenteditable: str.is('true')
+            },
+            children: [
+              s.text(str.is('Caption'))
+            ]
+          })
+        ]
+      });
+    }), data);
+    assertFigure(data);
+  });
+
+  it('TBA: Create decorative image from data', () => {
+    const image = create({
+      src: 'some.gif',
+      alt: 'alt',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'class',
+      style: 'border: 1px solid red',
+      caption: false,
+      hspace: '2',
+      vspace: '3',
+      border: '4',
+      borderStyle: 'dotted',
+      isDecorative: true
+    });
+    const data = readFromImage(image);
+    assertModel({
+      src: 'some.gif',
+      alt: '',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'class',
+      style: 'border: 4px dotted red; margin: 3px 2px;',
+      caption: false,
+      hspace: '2',
+      vspace: '3',
+      border: '4',
+      borderStyle: 'dotted',
+      isDecorative: true
+    }, data);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some.gif'),
+          alt: str.is(''),
+          title: str.is('title'),
+          width: str.is('100'),
+          height: str.is('200'),
+          class: str.is('class'),
+          role: str.is('presentation')
+        },
+        styles: {
+          'border-width': str.is('4px'),
+          'border-style': str.is('dotted'),
+          'border-color': str.is('red'),
+          'margin-top': str.is('3px'),
+          'margin-bottom': str.is('3px'),
+          'margin-left': str.is('2px'),
+          'margin-right': str.is('2px')
+        }
+      });
+    }), data);
+    assertImage(data);
+  });
+
+  it('TBA: Read/write model to simple image without change', () => {
+    const image = createHtml('<img src="some.gif">');
+    const data = readFromImage(image);
+    assertModel({
+      src: 'some.gif',
+      alt: '',
+      title: '',
+      width: '',
+      height: '',
+      class: '',
+      style: '',
+      caption: false,
+      hspace: '',
+      vspace: '',
+      border: '',
+      borderStyle: '',
+      isDecorative: false
+    }, data);
+    writeToImage(data);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some.gif'),
+          style: str.none('no style'),
+          width: str.none('no width'),
+          height: str.none('no height'),
+          alt: str.none('no alt'),
+          title: str.none('no title')
+        },
+        styles: {
+          'border-width': str.none('no width'),
+          'border-style': str.none('no style'),
+          'border-color': str.none('no color'),
+          'margin-top': str.none('no top'),
+          'margin-bottom': str.none('no bottom'),
+          'margin-left': str.none('no left'),
+          'margin-right': str.none('no right')
+        }
+      });
+    }), data);
+  });
+
+  it('TBA: Read/write model to complex image without change', () => {
+    const image = createHtml('<img src="some.gif" class="class" width="100" height="200" style="margin: 1px 2px; border: 1px solid red" alt="alt" title="title">');
+    const data = readFromImage(image);
+    assertModel({
+      src: 'some.gif',
+      alt: 'alt',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'class',
+      style: 'border: 1px solid red; margin: 1px 2px;',
+      caption: false,
+      hspace: '2',
+      vspace: '1',
+      border: '1',
+      borderStyle: 'solid',
+      isDecorative: false
+    }, data);
+    writeToImage(data);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some.gif'),
+          alt: str.is('alt'),
+          title: str.is('title'),
+          width: str.is('100'),
+          height: str.is('200'),
+          class: str.is('class')
+        },
+        styles: {
+          'border-width': str.is('1px'),
+          'border-style': str.is('solid'),
+          'border-color': str.is('red'),
+          'margin-top': str.is('1px'),
+          'margin-bottom': str.is('1px'),
+          'margin-left': str.is('2px'),
+          'margin-right': str.is('2px')
+        }
+      });
+    }), data);
+  });
+
+  it('TBA: Read/write model to simple image with changes', () => {
+    const image = createHtml('<img src="some.gif">');
+    const data = readFromImage(image);
+    const newData = updateModel({
+      src: 'some2.gif',
+      alt: 'alt',
+      title: 'title',
+      width: '100',
+      height: '200',
+      class: 'class',
+      style: 'border: 1px solid red;',
+      caption: false,
+      hspace: '1',
+      vspace: '2',
+      border: '3',
+      borderStyle: 'dotted',
+      isDecorative: false
+    }, data);
+    writeToImage(newData);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some2.gif'),
+          alt: str.is('alt'),
+          title: str.is('title'),
+          width: str.is('100'),
+          height: str.is('200'),
+          class: str.is('class')
+        },
+        styles: {
+          'border-width': str.is('3px'),
+          'border-style': str.is('dotted'),
+          'border-color': str.is('red'),
+          'margin-top': str.is('2px'),
+          'margin-bottom': str.is('2px'),
+          'margin-left': str.is('1px'),
+          'margin-right': str.is('1px')
+        }
+      });
+    }), newData);
+  });
+
+  it('TBA: Read/write model to complex image with changes', () => {
+    const image = createHtml('<img src="some.gif" class="class" width="100" height="200" style="margin: 1px 2px; border: 1px solid red" alt="alt" title="title">');
+    const data = readFromImage(image);
+    const newData = updateModel({
+      src: 'some2.gif',
+      alt: 'alt2',
+      title: 'title2',
+      width: '101',
+      height: '201',
+      class: 'class2',
+      style: 'border: 1px solid blue;',
+      caption: false,
+      hspace: '3',
+      vspace: '4',
+      border: '4',
+      borderStyle: 'dotted',
+      isDecorative: false
+    }, data);
+    writeToImage(newData);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some2.gif'),
+          alt: str.is('alt2'),
+          title: str.is('title2'),
+          width: str.is('101'),
+          height: str.is('201'),
+          class: str.is('class2')
+        },
+        styles: {
+          'border-width': str.is('4px'),
+          'border-style': str.is('dotted'),
+          'border-color': str.is('blue'),
+          'margin-top': str.is('4px'),
+          'margin-bottom': str.is('4px'),
+          'margin-left': str.is('3px'),
+          'margin-right': str.is('3px')
+        }
+      });
+    }), newData);
+  });
+
+  it('TBA: write null as alt will remove the attribute', () => {
+    const image = createHtml('<img src="some.gif" alt="alt">');
+    const data = readFromImage(image);
+    const newData = updateModel({
+      src: 'some2.gif',
+      alt: null,
+      title: '',
+      width: '',
+      height: '',
+      class: '',
+      style: '',
+      caption: false,
+      hspace: '',
+      vspace: '',
+      border: '',
+      borderStyle: '',
+      isDecorative: false
+    }, data);
+    writeToImage(newData);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some2.gif'),
+          alt: str.none('no alt')
+        }
+      });
+    }), newData);
+  });
+
+  it('TBA: Toggle caption on', () => {
+    const image = createHtml('<div><img src="some.gif"></div>');
+    const data = readFromImage(image);
+    const newData = updateModel({
+      caption: true
+    }, data);
+    writeToImage(newData);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('div', {
+        children: [
+          s.element('figure', {
+            attrs: {
+              contenteditable: str.is('false'),
+              class: str.is('image')
+            },
+            children: [
+              s.element('img', {
+                attrs: {
+                  src: str.is('some.gif')
+                }
+              }),
+              s.element('figcaption', {
+                attrs: {
+                  contenteditable: str.is('true')
+                },
+                children: [
+                  s.text(str.is('Caption'))
+                ]
+              })
+            ]
+          })
+        ]
+      });
+    }), newData);
+  });
+
+  it('TBA: Toggle caption off', () => {
+    const image = createHtml('<div><figure class="image" contenteditable="false"><img src="some.gif"><figcaption contenteditable="true">Caption</figcaption></figure></div>');
+    const data = readFromImage(image);
+    const newData = updateModel({
+      caption: false
+    }, data);
+    writeToImage(newData);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('div', {
+        children: [
+          s.element('img', {
+            attrs: {
+              src: str.is('some.gif')
+            }
+          })
+        ]
+      });
+    }), newData);
+  });
+
+  it('TBA: Update figure image data', () => {
+    const image = createHtml('<figure class="image" contenteditable="false"><img src="some.gif"><figcaption contenteditable="true">Caption</figcaption></figure>');
+    const data = readFromImage(image);
+    const newData = updateModel({
+      src: 'some2.gif'
+    }, data);
+    writeToImage(newData);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('figure', {
+        attrs: {
+          contenteditable: str.is('false'),
+          class: str.is('image')
+        },
+        children: [
+          s.element('img', {
+            attrs: {
+              src: str.is('some2.gif')
+            }
+          }),
+          s.element('figcaption', {
+            attrs: {
+              contenteditable: str.is('true')
+            },
+            children: [
+              s.text(str.is('Caption'))
+            ]
+          })
+        ]
+      });
+    }), newData);
+  });
+
+  it('TBA: Read/write model to image with style size without change', () => {
+    const image = createHtml('<img src="some.gif" style="width: 100px; height: 200px">');
+    const data = readFromImage(image);
+    assertModel({
+      src: 'some.gif',
+      alt: '',
+      title: '',
+      width: '100',
+      height: '200',
+      class: '',
+      style: 'height: 200px; width: 100px;',
+      caption: false,
+      hspace: '',
+      vspace: '',
+      border: '',
+      borderStyle: '',
+      isDecorative: false
+    }, data);
+    writeToImage(data);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some.gif'),
+          width: str.none('no width'),
+          height: str.none('no height'),
+          alt: str.none('no alt'),
+          title: str.none('no title')
+        },
+        styles: {
+          'width': str.is('100px'),
+          'height': str.is('200px'),
+          'border-width': str.none('no width'),
+          'border-style': str.none('no style'),
+          'border-color': str.none('no color'),
+          'margin-top': str.none('no top'),
+          'margin-bottom': str.none('no bottom'),
+          'margin-left': str.none('no left'),
+          'margin-right': str.none('no right')
+        }
+      });
+    }), data);
+  });
+
+  it('TBA: Read/write model to image with style size with size change', () => {
+    const image = createHtml('<img src="some.gif" style="width: 100px; height: 200px">');
+    const data = readFromImage(image);
+    assertModel({
+      src: 'some.gif',
+      alt: '',
+      title: '',
+      width: '100',
+      height: '200',
+      class: '',
+      style: 'height: 200px; width: 100px;',
+      caption: false,
+      hspace: '',
+      vspace: '',
+      border: '',
+      borderStyle: '',
+      isDecorative: false
+    }, data);
+    const newData = updateModel({
+      width: '150',
+      height: '250'
+    }, data);
+    writeToImage(newData);
+    assertStructure(ApproxStructure.build((s, str) => {
+      return s.element('img', {
+        attrs: {
+          src: str.is('some.gif'),
+          width: str.none('no width'),
+          height: str.none('no height'),
+          alt: str.none('no alt'),
+          title: str.none('no title')
+        },
+        styles: {
+          'width': str.is('150px'),
+          'height': str.is('250px'),
+          'border-width': str.none('no width'),
+          'border-style': str.none('no style'),
+          'border-color': str.none('no color'),
+          'margin-top': str.none('no top'),
+          'margin-bottom': str.none('no bottom'),
+          'margin-left': str.none('no left'),
+          'margin-right': str.none('no right')
+        }
+      });
+    }), newData);
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
@@ -1,40 +1,40 @@
-import { Chain, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { Editor } from '@ephox/mcagar';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
 
-import {
-  cAssertCleanHtml, cAssertInputValue, cExecCommand, cFillActiveDialog, cSubmitDialog, cWaitForDialog, generalTabSelectors, silverSettings
-} from '../../module/Helpers';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('Default image dialog on empty data', (success, failure) => {
-  SilverTheme();
-  ImagePlugin();
-  Pipeline.async({}, [
-    Log.chainsAsStep('TBA', 'Image: default image dialog on empty data', [
-      Editor.cFromSettings(silverSettings),
-      cExecCommand('mceImage', true),
-      cWaitForDialog(),
-      Chain.fromParent(Chain.identity, [
-        cAssertInputValue(generalTabSelectors.src, ''),
-        cAssertInputValue(generalTabSelectors.alt, ''),
-        cAssertInputValue(generalTabSelectors.height, ''),
-        cAssertInputValue(generalTabSelectors.width, '')
-      ]),
-      cFillActiveDialog({
-        src: {
-          value: 'src'
-        },
-        alt: 'alt',
-        dimensions: {
-          width: '200',
-          height: '100'
-        }
-      }),
-      cSubmitDialog(),
-      cAssertCleanHtml('Checking output', '<p><img src="src" alt="alt" width="200" height="100" /></p>'),
-      Editor.cRemove
-    ])
-  ], () => success(), failure);
+import { assertCleanHtml, assertInputValue, fillActiveDialog, generalTabSelectors, pWaitForDialog, submitDialog } from '../../module/Helpers';
+
+describe('browser.tinymce.plugins.image.plugin.DefaultEmptyTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'image',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin, Theme ]);
+
+  it('TBA: default image dialog on empty data', async () => {
+    const editor = hook.editor();
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+
+    assertInputValue(generalTabSelectors.src, '');
+    assertInputValue(generalTabSelectors.alt, '');
+    assertInputValue(generalTabSelectors.height, '');
+    assertInputValue(generalTabSelectors.width, '');
+
+    fillActiveDialog({
+      src: {
+        value: 'src'
+      },
+      alt: 'alt',
+      dimensions: {
+        width: '200',
+        height: '100'
+      }
+    });
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="src" alt="alt" width="200" height="100" /></p>');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DimensionsFalseTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DimensionsFalseTest.ts
@@ -1,31 +1,32 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { Editor } from '@ephox/mcagar';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
 
-import { cAssertCleanHtml, cExecCommand, cFillActiveDialog, cSubmitDialog, cWaitForDialog, silverSettings } from '../../module/Helpers';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('Image dialog image_dimensions: false', (success, failure) => {
-  SilverTheme();
-  ImagePlugin();
-  Pipeline.async({}, [
-    Log.chainsAsStep('TBA', 'Image: image dialog image_dimensions: false', [
-      Editor.cFromSettings({
-        ...silverSettings,
-        image_dimensions: false
-      }),
-      cExecCommand('mceImage', true),
-      cWaitForDialog(),
-      cFillActiveDialog({
-        src: {
-          value: 'src'
-        },
-        alt: 'alt'
-      }),
-      cSubmitDialog(),
-      cAssertCleanHtml('Checking output', '<p><img src="src" alt="alt" /></p>'),
-      Editor.cRemove
-    ])
-  ], () => success(), failure);
+import { assertCleanHtml, fillActiveDialog, pWaitForDialog, submitDialog } from '../../module/Helpers';
+
+describe('browser.tinymce.plugins.image.plugin.DimensionsFalseTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'image',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    image_dimensions: false
+  }, [ Plugin, Theme ]);
+
+  it('TBA: image dialog image_dimensions: false', async () => {
+    const editor = hook.editor();
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+
+    fillActiveDialog({
+      src: {
+        value: 'src'
+      },
+      alt: 'alt'
+    });
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="src" alt="alt" /></p>');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
@@ -1,58 +1,50 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { Editor } from '@ephox/mcagar';
-import Env from 'tinymce/core/api/Env';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
 
-import { cAssertCleanHtml, cExecCommand, cFillActiveDialog, cSubmitDialog, cWaitForDialog, silverSettings } from '../../module/Helpers';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('All image dialog ui options on empty editor' + (Env.ceFalse ? '' : ' (old IE)'), (success, failure) => {
-  SilverTheme();
-  ImagePlugin();
-  Pipeline.async({}, [
-    Log.chainsAsStep('TBA', 'Image: all image dialog ui options on empty editor' + (Env.ceFalse ? '' : ' (old IE)'), [
-      Editor.cFromSettings({
-        ...silverSettings,
-        image_caption: true,
-        image_list: [
-          { title: 'link1', value: 'link1' },
-          { title: 'link2', value: 'link2' }
-        ],
-        image_class_list: [
-          { title: 'None', value: '' },
-          { title: 'class1', value: 'class1' },
-          { title: 'class2', value: 'class2' }
-        ]
-      }),
-      cExecCommand('mceImage', true),
-      cWaitForDialog(),
-      cFillActiveDialog({
-        src: { value: 'src' },
-        alt: 'alt',
-        class: 'class1',
-        dimensions: {
-          width: '100',
-          height: '200'
-        },
-        caption: true
-      }),
-      cSubmitDialog(),
-      cAssertCleanHtml('Checking output', (() => {
-        if (Env.ceFalse) {
-          return (
-            '<figure class="image">' +
-            '<img class="class1" src="src" alt="alt" width="100" height="200" />' +
-            '<figcaption>Caption</figcaption>' +
-            '</figure>'
-          );
-        } else { // old IE
-          return (
-            '<p><img class="class1" src="src" alt="alt" width="100" height="200" /></p>'
-          );
-        }
-      })()),
-      Editor.cRemove
-    ])
-  ], () => success(), failure);
+import { assertCleanHtml, fillActiveDialog, pWaitForDialog, submitDialog } from '../../module/Helpers';
+
+describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'image',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    image_caption: true,
+    image_list: [
+      { title: 'link1', value: 'link1' },
+      { title: 'link2', value: 'link2' }
+    ],
+    image_class_list: [
+      { title: 'None', value: '' },
+      { title: 'class1', value: 'class1' },
+      { title: 'class2', value: 'class2' }
+    ]
+  }, [ Plugin, Theme ]);
+
+  it('TBA: all image dialog ui options on empty editor', async () => {
+    const editor = hook.editor();
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+
+    fillActiveDialog({
+      src: { value: 'src' },
+      alt: 'alt',
+      class: 'class1',
+      dimensions: {
+        width: '100',
+        height: '200'
+      },
+      caption: true
+    });
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, (
+      '<figure class="image">' +
+      '<img class="class1" src="src" alt="alt" width="100" height="200" />' +
+      '<figcaption>Caption</figcaption>' +
+      '</figure>'
+    ));
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
@@ -1,40 +1,37 @@
-import { Chain, Log, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { Editor } from '@ephox/mcagar';
+import { UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
 
-import {
-  cAssertCleanHtml, cExecCommand, cFakeEvent, cFillActiveDialog, cOpFromChains, cSubmitDialog, cWaitForDialog, generalTabSelectors, silverSettings
-} from '../../module/Helpers';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('Image recognizes relative src url and prepends absolute image_prepend_url setting.', (success, failure) => {
-  SilverTheme();
-  ImagePlugin();
+import { assertCleanHtml, fakeEvent, fillActiveDialog, generalTabSelectors, pWaitForDialog, submitDialog } from '../../module/Helpers';
+
+describe('browser.tinymce.plugins.image.plugin.PrependAbsoluteTest', () => {
   const prependUrl = 'http://abc.local/images/';
-  Pipeline.async({}, [
-    Log.chainsAsStep('TBA', 'Image: image recognizes relative src url and prepends absolute image_prepend_url setting.', [
-      Editor.cFromSettings({
-        ...silverSettings,
-        image_prepend_url: prependUrl
-      }),
-      cExecCommand('mceImage', true),
-      cWaitForDialog(),
-      cFillActiveDialog({
-        src: {
-          value: 'src'
-        },
-        alt: 'alt'
-      }),
-      cOpFromChains([
-        Chain.inject(SugarBody.body()),
-        UiFinder.cFindIn(generalTabSelectors.src),
-        cFakeEvent('change')
-      ]),
-      cSubmitDialog(),
-      cAssertCleanHtml('Checking output', '<p><img src="' + prependUrl + 'src" alt="alt" /></p>'),
-      Editor.cRemove
-    ])
-  ], () => success(), failure);
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'image',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    image_prepend_url: prependUrl
+  }, [ Plugin, Theme ]);
+
+  it('TBA: image recognizes relative src url and prepends absolute image_prepend_url setting.', async () => {
+    const editor = hook.editor();
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+
+    fillActiveDialog({
+      src: {
+        value: 'src'
+      },
+      alt: 'alt'
+    });
+    const srcElem = UiFinder.findIn(SugarBody.body(), generalTabSelectors.src).getOrDie();
+    fakeEvent(srcElem, 'change');
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="' + prependUrl + 'src" alt="alt" /></p>');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
@@ -1,40 +1,37 @@
-import { Chain, Log, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { Editor } from '@ephox/mcagar';
+import { UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
 
-import {
-  cAssertCleanHtml, cExecCommand, cFakeEvent, cFillActiveDialog, cOpFromChains, cSubmitDialog, cWaitForDialog, generalTabSelectors, silverSettings
-} from '../../module/Helpers';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('Image recognizes relative src url and prepends relative image_prepend_url setting.', (success, failure) => {
-  SilverTheme();
-  ImagePlugin();
+import { assertCleanHtml, fakeEvent, fillActiveDialog, generalTabSelectors, pWaitForDialog, submitDialog } from '../../module/Helpers';
+
+describe('browser.tinymce.plugins.image.plugin.PrependRelativeTest', () => {
   const prependUrl = 'testing/images/';
-  Pipeline.async({}, [
-    Log.chainsAsStep('TBA', 'Image: image recognizes relative src url and prepends relative image_prepend_url setting.', [
-      Editor.cFromSettings({
-        ...silverSettings,
-        image_prepend_url: prependUrl
-      }),
-      cExecCommand('mceImage', true),
-      cWaitForDialog(),
-      cFillActiveDialog({
-        src: {
-          value: 'src'
-        },
-        alt: 'alt'
-      }),
-      cOpFromChains([
-        Chain.inject(SugarBody.body()),
-        UiFinder.cFindIn(generalTabSelectors.src),
-        cFakeEvent('change')
-      ]),
-      cSubmitDialog(),
-      cAssertCleanHtml('Checking output', '<p><img src="' + prependUrl + 'src" alt="alt" /></p>'),
-      Editor.cRemove
-    ])
-  ], () => success(), failure);
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'image',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    image_prepend_url: prependUrl
+  }, [ Plugin, Theme ]);
+
+  it('TBA: image recognizes relative src url and prepends relative image_prepend_url setting.', async () => {
+    const editor = hook.editor();
+    editor.execCommand('mceImage');
+    await pWaitForDialog(editor);
+
+    fillActiveDialog({
+      src: {
+        value: 'src'
+      },
+      alt: 'alt'
+    });
+    const srcElem = UiFinder.findIn(SugarBody.body(), generalTabSelectors.src).getOrDie();
+    fakeEvent(srcElem, 'change');
+    submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="' + prependUrl + 'src" alt="alt" /></p>');
+  });
 });

--- a/versions.txt
+++ b/versions.txt
@@ -4,3 +4,4 @@
 agar@5.2.0
 mcagar@5.2.0
 snooker@7.2.0
+sugar@7.1.0


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Converts the `image` plugin to use BDD style tests
* Added more helper functions

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
