### PR TITLE
TINY-7098: fixed issue with setup function not always being available

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -251,12 +251,11 @@ const makeNoopAdaptor = (): RtcAdaptor => {
 
 export const isRtc = (editor: Editor) => Obj.has(editor.plugins, 'rtc');
 
-const getRtcSetup = (editor: Editor): Optional<() => Promise<RtcRuntimeApi>> => {
-  return (Obj.get(editor.plugins, 'rtc') as Optional<RtcPluginApi>).bind((rtcPlugin) => {
+const getRtcSetup = (editor: Editor): Optional<() => Promise<RtcRuntimeApi>> =>
+  (Obj.get(editor.plugins, 'rtc') as Optional<RtcPluginApi>).bind((rtcPlugin) =>
     // This might not exist if the stub plugin is loaded on cloud
-    return Optional.from(rtcPlugin.setup);
-  });
-};
+    Optional.from(rtcPlugin.setup)
+  );
 
 export const setup = (editor: Editor): Optional<Promise<boolean>> => {
   const editorCast = editor as RtcEditor;


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* When rtc is not enabled for a specific api key a sub plugin gets loaded instead of the real plugin. That plugin doesn't have any setup function so the Rtc integration would try to call a setup function on a plugin that doesn't have that function exported. This fix just check if the setup function exists if it doesn't it falls back to the normal editor setup but since the stub plugin will present a notification of that rtc is not enabled the user would be presented with a nice error message.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
