### PR TITLE
TINY-7031: Change changelog URL in help plugin

### DIFF
--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,5 +1,5 @@
 Version 5.7.1 (TBD)
-    Fixed the help dialog incorrectly linking to the changelog of TinyMCE 4 instead of TinyMCE 5 #TINY-7031
+    Fixed the `help` dialog incorrectly linking to the changelog of TinyMCE 4 instead of TinyMCE 5 #TINY-7031
     Fixed a bug where error messages were displayed incorrectly in the image dialog #TINY-7099
     Fixed an issue where URLs were not correctly filtered in some cases #TINY-7025
     Fixed a bug where context menu items with names that contained uppercase characters were not displayed #TINY-7072

--- a/modules/tinymce/changelog.txt
+++ b/modules/tinymce/changelog.txt
@@ -1,4 +1,5 @@
 Version 5.7.1 (TBD)
+    Fixed the help dialog incorrectly linking to the changelog of TinyMCE 4 instead of TinyMCE 5 #TINY-7031
     Fixed a bug where error messages were displayed incorrectly in the image dialog #TINY-7099
     Fixed an issue where URLs were not correctly filtered in some cases #TINY-7025
     Fixed a bug where context menu items with names that contained uppercase characters were not displayed #TINY-7072

--- a/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
@@ -12,7 +12,7 @@ import I18n from 'tinymce/core/api/util/I18n';
 const tab = (): Dialog.TabSpec => {
   const getVersion = (major: string, minor: string) => major.indexOf('@') === 0 ? 'X.X.X' : major + '.' + minor;
   const version = getVersion(EditorManager.majorVersion, EditorManager.minorVersion);
-  const changeLogLink = '<a href="https://www.tinymce.com/docs/changelog/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" target="_blank">TinyMCE ' + version + '</a>';
+  const changeLogLink = '<a href="https://www.tiny.cloud/docs/changelog/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" target="_blank">TinyMCE ' + version + '</a>';
 
   const htmlPanel: Dialog.HtmlPanelSpec = {
     type: 'htmlpanel',


### PR DESCRIPTION
Related Ticket: TINY-7031

Description of Changes:
* Change the URL from tinymce.com to tiny.cloud — tinymce.com does redirect to tiny.cloud, but it goes to the 4x docs instead of the modern ones.

Pre-checks:
* [x] Changelog entry added
* ~[ ] Tests have been added (if applicable)~
* ~[ ] Branch prefixed with `feature/` for new features (if applicable)~
* ~[ ] License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): N/A
