### PR TITLE
Downgrade chai due to a regression introduced in 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tinymce/eslint-plugin": "^1.7.2",
     "@types/chai": "^4.2.15",
     "awesome-typescript-loader": "^5.2.0",
-    "chai": "^4.3.1",
+    "chai": "^4.2.0",
     "chalk": "^4.1.0",
     "emojilib": "^2.4.0",
     "eslint-plugin-mocha": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2913,16 +2913,16 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.1.tgz#6fc6af447610709818e5c45116207d60b8a49cfd"
-  integrity sha512-JClPZFGRcSl7X8dYzlCJY7v+X1fBA+9Y339Y8EqhBVfp0QC1hTnaf7nMfR+XZ74clkBC64b0iEw2cWKHt3EVqA==
+chai@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
   dependencies:
     assertion-error "^1.1.0"
     check-error "^1.0.2"
     deep-eql "^3.0.1"
     get-func-name "^2.0.0"
-    pathval "^1.1.1"
+    pathval "^1.1.0"
     type-detect "^4.0.5"
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
@@ -8955,7 +8955,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pathval@^1.1.1:
+pathval@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
I found the IE 11 tests were passing far too quickly and it turns out it was because chai 4.3.0 used an arrow function which causes tests to be skipped due to the `SyntaxError` thrown. As such this downgrades chai to 4.2.0 and I've also logged a PR to fix chai.

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
