### PR TITLE
TINY-6686: Close popups when the throbber is opened

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,7 +7,7 @@ Version 5.7.0 (TBD)
     Added new `font_css` setting for fonts to be added to both containing document and the editor #TINY-6199
     Added a new `ImageUploader` API to simplify uploading image data to the configured `images_upload_url` or `images_upload_handler` #TINY-4601
     Added Oxide variable to define the container background color in fullscreen mode #TINY-6903
-    Added a new `AfterProgressState` event that's fired after ProgressState calls resolve #TINY-6686
+    Added a new `AfterProgressState` event that's fired after `editor.setProgressState` calls complete #TINY-6686
     Changed copying table columns or entire tables will now retain an appropriate width when pasted #TINY-6664
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -7,12 +7,14 @@ Version 5.7.0 (TBD)
     Added new `font_css` setting for fonts to be added to both containing document and the editor #TINY-6199
     Added a new `ImageUploader` API to simplify uploading image data to the configured `images_upload_url` or `images_upload_handler` #TINY-4601
     Added Oxide variable to define the container background color in fullscreen mode #TINY-6903
+    Added a new `AfterProgressState` event that's fired after ProgressState calls resolve #TINY-6686
     Changed copying table columns or entire tables will now retain an appropriate width when pasted #TINY-6664
     Changed the `lists` plugin to apply list styles to all text blocks within a selection #TINY-3755
     Changed the `advlist` plugin to log a console error message when the `list` plugin isn't enabled #TINY-6585
     Changed the z-index of the `setProgressState(true)` throbber so it does not hide notifications #TINY-6686
     Changed the type signature for `editor.selection.getRng()` incorrectly returning `null` #TINY-6843
     Changed some `SaxParser` regular expressions to improve performance #TINY-6823
+    Changed `editor.setProgressState(true)` to close any open popups #TINY-6686
     Fixed `col` elements incorrectly transformed to `th` elements when converting columns to header columns #TINY-6715
     Fixed a number of table operations not working when selecting 2 table cells on Mozilla Firefox #TINY-3897
     Fixed a memory leak by backporting an upstream Sizzle fix #TINY-6859
@@ -32,7 +34,6 @@ Version 5.7.0 (TBD)
     Fixed incorrect behaviour when editor is destroyed while loading stylesheets #INT-2282
     Fixed figure elements incorrectly splitting from a valid parent element when editing the image within #TINY-6592
     Fixed inserting multiple rows or columns in a table cloning from the incorrect source row or column #TINY-6906
-    Fixed popups incorrectly remaining open when `editor.setProgressState(true)` is called #TINY-6686
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -32,6 +32,7 @@ Version 5.7.0 (TBD)
     Fixed incorrect behaviour when editor is destroyed while loading stylesheets #INT-2282
     Fixed figure elements incorrectly splitting from a valid parent element when editing the image within #TINY-6592
     Fixed inserting multiple rows or columns in a table cloning from the incorrect source row or column #TINY-6906
+    Fixed popups incorrectly remaining open when `editor.setProgressState(true)` is called #TINY-6686
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -41,6 +41,8 @@ export interface WindowEvent<T extends Dialog.DialogData> { dialog: InstanceApi<
 
 export interface ProgressStateEvent { state: boolean; time?: number }
 
+export interface AfterProgressStateEvent { state: boolean }
+
 export interface PlaceholderToggleEvent { state: boolean }
 
 export interface LoadErrorEvent { message: string }
@@ -97,6 +99,7 @@ export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
   'CloseWindow': WindowEvent<any>;
   'OpenWindow': WindowEvent<any>;
   'ProgressState': ProgressStateEvent;
+  'AfterProgressState': AfterProgressStateEvent;
   'PlaceholderToggle': PlaceholderToggleEvent;
   'tap': TouchEvent;
   'longpress': TouchEvent;

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -163,7 +163,7 @@ const NotificationManager = (editor: Editor): NotificationManager => {
       Delay.requestAnimationFrame(reposition);
     });
 
-    editor.on('remove NeilsUntitledEvent', () => {
+    editor.on('remove AfterProgressState', () => {
       Arr.each(notifications.slice(), (notification) => {
         getImplementation().close(notification);
       });

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -163,7 +163,7 @@ const NotificationManager = (editor: Editor): NotificationManager => {
       Delay.requestAnimationFrame(reposition);
     });
 
-    editor.on('remove', () => {
+    editor.on('remove NeilsUntitledEvent', () => {
       Arr.each(notifications.slice(), (notification) => {
         getImplementation().close(notification);
       });

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -95,12 +95,6 @@ const NotificationManager = (editor: Editor): NotificationManager => {
     });
   };
 
-  const closeAll = () => {
-    Arr.each(notifications.slice(), (notification) => {
-      getImplementation().close(notification);
-    });
-  };
-
   const open = (spec: NotificationSpec, fireEvent: boolean = true) => {
     // Never open notification if editor has been removed.
     if (editor.removed || !EditorView.isEditorAttachedToDom(editor)) {
@@ -169,13 +163,11 @@ const NotificationManager = (editor: Editor): NotificationManager => {
       Delay.requestAnimationFrame(reposition);
     });
 
-    editor.on('AfterProgressState', (evt) => {
-      if (evt.state) {
-        closeAll();
-      }
+    editor.on('remove', () => {
+      Arr.each(notifications.slice(), (notification) => {
+        getImplementation().close(notification);
+      });
     });
-
-    editor.on('remove', closeAll);
   };
 
   registerEvents(editor);

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -95,6 +95,12 @@ const NotificationManager = (editor: Editor): NotificationManager => {
     });
   };
 
+  const closeAll = () => {
+    Arr.each(notifications.slice(), (notification) => {
+      getImplementation().close(notification);
+    });
+  };
+
   const open = (spec: NotificationSpec, fireEvent: boolean = true) => {
     // Never open notification if editor has been removed.
     if (editor.removed || !EditorView.isEditorAttachedToDom(editor)) {
@@ -163,11 +169,13 @@ const NotificationManager = (editor: Editor): NotificationManager => {
       Delay.requestAnimationFrame(reposition);
     });
 
-    editor.on('remove AfterProgressState', () => {
-      Arr.each(notifications.slice(), (notification) => {
-        getImplementation().close(notification);
-      });
+    editor.on('AfterProgressState', (evt) => {
+      if (evt.state) {
+        closeAll();
+      }
     });
+
+    editor.on('remove', closeAll);
   };
 
   registerEvents(editor);

--- a/modules/tinymce/src/themes/silver/main/ts/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Events.ts
@@ -58,7 +58,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiS
   const onEditorResize = () => broadcastOn(Channels.repositionPopups(), {});
   const onEditorProgress = (evt: EditorEvent<AfterProgressStateEvent>) => {
     if (evt.state) {
-      broadcastOn(Channels.dismissPopups(), { target: evt.target });
+      broadcastOn(Channels.dismissPopups(), { target: SugarElement.fromDom(editor.getContainer()) });
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Events.ts
@@ -63,6 +63,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiS
     editor.on('ScrollWindow', onWindowScroll);
     editor.on('ResizeWindow', onWindowResize);
     editor.on('ResizeEditor', onEditorResize);
+    editor.on('NeilsUntitledEvent', fireDismissPopups);
   });
 
   editor.on('remove', () => {
@@ -73,6 +74,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiS
     editor.off('ScrollWindow', onWindowScroll);
     editor.off('ResizeWindow', onWindowResize);
     editor.off('ResizeEditor', onEditorResize);
+    editor.off('NeilsUntitledEvent', fireDismissPopups);
 
     onMousedown.unbind();
     onTouchstart.unbind();

--- a/modules/tinymce/src/themes/silver/main/ts/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Events.ts
@@ -63,7 +63,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiS
     editor.on('ScrollWindow', onWindowScroll);
     editor.on('ResizeWindow', onWindowResize);
     editor.on('ResizeEditor', onEditorResize);
-    editor.on('NeilsUntitledEvent', fireDismissPopups);
+    editor.on('AfterProgressState', fireDismissPopups);
   });
 
   editor.on('remove', () => {
@@ -74,7 +74,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiS
     editor.off('ScrollWindow', onWindowScroll);
     editor.off('ResizeWindow', onWindowResize);
     editor.off('ResizeEditor', onEditorResize);
-    editor.off('NeilsUntitledEvent', fireDismissPopups);
+    editor.off('AfterProgressState', fireDismissPopups);
 
     onMousedown.unbind();
     onTouchstart.unbind();

--- a/modules/tinymce/src/themes/silver/main/ts/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Events.ts
@@ -9,6 +9,8 @@ import { Attachment, Channels, Gui, SystemEvents } from '@ephox/alloy';
 import { Arr } from '@ephox/katamari';
 import { DomEvent, EventArgs, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
+import { AfterProgressStateEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiSystem) => {
   const broadcastEvent = (name: string, evt: EventArgs) => {
@@ -49,11 +51,16 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiS
   // Window events
   const onWindowScroll = (evt: UIEvent) => broadcastEvent(SystemEvents.windowScroll(), DomEvent.fromRawEvent(evt));
   const onWindowResize = (evt: UIEvent) => {
-    broadcastOn(Channels.repositionPopups(), { });
+    broadcastOn(Channels.repositionPopups(), {});
     broadcastEvent(SystemEvents.windowResize(), DomEvent.fromRawEvent(evt));
   };
 
-  const onEditorResize = () => broadcastOn(Channels.repositionPopups(), { });
+  const onEditorResize = () => broadcastOn(Channels.repositionPopups(), {});
+  const onEditorProgress = (evt: EditorEvent<AfterProgressStateEvent>) => {
+    if (evt.state) {
+      broadcastOn(Channels.dismissPopups(), { target: evt.target });
+    }
+  };
 
   // Don't start listening to events until the UI has rendered
   editor.on('PostRender', () => {
@@ -63,7 +70,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiS
     editor.on('ScrollWindow', onWindowScroll);
     editor.on('ResizeWindow', onWindowResize);
     editor.on('ResizeEditor', onEditorResize);
-    editor.on('AfterProgressState', fireDismissPopups);
+    editor.on('AfterProgressState', onEditorProgress);
   });
 
   editor.on('remove', () => {
@@ -74,7 +81,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiS
     editor.off('ScrollWindow', onWindowScroll);
     editor.off('ResizeWindow', onWindowResize);
     editor.off('ResizeEditor', onEditorResize);
-    editor.off('AfterProgressState', fireDismissPopups);
+    editor.off('AfterProgressState', onEditorProgress);
 
     onMousedown.unbind();
     onTouchstart.unbind();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemEvents.ts
@@ -22,7 +22,7 @@ export interface OnMenuItemExecuteType<T> extends GetApiType<T> {
 const onMenuItemExecute = <T>(info: OnMenuItemExecuteType<T>, itemResponse: ItemResponse) => AlloyEvents.runOnExecute((comp, simulatedEvent) => {
   // If there is an action, run the action
   runWithApi(info, comp)(info.onAction);
-  if (!info.triggersSubmenu && itemResponse === ItemResponse.CLOSE_ON_EXECUTE) {
+  if (!info.triggersSubmenu && itemResponse === ItemResponse.CLOSE_ON_EXECUTE && comp.getSystem().isConnected()) {
     AlloyTriggers.emit(comp, SystemEvents.sandboxClose());
     simulatedEvent.stop();
   }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemEvents.ts
@@ -22,8 +22,10 @@ export interface OnMenuItemExecuteType<T> extends GetApiType<T> {
 const onMenuItemExecute = <T>(info: OnMenuItemExecuteType<T>, itemResponse: ItemResponse) => AlloyEvents.runOnExecute((comp, simulatedEvent) => {
   // If there is an action, run the action
   runWithApi(info, comp)(info.onAction);
-  if (!info.triggersSubmenu && itemResponse === ItemResponse.CLOSE_ON_EXECUTE && comp.getSystem().isConnected()) {
-    AlloyTriggers.emit(comp, SystemEvents.sandboxClose());
+  if (!info.triggersSubmenu && itemResponse === ItemResponse.CLOSE_ON_EXECUTE) {
+    if (comp.getSystem().isConnected()) {
+      AlloyTriggers.emit(comp, SystemEvents.sandboxClose());
+    }
     simulatedEvent.stop();
   }
 });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
@@ -73,6 +73,9 @@ const setup = (editor: Editor, lazyThrobber: () => AlloyComponent, sharedBacksta
 
   const toggle = (state: boolean) => {
     if (state !== throbberState.get()) {
+      if (state) {
+        editor.fire('NeilsUntitledEvent');
+      }
       toggleThrobber(lazyThrobber(), state, sharedBackstage.providers);
       throbberState.set(state);
     }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
@@ -75,9 +75,7 @@ const setup = (editor: Editor, lazyThrobber: () => AlloyComponent, sharedBacksta
     if (state !== throbberState.get()) {
       toggleThrobber(lazyThrobber(), state, sharedBackstage.providers);
       throbberState.set(state);
-      if (state) {
-        editor.fire('AfterProgressState');
-      }
+      editor.fire('AfterProgressState', { state });
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
@@ -73,11 +73,11 @@ const setup = (editor: Editor, lazyThrobber: () => AlloyComponent, sharedBacksta
 
   const toggle = (state: boolean) => {
     if (state !== throbberState.get()) {
-      if (state) {
-        editor.fire('NeilsUntitledEvent');
-      }
       toggleThrobber(lazyThrobber(), state, sharedBackstage.providers);
       throbberState.set(state);
+      if (state) {
+        editor.fire('AfterProgressState');
+      }
     }
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -1,5 +1,5 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { after, describe, it } from '@ephox/bedrock-client';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
@@ -8,13 +8,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
-
-  const pWaitForThrobber = async (): Promise<void> => {
-    await UiFinder.pWaitForVisible('waiting for throbber to open', SugarBody.body(), '.tox-throbber');
-  };
-
   const hook = TinyHooks.bddSetup<Editor>({
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce',
     setup: (ed: Editor) => {
       ed.ui.registry.addMenuItem('test-item', {
@@ -29,7 +23,10 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
     contextmenu: 'test'
   }, [ Theme ]);
 
-  after(() => {
+  const pWaitForThrobber = () =>
+    UiFinder.pWaitForVisible('waiting for throbber to open', SugarBody.body(), '.tox-throbber');
+
+  afterEach(() => {
     hook.editor().setProgressState(false);
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -1,0 +1,77 @@
+import { UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+import { SugarBody } from '@ephox/sugar';
+import { assert } from 'chai';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
+
+const openThrobber = async (editor: Editor, delay?: number): Promise<void> => {
+  editor.setProgressState(true, delay);
+  await new Promise((resolve) => setTimeout(resolve, delay));
+  await UiFinder.pWaitForVisible('throbber to open', SugarBody.body(), '.tox-throbber');
+}
+
+describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    theme: 'silver',
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed: Editor) => {
+      ed.ui.registry.addMenuItem('test-item', {
+        icon: 'nope',
+        text: 'do the thing',
+        onAction: Fun.die('please do not click this')
+      });
+      ed.ui.registry.addContextMenu('test', {
+        update: Fun.constant('test-item')
+      });
+    },
+    contextmenu: 'test'
+  }, [ Theme ]);
+
+  it('cancels all open notifications when it opens', async () => {
+    const ed = hook.editor();
+    ed.notificationManager.open({
+      type: 'success',
+      text: 'lorem ipsum'
+    });
+
+    await openThrobber(ed);
+
+    assert.isEmpty(ed.notificationManager.getNotifications(), 'No notifications should be open');
+    ed.setProgressState(false);
+  });
+
+  it('closes the context menu when it opens', async () => {
+    const ed = hook.editor();
+    ed.setContent('<p>Hello world</p>');
+    await TinyUiActions.pTriggerContextMenu(ed, 'p', '.tox-menu');
+
+    await openThrobber(ed);
+
+    await Waiter.pTryUntil('context menu is closed', () => {
+      UiFinder.notExists(SugarBody.body(), '.tox-menu');
+    });
+    ed.setProgressState(false);
+  });
+
+  it('does not close things until the throbber actually opens', async () => {
+    const ed = hook.editor();
+    ed.notificationManager.open({
+      type: 'success',
+      text: 'lorem ipsum'
+    });
+
+    const doTheClose = openThrobber(ed, 300);
+    const assertInParallel = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      assert.isNotEmpty(ed.notificationManager.getNotifications(), 'The notification should not be closed yet');
+    };
+
+    await Promise.all([ doTheClose, assertInParallel() ]);
+
+    assert.isEmpty(ed.notificationManager.getNotifications(), 'The notification should now be closed');
+    ed.setProgressState(false);
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -4,14 +4,16 @@ import { Fun } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
 import { assert } from 'chai';
+
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
-const pWaitForThrobber = async (): Promise<void> => {
-  await UiFinder.pWaitForVisible('waiting for throbber to open', SugarBody.body(), '.tox-throbber');
-};
-
 describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
+
+  const pWaitForThrobber = async (): Promise<void> => {
+    await UiFinder.pWaitForVisible('waiting for throbber to open', SugarBody.body(), '.tox-throbber');
+  };
+
   const hook = TinyHooks.bddSetup<Editor>({
     theme: 'silver',
     base_url: '/project/tinymce/js/tinymce',
@@ -38,6 +40,8 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
       type: 'success',
       text: 'lorem ipsum'
     });
+
+    assert.isNotEmpty(editor.notificationManager.getNotifications(), 'Notification should be present');
 
     editor.setProgressState(true);
     await pWaitForThrobber();


### PR DESCRIPTION
Related Ticket: TINY-6686

Description of Changes:
* Closed popups when the throbber is opened
* This required adding a new event to distinguish between "the throbber is going to open at {time}" and "the throbber is opening right now"

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* ~[ ] License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved
* [x] NeilsUntitledEvent has a better name

GitHub issues (if applicable): N/A