### PR TITLE
Fixed a test flake in the inline editor test

### DIFF
--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { ApproxStructure, Assertions, Keys, UiFinder } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Cell, Fun } from '@ephox/katamari';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Css, SugarBody } from '@ephox/sugar';
@@ -132,10 +132,13 @@ describe('browser.tinymce.themes.silver.editor.SilverInlineEditorTest', () => {
     }
   }, [ Theme ]);
 
+  beforeEach(() => {
+    hook.editor().focus();
+  });
+
   it('Check basic container structure and actions', () => {
     const editor = hook.editor();
     const container = TinyDom.container(editor);
-    editor.focus();
     Assertions.assertStructure(
       'Container structure',
       ApproxStructure.build((s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
       });
     },
     contextmenu: 'test'
-  }, [ Theme ]);
+  }, [ Theme ], true);
 
   const pWaitForThrobber = () =>
     UiFinder.pWaitForVisible('waiting for throbber to open', SugarBody.body(), '.tox-throbber');


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Fixed the `SilverInlineEditorTest` flaking due to not having focus if the first test isn't run.
* Backported the flake fix from https://github.com/tinymce/tinymce/pull/6578

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
