### PR TITLE
TINY-7138: Add type guards to array find methods in Katamari

### DIFF
--- a/modules/katamari/CHANGELOG.md
+++ b/modules/katamari/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Added type guard predicates to `Arr.find` methods #TINY-7138
+
+## 7.1.0 - 2020-02-02
+
+### Added
+- New `Regex` module
+
 ## 7.0.0
 
 ### Removed

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -4,6 +4,7 @@ import { Optional } from './Optional';
 import * as Type from './Type';
 
 type ArrayMorphism<T, U> = (x: T, i: number) => U;
+type ArrayGuardPredicate<T, U extends T> = (x: T, i: number) => x is U;
 type ArrayPredicate<T> = ArrayMorphism<T, boolean>;
 type Comparator<T> = (a: T, b: T) => number;
 
@@ -100,7 +101,7 @@ export const partition = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): {
 };
 
 export const filter: {
-  <T, Q extends T>(xs: ArrayLike<T>, pred: (x: T, i: number) => x is Q): Q[];
+  <T, U extends T>(xs: ArrayLike<T>, pred: ArrayGuardPredicate<T, U>): U[];
   <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): T[];
 } = <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): T[] => {
   const r: T[] = [];
@@ -163,7 +164,10 @@ export const foldl = <T = any, U = any>(xs: ArrayLike<T>, f: (acc: U, x: T) => U
   return acc;
 };
 
-export const findUntil = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>, until: ArrayPredicate<T>): Optional<T> => {
+export const findUntil: {
+  <T, U extends T>(xs: ArrayLike<T>, pred: ArrayGuardPredicate<T, U>, until: ArrayPredicate<T>): Optional<U>;
+  <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>, until: ArrayPredicate<T>): Optional<T>;
+} = <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>, until: ArrayPredicate<T>): Optional<T> => {
   for (let i = 0, len = xs.length; i < len; i++) {
     const x = xs[i];
     if (pred(x, i)) {
@@ -175,7 +179,12 @@ export const findUntil = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>, un
   return Optional.none();
 };
 
-export const find = <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<T> => findUntil(xs, pred, Fun.never);
+export const find: {
+  <T, U extends T>(xs: ArrayLike<T>, pred: ArrayGuardPredicate<T, U>): Optional<U>;
+  <T = any>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<T>;
+} = <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<T> => {
+  return findUntil(xs, pred, Fun.never);
+};
 
 export const findIndex = <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<number> => {
   for (let i = 0, len = xs.length; i < len; i++) {

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
@@ -28,6 +28,11 @@ UnitTest.test('Arr.find: Unit tests', () => {
     checkArrHelper(expected, Object.freeze(input), pred);
   };
 
+  const checkArrGuard = <T, U extends T>(expected: U, input: ArrayLike<T>, pred: (n: T, i: number) => n is U): void => {
+    const actual: Optional<U> = Arr.find(input, pred);
+    Assert.eq('some', Optional.some(expected), actual, tOptional());
+  };
+
   checkNone([], (x) => x > 0);
   checkNone([], (_x) => {
     throw new Error('should not be called');
@@ -39,6 +44,8 @@ UnitTest.test('Arr.find: Unit tests', () => {
   checkNone([ 4, 2, 10, 412, 3 ], (x) => x === 41);
 
   checkArr(10, [ 4, 2, 10, 412, 3 ], (x, i) => i === 2);
+
+  checkArrGuard('foo', [ 'foo', 'bar' ], (s): s is 'foo' => s === 'foo');
 });
 
 UnitTest.test('Arr.find: finds a value in the array', () => {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyUi.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyUi.ts
@@ -106,7 +106,7 @@ export const TinyUi = (editor: Editor): TinyUi => {
   };
 
   const getDialogByElement = (element: SugarElement) => {
-    return Arr.find(editor.windowManager.getWindows(), (win) => {
+    return Arr.find(editor.windowManager.getWindows(), (win: any) => {
       return element.dom.id === win._id;
     });
   };

--- a/modules/polaris/src/main/ts/ephox/polaris/parray/Query.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/parray/Query.ts
@@ -40,9 +40,7 @@ const sublist = <T extends PRange>(parray: T[], start: number, finish: number): 
   }).getOr([]);
 };
 
-const find: typeof Arr.find = (parray, pred) => {
-  return Arr.find(parray, pred);
-};
+const find = Arr.find;
 
 export {
   get,

--- a/versions.txt
+++ b/versions.txt
@@ -4,4 +4,5 @@
 acid@3.0.0
 agar@5.3.0
 alloy@8.2.0
+katamari@7.2.0
 mcagar@6.1.0


### PR DESCRIPTION
Related Ticket:

TINY-7138

Description of Changes:

Adds type guard predicates to `Arr.find` and `Arr.findUntil`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
