### PR TITLE
TINY-6907: Added new mceListUpdate command

### DIFF
--- a/modules/tinymce/src/plugins/lists/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/Plugin.ts
@@ -17,6 +17,8 @@ export default () => {
     if (editor.hasPlugin('rtc', true) === false) {
       Keyboard.setup(editor);
       Commands.register(editor);
+    } else {
+      Commands.registerDialog(editor);
     }
 
     Buttons.register(editor);

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/Attributes.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/Attributes.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Obj } from '@ephox/katamari';
+import { getParentList } from '../core/Selection';
+
+export const setParentListAttributes = (editor, attrs) => {
+  const parentList = getParentList(editor);
+  editor.undoManager.transact(() =>
+    Obj.each(attrs, (v, k) => editor.dom.setAttrib(parentList, k, v))
+  );
+};

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/Attributes.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/Attributes.ts
@@ -6,9 +6,10 @@
  */
 
 import { Obj } from '@ephox/katamari';
+import Editor from 'tinymce/core/api/Editor';
 import { getParentList } from '../core/Selection';
 
-export const setParentListAttributes = (editor, attrs) => {
+export const setParentListAttributes = (editor: Editor, attrs: Record<string, string>) => {
   const parentList = getParentList(editor);
   editor.undoManager.transact(() =>
     Obj.each(attrs, (v, k) => editor.dom.setAttrib(parentList, k, v))

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Type } from '@ephox/katamari';
 import BookmarkManager from 'tinymce/core/api/dom/BookmarkManager';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -283,9 +284,11 @@ const toggleSingleList = (editor, parentList: HTMLElement, listName: 'UL' | 'OL'
   }
 };
 
-const toggleList = (editor: Editor, listName: 'UL' | 'OL' | 'DL', detail: ListDetail = {}) => {
+const toggleList = (editor: Editor, listName: 'UL' | 'OL' | 'DL', _detail: ListDetail | null) => {
   const parentList = Selection.getParentList(editor);
   const selectedSubLists = Selection.getSelectedSubLists(editor);
+
+  const detail = Type.isObject(_detail) ? _detail : {};
 
   if (selectedSubLists.length > 0) {
     toggleMultipleLists(editor, parentList, selectedSubLists, listName, detail);

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/Update.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/Update.ts
@@ -9,9 +9,15 @@ import { Obj } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { getParentList } from '../core/Selection';
 
-export const setParentListAttributes = (editor: Editor, attrs: Record<string, string>) => {
+interface ListUpdate {
+  attrs?: Record<string, string>;
+}
+
+export const updateList = (editor: Editor, update: ListUpdate) => {
   const parentList = getParentList(editor);
-  editor.undoManager.transact(() =>
-    Obj.each(attrs, (v, k) => editor.dom.setAttrib(parentList, k, v))
-  );
+  editor.undoManager.transact(() => {
+    if (update.attrs) {
+      Obj.each(update.attrs, (v, k) => editor.dom.setAttrib(parentList, k, v));
+    }
+  });
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
@@ -5,26 +5,27 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
 import { setParentListAttributes } from '../actions/Attributes';
 import { flattenListSelection, indentListSelection, outdentListSelection } from '../actions/Indendation';
 import * as ToggleList from '../actions/ToggleList';
 import { getParentList } from '../core/Selection';
 import * as Dialog from '../ui/Dialog';
 
-const queryListCommandState = (editor, listName) => {
+const queryListCommandState = (editor: Editor, listName: string) => {
   return () => {
     const parentList = getParentList(editor);
     return parentList && parentList.nodeName === listName;
   };
 };
 
-const registerDialog = (editor) => {
+const registerDialog = (editor: Editor) => {
   editor.addCommand('mceListProps', () => {
     Dialog.open(editor);
   });
 };
 
-const register = (editor) => {
+const register = (editor: Editor) => {
   editor.on('BeforeExecCommand', (e) => {
     const cmd = e.command.toLowerCase();
 

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
@@ -18,6 +18,12 @@ const queryListCommandState = (editor, listName) => {
   };
 };
 
+const registerDialog = (editor) => {
+  editor.addCommand('mceListProps', () => {
+    Dialog.open(editor);
+  });
+};
+
 const register = (editor) => {
   editor.on('BeforeExecCommand', (e) => {
     const cmd = e.command.toLowerCase();
@@ -45,9 +51,7 @@ const register = (editor) => {
     flattenListSelection(editor);
   });
 
-  editor.addCommand('mceListProps', () => {
-    Dialog.open(editor);
-  });
+  registerDialog(editor);
 
   editor.addCommand('SetListAttributes', (ui, detail) => {
     setParentListAttributes(editor, detail);
@@ -59,5 +63,6 @@ const register = (editor) => {
 };
 
 export {
+  registerDialog,
   register
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
@@ -5,13 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { setParentListAttributes } from '../actions/Attributes';
 import { flattenListSelection, indentListSelection, outdentListSelection } from '../actions/Indendation';
 import * as ToggleList from '../actions/ToggleList';
+import { getParentList } from '../core/Selection';
 import * as Dialog from '../ui/Dialog';
 
 const queryListCommandState = (editor, listName) => {
   return () => {
-    const parentList = editor.dom.getParent(editor.selection.getStart(), 'UL,OL,DL');
+    const parentList = getParentList(editor);
     return parentList && parentList.nodeName === listName;
   };
 };
@@ -45,6 +47,10 @@ const register = (editor) => {
 
   editor.addCommand('mceListProps', () => {
     Dialog.open(editor);
+  });
+
+  editor.addCommand('SetListAttributes', (ui, detail) => {
+    setParentListAttributes(editor, detail);
   });
 
   editor.addQueryStateHandler('InsertUnorderedList', queryListCommandState(editor, 'UL'));

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
@@ -6,9 +6,9 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
-import { setParentListAttributes } from '../actions/Attributes';
 import { flattenListSelection, indentListSelection, outdentListSelection } from '../actions/Indendation';
 import * as ToggleList from '../actions/ToggleList';
+import { updateList } from '../actions/Update';
 import { getParentList } from '../core/Selection';
 import * as Dialog from '../ui/Dialog';
 
@@ -54,8 +54,8 @@ const register = (editor: Editor) => {
 
   registerDialog(editor);
 
-  editor.addCommand('SetListAttributes', (ui, detail) => {
-    setParentListAttributes(editor, detail);
+  editor.addCommand('mceListUpdate', (ui, detail) => {
+    updateList(editor, detail);
   });
 
   editor.addQueryStateHandler('InsertUnorderedList', queryListCommandState(editor, 'UL'));

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { flattenListSelection, indentListSelection, outdentListSelection } from '../actions/Indendation';
 import * as ToggleList from '../actions/ToggleList';
@@ -55,7 +56,9 @@ const register = (editor: Editor) => {
   registerDialog(editor);
 
   editor.addCommand('mceListUpdate', (ui, detail) => {
-    updateList(editor, detail);
+    if (Type.isObject(detail)) {
+      updateList(editor, detail);
+    }
   });
 
   editor.addQueryStateHandler('InsertUnorderedList', queryListCommandState(editor, 'UL'));

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -217,7 +217,7 @@ const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean) => {
     if (otherLi) {
       editor.undoManager.transact(() => {
         removeBlock(dom, block, root);
-        ToggleList.mergeWithAdjacentLists(dom, otherLi.parentNode);
+        ToggleList.mergeWithAdjacentLists(dom, otherLi.parentNode as Element);
         editor.selection.select(otherLi, true);
         editor.selection.collapse(isForward);
       });

--- a/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
@@ -31,7 +31,7 @@ const isFirstChild = (node: Node) => node.parentNode.firstChild === node;
 
 const isLastChild = (node: Node) => node.parentNode.lastChild === node;
 
-const isTextBlock = (editor: Editor, node: Node) => node && !!editor.schema.getTextBlockElements()[node.nodeName];
+const isTextBlock = (editor: Editor, node: Node): node is HTMLElement => node && !!editor.schema.getTextBlockElements()[node.nodeName];
 
 const isBlock = (node: Node, blockElements: Record<string, any>) => node && node.nodeName in blockElements;
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
@@ -15,7 +15,7 @@ import * as NodeType from './NodeType';
 const getParentList = (editor: Editor, node?: Node) => {
   const selectionStart = node || editor.selection.getStart(true);
 
-  return editor.dom.getParent(selectionStart, 'OL,UL,DL', getClosestListRootElm(editor, selectionStart));
+  return editor.dom.getParent(selectionStart, 'OL,UL,DL', getClosestListRootElm(editor, selectionStart)) as HTMLElement;
 };
 
 const isParentListSelected = (parentList, selectedBlocks) => {
@@ -33,11 +33,11 @@ const getSelectedSubLists = (editor) => {
   const selectedBlocks = editor.selection.getSelectedBlocks();
 
   if (isParentListSelected(parentList, selectedBlocks)) {
-    return findSubLists(parentList);
+    return findSubLists(parentList) as HTMLElement[];
   } else {
     return Tools.grep(selectedBlocks, (elm: Node) => {
       return NodeType.isListNode(elm) && parentList !== elm;
-    });
+    }) as HTMLElement[];
   }
 };
 

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
@@ -47,8 +47,10 @@ const open = (editor: Editor) => {
     ],
     onSubmit: (api) => {
       const data = api.getData();
-      editor.execCommand('SetListAttributes', false, {
-        start: data.start === '1' ? '' : data.start
+      editor.execCommand('mceListUpdate', false, {
+        attrs: {
+          start: data.start === '1' ? '' : data.start
+        }
       });
       api.close();
     }

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
@@ -10,8 +10,6 @@ import { isOlNode } from '../core/NodeType';
 import { getParentList } from '../core/Selection';
 
 const open = (editor: Editor) => {
-  const dom = editor.dom;
-
   // Find the current list and skip opening if the selection isn't in an ordered list
   const currentList = getParentList(editor);
   if (!isOlNode(currentList)) {
@@ -32,7 +30,7 @@ const open = (editor: Editor) => {
       ]
     },
     initialData: {
-      start: dom.getAttrib(currentList, 'start') || '1'
+      start: editor.dom.getAttrib(currentList, 'start') || '1'
     },
     buttons: [
       {
@@ -49,8 +47,8 @@ const open = (editor: Editor) => {
     ],
     onSubmit: (api) => {
       const data = api.getData();
-      editor.undoManager.transact(() => {
-        dom.setAttrib(getParentList(editor), 'start', data.start === '1' ? '' : data.start);
+      editor.execCommand('SetListAttributes', false, {
+        start: data.start === '1' ? '' : data.start
       });
       api.close();
     }

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/MenuItems.ts
@@ -10,13 +10,12 @@ import { Menu } from 'tinymce/core/api/ui/Ui';
 import { isOlNode } from '../core/NodeType';
 import { getParentList } from '../core/Selection';
 import * as Util from '../core/Util';
-import * as Dialog from './Dialog';
 
 const register = (editor: Editor) => {
   const listProperties: Menu.MenuItemSpec = {
     text: 'List properties...',
     icon: 'ordered-list',
-    onAction: () => Dialog.open(editor),
+    onAction: () => editor.execCommand('mceListProps'),
     onSetup: (api) => Util.listState(editor, 'OL', (active) => api.setDisabled(!active))
   };
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -165,6 +165,15 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
     TinyAssertions.assertContent(editor, '<ol start="5"><li>Item 1</li><li>Item 2</li></ol>');
   });
 
+  it('TINY-6907: mceListUpdate command can remove the start attribute', () => {
+    const editor = hook.editor();
+    editor.setContent('<ol start="5"><li>Item 1</li><li>Item 2</li></ol>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+
+    editor.execCommand('mceListUpdate', false, { attrs: { start: '' }});
+    TinyAssertions.assertContent(editor, '<ol><li>Item 1</li><li>Item 2</li></ol>');
+  });
+
   it('TINY-6907: mceListUpdate command does not break when used on a paragraph', () => {
     const editor = hook.editor();
     editor.setContent('<p>some text</p>');
@@ -174,12 +183,12 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
     TinyAssertions.assertContent(editor, '<p>some text</p>');
   });
 
-  it('TINY-6907: mceListUpdate command can remove the start attribute', () => {
+  it('TINY-6907: mceListUpdate command does not break when passed null', () => {
     const editor = hook.editor();
-    editor.setContent('<ol start="5"><li>Item 1</li><li>Item 2</li></ol>');
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    editor.setContent('<p>some text</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
 
-    editor.execCommand('mceListUpdate', false, { attrs: { start: '' }});
-    TinyAssertions.assertContent(editor, '<ol><li>Item 1</li><li>Item 2</li></ol>');
+    editor.execCommand('mceListUpdate', false, null);
+    TinyAssertions.assertContent(editor, '<p>some text</p>');
   });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -5,6 +5,8 @@ import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { ExecCommandEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/PublicApi';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
@@ -136,7 +138,7 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
   it('TINY-6907: List properties command is used to update the DOM', async () => {
     const editor = hook.editor();
 
-    const blockCommand = (event) => {
+    const blockCommand = (event: EditorEvent<ExecCommandEvent>) => {
       if (event.command.toLowerCase() === 'setlistattributes') {
         event.preventDefault();
       }

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -135,7 +135,7 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
     TinyUiActions.clickOnMenu(editor, '.tox-mbtn:contains("Custom")');
   });
 
-  it('TINY-6907: List properties command is used to update the DOM', async () => {
+  it('TINY-6907: List properties dialog uses mceListUpdate command internally to update the DOM', async () => {
     const editor = hook.editor();
 
     const blockCommand = (event: EditorEvent<ExecCommandEvent>) => {

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -171,4 +171,13 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
     editor.execCommand('SetListAttributes', false, { start: 5 });
     TinyAssertions.assertContent(editor, '<p>some text</p>');
   });
+
+  it('TINY-6907: SetListAttributes command can remove the start attribute', () => {
+    const editor = hook.editor();
+    editor.setContent('<ol start="5"><li>Item 1</li><li>Item 2</li></ol>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+
+    editor.execCommand('SetListAttributes', false, { start: '' });
+    TinyAssertions.assertContent(editor, '<ol><li>Item 1</li><li>Item 2</li></ol>');
+  });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -139,7 +139,7 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
     const editor = hook.editor();
 
     const blockCommand = (event: EditorEvent<ExecCommandEvent>) => {
-      if (event.command.toLowerCase() === 'setlistattributes') {
+      if (event.command.toLowerCase() === 'mcelistupdate') {
         event.preventDefault();
       }
     };
@@ -156,30 +156,30 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
     editor.off('BeforeExecCommand', blockCommand);
   });
 
-  it('TINY-6907: SetListAttributes command sets the start attribute', () => {
+  it('TINY-6907: mceListUpdate command sets the start attribute', () => {
     const editor = hook.editor();
     editor.setContent('<ol><li>Item 1</li><li>Item 2</li></ol>');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
 
-    editor.execCommand('SetListAttributes', false, { start: 5 });
+    editor.execCommand('mceListUpdate', false, { attrs: { start: 5 }});
     TinyAssertions.assertContent(editor, '<ol start="5"><li>Item 1</li><li>Item 2</li></ol>');
   });
 
-  it('TINY-6907: SetListAttributes command does not break when used on a paragraph', () => {
+  it('TINY-6907: mceListUpdate command does not break when used on a paragraph', () => {
     const editor = hook.editor();
     editor.setContent('<p>some text</p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
 
-    editor.execCommand('SetListAttributes', false, { start: 5 });
+    editor.execCommand('mceListUpdate', false, { attrs: { start: 5 }});
     TinyAssertions.assertContent(editor, '<p>some text</p>');
   });
 
-  it('TINY-6907: SetListAttributes command can remove the start attribute', () => {
+  it('TINY-6907: mceListUpdate command can remove the start attribute', () => {
     const editor = hook.editor();
     editor.setContent('<ol start="5"><li>Item 1</li><li>Item 2</li></ol>');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
 
-    editor.execCommand('SetListAttributes', false, { start: '' });
+    editor.execCommand('mceListUpdate', false, { attrs: { start: '' }});
     TinyAssertions.assertContent(editor, '<ol><li>Item 1</li><li>Item 2</li></ol>');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-6907

Description of Changes:

The list properties dialog now uses a new `SetListAttributes` command to set the list start attribute. I've also ensured the `mceListProps` command is registered in RTC mode and made use of it in the menu item instead of opening the dialog directly.

I didn't add a changelog for this because the list properties dialog doesn't seem to be documented yet; it's also an internal change that should have no impact on the feature.


Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
