### PR TITLE
TINY-7099: Ensure that error message is displayed in image upload dialog

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.7.1 (TBD)
+    Fixed a bug where error messages were displayed incorrectly in the image dialog #TINY-7099
     Fixed a bug where context menu items with names that contained uppercase characters were not displayed #TINY-7072
     Fixed an issue where URLs were not correctly filtered in some cases #TINY-7025
     Fixed context menu items lacking support for the `disabled` and `shortcut` properties #TINY-7073

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
@@ -421,7 +421,7 @@ const uploadImage = (editor: Editor) => (blobInfo: BlobInfo) => ImageUploader(ed
   if (results.length === 0) {
     return Promise.reject('Failed to upload image');
   } else if (results[0].status === false) {
-    return Promise.reject(results[0].error);
+    return Promise.reject(results[0].error.message);
   } else {
     return results[0];
   }

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -148,9 +148,11 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
     TinyUiActions.clickOnUi(editor, '.tox-tab:contains("Upload")');
     await pTriggerUpload(editor);
     await TinyUiActions.pWaitForUi(editor, '.tox-alert-dialog');
+    // TINY-7099: Ensure that the correct error message is displayed
+    UiFinder.exists(SugarBody.body(), '.tox-alert-dialog .tox-dialog__body-content:contains("Error occurred")');
     TinyUiActions.clickOnUi(editor, '.tox-alert-dialog .tox-button:contains("OK")');
-    UiFinder.sNotExists(SugarBody.body(), '.tox-alert-dialog');
-    UiFinder.sExists(SugarBody.body(), '.tox-dialog__body-nav-item--active:contains("Upload")');
+    UiFinder.notExists(SugarBody.body(), '.tox-alert-dialog');
+    UiFinder.exists(SugarBody.body(), '.tox-dialog__body-nav-item--active:contains("Upload")');
     closeDialog(editor);
   });
 


### PR DESCRIPTION
Related Ticket: TINY-7099

Description of Changes:
* Fix a regression where the error message stopped being displayed correctly in the image upload dialog (was just `[object Object]`)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* ~[ ] Branch prefixed with `feature/` for new features (if applicable)~
* ~[ ] License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #6579 