### PR TITLE
TINY-6971: Fixed dialog block messages not getting translated

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -35,6 +35,7 @@ Version 5.7.0 (TBD)
     Fixed incorrect behaviour when editor is destroyed while loading stylesheets #INT-2282
     Fixed figure elements incorrectly splitting from a valid parent element when editing the image within #TINY-6592
     Fixed inserting multiple rows or columns in a table cloning from the incorrect source row or column #TINY-6906
+    Fixed dialog block messages unable to be translated #TINY-6971
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -44,7 +44,7 @@ const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverD
 
   const dialogEvents = SilverDialogEvents.initDialog(
     () => instanceApi,
-    SilverDialogCommon.getEventExtras(() => dialog, extra),
+    SilverDialogCommon.getEventExtras(() => dialog, backstage.shared.providers, extra),
     backstage.shared.getSink
   );
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -12,7 +12,7 @@ import {
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Arr, Cell, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 import { StoragedMenuButton, StoragedMenuItem } from '../button/MenuButton';
 import * as Dialogs from '../dialog/Dialogs';
@@ -39,12 +39,12 @@ const getHeader = (title: string, backstage: UiFactoryBackstage) => renderModalH
   draggable: backstage.dialog.isDraggableModal()
 }, backstage.shared.providers);
 
-const getBusySpec = (message: string, bs: Record<string, Behaviour.ConfiguredBehaviour<any, any, any>>) => ({
+const getBusySpec = (message: string, bs: Record<string, Behaviour.ConfiguredBehaviour<any, any, any>>, providers: UiFactoryBackstageProviders) => ({
   dom: {
     tag: 'div',
     classes: [ 'tox-dialog__busy-spinner' ],
     attributes: {
-      'aria-label': message
+      'aria-label': providers.translate(message)
     },
     styles: {
       left: '0px',
@@ -60,10 +60,10 @@ const getBusySpec = (message: string, bs: Record<string, Behaviour.ConfiguredBeh
   }]
 });
 
-const getEventExtras = (lazyDialog: () => AlloyComponent, extra: WindowExtra) => ({
+const getEventExtras = (lazyDialog: () => AlloyComponent, providers: UiFactoryBackstageProviders, extra: WindowExtra) => ({
   onClose: () => extra.closeWindow(),
   onBlock: (blockEvent: FormBlockEvent) => {
-    ModalDialog.setBusy(lazyDialog(), (_comp, bs) => getBusySpec(blockEvent.message, bs));
+    ModalDialog.setBusy(lazyDialog(), (_comp, bs) => getBusySpec(blockEvent.message, bs, providers));
   },
   onUnblock: () => {
     ModalDialog.setIdle(lazyDialog());

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -59,7 +59,7 @@ const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: S
     () => instanceApi,
     {
       onBlock: (event) => {
-        Blocking.block(dialog, (_comp, bs) => SilverDialogCommon.getBusySpec(event.message, bs));
+        Blocking.block(dialog, (_comp, bs) => SilverDialogCommon.getBusySpec(event.message, bs, backstage.shared.providers));
       },
       onUnblock: () => {
         Blocking.unblock(dialog);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialog.ts
@@ -64,7 +64,10 @@ const renderUrlDialog = (internalDialog: Dialog.UrlDialog, extra: WindowExtra, e
     }
   });
 
-  const dialogEvents = SilverDialogEvents.initUrlDialog(() => instanceApi, getEventExtras(() => dialog, extra));
+  const dialogEvents = SilverDialogEvents.initUrlDialog(
+    () => instanceApi,
+    getEventExtras(() => dialog, backstage.shared.providers, extra)
+  );
 
   // Add the styles for the modal width/height
   const styles = {


### PR DESCRIPTION
Related Ticket: TINY-6971

Description of Changes:
* Fixes dialog API block messages not getting passed through for translation

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
