### PR TITLE
TINY-6964: Ensure br elements are scrolled into view when they are inserted

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -35,7 +35,7 @@ Version 5.7.0 (TBD)
     Fixed incorrect behaviour when editor is destroyed while loading stylesheets #INT-2282
     Fixed figure elements incorrectly splitting from a valid parent element when editing the image within #TINY-6592
     Fixed inserting multiple rows or columns in a table cloning from the incorrect source row or column #TINY-6906
-    Fixed a bug where `br` elements were not scrolled into view upon insertion #TINY-6964
+    Fixed an issue where new lines were not scrolled into view when pressing Shift+Enter #TINY-6964
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -35,6 +35,7 @@ Version 5.7.0 (TBD)
     Fixed incorrect behaviour when editor is destroyed while loading stylesheets #INT-2282
     Fixed figure elements incorrectly splitting from a valid parent element when editing the image within #TINY-6592
     Fixed inserting multiple rows or columns in a table cloning from the incorrect source row or column #TINY-6906
+    Fixed a bug where `br` elements were not scrolled into view upon insertion #TINY-6964
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -218,7 +218,10 @@ interface DOMUtils {
   };
   is: (elm: Node | Node[], selector: string) => boolean;
   add: (parentElm: RunArguments, name: string | Node, attrs?: Record<string, string | boolean | number>, html?: string | Node, create?: boolean) => HTMLElement;
-  create: (name: string, attrs?: Record<string, string | boolean | number>, html?: string | Node) => HTMLElement;
+  create: {
+    <K extends keyof HTMLElementTagNameMap>(name: K, attrs?: Record<string, string | boolean | number>, html?: string | Node): HTMLElementTagNameMap[K];
+    (name: string, attrs?: Record<string, string | boolean | number>, html?: string | Node): HTMLElement;
+  };
   createHTML: (name: string, attrs?: Record<string, string>, html?: string) => string;
   createFragment: (html?: string) => DocumentFragment;
   remove: <T extends Node>(node: string | T | T[] | DomQuery<T>, keepChildren?: boolean) => T | T[];

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
@@ -1,6 +1,9 @@
 import { ApproxStructure } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { Arr } from '@ephox/katamari';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { Height, Scroll, WindowVisualViewport } from '@ephox/sugar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as InsertBr from 'tinymce/core/newline/InsertBr';
@@ -110,5 +113,17 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       }))
     );
     TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
+  });
+
+  it('Scrolls correctly to inserted br', () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    Arr.range(100, () => InsertBr.insert(editor));
+    const { top } = Scroll.get(TinyDom.document(editor));
+    const offsetHeight = Height.get(TinyDom.body(editor));
+    const { height } = WindowVisualViewport.getBounds(editor.getWin());
+
+    TinyAssertions.assertCursor(editor, [ 0 ], 100); // assert cursor is at the last br
+    assert.isAtMost(offsetHeight - top, height, 'Editor should be scrolled to the bottom of the view');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-6964

Description of Changes:
Previously when hitting `Shift+Enter` repeatedly, the editor would not scroll to the inserted `br` elements as they were pushed down out of the current view.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
