### PR TITLE
TINY-4823: Add keyboard control to the editor resize handle

### DIFF
--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -10,6 +10,7 @@
 //
 
 @statusbar-background-color: @background-color;
+@statusbar-focus-background-color: multiply(white, contrast(@background-color, fade(@color-black, 15), fade(@color-black, 85)));
 @statusbar-font-size: @font-size-xs;
 @statusbar-font-weight: @font-weight-normal;
 @statusbar-height: 18px;
@@ -88,6 +89,14 @@
     svg {
       display: block;
       fill: @statusbar-text-color;
+    }
+
+    &:focus {
+      svg {
+        background-color: @statusbar-focus-background-color;
+        border-radius: 1px;
+        box-shadow: 0 0 0 2px @statusbar-focus-background-color;
+      }
     }
   }
 }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891
+- The editor resize handle can now be controlled using the keyboard #TINY-4823
 
 ### Fixed
 - The RGB fields in the color picker dialog were not staying in sync with the color palette and hue slider #TINY-6952

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -330,7 +330,7 @@ const setup = (editor: Editor): RenderInfo => {
         }),
         Keying.config({
           mode: 'cyclic',
-          selector: '.tox-menubar, .tox-toolbar, .tox-toolbar__primary, .tox-toolbar__overflow--open, .tox-sidebar__overflow--open, .tox-statusbar__path, .tox-statusbar__wordcount, .tox-statusbar__branding a'
+          selector: '.tox-menubar, .tox-toolbar, .tox-toolbar__primary, .tox-toolbar__overflow--open, .tox-sidebar__overflow--open, .tox-statusbar__path, .tox-statusbar__wordcount, .tox-statusbar__branding a, .tox-statusbar__resize-handle'
         })
       ])
     } as OuterContainerSketchSpec)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -1,0 +1,80 @@
+import { AlloyEvents, Behaviour, Dragging, Focusing, NativeEvents, SimpleSpec, SimulatedEvent, Tabstopping } from '@ephox/alloy';
+import { Optional } from '@ephox/katamari';
+import { EventArgs, SugarPosition } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+import VK from 'tinymce/core/api/util/VK';
+
+import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import { get as getIcon } from '../icons/Icons';
+import { resize, ResizeTypes } from '../sizing/Resize';
+
+const getResizeType = (editor: Editor): ResizeTypes => {
+  // If autoresize is enabled, disable resize
+  const fallback = !editor.hasPlugin('autoresize');
+  const resize = editor.getParam('resize', fallback);
+  if (resize === false) {
+    return ResizeTypes.None;
+  } else if (resize === 'both') {
+    return ResizeTypes.Both;
+  } else {
+    return ResizeTypes.Vertical;
+  }
+};
+
+const keyboardHandler = (editor: Editor, resizeType: ResizeTypes, event: SimulatedEvent<EventArgs<KeyboardEvent>>) => {
+  const scale = 3;
+  let left = 0, top = 0;
+  switch (event.event.raw.keyCode) {
+    case VK.LEFT:
+      left -= scale;
+      break;
+    case VK.RIGHT:
+      left += scale;
+      break;
+    case VK.UP:
+      top -= scale;
+      break;
+    case VK.DOWN:
+      top += scale;
+      break;
+    default:
+      return;
+  }
+
+  const delta = SugarPosition(left, top);
+  event.stop();
+  resize(editor, delta, resizeType);
+};
+
+export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactoryBackstageProviders): Optional<SimpleSpec> => {
+  const resizeType = getResizeType(editor);
+  if (resizeType === ResizeTypes.None) {
+    return Optional.none();
+  }
+
+  return Optional.some({
+    dom: {
+      tag: 'div',
+      classes: [ 'tox-statusbar__resize-handle' ],
+      attributes: {
+        'title': providersBackstage.translate('Resize'), // TODO: tooltips AP-213
+        'aria-hidden': 'true'
+      },
+      innerHtml: getIcon('resize-handle', providersBackstage.icons)
+    },
+    events: AlloyEvents.derive([
+      AlloyEvents.run<EventArgs<KeyboardEvent>>(NativeEvents.keydown(), (_comp, event) => keyboardHandler(editor, resizeType, event))
+    ]),
+    behaviours: Behaviour.derive([
+      Dragging.config({
+        mode: 'mouse',
+        repositionTarget: false,
+        onDrag: (_comp, _target, delta) => resize(editor, delta, resizeType),
+        blockerClass: 'tox-blocker'
+      }),
+      Tabstopping.config({}),
+      Focusing.config({})
+    ])
+  });
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyEvents, Behaviour, Dragging, Focusing, NativeEvents, SimpleSpec, SimulatedEvent, Tabstopping } from '@ephox/alloy';
+import { AlloyEvents, Behaviour, Dragging, Focusing, NativeEvents, NativeSimulatedEvent, SimpleSpec, Tabstopping } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { EventArgs, SugarPosition } from '@ephox/sugar';
 
@@ -29,7 +29,7 @@ const getResizeType = (editor: Editor): ResizeTypes => {
   }
 };
 
-const keyboardHandler = (editor: Editor, resizeType: ResizeTypes, event: SimulatedEvent<EventArgs<KeyboardEvent>>) => {
+const keyboardHandler = (editor: Editor, resizeType: ResizeTypes, event: NativeSimulatedEvent<KeyboardEvent>) => {
   const scale = 3;
   let left = 0, top = 0;
   switch (event.event.raw.keyCode) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -46,7 +46,7 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
       tag: 'div',
       classes: [ 'tox-statusbar__resize-handle' ],
       attributes: {
-        'title': providersBackstage.translate('Resize'), // TODO: tooltips AP-213
+        title: providersBackstage.translate('Resize'), // TODO: tooltips AP-213
       },
       innerHtml: getIcon('resize-handle', providersBackstage.icons)
     },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
 import { AlloyEvents, Behaviour, Dragging, Focusing, NativeEvents, SimpleSpec, SimulatedEvent, Tabstopping } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { EventArgs, SugarPosition } from '@ephox/sugar';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -29,7 +29,7 @@ const getResizeType = (editor: Editor): ResizeTypes => {
 };
 
 const keyboardHandler = (editor: Editor, resizeType: ResizeTypes, x: number, y: number): Optional<boolean> => {
-  const scale = 3;
+  const scale = 20;
   const delta = SugarPosition(x * scale, y * scale);
   resize(editor, delta, resizeType);
   return Optional.some(true);
@@ -47,7 +47,6 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
       classes: [ 'tox-statusbar__resize-handle' ],
       attributes: {
         'title': providersBackstage.translate('Resize'), // TODO: tooltips AP-213
-        'aria-hidden': 'true'
       },
       innerHtml: getIcon('resize-handle', providersBackstage.icons)
     },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
@@ -56,11 +56,9 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
 
   const getComponents = (): SimpleSpec[] => {
     const components: SimpleSpec[] = getTextComponents();
-
     const resizeHandler = ResizeHandler.renderResizeHandler(editor, providersBackstage);
-    resizeHandler.each((spec) => components.push(spec));
 
-    return components;
+    return components.concat(resizeHandler.toArray())
   };
 
   return {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
@@ -5,37 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Behaviour, Dragging, SimpleSpec } from '@ephox/alloy';
+import { SimpleSpec } from '@ephox/alloy';
 import Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import { get as getIcon } from '../icons/Icons';
-import { resize, ResizeTypes } from '../sizing/Resize';
 import * as ElementPath from './ElementPath';
+import * as ResizeHandler from './ResizeHandle';
 import { renderWordCount } from './WordCount';
 
 const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageProviders): SimpleSpec => {
-  const renderResizeHandlerIcon = (resizeType: ResizeTypes): SimpleSpec => ({
-    dom: {
-      tag: 'div',
-      classes: [ 'tox-statusbar__resize-handle' ],
-      attributes: {
-        'title': providersBackstage.translate('Resize'), // TODO: tooltips AP-213
-        'aria-hidden': 'true'
-      },
-      innerHtml: getIcon('resize-handle', providersBackstage.icons)
-    },
-    behaviours: Behaviour.derive([
-      Dragging.config({
-        mode: 'mouse',
-        repositionTarget: false,
-        onDrag: (comp, target, delta) => {
-          resize(editor, delta, resizeType);
-        },
-        blockerClass: 'tox-blocker'
-      })
-    ])
-  });
 
   const renderBranding = (): SimpleSpec => {
     const label = I18n.translate([ 'Powered by {0}', 'Tiny' ]);
@@ -47,19 +25,6 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
         innerHtml: linkHtml
       }
     };
-  };
-
-  const getResizeType = (editor: Editor): ResizeTypes => {
-    // If autoresize is enabled, disable resize
-    const fallback = !editor.hasPlugin('autoresize');
-    const resize = editor.getParam('resize', fallback);
-    if (resize === false) {
-      return ResizeTypes.None;
-    } else if (resize === 'both') {
-      return ResizeTypes.Both;
-    } else {
-      return ResizeTypes.Vertical;
-    }
   };
 
   const getTextComponents = (): SimpleSpec[] => {
@@ -92,10 +57,9 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
   const getComponents = (): SimpleSpec[] => {
     const components: SimpleSpec[] = getTextComponents();
 
-    const resizeType = getResizeType(editor);
-    if (resizeType !== ResizeTypes.None) {
-      components.push(renderResizeHandlerIcon(resizeType));
-    }
+    const resizeHandler = ResizeHandler.renderResizeHandler(editor, providersBackstage);
+    resizeHandler.each((spec) => components.push(spec));
+
     return components;
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
@@ -58,7 +58,7 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
     const components: SimpleSpec[] = getTextComponents();
     const resizeHandler = ResizeHandler.renderResizeHandler(editor, providersBackstage);
 
-    return components.concat(resizeHandler.toArray())
+    return components.concat(resizeHandler.toArray());
   };
 
   return {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
@@ -1,10 +1,11 @@
-import { Mouse, UiFinder } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { Keyboard, Mouse, UiFinder } from '@ephox/agar';
+import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks } from '@ephox/mcagar';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { Css, Focus, SugarBody, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import VK from 'tinymce/core/api/util/VK';
 import Theme from 'tinymce/themes/silver/Theme';
 
 import { resizeToPos } from '../../../module/UiUtils';
@@ -31,6 +32,16 @@ describe('browser.tinymce.themes.silver.editor.sizing.ResizeTTest', () => {
     // Add a border to ensure we're using the correct height/width (ie border-box sizing)
     editor.dom.setStyles(editor.getContainer(), {
       border: '2px solid #ccc'
+    });
+  });
+
+  // Make sure the height is reset
+  beforeEach(() => {
+    const editor = hook.editor();
+    const container = SugarElement.fromDom(editor.getContainer());
+    Css.setAll(container, {
+      width: '400px',
+      height: '400px'
     });
   });
 
@@ -68,5 +79,26 @@ describe('browser.tinymce.themes.silver.editor.sizing.ResizeTTest', () => {
     Mouse.mouseDown(resizeHandle);
     resizeToPos(300, 500, 550, 500);
     assertEditorSize(container, 500, 500);
+  });
+
+  it('TINY-4823: can be resized via the keyboard', () => {
+    const editor = hook.editor();
+    const container = TinyDom.container(editor);
+    const resizeHandle = UiFinder.findIn(SugarBody.body(), '.tox-statusbar__resize-handle').getOrDie();
+
+    Focus.focus(resizeHandle);
+
+    // Make it larger
+    for (let i = 0; i < 20; ++i) {
+      Keyboard.keystroke(VK.RIGHT, {}, resizeHandle);
+      Keyboard.keystroke(VK.DOWN, {}, resizeHandle);
+    }
+    assertEditorSize(container, 460, 460);
+
+    for (let i = 0; i < 20; ++i) {
+      Keyboard.keystroke(VK.LEFT, {}, resizeHandle);
+      Keyboard.keystroke(VK.UP, {}, resizeHandle);
+    }
+    assertEditorSize(container, 400, 400);
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
@@ -1,11 +1,10 @@
-import { FocusTools, Mouse, UiFinder } from '@ephox/agar';
+import { FocusTools, Keys, Mouse, UiFinder } from '@ephox/agar';
 import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Css, SugarBody, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import VK from 'tinymce/core/api/util/VK';
 import Theme from 'tinymce/themes/silver/Theme';
 
 import { resizeToPos } from '../../../module/UiUtils';
@@ -89,14 +88,23 @@ describe('browser.tinymce.themes.silver.editor.sizing.ResizeTTest', () => {
 
     // Make it larger
     for (let i = 0; i < 3; ++i) {
-      TinyUiActions.keystroke(editor, VK.RIGHT);
-      TinyUiActions.keystroke(editor, VK.DOWN);
+      TinyUiActions.keystroke(editor, Keys.right());
+    }
+    assertEditorSize(container, 460, 400);
+
+    for (let i = 0; i < 3; ++i) {
+      TinyUiActions.keystroke(editor, Keys.down());
     }
     assertEditorSize(container, 460, 460);
 
+    // Make it smaller again
     for (let i = 0; i < 3; ++i) {
-      TinyUiActions.keystroke(editor, VK.LEFT);
-      TinyUiActions.keystroke(editor, VK.UP);
+      TinyUiActions.keystroke(editor, Keys.left());
+    }
+    assertEditorSize(container, 400, 460);
+
+    for (let i = 0; i < 3; ++i) {
+      TinyUiActions.keystroke(editor, Keys.up());
     }
     assertEditorSize(container, 400, 400);
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
@@ -88,13 +88,13 @@ describe('browser.tinymce.themes.silver.editor.sizing.ResizeTTest', () => {
     FocusTools.setFocus(SugarBody.body(), '.tox-statusbar__resize-handle');
 
     // Make it larger
-    for (let i = 0; i < 20; ++i) {
+    for (let i = 0; i < 3; ++i) {
       TinyUiActions.keystroke(editor, VK.RIGHT);
       TinyUiActions.keystroke(editor, VK.DOWN);
     }
     assertEditorSize(container, 460, 460);
 
-    for (let i = 0; i < 20; ++i) {
+    for (let i = 0; i < 3; ++i) {
       TinyUiActions.keystroke(editor, VK.LEFT);
       TinyUiActions.keystroke(editor, VK.UP);
     }

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
@@ -1,7 +1,7 @@
-import { Keyboard, Mouse, UiFinder } from '@ephox/agar';
+import { FocusTools, Mouse, UiFinder } from '@ephox/agar';
 import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
-import { Css, Focus, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { Css, SugarBody, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -38,10 +38,10 @@ describe('browser.tinymce.themes.silver.editor.sizing.ResizeTTest', () => {
   // Make sure the height is reset
   beforeEach(() => {
     const editor = hook.editor();
-    const container = SugarElement.fromDom(editor.getContainer());
+    const container = TinyDom.container(editor);
     Css.setAll(container, {
-      width: '400px',
-      height: '400px'
+      width: editor.getParam('width') + 'px',
+      height: editor.getParam('height') + 'px',
     });
   });
 
@@ -84,20 +84,19 @@ describe('browser.tinymce.themes.silver.editor.sizing.ResizeTTest', () => {
   it('TINY-4823: can be resized via the keyboard', () => {
     const editor = hook.editor();
     const container = TinyDom.container(editor);
-    const resizeHandle = UiFinder.findIn(SugarBody.body(), '.tox-statusbar__resize-handle').getOrDie();
 
-    Focus.focus(resizeHandle);
+    FocusTools.setFocus(SugarBody.body(), '.tox-statusbar__resize-handle');
 
     // Make it larger
     for (let i = 0; i < 20; ++i) {
-      Keyboard.keystroke(VK.RIGHT, {}, resizeHandle);
-      Keyboard.keystroke(VK.DOWN, {}, resizeHandle);
+      TinyUiActions.keystroke(editor, VK.RIGHT);
+      TinyUiActions.keystroke(editor, VK.DOWN);
     }
     assertEditorSize(container, 460, 460);
 
     for (let i = 0; i < 20; ++i) {
-      Keyboard.keystroke(VK.LEFT, {}, resizeHandle);
-      Keyboard.keystroke(VK.UP, {}, resizeHandle);
+      TinyUiActions.keystroke(editor, VK.LEFT);
+      TinyUiActions.keystroke(editor, VK.UP);
     }
     assertEditorSize(container, 400, 400);
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -38,9 +38,6 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
       ]
     }),
     s.element('div', {
-      attrs: {
-        'aria-hidden': str.is('true')
-      },
       classes: [ arr.has('tox-statusbar__resize-handle') ]
     })
   ];
@@ -66,9 +63,6 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
       ]
     }),
     s.element('div', {
-      attrs: {
-        'aria-hidden': str.is('true')
-      },
       classes: [ arr.has('tox-statusbar__resize-handle') ]
     })
   ];


### PR DESCRIPTION
Related Ticket: TINY-4823

Description of Changes:
* Add keyboard control to the editor resize handle

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Other checks:
* [x] We need design changes so that the handle shows when it's selected
* [x] Do some work on the ARIA side of things until the time box runs out

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
