### PR TITLE
TINY-6870: Switch importcss plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
@@ -1,75 +1,62 @@
-import { ApproxStructure, Assertions, Chain, GeneralSteps, Log, Mouse, Pipeline, Step, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { ApproxStructure, Assertions, Mouse, UiFinder } from '@ephox/agar';
+import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { McEditor, TinyDom, TinyUiActions } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import Plugin from 'tinymce/plugins/importcss/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.importcss.ImportCssTest', (success, failure) => {
+interface MenuDetails {
+  readonly tag?: string;
+  readonly html: string;
+  readonly submenu: boolean;
+}
 
-  Plugin();
-  Theme();
+interface Assertion {
+  readonly choice: Optional<string>;
+  readonly menuHasIcons?: boolean;
+  readonly menuContents: MenuDetails[];
+}
 
-  const sTestEditorWithSettings = (assertions, pluginSettings) => Step.async((onStepSuccess, onStepFailure) => {
-    TinyLoader.setupLight((editor, onSuccess, onFailure) => {
+describe('browser.tinymce.plugins.importcss.ImportCssTest', () => {
+  before(() => {
+    Plugin();
+    Theme();
+  });
 
-      const tinyUi = TinyUi(editor);
-
-      const sAssertMenu = (label: string, expected) => Chain.asStep(SugarBody.body(), [
-        UiFinder.cWaitForVisible('Waiting for styles menu to appear', '[role="menu"]'),
-        Assertions.cAssertStructure('Checking structure', ApproxStructure.build((s, str, arr) => s.element('div', {
-          classes: [ arr.has('tox-menu') ],
-          children: [
-            s.element('div', {
-              classes: [ arr.has('tox-collection__group') ],
-              children: Arr.map(expected, (exp) => s.element('div', {
-                classes: [ arr.has('tox-collection__item') ],
+  const pAssertMenu = async (label: string, expected: MenuDetails[]) => {
+    const menu = await UiFinder.pWaitForVisible('Waiting for styles menu to appear', SugarBody.body(), '[role="menu"]');
+    Assertions.assertStructure('Checking structure', ApproxStructure.build((s, str, arr) => s.element('div', {
+      classes: [ arr.has('tox-menu') ],
+      children: [
+        s.element('div', {
+          classes: [ arr.has('tox-collection__group') ],
+          children: Arr.map(expected, (exp) => s.element('div', {
+            classes: [ arr.has('tox-collection__item') ],
+            children: [
+              s.element('div', exp.submenu ? {
+                classes: [ arr.has('tox-collection__item-label') ],
+                html: str.is(exp.html)
+              } : {
+                classes: [ arr.has('tox-collection__item-label') ],
                 children: [
-                  s.element('div', exp.submenu ? {
-                    classes: [ arr.has('tox-collection__item-label') ],
-                    html: str.is(exp.html)
-                  } : {
-                    classes: [ arr.has('tox-collection__item-label') ],
-                    children: [
-                      s.element(exp.tag, { html: str.is(exp.html) })
-                    ]
-                  })
-                ].concat(exp.submenu ? [ s.anything() ] : [ s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] }) ])
-              }))
-            })
-          ]
-        })))
-      ]);
+                  s.element(exp.tag, { html: str.is(exp.html) })
+                ]
+              })
+            ].concat(exp.submenu ? [ s.anything() ] : [ s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] }) ])
+          }))
+        })
+      ]
+    })), menu);
+  };
 
-      const sOpenStyleMenu = GeneralSteps.sequence([
-        tinyUi.sClickOnToolbar('Clicking on the styleselect dropdown', 'button')
-      ]);
-
-      Pipeline.async({}, [
-        sOpenStyleMenu,
-        sAssertMenu('Checking stuff', assertions.menuContents)
-      ].concat(assertions.choice.map((c) => [
-        Assertions.sAssertPresence(
-          `${c} should NOT be present before clicking`,
-          {
-            [c]: 0
-          },
-          SugarElement.fromDom(editor.getBody())
-        ),
-        Mouse.sClickOn(SugarBody.body(), `.tox-collection__item .tox-collection__item-label:contains(${c})`),
-        Assertions.sAssertPresence(
-          `${c} should be present`,
-          {
-            [c]: 1
-          },
-          SugarElement.fromDom(editor.getBody())
-        )
-      ]).getOr([ ])), onSuccess, onFailure);
-    }, {
+  const pTestEditorWithSettings = async (assertion: Assertion, pluginSettings: RawEditorSettings) => {
+    const editor = await McEditor.pFromSettings<Editor>({
       plugins: 'importcss',
       toolbar: 'styleselect',
-      theme: 'silver',
       content_css: pluginSettings.content_css,
       importcss_append: pluginSettings.importcss_append,
       importcss_selector_filter: pluginSettings.importcss_selector_filter,
@@ -78,283 +65,255 @@ UnitTest.asynctest('browser.tinymce.plugins.importcss.ImportCssTest', (success, 
       importcss_selector_converter: pluginSettings.importcss_selector_converter,
       importcss_exclusive: pluginSettings.importcss_exclusive,
       base_url: '/project/tinymce/js/tinymce'
-    }, () => onStepSuccess(), onStepFailure);
-  });
+    });
 
-  Pipeline.async({ }, [
-    Log.step(
-      'TBA',
-      'importcss: content_css with one file, append default',
-      sTestEditorWithSettings(
+    TinyUiActions.clickOnToolbar(editor, 'button');
+    await pAssertMenu('Checking stuff', assertion.menuContents);
+
+    assertion.choice.each((c) => {
+      Assertions.assertPresence(
+        `${c} should NOT be present before clicking`,
         {
-          menuContents: [
-            { tag: 'h1', html: 'h1.red', submenu: false },
-            { tag: 'p', html: 'p.other', submenu: false },
-            { tag: 'span', html: 'span.inline', submenu: false }
-          ],
-          choice: Optional.some('h1.red')
+          [c]: 0
         },
+        TinyDom.body(editor)
+      );
+      Mouse.clickOn(SugarBody.body(), `.tox-collection__item .tox-collection__item-label:contains(${c})`);
+      Assertions.assertPresence(
+        `${c} should be present`,
         {
-          content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
-          importcss_append: undefined
-        }
-      )
-    ),
-
-    Log.step(
-      'TBA',
-      'importcss: content_css with no files, append true',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { html: 'Headings', submenu: true },
-            { html: 'Inline', submenu: true },
-            { html: 'Blocks', submenu: true },
-            { html: 'Align', submenu: true }
-          ],
-          menuHasIcons: false,
-          choice: Optional.none()
+          [c]: 1
         },
-        {
-          content_css: [ ],
-          importcss_append: true
-        }
-      )
-    ),
+        TinyDom.body(editor)
+      );
+    });
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with a file, append true',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { html: 'Headings', submenu: true },
-            { html: 'Inline', submenu: true },
-            { html: 'Blocks', submenu: true },
-            { html: 'Align', submenu: true },
-            { tag: 'h1', html: 'h1.red', submenu: false },
-            { tag: 'p', html: 'p.other', submenu: false },
-            { tag: 'span', html: 'span.inline', submenu: false }
-          ],
-          menuHasIcons: true,
-          choice: Optional.none()
-        },
-        {
-          content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
-          importcss_append: true
-        }
-      )
-    ),
+    McEditor.remove(editor);
+  };
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with multiple files, append true',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { html: 'Headings', submenu: true },
-            { html: 'Inline', submenu: true },
-            { html: 'Blocks', submenu: true },
-            { html: 'Align', submenu: true },
-            { tag: 'h1', html: 'h1.red', submenu: false },
-            { tag: 'p', html: 'p.other', submenu: false },
-            { tag: 'span', html: 'span.inline', submenu: false },
-            { tag: 'h2', html: 'h2.advanced', submenu: false },
-            { tag: 'h3', html: 'h3.advanced', submenu: false },
-            { tag: 'h4', html: 'h4.advanced', submenu: false }
-          ],
-          menuHasIcons: true,
-          choice: Optional.none()
-        },
-        {
-          content_css: [
-            '/project/tinymce/src/plugins/importcss/test/css/basic.css',
-            '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
-            '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
-          ],
-          importcss_append: true
-        }
-      )
-    ),
+  it('TBA: content_css with one file, append default', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { tag: 'h1', html: 'h1.red', submenu: false },
+        { tag: 'p', html: 'p.other', submenu: false },
+        { tag: 'span', html: 'span.inline', submenu: false }
+      ],
+      choice: Optional.some('h1.red')
+    },
+    {
+      content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
+      importcss_append: undefined
+    }
+  ));
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with one file, with merge classes',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { tag: 'h1', html: 'h1.red', submenu: false },
-            { tag: 'p', html: 'p.other', submenu: false },
-            { tag: 'span', html: 'span.inline', submenu: false }
-          ],
-          menuHasIcons: true,
-          choice: Optional.none()
-        },
-        {
-          content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
-          importcss_merge_classes: false
-        }
-      )
-    ),
+  it('TBA: content_css with no files, append true', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { html: 'Headings', submenu: true },
+        { html: 'Inline', submenu: true },
+        { html: 'Blocks', submenu: true },
+        { html: 'Align', submenu: true }
+      ],
+      menuHasIcons: false,
+      choice: Optional.none()
+    },
+    {
+      content_css: [ ],
+      importcss_append: true
+    }
+  ));
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with one file, append false, selector filter (string)',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { tag: 'h1', html: 'h1.red', submenu: false }
-          ],
-          menuHasIcons: true,
-          choice: Optional.some('h1.red')
-        },
-        {
-          content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
-          importcss_append: false,
-          importcss_selector_filter: '.red'
-        }
-      )
-    ),
+  it('TBA: content_css with a file, append true', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { html: 'Headings', submenu: true },
+        { html: 'Inline', submenu: true },
+        { html: 'Blocks', submenu: true },
+        { html: 'Align', submenu: true },
+        { tag: 'h1', html: 'h1.red', submenu: false },
+        { tag: 'p', html: 'p.other', submenu: false },
+        { tag: 'span', html: 'span.inline', submenu: false }
+      ],
+      menuHasIcons: true,
+      choice: Optional.none()
+    },
+    {
+      content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
+      importcss_append: true
+    }
+  ));
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with one file, append false, selector filter (function)',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { tag: 'p', html: 'p.other', submenu: false },
-            { tag: 'span', html: 'span.inline', submenu: false }
-          ],
-          menuHasIcons: true,
-          choice: Optional.some('p.other')
-        },
-        {
-          content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
-          importcss_append: false,
-          importcss_selector_filter: (sel) => sel.indexOf('p') > -1 || sel.indexOf('inline') > -1
-        }
-      )
-    ),
+  it('TBA: content_css with multiple files, append true', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { html: 'Headings', submenu: true },
+        { html: 'Inline', submenu: true },
+        { html: 'Blocks', submenu: true },
+        { html: 'Align', submenu: true },
+        { tag: 'h1', html: 'h1.red', submenu: false },
+        { tag: 'p', html: 'p.other', submenu: false },
+        { tag: 'span', html: 'span.inline', submenu: false },
+        { tag: 'h2', html: 'h2.advanced', submenu: false },
+        { tag: 'h3', html: 'h3.advanced', submenu: false },
+        { tag: 'h4', html: 'h4.advanced', submenu: false }
+      ],
+      menuHasIcons: true,
+      choice: Optional.none()
+    },
+    {
+      content_css: [
+        '/project/tinymce/src/plugins/importcss/test/css/basic.css',
+        '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
+        '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
+      ],
+      importcss_append: true
+    }
+  ));
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with one file, append false, selector filter (regex)',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { tag: 'span', html: 'span.inline', submenu: false }
-          ],
-          menuHasIcons: true,
-          choice: Optional.some('span.inline')
-        },
-        {
-          content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
-          importcss_append: false,
-          importcss_selector_filter: /inline/
-        }
-      )
-    ),
+  it('TBA: content_css with one file, with merge classes', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { tag: 'h1', html: 'h1.red', submenu: false },
+        { tag: 'p', html: 'p.other', submenu: false },
+        { tag: 'span', html: 'span.inline', submenu: false }
+      ],
+      menuHasIcons: true,
+      choice: Optional.none()
+    },
+    {
+      content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
+      importcss_merge_classes: false
+    }
+  ));
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with three files, append false, file_filter (string)',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { tag: 'h2', html: 'h2.advanced', submenu: false },
-            { tag: 'h3', html: 'h3.advanced', submenu: false }
-          ],
-          menuHasIcons: true,
-          choice: Optional.some('h2.advanced')
-        },
-        {
-          content_css: [
-            '/project/tinymce/src/plugins/importcss/test/css/basic.css',
-            '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
-            '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
-          ],
-          importcss_append: false,
-          importcss_file_filter: 'advanced.css'
-        }
-      )
-    ),
+  it('TBA: content_css with one file, append false, selector filter (string)', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { tag: 'h1', html: 'h1.red', submenu: false }
+      ],
+      menuHasIcons: true,
+      choice: Optional.some('h1.red')
+    },
+    {
+      content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
+      importcss_append: false,
+      importcss_selector_filter: '.red'
+    }
+  ));
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with three files, append false, file_filter (function)',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { tag: 'h2', html: 'h2.advanced', submenu: false },
-            { tag: 'h3', html: 'h3.advanced', submenu: false },
-            { tag: 'h4', html: 'h4.advanced', submenu: false }
-          ],
-          menuHasIcons: true,
-          choice: Optional.some('h2.advanced')
-        },
-        {
-          content_css: [
-            '/project/tinymce/src/plugins/importcss/test/css/basic.css',
-            '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
-            '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
-          ],
-          importcss_append: false,
-          importcss_file_filter: (href) => href.indexOf('adv') > -1
-        }
-      )
-    ),
+  it('TBA: content_css with one file, append false, selector filter (function)', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { tag: 'p', html: 'p.other', submenu: false },
+        { tag: 'span', html: 'span.inline', submenu: false }
+      ],
+      menuHasIcons: true,
+      choice: Optional.some('p.other')
+    },
+    {
+      content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
+      importcss_append: false,
+      importcss_selector_filter: (sel) => sel.indexOf('p') > -1 || sel.indexOf('inline') > -1
+    }
+  ));
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with three files, append false, file_filter (regex)',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { tag: 'h2', html: 'h2.advanced', submenu: false },
-            { tag: 'h3', html: 'h3.advanced', submenu: false },
-            { tag: 'h4', html: 'h4.advanced', submenu: false }
-          ],
-          menuHasIcons: true,
-          choice: Optional.some('h2.advanced')
-        },
-        {
-          content_css: [
-            '/project/tinymce/src/plugins/importcss/test/css/basic.css',
-            '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
-            '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
-          ],
-          importcss_append: false,
-          importcss_file_filter: /adv/
-        }
-      )
-    ),
+  it('TBA: content_css with one file, append false, selector filter (regex)', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { tag: 'span', html: 'span.inline', submenu: false }
+      ],
+      menuHasIcons: true,
+      choice: Optional.some('span.inline')
+    },
+    {
+      content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
+      importcss_append: false,
+      importcss_selector_filter: /inline/
+    }
+  ));
 
-    Log.step(
-      'TBA',
-      'importcss: content_css with three files, append false, groups',
-      sTestEditorWithSettings(
-        {
-          menuContents: [
-            { html: 'Other', submenu: true },
-            { html: 'Advanced', submenu: true }
-          ],
-          menuHasIcons: false,
-          choice: Optional.none()
-        },
-        {
-          content_css: [
-            '/project/tinymce/src/plugins/importcss/test/css/basic.css',
-            '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
-            '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
-          ],
-          importcss_append: false,
-          importcss_groups: [
-            { title: 'Advanced', filter: /.adv/ },
-            { title: 'Other', custom: 'B' }
-          ]
-        }
-      )
-    )
-  ], () => success(), failure);
+  it('TBA: content_css with three files, append false, file_filter (string)', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { tag: 'h2', html: 'h2.advanced', submenu: false },
+        { tag: 'h3', html: 'h3.advanced', submenu: false }
+      ],
+      menuHasIcons: true,
+      choice: Optional.some('h2.advanced')
+    },
+    {
+      content_css: [
+        '/project/tinymce/src/plugins/importcss/test/css/basic.css',
+        '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
+        '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
+      ],
+      importcss_append: false,
+      importcss_file_filter: 'advanced.css'
+    }
+  ));
 
+  it('TBA: content_css with three files, append false, file_filter (function)', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { tag: 'h2', html: 'h2.advanced', submenu: false },
+        { tag: 'h3', html: 'h3.advanced', submenu: false },
+        { tag: 'h4', html: 'h4.advanced', submenu: false }
+      ],
+      menuHasIcons: true,
+      choice: Optional.some('h2.advanced')
+    },
+    {
+      content_css: [
+        '/project/tinymce/src/plugins/importcss/test/css/basic.css',
+        '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
+        '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
+      ],
+      importcss_append: false,
+      importcss_file_filter: (href) => href.indexOf('adv') > -1
+    }
+  ));
+
+  it('TBA: content_css with three files, append false, file_filter (regex)', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { tag: 'h2', html: 'h2.advanced', submenu: false },
+        { tag: 'h3', html: 'h3.advanced', submenu: false },
+        { tag: 'h4', html: 'h4.advanced', submenu: false }
+      ],
+      menuHasIcons: true,
+      choice: Optional.some('h2.advanced')
+    },
+    {
+      content_css: [
+        '/project/tinymce/src/plugins/importcss/test/css/basic.css',
+        '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
+        '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
+      ],
+      importcss_append: false,
+      importcss_file_filter: /adv/
+    }
+  ));
+
+  it('TBA: content_css with three files, append false, groups', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { html: 'Other', submenu: true },
+        { html: 'Advanced', submenu: true }
+      ],
+      menuHasIcons: false,
+      choice: Optional.none()
+    },
+    {
+      content_css: [
+        '/project/tinymce/src/plugins/importcss/test/css/basic.css',
+        '/project/tinymce/src/plugins/importcss/test/css/advanced.css',
+        '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
+      ],
+      importcss_append: false,
+      importcss_groups: [
+        { title: 'Advanced', filter: /.adv/ },
+        { title: 'Other', custom: 'B' }
+      ]
+    }
+  ));
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Switched the `importcss` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
