### PR TITLE
TINY-3897 & TINY-6667: Fixed issues with fake table selection on Firefox

### DIFF
--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -1,4 +1,4 @@
-import { Singleton, Type } from '@ephox/katamari';
+import { Singleton } from '@ephox/katamari';
 import { Compare, EventArgs, SelectorFind, SugarElement } from '@ephox/sugar';
 import { SelectionAnnotation } from '../api/SelectionAnnotation';
 import { WindowBridge } from '../api/WindowBridge';
@@ -8,7 +8,7 @@ export interface MouseSelection {
   readonly clearstate: () => void;
   readonly mousedown: (event: EventArgs<MouseEvent>) => void;
   readonly mouseover: (event: EventArgs<MouseEvent>) => void;
-  readonly mouseup: (event?: EventArgs<MouseEvent>) => void;
+  readonly mouseup: (event: EventArgs<MouseEvent>) => void;
 }
 
 const findCell = (target: SugarElement, isRoot: (e: SugarElement) => boolean) =>
@@ -50,12 +50,10 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement, is
   };
 
   /* Keep this as lightweight as possible when we're not in a table selection, it runs constantly */
-  const mouseup = (event?: EventArgs<MouseEvent>) => {
-    if (Type.isNonNullable(event)) {
-      // Needed as Firefox will change the selection between the mouseover and mouseup when selecting
-      // just 2 cells as it supports multiple ranges
-      applySelection(event);
-    }
+  const mouseup = (event: EventArgs<MouseEvent>) => {
+    // Needed as Firefox will change the selection between the mouseover and mouseup when selecting
+    // just 2 cells as Firefox supports multiple selection ranges
+    applySelection(event);
     clearstate();
   };
 

--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -1,4 +1,4 @@
-import { Singleton } from '@ephox/katamari';
+import { Singleton, Type } from '@ephox/katamari';
 import { Compare, EventArgs, SelectorFind, SugarElement } from '@ephox/sugar';
 import { SelectionAnnotation } from '../api/SelectionAnnotation';
 import { WindowBridge } from '../api/WindowBridge';
@@ -18,14 +18,7 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement, is
   const cursor = Singleton.value<SugarElement>();
   const clearstate = cursor.clear;
 
-  /* Keep this as lightweight as possible when we're not in a table selection, it runs constantly */
-  const mousedown = (event: EventArgs) => {
-    annotations.clear(container);
-    findCell(event.target, isRoot).each(cursor.set);
-  };
-
-  /* Keep this as lightweight as possible when we're not in a table selection, it runs constantly */
-  const mouseover = (event: EventArgs) => {
+  const applySelection = (event: EventArgs<MouseEvent>) => {
     cursor.on((start) => {
       annotations.clearBeforeUpdate(container);
       findCell(event.target, isRoot).each((finish) => {
@@ -46,7 +39,23 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement, is
   };
 
   /* Keep this as lightweight as possible when we're not in a table selection, it runs constantly */
-  const mouseup = (_event?: EventArgs) => {
+  const mousedown = (event: EventArgs<MouseEvent>) => {
+    annotations.clear(container);
+    findCell(event.target, isRoot).each(cursor.set);
+  };
+
+  /* Keep this as lightweight as possible when we're not in a table selection, it runs constantly */
+  const mouseover = (event: EventArgs<MouseEvent>) => {
+    applySelection(event);
+  };
+
+  /* Keep this as lightweight as possible when we're not in a table selection, it runs constantly */
+  const mouseup = (event?: EventArgs<MouseEvent>) => {
+    if (Type.isNonNullable(event)) {
+      // Needed as Firefox will change the selection between the mouseover and mouseup when selecting
+      // just 2 cells as it supports multiple ranges
+      applySelection(event);
+    }
     clearstate();
   };
 

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -14,6 +14,7 @@ Version 5.7.0 (TBD)
     Changed the type signature for `editor.selection.getRng()` incorrectly returning `null` #TINY-6843
     Changed some `SaxParser` regular expressions to improve performance #TINY-6823
     Fixed `col` elements incorrectly transformed to `th` elements when converting columns to header columns #TINY-6715
+    Fixed a number of table operations not working when selecting 2 table cells on Mozilla Firefox #TINY-3897
     Fixed a memory leak by backporting an upstream Sizzle fix #TINY-6859
     Fixed table width style was removed when copying #TINY-6664
     Fixed base64 URLs used in style attributes were corrupted when parsing HTML #TINY-6828

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
@@ -1,0 +1,113 @@
+import { Mouse, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/table/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+const enum Direction {
+  Row,
+  Column
+}
+
+describe('browser.tinymce.plugins.table.TwoCellsSelectionTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'table',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+  }, [ Plugin, Theme ]);
+
+  const setup = (editor: Editor, colgroup: boolean, direction: Direction) => {
+    editor.setContent(
+      '<table>' +
+      (colgroup ? '<colgroup><col /><col /><col /></colgroup>' : '') +
+      '<tbody>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td></tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    const path = colgroup ? [ 0, 1, 1, 1, 0 ] : [ 0, 0, 1, 1, 0 ];
+    TinySelections.setCursor(editor, path, 1);
+    const startCell = UiFinder.findIn(TinyDom.body(editor), 'td:contains(B2)').getOrDie();
+    const endCellSelector = direction === Direction.Column ? 'td:contains(B1)' : 'td:contains(A2)';
+    const endCell = UiFinder.findIn(TinyDom.body(editor), endCellSelector).getOrDie();
+
+    // Drag over the 2 cells to select them
+    Mouse.mouseDown(startCell);
+    Mouse.mouseOver(startCell);
+    Mouse.mouseOver(endCell);
+    Mouse.mouseUp(endCell);
+  };
+
+  it('TINY-3897: Selecting 2 cells via the mouse should only have 1 range selection', () => {
+    const editor = hook.editor();
+    setup(editor, true, Direction.Row);
+    TinyAssertions.assertContentPresence(editor, {
+      'td[data-mce-selected]': 2
+    });
+    assert.equal(editor.selection.getSel().rangeCount, 1, 'there should only be 1 selection range');
+  });
+
+  it('TINY-3897: Select 2 cells in same row via mouse and merge them together', () => {
+    const editor = hook.editor();
+    setup(editor, true, Direction.Row);
+    editor.execCommand('mceTableMergeCells');
+    TinyAssertions.assertContent(editor,
+      '<table>' +
+      '<colgroup><col /><col /><col /></colgroup>' +
+      '<tbody>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td></tr>' +
+      '<tr><td colspan="2">A2<br />B2</td><td>C2</td></tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+  });
+
+  it('TINY-3897: Select 2 cells in same column via mouse and merge them together', () => {
+    const editor = hook.editor();
+    setup(editor, true, Direction.Column);
+    editor.execCommand('mceTableMergeCells');
+    TinyAssertions.assertContent(editor,
+      '<table>' +
+      '<colgroup><col /><col /><col /></colgroup>' +
+      '<tbody>' +
+      '<tr><td>A1</td><td rowspan="2">B1<br />B2</td><td>C1</td></tr>' +
+      '<tr><td>A2</td><td>C2</td></tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+  });
+
+  it('TINY-6667: Select 2 cells in same row via mouse and change to header', () => {
+    const editor = hook.editor();
+    setup(editor, false, Direction.Row);
+    editor.execCommand('mceTableRowType', false, { type: 'header' });
+    TinyAssertions.assertContent(editor,
+      '<table>' +
+      '<thead>' +
+      '<tr><td scope="col">A2</td><td scope="col">B2</td><td scope="col">C2</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td></tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+  });
+
+  it('TINY-6667: Select 2 cells in same column via mouse and change to header', () => {
+    const editor = hook.editor();
+    setup(editor, false, Direction.Column);
+    editor.execCommand('mceTableColType', false, { type: 'th' });
+    TinyAssertions.assertContent(editor,
+      '<table>' +
+      '<tbody>' +
+      '<tr><td>A1</td><th scope="row">B1</th><td>C1</td></tr>' +
+      '<tr><td>A2</td><th scope="row">B2</th><td>C2</td></tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+  });
+});

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
@@ -36,8 +36,12 @@ describe('browser.tinymce.plugins.table.TwoCellsSelectionTest', () => {
     const endCell = UiFinder.findIn(TinyDom.body(editor), endCellSelector).getOrDie();
 
     // Drag over the 2 cells to select them
-    Mouse.mouseDown(startCell);
     Mouse.mouseOver(startCell);
+    Mouse.mouseDown(startCell);
+
+    // Note: This additional mouseover is here to trigger/test the same cell checks in MouseSelection.ts
+    Mouse.mouseOver(startCell);
+
     Mouse.mouseOver(endCell);
     Mouse.mouseUp(endCell);
   };

--- a/versions.txt
+++ b/versions.txt
@@ -2,6 +2,7 @@
 # Format: [package_name]@[new_version]
 
 agar@5.2.0
+darwin@6.0.0
 mcagar@6.0.0
 snooker@7.2.0
 sugar@7.1.0


### PR DESCRIPTION
Related Ticket: TINY-3897 & TINY-6667

Description of Changes:
Fixes an issue with Firefox whereby the selection would be incorrect when selecting only 2 cells and then trying to do operations.

Note: I had tried preventing the mouseover, etc... events to try and stop Firefox changing the selection, but unfortunately nothing worked. Either way, it still makes sense to ensure the fake selection is correct on `mouseup` since we know that's the end point in the selection.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #4914
Fixes #5078