### PR TITLE
TINY-6732: Fixed a memory leak in the new TinyHooks module

### DIFF
--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyHooks.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyHooks.ts
@@ -21,7 +21,7 @@ const setupHooks = <T extends EditorType = EditorType>(
   createElement: () => Optional<SugarElement>,
   teardown = Fun.noop
 ): Hook<T> => {
-  let editor: T;
+  let editor: T | undefined;
   let teardownEditor: () => void = Fun.noop;
   let hasFailure = false;
 
@@ -33,7 +33,7 @@ const setupHooks = <T extends EditorType = EditorType>(
         editor = ed;
         teardownEditor = success;
         if (focusOnInit) {
-          editor.focus();
+          ed.focus();
         }
         done();
       },
@@ -53,10 +53,14 @@ const setupHooks = <T extends EditorType = EditorType>(
       teardownEditor();
       teardown();
     }
+
+    // Cleanup references
+    editor = undefined;
+    teardownEditor = Fun.noop;
   });
 
   return {
-    editor: () => editor
+    editor: () => editor as T
   };
 };
 
@@ -78,8 +82,8 @@ const bddSetupFromElement = <T extends EditorType = EditorType>(settings: Record
 };
 
 const bddSetupInShadowRoot = <T extends EditorType = EditorType>(settings: Record<string, any>, setupModules: Array<() => void> = [], focusOnInit: boolean = false): ShadowRootHook<T> => {
-  let shadowRoot: SugarElement<ShadowRoot>;
-  let editorDiv: SugarElement<HTMLElement>;
+  let shadowRoot: SugarElement<ShadowRoot> | undefined;
+  let editorDiv: SugarElement<HTMLElement> | undefined;
   let teardown: () => void = Fun.noop;
 
   before(function () {
@@ -97,6 +101,11 @@ const bddSetupInShadowRoot = <T extends EditorType = EditorType>(settings: Recor
 
     teardown = () => {
       Remove.remove(shadowHost);
+
+      // Cleanup references
+      shadowRoot = undefined;
+      editorDiv = undefined;
+      teardown = Fun.noop;
     };
   });
 
@@ -104,7 +113,7 @@ const bddSetupInShadowRoot = <T extends EditorType = EditorType>(settings: Recor
 
   return {
     ...hooks,
-    shadowRoot: () => shadowRoot
+    shadowRoot: () => shadowRoot as SugarElement<ShadowRoot>
   };
 };
 


### PR DESCRIPTION
Related Ticket: TINY-6732

Description of Changes:
* Was doing some profiling and noticed that editor instances were being retained due to the new `TinyHooks` implementation. So this makes sure we clean up the references when the test is done.

![image](https://user-images.githubusercontent.com/1575550/104452894-5c5bd900-55ef-11eb-8468-df9572d50b4c.png)
![image](https://user-images.githubusercontent.com/1575550/104448747-4ba86480-55e9-11eb-8219-d59c3f0099f5.png)

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
