### PR TITLE
TINY-7073: Support disabled and shortcut parameters for context menu items

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/ContextMenu.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/ContextMenu.ts
@@ -1,13 +1,13 @@
 import { SeparatorMenuItemSpec } from '../../api/Menu';
+import { CommonMenuItemSpec } from './CommonMenuItem';
 
-export interface ContextMenuItem {
-  text: string;
+export interface ContextMenuItem extends CommonMenuItemSpec {
   icon?: string;
   type?: 'item';
   onAction: () => void;
 }
 
-export interface ContextSubMenu {
+export interface ContextSubMenu extends CommonMenuItemSpec {
   type: 'submenu';
   text: string;
   icon?: string;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/ContextMenu.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/ContextMenu.ts
@@ -2,6 +2,7 @@ import { SeparatorMenuItemSpec } from '../../api/Menu';
 import { CommonMenuItemSpec } from './CommonMenuItem';
 
 export interface ContextMenuItem extends CommonMenuItemSpec {
+  text: string;
   icon?: string;
   type?: 'item';
   onAction: () => void;

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,6 +1,7 @@
 Version 5.7.1 (TBD)
     Fixed a bug where context menu items with names that contained uppercase characters were not displayed #TINY-7072
     Fixed an issue where URLs were not correctly filtered in some cases #TINY-7025
+    Fixed context menu items lacking support for the `disabled` and `shortcut` properties #TINY-7073
 Version 5.7.0 (2021-02-10)
     Added IPv6 address support to the URI API. Patch contributed by dev7355608 #GH-4409
     Added new `structure` and `style` properties to the `TableModified` event to indicate what kinds of modifications were made #TINY-6643

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/SilverContextMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/SilverContextMenu.ts
@@ -25,6 +25,13 @@ const separator: Menu.SeparatorMenuItemSpec = {
 };
 
 const makeContextItem = (item: string | Menu.ContextMenuItem | Menu.SeparatorMenuItemSpec | Menu.ContextSubMenu): MenuItem => {
+  const commonMenuItem = (item: Menu.ContextMenuItem | Menu.ContextSubMenu) => ({
+    text: item.text,
+    icon: item.icon,
+    disabled: item.disabled,
+    shortcut: item.shortcut,
+  });
+
   if (Type.isString(item)) {
     return item;
   } else {
@@ -34,8 +41,7 @@ const makeContextItem = (item: string | Menu.ContextMenuItem | Menu.SeparatorMen
       case 'submenu':
         return {
           type: 'nestedmenuitem',
-          text: item.text,
-          icon: item.icon,
+          ...commonMenuItem(item),
           getSubmenuItems: () => {
             const items = item.getSubmenuItems();
             if (Type.isString(items)) {
@@ -49,8 +55,7 @@ const makeContextItem = (item: string | Menu.ContextMenuItem | Menu.SeparatorMen
         // case 'item', or anything else really
         return {
           type: 'menuitem',
-          text: item.text,
-          icon: item.icon,
+          ...commonMenuItem(item),
           // disconnect the function from the menu item API bridge defines
           onAction: Fun.noarg(item.onAction)
         };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
@@ -1,5 +1,5 @@
 import { Keyboard, Keys, UiFinder, Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { before, context, describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 
@@ -11,39 +11,104 @@ describe('browser.tinymce.themes.silver.editor.contextmenu.CustomContextMenuTest
     base_url: '/project/tinymce/js/tinymce',
   }, [ Theme ], true);
 
-  before(() => {
-    const editor = hook.editor();
-    editor.ui.registry.addMenuItem('customMenuItem', {
-      icon: 'image',
-      text: 'Custom Context Menu',
-    });
-    editor.ui.registry.addContextMenu('customContextMenu', {
-      update: () => 'customMenuItem'
-    });
-  });
+  const pOpenContextMenu = async (editor: Editor, selector: string) =>
+    TinyUiActions.pTriggerContextMenu(editor, selector, '.tox-silver-sink .tox-menu.tox-collection [role="menuitem"]');
 
   const pCloseContextMenu = async () => {
     Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.escape());
     await Waiter.pTryUntil('Close context menu', () => UiFinder.notExists(SugarBody.body(), 'div[role="menu"]'));
   };
 
-  it('TINY-7072: Support custom context menu items with lowercase names', async () => {
-    const editor = hook.editor();
-    editor.settings.contextmenu = 'customcontextmenu';
-    editor.setContent('<p><a href="http://tiny.cloud/">Tiny</a></p>');
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 'Ti'.length);
-    await TinyUiActions.pTriggerContextMenu(editor, 'a', '.tox-silver-sink .tox-menu.tox-collection [role="menuitem"]');
-    UiFinder.exists(SugarBody.body(), '.tox-collection__item-label:contains("Custom Context Menu")');
-    await pCloseContextMenu();
+  context('Menu item names', () => {
+    before(() => {
+      const editor = hook.editor();
+      editor.ui.registry.addMenuItem('customMenuItem', {
+        icon: 'image',
+        text: 'Custom Context Menu',
+      });
+      editor.ui.registry.addContextMenu('customContextMenu', {
+        update: () => 'customMenuItem'
+      });
+    });
+
+    it('TINY-7072: Support custom context menu items with lowercase names', async () => {
+      const editor = hook.editor();
+      editor.settings.contextmenu = 'customcontextmenu';
+      editor.setContent('<p>Tiny</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 'Ti'.length);
+      await pOpenContextMenu(editor, 'p');
+      UiFinder.exists(SugarBody.body(), '.tox-collection__item-label:contains("Custom Context Menu")');
+      await pCloseContextMenu();
+    });
+
+    it('TINY-7072: Support custom context menu items with mixed case names', async () => {
+      const editor = hook.editor();
+      editor.settings.contextmenu = 'customContextMenu';
+      editor.setContent('<p>Tiny</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 'Ti'.length);
+      await pOpenContextMenu(editor, 'p');
+      UiFinder.exists(SugarBody.body(), '.tox-collection__item-label:contains("Custom Context Menu")');
+      await pCloseContextMenu();
+    });
   });
 
-  it('TINY-7072: Support custom context menu items with mixed case names', async () => {
-    const editor = hook.editor();
-    editor.settings.contextmenu = 'customContextMenu';
-    editor.setContent('<p><a href="http://tiny.cloud/">Tiny</a></p>');
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 'Ti'.length);
-    await TinyUiActions.pTriggerContextMenu(editor, 'a', '.tox-silver-sink .tox-menu.tox-collection [role="menuitem"]');
-    UiFinder.exists(SugarBody.body(), '.tox-collection__item-label:contains("Custom Context Menu")');
-    await pCloseContextMenu();
+  context('Menu item properties', () => {
+    before(() => {
+      const editor = hook.editor();
+      editor.settings.contextmenu = 'customcontextmenu';
+      editor.ui.registry.addContextMenu('customContextMenu', {
+        update: () => [
+          {
+            type: 'submenu',
+            text: 'customSubMenuItem',
+            shortcut: 'custom-shortcut',
+            disabled: false,
+            getSubmenuItems: () => [
+              {
+                text: 'disabledCustomNestedMenuItem',
+                disabled: true,
+              },
+              {
+                text: 'customNestedMenuItem',
+                shortcut: 'custom-nested-shortcut',
+                disabled: false,
+              }
+            ],
+          },
+          {
+            text: 'disabledCustomMenuItem',
+            disabled: true,
+          }
+        ],
+      });
+    });
+
+    it('TINY-7073: Support for disabled property on menu items', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>Tiny</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 'Ti'.length);
+      await pOpenContextMenu(editor, 'p');
+      // Open submenu
+      Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.right());
+      await Waiter.pTryUntil('menu items visible', () => {
+        UiFinder.exists(SugarBody.body(), 'div[title="customSubMenuItem"][aria-disabled="false"]');
+        UiFinder.exists(SugarBody.body(), 'div[title="disabledCustomNestedMenuItem"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'div[title="customNestedMenuItem"][aria-disabled="false"]');
+        UiFinder.exists(SugarBody.body(), 'div[title="disabledCustomMenuItem"][aria-disabled="true"]');
+      });
+    });
+
+    it('TINY-7073: Support shortcut property on menu items', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>Tiny</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 'Ti'.length);
+      await pOpenContextMenu(editor, 'p');
+      // Open submenu
+      Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.right());
+      await Waiter.pTryUntil('menu items visible', () => {
+        UiFinder.exists(SugarBody.body(), 'div[title="customSubMenuItem"] div.tox-collection__item-accessory:contains("custom-shortcut")');
+        UiFinder.exists(SugarBody.body(), 'div[title="customNestedMenuItem"] div.tox-collection__item-accessory:contains("custom-nested-shortcut")');
+      });
+    });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
@@ -12,7 +12,7 @@ describe('browser.tinymce.themes.silver.editor.contextmenu.CustomContextMenuTest
   }, [ Theme ], true);
 
   const pOpenContextMenu = async (editor: Editor, selector: string) =>
-    TinyUiActions.pTriggerContextMenu(editor, selector, '.tox-silver-sink .tox-menu.tox-collection [role="menuitem"]');
+    await TinyUiActions.pTriggerContextMenu(editor, selector, '.tox-silver-sink .tox-menu.tox-collection [role="menuitem"]');
 
   const pCloseContextMenu = async () => {
     Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.escape());

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,4 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+
+bridge@2.2.0


### PR DESCRIPTION
Related Ticket:

TINY-7073

Description of Changes:

Uses `CommonMenuItemSpec` for `ContextMenuItem` and `ContextSubMenu` in order to enable the following properties:
- `disabled`
- `shortcut`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
