### PR TITLE
TINY-6706: disabled SelectionOverrides and dom/selection mutating quirks

### DIFF
--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -26,6 +26,7 @@ import * as EditorView from './EditorView';
 import * as CefFocus from './focus/CefFocus';
 import * as EditorFocus from './focus/EditorFocus';
 import * as MediaFocus from './focus/MediaFocus';
+import * as Rtc from './Rtc';
 
 const isContentEditableTrue = NodeType.isContentEditableTrue;
 const isContentEditableFalse = NodeType.isContentEditableFalse;
@@ -470,7 +471,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
     fakeCaret.hide();
   };
 
-  if (Env.ceFalse) {
+  if (Env.ceFalse && !Rtc.isRtc(editor)) {
     registerEvents();
   }
 

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -13,6 +13,7 @@ import Delay from '../api/util/Delay';
 import Tools from '../api/util/Tools';
 import VK from '../api/util/VK';
 import * as CaretContainer from '../caret/CaretContainer';
+import * as Rtc from '../Rtc';
 import * as CaretRangeFromPoint from '../selection/CaretRangeFromPoint';
 
 /**
@@ -769,58 +770,79 @@ const Quirks = (editor: Editor): Quirks => {
     return (!sel || !sel.rangeCount || sel.rangeCount === 0);
   };
 
-  // All browsers
-  removeBlockQuoteOnBackSpace();
-  emptyEditorWhenDeleting();
-
-  // Windows phone will return a range like [body, 0] on mousedown so
-  // it will always normalize to the wrong location
-  if (!Env.windowsPhone) {
-    normalizeSelection();
-  }
-
-  // WebKit
-  if (isWebKit) {
-    inputMethodFocus();
-    selectControlElements();
-    setDefaultBlockType();
-    blockFormSubmitInsideEditor();
-    disableBackspaceIntoATable();
-    removeAppleInterchangeBrs();
-
-    // touchClickEvent();
-
-    // iOS
-    if (Env.iOS) {
-      restoreFocusOnKeyDown();
-      bodyHeight();
-      tapLinksAndImages();
-    } else {
+  if (Rtc.isRtc(editor)) {
+    if (isWebKit) {
+      selectControlElements();
+      blockFormSubmitInsideEditor();
       selectAll();
+
+      if (Env.iOS) {
+        restoreFocusOnKeyDown();
+        bodyHeight();
+        tapLinksAndImages();
+      }
     }
-  }
 
-  if (Env.ie >= 11) {
-    bodyHeight();
-    disableBackspaceIntoATable();
-  }
+    if (isGecko) {
+      focusBody();
+      setGeckoEditingOptions();
+      showBrokenImageIcon();
+      blockCmdArrowNavigation();
+    }
+  } else {
+    // All browsers
+    removeBlockQuoteOnBackSpace();
+    emptyEditorWhenDeleting();
 
-  if (Env.ie) {
-    selectAll();
-    disableAutoUrlDetect();
-    ieInternalDragAndDrop();
-  }
+    // Windows phone will return a range like [body, 0] on mousedown so
+    // it will always normalize to the wrong location
+    if (!Env.windowsPhone) {
+      normalizeSelection();
+    }
 
-  // Gecko
-  if (isGecko) {
-    removeHrOnBackspace();
-    focusBody();
-    removeStylesWhenDeletingAcrossBlockElements();
-    setGeckoEditingOptions();
-    addBrAfterLastLinks();
-    showBrokenImageIcon();
-    blockCmdArrowNavigation();
-    disableBackspaceIntoATable();
+    // WebKit
+    if (isWebKit) {
+      inputMethodFocus();
+      selectControlElements();
+      setDefaultBlockType();
+      blockFormSubmitInsideEditor();
+      disableBackspaceIntoATable();
+      removeAppleInterchangeBrs();
+
+      // touchClickEvent();
+
+      // iOS
+      if (Env.iOS) {
+        restoreFocusOnKeyDown();
+        bodyHeight();
+        tapLinksAndImages();
+      } else {
+        selectAll();
+      }
+    }
+
+    if (Env.ie >= 11) {
+      bodyHeight();
+      disableBackspaceIntoATable();
+    }
+
+    if (Env.ie) {
+      selectAll();
+      disableAutoUrlDetect();
+      ieInternalDragAndDrop();
+    }
+
+    // Gecko
+    if (isGecko) {
+      removeHrOnBackspace();
+      focusBody();
+      removeStylesWhenDeletingAcrossBlockElements();
+      setGeckoEditingOptions();
+      addBrAfterLastLinks();
+      showBrokenImageIcon();
+      blockCmdArrowNavigation();
+      disableBackspaceIntoATable();
+    }
   }
 
   return {

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -770,7 +770,7 @@ const Quirks = (editor: Editor): Quirks => {
     return (!sel || !sel.rangeCount || sel.rangeCount === 0);
   };
 
-  if (Rtc.isRtc(editor)) {
+  const setupRtc = () => {
     if (isWebKit) {
       selectControlElements();
       blockFormSubmitInsideEditor();
@@ -789,7 +789,9 @@ const Quirks = (editor: Editor): Quirks => {
       showBrokenImageIcon();
       blockCmdArrowNavigation();
     }
-  } else {
+  };
+
+  const setup = () => {
     // All browsers
     removeBlockQuoteOnBackSpace();
     emptyEditorWhenDeleting();
@@ -843,6 +845,12 @@ const Quirks = (editor: Editor): Quirks => {
       blockCmdArrowNavigation();
       disableBackspaceIntoATable();
     }
+  };
+
+  if (Rtc.isRtc(editor)) {
+    setupRtc();
+  } else {
+    setup();
   }
 
   return {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Disables SelectionOverrides for content editable false elements since those are now handled by the RTC model.
* Disables some of the mutating quirks when running with RTC.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
