### PR TITLE
TINY-7053: Convert link plugin tests to use BDD style

### DIFF
--- a/modules/tinymce/src/plugins/link/test/ts/atomic/DialogChangesTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/atomic/DialogChangesTest.ts
@@ -1,5 +1,4 @@
-import { Logger } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, describe, context, it } from '@ephox/bedrock-client';
 import { Fun, Optional, OptionalInstances } from '@ephox/katamari';
 import fc from 'fast-check';
 
@@ -8,119 +7,126 @@ import { LinkDialogCatalog, LinkDialogData, ListItem } from 'tinymce/plugins/lin
 
 const tOptional = OptionalInstances.tOptional;
 
-UnitTest.test('DialogChanges.getDelta', () => {
-  const anchorList: ListItem[] = [
-    { value: 'alpha', text: 'Alpha' },
-    {
-      text: 'GroupB',
-      items: [
-        { value: 'gamma', text: 'Gamma' }
-      ]
-    }
-  ];
+describe('browser.tinymce.plugins.link.DialogChangesTest', () => {
+  context('getDelta', () => {
+    const anchorList: ListItem[] = [
+      { value: 'alpha', text: 'Alpha' },
+      {
+        text: 'GroupB',
+        items: [
+          { value: 'gamma', text: 'Gamma' }
+        ]
+      }
+    ];
 
-  const assertNone = (label: string, previousText: string, catalog: ListItem[], data: Partial<LinkDialogData>) => {
-    Logger.sync('assertNone(' + label + ')', () => {
+    const assertNone = (previousText: string, catalog: ListItem[], data: Partial<LinkDialogData>) => {
       const actual = DialogChanges.getDelta(previousText, 'anchor', catalog, data);
       Assert.eq('Should not have found replacement text', Optional.none(), actual, tOptional());
-    });
-  };
+    };
 
-  const assertSome = (label: string, expected: DialogDelta, previousText: string, catalog: ListItem[], data: Partial<LinkDialogData>) => {
-    Logger.sync('assertSome(' + label + ')', () => {
+    const assertSome = (expected: DialogDelta, previousText: string, catalog: ListItem[], data: Partial<LinkDialogData>) => {
       const actual = DialogChanges.getDelta(previousText, 'anchor', catalog, data);
       Assert.eq('Checking replacement text', Optional.some(expected), actual, tOptional());
-    });
-  };
+    };
 
-  assertSome('Current text empty + Has mapping', {
-    url: {
-      value: 'alpha',
-      meta: {
-        attach: Fun.noop,
+    it('Current text empty + Has mapping', () => {
+      assertSome({
+        url: {
+          value: 'alpha',
+          meta: {
+            attach: Fun.noop,
+            text: 'Alpha'
+          }
+        },
         text: 'Alpha'
-      }
-    },
-    text: 'Alpha'
-  }, '', anchorList, {
-    anchor: 'alpha',
-    text: ''
-  });
+      }, '', anchorList, {
+        anchor: 'alpha',
+        text: ''
+      });
+    });
 
-  assertNone('Current text empty + Has no mapping', '', anchorList, {
-    anchor: 'beta',
-    text: ''
-  });
+    it('Current text empty + Has no mapping', () => {
+      assertNone('', anchorList, {
+        anchor: 'beta',
+        text: ''
+      });
+    });
 
-  assertSome('Current text empty + Has mapping in nested list', {
-    url: {
-      value: 'gamma',
-      meta: {
-        attach: Fun.noop,
+    it('Current text empty + Has mapping in nested list', () => {
+      assertSome({
+        url: {
+          value: 'gamma',
+          meta: {
+            attach: Fun.noop,
+            text: 'Gamma'
+          }
+        },
         text: 'Gamma'
-      }
-    },
-    text: 'Gamma'
-  }, '', anchorList, {
-    anchor: 'gamma',
-    text: ''
+      }, '', anchorList, {
+        anchor: 'gamma',
+        text: ''
+      });
+    });
+  });
+
+  context('init', () => {
+    it('no initial data', () => {
+      const dialogChange = DialogChanges.init({ title: '', text: '' } as LinkDialogData, { } as LinkDialogCatalog);
+
+      fc.assert(fc.property(fc.webUrl(), fc.asciiString(), fc.asciiString(), (url, title, text) => {
+        const data = Fun.constant({ url: {
+          value: url,
+          meta: { title, text }
+        }} as LinkDialogData);
+        const dataNoMeta = Fun.constant({ url: {
+          value: url,
+          meta: { }
+        }} as LinkDialogData);
+
+        Assert.eq('on url change should include url title and text',
+          Optional.some<Partial<LinkDialogData>>({ title, text }),
+          dialogChange.onChange(data, { name: 'url' }),
+          tOptional()
+        );
+
+        Assert.eq('on url change should fallback to url for text',
+          Optional.some<Partial<LinkDialogData>>({ title: '', text: url }),
+          dialogChange.onChange(dataNoMeta, { name: 'url' }),
+          tOptional()
+        );
+      }));
+    });
+
+    it('with original data', () => {
+      const dialogChange = DialogChanges.init({ title: 'orig title', text: 'orig text' } as LinkDialogData, { } as LinkDialogCatalog);
+      const dialogChangeNoTitle = DialogChanges.init({ title: '', text: 'orig text' } as LinkDialogData, { } as LinkDialogCatalog);
+      const dialogChangeNoText = DialogChanges.init({ title: 'orig title', text: '' } as LinkDialogData, { } as LinkDialogCatalog);
+
+      fc.assert(fc.property(fc.webUrl(), fc.asciiString(), fc.asciiString(), (url, title, text) => {
+        const data = Fun.constant({ url: {
+          value: url,
+          meta: { title, text }
+        }} as LinkDialogData);
+
+        Assert.eq('on url change should not try to change title and text',
+          Optional.none(),
+          dialogChange.onChange(data, { name: 'url' }),
+          tOptional()
+        );
+
+        Assert.eq('No Title - on url change should only try to change title',
+          Optional.some<Partial<LinkDialogData>>({ title }),
+          dialogChangeNoTitle.onChange(data, { name: 'url' }),
+          tOptional()
+        );
+
+        Assert.eq('No Text - on url change should only try to change text',
+          Optional.some<Partial<LinkDialogData>>({ text }),
+          dialogChangeNoText.onChange(data, { name: 'url' }),
+          tOptional()
+        );
+      }));
+    });
   });
 });
 
-UnitTest.test('DialogChanges.init - no initial data', () => {
-  const dialogChange = DialogChanges.init({ title: '', text: '' } as LinkDialogData, { } as LinkDialogCatalog);
-
-  fc.assert(fc.property(fc.webUrl(), fc.asciiString(), fc.asciiString(), (url, title, text) => {
-    const data = Fun.constant({ url: {
-      value: url,
-      meta: { title, text }
-    }} as LinkDialogData);
-    const dataNoMeta = Fun.constant({ url: {
-      value: url,
-      meta: { }
-    }} as LinkDialogData);
-
-    Assert.eq('on url change should include url title and text',
-      Optional.some<Partial<LinkDialogData>>({ title, text }),
-      dialogChange.onChange(data, { name: 'url' }),
-      tOptional()
-    );
-
-    Assert.eq('on url change should fallback to url for text',
-      Optional.some<Partial<LinkDialogData>>({ title: '', text: url }),
-      dialogChange.onChange(dataNoMeta, { name: 'url' }),
-      tOptional()
-    );
-  }));
-});
-
-UnitTest.test('DialogChanges.init - with original data', () => {
-  const dialogChange = DialogChanges.init({ title: 'orig title', text: 'orig text' } as LinkDialogData, { } as LinkDialogCatalog);
-  const dialogChangeNoTitle = DialogChanges.init({ title: '', text: 'orig text' } as LinkDialogData, { } as LinkDialogCatalog);
-  const dialogChangeNoText = DialogChanges.init({ title: 'orig title', text: '' } as LinkDialogData, { } as LinkDialogCatalog);
-
-  fc.assert(fc.property(fc.webUrl(), fc.asciiString(), fc.asciiString(), (url, title, text) => {
-    const data = Fun.constant({ url: {
-      value: url,
-      meta: { title, text }
-    }} as LinkDialogData);
-
-    Assert.eq('on url change should not try to change title and text',
-      Optional.none(),
-      dialogChange.onChange(data, { name: 'url' }),
-      tOptional()
-    );
-
-    Assert.eq('No Title - on url change should only try to change title',
-      Optional.some<Partial<LinkDialogData>>({ title }),
-      dialogChangeNoTitle.onChange(data, { name: 'url' }),
-      tOptional()
-    );
-
-    Assert.eq('No Text - on url change should only try to change text',
-      Optional.some<Partial<LinkDialogData>>({ text }),
-      dialogChangeNoText.onChange(data, { name: 'url' }),
-      tOptional()
-    );
-  }));
-});

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from '@ephox/bedrock-client';
+import { describe, it, before, after, afterEach } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
@@ -24,12 +24,15 @@ describe('browser.tinymce.plugins.link.AllowUnsafeLinkTargetTest', () => {
     TestLinkUi.clearHistory();
   });
 
+  afterEach(() => {
+    hook.editor().setContent('');
+  });
+
   it(`TBA: doesn't add rel noopener stuff with allow_unsafe_link_target: true`, async () => {
     const editor = hook.editor();
     editor.settings.allow_unsafe_link_target = true;
     await TestLinkUi.pInsertLink(editor, 'http://www.google.com');
     await TestLinkUi.pAssertContentPresence(editor, { 'a[rel="noopener"]': 0, 'a': 1 });
-    editor.setContent('');
   });
 
   it('TBA: adds if allow_unsafe_link_target: false', async () => {
@@ -37,7 +40,6 @@ describe('browser.tinymce.plugins.link.AllowUnsafeLinkTargetTest', () => {
     editor.settings.allow_unsafe_link_target = false;
     await TestLinkUi.pInsertLink(editor, 'http://www.google.com');
     await TestLinkUi.pAssertContentPresence(editor, { 'a[rel="noopener"]': 1 });
-    editor.setContent('');
   });
 
   it(`TBA: adds if allow_unsafe_link_target: undefined`, async () => {
@@ -52,7 +54,6 @@ describe('browser.tinymce.plugins.link.AllowUnsafeLinkTargetTest', () => {
     editor.settings.allow_unsafe_link_target = false;
     editor.setContent('<a href="http://www.google.com" target="_blank" rel="nofollow alternate">Google</a>');
     TinyAssertions.assertContent(editor, '<p><a href="http://www.google.com" target="_blank" rel="alternate nofollow noopener">Google</a></p>');
-    editor.setContent('');
   });
 
   it('TBA: allow_unsafe_link_target=false: proper option selected for defined rel_list', async () => {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AnchorFalseTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AnchorFalseTest.ts
@@ -1,51 +1,40 @@
-import { Chain, FocusTools, Log, Pipeline, Step, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { FocusTools, UiFinder } from '@ephox/agar';
+import { describe, it, before, after } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.AnchorFalseTest', (success, failure) => {
-  SilverTheme();
-  LinkPlugin();
-
-  TinyLoader.setup((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-    const doc = SugarDocument.getDocument();
-
-    Pipeline.async({}, [
-      tinyApis.sFocus(),
-      Step.sync(() => {
-        LocalStorage.setItem('tinymce-url-history', JSON.stringify({
-          file: [ 'http://www.tiny.cloud/' ]
-        }));
-      }),
-      Log.stepsAsStep('TINY-6256', 'With anchor top/bottom set to false, they shouldn\'t be shown in the url list options', [
-        TestLinkUi.sOpenLinkDialog(tinyUi),
-        FocusTools.sSetActiveValue(doc, 't'),
-        Chain.asStep(doc, [
-          FocusTools.cGetFocused,
-          TestLinkUi.cFireEvent('input')
-        ]),
-        tinyUi.sWaitForUi('Wait for the typeahead to open', '.tox-dialog__popups .tox-menu'),
-        UiFinder.sNotExists(SugarBody.body(), '.tox-dialog__popups .tox-menu .tox-collection__item:contains(<top>)'),
-        UiFinder.sNotExists(SugarBody.body(), '.tox-dialog__popups .tox-menu .tox-collection__item:contains(<bottom>)')
-      ]),
-      Step.sync(() => {
-        LocalStorage.removeItem('tinymce-url-history');
-      })
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.link.AnchorFalseTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link',
-    menubar: false,
-    base_url: '/project/tinymce/js/tinymce',
     anchor_top: false,
-    anchor_bottom: false
-  }, success, failure);
+    anchor_bottom: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin, Theme ], true);
+
+  before(() => {
+    LocalStorage.setItem('tinymce-url-history', JSON.stringify({
+      file: [ 'http://www.tiny.cloud/' ]
+    }));
+  });
+
+  after(() => {
+    LocalStorage.removeItem('tinymce-url-history');
+  });
+
+  it('TINY-6256: With anchor top/bottom set to false, they shouldn\'t be shown in the url list options', async () => {
+    const editor = hook.editor();
+    await TestLinkUi.pOpenLinkDialog(editor);
+    const focused = FocusTools.setActiveValue(SugarDocument.getDocument(), 't');
+    TestLinkUi.fireEvent(focused, 'input');
+    await TinyUiActions.pWaitForUi(editor, '.tox-dialog__popups .tox-menu');
+    UiFinder.notExists(SugarBody.body(), '.tox-dialog__popups .tox-menu .tox-collection__item:contains(<top>)');
+    UiFinder.notExists(SugarBody.body(), '.tox-dialog__popups .tox-menu .tox-collection__item:contains(<bottom>)');
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -13,8 +13,8 @@ describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin, Theme ]);
 
-  context('TBA: Default setting', () => {
-    it('www-urls are prompted to add http:// prefix, accept', async () => {
+  context('Default setting', () => {
+    it('TBA: www-urls are prompted to add http:// prefix, accept', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'www.google.com');
       await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
@@ -22,7 +22,7 @@ describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://www.google.com"]': 1 });
     });
 
-    it('www-urls are prompted to add http:// prefix, cancel', async () => {
+    it('TBA: www-urls are prompted to add http:// prefix, cancel', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'www.google.com');
       await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
@@ -30,20 +30,20 @@ describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="www.google.com"]': 1 });
     });
 
-    it('other urls are not prompted', async () => {
+    it('TBA: other urls are not prompted', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'google.com');
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="google.com"]': 1 });
     });
   });
 
-  context('TBA: link_assume_external_targets: true', () => {
+  context('link_assume_external_targets: true', () => {
     before(() => {
       const editor = hook.editor();
       editor.settings.link_assume_external_targets = true;
     });
 
-    it('www-urls are prompted to add http:// prefix', async () => {
+    it('TBA: www-urls are prompted to add http:// prefix', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'www.google.com');
       await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
@@ -51,7 +51,7 @@ describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://www.google.com"]': 1 });
     });
 
-    it('other urls are prompted to add http:// prefix', async () => {
+    it('TBA: other urls are prompted to add http:// prefix', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'google.com');
       await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
@@ -59,7 +59,7 @@ describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://google.com"]': 1 });
     });
 
-    it('url not updated when prompt canceled', async () => {
+    it('TBA: url not updated when prompt canceled', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'google.com');
       await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
@@ -68,38 +68,38 @@ describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
     });
   });
 
-  context('TBA: link_assume_external_targets: http', () => {
+  context('link_assume_external_targets: http', () => {
     before(() => {
       const editor = hook.editor();
       editor.settings.link_assume_external_targets = 'http';
     });
 
-    it('add http:// prefix to www-urls', async () => {
+    it('TBA: add http:// prefix to www-urls', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'www.google.com');
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://www.google.com"]': 1 });
     });
 
-    it('add http:// prefix to other urls', async () => {
+    it('TBA: add http:// prefix to other urls', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'google.com');
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://google.com"]': 1 });
     });
   });
 
-  context('TBA: link_assume_external_targets: https', () => {
+  context('link_assume_external_targets: https', () => {
     before(() => {
       const editor = hook.editor();
       editor.settings.link_assume_external_targets = 'https';
     });
 
-    it('add https:// prefix to www-urls', async () => {
+    it('TBA: add https:// prefix to www-urls', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'www.google.com');
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="https://www.google.com"]': 1 });
     });
 
-    it('add https:// prefix to other urls', async () => {
+    it('TBA: add https:// prefix to other urls', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'google.com');
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="https://google.com"]': 1 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -1,114 +1,108 @@
-import { GeneralSteps, Log, Logger, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { describe, it, context, before } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.AssumeExternalTargetsTest', (success, failure) => {
-
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Default setting', [
-        Logger.t('www-urls are prompted to add http:// prefix, accept', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'www.google.com'),
-          TestLinkUi.sWaitForUi(
-            'wait for dialog',
-            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-          ),
-          TestLinkUi.sClickConfirmYes,
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1 })
-        ])),
-
-        Logger.t('www-urls are prompted to add http:// prefix, cancel', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'www.google.com'),
-          TestLinkUi.sWaitForUi(
-            'wait for dialog',
-            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-          ),
-          TestLinkUi.sClickConfirmNo,
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="www.google.com"]': 1 })
-        ])),
-
-        Logger.t('others urls are not prompted', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'google.com'),
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="google.com"]': 1 })
-        ]))
-      ]),
-
-      Log.stepsAsStep('TBA', 'link_assume_external_targets: true', [
-        tinyApis.sSetSetting('link_assume_external_targets', true),
-
-        Logger.t('www-urls are prompted to add http:// prefix', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'www.google.com'),
-          TestLinkUi.sWaitForUi(
-            'wait for dialog',
-            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-          ),
-          TestLinkUi.sClickConfirmYes,
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1 })
-        ])),
-
-        Logger.t('other urls are prompted to add http:// prefix', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'google.com'),
-          TestLinkUi.sWaitForUi(
-            'wait for dialog',
-            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-          ),
-          TestLinkUi.sClickConfirmYes,
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://google.com"]': 1 })
-        ])),
-
-        Logger.t('url not updated when prompt canceled', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'google.com'),
-          TestLinkUi.sWaitForUi(
-            'wait for dialog',
-            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-          ),
-          TestLinkUi.sClickConfirmNo,
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="google.com"]': 1 })
-        ]))
-      ]),
-
-      Log.stepsAsStep('TBA', 'link_assume_external_targets: http', [
-        tinyApis.sSetSetting('link_assume_external_targets', 'http'),
-
-        Logger.t('add http:// prefix to www-urls', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'www.google.com'),
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1 })
-        ])),
-
-        Logger.t('add http:// prefix to other urls', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'google.com'),
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://google.com"]': 1 })
-        ]))
-      ]),
-
-      Log.stepsAsStep('TBA', 'link_assume_external_targets: https', [
-        tinyApis.sSetSetting('link_assume_external_targets', 'https'),
-
-        Logger.t('add https:// prefix to www-urls', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'www.google.com'),
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="https://www.google.com"]': 1 })
-        ])),
-
-        Logger.t('add https:// prefix to other urls', GeneralSteps.sequence([
-          TestLinkUi.sInsertLink(tinyUi, 'google.com'),
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="https://google.com"]': 1 })
-        ]))
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  context('TBA: Default setting', () => {
+    it('www-urls are prompted to add http:// prefix, accept', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'www.google.com');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TestLinkUi.pClickConfirmYes(editor);
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://www.google.com"]': 1 });
+    });
+
+    it('www-urls are prompted to add http:// prefix, cancel', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'www.google.com');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TestLinkUi.pClickConfirmNo(editor);
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="www.google.com"]': 1 });
+    });
+
+    it('other urls are not prompted', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'google.com');
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="google.com"]': 1 });
+    });
+  });
+
+  context('TBA: link_assume_external_targets: true', () => {
+    before(() => {
+      const editor = hook.editor();
+      editor.settings.link_assume_external_targets = true;
+    });
+
+    it('www-urls are prompted to add http:// prefix', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'www.google.com');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TestLinkUi.pClickConfirmYes(editor);
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://www.google.com"]': 1 });
+    });
+
+    it('other urls are prompted to add http:// prefix', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'google.com');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TestLinkUi.pClickConfirmYes(editor);
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://google.com"]': 1 });
+    });
+
+    it('url not updated when prompt canceled', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'google.com');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TestLinkUi.pClickConfirmNo(editor);
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="google.com"]': 1 });
+    });
+  });
+
+  context('TBA: link_assume_external_targets: http', () => {
+    before(() => {
+      const editor = hook.editor();
+      editor.settings.link_assume_external_targets = 'http';
+    });
+
+    it('add http:// prefix to www-urls', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'www.google.com');
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://www.google.com"]': 1 });
+    });
+
+    it('add http:// prefix to other urls', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'google.com');
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://google.com"]': 1 });
+    });
+  });
+
+  context('TBA: link_assume_external_targets: https', () => {
+    before(() => {
+      const editor = hook.editor();
+      editor.settings.link_assume_external_targets = 'https';
+    });
+
+    it('add https:// prefix to www-urls', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'www.google.com');
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="https://www.google.com"]': 1 });
+    });
+
+    it('add https:// prefix to other urls', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'google.com');
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="https://google.com"]': 1 });
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
@@ -1,64 +1,63 @@
-import { Chain, Log, Mouse, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyDom, TinyLoader, TinyUi } from '@ephox/mcagar';
-
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
+import { Mouse, UiFinder } from '@ephox/agar';
+import { describe, it, before, after } from '@ephox/bedrock-client';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
+
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.ContextToolbarTest', (success, failure) => {
-  Theme();
-  LinkPlugin();
-
-  TinyLoader.setup((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-    const editorEle = TinyDom.fromDom(editor.getBody());
-    const docEle = TinyDom.fromDom(document.body);
-
-    Pipeline.async({}, [
-      TestLinkUi.sClearHistory,
-      tinyApis.sFocus(),
-      Log.stepsAsStep('TBA', 'no toolbar on by default', [
-        tinyApis.sSetContent('<a href="http://www.google.com">google</a>'),
-        Mouse.sTrueClickOn(editorEle, 'a'),
-        UiFinder.sNotExists(editorEle, '.tox-toolbar button[aria-label="Link"]'),
-        tinyApis.sSetContent('')
-      ]),
-      Log.stepsAsStep('TBA', 'only after setting set to true', [
-        tinyApis.sSetSetting('link_context_toolbar', true),
-        tinyApis.sSetContent('<a href="http://www.google.com">google</a>'),
-        Mouse.sTrueClickOn(editorEle, 'a'),
-        tinyUi.sWaitForUi('wait for toolbar link button', '.tox-toolbar button[aria-label="Link"]'),
-        tinyUi.sWaitForUi('wait for toolbar unlink button', '.tox-toolbar button[aria-label="Remove link"]'),
-        tinyUi.sWaitForUi('wait for toolbar open link button', '.tox-toolbar button[aria-label="Open link"]'),
-        Chain.asStep(docEle, [
-          UiFinder.cWaitForState('check link content', '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com')
-        ])
-      ]),
-      Log.stepsAsStep('TBA', 'shows relative link urls', [
-        tinyApis.sSetSetting('link_context_toolbar', true),
-        tinyApis.sSetContent('<a href="#heading-1">heading</a>'),
-        Mouse.sTrueClickOn(editorEle, 'a'),
-        tinyUi.sWaitForUi('wait for toolbar link button', '.tox-toolbar button[aria-label="Link"]'),
-        Chain.asStep(docEle, [
-          UiFinder.cWaitForState('check link content', '.tox-toolbar input', (ele) => ele.dom.value === '#heading-1')
-        ])
-      ]),
-      Log.stepsAsStep('TBA', 'works with non text elements (e.g. images)', [
-        tinyApis.sSetSetting('link_context_toolbar', true),
-        tinyApis.sSetContent('<a href="http://www.google.com/"><img src="image.jpg"></a>'),
-        Mouse.sTrueClickOn(editorEle, 'a'),
-        tinyUi.sWaitForUi('wait for toolbar link button', '.tox-toolbar button[aria-label="Link"]'),
-        Chain.asStep(docEle, [
-          UiFinder.cWaitForState('check link content', '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com/')
-        ])
-      ]),
-      TestLinkUi.sClearHistory
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  before(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  after(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  it('TBA: no toolbar on by default', () => {
+    const editor = hook.editor();
+    const editorBody = TinyDom.body(editor);
+    editor.setContent('<a href="http://www.google.com">google</a>');
+    Mouse.trueClickOn(editorBody, 'a');
+    UiFinder.notExists(editorBody, '.tox-toolbar button[aria-label="Link"]');
+    editor.setContent('');
+  });
+
+  it('TBA: only after setting set to true', async () => {
+    const editor = hook.editor();
+    editor.settings.link_context_toolbar = true;
+    editor.setContent('<a href="http://www.google.com">google</a>');
+    Mouse.trueClickOn(TinyDom.body(editor), 'a');
+    await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Link"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Remove link"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Open link"]');
+    await UiFinder.pWaitForState('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com');
+  });
+
+  it('TBA: shows relative link urls', async () => {
+    const editor = hook.editor();
+    editor.settings.link_context_toolbar = true;
+    editor.setContent('<a href="#heading-1">heading</a>');
+    Mouse.trueClickOn(TinyDom.body(editor), 'a');
+    await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Link"]');
+    await UiFinder.pWaitForState('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === '#heading-1');
+  });
+
+  it('TBA: works with non text elements (e.g. images)', async () => {
+    const editor = hook.editor();
+    editor.settings.link_context_toolbar = true;
+    editor.setContent('<a href="http://www.google.com/"><img src="image.jpg"></a>');
+    Mouse.trueClickOn(TinyDom.body(editor), 'a');
+    await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Link"]');
+    await UiFinder.pWaitForState('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com/');
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkProtocolTest.ts
@@ -1,83 +1,73 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { describe, it, context, before } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.DefaultLinkProtocolTest', (success, failure) => {
-
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'link_default_protocol: "http"', [
-        tinyApis.sSetSetting('link_default_protocol', 'http'),
-
-        Log.stepsAsStep('TBA', 'www-urls are prompted to add http:// prefix, accept', [
-          TestLinkUi.sInsertLink(tinyUi, 'www.google.com'),
-          TestLinkUi.sWaitForUi(
-            'wait for dialog',
-            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-          ),
-          TestLinkUi.sClickConfirmYes,
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="http://www.google.com"]': 1 })
-        ]),
-
-        Log.stepsAsStep('TBA', 'www-urls are prompted to add http:// prefix, cancel', [
-          TestLinkUi.sInsertLink(tinyUi, 'www.google.com'),
-          TestLinkUi.sWaitForUi(
-            'wait for dialog',
-            'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")'
-          ),
-          TestLinkUi.sClickConfirmNo,
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="www.google.com"]': 1 })
-        ]),
-
-        Log.stepsAsStep('TBA', 'other urls are not prompted to add http:// prefix', [
-          TestLinkUi.sInsertLink(tinyUi, 'google.com'),
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="google.com"]': 1 })
-        ])
-      ]),
-
-      Log.stepsAsStep('TBA', 'link_default_protocol: "https"', [
-        tinyApis.sSetSetting('link_default_protocol', 'https'),
-
-        Log.stepsAsStep('TBA', 'www-urls are prompted to add https:// prefix, accept', [
-          TestLinkUi.sInsertLink(tinyUi, 'www.google.com'),
-          TestLinkUi.sWaitForUi(
-            'wait for dialog',
-            'p:contains("The URL you entered seems to be an external link. Do you want to add the required https:// prefix?")'
-          ),
-          TestLinkUi.sClickConfirmYes,
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="https://www.google.com"]': 1 })
-        ]),
-
-        Log.stepsAsStep('TBA', 'www-urls are prompted to add https:// prefix, cancel', [
-          TestLinkUi.sInsertLink(tinyUi, 'www.google.com'),
-          TestLinkUi.sWaitForUi(
-            'wait for dialog',
-            'p:contains("The URL you entered seems to be an external link. Do you want to add the required https:// prefix?")'
-          ),
-          TestLinkUi.sClickConfirmNo,
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="www.google.com"]': 1 })
-        ]),
-
-        Log.stepsAsStep('TBA', 'other urls are not prompted to add https:// prefix', [
-          TestLinkUi.sInsertLink(tinyUi, 'google.com'),
-          TestLinkUi.sAssertContentPresence(tinyApis, { 'a': 1, 'a[href="google.com"]': 1 })
-        ])
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.DefaultLinkProtocolTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  context('TBA: link_default_protocol: "http"', () => {
+    before(() => {
+      const editor = hook.editor();
+      editor.settings.link_default_protocol = 'http';
+    });
+
+    it('TBA: www-urls are prompted to add http:// prefix, accept', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'www.google.com');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TestLinkUi.pClickConfirmYes(editor);
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://www.google.com"]': 1 });
+    });
+
+    it('TBA: www-urls are prompted to add http:// prefix, cancel', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'www.google.com');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TestLinkUi.pClickConfirmNo(editor);
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="www.google.com"]': 1 });
+    });
+
+    it('TBA: other urls are not prompted to add http:// prefix', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'google.com');
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="google.com"]': 1 });
+    });
+  });
+
+  context('TBA: link_default_protocol: "https"', () => {
+    before(() => {
+      const editor = hook.editor();
+      editor.settings.link_default_protocol = 'https';
+    });
+
+    it('TBA: www-urls are prompted to add https:// prefix, accept', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'www.google.com');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required https:// prefix?")');
+      await TestLinkUi.pClickConfirmYes(editor);
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="https://www.google.com"]': 1 });
+    });
+
+    it('TBA: www-urls are prompted to add https:// prefix, cancel', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'www.google.com');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required https:// prefix?")');
+      await TestLinkUi.pClickConfirmNo(editor);
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="www.google.com"]': 1 });
+    });
+
+    it('TBA: other urls are not prompted to add https:// prefix', async () => {
+      const editor = hook.editor();
+      await TestLinkUi.pInsertLink(editor, 'google.com');
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="google.com"]': 1 });
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkProtocolTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.plugins.link.DefaultLinkProtocolTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin, Theme ]);
 
-  context('TBA: link_default_protocol: "http"', () => {
+  context('link_default_protocol: "http"', () => {
     before(() => {
       const editor = hook.editor();
       editor.settings.link_default_protocol = 'http';
@@ -42,7 +42,7 @@ describe('browser.tinymce.plugins.link.DefaultLinkProtocolTest', () => {
     });
   });
 
-  context('TBA: link_default_protocol: "https"', () => {
+  context('link_default_protocol: "https"', () => {
     before(() => {
       const editor = hook.editor();
       editor.settings.link_default_protocol = 'https';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
@@ -30,7 +30,6 @@ describe('browser.tinymce.plugins.link.DialogFlowTest', () => {
     assert.equal(value, expected, 'Checking input value');
   };
 
-  // FIX: Dupe
   const pAssertUrlStructure = async (editor: Editor, expected: ApproxStructure.Builder<StructAssert>) => {
     const input = await TestLinkUi.pFindInDialog(editor, 'label:contains("URL") + .tox-form__controls-h-stack input');
     Assertions.assertStructure(

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
@@ -1,4 +1,4 @@
-import { ApproxStructure, Assertions, FocusTools, Keys, UiControls, UiFinder } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, UiControls, UiFinder } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
@@ -31,7 +31,7 @@ describe('browser.tinymce.plugins.link.DialogFlowTest', () => {
   };
 
   // FIX: Dupe
-  const pAssertUrlStructure = async (editor: Editor, expected: (s, str, arr) => any) => {
+  const pAssertUrlStructure = async (editor: Editor, expected: ApproxStructure.Builder<StructAssert>) => {
     const input = await TestLinkUi.pFindInDialog(editor, 'label:contains("URL") + .tox-form__controls-h-stack input');
     Assertions.assertStructure(
       'Checking content of url input',

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
@@ -1,151 +1,137 @@
-import {
-  ApproxStructure, Assertions, Chain, FocusTools, GeneralSteps, Keyboard, Keys, Log, Logger, Mouse, NamedChain, Pipeline, Step, UiControls, UiFinder
-} from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyDom, TinyLoader, TinyUi } from '@ephox/mcagar';
-import { Attribute } from '@ephox/sugar';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { ApproxStructure, Assertions, FocusTools, Keys, UiControls, UiFinder } from '@ephox/agar';
+import { describe, it, before, after } from '@ephox/bedrock-client';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
+import { assert } from 'chai';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.DialogFlowTest', (success, failure) => {
-
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-    const doc = TinyDom.fromDom(document);
-
-    const sAssertInputValue = (expected: string, group: string) => Logger.t('Assert input value', Chain.asStep({ }, [
-      TestLinkUi.cFindInDialog('label:contains("' + group + '") + input'),
-      UiControls.cGetValue,
-      Assertions.cAssertEq('Checking input value', expected)
-    ]));
-
-    // FIX: Dupe
-    const sAssertUrlStructure = (expected: (s, str, arr) => any) => Logger.t('Assert url structure', Chain.asStep({ }, [
-      TestLinkUi.cFindInDialog('label:contains("URL") + .tox-form__controls-h-stack input'),
-      Chain.op((urlinput) => {
-        Assertions.assertStructure(
-          'Checking content of url input',
-          ApproxStructure.build(expected),
-          urlinput
-        );
-      })
-    ]));
-
-    const testChangingAnchorValue = Log.stepsAsStep('TBA', 'Link: Switching anchor changes the href and text', [
-      tinyApis.sSetContent('<p><a name="anchor1"></a>Our Anchor1</p><p><a name="anchor2"></a>Our Anchor2</p>'),
-      TestLinkUi.sOpenLinkDialog(tinyUi),
-      TestLinkUi.sSetListBoxItem('Anchor', 'anchor2'),
-      TestLinkUi.sAssertDialogContents({
-        href: '#anchor2',
-        text: 'anchor2',
-        title: '',
-        anchor: '#anchor2',
-        target: ''
-      }),
-      TestLinkUi.sSetListBoxItem('Anchor', 'anchor1'),
-      TestLinkUi.sAssertDialogContents({
-        href: '#anchor1',
-        text: 'anchor1',
-        title: '',
-        anchor: '#anchor1',
-        target: ''
-      }),
-
-      // Change the text ...so text won't change, but href will still
-      TestLinkUi.sSetInputFieldValue('Text to display', 'Other text'),
-      TestLinkUi.sSetListBoxItem('Anchor', 'anchor2'),
-      TestLinkUi.sAssertDialogContents({
-        href: '#anchor2',
-        text: 'Other text',
-        title: '',
-        anchor: '#anchor2',
-        target: ''
-      }),
-
-      TestLinkUi.sClickSave,
-      TestLinkUi.sAssertContentPresence(tinyApis, {
-        'a[href]': 1,
-        'a[href="#anchor2"]:contains("Other text")': 1
-      })
-    ]);
-
-    const testChangingUrlValueWith = (sChooseItem: Step<any, any>) => Log.stepsAsStep('TBA', 'Link: Choosing something in the urlinput changes text and value', [
-      tinyApis.sSetContent('<h1>Header One</h1><h2 id="existing-id">Header2</h2>'),
-      TestLinkUi.sOpenLinkDialog(tinyUi),
-      Keyboard.sKeydown(doc, Keys.down(), { }),
-      UiFinder.sWaitForVisible('Waiting for dropdown', TinyDom.fromDom(document.body), '.tox-menu'),
-      sChooseItem,
-      sAssertUrlStructure((s, str, _arr) => s.element('input', {
-        value: str.startsWith('#h_')
-      })),
-      sAssertInputValue('Header One', 'Text to display'),
-      TestLinkUi.sAssertContentPresence(tinyApis, {
-        'h1[id]': 0,
-        'h2[id]': 1
-      }),
-      TestLinkUi.sClickSave,
-      TestLinkUi.sAssertContentPresence(tinyApis, {
-        'h1[id]': 1
-      }),
-
-      // Check that the h1's id value is referred to by a link containing dog
-      Chain.asStep(TinyDom.fromDom(editor.getBody()), [
-        NamedChain.asChain([
-          NamedChain.direct(NamedChain.inputName(), UiFinder.cFindIn('h1'), 'h1'),
-          NamedChain.direct('h1', Chain.mapper((h1) => Attribute.get(h1, 'id')), 'h1-id'),
-          NamedChain.bundle((obj) => UiFinder.findIn(obj[NamedChain.inputName()], `a[href="#${obj['h1-id']}"]:contains("Header One")`))
-        ])
-      ])
-    ]);
-
-    const testChangingUrlValueWithKeyboard = Log.step('TBA', 'Link: With Keyboard',
-      testChangingUrlValueWith(GeneralSteps.sequence([
-        Keyboard.sKeydown(doc, Keys.enter(), { })
-      ]))
-    );
-
-    const testChangingUrlValueWithMouse = Log.step('TBA', 'Link: With Mouse',
-      testChangingUrlValueWith(Mouse.sClickOn(TinyDom.fromDom(document.body), '.tox-collection__item')
-      )
-    );
-
-    const testChangingUrlValueManually = Log.stepsAsStep('TBA', 'Link: Change urlinput value manually', [
-      tinyApis.sSetContent('<h1>Something</h2>'),
-      tinyApis.sSetSelection([ 0, 0 ], ''.length, [ 0, 0 ], 'Something'.length),
-      TestLinkUi.sOpenLinkDialog(tinyUi),
-
-      FocusTools.sSetActiveValue(doc, 'http://www.tiny.cloud'),
-      TestLinkUi.sAssertDialogContents({
-        href: 'http://www.tiny.cloud',
-        text: 'Something',
-        title: '',
-        target: ''
-      }),
-      TestLinkUi.sClickSave,
-      TestLinkUi.sAssertContentPresence(tinyApis, {
-        a: 1
-      })
-    ]
-    );
-
-    Pipeline.async({}, [
-      TestLinkUi.sClearHistory,
-      testChangingAnchorValue,
-      testChangingUrlValueWithKeyboard,
-      testChangingUrlValueWithMouse,
-      testChangingUrlValueManually,
-      TestLinkUi.sClearHistory
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.DialogFlowTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  before(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  after(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  const pAssertInputValue = async (editor: Editor, expected: string, group: string) => {
+    const input = await TestLinkUi.pFindInDialog(editor, 'label:contains("' + group + '") + input');
+    const value = UiControls.getValue(input);
+    assert.equal(value, expected, 'Checking input value');
+  };
+
+  // FIX: Dupe
+  const pAssertUrlStructure = async (editor: Editor, expected: (s, str, arr) => any) => {
+    const input = await TestLinkUi.pFindInDialog(editor, 'label:contains("URL") + .tox-form__controls-h-stack input');
+    Assertions.assertStructure(
+      'Checking content of url input',
+      ApproxStructure.build(expected),
+      input
+    );
+  };
+
+  const pTestChangingUrlValueWith = async (editor: Editor, chooseItem: () => void) => {
+    editor.setContent('<h1>Header One</h1><h2 id="existing-id">Header2</h2>');
+    await TestLinkUi.pOpenLinkDialog(editor);
+    TinyUiActions.keydown(editor, Keys.down());
+    await UiFinder.pWaitForVisible('Waiting for dropdown', SugarBody.body(), '.tox-menu');
+    chooseItem();
+    await pAssertUrlStructure(editor, (s, str, _arr) => s.element('input', {
+      value: str.startsWith('#h_')
+    }));
+    await pAssertInputValue(editor, 'Header One', 'Text to display');
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'h1[id]': 0,
+      'h2[id]': 1
+    });
+    await TestLinkUi.pClickSave(editor);
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'h1[id]': 1
+    });
+
+    // Check that the h1's id value is referred to by a link containing dog
+    const editorBody = TinyDom.body(editor);
+    const h1ID = UiFinder.findIn(editorBody, 'h1').map((h1) => Attribute.get(h1, 'id')).getOrDie();
+    UiFinder.exists(editorBody, `a[href="#${h1ID}"]:contains("Header One")`);
+  };
+
+  it('TBA: Switching anchor changes the href and text', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a name="anchor1"></a>Our Anchor1</p><p><a name="anchor2"></a>Our Anchor2</p>');
+
+    await TestLinkUi.pOpenLinkDialog(editor);
+    await TestLinkUi.pSetListBoxItem(editor, 'Anchor', 'anchor2');
+    TestLinkUi.assertDialogContents({
+      href: '#anchor2',
+      text: 'anchor2',
+      title: '',
+      anchor: '#anchor2',
+      target: ''
+    });
+
+    await TestLinkUi.pSetListBoxItem(editor, 'Anchor', 'anchor1');
+    TestLinkUi.assertDialogContents({
+      href: '#anchor1',
+      text: 'anchor1',
+      title: '',
+      anchor: '#anchor1',
+      target: ''
+    });
+
+    // Change the text ...so text won't change, but href will still
+    await TestLinkUi.pSetInputFieldValue(editor, 'Text to display', 'Other text');
+    await TestLinkUi.pSetListBoxItem(editor, 'Anchor', 'anchor2');
+    TestLinkUi.assertDialogContents({
+      href: '#anchor2',
+      text: 'Other text',
+      title: '',
+      anchor: '#anchor2',
+      target: ''
+    });
+
+    await TestLinkUi.pClickSave(editor);
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href]': 1,
+      'a[href="#anchor2"]:contains("Other text")': 1
+    });
+  });
+
+  it('TBA: Change urlinput value with keyboard', async () => {
+    const editor = hook.editor();
+    await pTestChangingUrlValueWith(editor, () => TinyUiActions.keydown(editor, Keys.enter()));
+  });
+
+  it('TBA: Change urlinput value with mouse', async () => {
+    const editor = hook.editor();
+    await pTestChangingUrlValueWith(editor, () => TinyUiActions.clickOnUi(editor, '.tox-collection__item'));
+  });
+
+  it('TBA: Change urlinput value manually', async () => {
+    const editor = hook.editor();
+    editor.setContent('<h1>Something</h2>');
+    TinySelections.setSelection(editor, [ 0, 0 ], ''.length, [ 0, 0 ], 'Something'.length);
+    await TestLinkUi.pOpenLinkDialog(editor);
+
+    FocusTools.setActiveValue(SugarDocument.getDocument(), 'http://www.tiny.cloud');
+    TestLinkUi.assertDialogContents({
+      href: 'http://www.tiny.cloud',
+      text: 'Something',
+      title: '',
+      target: ''
+    });
+    await TestLinkUi.pClickSave(editor);
+    await TestLinkUi.pAssertContentPresence(editor, {
+      a: 1
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
@@ -10,9 +10,9 @@ import Theme from 'tinymce/themes/silver/Theme';
 import { TestLinkUi } from '../module/TestLinkUi';
 
 interface TestSection {
-  setting: { key: string; value: Optional<any> };
-  selector: string;
-  exists: boolean;
+  readonly setting: { key: string; value: Optional<any> };
+  readonly selector: string;
+  readonly exists: boolean;
 }
 
 describe('browser.tinymce.plugins.link.DialogSectionsTest', () => {
@@ -122,13 +122,13 @@ describe('browser.tinymce.plugins.link.DialogSectionsTest', () => {
     ]);
   };
 
-  context('TBA: Check Target section', () => {
+  context('Check Target section', () => {
     checkTargetSection(false, Optional.some(false));
     checkTargetSection(true, Optional.some(true));
     checkTargetSection(true, Optional.none());
   });
 
-  context('TBA: Check rel section', () => {
+  context('Check rel section', () => {
     checkRelSection(true, Optional.some([
       { title: 'a', value: 'b' },
       { title: 'c', value: 'd' }
@@ -136,12 +136,12 @@ describe('browser.tinymce.plugins.link.DialogSectionsTest', () => {
     checkRelSection(false, Optional.none());
   });
 
-  context('TBA: Check Title section', () => {
+  context('Check Title section', () => {
     checkTitleSection(false, Optional.some(false));
     checkTitleSection(true, Optional.none());
   });
 
-  context('TBA: Check class section', () => {
+  context('Check class section', () => {
     checkClassSection(true, Optional.some([
       { title: 'a', value: 'b' },
       { title: 'c', value: 'd' }
@@ -149,7 +149,7 @@ describe('browser.tinymce.plugins.link.DialogSectionsTest', () => {
     checkClassSection(false, Optional.none());
   });
 
-  context('TBA: Check LinkList section', () => {
+  context('Check LinkList section', () => {
     checkLinkListSection(true, Optional.some([
       { title: 'a', value: 'b' },
       { title: 'c', value: 'd' }

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
@@ -1,140 +1,159 @@
-import { GeneralSteps, Log, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { UiFinder } from '@ephox/agar';
+import { describe, it, before, after, context } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
-import { TinyApis, TinyDom, TinyLoader, TinyUi } from '@ephox/mcagar';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { TinyHooks } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.DialogSectionsTest', (success, failure) => {
+interface TestSection {
+  setting: { key: string; value: Optional<any> };
+  selector: string;
+  exists: boolean;
+}
 
-  LinkPlugin();
-  SilverTheme();
+describe('browser.tinymce.plugins.link.DialogSectionsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'link',
+    toolbar: 'link',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin, Theme ]);
+
+  before(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  after(() => {
+    TestLinkUi.clearHistory();
+  });
 
   const getStr = (sections: TestSection[]) => {
-    const r = { };
+    const r = {};
     Arr.each(sections, (section) => {
       r[section.setting.key] = section.setting.value.getOr('{ default }');
     });
     return JSON.stringify(r, null, 2);
   };
 
-  interface TestSection {
-    setting: { key: string; value: Optional<any> };
-    selector: string;
-    exists: boolean;
-  }
+  // NOTE: This will open the dialog once. It is expected that you specify all the settings that you want
+  // in the sections array. Then once it has opened the dialog, it will check whether each section is
+  // there or not
+  const checkSections = (sections: TestSection[]) => {
+    it('Settings: ' + getStr(sections), async () => {
+      const editor = hook.editor();
 
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    // NOTE: This will open the dialog once. It is expected that you specify all the settings that you want
-    // in the sections array. Then once it has opened the dialog, it will check whether each section is
-    // there or not
-    const sCheckSections = (sections: TestSection[]) => Log.stepsAsStep('TBA', 'Link: Settings: ' + getStr(sections), [
-      GeneralSteps.sequence(
-        Arr.map(sections, ({ setting }) => setting.value.map((v) => tinyApis.sSetSetting(setting.key, v)).getOrThunk(() => tinyApis.sDeleteSetting(setting.key)))
-      ),
-      TestLinkUi.sOpenLinkDialog(tinyUi),
-      GeneralSteps.sequence(
-        Arr.map(
-          sections,
-          ({ selector, exists }) => {
-            // eslint-disable-next-line no-console
-            console.log('selector', selector, 'exists', exists);
-            const sExistence = exists ? UiFinder.sExists : UiFinder.sNotExists;
-            return sExistence(TinyDom.fromDom(document.body), selector);
+      Arr.each(sections, ({ setting }) => {
+        setting.value.fold(
+          () => {
+            delete editor.settings[setting.key];
+          },
+          (v) => {
+            editor.settings[setting.key] = v;
           }
-        )
-      ),
-      TestLinkUi.sClickOnDialog('click on cancel', 'button:contains("Cancel")')
+        );
+      });
+
+      await TestLinkUi.pOpenLinkDialog(editor);
+
+      Arr.each(
+        sections,
+        ({ selector, exists }) => {
+          // eslint-disable-next-line no-console
+          console.log('selector', selector, 'exists', exists);
+          const existence = exists ? UiFinder.exists : UiFinder.notExists;
+          existence(SugarBody.body(), selector);
+        }
+      );
+
+      await TestLinkUi.pClickCancel(editor);
+    });
+  };
+
+  const checkTargetSection = (exists: boolean, value: Optional<boolean>) => {
+    checkSections([
+      {
+        setting: { key: 'target_list', value },
+        selector: 'label:contains("Open link in...")',
+        exists
+      }
     ]);
+  };
 
-    const sCheckTargetSection = (exists: boolean, value: Optional<boolean>) => Log.step('TBA', 'Link: sCheckTargetSection',
-      sCheckSections([
-        {
-          setting: { key: 'target_list', value },
-          selector: 'label:contains("Open link in...")',
-          exists
-        }
-      ])
-    );
+  const checkTitleSection = (exists: boolean, value: Optional<boolean>) => {
+    checkSections([
+      {
+        setting: { key: 'link_title', value },
+        selector: 'label:contains("Title")',
+        exists
+      }
+    ]);
+  };
 
-    const sCheckTitleSection = (exists: boolean, value: Optional<boolean>) => Log.step('TBA', 'Link: sCheckTitleSection',
-      sCheckSections([
-        {
-          setting: { key: 'link_title', value },
-          selector: 'label:contains("Title")',
-          exists
-        }
-      ])
-    );
+  const checkRelSection = (exists: boolean, value: Optional<Array<{ value: string; title: string }>>) => {
+    checkSections([
+      {
+        setting: { key: 'rel_list', value },
+        selector: 'label:contains("Rel")',
+        exists
+      }
+    ]);
+  };
 
-    const sCheckRelSection = (exists: boolean, value: Optional<Array<{ value: string; title: string }>>) => Log.step('TBA', 'Link: sCheckRelSection',
-      sCheckSections([
-        {
-          setting: { key: 'rel_list', value },
-          selector: 'label:contains("Rel")',
-          exists
-        }
-      ])
-    );
+  const checkClassSection = (exists: boolean, value: Optional<Array<{ value: string; title: string }>>) => {
+    checkSections([
+      {
+        setting: { key: 'link_class_list', value },
+        selector: 'label:contains("Class")',
+        exists
+      }
+    ]);
+  };
 
-    const sCheckClassSection = (exists: boolean, value: Optional<Array<{ value: string; title: string }>>) => Log.step('TBA', 'Link: sCheckClassSection',
-      sCheckSections([
-        {
-          setting: { key: 'link_class_list', value },
-          selector: 'label:contains("Class")',
-          exists
-        }
-      ])
-    );
+  const checkLinkListSection = (exists: boolean, value: Optional<Array<{ value: string; title: string }>>) => {
+    checkSections([
+      {
+        setting: { key: 'link_list', value },
+        selector: 'label:contains("Link list")',
+        exists
+      }
+    ]);
+  };
 
-    const sCheckLinkListSection = (exists: boolean, value: Optional<Array<{ value: string; title: string }>>) => Log.step('TBA', 'Link: sCheckLinkListSection',
-      sCheckSections([
-        {
-          setting: { key: 'link_list', value },
-          selector: 'label:contains("Link list")',
-          exists
-        }
-      ])
-    );
+  context('TBA: Check Target section', () => {
+    checkTargetSection(false, Optional.some(false));
+    checkTargetSection(true, Optional.some(true));
+    checkTargetSection(true, Optional.none());
+  });
 
-    // NOTE: Always end with none to remove the setting from future tests
-    Pipeline.async({}, [
-      TestLinkUi.sClearHistory,
-      sCheckTargetSection(false, Optional.some(false)),
-      sCheckTargetSection(true, Optional.some(true)),
-      sCheckTargetSection(true, Optional.none()),
+  context('TBA: Check rel section', () => {
+    checkRelSection(true, Optional.some([
+      { title: 'a', value: 'b' },
+      { title: 'c', value: 'd' }
+    ]));
+    checkRelSection(false, Optional.none());
+  });
 
-      sCheckRelSection(true, Optional.some([
-        { title: 'a', value: 'b' },
-        { title: 'c', value: 'd' }
-      ])),
-      sCheckRelSection(false, Optional.none()),
+  context('TBA: Check Title section', () => {
+    checkTitleSection(false, Optional.some(false));
+    checkTitleSection(true, Optional.none());
+  });
 
-      sCheckTitleSection(false, Optional.some(false)),
-      sCheckTitleSection(true, Optional.none()),
+  context('TBA: Check class section', () => {
+    checkClassSection(true, Optional.some([
+      { title: 'a', value: 'b' },
+      { title: 'c', value: 'd' }
+    ]));
+    checkClassSection(false, Optional.none());
+  });
 
-      sCheckClassSection(true, Optional.some([
-        { title: 'a', value: 'b' },
-        { title: 'c', value: 'd' }
-      ])),
-      sCheckClassSection(false, Optional.none()),
-
-      sCheckLinkListSection(true, Optional.some([
-        { title: 'a', value: 'b' },
-        { title: 'c', value: 'd' }
-      ])),
-      sCheckLinkListSection(false, Optional.none()),
-      TestLinkUi.sClearHistory
-    ], onSuccess, onFailure);
-  }, {
-    plugins: 'link',
-    toolbar: 'link',
-    theme: 'silver',
-    base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  context('TBA: Check LinkList section', () => {
+    checkLinkListSection(true, Optional.some([
+      { title: 'a', value: 'b' },
+      { title: 'c', value: 'd' }
+    ]));
+    checkLinkListSection(false, Optional.none());
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
@@ -1,59 +1,42 @@
-import { Assertions, Log, Logger, Pipeline, Step, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyDom, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { describe, it, before, after } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
 import * as LinkPluginUtils from 'tinymce/plugins/link/core/Utils';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.ImageFigureLinkTest', (success, failure) => {
-
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const api = TinyApis(editor);
-    const ui = TinyUi(editor);
-
-    const sLinkTheSelection = () => {
-      return Logger.t('Link the selection', TestLinkUi.sInsertLink(ui, 'http://google.com'));
-    };
-
-    const sUnlinkSelection = () => {
-      return Logger.t('Unlink the selection', Step.sync(() => {
-        LinkPluginUtils.unlink(editor);
-      }));
-    };
-
-    const sAssertPresence = (selector: Record<string, number>) => {
-      return Waiter.sTryUntil('Assert element is present',
-        Assertions.sAssertPresence('Detect presence of the element', selector, TinyDom.fromDom(editor.getBody()))
-      );
-    };
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Link: Set content, select and link the selection, assert link is present. Then select and unlink the selection, assert link is not present', [
-        TestLinkUi.sClearHistory,
-        api.sSetContent(
-          '<figure class="image">' +
-            '<img src="http://moxiecode.cachefly.net/tinymce/v9/images/logo.png" />' +
-            '<figcaption>TinyMCE</figcaption>' +
-          '</figure>'
-        ),
-        api.sSetSelection([ 0 ], 0, [ 0 ], 0),
-        sLinkTheSelection(),
-        sAssertPresence({ 'figure.image > a[href="http://google.com"] > img': 1 }),
-
-        api.sSetSelection([ 0 ], 0, [ 0 ], 0),
-        sUnlinkSelection(),
-        sAssertPresence({ 'figure.image > img': 1 }),
-        TestLinkUi.sClearHistory
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.ImageFigureLinkTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  before(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  after(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  it('TBA: Set content, select and link the selection, assert link is present. Then select and unlink the selection, assert link is not present', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<figure class="image">' +
+        '<img src="http://moxiecode.cachefly.net/tinymce/v9/images/logo.png" />' +
+        '<figcaption>TinyMCE</figcaption>' +
+      '</figure>'
+    );
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 0);
+    await TestLinkUi.pInsertLink(editor, 'http://google.com');
+    await TestLinkUi.pAssertContentPresence(editor, { 'figure.image > a[href="http://google.com"] > img': 1 });
+
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 0);
+    LinkPluginUtils.unlink(editor);
+    await TestLinkUi.pAssertContentPresence(editor, { 'figure.image > img': 1 });
+  });
+
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
@@ -22,7 +22,7 @@ describe('browser.tinymce.plugins.link.ImageFigureLinkTest', () => {
     TestLinkUi.clearHistory();
   });
 
-  it('TBA: Set content, select and link the selection, assert link is present. Then select and unlink the selection, assert link is not present', async () => {
+  it('TBA: Select and link the selection, assert link is present', async () => {
     const editor = hook.editor();
     editor.setContent(
       '<figure class="image">' +
@@ -33,10 +33,18 @@ describe('browser.tinymce.plugins.link.ImageFigureLinkTest', () => {
     TinySelections.setCursor(editor, [ 0 ], 0);
     await TestLinkUi.pInsertLink(editor, 'http://google.com');
     await TestLinkUi.pAssertContentPresence(editor, { 'figure.image > a[href="http://google.com"] > img': 1 });
+  });
 
+  it('TBA: Select and unlink the selection, assert link is not present', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<figure class="image">' +
+        '<a href="http://google.com"><img src="http://moxiecode.cachefly.net/tinymce/v9/images/logo.png" /></a>' +
+        '<figcaption>TinyMCE</figcaption>' +
+      '</figure>'
+    );
     TinySelections.setCursor(editor, [ 0 ], 0);
     LinkPluginUtils.unlink(editor);
     await TestLinkUi.pAssertContentPresence(editor, { 'figure.image > img': 1 });
   });
-
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
@@ -30,11 +30,11 @@ describe('browser.tinymce.plugins.link.ImageFigureLinkTest', () => {
         '<figcaption>TinyMCE</figcaption>' +
       '</figure>'
     );
-    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 0);
+    TinySelections.setCursor(editor, [ 0 ], 0);
     await TestLinkUi.pInsertLink(editor, 'http://google.com');
     await TestLinkUi.pAssertContentPresence(editor, { 'figure.image > a[href="http://google.com"] > img': 1 });
 
-    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 0);
+    TinySelections.setCursor(editor, [ 0 ], 0);
     LinkPluginUtils.unlink(editor);
     await TestLinkUi.pAssertContentPresence(editor, { 'figure.image > img': 1 });
   });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -95,7 +95,7 @@ describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
   it('TBA: Checking that QuickLink can remove an existing link', async () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tiny.cloud/4">Word</a></p>');
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 'Wor'.length, [ 0, 0, 0 ], 'Wor'.length);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 'Wor'.length);
     // TODO FIXME TINY-2691
     // Note the following assert fails on IE
     // TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 'Wor'.length, [ 0, 0, 0 ], 'Wor'.length);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -29,7 +29,7 @@ describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
   const pOpenQuickLink = async (editor: Editor) => {
     editor.execCommand('mceLink');
     // tests were erroneously allowed to pass when the quick link dialog would
-    // open and very quickly close because this was happing at superhuman
+    // open and very quickly close because this was happening at superhuman
     // speeds. So I'm slowing it down.
     await Waiter.pWait(100);
     await FocusTools.pTryOnSelector('Selector should be in context form input', doc, '.tox-toolbar input');
@@ -96,9 +96,6 @@ describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tiny.cloud/4">Word</a></p>');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 'Wor'.length);
-    // TODO FIXME TINY-2691
-    // Note the following assert fails on IE
-    // TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 'Wor'.length, [ 0, 0, 0 ], 'Wor'.length);
     await pOpenQuickLink(editor);
     TinyUiActions.keydown(editor, Keys.tab());
     TinyUiActions.keydown(editor, Keys.right());

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -1,158 +1,162 @@
-import { FocusTools, GeneralSteps, Keyboard, Keys, Log, Pipeline, Step, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyDom, TinyLoader } from '@ephox/mcagar';
-import { SugarBody } from '@ephox/sugar';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
+import { describe, it, before, after } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { SugarBody, SugarDocument } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.QuickLinkTest', (success, failure) => {
-  SilverTheme();
-  LinkPlugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const doc = TinyDom.fromDom(document);
-
-    const sOpenQuickLink = GeneralSteps.sequence([
-      Step.sync(() => {
-        editor.execCommand('mceLink');
-      }),
-      // tests were erronously allowed to pass when the quick link dialog would
-      // open and very quickly close because this was happing at superhuman
-      // speeds. So I'm slowing it down.
-      Step.wait(100),
-      FocusTools.sTryOnSelector('Selector should be in contextform input', doc, '.tox-toolbar input')
-    ]);
-
-    Pipeline.async({}, [
-      tinyApis.sFocus(),
-      TestLinkUi.sClearHistory,
-
-      Log.stepsAsStep('TBA', 'Checking that QuickLink can insert a link', [
-        sOpenQuickLink,
-        FocusTools.sSetActiveValue(doc, 'http://tiny.cloud'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        tinyApis.sAssertContentPresence({
-          'a[href="http://tiny.cloud"]': 1,
-          'a:contains("http://tiny.cloud")': 1
-        }),
-        UiFinder.sNotExists(SugarBody.body(), '.tox-pop__dialog')
-      ]),
-
-      Log.stepsAsStep('TBA', 'Checking that QuickLink can add a link to selected text and keep the current text', [
-        tinyApis.sSetContent('<p>Word</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], ''.length, [ 0, 0 ], 'Word'.length),
-        sOpenQuickLink,
-        FocusTools.sSetActiveValue(doc, 'http://tiny.cloud/2'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        tinyApis.sAssertContentPresence({
-          'a[href="http://tiny.cloud/2"]': 1,
-          'a:contains("http://tiny.cloud/2")': 0,
-          'a:contains("Word")': 1
-        }),
-        UiFinder.sNotExists(SugarBody.body(), '.tox-pop__dialog')
-      ]),
-
-      Log.stepsAsStep('TBA', 'Checking that QuickLink can add a link to a selected image and keep the current image', [
-        tinyApis.sSetContent('<p><img src="image.jpg"></p>'),
-        tinyApis.sSelect('img', []),
-        sOpenQuickLink,
-        FocusTools.sSetActiveValue(doc, 'http://tiny.cloud/2'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        tinyApis.sAssertContentPresence({
-          'a[href="http://tiny.cloud/2"]': 1,
-          'a:contains("http://tiny.cloud/2")': 0,
-          'img[src="image.jpg"]': 1
-        }),
-        UiFinder.sNotExists(SugarBody.body(), '.tox-pop__dialog')
-      ]),
-
-      Log.stepsAsStep('TBA', 'Checking that QuickLink can edit an existing link', [
-        tinyApis.sSetContent('<p><a href="http://tiny.cloud/3">Word</a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 'W'.length, [ 0, 0, 0 ], 'Wo'.length),
-        sOpenQuickLink,
-        FocusTools.sSetActiveValue(doc, 'http://tiny.cloud/changed/3'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        tinyApis.sAssertContentPresence({
-          'a[href="http://tiny.cloud/changed/3"]': 1,
-          'a:contains("http://tiny.cloud/3")': 0,
-          'a:contains("Word")': 1
-        }),
-        UiFinder.sNotExists(SugarBody.body(), '.tox-pop__dialog')
-      ]),
-
-      Log.stepsAsStep('TBA', 'Checking that QuickLink can remove an existing link', [
-        tinyApis.sSetContent('<p><a href="http://tiny.cloud/4">Word</a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 'Wor'.length, [ 0, 0, 0 ], 'Wor'.length),
-        // TODO FIXME TINY-2691
-        // Note the following assert fails on IE
-        // tinyApis.sAssertSelection([ 0, 0, 0 ], 'Wor'.length, [ 0, 0, 0 ], 'Wor'.length),
-        sOpenQuickLink,
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        Keyboard.sKeydown(doc, Keys.right(), { }),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        tinyApis.sAssertContentPresence({
-          'a': 0,
-          'p:contains("Word")': 1
-        }),
-        UiFinder.sNotExists(SugarBody.body(), '.tox-pop__dialog')
-      ]),
-
-      Log.stepsAsStep('TINY-5952', 'Checking that QuickLink link-creations end up on the undo stack', [
-        tinyApis.sSetContent('<p>Word</p>'),
-        // add link to word
-        tinyApis.sSetSelection([ 0, 0 ], ''.length, [ 0, 0 ], 'Word'.length),
-        sOpenQuickLink,
-        FocusTools.sSetActiveValue(doc, 'http://tiny.cloud/5'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        // undo
-        tinyApis.sExecCommand('undo'),
-        tinyApis.sAssertContentPresence({
-          'a': 0,
-          'p:contains("Word")': 1
-        })
-      ]),
-
-      Log.stepsAsStep('TINY-5952', 'Checking that QuickLink link-edits end up on the undo stack', [
-        tinyApis.sSetContent('<p><a href="http://tiny.cloud/6">Word</a></p>'),
-        // change the existing link
-        tinyApis.sSetSelection([ 0, 0, 0 ], ''.length, [ 0, 0, 0 ], 'Word'.length),
-        sOpenQuickLink,
-        FocusTools.sSetActiveValue(doc, 'http://tiny.cloud/changed/6'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        // undo (to old link)
-        tinyApis.sExecCommand('undo'),
-        tinyApis.sAssertContentPresence({
-          'a:contains("http://tiny.cloud/changed/6")': 0,
-          'a[href="http://tiny.cloud/6"]': 1,
-          'a:contains("Word")': 1
-        })
-      ]),
-
-      Log.stepsAsStep('TINY-5952', 'Checking that QuickLink link-deletes end up on the undo stack', [
-        tinyApis.sSetContent('<p><a href="http://tiny.cloud/7">Word</a></p>'),
-        // remove the link
-        tinyApis.sSetSelection([ 0, 0, 0 ], ''.length, [ 0, 0, 0 ], 'Word'.length),
-        sOpenQuickLink,
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        Keyboard.sKeydown(doc, Keys.right(), { }),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        // undo once (bring back link)
-        tinyApis.sExecCommand('undo'),
-        tinyApis.sAssertContentPresence({
-          'a[href="http://tiny.cloud/7"]': 1,
-          'a:contains("Word")': 1
-        })
-      ]),
-
-      TestLinkUi.sClearHistory
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link',
     link_quicklink: true,
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ], true);
+
+  const doc = SugarDocument.getDocument();
+
+  before(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  after(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  const pOpenQuickLink = async (editor: Editor) => {
+    editor.execCommand('mceLink');
+    // tests were erroneously allowed to pass when the quick link dialog would
+    // open and very quickly close because this was happing at superhuman
+    // speeds. So I'm slowing it down.
+    await Waiter.pWait(100);
+    await FocusTools.pTryOnSelector('Selector should be in context form input', doc, '.tox-toolbar input');
+  };
+
+  it('TBA: Checking that QuickLink can insert a link', async () => {
+    const editor = hook.editor();
+    await pOpenQuickLink(editor);
+    FocusTools.setActiveValue(doc, 'http://tiny.cloud');
+    TinyUiActions.keydown(editor, Keys.enter());
+    TinyAssertions.assertContentPresence(editor, {
+      'a[href="http://tiny.cloud"]': 1,
+      'a:contains("http://tiny.cloud")': 1
+    });
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog');
+  });
+
+  it('TBA: Checking that QuickLink can add a link to selected text and keep the current text', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Word</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], ''.length, [ 0, 0 ], 'Word'.length);
+    await pOpenQuickLink(editor);
+    FocusTools.setActiveValue(doc, 'http://tiny.cloud/2');
+    TinyUiActions.keydown(editor, Keys.enter());
+    TinyAssertions.assertContentPresence(editor, {
+      'a[href="http://tiny.cloud/2"]': 1,
+      'a:contains("http://tiny.cloud/2")': 0,
+      'a:contains("Word")': 1
+    });
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog');
+  });
+
+  it('TBA: Checking that QuickLink can add a link to a selected image and keep the current image', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="image.jpg"></p>');
+    TinySelections.select(editor, 'img', []);
+    await pOpenQuickLink(editor);
+    FocusTools.setActiveValue(doc, 'http://tiny.cloud/2');
+    TinyUiActions.keydown(editor, Keys.enter());
+    TinyAssertions.assertContentPresence(editor, {
+      'a[href="http://tiny.cloud/2"]': 1,
+      'a:contains("http://tiny.cloud/2")': 0,
+      'img[src="image.jpg"]': 1
+    });
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog');
+  });
+
+  it('TBA: Checking that QuickLink can edit an existing link', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tiny.cloud/3">Word</a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 'W'.length, [ 0, 0, 0 ], 'Wo'.length);
+    await pOpenQuickLink(editor);
+    FocusTools.setActiveValue(doc, 'http://tiny.cloud/changed/3');
+    TinyUiActions.keydown(editor, Keys.enter());
+    TinyAssertions.assertContentPresence(editor, {
+      'a[href="http://tiny.cloud/changed/3"]': 1,
+      'a:contains("http://tiny.cloud/3")': 0,
+      'a:contains("Word")': 1
+    });
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog');
+  });
+
+  it('TBA: Checking that QuickLink can remove an existing link', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tiny.cloud/4">Word</a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 'Wor'.length, [ 0, 0, 0 ], 'Wor'.length);
+    // TODO FIXME TINY-2691
+    // Note the following assert fails on IE
+    // TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 'Wor'.length, [ 0, 0, 0 ], 'Wor'.length);
+    await pOpenQuickLink(editor);
+    TinyUiActions.keydown(editor, Keys.tab());
+    TinyUiActions.keydown(editor, Keys.right());
+    TinyUiActions.keydown(editor, Keys.enter());
+    TinyAssertions.assertContentPresence(editor, {
+      'a': 0,
+      'p:contains("Word")': 1
+    });
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog');
+  });
+
+  it('TINY-5952: Checking that QuickLink link-creations end up on the undo stack', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Word</p>');
+    // add link to word
+    TinySelections.setSelection(editor, [ 0, 0 ], ''.length, [ 0, 0 ], 'Word'.length);
+    await pOpenQuickLink(editor);
+    FocusTools.setActiveValue(doc, 'http://tiny.cloud/5');
+    TinyUiActions.keydown(editor, Keys.enter());
+    // undo
+    editor.execCommand('undo');
+    TinyAssertions.assertContentPresence(editor, {
+      'a': 0,
+      'p:contains("Word")': 1
+    });
+  });
+
+  it('TINY-5952: Checking that QuickLink link-edits end up on the undo stack', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tiny.cloud/6">Word</a></p>');
+    // change the existing link
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], ''.length, [ 0, 0, 0 ], 'Word'.length);
+    await pOpenQuickLink(editor);
+    FocusTools.setActiveValue(doc, 'http://tiny.cloud/changed/6');
+    TinyUiActions.keydown(editor, Keys.enter());
+    // undo (to old link)
+    editor.execCommand('undo');
+    TinyAssertions.assertContentPresence(editor, {
+      'a:contains("http://tiny.cloud/changed/6")': 0,
+      'a[href="http://tiny.cloud/6"]': 1,
+      'a:contains("Word")': 1
+    });
+  });
+
+  it('TINY-5952: Checking that QuickLink link-deletes end up on the undo stack', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tiny.cloud/7">Word</a></p>');
+    // remove the link
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], ''.length, [ 0, 0, 0 ], 'Word'.length);
+    await pOpenQuickLink(editor);
+    TinyUiActions.keydown(editor, Keys.tab());
+    TinyUiActions.keydown(editor, Keys.right());
+    TinyUiActions.keydown(editor, Keys.enter());
+    // undo once (bring back link)
+    editor.execCommand('undo');
+    TinyAssertions.assertContentPresence(editor, {
+      'a[href="http://tiny.cloud/7"]': 1,
+      'a:contains("Word")': 1
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -14,7 +14,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
   it('TBA: Removing a link with a collapsed selection', async () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tiny.cloud">tiny</a></p>');
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
     TinyUiActions.clickOnUi(editor, 'div[title="Remove link"]');
     TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -1,61 +1,49 @@
-import { Assertions, Chain, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyDom, TinyLoader, TinyUi } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.RemoveLinkTest', (success, failure) => {
-
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-    const doc = TinyDom.fromDom(document);
-    const body = SugarElement.fromDom(editor.getBody());
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Removing a link with a collapsed selection', [
-        tinyApis.sSetContent('<p><a href="http://tiny.cloud">tiny</a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2),
-        Chain.asStep(doc, [
-          tinyUi.cTriggerContextMenu('open context menu', 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]')
-        ]),
-        tinyUi.sClickOnUi('Click unlink', 'div[title="Remove link"]'),
-        Assertions.sAssertPresence('Assert entire link removed', { 'a[href="http://tiny.cloud"]': 0 }, body)
-      ]),
-      Log.stepsAsStep('TBA', 'Removing a link with some text selected', [
-        tinyApis.sSetContent('<p><a href="http://tiny.cloud">tiny</a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2),
-        Chain.asStep(doc, [
-          tinyUi.cTriggerContextMenu('open context menu', 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]')
-        ]),
-        tinyUi.sClickOnUi('Click unlink', 'div[title="Remove link"]'),
-        Assertions.sAssertPresence('Assert entire link removed', { 'a[href="http://tiny.cloud"]': 0 }, body)
-      ]),
-      Log.stepsAsStep('TBA', 'Removing a link from an image', [
-        tinyApis.sSetContent('<p><a href="http://tiny.cloud"><img src="http://moxiecode.cachefly.net/tinymce/v9/images/logo.png" /></a></p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 1),
-        Chain.asStep(doc, [
-          tinyUi.cTriggerContextMenu('open context menu', 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]')
-        ]),
-        tinyUi.sClickOnUi('Click unlink', 'div[title="Remove link"]'),
-        Assertions.sAssertPresence('Assert entire link removed', { 'a[href="http://tiny.cloud"]': 0 }, body)
-      ]),
-      Log.stepsAsStep('TINY-4867', 'Removing multiple links in the selection', [
-        tinyApis.sSetContent('<p><a href="http://tiny.cloud">tiny</a> content <a href="http://tiny.cloud">link</a> with <a href="http://tiny.cloud">other</a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 1, [ 0, 4, 0 ], 2),
-        tinyUi.sClickOnToolbar('Click unlink', 'button[title="Remove link"]'),
-        Assertions.sAssertPresence('Assert entire link removed', { a: 0 }, body),
-        tinyApis.sAssertSelection([ 0, 0 ], 1, [ 0, 4 ], 2)
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'unlink',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  it('TBA: Removing a link with a collapsed selection', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tiny.cloud">tiny</a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2);
+    await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
+    TinyUiActions.clickOnUi(editor, 'div[title="Remove link"]');
+    TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
+  });
+
+  it('TBA: Removing a link with some text selected', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tiny.cloud">tiny</a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
+    await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
+    TinyUiActions.clickOnUi(editor, 'div[title="Remove link"]');
+    TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
+  });
+
+  it('TBA: Removing a link from an image', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tiny.cloud"><img src="http://moxiecode.cachefly.net/tinymce/v9/images/logo.png" /></a></p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+    await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
+    TinyUiActions.clickOnUi(editor, 'div[title="Remove link"]');
+    TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
+  });
+
+  it('TINY-4867: Removing multiple links in the selection', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tiny.cloud">tiny</a> content <a href="http://tiny.cloud">link</a> with <a href="http://tiny.cloud">other</a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 4, 0 ], 2);
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Remove link"]');
+    TinyAssertions.assertContentPresence(editor, { a: 0 });
+    TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 4 ], 2);
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     TestLinkUi.clearHistory();
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tinymce.com">tiny</a></p>');
-    TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 1);
+    TinySelections.setCursor(editor, [ 0 ], 1);
     editor.execCommand('mcelink');
     await TinyUiActions.pWaitForDialog(editor);
     TestLinkUi.assertDialogContents({
@@ -37,7 +37,7 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"].tox-tbtn--enabled');
     // Check the link button is enabled (collapsed in link)
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"].tox-tbtn--enabled');
     // Check the link button is disabled (text)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
@@ -54,7 +54,7 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"]:not(.tox-tbtn--disabled)');
     // Check the open link button is enabled (collapsed in link)
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"]:not(.tox-tbtn--disabled)');
     // Check the open link button is disabled (text)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
@@ -71,7 +71,7 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
     await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"]:not(.tox-tbtn--disabled)');
     // Check the unlink button is enabled (collapsed in link)
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"]:not(.tox-tbtn--disabled)');
     // Check the unlink button is disabled (text)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
@@ -1,73 +1,83 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.SelectedLinkTest', (success, failure) => {
-
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Link: should not get anchor info if not selected node', [
-        TestLinkUi.sClearHistory,
-        tinyApis.sSetContent('<p><a href="http://tinymce.com">tiny</a></p>'),
-        tinyApis.sSetSelection([ 0 ], 1, [ 0 ], 1),
-        tinyApis.sExecCommand('mcelink'),
-        TestLinkUi.sAssertDialogContents({
-          href: '',
-          text: '',
-          title: '',
-          target: ''
-        }),
-        TestLinkUi.sClickCancel,
-        TestLinkUi.sClearHistory
-      ]),
-      Log.stepsAsStep('TINY-4867', 'Link: link should not be active when multiple links or plain text selected', [
-        tinyApis.sSetContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>'),
-        tinyApis.sSetSelection( [ 0 ], 0, [ 0 ], 1),
-        tinyUi.sWaitForUi('Check the link button is enabled (single link)', 'button[title="Insert/edit link"].tox-tbtn--enabled'),
-        tinyApis.sSetSelection( [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0),
-        tinyUi.sWaitForUi('Check the link button is enabled (collapsed in link)', 'button[title="Insert/edit link"].tox-tbtn--enabled'),
-        tinyApis.sSetSelection( [ 0 ], 0, [ 0 ], 3),
-        tinyUi.sWaitForUi('Check the link button is disabled (text)', 'button[title="Insert/edit link"]:not(.tox-tbtn--enabled)'),
-        tinyApis.sSetSelection( [ 0, 1 ], 0, [ 0, 1 ], 2),
-        tinyUi.sWaitForUi('Check the link button is disabled (multiple links)', 'button[title="Insert/edit link"]:not(.tox-tbtn--enabled)')
-      ]),
-      Log.stepsAsStep('TINY-4867', 'Link: openlink should be disabled when multiple links or plain text selected', [
-        tinyApis.sSetContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>'),
-        tinyApis.sSetSelection( [ 0 ], 0, [ 0 ], 1),
-        tinyUi.sWaitForUi('Check the open link button is enabled (single link)', 'button[title="Open link"]:not(.tox-tbtn--disabled)'),
-        tinyApis.sSetSelection( [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0),
-        tinyUi.sWaitForUi('Check the open link button is enabled (collapsed in link)', 'button[title="Open link"]:not(.tox-tbtn--disabled)'),
-        tinyApis.sSetSelection( [ 0 ], 0, [ 0 ], 3),
-        tinyUi.sWaitForUi('Check the open link button is disabled (text)', 'button[title="Open link"].tox-tbtn--disabled'),
-        tinyApis.sSetSelection( [ 0, 1 ], 0, [ 0, 1 ], 2),
-        tinyUi.sWaitForUi('Check the open link button is disabled (multiple links)', 'button[title="Open link"].tox-tbtn--disabled')
-      ]),
-      Log.stepsAsStep('TINY-4867', 'Link: unlink should be enabled when single link or multiple links selected', [
-        tinyApis.sSetContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>'),
-        tinyApis.sSetSelection( [ 0 ], 0, [ 0 ], 3),
-        tinyUi.sWaitForUi('Check the unlink button is enabled (single link)', 'button[title="Remove link"]:not(.tox-tbtn--disabled)'),
-        tinyApis.sSetSelection( [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0),
-        tinyUi.sWaitForUi('Check the unlink button is enabled (collapsed in link)', 'button[title="Remove link"]:not(.tox-tbtn--disabled)'),
-        tinyApis.sSetSelection( [ 0, 1 ], 0, [ 0, 1 ], 2),
-        tinyUi.sWaitForUi('Check the unlink button is disabled (text)', 'button[title="Remove link"].tox-tbtn--disabled'),
-        tinyApis.sSetSelection( [ 0 ], 0, [ 0 ], 1),
-        tinyUi.sWaitForUi('Check the unlink button is enabled (multiple links)', 'button[title="Remove link"]:not(.tox-tbtn--disabled)')
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link openlink unlink',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  it('TBA: should not get anchor info if not selected node', async () => {
+    TestLinkUi.clearHistory();
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tinymce.com">tiny</a></p>');
+    TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 1);
+    editor.execCommand('mcelink');
+    await TinyUiActions.pWaitForDialog(editor);
+    TestLinkUi.assertDialogContents({
+      href: '',
+      text: '',
+      title: '',
+      target: ''
+    });
+    await TestLinkUi.pClickCancel(editor);
+    TestLinkUi.clearHistory();
+  });
+
+  it('TINY-4867: link should not be active when multiple links or plain text selected', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
+    // Check the link button is enabled (single link)
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"].tox-tbtn--enabled');
+    // Check the link button is enabled (collapsed in link)
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"].tox-tbtn--enabled');
+    // Check the link button is disabled (text)
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
+    // Check the link button is disabled (multiple links)
+    TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
+  });
+
+  it('TINY-4867: openlink should be disabled when multiple links or plain text selected', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
+    // Check the open link button is enabled (single link)
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"]:not(.tox-tbtn--disabled)');
+    // Check the open link button is enabled (collapsed in link)
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"]:not(.tox-tbtn--disabled)');
+    // Check the open link button is disabled (text)
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"].tox-tbtn--disabled');
+    // Check the open link button is disabled (multiple links)
+    TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"].tox-tbtn--disabled');
+  });
+
+  it('TINY-4867: unlink should be enabled when single link or multiple links selected', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
+    // Check the unlink button is enabled (single link)
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"]:not(.tox-tbtn--disabled)');
+    // Check the unlink button is enabled (collapsed in link)
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"]:not(.tox-tbtn--disabled)');
+    // Check the unlink button is disabled (text)
+    TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"].tox-tbtn--disabled');
+    // Check the unlink button is enabled (multiple links)
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"]:not(.tox-tbtn--disabled)');
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -105,7 +105,7 @@ describe('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
   it('TINY-5205: collapsed selection in complex structure should preserve the text when changing URL', async () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>');
-    TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 2, [ 0, 0, 0, 0 ], 2);
+    TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 2);
     await pOpenDialog(editor);
     FocusTools.setActiveValue(doc, 'http://something');
     await TestLinkUi.pClickSave(editor);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -1,158 +1,148 @@
-import { FocusTools, GeneralSteps, Keyboard, Keys, Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyDom, TinyLoader } from '@ephox/mcagar';
-import { SugarBody } from '@ephox/sugar';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { FocusTools, Keys, UiFinder } from '@ephox/agar';
+import { describe, it, before, after } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { SugarBody, SugarDocument } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.SelectedTextTest', (success, failure) => {
-
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const doc = TinyDom.fromDom(document);
-
-    const sTextToDisplayShown = UiFinder.sExists(SugarBody.body(), '.tox-label:contains("Text to display")');
-    const sTextToDisplayHidden = UiFinder.sNotExists(SugarBody.body(), '.tox-label:contains("Text to display")');
-
-    const sOpenDialog = (textToDisplayVisible: boolean = true) => GeneralSteps.sequence([
-      tinyApis.sExecCommand('mcelink'),
-      UiFinder.sWaitForVisible('wait for link dialog', TinyDom.fromDom(document.body), '[role="dialog"]'),
-      textToDisplayVisible ? sTextToDisplayShown : sTextToDisplayHidden
-    ]);
-
-    Pipeline.async({}, [
-      TestLinkUi.sClearHistory,
-      Log.stepsAsStep('TINY-5205', 'Link: basic text selection with existing link should preserve the text when changing URL', [
-        tinyApis.sSetContent('<p><a href="http://oldlink/">word</a></p>'),
-        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
-        sOpenDialog(),
-        FocusTools.sSetActiveValue(doc, 'http://something'),
-        TestLinkUi.sClickSave,
-        Waiter.sTryUntil(
-          'Wait until link is inserted',
-          tinyApis.sAssertContentPresence({
-            'a[href="http://something"]': 1,
-            'p:contains(word)': 1,
-            'p': 1
-          })
-        )
-      ]),
-      Log.stepsAsStep('TBA', 'Link: complex selections across paragraphs should preserve the text', [
-        tinyApis.sSetContent('<p><strong>word</strong></p><p><strong>other</strong></p>'),
-        tinyApis.sSetSelection([ 0 ], 0, [ 1 ], 1),
-        sOpenDialog(false),
-        FocusTools.sSetActiveValue(doc, 'http://something'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        Waiter.sTryUntil(
-          'Wait until link is inserted',
-          tinyApis.sAssertContentPresence({
-            'a[href="http://something"]': 2,
-            'p:contains(word)': 1,
-            'p:contains(other)': 1,
-            'p': 2
-          })
-        )
-      ]),
-      Log.stepsAsStep('TINY-5205', 'Link: complex selections with existing link should preserve the text when changing URL', [
-        tinyApis.sSetContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>'),
-        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
-        sOpenDialog(),
-        FocusTools.sSetActiveValue(doc, 'http://something'),
-        TestLinkUi.sClickSave,
-        Waiter.sTryUntil(
-          'Wait until link is inserted',
-          tinyApis.sAssertContentPresence({
-            'a[href="http://something"]': 1,
-            'strong:contains(word)': 1,
-            'em:contains(other)': 1,
-            'p': 1
-          })
-        )
-      ]),
-      Log.stepsAsStep('TINY-5205', 'Link: complex selections with existing link should replace the text when changing text', [
-        tinyApis.sSetContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>'),
-        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 1),
-        sOpenDialog(),
-        FocusTools.sSetActiveValue(doc, 'http://something'),
-        Keyboard.sKeydown(doc, Keys.tab(), { }),
-        FocusTools.sSetActiveValue(doc, 'new text'),
-        TestLinkUi.sClickSave,
-        Waiter.sTryUntil(
-          'Wait until link is inserted',
-          tinyApis.sAssertContentPresence({
-            'a[href="http://something"]': 1,
-            'a:contains(new text)': 1,
-            'strong': 0,
-            'em': 0,
-            'p': 1
-          })
-        )
-      ]),
-      Log.stepsAsStep('TINY-5205', 'Link: collapsed selection in complex structure should preserve the text when changing URL', [
-        tinyApis.sSetContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0, 0 ], 2, [ 0, 0, 0, 0 ], 2),
-        sOpenDialog(),
-        FocusTools.sSetActiveValue(doc, 'http://something'),
-        TestLinkUi.sClickSave,
-        Waiter.sTryUntil(
-          'Wait until link is inserted',
-          tinyApis.sAssertContentPresence({
-            'a[href="http://something"]': 1,
-            'strong:contains(word)': 1,
-            'em:contains(other)': 1,
-            'p': 1
-          })
-        )
-      ]),
-      Log.stepsAsStep('TINY-5205', 'Link: Selection with link inside should replace link', [
-        tinyApis.sSetContent('<p>a <a href="http://www.google.com/">b</a> c</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 2 ], 2),
-        sOpenDialog(),
-        FocusTools.sSetActiveValue(doc, 'http://something'),
-        TestLinkUi.sClickSave,
-        Waiter.sTryUntil(
-          'Wait until link is updated',
-          tinyApis.sAssertContentPresence({
-            'a[href="http://something"]': 1,
-            'a': 1,
-            'p': 1
-          })
-        )
-      ]),
-      Log.stepsAsStep('TINY-5205', 'Link: Selection across partial link should split and replace link', [
-        tinyApis.sSetContent('<p><a href="http://www.google.com/">a b</a> c</p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 2, [ 0, 1 ], 2),
-        sOpenDialog(),
-        FocusTools.sSetActiveValue(doc, 'http://something'),
-        TestLinkUi.sClickSave,
-        Waiter.sTryUntil(
-          'Wait until link is updated',
-          tinyApis.sAssertContentPresence({
-            'a[href="http://www.google.com/"]': 1,
-            'a[href="http://something"]': 1,
-            'a': 2,
-            'p': 1
-          })
-        )
-      ]),
-      TestLinkUi.sClearHistory
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: '',
-    theme: 'silver',
-    base_url: '/project/tinymce/js/tinymce',
-    setup: (editor) => {
+    setup: (editor: Editor) => {
       // Simulate comments being enabled
       editor.on('GetContent', (e) => {
         if (e.selection) {
           e.content += '<!-- TinyComments -->';
         }
       });
-    }
-  }, success, failure);
+    },
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin, Theme ]);
+
+  const doc = SugarDocument.getDocument();
+
+  before(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  after(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  const pOpenDialog = async (editor: Editor, textToDisplayVisible: boolean = true) => {
+    editor.execCommand('mcelink');
+    await TinyUiActions.pWaitForDialog(editor);
+    const existence = textToDisplayVisible ? UiFinder.exists : UiFinder.notExists;
+    existence(SugarBody.body(), '.tox-label:contains("Text to display")');
+  };
+
+  it('TINY-5205: basic text selection with existing link should preserve the text when changing URL', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://oldlink/">word</a></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    await pOpenDialog(editor);
+    FocusTools.setActiveValue(doc, 'http://something');
+    await TestLinkUi.pClickSave(editor);
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href="http://something"]': 1,
+      'p:contains(word)': 1,
+      'p': 1
+    });
+  });
+
+  it('TBA: complex selections across paragraphs should preserve the text', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><strong>word</strong></p><p><strong>other</strong></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
+    await pOpenDialog(editor, false);
+    FocusTools.setActiveValue(doc, 'http://something');
+    TinyUiActions.keydown(editor, Keys.enter());
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href="http://something"]': 2,
+      'p:contains(word)': 1,
+      'p:contains(other)': 1,
+      'p': 2
+    });
+  });
+
+  it('TINY-5205: complex selections with existing link should preserve the text when changing URL', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    await pOpenDialog(editor);
+    FocusTools.setActiveValue(doc, 'http://something');
+    await TestLinkUi.pClickSave(editor);
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href="http://something"]': 1,
+      'strong:contains(word)': 1,
+      'em:contains(other)': 1,
+      'p': 1
+    });
+  });
+
+  it('TINY-5205: complex selections with existing link should replace the text when changing text', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    await pOpenDialog(editor);
+    FocusTools.setActiveValue(doc, 'http://something');
+    TinyUiActions.keydown(editor, Keys.tab());
+    FocusTools.setActiveValue(doc, 'new text');
+    await TestLinkUi.pClickSave(editor);
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href="http://something"]': 1,
+      'a:contains(new text)': 1,
+      'strong': 0,
+      'em': 0,
+      'p': 1
+    });
+  });
+
+  it('TINY-5205: collapsed selection in complex structure should preserve the text when changing URL', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://oldlink/"><strong>word</strong><em>other</em></a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 2, [ 0, 0, 0, 0 ], 2);
+    await pOpenDialog(editor);
+    FocusTools.setActiveValue(doc, 'http://something');
+    await TestLinkUi.pClickSave(editor);
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href="http://something"]': 1,
+      'strong:contains(word)': 1,
+      'em:contains(other)': 1,
+      'p': 1
+    });
+  });
+
+  it('TINY-5205: Selection with link inside should replace link', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>a <a href="http://www.google.com/">b</a> c</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 2 ], 2);
+    await pOpenDialog(editor);
+    FocusTools.setActiveValue(doc, 'http://something');
+    await TestLinkUi.pClickSave(editor);
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href="http://something"]': 1,
+      'a': 1,
+      'p': 1
+    });
+  });
+
+  it('TINY-5205: Selection across partial link should split and replace link', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://www.google.com/">a b</a> c</p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 1 ], 2);
+    await pOpenDialog(editor);
+    FocusTools.setActiveValue(doc, 'http://something');
+    await TestLinkUi.pClickSave(editor);
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href="http://www.google.com/"]': 1,
+      'a[href="http://something"]': 1,
+      'a': 2,
+      'p': 1
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
@@ -1,73 +1,68 @@
-import { FocusTools, Keyboard, Keys, Log, Pipeline, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyDom, TinyLoader } from '@ephox/mcagar';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import { FocusTools, Keys } from '@ephox/agar';
+import { describe, it, before, afterEach } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { SugarDocument } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-UnitTest.asynctest('browser.tinymce.plugins.link.UpdateLinkTest', (success, failure) => {
-
-  LinkPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const doc = TinyDom.fromDom(document);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Link: should not get anchor info if not selected node', [
-        TestLinkUi.sClearHistory,
-        tinyApis.sSetContent('<p><a href="http://tinymce.com" class="shouldbekept" title="shouldalsobekept">tiny</a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2),
-        tinyApis.sExecCommand('mcelink'),
-        TestLinkUi.sAssertDialogContents({
-          href: 'http://tinymce.com',
-          text: 'tiny',
-          title: 'shouldalsobekept',
-          target: ''
-        }),
-        FocusTools.sSetActiveValue(doc, 'http://something'),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        Waiter.sTryUntil(
-          'Wait until link is inserted',
-          tinyApis.sAssertContentPresence({
-            'a[href="http://something"]': 1,
-            'a[class="shouldbekept"]': 1,
-            'a[title="shouldalsobekept"]': 1
-          })
-        ),
-        TestLinkUi.sClearHistory
-      ]),
-      Log.stepsAsStep('TBA', 'Link: should remove attributes if unset in the dialog', [
-        TestLinkUi.sClearHistory,
-        tinyApis.sSetContent('<p><a href="http://tinymce.com" class="shouldbekept" title="shouldnotbekept">tiny</a></p>'),
-        tinyApis.sSetSelection([ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2),
-        tinyApis.sExecCommand('mcelink'),
-        TestLinkUi.sAssertDialogContents({
-          href: 'http://tinymce.com',
-          text: 'tiny',
-          title: 'shouldnotbekept',
-          target: ''
-        }),
-        FocusTools.sSetActiveValue(doc, 'http://something'),
-        TestLinkUi.sSetInputFieldValue('Title', ''),
-        Keyboard.sKeydown(doc, Keys.enter(), { }),
-        Waiter.sTryUntil(
-          'Wait until link is inserted',
-          tinyApis.sAssertContentPresence({
-            'a[href="http://something"]': 1,
-            'a[class="shouldbekept"]': 1,
-            'a[title="shouldnotbekept"]': 0
-          })
-        ),
-        TestLinkUi.sClearHistory
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.UpdateLinkTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: '',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  before(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  afterEach(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  it('TBA: should not get anchor info if not selected node', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tinymce.com" class="shouldbekept" title="shouldalsobekept">tiny</a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2);
+    editor.execCommand('mcelink');
+    await TinyUiActions.pWaitForDialog(editor);
+    TestLinkUi.assertDialogContents({
+      href: 'http://tinymce.com',
+      text: 'tiny',
+      title: 'shouldalsobekept',
+      target: ''
+    });
+    FocusTools.setActiveValue(SugarDocument.getDocument(), 'http://something');
+    TinyUiActions.keydown(editor, Keys.enter());
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href="http://something"]': 1,
+      'a[class="shouldbekept"]': 1,
+      'a[title="shouldalsobekept"]': 1
+    });
+  });
+
+  it('TBA: should remove attributes if unset in the dialog', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://tinymce.com" class="shouldbekept" title="shouldnotbekept">tiny</a></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2);
+    editor.execCommand('mcelink');
+    await TinyUiActions.pWaitForDialog(editor);
+    TestLinkUi.assertDialogContents({
+      href: 'http://tinymce.com',
+      text: 'tiny',
+      title: 'shouldnotbekept',
+      target: ''
+    });
+    FocusTools.setActiveValue(SugarDocument.getDocument(), 'http://something');
+    await TestLinkUi.pSetInputFieldValue(editor, 'Title', '');
+    TinyUiActions.keydown(editor, Keys.enter());
+    await TestLinkUi.pAssertContentPresence(editor, {
+      'a[href="http://something"]': 1,
+      'a[class="shouldbekept"]': 1,
+      'a[title="shouldnotbekept"]': 0
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.plugins.link.UpdateLinkTest', () => {
   it('TBA: should not get anchor info if not selected node', async () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tinymce.com" class="shouldbekept" title="shouldalsobekept">tiny</a></p>');
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
     editor.execCommand('mcelink');
     await TinyUiActions.pWaitForDialog(editor);
     TestLinkUi.assertDialogContents({
@@ -47,7 +47,7 @@ describe('browser.tinymce.plugins.link.UpdateLinkTest', () => {
   it('TBA: should remove attributes if unset in the dialog', async () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tinymce.com" class="shouldbekept" title="shouldnotbekept">tiny</a></p>');
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
     editor.execCommand('mcelink');
     await TinyUiActions.pWaitForDialog(editor);
     TestLinkUi.assertDialogContents({

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlInputTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlInputTest.ts
@@ -1,61 +1,29 @@
-import { Assertions, Chain, GeneralSteps, Logger, Mouse, Pipeline, UiControls, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
-import { Attribute, SugarElement } from '@ephox/sugar';
-
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
+import { FocusTools } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { SugarDocument } from '@ephox/sugar';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-const cFakeEvent = (name) => {
-  return Chain.label('Fake event',
-    Chain.op((elm: SugarElement) => {
-      const evt = document.createEvent('HTMLEvents');
-      evt.initEvent(name, true, true);
-      elm.dom.dispatchEvent(evt);
-    })
-  );
-};
+import { TestLinkUi } from '../module/TestLinkUi';
 
-const cCloseDialog = Chain.fromChains([
-  UiFinder.cFindIn('button:contains("Cancel")'),
-  Mouse.cClick
-]);
-
-const cFindByLabelFor = (labelText: string) => Chain.binder((outer: SugarElement) => UiFinder.findIn(outer, 'label:contains("' + labelText + '")').bind((labelEle) => UiFinder.findIn(outer, '#' + Attribute.get(labelEle, 'for'))));
-
-UnitTest.asynctest('browser.tinymce.plugins.link.UrlInputTest', (success, failure) => {
-  Theme();
-  LinkPlugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-
-    Pipeline.async({}, [
-      Logger.t('insert url by typing', GeneralSteps.sequence([
-        tinyUi.sClickOnToolbar('click on link button', 'button[aria-label="Insert/edit link"]'),
-        Chain.asStep({}, [
-          Chain.fromParent(tinyUi.cWaitForPopup('Wait for dialog', 'div[role="dialog"]'),
-            [
-              Chain.fromChains([
-                cFindByLabelFor('URL'),
-                UiControls.cSetValue('http://www.test.com/'),
-                cFakeEvent('input')
-              ]),
-              Chain.fromChains([
-                cFindByLabelFor('Text to display'),
-                UiControls.cGetValue,
-                Assertions.cAssertEq('should be the same url', 'http://www.test.com/')
-              ]),
-              cCloseDialog
-            ]
-          )
-        ])
-
-      ]))
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.link.UrlInputTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  it('TBA: insert url by typing', async () => {
+    const editor = hook.editor();
+    await TestLinkUi.pOpenLinkDialog(editor);
+    const focused = FocusTools.setActiveValue(SugarDocument.getDocument(), 'http://www.test.com/');
+    TestLinkUi.fireEvent(focused, 'input');
+    TestLinkUi.assertDialogContents({
+      href: 'http://www.test.com/',
+      text: 'http://www.test.com/'
+    });
+    TinyUiActions.closeDialog(editor);
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
@@ -113,7 +113,7 @@ const pSetListBoxItem = async (editor: Editor, group: string, itemText: string) 
   Mouse.click(element);
   const list = await UiFinder.pWaitForVisible('Wait for list to open', SugarBody.body(), '.tox-menu.tox-collection--list');
   const item = UiFinder.findIn(list, '.tox-collection__item-label:contains(' + itemText + ')').getOrDie();
-  const parent = Traverse.parent(item).getOrDie();
+  const parent = Traverse.parent(item).getOrDie('Failed to find parent');
   Mouse.click(parent);
 };
 


### PR DESCRIPTION
Related Ticket:
TINY-7053

Description of Changes:
* Converts the `link` plugin to use BDD style tests

Pre-checks:
* [X] ~~Changelog entry added~~
* [X] ~~Tests have been added (if applicable)~~
* [X] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [X] ~~License headers added on new files (if applicable)~~

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
