### PR TITLE
TINY-6904: Fixed focus lost in the charmap and emoticons dialog when typing within a shadow root

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/TouchMenu.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/TouchMenu.ts
@@ -1,5 +1,5 @@
 import { Cell, Fun, Optional } from '@ephox/katamari';
-import { EventArgs, Focus } from '@ephox/sugar';
+import { EventArgs, Focus, SugarShadowDom } from '@ephox/sugar';
 
 import * as ElementFromPoint from '../../alien/ElementFromPoint';
 import { TransitionPropertiesSpec } from '../../behaviour/transitioning/TransitioningTypes';
@@ -168,7 +168,8 @@ const factory: CompositeSketchFactory<TouchMenuDetail, TouchMenuSpec> = (detail,
             Highlighting.dehighlightAll(iMenu);
 
             // INVESTIGATE: Should this focus.blur be called? Should it only be called here?
-            Focus.active().each(Focus.blur);
+            const dos = SugarShadowDom.getRootNode(component.element);
+            Focus.active(dos).each(Focus.blur);
 
             // could not find an item, so check the button itself
             const hoverF = ElementFromPoint.insideComponent(component, e.clientX, e.clientY).fold(

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -16,6 +16,7 @@ Version 5.7.0 (TBD)
     Fixed `col` elements incorrectly transformed to `th` elements when converting columns to header columns #TINY-6715
     Fixed a memory leak by backporting an upstream Sizzle fix #TINY-6859
     Fixed table width style was removed when copying #TINY-6664
+    Fixed focus lost while typing in the `charmap` or `emoticons` dialogs when the editor is rendered in a shadow root #TINY-6904
     Fixed base64 URLs used in style attributes were corrupted when parsing HTML #TINY-6828
     Fixed the order of CSS precedence of `content_style` and `content_css` in the `preview` and `template` plugins. `content_style` now has precedence #TINY-6529
     Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL #TINY-6611

--- a/modules/tinymce/src/core/demo/html/shadow_dom_open_demo.html
+++ b/modules/tinymce/src/core/demo/html/shadow_dom_open_demo.html
@@ -7,6 +7,7 @@
   <body>
   <h2>TinyMCE Shadow DOM Open Demo Page</h2>
     <div id="shadow-host"></div>
+    <input placeholder="Alternative">
     <script src="../../../../js/tinymce/tinymce.js"></script>
     <script src="../../../../scratch/demos/core/demo.js"></script>
     <script>demos.ShadowDomDemo({ mode: 'open' });</script>

--- a/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
@@ -3,6 +3,7 @@ declare let tinymce: any;
 export default (init: ShadowRootInit) => {
 
   const shadowHost = document.getElementById('shadow-host');
+  shadowHost.tabIndex = 1;
 
   const shadow = shadowHost.attachShadow(init);
 

--- a/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
+++ b/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
@@ -6,7 +6,7 @@
  */
 
 import { Optional } from '@ephox/katamari';
-import { Compare, Focus, SugarElement } from '@ephox/sugar';
+import { Compare, Focus, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import EditorSelection from '../api/dom/Selection';
 import Editor from '../api/Editor';
 import Env from '../api/Env';
@@ -66,10 +66,14 @@ const hasInlineFocus = (editor: Editor): boolean => {
   return rawBody && hasElementFocus(SugarElement.fromDom(rawBody));
 };
 
-const hasUiFocus = (editor: Editor): boolean =>
+const hasUiFocus = (editor: Editor): boolean => {
+  const dos = SugarShadowDom.getRootNode(SugarElement.fromDom(editor.getElement()));
   // Editor container is the obvious one (Menubar, Toolbar, Status bar, Sidebar) and dialogs and menus are in an auxiliary element (silver theme specific)
   // This can't use Focus.search() because only the theme has this element reference
-  Focus.active().filter((elem) => !FocusController.isEditorContentAreaElement(elem.dom) && FocusController.isUIElement(editor, elem.dom)).isSome();
+  return Focus.active(dos)
+    .filter((elem) => !FocusController.isEditorContentAreaElement(elem.dom) && FocusController.isUIElement(editor, elem.dom))
+    .isSome();
+};
 
 const hasFocus = (editor: Editor): boolean => editor.inline ? hasInlineFocus(editor) : hasIframeFocus(editor);
 

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
@@ -1,7 +1,8 @@
-import { FocusTools, UiFinder } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
-import { Css, SugarBody, SugarDocument, SugarElement, Traverse } from '@ephox/sugar';
+import { FocusTools, Keys, UiFinder } from '@ephox/agar';
+import { before, context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { Attribute, Css, SugarElement, SugarShadowDom, Traverse, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -10,30 +11,67 @@ import Theme from 'tinymce/themes/silver/Theme';
 import { fakeEvent } from '../module/Helpers';
 
 describe('browser.tinymce.plugins.charmap.DialogHeightTest', () => {
-  const hook = TinyHooks.bddSetupLight<Editor>({
-    plugins: 'charmap',
-    toolbar: 'charmap',
-    base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  Arr.each([
+    { label: 'IFrame Editor', setup: TinyHooks.bddSetupLight },
+    { label: 'Shadow Dom Editor', setup: TinyHooks.bddSetupInShadowRoot },
+  ], (tester) => {
+    context(tester.label, () => {
+      const hook = tester.setup<Editor>({
+        plugins: 'charmap',
+        toolbar: 'charmap',
+        base_url: '/project/tinymce/js/tinymce'
+      }, [ Plugin, Theme ], true);
 
-  const tabPanelHeight = (tabpanel: SugarElement<Element>) => Css.getRaw(tabpanel, 'height').getOrDie('tabpanel has no height');
+      before(() => {
+        // Make the shadow host focusable
+        const target = TinyDom.targetElement(hook.editor());
+        SugarShadowDom.getShadowRoot(target).each((sr) => {
+          const host = SugarShadowDom.getShadowHost(sr);
+          Attribute.set(host, 'tabindex', 1);
+        });
+      });
 
-  it('TBA: Search for items, dialog height should not change when fewer items returned', async () => {
-    const editor = hook.editor();
-    const body = SugarBody.body();
-    const doc = SugarDocument.getDocument();
+      const tabPanelHeight = (tabpanel: SugarElement<Element>) => Css.getRaw(tabpanel, 'height').getOrDie('tabpanel has no height');
 
-    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Special character"]');
-    await TinyUiActions.pWaitForDialog(editor);
-    await FocusTools.pTryOnSelector('Focus should start on', doc, 'input');
+      const type = (doc: SugarElement<Document | ShadowRoot>, text: string) => {
+        const input = FocusTools.getFocused(doc).getOrDie() as SugarElement<HTMLInputElement>;
+        Value.set(input, Value.get(input) + text);
+        fakeEvent(input, 'input');
+      };
 
-    const tabPanel = UiFinder.findIn(body, '[role="dialog"] [role="tabpanel"]').getOrDie();
-    const oldHeight = tabPanelHeight(tabPanel);
-    const input = FocusTools.setActiveValue(doc, '.');
-    fakeEvent(input, 'input');
-    // need to wait until '.tox-collection__group' has no children
-    await UiFinder.pWaitForState('Wait for search to finish', body, '[role="dialog"] .tox-collection__group', (e) => Traverse.childNodesCount(e) === 0);
-    const newHeight = tabPanelHeight(tabPanel);
-    assert.equal(parseInt(newHeight, 10), parseInt(oldHeight, 10), 'New height and old height differ');
+      it('TBA: Search for items, dialog height should not change when fewer items returned', async () => {
+        const editor = hook.editor();
+        const root = SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
+        const body = SugarShadowDom.getContentContainer(root);
+
+        TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Special character"]');
+        await TinyUiActions.pWaitForDialog(editor);
+        await FocusTools.pTryOnSelector('Focus should start on', root, 'input');
+
+        const tabPanel = UiFinder.findIn(body, '[role="dialog"] [role="tabpanel"]').getOrDie();
+        const oldHeight = tabPanelHeight(tabPanel);
+        type(root, '.');
+        // need to wait until '.tox-collection__group' has no children
+        await UiFinder.pWaitForState('Wait for search to finish', body, '[role="dialog"] .tox-collection__group', (e) => Traverse.childNodesCount(e) === 0);
+        const newHeight = tabPanelHeight(tabPanel);
+        assert.equal(parseInt(newHeight, 10), parseInt(oldHeight, 10), 'New height and old height differ');
+        TinyUiActions.keydown(editor, Keys.escape());
+      });
+
+      it('TINY-6904: Focus should remain while typing', async () => {
+        const editor = hook.editor();
+        const root = SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
+
+        TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Special character"]');
+        await TinyUiActions.pWaitForDialog(editor);
+        await FocusTools.pTryOnSelector('Focus should start on', root, 'input');
+
+        type(root, 'a');
+        await FocusTools.pTryOnSelector('Focus is still on input', root, 'input');
+        type(root, 'b');
+        await FocusTools.pTryOnSelector('Focus is still on input', root, 'input');
+        TinyUiActions.keydown(editor, Keys.escape());
+      });
+    });
   });
 });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/DialogTabHeight.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/DialogTabHeight.ts
@@ -8,7 +8,7 @@
 import { AlloyComponent, AlloyEvents, Replacing, SystemEvents, TabbarTypes, TabSection } from '@ephox/alloy';
 import { Arr, Cell, Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Css, Focus, Height, SelectorFind, SugarElement, Traverse, Width } from '@ephox/sugar';
+import { Css, Focus, Height, SelectorFind, SugarElement, SugarShadowDom, Traverse, Width } from '@ephox/sugar';
 import Delay from 'tinymce/core/api/util/Delay';
 import { formResizeEvent } from '../general/FormEvents';
 
@@ -131,7 +131,7 @@ const setMode = (allTabs: Array<Partial<TabbarTypes.TabButtonWithViewSpec>>) => 
       AlloyEvents.run(formResizeEvent, (comp, _se) => {
         const dialog = comp.element;
         getTabview(dialog).each((tabview) => {
-          const oldFocus = Focus.active();
+          const oldFocus = Focus.active(SugarShadowDom.getRootNode(tabview));
           Css.set(tabview, 'visibility', 'hidden');
           const oldHeight = Css.getRaw(tabview, 'height').map((h) => parseInt(h, 10));
           Css.remove(tabview, 'height');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -85,7 +85,6 @@ const renderContextToolbar = (spec: { onEscape: () => Optional<boolean>; sink: A
             stack.set(stack.get().concat([
               {
                 bar: oldContents,
-                // TODO: Not working
                 focus: Focus.active(SugarShadowDom.getRootNode(comp.element))
               }
             ]));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -9,7 +9,7 @@ import {
   AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, CustomEvent, GuiFactory, InlineView, Keying, NativeEvents
 } from '@ephox/alloy';
 import { Arr, Cell, Id, Optional, Result } from '@ephox/katamari';
-import { Class, Css, EventArgs, Focus, SugarElement, Width } from '@ephox/sugar';
+import { Class, Css, EventArgs, Focus, SugarElement, SugarShadowDom, Width } from '@ephox/sugar';
 import Delay from 'tinymce/core/api/util/Delay';
 
 const forwardSlideEvent = Id.generate('forward-slide');
@@ -57,21 +57,22 @@ const renderContextToolbar = (spec: { onEscape: () => Optional<boolean>; sink: A
         }),
 
         AlloyEvents.run<ChangeSlideEvent>(changeSlideEvent, (comp, se) => {
+          const elem = comp.element;
           // If it was partially through a slide, clear that and measure afresh
-          Css.remove(comp.element, 'width');
-          const currentWidth = Width.get(comp.element);
+          Css.remove(elem, 'width');
+          const currentWidth = Width.get(elem);
 
           InlineView.setContent(comp, se.event.contents);
-          Class.add(comp.element, resizingClass);
-          const newWidth = Width.get(comp.element);
-          Css.set(comp.element, 'width', currentWidth + 'px');
+          Class.add(elem, resizingClass);
+          const newWidth = Width.get(elem);
+          Css.set(elem, 'width', currentWidth + 'px');
           InlineView.getContent(comp).each((newContents) => {
             se.event.focus.bind((f) => {
               Focus.focus(f);
-              return Focus.search(comp.element);
+              return Focus.search(elem);
             }).orThunk(() => {
               Keying.focusIn(newContents);
-              return Focus.active();
+              return Focus.active(SugarShadowDom.getRootNode(elem));
             });
           });
           Delay.setTimeout(() => {
@@ -85,7 +86,7 @@ const renderContextToolbar = (spec: { onEscape: () => Optional<boolean>; sink: A
               {
                 bar: oldContents,
                 // TODO: Not working
-                focus: Focus.active()
+                focus: Focus.active(SugarShadowDom.getRootNode(comp.element))
               }
             ]));
           });


### PR DESCRIPTION
Related Ticket: TINY-6904

Description of Changes:
* Fixed incorrectly getting focus from the root document when attempting to preserve the focus while adjusting the dialog height for collections.
* Fixed a few other minor places where we were getting the focus incorrectly as well (worth noting `TouchMenu` is never used and we possibly should delete it one day).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
