### PR TITLE
TINY-2814: Show alert when submitting color picker dialog if hex color code is invalid

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The RGB fields in the color picker dialog were not staying in sync with the color palette and hue slider #TINY-6952
 - The color preview box in the color picker dialog was not correctly displaying the saturation and value of the chosen color #TINY-6952
+- The color picker dialog will now show an alert if it is submitted with an invalid hex color code #TINY-2814
 
 ## 5.7.0 - 2021-02-10
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/ColorInputBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/ColorInputBackstage.ts
@@ -6,21 +6,18 @@
  */
 
 import { Menu } from '@ephox/bridge';
-import { Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as ColorSwatch from '../ui/core/color/ColorSwatch';
 import * as Settings from '../ui/core/color/Settings';
 
-type ColorInputCallback = (valueOpt: Optional<string>) => void;
-
 export interface UiFactoryBackstageForColorInput {
-  colorPicker: (callback: ColorInputCallback, value: string) => void;
+  colorPicker: (callback: ColorSwatch.ColorInputCallback, value: string) => void;
   hasCustomColors: () => boolean;
   getColors: () => Menu.ChoiceMenuItemSpec[];
   getColorCols: () => number;
 }
 
-const colorPicker = (editor: Editor) => (callback: ColorInputCallback, value: string) => {
+const colorPicker = (editor: Editor) => (callback: ColorSwatch.ColorInputCallback, value: string) => {
   const dialog = ColorSwatch.colorPickerDialog(editor);
   dialog(callback, value);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -187,19 +187,22 @@ const registerTextColorMenuItem = (editor: Editor, name: string, format: string,
 };
 
 const colorPickerDialog = (editor: Editor) => (callback, value: string) => {
-  const getOnSubmit = (callback) => (api) => {
+  let isValid = false;
+
+  const getOnSubmit = (callback) => (api: Dialog.DialogInstanceApi<ColorSwatchDialogData>) => {
     const data = api.getData();
-    callback(Optional.from(data.colorpicker));
-    api.close();
+    const hex = data.colorpicker;
+    if (isValid) {
+      callback(Optional.from(hex));
+      api.close();
+    } else {
+      editor.windowManager.alert(editor.translate([ 'Invalid hex color code: {0}', hex ]));
+    }
   };
 
-  const onAction = (api: Dialog.DialogInstanceApi<ColorSwatchDialogData>, details) => {
+  const onAction = (_api: Dialog.DialogInstanceApi<ColorSwatchDialogData>, details) => {
     if (details.name === 'hex-valid') {
-      if (details.value) {
-        api.enable('ok');
-      } else {
-        api.disable('ok');
-      }
+      isValid = details.value;
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -12,6 +12,8 @@ import { Dialog, Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 import * as Events from '../../../api/Events';
 import * as Settings from './Settings';
 
+export type ColorInputCallback = (valueOpt: Optional<string>) => void;
+
 export interface ColorSwatchDialogData {
   colorpicker: string;
 }
@@ -186,10 +188,10 @@ const registerTextColorMenuItem = (editor: Editor, name: string, format: string,
   });
 };
 
-const colorPickerDialog = (editor: Editor) => (callback, value: string) => {
+const colorPickerDialog = (editor: Editor) => (callback: ColorInputCallback, value: string) => {
   let isValid = false;
 
-  const getOnSubmit = (callback) => (api: Dialog.DialogInstanceApi<ColorSwatchDialogData>) => {
+  const onSubmit = (api: Dialog.DialogInstanceApi<ColorSwatchDialogData>) => {
     const data = api.getData();
     const hex = data.colorpicker;
     if (isValid) {
@@ -210,7 +212,6 @@ const colorPickerDialog = (editor: Editor) => (callback, value: string) => {
     colorpicker: value
   };
 
-  const submit = getOnSubmit(callback);
   editor.windowManager.open({
     title: 'Color Picker',
     size: 'normal',
@@ -239,7 +240,7 @@ const colorPickerDialog = (editor: Editor) => (callback, value: string) => {
     ],
     initialData,
     onAction,
-    onSubmit: submit,
+    onSubmit,
     onClose: Fun.noop,
     onCancel: () => {
       callback(Optional.none());

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -1,8 +1,8 @@
 import { FocusTools, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Optional, Type } from '@ephox/katamari';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
-import { SelectorFilter, SugarShadowDom } from '@ephox/sugar';
+import { SelectorFilter, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -30,6 +30,20 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         });
       };
 
+      const fireEvent = (elem: SugarElement<Node>, event: string) => {
+        let evt: Event;
+        if (Type.isFunction(Event)) {
+          evt = new Event(event, {
+            bubbles: true,
+            cancelable: true
+          });
+        } else { // support IE
+          evt = document.createEvent('Event');
+          evt.initEvent(event, true, true);
+        }
+        elem.dom.dispatchEvent(evt);
+      };
+
       const assertColor = (expected: string) => {
         assert.equal(currentColor, expected, 'Asserting current colour is ' + expected);
       };
@@ -39,6 +53,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         const inputs = SelectorFilter.descendants<HTMLInputElement>(docBody, dialogSelector + ' input');
         const hexInput = inputs[inputs.length - 1];
         hexInput.dom.value = hex;
+        fireEvent(hexInput, 'input');
       };
 
       const pOpenDialog = async (editor: Editor) => {
@@ -52,12 +67,25 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
       const setHexWhite = setHex('ffffff');
       const setHexBlack = setHex('000000');
 
-      const pSubmitDialog = async (editor: Editor) => {
+      const submit = async (editor: Editor) => {
         const docBody = getBody(editor);
         FocusTools.setFocus(docBody, dialogSelector);
         await Waiter.pTryUntil('Button is not disabled', () => UiFinder.notExists(docBody, 'button.tox-button:contains("Save")[disabled]'));
         TinyUiActions.submitDialog(editor);
+        return docBody;
+      };
+
+      const pSubmitDialog = async (editor: Editor) => {
+        const docBody = await submit(editor);
         await Waiter.pTryUntil('Dialog should close', () => UiFinder.notExists(docBody, dialogSelector));
+      };
+
+      const pSubmitDialogWithExpectedAlert = async (editor: Editor, expectedAlert: string) => {
+        const docBody = await submit(editor);
+        await Waiter.pTryUntil('Alert should show correct message', () => UiFinder.exists(docBody, `p:contains(${expectedAlert})`));
+        // Close alert
+        TinyUiActions.clickOnUi(editor, 'button[title="OK"]');
+        TinyUiActions.cancelDialog(editor, dialogSelector);
       };
 
       const pCancelDialog = async (editor: Editor) => {
@@ -88,6 +116,13 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         setHexWhite(editor);
         await pCancelDialog(editor);
         assertColorBlack();
+      });
+
+      it('TINY-6952: Submitting an invalid hex color code will show an alert with an error message', async () => {
+        const editor = hook.editor();
+        await pOpenDialog(editor);
+        setHex('invalid')(editor);
+        await pSubmitDialogWithExpectedAlert(editor, 'Invalid hex color code: #invalid');
       });
     });
   });


### PR DESCRIPTION
**Related Ticket:**

TINY-2814

**Description of Changes:**

Shows an alert dialog when the color picker is submitted with an invalid hex color code.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
