### PR TITLE
Added Oxide variable to define the container background color in fullscreen mode

### DIFF
--- a/modules/oxide/src/less/theme/components/fullscreen/fullscreen.less
+++ b/modules/oxide/src/less/theme/components/fullscreen/fullscreen.less
@@ -9,6 +9,8 @@
 // Fullscreen mode
 //
 
+@fullscreen-container-background-color: transparent;
+
 .tox-fullscreen {
   border: 0;
   height: 100%;
@@ -29,6 +31,7 @@
 }
 
 .tox.tox-tinymce.tox-fullscreen {
+  background-color: @fullscreen-container-background-color;
   z-index: @z-index-fullscreen;
 }
 

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -5,6 +5,7 @@ Version 5.7.0 (TBD)
     Added the ability to resize `video` and `iframe` media elements #TINY-6229
     Added new `font_css` setting for fonts to be added to both containing document and the editor #TINY-6199
     Added a new `ImageUploader` API to simplify uploading image data to the configured `images_upload_url` or `images_upload_handler` #TINY-4601
+    Added Oxide variable to define the container background color in fullscreen mode #TINY-6903
     Changed copying table columns or entire tables will now retain an appropriate width when pasted #TINY-6664
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585


### PR DESCRIPTION
Related Ticket: TINY-6903

Description of Changes:
* Added Oxide variable to define the container background color in fullscreen mode

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
