### PR TITLE
TINY-7039: Fix failure messages for agar selenium actions

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/server/SeleniumAction.ts
+++ b/modules/agar/src/main/ts/ephox/agar/server/SeleniumAction.ts
@@ -12,7 +12,7 @@ const postInfo = (path: string, info: any, die: (err: any) => void, next: (v: {}
     },
     responseType: DataType.JSON
   }).get((res) => {
-    res.fold(die, next);
+    res.fold((e) => die(JSON.stringify(e)), next);
   });
 };
 


### PR DESCRIPTION
Related Ticket: TINY-7039

Description of Changes:
* IE 11 tests are failing with the following error sometimes in CI. Due to this bug we're not able to find out why it's failing, so this just makes sure the failure is readable.

```
Test failed: webdriver.tinymce.core.content.PlaceholderTest - TINY-3917: Check placeholder hides when typing content and returns once content is deleted (modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts)
[object Object]
```

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
