### PR TITLE
TINY-6711: Fixed an issue with widths being incorrectly cloned when inserting a new column that had a colspan previously

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/CellMutations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CellMutations.ts
@@ -4,7 +4,7 @@ import * as CellUtils from '../util/CellUtils';
 
 const halve = (main: SugarElement, other: SugarElement): void => {
   const colspan = CellUtils.getSpan(main, 'colspan');
-  // Don't set a width on the new cell if we have a colspan as we can only safely do that for cells
+  // Only set width on the new cell if we have a colspan of 1 (or no colspan) as we can only safely do that for cells
   // that are a single column, since we don't know the individual column widths for a cell with a colspan.
   // Instead, we'll rely on the adjustments/postAction logic to set the widths based on other cells in the column
   if (colspan === 1) {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CellMutations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CellMutations.ts
@@ -1,13 +1,20 @@
 import { SugarElement } from '@ephox/sugar';
 import * as Sizes from '../resize/Sizes';
+import * as CellUtils from '../util/CellUtils';
 
 const halve = (main: SugarElement, other: SugarElement): void => {
-  const width = Sizes.getGenericWidth(main);
-  width.each((w) => {
-    const newWidth = w.value / 2;
-    Sizes.setGenericWidth(main, newWidth, w.unit);
-    Sizes.setGenericWidth(other, newWidth, w.unit);
-  });
+  const colspan = CellUtils.getSpan(main, 'colspan');
+  // Don't set a width on the new cell if we have a colspan as we can only safely do that for cells
+  // that are a single column, since we don't know the individual column widths for a cell with a colspan.
+  // Instead, we'll rely on the adjustments/postAction logic to set the widths based on other cells in the column
+  if (colspan === 1) {
+    const width = Sizes.getGenericWidth(main);
+    width.each((w) => {
+      const newWidth = w.value / 2;
+      Sizes.setGenericWidth(main, newWidth, w.unit);
+      Sizes.setGenericWidth(other, newWidth, w.unit);
+    });
+  }
 };
 
 export {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
@@ -77,7 +77,7 @@ const cellOperations = (mutate: (e1: SugarElement, e2: SugarElement) => void, do
     Css.remove(clone, 'height');
     // dont inherit the width of spanning columns
     if (prev.colspan !== 1) {
-      Css.remove(prev.element, 'width');
+      Css.remove(clone, 'width');
     }
   };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -1,9 +1,9 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Remove, SugarElement, SugarNode, Width } from '@ephox/sugar';
+import * as Blocks from '../lookup/Blocks';
 import * as DetailsList from '../model/DetailsList';
 import * as GridRow from '../model/GridRow';
 import * as RunOperation from '../model/RunOperation';
-
 import * as TableMerge from '../model/TableMerge';
 import * as Transitions from '../model/Transitions';
 import * as MergingOperations from '../operate/MergingOperations';
@@ -359,9 +359,14 @@ const firstColumnIsLocked = (_warehouse: Warehouse, details: Structs.DetailExt[]
 const lastColumnIsLocked = (warehouse: Warehouse, details: Structs.DetailExt[]) =>
   Arr.exists(details, (detail) => detail.column + detail.colspan >= warehouse.grid.columns && detail.isLocked);
 
-const getColumnsWidth = (details: Structs.DetailExt[]) => {
+const getColumnsWidth = (warehouse: Warehouse, details: Structs.DetailExt[]) => {
+  const columns = Blocks.columns(warehouse);
   const uniqueCols = ColUtils.uniqueColumns(details);
-  return Arr.foldl(uniqueCols, (acc, detail) => acc + Width.getOuter(detail.element), 0);
+  return Arr.foldl(uniqueCols, (acc, detail) => {
+    const column = columns[detail.column];
+    const colWidth = column.map(Width.getOuter).getOr(0);
+    return acc + colWidth;
+  }, 0);
 };
 
 const insertColumnExtractor = (before: boolean) => (warehouse: Warehouse, target: RunOperation.TargetElement): Optional<ExtractColDetail> =>
@@ -370,7 +375,7 @@ const insertColumnExtractor = (before: boolean) => (warehouse: Warehouse, target
     return !checkLocked(warehouse, [ detail ]);
   }).map((detail) => ({
     detail,
-    pixelDelta: getColumnsWidth([ detail ]),
+    pixelDelta: getColumnsWidth(warehouse, [ detail ]),
   }));
 
 const insertColumnsExtractor = (before: boolean) => (warehouse: Warehouse, target: TargetSelection): Optional<ExtractColsDetail> =>
@@ -379,13 +384,13 @@ const insertColumnsExtractor = (before: boolean) => (warehouse: Warehouse, targe
     return !checkLocked(warehouse, details);
   }).map((details) => ({
     details,
-    pixelDelta: getColumnsWidth(details),
+    pixelDelta: getColumnsWidth(warehouse, details),
   }));
 
 const eraseColumnsExtractor = (warehouse: Warehouse, target: TargetSelection): Optional<ExtractColsDetail> =>
   RunOperation.onUnlockedCells(warehouse, target).map((details) => ({
     details,
-    pixelDelta: -getColumnsWidth(details), // needs to be negative as we are removing columns
+    pixelDelta: -getColumnsWidth(warehouse, details), // needs to be negative as we are removing columns
   }));
 
 const pasteColumnsExtractor = (before: boolean) => (warehouse: Warehouse, target: RunOperation.TargetPasteRows): Optional<ExtractPasteRows> =>

--- a/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
@@ -3,13 +3,15 @@ import { SugarElement } from '@ephox/sugar';
 import { DetailExt } from '../api/Structs';
 import { Warehouse } from '../api/Warehouse';
 
+type ValidCellFn = (cell: SugarElement<HTMLTableCellElement>) => boolean;
+
 /*
  * Identify for each column, a cell that has colspan 1. Note, this
  * may actually fail, and future work will be to calculate column
  * sizes that are only available through the difference of two
  * spanning columns.
  */
-const columns = (warehouse: Warehouse, isValidCell: (detail: SugarElement<HTMLTableCellElement>) => boolean = Fun.always): Optional<SugarElement<HTMLTableCellElement>>[] => {
+const columns = (warehouse: Warehouse, isValidCell: ValidCellFn = Fun.always): Optional<SugarElement<HTMLTableCellElement>>[] => {
   const grid = warehouse.grid;
   const cols = Arr.range(grid.columns, Fun.identity);
   const rowsArr = Arr.range(grid.rows, Fun.identity);

--- a/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
@@ -9,7 +9,7 @@ import { Warehouse } from '../api/Warehouse';
  * sizes that are only available through the difference of two
  * spanning columns.
  */
-const columns = (warehouse: Warehouse): Optional<SugarElement<HTMLTableCellElement>>[] => {
+const columns = (warehouse: Warehouse, isValidCell: (detail: SugarElement<HTMLTableCellElement>) => boolean = Fun.always): Optional<SugarElement<HTMLTableCellElement>>[] => {
   const grid = warehouse.grid;
   const cols = Arr.range(grid.columns, Fun.identity);
   const rowsArr = Arr.range(grid.rows, Fun.identity);
@@ -22,16 +22,16 @@ const columns = (warehouse: Warehouse): Optional<SugarElement<HTMLTableCellEleme
           .toArray()
       );
 
-    const isSingle = (detail: DetailExt) => detail.colspan === 1;
+    const isValid = (detail: DetailExt) => detail.colspan === 1 && isValidCell(detail.element);
     const getFallback = () => Warehouse.getAt(warehouse, 0, col);
-    return decide(getBlock, isSingle, getFallback);
+    return decide(getBlock, isValid, getFallback);
   });
 };
 
-const decide = (getBlock: () => DetailExt[], isSingle: (detail: DetailExt) => boolean, getFallback: () => Optional<DetailExt>): Optional<SugarElement> => {
+const decide = (getBlock: () => DetailExt[], isValid: (detail: DetailExt) => boolean, getFallback: () => Optional<DetailExt>): Optional<SugarElement> => {
   const inBlock = getBlock();
-  const singleInBlock = Arr.find(inBlock, isSingle);
-  const detailOption = singleInBlock.orThunk(() => Optional.from(inBlock[0]).orThunk(getFallback));
+  const validInBlock = Arr.find(inBlock, isValid);
+  const detailOption = validInBlock.orThunk(() => Optional.from(inBlock[0]).orThunk(getFallback));
   return detailOption.map((detail) => detail.element);
 };
 

--- a/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
+++ b/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
@@ -8,6 +8,12 @@ import * as ColumnSizes from 'ephox/snooker/resize/ColumnSizes';
 
 const noneTableHtml = '<table><tbody><tr><td>A</td><td>A</td></tr></tbody></table>';
 const pixelTableHtml = '<table style="width: 400px; border-collapse: collapse"><tbody><tr><td style="width: 200px;">A</td><td style="width: 200px;">A</td></tr></tbody></table>';
+const pixelTableMissingWidthsHtml = `<table style="width: 400px; border-collapse: collapse">
+  <tbody>
+    <tr><td>A</td><td style="width: 200px;">B</td></tr>
+    <tr><td style="width: 200px;">C</td><td>D</td></tr>
+  </tbody>
+</table>`;
 const tableWithSpansHtml = '<table style="width: 400px; border-collapse: collapse"><tbody><tr><td style="width: 400px;" colspan="2">A</td></tr></tbody></table>';
 const noneTableWithColsHtml = '<table><colgroup><col><col></colgroup><tbody><tr><td>A</td><td>A</td></tr></tbody></table>';
 
@@ -29,10 +35,11 @@ UnitTest.test('ColumnSizes.getPixelWidths', () => {
     Remove.remove(table);
   };
 
-  sTest('Pixel Table - Cell widths should be the raw size of the cell', pixelTableHtml, () => [ 200, 200 ]);
-  sTest('Pixel Table - Cell width should be the size of the table when using colspans', tableWithSpansHtml, () => [ 0, 400 ]);
-  sTest('None Table - Cell widths should be the computed size of the cell', noneTableHtml, (width) => [ width, width ]);
-  sTest('None Table - Cell widths for cols should be the computed size of the cell', noneTableWithColsHtml, (width) => [ width + 2, width + 2 ]); // Add 2 to account for the borders
+  sTest('Pixel Table - Column widths should be the raw size of the cell', pixelTableHtml, () => [ 200, 200 ]);
+  sTest('Pixel Table - Column widths with missing widths on some cells should be the raw size of the cell', pixelTableMissingWidthsHtml, () => [ 200, 200 ]);
+  sTest('Pixel Table - Column width should be the size of the table when using colspans', tableWithSpansHtml, () => [ 0, 400 ]);
+  sTest('None Table - Column widths should be the computed size of the cell', noneTableHtml, (width) => [ width, width ]);
+  sTest('None Table - Column widths for cols should be the computed size of the cell', noneTableWithColsHtml, (width) => [ width + 2, width + 2 ]); // Add 2 to account for the borders
 });
 
 UnitTest.test('ColumnSizes.getPixelHeights', () => {
@@ -47,7 +54,7 @@ UnitTest.test('ColumnSizes.getPixelHeights', () => {
 
   // Round to account for precision issues
   const roundedPixelHeights = Arr.map(pixelHeights, Math.round);
-  Assert.eq('Cell heights should be the computed size of the cell', [ cellHeight ], roundedPixelHeights);
+  Assert.eq('Row heights should be the computed size of the cell', [ cellHeight ], roundedPixelHeights);
 
   Remove.remove(table);
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
@@ -39,7 +39,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
     } else {
       const afterWidth = getTableWidth(editor);
       // 2px margin of error, 30px margin of error for IE
-      assert.approximately(afterWidth, beforeWidth * multiplier, platform.browser.isIE() ? 30 : 2);
+      assert.approximately(afterWidth, beforeWidth * multiplier, platform.browser.isIE() ? 30 : 2, 'Assert table width');
     }
   };
 
@@ -133,6 +133,28 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
           mceTableDeleteCol: 0
         });
       });
+
+      it('TINY-6711: will function with a colspan', () => {
+        const editor = hook.editor();
+        const content = (`
+          <table>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" colspan="2"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        performCommandsAndAssertWidths(editor, content, {
+          mceTableInsertColBefore: 1.5,
+          mceTableInsertColAfter: 1.5,
+          mceTableDeleteCol: 0.5
+        });
+      });
     });
 
     context('table_column_resizing=resizetable', () => {
@@ -212,6 +234,32 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
           mceTableInsertColBefore: 2,
           mceTableInsertColAfter: 2,
           mceTableDeleteCol: 0
+        });
+      });
+
+      it('TINY-6711: will function with a colspan', () => {
+        const editor = hook.editor();
+        const content = (`
+          <table>
+            <colgroup>
+              <col>
+              <col>
+            </colgroup>
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" colspan="2"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        performCommandsAndAssertWidths(editor, content, {
+          mceTableInsertColBefore: 1.5,
+          mceTableInsertColAfter: 1.5,
+          mceTableDeleteCol: 0.5
         });
       });
     });
@@ -297,6 +345,28 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
           mceTableDeleteCol: 0
         });
       });
+
+      it('TINY-6711: will preserve width with a colspan', () => {
+        const editor = hook.editor();
+        const content = (`
+          <table style="width: 455px;">
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" style="width: 440.219px;" colspan="2"></td>
+              </tr>
+              <tr>
+                <td style="width: 184.219px;"></td>
+                <td style="width: 242.219px;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        performCommandsAndAssertWidths(editor, content, {
+          mceTableInsertColBefore: 1,
+          mceTableInsertColAfter: 1,
+          mceTableDeleteCol: 1
+        });
+      });
     });
 
     context('table_column_resizing=resizetable', () => {
@@ -376,6 +446,29 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
           mceTableInsertColBefore: 2,
           mceTableInsertColAfter: 2,
           mceTableDeleteCol: 0
+        });
+      });
+
+      it('TINY-6711: should resize table by single column width with a colspan', () => {
+        const editor = hook.editor();
+        const content = (`
+          <table style="width: 455px;">
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" style="width: 440.219px;" colspan="2"></td>
+              </tr>
+              <tr>
+                <td style="width: 184.219px;"></td>
+                <td style="width: 242.219px;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        performCommandsAndAssertWidths(editor, content, {
+          // 184/(184+242) === 0.432 so the table should be adjusted by 43.2%
+          mceTableInsertColBefore: 1.432,
+          mceTableInsertColAfter: 1.432,
+          mceTableDeleteCol: 0.568
         });
       });
     });
@@ -461,6 +554,28 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
           mceTableDeleteCol: 0
         });
       });
+
+      it('TINY-6711: should preserve table width when using a colspan', () => {
+        const editor = hook.editor();
+        const content = (`
+          <table style="width: 50%;">
+            <tbody>
+              <tr style="height: 21px;">
+                <td data-mce-selected="1" style="width: 100%;" colspan="2"></td>
+              </tr>
+              <tr style="height: 22px;">
+                <td style="width: 50.6463%;"></td>
+                <td style="width: 49.3537%;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        performCommandsAndAssertWidths(editor, content, {
+          mceTableInsertColBefore: 1,
+          mceTableInsertColAfter: 1,
+          mceTableDeleteCol: 1
+        });
+      });
     });
 
     context('table_column_resizing=resizetable', () => {
@@ -470,18 +585,18 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         table_column_resizing: 'resizetable',
       }, [ Plugin, Theme ]);
 
-      it('TINY-6711: should should resize table when inserting a column', () => {
+      it('TINY-6711: should resize table when inserting a column', () => {
         const editor = hook.editor();
         const content = (`
-          <table width: 33.3433%; border="1">
+          <table style="width: 33.3433%;" border="1">
             <tbody>
               <tr>
-                <td style="width: 47.0386%;"></td>
-                <td data-mce-selected="1" style="width: 47.9985%;"></td>
+                <td style="width: 47.4386%;"></td>
+                <td data-mce-selected="1" style="width: 47.5985%;"></td>
               </tr>
               <tr>
-                <td style="width: 47.0386%;"></td>
-                <td style="width: 47.9985%;"></td>
+                <td style="width: 47.4386%;"></td>
+                <td style="width: 47.5985%;"></td>
               </tr>
             </tbody>
           </table>
@@ -493,7 +608,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         });
       });
 
-      it('TINY-6711: should should resize table when inserting multiple columns', () => {
+      it('TINY-6711: should resize table when inserting multiple columns', () => {
         const editor = hook.editor();
         const content = (`
           <table width: 33.3433%; border="1">
@@ -516,7 +631,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         });
       });
 
-      it('TINY-6711: should should resize table when using a colgroup', () => {
+      it('TINY-6711: should resize table when using a colgroup', () => {
         const editor = hook.editor();
         const content = (`
           <table style="width: 57.8035%;">
@@ -540,6 +655,28 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
           mceTableInsertColBefore: 2,
           mceTableInsertColAfter: 2,
           mceTableDeleteCol: 0
+        });
+      });
+
+      it('TINY-6711: should resize table width when using a colspan', () => {
+        const editor = hook.editor();
+        const content = (`
+          <table style="width: 33.3433%;" border="1">
+            <tbody>
+              <tr>
+                <td data-mce-selected="1" style="width: 95.0371%;" colspan="2"></td>
+              </tr>
+              <tr>
+                <td style="width: 47.4386%;"></td>
+                <td style="width: 47.5985%;"></td>
+              </tr>
+            </tbody>
+          </table>
+        `);
+        performCommandsAndAssertWidths(editor, content, {
+          mceTableInsertColBefore: 1.5,
+          mceTableInsertColAfter: 1.5,
+          mceTableDeleteCol: 0.5
         });
       });
     });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
@@ -52,7 +52,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
     assertWidth(editor, multipliers.mceTableDeleteCol, 'mceTableDeleteCol');
   };
 
-  // TODO: tests for colspan #TINY-6949
+  // TODO: more complex tests for colspan #TINY-6949
   context('Responsive table', () => {
     context('table_column_resizing=preservetable', () => {
       const hook = TinyHooks.bddSetupLight<Editor>({


### PR DESCRIPTION
Related Ticket: TINY-6711

Description of Changes:
* Fixes the width being removed on the source cell, not the cloned cell when a colspan existed.
* Fixes widths incorrectly being cloned for a colspan (it used the width of multiple cols when it should only use the cloned column width).
* Fixed getting column widths not working when a cell in the first row didn't have a width (it'd always use the computed width in that case, not the raw width specified on other cells in the column).

**Note:** I would like to redo how the cell halving is done, as this would still fail in some cases (eg every cell has a colspan) and it's not great we're relying on other code to set the cell width. However, to do that is going to require much larger changes and not something we should be including in 5.7.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
