### PR TITLE
TINY-6869: Menu items no longer squash and distort in certain situations

### DIFF
--- a/modules/oxide/src/less/theme/components/menu/menu.less
+++ b/modules/oxide/src/less/theme/components/menu/menu.less
@@ -27,6 +27,7 @@
     display: inline-block;
     overflow: hidden;
     vertical-align: top;
+    white-space: pre;
     z-index: @z-index-menu;
   }
 


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Added `white-space: pre` to menues to prevent squashing in some situations.

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
