### PR TITLE
TINY-6940: Support mixed case files extensions when handling images

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -36,6 +36,7 @@ Version 5.7.0 (TBD)
     Fixed figure elements incorrectly splitting from a valid parent element when editing the image within #TINY-6592
     Fixed inserting multiple rows or columns in a table cloning from the incorrect source row or column #TINY-6906
     Fixed an issue where new lines were not scrolled into view when pressing Shift+Enter #TINY-6964
+    Fixed an issue where file extensions with uppercase characters were treated as invalid #TINY-6940
 Version 5.6.2 (2020-12-08)
     Fixed a UI rendering regression when the document body is using `display: flex` #TINY-6783
 Version 5.6.1 (2020-11-25)

--- a/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
@@ -33,7 +33,7 @@ const isAbsoluteUrl = (url: string) => {
 };
 
 const isImageUrl = (editor: Editor, url: string) => {
-  return isAbsoluteUrl(url) && Arr.exists(Settings.getAllowedImageFileTypes(editor), (type) => Strings.endsWith(url.toLowerCase(), `.${type}`));
+  return isAbsoluteUrl(url) && Arr.exists(Settings.getAllowedImageFileTypes(editor), (type) => Strings.endsWith(url.toLowerCase(), `.${type.toLowerCase()}`));
 };
 
 const createImage = (editor: Editor, url: string, pasteHtmlFn: typeof pasteHtml) => {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
@@ -33,7 +33,7 @@ const isAbsoluteUrl = (url: string) => {
 };
 
 const isImageUrl = (editor: Editor, url: string) => {
-  return isAbsoluteUrl(url) && Arr.exists(Settings.getAllowedImageFileTypes(editor), (type) => Strings.endsWith(url, `.${type}`));
+  return isAbsoluteUrl(url) && Arr.exists(Settings.getAllowedImageFileTypes(editor), (type) => Strings.endsWith(url.toLowerCase(), `.${type}`));
 };
 
 const createImage = (editor: Editor, url: string, pasteHtmlFn: typeof pasteHtml) => {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
@@ -137,6 +137,7 @@ const createIdGenerator = (prefix: string) => {
 };
 
 const getImageMimeType = (ext: string): string => {
+  const lowerExt = ext.toLowerCase();
   const mimeOverrides = {
     jpg: 'jpeg',
     jpe: 'jpeg',
@@ -147,7 +148,7 @@ const getImageMimeType = (ext: string): string => {
     pjp: 'jpeg',
     svg: 'svg+xml'
   };
-  return Tools.hasOwn(mimeOverrides, ext) ? 'image/' + mimeOverrides[ext] : 'image/' + ext;
+  return Tools.hasOwn(mimeOverrides, lowerExt) ? 'image/' + mimeOverrides[lowerExt] : 'image/' + lowerExt;
 };
 
 export {

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
@@ -61,7 +61,9 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.SmartPasteTest', (success, fai
       'png',
       'gif',
       'bmp',
-      'webp'
+      'webp',
+      'PNG',
+      'WEBP',
     ], (image_file_type) => LegacyUnit.equal(
       SmartPaste.isImageUrl(editor, `https://www.site.com/file.${image_file_type}`),
       true,
@@ -87,6 +89,11 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.SmartPasteTest', (success, fai
       SmartPaste.isImageUrl(editor, 'https://www.site.com/file.svg'),
       true,
       'File type "svg" is valid when set by settings'
+    );
+    LegacyUnit.equal(
+      SmartPaste.isImageUrl(editor, 'https://www.site.com/file.SVG'),
+      true,
+      'File type "SVG" (capitals) is valid when set by settings'
     );
     delete editor.settings.images_file_types;
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -28,7 +28,7 @@ const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp';
 
 const filterByExtension = (files: FileList, providersBackstage: UiFactoryBackstageProviders) => {
   const allowedImageFileTypes = Tools.explode(providersBackstage.getSetting('images_file_types', defaultImageFileTypes, 'string'));
-  const isFileInAllowedTypes = (file: File) => Arr.exists(allowedImageFileTypes, (type) => Strings.endsWith(file.name, `.${type}`));
+  const isFileInAllowedTypes = (file: File) => Arr.exists(allowedImageFileTypes, (type) => Strings.endsWith(file.name.toLowerCase(), `.${type}`));
 
   return Arr.filter(Arr.from(files), isFileInAllowedTypes);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -28,7 +28,7 @@ const defaultImageFileTypes = 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp';
 
 const filterByExtension = (files: FileList, providersBackstage: UiFactoryBackstageProviders) => {
   const allowedImageFileTypes = Tools.explode(providersBackstage.getSetting('images_file_types', defaultImageFileTypes, 'string'));
-  const isFileInAllowedTypes = (file: File) => Arr.exists(allowedImageFileTypes, (type) => Strings.endsWith(file.name.toLowerCase(), `.${type}`));
+  const isFileInAllowedTypes = (file: File) => Arr.exists(allowedImageFileTypes, (type) => Strings.endsWith(file.name.toLowerCase(), `.${type.toLowerCase()}`));
 
   return Arr.filter(Arr.from(files), isFileInAllowedTypes);
 };

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/dropzone/DropzoneTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/dropzone/DropzoneTest.ts
@@ -50,7 +50,9 @@ UnitTest.asynctest('Dropzone component Test', (success, failure) => {
                     { name: 'image7.jfif' },
                     { name: 'image8.gif' },
                     { name: 'image9.bmp' },
-                    { name: 'image10.webp' }
+                    { name: 'image10.webp' },
+                    { name: 'image11.PNG' },
+                    { name: 'image12.WEBP' },
                   ]
                 }
               }
@@ -73,7 +75,9 @@ UnitTest.asynctest('Dropzone component Test', (success, failure) => {
           { name: 'image7.jfif' },
           { name: 'image8.gif' },
           { name: 'image9.bmp' },
-          { name: 'image10.webp' }
+          { name: 'image10.webp' },
+          { name: 'image11.PNG' },
+          { name: 'image12.WEBP' },
         ], filesValue);
       })
     ],


### PR DESCRIPTION
Related Ticket:

TINY-6940

Description of Changes:

Fixed an issue introduced by TINY-6306 where capitalised file extensions were treated as invalid.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #6459