### PR TITLE
GH-6607: Add missing type for images_file_types setting

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891
-- Added missing type for `images_file_types` setting #GH-6607
 
 ### Fixed
 - The RGB fields in the color picker dialog were not staying in sync with the color palette and hue slider #TINY-6952
 - The color preview box in the color picker dialog was not correctly displaying the saturation and value of the chosen color #TINY-6952
 - The color picker dialog will now show an alert if it is submitted with an invalid hex color code #TINY-2814
 - Fixed a bug where the `TableModified` event was not fired when adding a table row via the Tab key #TINY-7006
+- Added missing type for `images_file_types` setting #GH-6607
 
 ## 5.7.1 - 2021-03-17
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891
+- Added missing type for `images_file_types` setting #GH-6607
 
 ### Fixed
 - The RGB fields in the color picker dialog were not staying in sync with the color palette and hue slider #TINY-6952

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -108,6 +108,7 @@ interface BaseEditorSettings {
   icons_url?: string;
   id?: string;
   images_dataimg_filter?: (imgElm: HTMLImageElement) => boolean;
+  images_file_types?: string;
   images_replace_blob_uris?: boolean;
   images_reuse_filename?: boolean;
   images_upload_base_path?: string;


### PR DESCRIPTION
Related Ticket: #6607 

Description of Changes:

Adds missing settings type for `images_file_types`.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] ~~Branch prefixed with `feature/` for new features (if applicable)~~
* [x] ~~License headers added on new files (if applicable)~~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): #6607 
