### PR TITLE
TINY-6686: Ensure context toolbars also close when the throbber opens

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
@@ -323,6 +323,13 @@ const register = (editor: Editor, registryContextToolbars, sink: AlloyComponent,
       }
     });
 
+    editor.on('AfterProgressState', (event) => {
+      if (event.state) {
+        lastAnchor.set(Optional.none());
+        InlineView.hide(contextbar);
+      }
+    });
+
     editor.on('NodeChange', (_e) => {
       Focus.search(contextbar.element).fold(
         () => {

--- a/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
@@ -191,12 +191,7 @@ const register = (editor: Editor, registryContextToolbars, sink: AlloyComponent,
     });
   }));
 
-  type ContextToolbarButtonTypes =
-    Toolbar.ToolbarButtonSpec
-    | Toolbar.ToolbarMenuButtonSpec
-    | Toolbar.ToolbarSplitButtonSpec
-    | Toolbar.ToolbarToggleButtonSpec
-    | Toolbar.GroupToolbarButtonSpec;
+  type ContextToolbarButtonTypes = Toolbar.ToolbarButtonSpec | Toolbar.ToolbarMenuButtonSpec | Toolbar.ToolbarSplitButtonSpec | Toolbar.ToolbarToggleButtonSpec | Toolbar.GroupToolbarButtonSpec;
 
   const buildContextToolbarGroups = (allButtons: Record<string, ContextToolbarButtonTypes>, ctx: InlineContent.ContextToolbar) =>
     identifyButtons(editor, { buttons: allButtons, toolbar: ctx.items, allowToolbarGroups: false }, extras, Optional.some([ 'form:' ]));

--- a/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
@@ -135,6 +135,11 @@ const register = (editor: Editor, registryContextToolbars, sink: AlloyComponent,
     );
   };
 
+  const close = () => {
+    lastAnchor.set(Optional.none());
+    InlineView.hide(contextbar);
+  };
+
   const forceHide = () => {
     InlineView.hide(contextbar);
   };
@@ -271,10 +276,7 @@ const register = (editor: Editor, registryContextToolbars, sink: AlloyComponent,
 
     const scopes = getScopes();
     ToolbarLookup.lookup(scopes, editor).fold(
-      () => {
-        lastAnchor.set(Optional.none());
-        InlineView.hide(contextbar);
-      },
+      close,
 
       (info) => {
         launchContext(info.toolbars, Optional.some(info.elem.dom));
@@ -310,23 +312,20 @@ const register = (editor: Editor, registryContextToolbars, sink: AlloyComponent,
     editor.on('focusout', (_e) => {
       Delay.setEditorTimeout(editor, () => {
         if (Focus.search(sink.element).isNone() && Focus.search(contextbar.element).isNone()) {
-          lastAnchor.set(Optional.none());
-          InlineView.hide(contextbar);
+          close();
         }
       }, 0);
     });
 
     editor.on('SwitchMode', () => {
       if (editor.mode.isReadOnly()) {
-        lastAnchor.set(Optional.none());
-        InlineView.hide(contextbar);
+        close();
       }
     });
 
     editor.on('AfterProgressState', (event) => {
       if (event.state) {
-        lastAnchor.set(Optional.none());
-        InlineView.hide(contextbar);
+        close();
       }
     });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -52,23 +52,7 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
     });
   });
 
-  it('closes the context toolbar when it opens', async () => {
-    const editor = hook.editor();
-    editor.setContent('<p class="ctx-menu-me">Hello World</p>');
-
-    await Waiter.pTryUntil('Waiting for context toolbar to open', () => {
-      UiFinder.findIn(SugarBody.body(), '.tox-pop');
-    });
-
-    editor.setProgressState(true);
-    await pWaitForThrobber();
-
-    await Waiter.pTryUntil('context toolbar is closed', () => {
-      UiFinder.notExists(SugarBody.body(), '.tox-pop');
-    });
-  });
-
-  context('correctly re-opens (or does not re-open) the context toolbar when it closes', () => {
+  context('context toolbar', () => {
     beforeEach(async () => {
       const editor = hook.editor();
       editor.setContent('<p class="ctx-menu-me">Hello World</p>');
@@ -81,7 +65,13 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
       await pWaitForThrobber();
     });
 
-    it('re-opens the context toolbar if focus is on the editor', async () => {
+    it('closed by throbber opening', async () => {
+      await Waiter.pTryUntil('context toolbar is closed', () => {
+        UiFinder.notExists(SugarBody.body(), '.tox-pop');
+      });
+    });
+
+    it('re-opens when the throbber closes', async () => {
       const editor = hook.editor();
       editor.setProgressState(false);
       await Waiter.pTryUntil('context toolbar is open again', () => {
@@ -89,7 +79,7 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
       });
     });
 
-    it('does not re-open the context toolbar if focus is not on the editor', async () => {
+    it('does not re-open when the throbber closes - if there is no focus on the editor', async () => {
       // blur the editor
       const input = SugarElement.fromTag('input');
       Insert.append(SugarBody.body(), input);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -2,7 +2,7 @@ import { UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
-import { SugarBody } from '@ephox/sugar';
+import { NodeTypes, SugarBody } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
@@ -18,6 +18,20 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
       });
       ed.ui.registry.addContextMenu('test', {
         update: Fun.constant('test-item')
+      });
+      ed.ui.registry.addContextToolbar('test-2', {
+        items: 'bold | italic',
+        scope: 'node',
+        position: 'selection',
+        predicate: (node: Node) => {
+          if (node.nodeType === NodeTypes.ELEMENT) {
+            const elem = node as HTMLElement;
+            if (elem.classList.contains('ctx-menu-me')) {
+              return true;
+            }
+          }
+          return false;
+        }
       });
     },
     contextmenu: 'test'
@@ -40,6 +54,22 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
 
     await Waiter.pTryUntil('context menu is closed', () => {
       UiFinder.notExists(SugarBody.body(), '.tox-menu');
+    });
+  });
+
+  it('closes the context toolbar on popup', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p class="ctx-menu-me">Hello World</p>');
+
+    await Waiter.pTryUntil('Waiting for context toolbar to open', () => {
+      UiFinder.findIn(SugarBody.body(), '.tox-pop');
+    });
+
+    editor.setProgressState(true);
+    await pWaitForThrobber();
+
+    await Waiter.pTryUntil('context toolbar is closed', () => {
+      UiFinder.notExists(SugarBody.body(), '.tox-pop');
     });
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -88,7 +88,7 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
       // close the throbber
       const editor = hook.editor();
       editor.setProgressState(false);
-      await UiFinder.pWaitForState('throbber is closed', SugarBody.body(), '.tox-throbber', Fun.not(Visibility.isVisible));
+      await UiFinder.pWaitForHidden('throbber is closed', SugarBody.body(), '.tox-throbber');
       // give the context toolbar time to re-open (note: it should not re-open during this time)
       await Waiter.pWait(50);
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -2,7 +2,7 @@ import { UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
-import { NodeTypes, SugarBody } from '@ephox/sugar';
+import { Class, SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
@@ -23,14 +23,9 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
         items: 'bold | italic',
         scope: 'node',
         position: 'selection',
-        predicate: (node: Node) => {
-          if (node.nodeType === NodeTypes.ELEMENT) {
-            const elem = node as HTMLElement;
-            if (elem.classList.contains('ctx-menu-me')) {
-              return true;
-            }
-          }
-          return false;
+        predicate: (n: Node) => {
+          const node = SugarElement.fromDom(n);
+          return SugarNode.isHTMLElement(node) && Class.has(node, 'ctx-menu-me');
         }
       });
     },

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { afterEach, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
-import { Class, SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
+import { Class, Focus, Insert, Remove, SugarBody, SugarElement, SugarNode, Visibility } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
@@ -52,7 +52,7 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
     });
   });
 
-  it('closes the context toolbar on popup', async () => {
+  it('closes the context toolbar when it opens', async () => {
     const editor = hook.editor();
     editor.setContent('<p class="ctx-menu-me">Hello World</p>');
 
@@ -65,6 +65,48 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
 
     await Waiter.pTryUntil('context toolbar is closed', () => {
       UiFinder.notExists(SugarBody.body(), '.tox-pop');
+    });
+  });
+
+  context('correctly re-opens (or does not re-open) the context toolbar when it closes', () => {
+    beforeEach(async () => {
+      const editor = hook.editor();
+      editor.setContent('<p class="ctx-menu-me">Hello World</p>');
+
+      await Waiter.pTryUntil('Waiting for context toolbar to open', () => {
+        UiFinder.findIn(SugarBody.body(), '.tox-pop');
+      });
+
+      editor.setProgressState(true);
+      await pWaitForThrobber();
+    });
+
+    it('re-opens the context toolbar if focus is on the editor', async () => {
+      const editor = hook.editor();
+      editor.setProgressState(false);
+      await Waiter.pTryUntil('context toolbar is open again', () => {
+        UiFinder.exists(SugarBody.body(), '.tox-pop');
+      });
+    });
+
+    it('does not re-open the context toolbar if focus is not on the editor', async () => {
+      // blur the editor
+      const input = SugarElement.fromTag('input');
+      Insert.append(SugarBody.body(), input);
+      Focus.focus(input);
+
+      // close the throbber
+      const editor = hook.editor();
+      editor.setProgressState(false);
+      await UiFinder.pWaitForState('throbber is closed', SugarBody.body(), '.tox-throbber', Fun.not(Visibility.isVisible));
+      // give the context toolbar time to re-open (note: it should not re-open during this time)
+      await Waiter.pWait(50);
+
+      // ensure that the context toolbar does not re-open
+      UiFinder.notExists(SugarBody.body(), '.tox-pop');
+
+      // clean up
+      Remove.remove(input);
     });
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -2,7 +2,7 @@ import { UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
-import { Class, Focus, Insert, Remove, SugarBody, SugarElement, SugarNode, Visibility } from '@ephox/sugar';
+import { Class, Focus, Insert, Remove, SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';


### PR DESCRIPTION
Related Ticket: TINY-6686

Description of Changes:
* Same as the last 6686 PR, it's closing popups when the editor is blocked
* This time I made it work for context toolbars

Pre-checks:
* ~[ ] Changelog entry added~
* [x] Tests have been added (if applicable)
* ~[ ] Branch prefixed with `feature/` for new features (if applicable)~
* ~[ ] License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
