### PR TITLE
TINY-7074: Fixed a regression with widths/heights not being included on the media wrapper span

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -2,7 +2,7 @@ Version 5.7.1 (TBD)
     Fixed an issue where URLs were not correctly filtered in some cases #TINY-7025
     Fixed a bug where context menu items with names that contained uppercase characters were not displayed #TINY-7072
     Fixed context menu items lacking support for the `disabled` and `shortcut` properties #TINY-7073
-    Fixed a regression whereby the width and height weren't set correctly when embedded content using the `media` dialog #TINY-7074
+    Fixed a regression whereby the width and height weren't set correctly when embedding content using the `media` dialog #TINY-7074
 Version 5.7.0 (2021-02-10)
     Added IPv6 address support to the URI API. Patch contributed by dev7355608 #GH-4409
     Added new `structure` and `style` properties to the `TableModified` event to indicate what kinds of modifications were made #TINY-6643

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,7 +1,8 @@
 Version 5.7.1 (TBD)
-    Fixed a bug where context menu items with names that contained uppercase characters were not displayed #TINY-7072
     Fixed an issue where URLs were not correctly filtered in some cases #TINY-7025
+    Fixed a bug where context menu items with names that contained uppercase characters were not displayed #TINY-7072
     Fixed context menu items lacking support for the `disabled` and `shortcut` properties #TINY-7073
+    Fixed a regression whereby the width and height weren't set correctly when embedded content using the `media` dialog #TINY-7074
 Version 5.7.0 (2021-02-10)
     Added IPv6 address support to the URI API. Patch contributed by dev7355608 #GH-4409
     Added new `structure` and `style` properties to the `TableModified` event to indicate what kinds of modifications were made #TINY-6643

--- a/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
@@ -56,7 +56,7 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
     const dimension = Css.getRaw(element, name).orThunk(() => Attribute.getOpt(element, name))
       .map((v) => parseInt(v, 10))
       .getOr(0);
-    assert.isBelow(Math.abs(dimension - expectedDimension), 3, label + ` ${dimension}px ~= ${expectedDimension}px`);
+    assert.approximately(dimension, expectedDimension, 3, `${label} ${dimension}px ~= ${expectedDimension}px`);
   };
 
   const getAndAssertDimensions = (element: SugarElement<Element>, width: number, height: number) => {
@@ -178,5 +178,14 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
       'span[data-mce-selected=2] video': 1,
       'span[data-mce-selected] audio': 0
     });
+  });
+
+  it('TINY-7074: Resizing a media element should update both the root and wrapper element dimensions', async () => {
+    const editor = hook.editor();
+    editor.setContent(`<p><span contenteditable="false" class="mce-preview-object mce-object-iframe"><iframe style="border: 1px solid black; width: 400px; height: 200px" src="${Env.transparentSrc}"></iframe></span></p>`);
+    TinySelections.select(editor, 'span', [ ]);
+    await pResizeAndAssertDimensions(editor, 'iframe', '#mceResizeHandlese', 100, 50, 402, 202);
+    const wrapper = UiFinder.findIn(TinyDom.body(editor), 'span.mce-preview-object').getOrDie();
+    getAndAssertDimensions(wrapper, 402 + 100, 202 + 50);
   });
 });

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -76,20 +76,17 @@ const createPlaceholderNode = (editor: Editor, node: AstNode) => {
 const createPreviewNode = (editor: Editor, node: AstNode) => {
   const name = node.name;
 
-  const styles = editor.dom.parseStyle(node.attr('style'));
-  // Exclude width/height as they should be on the preview element, not on the wrapper
-  const filteredStyles = Obj.filter(styles, ((value, key) => key !== 'width' && key !== 'height'));
-
   const previewWrapper = new AstNode('span', 1);
   previewWrapper.attr({
     'contentEditable': 'false',
-    'style': editor.dom.serializeStyle(filteredStyles),
+    'style': node.attr('style'),
     'data-mce-object': name,
     'class': 'mce-preview-object mce-object-' + name
   });
 
   retainAttributesAndInnerHtml(editor, node, previewWrapper);
 
+  const styles = editor.dom.parseStyle(node.attr('style'));
   const previewNode = new AstNode(name, 1);
   setDimensions(node, previewNode, styles);
   previewNode.attr({

--- a/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
@@ -20,7 +20,9 @@ describe('browser.tinymce.plugins.media.core.LiveEmbedNodeTest', () => {
       classes: [ arr.has('mce-object-' + tag) ],
       styles: {
         height: str.none('should not have height style'),
-        width: str.none('should not have width style')
+        width: str.none('should not have width style'),
+        // TINY-7074: The wrapper span should have the same width/height styles
+        ...Obj.map(styles, (value) => str.is(value))
       },
       children: [
         s.element(tag, {
@@ -89,5 +91,11 @@ describe('browser.tinymce.plugins.media.core.LiveEmbedNodeTest', () => {
     const editor = hook.editor();
     editor.setContent('<audio controls="controls" src="about:blank"></audio>');
     assertStructure(editor, 'audio', [ ], { controls: 'controls', src: 'about:blank' }, { });
+  });
+
+  it('TINY-7074: iframe element with responsive styles', () => {
+    const editor = hook.editor();
+    editor.setContent('<div style="width: 100%; height: 0; padding-top: 50%;"><iframe style="width: 100%; height: 100%;"></iframe></div>');
+    assertStructure(editor, 'iframe', [ ], { }, { width: '100%', height: '100%' });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-7074

Description of Changes:
* Fixes the width/height not being copied to the "wrapper" span used in the media plugin.
* Ensure when resizing the width/height are set on both the wrapper span and original media element.

Note: This will convert `%` to `px` when resizing but that's outside the scope of this, as TinyMCE's resizing logic has never supported that outside tables.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
