### PR TITLE
Fix color picker xhtml

### DIFF
--- a/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
@@ -36,7 +36,7 @@ const paletteFactory = (_translate: (key: string) => string, getClass: (key: str
         role: 'presentation'
       },
       classes: [ getClass('sv-palette-thumb') ],
-      innerHtml: `<div class=${getClass('sv-palette-inner-thumb')} role="presentation"></div>`
+      innerHtml: `<div class="${getClass('sv-palette-inner-thumb')}" role="presentation"></div>`
     }
   });
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The color preview box in the color picker dialog was not correctly displaying the saturation and value of the chosen color #TINY-6952
 - The color picker dialog will now show an alert if it is submitted with an invalid hex color code #TINY-2814
 - Fixed a bug where the `TableModified` event was not fired when adding a table row via the Tab key #TINY-7006
+- Fixed a bug where the color picker dialog was not opening in xhtml documents.
 
 ## 5.7.1 - 2021-03-17
 


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Add quotes around sv-palette-inner-thumb class to fix invalid xml error when opening color picker in xhtml documents.

Pre-checks:
* [x] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)
* [ ] License headers added on new files (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
