### PR TITLE
TINY-6942: blocked mutation from happening on resize end

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -10,6 +10,7 @@ import { Selectors, SugarElement } from '@ephox/sugar';
 import * as CefUtils from '../../dom/CefUtils';
 import * as NodeType from '../../dom/NodeType';
 import * as RangePoint from '../../dom/RangePoint';
+import * as Rtc from '../../Rtc';
 import Editor from '../Editor';
 import Env from '../Env';
 import * as Events from '../Events';
@@ -19,7 +20,6 @@ import { EditorEvent } from '../util/EventDispatcher';
 import Tools from '../util/Tools';
 import VK from '../util/VK';
 import EditorSelection from './Selection';
-
 interface ControlSelection {
   isResizable: (elm: Element) => boolean;
   showResizeRect: (elm: Element) => void;
@@ -248,7 +248,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
     };
 
     // Set width/height properties
-    if (wasResizeStarted) {
+    if (!Rtc.isRtc(editor) && wasResizeStarted) {
       setSizeProp('width', width);
       setSizeProp('height', height);
     }
@@ -270,7 +270,10 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
 
     if (wasResizeStarted) {
       Events.fireObjectResized(editor, selectedElm, width, height, 'corner-' + selectedHandle.name);
-      dom.setAttrib(selectedElm, 'style', dom.getAttrib(selectedElm, 'style'));
+
+      if (!Rtc.isRtc(editor)) {
+        dom.setAttrib(selectedElm, 'style', dom.getAttrib(selectedElm, 'style'));
+      }
     }
     editor.nodeChanged();
   };

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -20,6 +20,7 @@ import { EditorEvent } from '../util/EventDispatcher';
 import Tools from '../util/Tools';
 import VK from '../util/VK';
 import EditorSelection from './Selection';
+
 interface ControlSelection {
   isResizable: (elm: Element) => boolean;
   showResizeRect: (elm: Element) => void;


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This PR blocks some mutations on resize end when the RTC plugin is enabled.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
