### PR TITLE
TINY-6711: Improved table resizing on column insertion and deletion

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/ResizeBehaviour.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/ResizeBehaviour.ts
@@ -149,12 +149,10 @@ const preserveTable = (): ResizeBehaviour => {
     }
   };
 
-  const calcRedestributedWidths = (sizes: number[], _totalWidth: number, _pixelDelta: number, _isRelative: boolean) => {
-    return {
-      delta: 0,
-      newSizes: sizes,
-    };
-  };
+  const calcRedestributedWidths = (sizes: number[], _totalWidth: number, _pixelDelta: number, _isRelative: boolean) => ({
+    delta: 0,
+    newSizes: sizes,
+  });
 
   return {
     resizeTable,

--- a/modules/snooker/src/main/ts/ephox/snooker/api/ResizeBehaviour.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/ResizeBehaviour.ts
@@ -5,11 +5,10 @@ type TableResizer = (delta: number) => void;
 export interface ResizeBehaviour {
   readonly resizeTable: (resizer: TableResizer, delta: number, isLastColumn: boolean) => void;
   readonly clampTableDelta: (sizes: number[], index: number, delta: number, minCellSize: number, isLastColumn: boolean) => number;
-  readonly calcLeftEdgeDeltas: (sizes: number[], index: number, nextIndex: number, delta: number, minCellSize: number, relativeSizing: boolean) => number[];
-  readonly calcMiddleDeltas: (sizes: number[], previousIndex: number, index: number, nextIndex: number, delta: number, minCellSize: number, relativeSizing: boolean) => number[];
-  readonly calcRightEdgeDeltas: (sizes: number[], previousIndex: number, index: number, delta: number, minCellSize: number, relativeSizing: boolean) => number[];
+  readonly calcLeftEdgeDeltas: (sizes: number[], index: number, nextIndex: number, delta: number, minCellSize: number, isRelative: boolean) => number[];
+  readonly calcMiddleDeltas: (sizes: number[], previousIndex: number, index: number, nextIndex: number, delta: number, minCellSize: number, isRelative: boolean) => number[];
+  readonly calcRightEdgeDeltas: (sizes: number[], previousIndex: number, index: number, delta: number, minCellSize: number, isRelative: boolean) => number[];
   readonly calcRedestributedWidths: (sizes: number[], total: number, pixelDelta: number, isRelative: boolean) => { delta: number; newSizes: number[] };
-  // readonly calcRedestributedWidths: (table: SugarElement<HTMLTableElement>, warehouse: Warehouse, tableSize: TableSize, pixelDelta: number) => { delta: number; newSizes: number[] };
 }
 
 const zero = (array: number[]) => Arr.map(array, Fun.constant(0));
@@ -53,23 +52,23 @@ const resizeTable = (): ResizeBehaviour => {
   };
 
   // Calculations for the inner columns/rows
-  const calcLeftEdgeDeltas = (sizes: number[], index: number, next: number, delta: number, minCellSize: number, relativeSizing: boolean) => {
-    if (relativeSizing) {
+  const calcLeftEdgeDeltas = (sizes: number[], index: number, next: number, delta: number, minCellSize: number, isRelative: boolean) => {
+    if (isRelative) {
       return calcRelativeDeltas(sizes, index, delta, minCellSize);
     } else {
       return calcFixedDeltas(sizes, index, next, delta, minCellSize);
     }
   };
 
-  const calcMiddleDeltas = (sizes: number[], _prev: number, index: number, next: number, delta: number, minCellSize: number, relativeSizing: boolean) =>
-    calcLeftEdgeDeltas(sizes, index, next, delta, minCellSize, relativeSizing);
+  const calcMiddleDeltas = (sizes: number[], _prev: number, index: number, next: number, delta: number, minCellSize: number, isRelative: boolean) =>
+    calcLeftEdgeDeltas(sizes, index, next, delta, minCellSize, isRelative);
 
   const resizeTable = (resizer: TableResizer, delta: number) =>
     resizer(delta);
 
   // Calculations for the last column/row resizer
-  const calcRightEdgeDeltas = (sizes: number[], _prev: number, index: number, delta: number, minCellSize: number, relativeSizing: boolean) => {
-    if (relativeSizing) {
+  const calcRightEdgeDeltas = (sizes: number[], _prev: number, index: number, delta: number, minCellSize: number, isRelative: boolean) => {
+    if (isRelative) {
       return calcRelativeDeltas(sizes, index, delta, minCellSize);
     } else {
       const clampedDelta = clampNegativeDelta(sizes, index, delta, minCellSize);
@@ -124,8 +123,8 @@ const preserveTable = (): ResizeBehaviour => {
   };
 
   // Calculations for the last column/row resizer
-  const calcRightEdgeDeltas = (sizes: number[], _prev: number, _index: number, delta: number, _minCellSize: number, relativeSizing: boolean) => {
-    if (relativeSizing) {
+  const calcRightEdgeDeltas = (sizes: number[], _prev: number, _index: number, delta: number, _minCellSize: number, isRelative: boolean) => {
+    if (isRelative) {
       return zero(sizes);
     } else {
       // Distribute the delta amongst all of the columns/rows

--- a/modules/snooker/src/main/ts/ephox/snooker/api/ResizeBehaviour.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/ResizeBehaviour.ts
@@ -1,7 +1,4 @@
 import { Arr, Fun } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
-import { TableSize } from './TableSize';
-import { Warehouse } from './Warehouse';
 
 type TableResizer = (delta: number) => void;
 
@@ -11,7 +8,8 @@ export interface ResizeBehaviour {
   readonly calcLeftEdgeDeltas: (sizes: number[], index: number, nextIndex: number, delta: number, minCellSize: number, relativeSizing: boolean) => number[];
   readonly calcMiddleDeltas: (sizes: number[], previousIndex: number, index: number, nextIndex: number, delta: number, minCellSize: number, relativeSizing: boolean) => number[];
   readonly calcRightEdgeDeltas: (sizes: number[], previousIndex: number, index: number, delta: number, minCellSize: number, relativeSizing: boolean) => number[];
-  readonly getNewWidths: (table: SugarElement<HTMLTableElement>, warehouse: Warehouse, tableSize: TableSize, pixelDelta: number) => { delta: number; newSizes: number[] };
+  readonly calcRedestributedWidths: (sizes: number[], total: number, pixelDelta: number, isRelative: boolean) => { delta: number; newSizes: number[] };
+  // readonly calcRedestributedWidths: (table: SugarElement<HTMLTableElement>, warehouse: Warehouse, tableSize: TableSize, pixelDelta: number) => { delta: number; newSizes: number[] };
 }
 
 const zero = (array: number[]) => Arr.map(array, Fun.constant(0));
@@ -79,12 +77,10 @@ const resizeTable = (): ResizeBehaviour => {
     }
   };
 
-  const getNewWidths = (_table: SugarElement<HTMLTableElement>, warehouse: Warehouse, tableSize: TableSize, pixelDelta: number) => {
-    const sizes = tableSize.getWidths(warehouse, tableSize);
-
-    if (tableSize.isRelative) {
-      const tableWidth = tableSize.pixelWidth() + pixelDelta;
-      const ratio = tableWidth / tableSize.pixelWidth();
+  const calcRedestributedWidths = (sizes: number[], totalWidth: number, pixelDelta: number, isRelative: boolean) => {
+    if (isRelative) {
+      const tableWidth = totalWidth + pixelDelta;
+      const ratio = tableWidth / totalWidth;
       const newSizes = Arr.map(sizes, (size) => size / ratio);
       return {
         delta: (ratio * 100) - 100,
@@ -104,7 +100,7 @@ const resizeTable = (): ResizeBehaviour => {
     calcLeftEdgeDeltas,
     calcMiddleDeltas,
     calcRightEdgeDeltas,
-    getNewWidths,
+    calcRedestributedWidths,
   };
 };
 
@@ -154,12 +150,10 @@ const preserveTable = (): ResizeBehaviour => {
     }
   };
 
-  const getNewWidths = (_table: SugarElement<HTMLTableElement>, warehouse: Warehouse, tableSize: TableSize, _pixelDelta: number) => {
-    const newSizes = tableSize.getWidths(warehouse, tableSize);
-
+  const calcRedestributedWidths = (sizes: number[], _totalWidth: number, _pixelDelta: number, _isRelative: boolean) => {
     return {
       delta: 0,
-      newSizes,
+      newSizes: sizes,
     };
   };
 
@@ -169,7 +163,7 @@ const preserveTable = (): ResizeBehaviour => {
     calcLeftEdgeDeltas,
     calcMiddleDeltas,
     calcRightEdgeDeltas,
-    getNewWidths
+    calcRedestributedWidths
   };
 };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -352,7 +352,7 @@ const firstColumnIsLocked = (_warehouse: Warehouse, details: Structs.DetailExt[]
 const lastColumnIsLocked = (warehouse: Warehouse, details: Structs.DetailExt[]) =>
   Arr.exists(details, (detail) => detail.column + detail.colspan >= warehouse.grid.columns && detail.isLocked);
 
-const getPixelDelta = (details: Structs.DetailExt[]) => {
+const getColumnsWidth = (details: Structs.DetailExt[]) => {
   const uniqueCols = ColUtils.uniqueColumns(details);
   return Arr.foldl(uniqueCols, (acc, detail) => acc + Width.getOuter(detail.element), 0);
 };
@@ -363,7 +363,7 @@ const insertColumnExtractor = (before: boolean) => (warehouse: Warehouse, target
     return !checkLocked(warehouse, [ detail ]);
   }).map((detail) => ({
     detail,
-    pixelDelta: getPixelDelta([ detail ]),
+    pixelDelta: getColumnsWidth([ detail ]),
   }));
 
 const insertColumnsExtractor = (before: boolean) => (warehouse: Warehouse, target: TargetSelection): Optional<ExtractColsDetail> =>
@@ -372,13 +372,13 @@ const insertColumnsExtractor = (before: boolean) => (warehouse: Warehouse, targe
     return !checkLocked(warehouse, details);
   }).map((details) => ({
     details,
-    pixelDelta: getPixelDelta(details),
+    pixelDelta: getColumnsWidth(details),
   }));
 
 const eraseColumnsExtractor = (warehouse: Warehouse, target: TargetSelection): Optional<ExtractColsDetail> =>
   RunOperation.onUnlockedCells(warehouse, target).map((details) => ({
     details,
-    pixelDelta: -getPixelDelta(details), // needs to be negative as we are removing columns
+    pixelDelta: -getColumnsWidth(details), // needs to be negative as we are removing columns
   }));
 
 const pasteColumnsExtractor = (before: boolean) => (warehouse: Warehouse, target: RunOperation.TargetPasteRows): Optional<ExtractPasteRows> =>

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -27,8 +27,15 @@ type ExtractPaste = RunOperation.ExtractPaste;
 type ExtractPasteRows = RunOperation.ExtractPasteRows;
 type TargetSelection = RunOperation.TargetSelection;
 
-interface ExtractColDetail { detail: Structs.DetailExt; pixelDelta: number }
-interface ExtractColsDetail { details: Structs.DetailExt[]; pixelDelta: number }
+interface ExtractColDetail {
+  readonly detail: Structs.DetailExt;
+  readonly pixelDelta: number;
+}
+
+interface ExtractColsDetail {
+  readonly details: Structs.DetailExt[];
+  readonly pixelDelta: number;
+}
 
 type CompElm = (e1: SugarElement, e2: SugarElement) => boolean;
 
@@ -342,7 +349,7 @@ export const getCellsType = <T>(cells: T[], headerPred: (x: T) => boolean): Opti
 
 // Only column modifications force a resizing. Everything else just tries to preserve the table as is.
 const resize = Adjustments.adjustWidthTo;
-const adjustAndRedistribute = Adjustments.adjustAndRedistribute;
+const adjustAndRedistributeWidths = Adjustments.adjustAndRedistributeWidths;
 
 // Custom selection extractors
 
@@ -391,13 +398,13 @@ export const insertRowBefore = RunOperation.run(opInsertRowBefore, RunOperation.
 export const insertRowsBefore = RunOperation.run(opInsertRowsBefore, RunOperation.onCells, Fun.noop, Fun.noop, Generators.modification);
 export const insertRowAfter = RunOperation.run(opInsertRowAfter, RunOperation.onCell, Fun.noop, Fun.noop, Generators.modification);
 export const insertRowsAfter = RunOperation.run(opInsertRowsAfter, RunOperation.onCells, Fun.noop, Fun.noop, Generators.modification);
-export const insertColumnBefore = RunOperation.run(opInsertColumnBefore, insertColumnExtractor(true), adjustAndRedistribute, Fun.noop, Generators.modification);
-export const insertColumnsBefore = RunOperation.run(opInsertColumnsBefore, insertColumnsExtractor(true), adjustAndRedistribute, Fun.noop, Generators.modification);
-export const insertColumnAfter = RunOperation.run(opInsertColumnAfter, insertColumnExtractor(false), adjustAndRedistribute, Fun.noop, Generators.modification);
-export const insertColumnsAfter = RunOperation.run(opInsertColumnsAfter, insertColumnsExtractor(false), adjustAndRedistribute, Fun.noop, Generators.modification);
+export const insertColumnBefore = RunOperation.run(opInsertColumnBefore, insertColumnExtractor(true), adjustAndRedistributeWidths, Fun.noop, Generators.modification);
+export const insertColumnsBefore = RunOperation.run(opInsertColumnsBefore, insertColumnsExtractor(true), adjustAndRedistributeWidths, Fun.noop, Generators.modification);
+export const insertColumnAfter = RunOperation.run(opInsertColumnAfter, insertColumnExtractor(false), adjustAndRedistributeWidths, Fun.noop, Generators.modification);
+export const insertColumnsAfter = RunOperation.run(opInsertColumnsAfter, insertColumnsExtractor(false), adjustAndRedistributeWidths, Fun.noop, Generators.modification);
 export const splitCellIntoColumns = RunOperation.run(opSplitCellIntoColumns, RunOperation.onUnlockedCell, resize, Fun.noop, Generators.modification);
 export const splitCellIntoRows = RunOperation.run(opSplitCellIntoRows, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.modification);
-export const eraseColumns = RunOperation.run(opEraseColumns, eraseColumnsExtractor, adjustAndRedistribute, prune, Generators.modification);
+export const eraseColumns = RunOperation.run(opEraseColumns, eraseColumnsExtractor, adjustAndRedistributeWidths, prune, Generators.modification);
 export const eraseRows = RunOperation.run(opEraseRows, RunOperation.onCells, Fun.noop, prune, Generators.modification);
 export const makeColumnHeader = RunOperation.run(opMakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('row', 'th'));
 export const makeColumnsHeader = RunOperation.run(opMakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('row', 'th'));

--- a/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
@@ -1,6 +1,7 @@
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import { Attribute, Compare, SugarElement, Traverse } from '@ephox/sugar';
 import { Generators, GeneratorsWrapper, SimpleGenerators } from '../api/Generators';
+import * as ResizeBehaviour from '../api/ResizeBehaviour';
 import { ResizeWire } from '../api/ResizeWire';
 import * as Structs from '../api/Structs';
 import * as TableLookup from '../api/TableLookup';
@@ -111,15 +112,15 @@ const extractCells = (warehouse: Warehouse, target: TargetSelection, predicate: 
 type EqEle = (e1: SugarElement, e2: SugarElement) => boolean;
 type Operation<INFO, GW extends GeneratorsWrapper> = (model: Structs.RowCells[], info: INFO, eq: EqEle, w: GW) => TableOperationResult;
 type Extract<RAW, INFO> = (warehouse: Warehouse, target: RAW) => Optional<INFO>;
-type Adjustment = <T extends Structs.DetailNew>(table: SugarElement, grid: Structs.RowDataNew<T>[], tableSize: TableSize) => void;
+type Adjustment<INFO> = <T extends Structs.DetailNew>(table: SugarElement, grid: Structs.RowDataNew<T>[], tableSize: TableSize, resizeBehaviour: ResizeBehaviour.ResizeBehaviour, info: INFO) => void;
 type PostAction = (e: SugarElement) => void;
 type GenWrap<GW extends GeneratorsWrapper> = (g: Generators) => GW;
 
-export type OperationCallback<T> = (wire: ResizeWire, table: SugarElement<HTMLTableElement>, target: T, generators: Generators, sizing?: TableSize) => Optional<RunOperationOutput>;
+export type OperationCallback<T> = (wire: ResizeWire, table: SugarElement<HTMLTableElement>, target: T, generators: Generators, sizing?: TableSize, resizeBehaviour?: ResizeBehaviour.ResizeBehaviour) => Optional<RunOperationOutput>;
 
 const run = <RAW, INFO, GW extends GeneratorsWrapper>
-(operation: Operation<INFO, GW>, extract: Extract<RAW, INFO>, adjustment: Adjustment, postAction: PostAction, genWrappers: GenWrap<GW>): OperationCallback<RAW> =>
-  (wire: ResizeWire, table: SugarElement<HTMLTableElement>, target: RAW, generators: Generators, sizing?: TableSize): Optional<RunOperationOutput> => {
+(operation: Operation<INFO, GW>, extract: Extract<RAW, INFO>, adjustment: Adjustment<INFO>, postAction: PostAction, genWrappers: GenWrap<GW>): OperationCallback<RAW> =>
+  (wire: ResizeWire, table: SugarElement<HTMLTableElement>, target: RAW, generators: Generators, sizing?: TableSize, resizeBehaviour?: ResizeBehaviour.ResizeBehaviour): Optional<RunOperationOutput> => {
     const warehouse = Warehouse.fromTable(table);
     const output = extract(warehouse, target).map((info) => {
       const model = fromWarehouse(warehouse, generators);
@@ -127,6 +128,7 @@ const run = <RAW, INFO, GW extends GeneratorsWrapper>
       const lockedColumns = LockedColumnUtils.getLockedColumnsFromGrid(result.grid);
       const grid = toDetailList(result.grid, generators);
       return {
+        info,
         grid,
         cursor: result.cursor,
         lockedColumns
@@ -136,7 +138,8 @@ const run = <RAW, INFO, GW extends GeneratorsWrapper>
     return output.bind((out) => {
       const newElements = Redraw.render(table, out.grid);
       const tableSizing = Optional.from(sizing).getOrThunk(() => TableSize.getTableSize(table));
-      adjustment(table, out.grid, tableSizing);
+      const resizing = Optional.from(resizeBehaviour).getOrThunk(ResizeBehaviour.preserveTable);
+      adjustment(table, out.grid, tableSizing, resizing, out.info);
       postAction(table);
       Bars.refresh(wire, table);
       // Update locked cols attribute

--- a/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
@@ -112,7 +112,7 @@ const extractCells = (warehouse: Warehouse, target: TargetSelection, predicate: 
 type EqEle = (e1: SugarElement, e2: SugarElement) => boolean;
 type Operation<INFO, GW extends GeneratorsWrapper> = (model: Structs.RowCells[], info: INFO, eq: EqEle, w: GW) => TableOperationResult;
 type Extract<RAW, INFO> = (warehouse: Warehouse, target: RAW) => Optional<INFO>;
-type Adjustment<INFO> = <T extends Structs.DetailNew>(table: SugarElement, grid: Structs.RowDataNew<T>[], tableSize: TableSize, resizeBehaviour: ResizeBehaviour.ResizeBehaviour, info: INFO) => void;
+type Adjustment<INFO> = <T extends Structs.DetailNew>(table: SugarElement, grid: Structs.RowDataNew<T>[], info: INFO, tableSize: TableSize, resizeBehaviour: ResizeBehaviour.ResizeBehaviour) => void;
 type PostAction = (e: SugarElement) => void;
 type GenWrap<GW extends GeneratorsWrapper> = (g: Generators) => GW;
 
@@ -139,7 +139,7 @@ const run = <RAW, INFO, GW extends GeneratorsWrapper>
       const newElements = Redraw.render(table, out.grid);
       const tableSizing = Optional.from(sizing).getOrThunk(() => TableSize.getTableSize(table));
       const resizing = Optional.from(resizeBehaviour).getOrThunk(ResizeBehaviour.preserveTable);
-      adjustment(table, out.grid, tableSizing, resizing, out.info);
+      adjustment(table, out.grid, out.info, tableSizing, resizing);
       postAction(table);
       Bars.refresh(wire, table);
       // Update locked cols attribute

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
-import { ResizeBehaviour } from '../api/ResizeBehaviour';
+import * as ResizeBehaviour from '../api/ResizeBehaviour';
 import { Detail, RowData } from '../api/Structs';
 import { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
@@ -30,7 +30,7 @@ const recalculateAndApply = (warehouse: Warehouse, widths: number[], tableSize: 
   });
 };
 
-const adjustWidth = (table: SugarElement, delta: number, index: number, resizing: ResizeBehaviour, tableSize: TableSize): void => {
+const adjustWidth = (table: SugarElement, delta: number, index: number, resizing: ResizeBehaviour.ResizeBehaviour, tableSize: TableSize): void => {
   const warehouse = Warehouse.fromTable(table);
   const step = tableSize.getCellDelta(delta);
   const widths = tableSize.getWidths(warehouse, tableSize);
@@ -66,6 +66,15 @@ const adjustHeight = (table: SugarElement, delta: number, index: number, directi
   Sizes.setHeight(table, total);
 };
 
+// Using the width of the added/removed columns gathered on extraction (pixelDelta), get and apply the new column sizes and overall table width delta
+const adjustAndRedistribute = <T extends Detail> (table: SugarElement<HTMLTableElement>, list: RowData<T>[], tableSize: TableSize, resizeBehaviour: ResizeBehaviour.ResizeBehaviour, details: { pixelDelta: number }): void => {
+  const warehouse = Warehouse.generate(list);
+
+  const { newSizes, delta } = resizeBehaviour.getNewWidths(table, warehouse, tableSize, details.pixelDelta);
+  recalculateAndApply(warehouse, newSizes, tableSize);
+  tableSize.adjustTableWidth(delta);
+};
+
 // Ensure that the width of table cells match the passed in table information.
 const adjustWidthTo = <T extends Detail> (table: SugarElement, list: RowData<T>[], tableSize: TableSize): void => {
   const warehouse = Warehouse.generate(list);
@@ -74,4 +83,4 @@ const adjustWidthTo = <T extends Detail> (table: SugarElement, list: RowData<T>[
   recalculateAndApply(warehouse, widths, tableSize);
 };
 
-export { adjustWidth, adjustHeight, adjustWidthTo };
+export { adjustWidth, adjustHeight, adjustWidthTo, adjustAndRedistribute };

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
-import * as ResizeBehaviour from '../api/ResizeBehaviour';
+import { ResizeBehaviour } from '../api/ResizeBehaviour';
 import { Detail, RowData } from '../api/Structs';
 import { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
@@ -30,7 +30,7 @@ const recalculateAndApply = (warehouse: Warehouse, widths: number[], tableSize: 
   });
 };
 
-const adjustWidth = (table: SugarElement, delta: number, index: number, resizing: ResizeBehaviour.ResizeBehaviour, tableSize: TableSize): void => {
+const adjustWidth = (table: SugarElement, delta: number, index: number, resizing: ResizeBehaviour, tableSize: TableSize): void => {
   const warehouse = Warehouse.fromTable(table);
   const step = tableSize.getCellDelta(delta);
   const widths = tableSize.getWidths(warehouse, tableSize);
@@ -67,16 +67,18 @@ const adjustHeight = (table: SugarElement, delta: number, index: number, directi
 };
 
 // Using the width of the added/removed columns gathered on extraction (pixelDelta), get and apply the new column sizes and overall table width delta
-const adjustAndRedistribute = <T extends Detail> (table: SugarElement<HTMLTableElement>, list: RowData<T>[], tableSize: TableSize, resizeBehaviour: ResizeBehaviour.ResizeBehaviour, details: { pixelDelta: number }): void => {
+const adjustAndRedistribute = <T extends Detail> (_table: SugarElement<HTMLTableElement>, list: RowData<T>[], details: { pixelDelta: number }, tableSize: TableSize, resizeBehaviour: ResizeBehaviour): void => {
   const warehouse = Warehouse.generate(list);
+  const sizes = tableSize.getWidths(warehouse, tableSize);
+  const tablePixelWidth = tableSize.pixelWidth();
 
-  const { newSizes, delta } = resizeBehaviour.getNewWidths(table, warehouse, tableSize, details.pixelDelta);
+  const { newSizes, delta } = resizeBehaviour.calcRedestributedWidths(sizes, tablePixelWidth, details.pixelDelta, tableSize.isRelative);
   recalculateAndApply(warehouse, newSizes, tableSize);
   tableSize.adjustTableWidth(delta);
 };
 
 // Ensure that the width of table cells match the passed in table information.
-const adjustWidthTo = <T extends Detail> (table: SugarElement, list: RowData<T>[], tableSize: TableSize): void => {
+const adjustWidthTo = <T extends Detail> (_table: SugarElement, list: RowData<T>[], _info: { }, tableSize: TableSize): void => {
   const warehouse = Warehouse.generate(list);
   const widths = tableSize.getWidths(warehouse, tableSize);
 

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
@@ -67,7 +67,7 @@ const adjustHeight = (table: SugarElement, delta: number, index: number, directi
 };
 
 // Using the width of the added/removed columns gathered on extraction (pixelDelta), get and apply the new column sizes and overall table width delta
-const adjustAndRedistribute = <T extends Detail> (_table: SugarElement<HTMLTableElement>, list: RowData<T>[], details: { pixelDelta: number }, tableSize: TableSize, resizeBehaviour: ResizeBehaviour): void => {
+const adjustAndRedistributeWidths = <T extends Detail> (_table: SugarElement<HTMLTableElement>, list: RowData<T>[], details: { pixelDelta: number }, tableSize: TableSize, resizeBehaviour: ResizeBehaviour): void => {
   const warehouse = Warehouse.generate(list);
   const sizes = tableSize.getWidths(warehouse, tableSize);
   const tablePixelWidth = tableSize.pixelWidth();
@@ -85,4 +85,4 @@ const adjustWidthTo = <T extends Detail> (_table: SugarElement, list: RowData<T>
   recalculateAndApply(warehouse, widths, tableSize);
 };
 
-export { adjustWidth, adjustHeight, adjustWidthTo, adjustAndRedistribute };
+export { adjustWidth, adjustHeight, adjustWidthTo, adjustAndRedistributeWidths };

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,6 +7,7 @@ Version 5.7.0 (TBD)
     Added new `font_css` setting for fonts to be added to both containing document and the editor #TINY-6199
     Added a new `ImageUploader` API to simplify uploading image data to the configured `images_upload_url` or `images_upload_handler` #TINY-4601
     Added Oxide variable to define the container background color in fullscreen mode #TINY-6903
+    Added enhanced table resizing behavior when inserting or deleting columns with improved respect for the `table_column_resizing` option #TINY-6711
     Changed copying table columns or entire tables will now retain an appropriate width when pasted #TINY-6664
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,13 +7,13 @@ Version 5.7.0 (TBD)
     Added new `font_css` setting for fonts to be added to both containing document and the editor #TINY-6199
     Added a new `ImageUploader` API to simplify uploading image data to the configured `images_upload_url` or `images_upload_handler` #TINY-4601
     Added Oxide variable to define the container background color in fullscreen mode #TINY-6903
-    Added enhanced table resizing behavior when inserting or deleting columns with improved respect for the `table_column_resizing` option #TINY-6711
     Changed copying table columns or entire tables will now retain an appropriate width when pasted #TINY-6664
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
     Changed the z-index of the `setProgressState(true)` throbber so it does not hide notifications #TINY-6686
     Changed the type signature for `editor.selection.getRng()` incorrectly returning `null` #TINY-6843
     Changed some `SaxParser` regular expressions to improve performance #TINY-6823
+    Changed table and column resizing behavior when using the `table_column_resizing` option #TINY-6711
     Fixed `col` elements incorrectly transformed to `th` elements when converting columns to header columns #TINY-6715
     Fixed a number of table operations not working when selecting 2 table cells on Mozilla Firefox #TINY-3897
     Fixed a memory leak by backporting an upstream Sizzle fix #TINY-6859
@@ -32,6 +32,7 @@ Version 5.7.0 (TBD)
     Fixed the type signature for `editor.selection.setCursorLocation()` incorrectly allowing a node with no `offset` #TINY-6843
     Fixed incorrect behaviour when editor is destroyed while loading stylesheets #INT-2282
     Fixed inserting multiple rows or columns in a table cloning from the incorrect source row or column #TINY-6906
+    Fixed a bug where inserting columns into a table would result in incorrect table and column widths #TINY-6711
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,13 +7,13 @@ Version 5.7.0 (TBD)
     Added new `font_css` setting for fonts to be added to both containing document and the editor #TINY-6199
     Added a new `ImageUploader` API to simplify uploading image data to the configured `images_upload_url` or `images_upload_handler` #TINY-4601
     Added Oxide variable to define the container background color in fullscreen mode #TINY-6903
+    Added support for `table_column_resizing` when inserting or deleting columns #TINY-6711
     Changed copying table columns or entire tables will now retain an appropriate width when pasted #TINY-6664
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
     Changed the z-index of the `setProgressState(true)` throbber so it does not hide notifications #TINY-6686
     Changed the type signature for `editor.selection.getRng()` incorrectly returning `null` #TINY-6843
     Changed some `SaxParser` regular expressions to improve performance #TINY-6823
-    Changed table and column resizing behavior when using the `table_column_resizing` option #TINY-6711
     Fixed `col` elements incorrectly transformed to `th` elements when converting columns to header columns #TINY-6715
     Fixed a number of table operations not working when selecting 2 table cells on Mozilla Firefox #TINY-3897
     Fixed a memory leak by backporting an upstream Sizzle fix #TINY-6859
@@ -32,7 +32,6 @@ Version 5.7.0 (TBD)
     Fixed the type signature for `editor.selection.setCursorLocation()` incorrectly allowing a node with no `offset` #TINY-6843
     Fixed incorrect behaviour when editor is destroyed while loading stylesheets #INT-2282
     Fixed inserting multiple rows or columns in a table cloning from the incorrect source row or column #TINY-6906
-    Fixed a bug where inserting columns into a table would result in incorrect table and column widths #TINY-6711
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
@@ -68,7 +68,7 @@ export const TableActions = (editor: Editor, lazyWire: () => ResizeWire, selecti
   // Optional.none gives the default cloneFormats.
   const cloneFormats = getCloneElements(editor);
 
-  const colMutationOp = isResizeTableColumnResizing(editor) ? Fun.identity : CellMutations.halve;
+  const colMutationOp = isResizeTableColumnResizing(editor) ? Fun.noop : CellMutations.halve;
 
   const execute = <T> (operation: RunOperation.OperationCallback<T>, guard: GuardFn, mutate: MutateFn, lazyWire: () => ResizeWire, effect: Events.TableEventData) =>
     (table: SugarElement<HTMLTableElement>, target: T): Optional<TableActionResult> => {

--- a/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
@@ -8,11 +8,11 @@
 import { Selections } from '@ephox/darwin';
 import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
 import { DomDescent } from '@ephox/phoenix';
-import { CellMutations, ResizeWire, RunOperation, TableFill, TableGridSize, TableOperations } from '@ephox/snooker';
+import { CellMutations, ResizeBehaviour, ResizeWire, RunOperation, TableFill, TableGridSize, TableOperations } from '@ephox/snooker';
 import { SugarElement, SugarNode } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import * as Events from '../api/Events';
-import { getCloneElements } from '../api/Settings';
+import { getCloneElements, isResizeTableColumnResizing } from '../api/Settings';
 import { getRowType, switchCellsType, switchSectionType } from '../core/TableSections';
 import * as Util from '../core/Util';
 import * as TableSize from '../queries/TableSize';
@@ -68,6 +68,8 @@ export const TableActions = (editor: Editor, lazyWire: () => ResizeWire, selecti
   // Optional.none gives the default cloneFormats.
   const cloneFormats = getCloneElements(editor);
 
+  const colMutationOp = isResizeTableColumnResizing(editor) ? Fun.identity : CellMutations.halve;
+
   const execute = <T> (operation: RunOperation.OperationCallback<T>, guard: GuardFn, mutate: MutateFn, lazyWire: () => ResizeWire, effect: Events.TableEventData) =>
     (table: SugarElement<HTMLTableElement>, target: T): Optional<TableActionResult> => {
       Util.removeDataStyle(table);
@@ -75,7 +77,8 @@ export const TableActions = (editor: Editor, lazyWire: () => ResizeWire, selecti
       const doc = SugarElement.fromDom(editor.getDoc());
       const generators = TableFill.cellOperations(mutate, doc, cloneFormats);
       const sizing = TableSize.get(editor, table);
-      return guard(table) ? operation(wire, table, target, generators, sizing).bind((result) => {
+      const resizeBehaviour = isResizeTableColumnResizing(editor) ? ResizeBehaviour.resizeTable() : ResizeBehaviour.preserveTable();
+      return guard(table) ? operation(wire, table, target, generators, sizing, resizeBehaviour).bind((result) => {
         Arr.each(result.newRows, (row) => {
           Events.fireNewRow(editor, row.dom);
         });
@@ -103,9 +106,9 @@ export const TableActions = (editor: Editor, lazyWire: () => ResizeWire, selecti
 
   const insertRowsAfter = execute(TableOperations.insertRowsAfter, Fun.always, Fun.noop, lazyWire, Events.structureModified);
 
-  const insertColumnsBefore = execute(TableOperations.insertColumnsBefore, Fun.always, CellMutations.halve, lazyWire, Events.structureModified);
+  const insertColumnsBefore = execute(TableOperations.insertColumnsBefore, Fun.always, colMutationOp, lazyWire, Events.structureModified);
 
-  const insertColumnsAfter = execute(TableOperations.insertColumnsAfter, Fun.always, CellMutations.halve, lazyWire, Events.structureModified);
+  const insertColumnsAfter = execute(TableOperations.insertColumnsAfter, Fun.always, colMutationOp, lazyWire, Events.structureModified);
 
   const mergeCells = execute(TableOperations.mergeCells, Fun.always, Fun.noop, lazyWire, Events.structureModified);
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
@@ -1,5 +1,6 @@
 import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { PlatformDetection } from '@ephox/sand';
 import { SelectorFind, Width } from '@ephox/sugar';
 import { assert } from 'chai';
 
@@ -17,6 +18,8 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
     base_url: '/project/tinymce/js/tinymce',
   };
 
+  const platform = PlatformDetection.detect();
+
   const getTableWidth = (editor: Editor) =>
     SelectorFind.child<HTMLTableElement>(TinyDom.body(editor), 'table').map(Width.get).getOrDie();
 
@@ -25,7 +28,8 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
     editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
     editor.execCommand('mceTableInsertColAfter');
     const afterWidth = getTableWidth(editor);
-    assert.approximately(afterWidth, beforeWidth * multiplier, 2);
+    // 2px margin of error, 30px margin of error for IE
+    assert.approximately(afterWidth, beforeWidth * multiplier, platform.browser.isIE() ? 30 : 2);
   };
 
   // TODO: tests for colspan #TINY-6949

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
@@ -1,5 +1,5 @@
 import { before, context, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, McEditor, TinyDom } from '@ephox/mcagar';
+import { McEditor, TinyDom } from '@ephox/mcagar';
 import { SelectorFind, Width } from '@ephox/sugar';
 import { assert } from 'chai';
 
@@ -26,9 +26,6 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
   const getTableWidth = (editor: Editor) =>
     SelectorFind.child<HTMLTableElement>(TinyDom.body(editor), 'table').map((table) => Width.get(table)).getOrDie();
 
-  // TODO: colgroups
-  // TODO: Insert multiple
-  // TODO: use data-mce-selected
   // TODO: colspan
   context('Responsive table', () => {
     context('table_column_resizing=preservetable', () => {
@@ -42,7 +39,7 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
             <tbody>
               <tr>
                 <td></td>
-                <td id="selected"></td>
+                <td data-mce-selected="1"></td>
               </tr>
               <tr>
                 <td></td>
@@ -52,10 +49,68 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
           </table>
         `);
         const beforeWidth = getTableWidth(editor);
-        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
         editor.execCommand('mceTableInsertColAfter');
         const afterWidth = getTableWidth(editor);
         assert.closeTo(afterWidth, beforeWidth * 1.5, 2);
+        McEditor.remove(editor);
+      });
+
+      it('will resize when inserting multiple columns', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'responsive',
+          table_column_resizing: 'preservetable',
+        });
+        editor.setContent(`
+          <table>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 2, 2);
+        McEditor.remove(editor);
+      });
+
+      it('will function with a colgroup', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'responsive',
+          table_column_resizing: 'preservetable',
+        });
+        editor.setContent(`
+          <table>
+            <colgroup>
+              <col>
+              <col>
+            </colgroup>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 2, 2);
         McEditor.remove(editor);
       });
     });
@@ -71,7 +126,7 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
             <tbody>
               <tr>
                 <td></td>
-                <td id="selected"></td>
+                <td data-mce-selected="1"></td>
               </tr>
               <tr>
                 <td></td>
@@ -81,10 +136,68 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
           </table>
         `);
         const beforeWidth = getTableWidth(editor);
-        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
         editor.execCommand('mceTableInsertColAfter');
         const afterWidth = getTableWidth(editor);
         assert.closeTo(afterWidth, beforeWidth * 1.5, 2);
+        McEditor.remove(editor);
+      });
+
+      it('will resize when inserting multiple columns', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'responsive',
+          table_column_resizing: 'resizetable',
+        });
+        editor.setContent(`
+          <table>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 2, 2);
+        McEditor.remove(editor);
+      });
+
+      it('will function with a colgroup', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'responsive',
+          table_column_resizing: 'resizetable',
+        });
+        editor.setContent(`
+          <table>
+            <colgroup>
+              <col>
+              <col>
+            </colgroup>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 2, 2);
         McEditor.remove(editor);
       });
     });
@@ -102,7 +215,7 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
             <tbody>
               <tr>
                 <td style="width: 184.219px;"></td>
-                <td id="selected" style="width: 242.219px;"></td>
+                <td data-mce-selected="1" style="width: 242.219px;"></td>
               </tr>
               <tr>
                 <td style="width: 184.219px;"></td>
@@ -112,7 +225,65 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
           </table>
         `);
         const beforeWidth = getTableWidth(editor);
-        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth, 2);
+        McEditor.remove(editor);
+      });
+
+      it('should preserve table width when inserting multiple columns', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'fixed',
+          table_column_resizing: 'preservetable',
+        });
+        editor.setContent(`
+          <table style="width: 455px;">
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1" style="width: 184.219px;"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1" style="width: 242.219px;"></td>
+              </tr>
+              <tr>
+                <td style="width: 184.219px;"></td>
+                <td style="width: 242.219px;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth, 2);
+        McEditor.remove(editor);
+      });
+
+      it('will preserve width with a colgroup', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'fixed',
+          table_column_resizing: 'preservetable',
+        });
+        editor.setContent(`
+          <table style="width: 865px;">
+            <colgroup>
+              <col style="width: 432px;"/>
+              <col style="width: 432px;"/>
+            </colgroup>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
         editor.execCommand('mceTableInsertColAfter');
         const afterWidth = getTableWidth(editor);
         assert.closeTo(afterWidth, beforeWidth, 2);
@@ -131,7 +302,7 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
             <tbody>
               <tr>
                 <td style="width: 323px;"></td>
-                <td id="selected" style="width: 322px;"></td>
+                <td data-mce-selected="1" style="width: 322px;"></td>
               </tr>
               <tr>
                 <td style="width: 323px;"></td>
@@ -141,10 +312,68 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
           </table>
         `);
         const beforeWidth = getTableWidth(editor);
-        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
         editor.execCommand('mceTableInsertColAfter');
         const afterWidth = getTableWidth(editor);
         assert.closeTo(afterWidth, beforeWidth * 1.5, 2);
+        McEditor.remove(editor);
+      });
+
+      it('should resize table when inserting multiple columns', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'fixed',
+          table_column_resizing: 'resizetable',
+        });
+        editor.setContent(`
+          <table style="width: 674px">
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1" style="width: 323px;"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1" style="width: 322px;"></td>
+              </tr>
+              <tr>
+                <td style="width: 323px;"></td>
+                <td style="width: 322px;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 2, 2);
+        McEditor.remove(editor);
+      });
+
+      it('should resize table when using a colgroup', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'fixed',
+          table_column_resizing: 'resizetable',
+        });
+        editor.setContent(`
+          <table style="width: 432px;">
+            <colgroup>
+              <col style="width: 216px;"/>
+              <col style="width: 216px;"/>
+            </colgroup>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 2, 2);
         McEditor.remove(editor);
       });
     });
@@ -162,7 +391,7 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
             <tbody>
               <tr style="height: 21px;">
                 <td style="width: 50.6463%;"></td>
-                <td id="selected" style="width: 49.3537%;"></td>
+                <td data-mce-selected="1" style="width: 49.3537%;"></td>
               </tr>
               <tr style="height: 22px;">
                 <td style="width: 50.6463%;"></td>
@@ -172,7 +401,65 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
           </table>
         `);
         const beforeWidth = getTableWidth(editor);
-        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth, 2);
+        McEditor.remove(editor);
+      });
+
+      it('should preserve table width when inserting multiple columns', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'relative',
+          table_column_resizing: 'preservetable',
+        });
+        editor.setContent(`
+          <table style="width: 50%;">
+            <tbody>
+              <tr style="height: 21px;">
+                <td data-mce-selected="1" data-mce-first-selected="1" style="width: 50.6463%;"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1" style="width: 49.3537%;"></td>
+              </tr>
+              <tr style="height: 22px;">
+                <td style="width: 50.6463%;"></td>
+                <td style="width: 49.3537%;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth, 2);
+        McEditor.remove(editor);
+      });
+
+      it('should preserve table width when using a colgroup', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'relative',
+          table_column_resizing: 'preservetable',
+        });
+        editor.setContent(`
+          <table style="width: 57.8035%;">
+            <colgroup>
+              <col style="width: 49.9422%;"/>
+              <col style="width: 49.9422%;"/>
+            </colgroup>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
         editor.execCommand('mceTableInsertColAfter');
         const afterWidth = getTableWidth(editor);
         assert.closeTo(afterWidth, beforeWidth, 2);
@@ -191,7 +478,7 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
             <tbody>
               <tr>
                 <td style="width: 47.0386%;"></td>
-                <td id="selected" style="width: 47.9985%;"></td>
+                <td data-mce-selected="1" style="width: 47.9985%;"></td>
               </tr>
               <tr>
                 <td style="width: 47.0386%;"></td>
@@ -201,10 +488,68 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
           </table>
         `);
         const beforeWidth = getTableWidth(editor);
-        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
         editor.execCommand('mceTableInsertColAfter');
         const afterWidth = getTableWidth(editor);
         assert.closeTo(afterWidth, beforeWidth * 1.5, 2);
+        McEditor.remove(editor);
+      });
+
+      it('should should resize table when inserting multiple columns', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'relative',
+          table_column_resizing: 'resizetable',
+        });
+        editor.setContent(`
+          <table width: 33.3433%; border="1">
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1" style="width: 47.0386%;"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1" style="width: 47.9985%;"></td>
+              </tr>
+              <tr>
+                <td style="width: 47.0386%;"></td>
+                <td style="width: 47.9985%;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 2, 2);
+        McEditor.remove(editor);
+      });
+
+      it('should should resize table when using a colgroup', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'relative',
+          table_column_resizing: 'resizetable',
+        });
+        editor.setContent(`
+          <table style="width: 57.8035%;">
+            <colgroup>
+              <col style="width: 49.9422%;"/>
+              <col style="width: 49.9422%;"/>
+            </colgroup>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" data-mce-first-selected="1"></td>
+                <td data-mce-selected="1" data-mce-last-selected="1"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 2, 2);
         McEditor.remove(editor);
       });
     });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
@@ -1,200 +1,212 @@
-import { Assertions, Chain, Guard, Log, NamedChain, TestLogs, UiFinder } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { McEditor, TinyDom } from '@ephox/mcagar';
-import { SelectorFind } from '@ephox/sugar';
+import { before, context, describe, it } from '@ephox/bedrock-client';
+import { LegacyUnit, McEditor, TinyDom } from '@ephox/mcagar';
+import { SelectorFind, Width } from '@ephox/sugar';
+import { assert } from 'chai';
 
+import Editor from 'tinymce/core/api/Editor';
+import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-import * as TableTestUtils from '../module/test/TableTestUtils';
 
-UnitTest.asynctest('browser.tinymce.plugins.table.InsertColumnTableResizeTest', (success, failure) => {
+describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
+  /**
+   * Test the width of tables before and after column operations
+   * There is a 2 pixel delta allowed from the expected width, to account for table borders
+   */
 
-  Plugin();
-  SilverTheme();
+  before(() => {
+    Plugin();
+  });
 
-  interface TestData {
-    html: string;
-  }
+  const pCreateEditor = (settings: RawEditorSettings) => McEditor.pFromSettings<Editor>({
+    ...settings,
+    plugins: 'table',
+    base_url: '/project/tinymce/js/tinymce',
+  });
 
-  const emptyTable = {
-    html: '<table style = "width: 100%;">' +
-            '<tbody>' +
-              '<tr>' +
-                '<td></td>' +
-                '<td></td>' +
-              '</tr>' +
-              '<tr>' +
-                '<td></td>' +
-                '<td></td>' +
-              '</tr>' +
-            '</tbody>' +
-            '</table>'
-  };
+  const getTableWidth = (editor: Editor) =>
+    SelectorFind.child<HTMLTableElement>(TinyDom.body(editor), 'table').map((table) => Width.get(table)).getOrDie();
 
-  const contentsInSomeCells = {
-    html: '<table style = "width: 100%;">' +
-            '<tbody>' +
-              '<tr>' +
-                '<td>a1</td>' +
-                '<td>b1</td>' +
-              '</tr>' +
-              '<tr>' +
-                '<td></td>' +
-                '<td></td>' +
-              '</tr>' +
-            '</tbody>' +
-          '</table>'
-  };
-
-  const contentsInAllCells = {
-    html: '<table style = "width: 100%;">' +
-            '<tbody>' +
-              '<tr>' +
-                '<td>a1</td>' +
-                '<td>b1</td>' +
-              '</tr>' +
-              '<tr>' +
-                '<td>a2</td>' +
-                '<td>b2</td>' +
-              '</tr>' +
-              '<tr>' +
-                '<td>a3</td>' +
-                '<td>b3</td>' +
-              '</tr>' +
-            '</tbody>' +
-          '</table>'
-  };
-
-  const tableWithHeadings = {
-    html: '<table style = "width: 100%;">' +
-            '<tbody>' +
-              '<tr>' +
-                '<th>a1</th>' +
-                '<th>b1</th>' +
-              '</tr>' +
-              '<tr>' +
-                '<td>a1</td>' +
-                '<td>b1</td>' +
-              '</tr>' +
-              '<tr>' +
-                '<td>a2</td>' +
-                '<td>b2</td>' +
-              '</tr>' +
-            '</tbody>' +
-          '</table>'
-  };
-
-  const tableWithCaption = {
-    html: '<table style = "width: 100%;">' +
-            '<caption>alphabet</caption>' +
-            '<tbody>' +
-              '<tr>' +
-                '<td>a1</td>' +
-                '<td>b1</td>' +
-              '</tr>' +
-              '<tr>' +
-                '<td>a2</td>' +
-                '<td>b2</td>' +
-              '</tr>' +
-            '</tbody>' +
-          '</table>'
-  };
-
-  const nestedTables = {
-    html: '<table style = "width: 100%;">' +
-            '<tbody>' +
-              '<tr>' +
-                '<td>a1' +
-                  '<table style = "width: 100%;">' +
-                  '<tbody>' +
-                    '<tr>' +
-                      '<td></td>' +
-                      '<td></td>' +
-                    '</tr>' +
-                    '<tr>' +
-                      '<td></td>' +
-                      '<td></td>' +
-                    '</tr>' +
-                  '</tbody>' +
-                  '</table>' +
-                '</td>' +
-                '<td>b1</td>' +
-              '</tr>' +
-              '<tr>' +
-                '<td>a2</td>' +
-                '<td>b2</td>' +
-              '</tr>' +
-            '</tbody>' +
-          '</table>'
-  };
-
-  const cInsertTable = (label: string, table: string) => Chain.control(
-    Chain.mapper((editor: any) => {
-      editor.setContent(table);
-      const bodyElem = TinyDom.fromDom(editor.getBody());
-      const tableElem = UiFinder.findIn(bodyElem, 'table').getOr(bodyElem);
-      SelectorFind.descendant(tableElem, 'td,th').each((cell) => {
-        editor.selection.select(cell.dom, true);
-        editor.selection.collapse(true);
+  // TODO: colgroups
+  // TODO: Insert multiple
+  // TODO: use data-mce-selected
+  // TODO: colspan
+  context('Responsive table', () => {
+    context('table_column_resizing=preservetable', () => {
+      it('will resize table because responsive tables cannot honour this setting', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'responsive',
+          table_column_resizing: 'preservetable',
+        });
+        editor.setContent(`
+          <table>
+            <tbody>
+              <tr>
+                <td></td>
+                <td id="selected"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 1.5, 2);
+        McEditor.remove(editor);
       });
-      return tableElem;
-    }),
-    Guard.addLogging(`Insert ${label}`)
-  );
+    });
 
-  const cInsertColumnMeasureWidth = (label: string, data: TestData) => Log.chain('TBA', 'Insert column before, insert column after, erase column and measure table widths', NamedChain.asChain(
-    [
-      NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
-      Chain.label('Insert table', NamedChain.direct('editor', cInsertTable(label, data.html), 'element')),
-      Chain.label('Drag SE (-100, 0)', NamedChain.read('editor', TableTestUtils.cDragHandle('se', -100, 0))),
-      Chain.label('Store width before split', NamedChain.write('widthBefore', TableTestUtils.cGetWidth)),
-      Chain.label('Insert column before', NamedChain.read('editor', TableTestUtils.cInsertColumnBefore)),
-      Chain.label('Insert column after', NamedChain.read('editor', TableTestUtils.cInsertColumnAfter)),
-      Chain.label('Delete column', NamedChain.read('editor', TableTestUtils.cDeleteColumn)),
-      Chain.label('Store width after split', NamedChain.write('widthAfter', TableTestUtils.cGetWidth)),
-      NamedChain.merge([ 'widthBefore', 'widthAfter' ], 'widths'),
-      NamedChain.output('widths')
-    ]
-  ));
+    context('table_column_resizing=resizetable', () => {
+      it('should resize table when inserting a column', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'responsive',
+          table_column_resizing: 'resizetable',
+        });
+        editor.setContent(`
+          <table>
+            <tbody>
+              <tr>
+                <td></td>
+                <td id="selected"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 1.5, 2);
+        McEditor.remove(editor);
+      });
+    });
+  });
 
-  const cAssertWidths = Chain.label(
-    'Assert widths before and after insert column are equal',
-    Chain.op((input: any) => {
-      if (input.widthBefore.isPercent) {
-        // due to rounding errors we can be off by one pixel for percentage tables
-        const actualDiff = Math.abs(input.widthBefore.px - input.widthAfter.px);
-        Assert.eq(`table width should be approx (within 1px): ${input.widthBefore.raw}% (${input.widthBefore.px}px) ~= ${input.widthAfter.raw}% (${input.widthAfter.px}px)`, true, actualDiff <= 1);
-      } else {
-        Assertions.assertEq('table width should not change', input.widthBefore, input.widthAfter);
-      }
-    })
-  );
+  context('Fixed width table', () => {
+    context('table_column_resizing=preservetable', () => {
+      it('should preserve table width when inserting a column', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'fixed',
+          table_column_resizing: 'preservetable',
+        });
+        editor.setContent(`
+          <table style="width: 455px;">
+            <tbody>
+              <tr>
+                <td style="width: 184.219px;"></td>
+                <td id="selected" style="width: 242.219px;"></td>
+              </tr>
+              <tr>
+                <td style="width: 184.219px;"></td>
+                <td style="width: 242.219px;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth, 2);
+        McEditor.remove(editor);
+      });
+    });
 
-  const cAssertWidth = (label: string, data: TestData) => Chain.label(
-    `Assert width of table ${label} after inserting column`,
-    NamedChain.asChain([
-      NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
-      NamedChain.direct('editor', cInsertColumnMeasureWidth(label, data), 'widths'),
-      NamedChain.read('widths', cAssertWidths)
-    ])
-  );
+    context('table_column_resizing=resizetable', () => {
+      it('should resize table when inserting a column', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'fixed',
+          table_column_resizing: 'resizetable',
+        });
+        editor.setContent(`
+          <table style="width: 674px">
+            <tbody>
+              <tr>
+                <td style="width: 323px;"></td>
+                <td id="selected" style="width: 322px;"></td>
+              </tr>
+              <tr>
+                <td style="width: 323px;"></td>
+                <td style="width: 322px;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 1.5, 2);
+        McEditor.remove(editor);
+      });
+    });
+  });
 
-  NamedChain.pipeline(Log.chains('TBA', 'Table: Insert columns, erase column and assert the table width does not change', [
-    NamedChain.write('editor', McEditor.cFromSettings({
-      plugins: 'table',
-      width: 400,
-      theme: 'silver',
-      base_url: '/project/tinymce/js/tinymce'
-    })),
+  context('Relative table', () => {
+    context('table_column_resizing=preservetable', () => {
+      it('should preserve table width when inserting a column', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'relative',
+          table_column_resizing: 'preservetable',
+        });
+        editor.setContent(`
+          <table style="width: 50%;">
+            <tbody>
+              <tr style="height: 21px;">
+                <td style="width: 50.6463%;"></td>
+                <td id="selected" style="width: 49.3537%;"></td>
+              </tr>
+              <tr style="height: 22px;">
+                <td style="width: 50.6463%;"></td>
+                <td style="width: 49.3537%;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth, 2);
+        McEditor.remove(editor);
+      });
+    });
 
-    NamedChain.read('editor', cAssertWidth('which is empty', emptyTable)),
-    NamedChain.read('editor', cAssertWidth('with contents in some cells', contentsInSomeCells)),
-    NamedChain.read('editor', cAssertWidth('with contents in all cells', contentsInAllCells)),
-    NamedChain.read('editor', cAssertWidth('with headings', tableWithHeadings)),
-    NamedChain.read('editor', cAssertWidth('with caption', tableWithCaption)),
-    NamedChain.read('editor', cAssertWidth('with nested tables', nestedTables)),
-
-    NamedChain.read('editor', McEditor.cRemove)
-  ]),
-  success, failure, TestLogs.init());
+    context('table_column_resizing=resizetable', () => {
+      it('should should resize table when inserting a column', async () => {
+        const editor = await pCreateEditor({
+          table_sizing_mode: 'relative',
+          table_column_resizing: 'resizetable',
+        });
+        editor.setContent(`
+          <table width: 33.3433%; border="1">
+            <tbody>
+              <tr>
+                <td style="width: 47.0386%;"></td>
+                <td id="selected" style="width: 47.9985%;"></td>
+              </tr>
+              <tr>
+                <td style="width: 47.0386%;"></td>
+                <td style="width: 47.9985%;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        const beforeWidth = getTableWidth(editor);
+        LegacyUnit.setSelection(editor, '#selected', 0);
+        editor.execCommand('mceTableInsertColAfter');
+        const afterWidth = getTableWidth(editor);
+        assert.closeTo(afterWidth, beforeWidth * 1.5, 2);
+        McEditor.remove(editor);
+      });
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableResizeTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.plugins.table.InsertColumnTableResizeTest', () => {
   const getTableWidth = (editor: Editor) =>
     SelectorFind.child<HTMLTableElement>(TinyDom.body(editor), 'table').map((table) => Width.get(table)).getOrDie();
 
-  // TODO: colspan
+  // TODO: tests for colspan #TINY-6949
   context('Responsive table', () => {
     context('table_column_resizing=preservetable', () => {
       it('will resize table because responsive tables cannot honour this setting', async () => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableSizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableSizeTest.ts
@@ -1,0 +1,200 @@
+import { Assertions, Chain, Guard, Log, NamedChain, TestLogs, UiFinder } from '@ephox/agar';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { McEditor, TinyDom } from '@ephox/mcagar';
+import { SelectorFind } from '@ephox/sugar';
+
+import Plugin from 'tinymce/plugins/table/Plugin';
+import SilverTheme from 'tinymce/themes/silver/Theme';
+import * as TableTestUtils from '../module/test/TableTestUtils';
+
+UnitTest.asynctest('browser.tinymce.plugins.table.InsertColumnTableSizeTest', (success, failure) => {
+
+  Plugin();
+  SilverTheme();
+
+  interface TestData {
+    html: string;
+  }
+
+  const emptyTable = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<td></td>' +
+                '<td></td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td></td>' +
+                '<td></td>' +
+              '</tr>' +
+            '</tbody>' +
+            '</table>'
+  };
+
+  const contentsInSomeCells = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>a1</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td></td>' +
+                '<td></td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const contentsInAllCells = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>a1</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a2</td>' +
+                '<td>b2</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a3</td>' +
+                '<td>b3</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const tableWithHeadings = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<th>a1</th>' +
+                '<th>b1</th>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a1</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a2</td>' +
+                '<td>b2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const tableWithCaption = {
+    html: '<table style = "width: 100%;">' +
+            '<caption>alphabet</caption>' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>a1</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a2</td>' +
+                '<td>b2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const nestedTables = {
+    html: '<table style = "width: 100%;">' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>a1' +
+                  '<table style = "width: 100%;">' +
+                  '<tbody>' +
+                    '<tr>' +
+                      '<td></td>' +
+                      '<td></td>' +
+                    '</tr>' +
+                    '<tr>' +
+                      '<td></td>' +
+                      '<td></td>' +
+                    '</tr>' +
+                  '</tbody>' +
+                  '</table>' +
+                '</td>' +
+                '<td>b1</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td>a2</td>' +
+                '<td>b2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+  };
+
+  const cInsertTable = (label: string, table: string) => Chain.control(
+    Chain.mapper((editor: any) => {
+      editor.setContent(table);
+      const bodyElem = TinyDom.fromDom(editor.getBody());
+      const tableElem = UiFinder.findIn(bodyElem, 'table').getOr(bodyElem);
+      SelectorFind.descendant(tableElem, 'td,th').each((cell) => {
+        editor.selection.select(cell.dom, true);
+        editor.selection.collapse(true);
+      });
+      return tableElem;
+    }),
+    Guard.addLogging(`Insert ${label}`)
+  );
+
+  const cInsertColumnMeasureWidth = (label: string, data: TestData) => Log.chain('TBA', 'Insert column before, insert column after, erase column and measure table widths', NamedChain.asChain(
+    [
+      NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
+      Chain.label('Insert table', NamedChain.direct('editor', cInsertTable(label, data.html), 'element')),
+      Chain.label('Drag SE (-100, 0)', NamedChain.read('editor', TableTestUtils.cDragHandle('se', -100, 0))),
+      Chain.label('Store width before split', NamedChain.write('widthBefore', TableTestUtils.cGetWidth)),
+      Chain.label('Insert column before', NamedChain.read('editor', TableTestUtils.cInsertColumnBefore)),
+      Chain.label('Insert column after', NamedChain.read('editor', TableTestUtils.cInsertColumnAfter)),
+      Chain.label('Delete column', NamedChain.read('editor', TableTestUtils.cDeleteColumn)),
+      Chain.label('Store width after split', NamedChain.write('widthAfter', TableTestUtils.cGetWidth)),
+      NamedChain.merge([ 'widthBefore', 'widthAfter' ], 'widths'),
+      NamedChain.output('widths')
+    ]
+  ));
+
+  const cAssertWidths = Chain.label(
+    'Assert widths before and after insert column are equal',
+    Chain.op((input: any) => {
+      if (input.widthBefore.isPercent) {
+        // due to rounding errors we can be off by one pixel for percentage tables
+        const actualDiff = Math.abs(input.widthBefore.px - input.widthAfter.px);
+        Assert.eq(`table width should be approx (within 1px): ${input.widthBefore.raw}% (${input.widthBefore.px}px) ~= ${input.widthAfter.raw}% (${input.widthAfter.px}px)`, true, actualDiff <= 1);
+      } else {
+        Assertions.assertEq('table width should not change', input.widthBefore, input.widthAfter);
+      }
+    })
+  );
+
+  const cAssertWidth = (label: string, data: TestData) => Chain.label(
+    `Assert width of table ${label} after inserting column`,
+    NamedChain.asChain([
+      NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
+      NamedChain.direct('editor', cInsertColumnMeasureWidth(label, data), 'widths'),
+      NamedChain.read('widths', cAssertWidths)
+    ])
+  );
+
+  NamedChain.pipeline(Log.chains('TBA', 'Table: Insert columns, erase column and assert the table width does not change', [
+    NamedChain.write('editor', McEditor.cFromSettings({
+      plugins: 'table',
+      width: 400,
+      theme: 'silver',
+      base_url: '/project/tinymce/js/tinymce'
+    })),
+
+    NamedChain.read('editor', cAssertWidth('which is empty', emptyTable)),
+    NamedChain.read('editor', cAssertWidth('with contents in some cells', contentsInSomeCells)),
+    NamedChain.read('editor', cAssertWidth('with contents in all cells', contentsInAllCells)),
+    NamedChain.read('editor', cAssertWidth('with headings', tableWithHeadings)),
+    NamedChain.read('editor', cAssertWidth('with caption', tableWithCaption)),
+    NamedChain.read('editor', cAssertWidth('with nested tables', nestedTables)),
+
+    NamedChain.read('editor', McEditor.cRemove)
+  ]),
+  success, failure, TestLogs.init());
+});

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { SelectorFind, Width } from '@ephox/sugar';
 import { assert } from 'chai';
@@ -34,9 +34,13 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
     const beforeWidth = getTableWidth(editor);
     editor.selection.select(editor.dom.select('td[data-mce-selected]')[0], true);
     editor.execCommand(command);
-    const afterWidth = getTableWidth(editor);
-    // 2px margin of error, 30px margin of error for IE
-    assert.approximately(afterWidth, beforeWidth * multiplier, platform.browser.isIE() ? 30 : 2);
+    if (multiplier === 0) {
+      TinyAssertions.assertContent(editor, '');
+    } else {
+      const afterWidth = getTableWidth(editor);
+      // 2px margin of error, 30px margin of error for IE
+      assert.approximately(afterWidth, beforeWidth * multiplier, platform.browser.isIE() ? 30 : 2);
+    }
   };
 
   const performCommandsAndAssertWidths = (editor: Editor, content: string, multipliers: TableCommandMap) => {
@@ -263,7 +267,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         performCommandsAndAssertWidths(editor, content, {
           mceTableInsertColBefore: 1,
           mceTableInsertColAfter: 1,
-          mceTableDeleteCol: 1
+          mceTableDeleteCol: 0
         });
       });
 
@@ -290,7 +294,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         performCommandsAndAssertWidths(editor, content, {
           mceTableInsertColBefore: 1,
           mceTableInsertColAfter: 1,
-          mceTableDeleteCol: 1
+          mceTableDeleteCol: 0
         });
       });
     });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
@@ -8,6 +8,12 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
+interface TableCommandMap {
+  readonly mceTableInsertColBefore: number;
+  readonly mceTableInsertColAfter: number;
+  readonly mceTableDeleteCol: number;
+}
+
 describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
   /**
    * Test the width of tables before and after column operations
@@ -32,12 +38,6 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
     // 2px margin of error, 30px margin of error for IE
     assert.approximately(afterWidth, beforeWidth * multiplier, platform.browser.isIE() ? 30 : 2);
   };
-
-  interface TableCommandMap {
-    readonly mceTableInsertColBefore: number;
-    readonly mceTableInsertColAfter: number;
-    readonly mceTableDeleteCol: number;
-  }
 
   const performCommandsAndAssertWidths = (editor: Editor, content: string, multipliers: TableCommandMap) => {
     editor.setContent(content);

--- a/versions.txt
+++ b/versions.txt
@@ -4,6 +4,6 @@
 agar@5.2.0
 darwin@6.0.0
 mcagar@6.0.0
-snooker@7.2.0
+snooker@8.0.0
 sugar@7.1.0
 boss@4.1.0


### PR DESCRIPTION
Related Ticket: TINY-6711

Description of Changes:
Improved table resizing behaviour (when adding/removing columns) when using the `table_column_resizing` option.

| `table_column_resizing` | `table_sizing_mode` | `table_use_colgroups` | 
|--|--|--|
| `resizetable` | `fixed` | `true` | 
| `resizetable` | `fixed` | `false` | 
| `resizetable` | `relative` | `true` | 
| `resizetable` | `relative` | `false` |
| `resizetable` | `responsive` | `true` |  
| `resizetable` | `responsive` | `false` |  
| `preservetable` | `fixed` | `true` | 
| `preservetable` | `fixed` | `false` | 
| `preservetable` | `relative` | `true` | 
| `preservetable` | `relative` | `false` |
| `preservetable` | `responsive` | `true` |  
| `preservetable` | `responsive` | `false` |  

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
