### PR TITLE
Bug/tiny 6903

### DIFF
--- a/modules/oxide/src/less/theme/components/fullscreen/fullscreen.less
+++ b/modules/oxide/src/less/theme/components/fullscreen/fullscreen.less
@@ -9,6 +9,8 @@
 // Fullscreen mode
 //
 
+@fullscreen-container-background-color: transparent;
+
 .tox-fullscreen {
   border: 0;
   height: 100%;
@@ -29,6 +31,7 @@
 }
 
 .tox.tox-tinymce.tox-fullscreen {
+  background-color: @fullscreen-container-background-color;
   z-index: @z-index-fullscreen;
 }
 

--- a/modules/oxide/src/less/theme/globals/reset.less
+++ b/modules/oxide/src/less/theme/globals/reset.less
@@ -10,6 +10,7 @@
 //
 
 .tox {
+  box-shadow: none;
   box-sizing: content-box;
   color: @color-black;
   cursor: auto;
@@ -49,6 +50,7 @@
     // remaining specific reset styles for properties that shouldn't be inherited
     background: transparent;
     border: 0;
+    box-shadow: none;
     float: none;
     height: auto;
     margin: 0;

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -8,6 +8,7 @@ Version 5.7.0 (TBD)
     Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL #TINY-6611
     Fixed an issue where `scope` attributes on table cells would not change as expected when merging or unmerging cells #TINY-6486
     Fixed the plugin documentation links in the `help` plugin #DOC-703
+    Fixed an issue with external styles bleeding into TinyMCE #TINY-6735
 Version 5.6.1 (2020-11-25)
     Fixed the `mceTableRowType` and `mceTableCellType` commands were not firing the `newCell` event #TINY-6692
     Fixed the HTML5 `s` element was not recognized when editing or clearing text formatting #TINY-6681

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.7.0 (TBD)
     Added new `font_css` setting for fonts to be added to both containing document and the editor #TINY-6199
     Added a new `ImageUploader` API to simplify uploading image data to the configured `images_upload_url` or `images_upload_handler` #TINY-4601
+    Added Oxide variable to define the container background color in fullscreen mode #TINY-6903
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
     Changed the z-index of the `setProgressState(true)` throbber so it does not hide notifications #TINY-6686


### PR DESCRIPTION
Related Ticket: Tiny-6903

Description of Changes:
* Added Oxide variable to define the container background color in fullscreen mode #TINY-6903

Pre-checks:
* [x] Changelog entry added
* [ ] ~~Tests have been added (if applicable)~~
* [ ] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [ ] ~~License headers added on new files (if applicable)~~

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
