### PR TITLE
TINY-7201: always let rtc plugin load the content from target element

### DIFF
--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -309,7 +309,7 @@ const loadContentCss = (editor: Editor, css: string[]) => {
   Promise.all(makeStylesheetLoadingPromises(editor, css, fontCss)).then(loaded).catch(loaded);
 };
 
-const preInit = (editor: Editor, rtcMode: boolean) => {
+const preInit = (editor: Editor) => {
   const settings = editor.settings, doc = editor.getDoc(), body = editor.getBody();
 
   if (!settings.browser_spellcheck && !settings.gecko_spellcheck) {
@@ -340,8 +340,7 @@ const preInit = (editor: Editor, rtcMode: boolean) => {
     editor.addVisual(editor.getBody());
   });
 
-  // When connected to a server the value on the server should get priority
-  if (rtcMode === false) {
+  if (!Rtc.isRtc(editor)) {
     editor.load({ initial: true, format: 'html' });
   }
 
@@ -456,15 +455,15 @@ const initContentBody = (editor: Editor, skipWrite?: boolean) => {
   Events.firePreInit(editor);
 
   Rtc.setup(editor).fold(() => {
-    preInit(editor, false);
+    preInit(editor);
   }, (loadingRtc) => {
     editor.setProgressState(true);
-    loadingRtc.then((rtcMode) => {
+    loadingRtc.then((_rtcMode) => {
       editor.setProgressState(false);
-      preInit(editor, rtcMode);
+      preInit(editor);
     }, (err) => {
       editor.notificationManager.open({ type: 'error', text: String(err) });
-      preInit(editor, true);
+      preInit(editor);
     });
   });
 };


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This moved the initial content setup to the RTC plugin for both standalone mode and rtc mode. I'm keeping rtcMode as a return value for now maybe we need it for other things later.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
