### PR TITLE
TINY-6493: Paste plugin with smart_paste not pasting url over highlighted text

### DIFF
--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -325,10 +325,11 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
 
     const isPlainTextHtml = (internal === false && Newlines.isPlainText(content));
     const isImage = SmartPaste.isImageUrl(editor, content);
+    const isAbsoluteUrl = SmartPaste.isAbsoluteUrl(content);
 
     // If we got nothing from clipboard API and pastebin or the content is a plain text (with only
     // some BRs, Ps or DIVs as newlines) then we fallback to plain/text
-    if (!content.length || (isPlainTextHtml && !isImage)) {
+    if (!content.length || (isPlainTextHtml && !isImage && !isAbsoluteUrl)) {
       plainTextMode = true;
     }
 


### PR DESCRIPTION
Related Ticket:
https://github.com/tinymce/tinymce/issues/6493

Description of Changes:
Fix issue with smart paste not detecting urls, instead replacing the highlighted text with the content of the url. This PR adds a change to detect if the content in the clipboard is an absolute URL, and if so, bypasses the `plainTextMode`.

There may be a better fix, but from what I can understand, `plainTextMode` is used to determine if `smartInsertContent` should be used, or bypassed entirely. Without `smartInsertContent`, the URL's won't be set properly, and will just replace the content highlighted.

Here is where the branching of the `smartPaste` vs text paste:
https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts#L358

With the `pasteAsText` being passed, the `smartInsertContent` won't get called in SmartPaste.ts:
https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts#L78

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)
* [ ] License headers added on new files (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
