### PR TITLE
TINY-6918: Additional helpers/fixes needed to convert silver theme tests

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/Touch.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Touch.ts
@@ -5,6 +5,13 @@ import { Chain } from './Chain';
 import { Step } from './Step';
 import * as UiFinder from './UiFinder';
 
+const touchStart = Touches.touchstart;
+const touchStartAt = (element: SugarElement<any>, dx: number, dy: number): void => Touches.touchstartAt(dx, dy)(element);
+const touchEnd = Touches.touchend;
+const touchEndAt = (element: SugarElement<any>, dx: number, dy: number): void => Touches.touchendAt(dx, dy)(element);
+const touchMove = Touches.touchmove;
+const touchMoveTo = (element: SugarElement<any>, dx: number, dy: number): void => Touches.touchmoveTo(dx, dy)(element);
+
 const cTrigger = (selector: string, action: (ele: SugarElement<any>) => void) => Chain.async<SugarElement, SugarElement>((container, next, die) => {
   UiFinder.findIn(container, selector).fold(
     () => die('Could not find element: ' + selector),
@@ -60,6 +67,16 @@ const cTouchEnd = Chain.op(Touches.touchend);
 
 export {
   point,
+
+  tap,
+  trueTap,
+
+  touchStart,
+  touchStartAt,
+  touchEnd,
+  touchEndAt,
+  touchMove,
+  touchMoveTo,
 
   sTap,
   sTapOn,

--- a/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
@@ -60,7 +60,7 @@ const selectAll = (element: SugarElement<any>, selector: string): Array<SugarEle
 
 const toResult = <T>(message: TestLabel, option: Optional<T>): Result<T, TestLabel> =>
   option.fold(
-    () => Result.error<T, TestLabel>(message),
+    () => Result.error<T, TestLabel>(TestLabel.asString(message)),
     Result.value
   );
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/testhelpers/GuiSetup.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/testhelpers/GuiSetup.ts
@@ -1,5 +1,5 @@
 import { Assertions, Pipeline, Step, TestLogs } from '@ephox/agar';
-import { Merger } from '@ephox/katamari';
+import { Fun, Global, Merger, Obj } from '@ephox/katamari';
 import { DomEvent, EventUnbinder, Html, Insert, Remove, SugarBody, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import { AlloyComponent } from '../component/ComponentApi';
@@ -9,19 +9,32 @@ import { TestStore } from './TestStore';
 
 type RootNode = SugarShadowDom.RootNode;
 
-interface KeyLoggerState {
-  log: string[];
-  onKeydown: EventUnbinder;
+export interface KeyLoggerState {
+  readonly log: string[];
+  readonly onKeydown: EventUnbinder;
 }
 
 interface StyleState {
-  style: SugarElement<HTMLStyleElement>;
+  readonly style: SugarElement<HTMLStyleElement>;
 }
 
-const setupIn = (
-  root: RootNode,
-  createComponent: (store: TestStore, doc: SugarElement, body: SugarElement) => AlloyComponent,
-  f: (doc: RootNode, body: SugarElement, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore
+interface SetupRootElement<T extends RootNode> {
+  readonly root: T;
+  readonly teardown: () => void;
+}
+
+export interface Hook<T extends RootNode> {
+  readonly root: () => T;
+  readonly body: () => SugarElement<Node>;
+  readonly gui: () => Gui.GuiSystem;
+  readonly component: () => AlloyComponent;
+  readonly store: () => TestStore;
+}
+
+const setupIn = <T extends RootNode>(
+  root: T,
+  createComponent: (store: TestStore, doc: T, body: SugarElement<Node>) => AlloyComponent,
+  f: (doc: T, body: SugarElement, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore
   ) => Array<Step<any, any>>, success: () => void, failure: (err: any, logs?: TestLogs) => void
 ) => {
   const store = TestStore();
@@ -47,6 +60,59 @@ const setupIn = (
   }
 };
 
+const bddSetupIn = <T extends RootNode>(
+  setupRoot: () => SetupRootElement<T>,
+  createComponent: (store: TestStore, doc: T, body: SugarElement<Node>) => AlloyComponent,
+  skip: () => boolean = Fun.never
+): Hook<T> => {
+  let state: Record<string, any> = {};
+  let teardown: () => void = Fun.noop;
+
+  // Note: Don't use bedrock imports here so as to avoid requiring bedrock as a
+  // dependency. It'll still work the same, but we'll be missing the types.
+  Global.before(function (this: any) {
+    if (skip()) {
+      this.skip();
+    }
+
+    const store = TestStore();
+    const setup = setupRoot();
+    teardown = setup.teardown;
+    const root = setup.root;
+
+    const gui = Gui.create();
+    const contentContainer = SugarShadowDom.getContentContainer(root);
+
+    Attachment.attachSystem(contentContainer, gui);
+
+    const component = createComponent(store, root, contentContainer);
+    gui.add(component);
+
+    state = {
+      root,
+      body: contentContainer,
+      gui,
+      component,
+      store
+    };
+  });
+
+  Global.after(() => {
+    Obj.get(state, 'gui').each(Attachment.detachSystem);
+    teardown();
+    state = {};
+  });
+
+  const lazyGet = (name: string) => () => Obj.get(state, name).getOrDie('The setup hooks have not run yet');
+  return {
+    root: lazyGet('root'),
+    body: lazyGet('body'),
+    gui: lazyGet('gui'),
+    component: lazyGet('component'),
+    store: lazyGet('store')
+  };
+};
+
 /**
  * Setup in the body, run list of untyped Steps, then tear down.
  * Use #guiSetup for type-safe steps.
@@ -57,25 +123,33 @@ const setupIn = (
  * @param failure
  */
 const setup = (
-  createComponent: (store: TestStore, doc: SugarElement, body: SugarElement) => AlloyComponent,
-  f: (doc: SugarElement, body: SugarElement, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Array<Step<any, any>>,
+  createComponent: (store: TestStore, doc: SugarElement<Document>, body: SugarElement<Node>) => AlloyComponent,
+  f: (doc: SugarElement<Document>, body: SugarElement<HTMLElement>, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Array<Step<any, any>>,
   success: () => void,
   failure: (err: any, logs?: TestLogs) => void
 ): void => {
   setupIn(SugarDocument.getDocument(), createComponent, f, success, failure);
 };
 
+const bddSetup = (
+  createComponent: (store: TestStore, doc: SugarElement<Document>, body: SugarElement<Node>) => AlloyComponent
+): Hook<SugarElement<Document>> =>
+  bddSetupIn(() => ({
+    root: SugarDocument.getDocument(),
+    teardown: Fun.noop
+  }), createComponent);
+
 /**
-* Setup in a Shadow Root, run list of untyped Steps, then tear down.
-*
-* @param createComponent
-* @param f
-* @param success
-* @param failure
-*/
+ * Setup in a Shadow Root, run list of untyped Steps, then tear down.
+ *
+ * @param createComponent
+ * @param f
+ * @param success
+ * @param failure
+ */
 const setupInShadowRoot = (
-  createComponent: (store: TestStore, doc: SugarElement, body: SugarElement) => AlloyComponent,
-  f: (doc: SugarElement, body: SugarElement, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Array<Step<any, any>>,
+  createComponent: (store: TestStore, doc: SugarElement<ShadowRoot>, body: SugarElement<Node>) => AlloyComponent,
+  f: (doc: SugarElement<ShadowRoot>, body: SugarElement<Node>, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Array<Step<any, any>>,
   success: () => void,
   failure: (err: any, logs?: TestLogs) => void
 ): void => {
@@ -91,9 +165,23 @@ const setupInShadowRoot = (
   }, failure);
 };
 
+const bddSetupInShadowRoot = (
+  createComponent: (store: TestStore, doc: SugarElement<ShadowRoot>, body: SugarElement<Node>) => AlloyComponent
+): Hook<SugarElement<ShadowRoot>> => {
+  return bddSetupIn(() => {
+    const sh = SugarElement.fromTag('div');
+    Insert.append(SugarBody.body(), sh);
+    const sr = SugarElement.fromDom(sh.dom.attachShadow({ mode: 'open' }));
+    return {
+      root: sr,
+      teardown: () => Remove.remove(sh)
+    };
+  }, createComponent, () => !SugarShadowDom.isSupported());
+};
+
 const setupInBodyAndShadowRoot = (
-  createComponent: (store: TestStore, doc: SugarElement, body: SugarElement) => AlloyComponent,
-  f: (doc: SugarElement, body: SugarElement, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Array<Step<any, any>>,
+  createComponent: (store: TestStore, doc: RootNode, body: SugarElement<Node>) => AlloyComponent,
+  f: (doc: RootNode, body: SugarElement<Node>, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Array<Step<any, any>>,
   success: () => void,
   failure: (err: any, logs?: TestLogs) => void
 ): void => {
@@ -112,47 +200,64 @@ const setupInBodyAndShadowRoot = (
  * @param failure
  */
 const guiSetup = <A, B> (createComponent: (store: TestStore, doc: SugarElement, body: SugarElement) => AlloyComponent,
-  f: (doc: SugarElement, body: SugarElement, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Step<A, B>,
+  f: (doc: SugarElement<Document>, body: SugarElement<Node>, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Step<A, B>,
   success: () => void, failure: (err: any, logs?: TestLogs) => void): void => {
   setup(createComponent, (doc, body, gui, component, store) => [
     f(doc, body, gui, component, store)
   ], success, failure);
 };
 
-const mSetupKeyLogger = <T> (body: SugarElement): Step<T, T & KeyLoggerState> => Step.stateful((oldState, next, _die) => {
+const setupKeyLogger = (body: SugarElement<Node>): KeyLoggerState => {
   const onKeydown: EventUnbinder = DomEvent.bind(body, 'keydown', (event) => {
     newState.log.push('keydown.to.body: ' + event.raw.which);
   });
 
   const log: string[] = [ ];
   const newState = {
-    ...oldState,
     log,
     onKeydown
   };
-  next(newState);
-});
+  return newState;
+};
 
-const mTeardownKeyLogger = <T>(body: SugarElement, expected: string[]): Step<T & KeyLoggerState, T> => Step.stateful((state, next, _die) => {
+const teardownKeyLogger = (state: KeyLoggerState, expected: string[]): void => {
   Assertions.assertEq('Checking key log outside context (on teardown)', expected, state.log);
   state.onKeydown.unbind();
-  const { onKeydown, log, ...rest } = state;
-  next(rest as unknown as T);
-});
+};
 
-const mAddStyles = <T>(dos: RootNode, styles: string[]): Step<T, T & StyleState> => Step.stateful((value, next, _die) => {
+const addStyles = (dos: RootNode, styles: string[]): SugarElement<HTMLStyleElement> => {
   const style = SugarElement.fromTag('style');
   const head = SugarShadowDom.getStyleContainer(dos);
   Insert.append(head, style);
   Html.set(style, styles.join('\n'));
 
+  return style;
+};
+
+const removeStyles = (style: SugarElement<HTMLStyleElement>): void =>
+  Remove.remove(style);
+
+const mSetupKeyLogger = <T>(body: SugarElement<Node>): Step<T, T & KeyLoggerState> => Step.stateful((oldState, next, _die) => {
+  next({
+    ...oldState,
+    ...setupKeyLogger(body)
+  });
+});
+
+const mTeardownKeyLogger = <T>(body: SugarElement<Node>, expected: string[]): Step<T & KeyLoggerState, T> => Step.stateful((state, next, _die) => {
+  teardownKeyLogger(state, expected);
+  const { onKeydown, log, ...rest } = state;
+  next(rest as unknown as T);
+});
+
+const mAddStyles = <T>(dos: RootNode, styles: string[]): Step<T, T & StyleState> => Step.stateful((value, next, _die) => {
   next(Merger.deepMerge(value, {
-    style
+    style: addStyles(dos, styles)
   }));
 });
 
 const mRemoveStyles = Step.stateful((value: StyleState, next, _die) => {
-  Remove.remove(value.style);
+  removeStyles(value.style);
   next(value);
 });
 
@@ -161,9 +266,17 @@ export {
   setupInShadowRoot,
   setupInBodyAndShadowRoot,
   guiSetup,
+
+  bddSetup,
+  bddSetupInShadowRoot,
+
+  setupKeyLogger,
+  teardownKeyLogger,
+  addStyles,
+  removeStyles,
+
   mSetupKeyLogger,
   mTeardownKeyLogger,
-
   mAddStyles,
   mRemoveStyles
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/api/testhelpers/GuiSetup.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/testhelpers/GuiSetup.ts
@@ -1,5 +1,5 @@
 import { Assertions, Pipeline, Step, TestLogs } from '@ephox/agar';
-import { Fun, Global, Merger, Obj } from '@ephox/katamari';
+import { Fun, Global, Merger, Obj, Optional } from '@ephox/katamari';
 import { DomEvent, EventUnbinder, Html, Insert, Remove, SugarBody, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import { AlloyComponent } from '../component/ComponentApi';
@@ -237,6 +237,21 @@ const addStyles = (dos: RootNode, styles: string[]): SugarElement<HTMLStyleEleme
 const removeStyles = (style: SugarElement<HTMLStyleElement>): void =>
   Remove.remove(style);
 
+const bddAddStyles = (dos: RootNode, styles: string[]): void => {
+  let style = Optional.none<SugarElement<HTMLStyleElement>>();
+
+  // Note: Don't use bedrock imports here so as to avoid requiring bedrock as a
+  // dependency. It'll still work the same, but we'll be missing the types.
+  Global.before(() => {
+    style = Optional.some(addStyles(dos, styles));
+  });
+
+  Global.after(() => {
+    style.each(Remove.remove);
+    style = Optional.none();
+  });
+};
+
 const mSetupKeyLogger = <T>(body: SugarElement<Node>): Step<T, T & KeyLoggerState> => Step.stateful((oldState, next, _die) => {
   next({
     ...oldState,
@@ -274,6 +289,8 @@ export {
   teardownKeyLogger,
   addStyles,
   removeStyles,
+
+  bddAddStyles,
 
   mSetupKeyLogger,
   mTeardownKeyLogger,

--- a/modules/alloy/src/test/ts/browser/behaviour/BlockingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/BlockingTest.ts
@@ -22,7 +22,7 @@ UnitTest.asyncTest('BlockingTest', (success, failure) => {
     ])
   });
 
-  const makeComponent = (store: TestStore, _doc: SugarElement<Document>, _body: SugarElement<HTMLBodyElement>) => {
+  const makeComponent = (store: TestStore, _doc: SugarElement<Document>, _body: SugarElement<Node>) => {
     const component = GuiFactory.build({
       dom: {
         tag: 'div'

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
@@ -15,6 +15,7 @@ export interface ThemeSelectors {
   toolBarSelector: (editor: Editor) => string;
   menuBarSelector: string;
   dialogSelector: string;
+  dialogCancelSelector: string;
   dialogCloseSelector: string;
   dialogSubmitSelector: string;
 }
@@ -23,7 +24,8 @@ const ModernThemeSelectors: ThemeSelectors = {
   toolBarSelector: () => '.mce-toolbar-grp',
   menuBarSelector: '.mce-menubar',
   dialogSelector: '.mce-window',
-  dialogCloseSelector: 'div[role="button"]:contains(Cancel)',
+  dialogCancelSelector: 'div[role="button"]:contains(Cancel)',
+  dialogCloseSelector: 'div[role="button"].mce-close',
   dialogSubmitSelector: 'div[role="button"].mce-primary'
 };
 
@@ -31,7 +33,8 @@ const SilverThemeSelectors: ThemeSelectors = {
   toolBarSelector: (editor: Editor) => Arr.exists([ editor.getParam('toolbar_mode'), editor.getParam('toolbar_drawer') ], (s) => s === 'floating' || s === 'sliding') ? '.tox-toolbar-overlord' : '.tox-toolbar',
   menuBarSelector: '.tox-menubar',
   dialogSelector: 'div[role="dialog"]',
-  dialogCloseSelector: '.tox-button:contains("Cancel")',
+  dialogCancelSelector: '.tox-button:contains("Cancel")',
+  dialogCloseSelector: '.tox-button[title="Close"]',
   dialogSubmitSelector: '.tox-button:contains("Save")'
 };
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
@@ -54,6 +54,11 @@ const submitDialog = (editor: Editor, selector?: string): void => {
   clickDialogButton(editor, dialogSelector, getThemeSelectors().dialogSubmitSelector);
 };
 
+const cancelDialog = (editor: Editor, selector?: string): void => {
+  const dialogSelector = Type.isUndefined(selector) ? getThemeSelectors().dialogSelector : selector;
+  clickDialogButton(editor, dialogSelector, getThemeSelectors().dialogCancelSelector);
+};
+
 const closeDialog = (editor: Editor, selector?: string): void => {
   const dialogSelector = Type.isUndefined(selector) ? getThemeSelectors().dialogSelector : selector;
   clickDialogButton(editor, dialogSelector, getThemeSelectors().dialogCloseSelector);
@@ -93,6 +98,7 @@ export {
   clickOnUi,
 
   submitDialog,
+  cancelDialog,
   closeDialog,
 
   keydown,

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Truncate.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Truncate.ts
@@ -1,10 +1,15 @@
 import { SugarElement } from '../node/SugarElement';
+import * as SugarShadowDom from '../node/SugarShadowDom';
 import * as Html from '../properties/Html';
 import * as Replication from './Replication';
 
 const getHtml = (element: SugarElement<any>): string => {
-  const clone = Replication.shallow(element);
-  return Html.getOuter(clone);
+  if (SugarShadowDom.isShadowRoot(element)) {
+    return '#shadow-root';
+  } else {
+    const clone = Replication.shallow(element);
+    return Html.getOuter(clone);
+  }
 };
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
@@ -41,11 +41,11 @@ export const createElement: {
   SugarElement.fromTag(tag, Traverse.documentOrOwner(dos).dom);
 
 /** Where style tags need to go. ShadowRoot or document head */
-export const getStyleContainer = (dos: RootNode): SugarElement<Node> =>
+export const getStyleContainer = (dos: RootNode): SugarElement<HTMLHeadElement | ShadowRoot> =>
   isShadowRoot(dos) ? dos : SugarHead.getHead(Traverse.documentOrOwner(dos));
 
 /** Where content needs to go. ShadowRoot or document body */
-export const getContentContainer = (dos: RootNode): SugarElement<Node> =>
+export const getContentContainer = (dos: RootNode): SugarElement<HTMLElement | ShadowRoot> =>
   // Can't use SugarBody.body without causing a circular module reference (since SugarBody.inBody uses SugarShadowDom)
   isShadowRoot(dos) ? dos : SugarElement.fromDom(Traverse.documentOrOwner(dos).dom.body);
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
@@ -13,7 +13,7 @@ export type RootNode = SugarElement<Document | ShadowRoot>;
  * a Document and a ShadowRoot.
  */
 export const isShadowRoot = (dos: RootNode): dos is SugarElement<ShadowRoot> =>
-  SugarNode.isDocumentFragment(dos);
+  SugarNode.isDocumentFragment(dos) && Type.isNonNullable(dos.dom.host);
 
 /* eslint-disable @tinymce/no-implicit-dom-globals, @typescript-eslint/unbound-method */
 const supported: boolean =

--- a/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
+++ b/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
@@ -38,7 +38,7 @@ describe('browser.tinymce.plugins.code.CodeSanityTest', () => {
     TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
     await TinyUiActions.pWaitForDialog(editor);
     assertTextareaContent('<p><em>a</em></p>');
-    TinyUiActions.closeDialog(editor);
+    TinyUiActions.cancelDialog(editor);
   });
 
   it('TBA: Change source code and assert editor content changes', async () => {

--- a/modules/tinymce/src/plugins/code/test/ts/browser/CodeTextareaTest.ts
+++ b/modules/tinymce/src/plugins/code/test/ts/browser/CodeTextareaTest.ts
@@ -32,6 +32,6 @@ describe('browser.tinymce.plugins.code.CodeTextareaTest', () => {
   it('TBA: Verify if "white-space: pre-wrap" style is set on the textarea', async () => {
     const editor = hook.editor();
     await pAssertWhiteSpace(editor);
-    TinyUiActions.closeDialog(editor, 'div[role="dialog"]');
+    TinyUiActions.cancelDialog(editor);
   });
 });

--- a/modules/tinymce/src/plugins/codesample/test/ts/module/CodeSampleTestUtils.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/module/CodeSampleTestUtils.ts
@@ -63,7 +63,7 @@ const pSubmitDialog = async (editor: Editor) => {
 };
 
 const pCancelDialog = async (editor: Editor) => {
-  TinyUiActions.closeDialog(editor, dialogSelector);
+  TinyUiActions.cancelDialog(editor, dialogSelector);
   await Waiter.pTryUntil('Dialog should close', () => UiFinder.notExists(SugarBody.body(), dialogSelector));
 };
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -21,7 +21,7 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
   }, [ Plugin, Theme ]);
 
   const closeDialog = (editor: Editor) =>
-    TinyUiActions.closeDialog(editor, 'div[role="dialog"]');
+    TinyUiActions.cancelDialog(editor);
 
   const pAssertImageTab = async (editor: Editor, title: string, isPresent: boolean) => {
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ContextToolbarTest.ts
@@ -36,7 +36,7 @@ describe('browser.tinymce.plugins.imagetools.ContextToolbarTest', () => {
   const pWaitForDialogOpenThenCloseDialog = async (editor: Editor, childSelector: string) => {
     await TinyUiActions.pWaitForDialog(editor);
     await TinyUiActions.pWaitForPopup(editor, childSelector);
-    TinyUiActions.closeDialog(editor);
+    TinyUiActions.cancelDialog(editor);
     await Waiter.pTryUntil('Wait for dialog to close', () => UiFinder.notExists(SugarBody.body(), 'div[role="dialog"]'));
   };
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListTest.ts
@@ -38,7 +38,7 @@ describe('browser.tinymce.plugins.lists.TableInListTest', () => {
     const editor = hook.editor();
     editor.setContent('<ul><li><table><tbody><tr><td>a</td><td>b</td></tr></tbody></table></li></ul>');
     TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0, 0, 0 ], 0);
-    UiFinder.notExists(TinyDom.document(editor), 'div[aria-label="Bullet list"][aria-pressed="true"]');
+    UiFinder.notExists(TinyDom.container(editor), 'div[aria-label="Bullet list"][aria-pressed="true"]');
   });
 
   it('TBA: indent and outdent li in ul in list in table in list', () => {


### PR DESCRIPTION
Related Ticket: TINY-6918

Description of Changes:
* Renamed `TinyUiActions.closeDialog` to `TinyUiActions.cancelDialog` as it was clicking the cancel button.
* Added `TinyUiActions.closeDialog` which will actually press the close button (needed for dialogs that don't have a cancel, etc...)
* Fixed `UiSearcher.findIn` logging a function string, rather than the actual error message.
* Fixed `Truncate.getHtml` not working for shadow root elements
* Added BDD helper functions to the Agar `Touch` module
* Added BDD helper functions to the Alloy `TestHelpers.GuiSetup` module
* Improved some types in the `SugarShadowDom` returns

Note: I've done this as a separate PR to make it easier to review. Actual silver theme test conversions are still a WIP.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
