### PR TITLE
TINY-6738  Remove 'scope' parameter from Table RowDialog

### DIFF
--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -41,7 +41,6 @@ export type TableData = {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type RowData = {
   height: string;
-  scope: string;
   class: string;
   align: string;
   type: string;
@@ -283,7 +282,6 @@ const extractDataFromRowElement = (editor: Editor, elm: HTMLTableRowElement, has
   const dom = editor.dom;
   return {
     height: dom.getStyle(elm, 'height') || dom.getAttrib(elm, 'height'),
-    scope: dom.getAttrib(elm, 'scope'),
     class: dom.getAttrib(elm, 'class', ''),
     type: getRowType(editor, elm),
     align: getHAlignment(editor, elm),

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -24,7 +24,6 @@ import * as RowDialogGeneralTab from './RowDialogGeneralTab';
 type RowData = Helpers.RowData;
 
 const updateSimpleProps = (modifier: DomModifier, data: RowData) => {
-  modifier.setAttrib('scope', data.scope);
   modifier.setAttrib('class', data.class);
   modifier.setStyle('height', Util.addPxSuffix(data.height));
 };

--- a/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
@@ -166,7 +166,7 @@ UnitTest.asynctest('browser.tinymce.plugins.table.HelpersTest', (success, failur
       Log.stepsAsStep('TBA', 'Table: extractDataFromRowElement', [
         tinyApis.sSetContent(
           '<table style="border-collapse: collapse;" border="1"><tbody>' +
-          '<tr scope="row" class="foo" style="height:30px; ' +
+          '<tr class="foo" style="height:30px; ' +
           'background-color: #333333; text-align:left; vertical-align:middle; ' +
           'border-style: dashed; border-color: #d91111"><td>a</td></tr>' +
           '</tbody></table>'
@@ -176,7 +176,6 @@ UnitTest.asynctest('browser.tinymce.plugins.table.HelpersTest', (success, failur
           Chain.op((tr) => {
             const rowData = Helpers.extractDataFromRowElement(editor, tr.dom, true);
             Assertions.assertEq('Extracts height', '30px', rowData.height);
-            // Assertions.assertEq('Extracts scope', 'row', rowData.scope); // Chrome won't set a scope on a tr?
             Assertions.assertEq('Extracts class', 'foo', rowData.class);
             Assertions.assertEq('Extracts align', 'left', rowData.align);
             Assertions.assertEq('Extracts type', 'body', rowData.type);


### PR DESCRIPTION
Related Ticket: TINY-6738

Description of Changes:
* Unsupported attribute removed
* Pass test
![image](https://user-images.githubusercontent.com/6851052/105695684-a6ec2800-5f02-11eb-88ca-3121ccf04474.png)


Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
