### PR TITLE
TINY-7191: Restricts placement at the right and bottom side in addition to top and left side for the purposes of context toolbar placement.

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added a new `setValue` method to the `SliderUi`. This allows the slider value to be modified without firing a change event.
+- Fixed a case where the context toolbar would not stick to the bottom of the view.
 
 ## 8.1.0 - 2020-11-18
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
@@ -64,7 +64,7 @@ const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningC
 
     const getBounds = bounds.map(Fun.constant).or(posConfig.getBounds);
 
-    placer(component, anchorage, origin).each((anchoring) => {
+    placer(component, anchorage, origin, getBounds).each((anchoring) => {
       const doPlace = anchoring.placer.getOr(place);
       doPlace(component, origin, anchoring, getBounds, placee);
     });

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
@@ -18,7 +18,7 @@ export interface CommonAnchorSpec {
 export type AnchorSpec = SelectionAnchorSpec | HotspotAnchorSpec | SubmenuAnchorSpec | MakeshiftAnchorSpec | NodeAnchorSpec;
 
 export interface AnchorDetail<D> {
-  placement: (comp: AlloyComponent, anchor: D, origin: OriginAdt) => Optional<Anchoring>;
+  placement: (comp: AlloyComponent, anchor: D, origin: OriginAdt, getBounds: Optional<() => Bounds>) => Optional<Anchoring>;
 }
 
 export type MaxHeightFunction = (elem: SugarElement, available: number) => void;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
@@ -9,8 +9,11 @@ import * as Origins from '../layout/Origins';
 import { Anchoring, NodeAnchor, nu as NuAnchor, SelectionAnchor } from './Anchoring';
 import * as AnchorLayouts from './AnchorLayouts';
 
-const capRect = (left: number, top: number, width: number, height: number): Optional<Boxes.BoxByPoint> => {
-  let newLeft = left, newTop = top, newWidth = width, newHeight = height;
+const capRect = (left: number, top: number, width: number, height: number, cappingViewport: Optional<Boxes.Bounds>): Optional<Boxes.BoxByPoint> => {
+  let newLeft = left;
+  let newTop = top;
+  let newWidth = width;
+  let newHeight = height;
   // Try to prevent the context toolbar from getting above the editor toolbar
   if (left < 0) {
     newLeft = 0;
@@ -20,6 +23,18 @@ const capRect = (left: number, top: number, width: number, height: number): Opti
     newTop = 0;
     newHeight = height + top;
   }
+
+  // Try to prevent the context toolbar from getting below the editor toolbar if we know the bounds of the viewport.
+  cappingViewport.each((cap) => {
+    if ((newLeft + newWidth) > cap.width) {
+      newWidth = cap.width - newLeft;
+    }
+
+    if ((newTop + newHeight) > cap.height) {
+      newHeight = cap.height - newTop;
+    }
+  });
+
   const point = CssPosition.screen(SugarPosition(newLeft, newTop));
   return Optional.some(Boxes.pointed(point, newWidth, newHeight));
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/NodeAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/NodeAnchor.ts
@@ -1,6 +1,7 @@
 import { FieldSchema } from '@ephox/boulder';
 import { Optional } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
+import { Bounds } from '../../alien/Boxes';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as Fields from '../../data/Fields';
@@ -10,15 +11,16 @@ import * as AnchorLayouts from './AnchorLayouts';
 import * as ContainerOffsets from './ContainerOffsets';
 import * as ContentAnchorCommon from './ContentAnchorCommon';
 
-const placement = (component: AlloyComponent, anchorInfo: NodeAnchor, origin: Origins.OriginAdt): Optional<Anchoring> => {
+const placement = (component: AlloyComponent, anchorInfo: NodeAnchor, origin: Origins.OriginAdt, getBounds: Optional<() => Bounds>): Optional<Anchoring> => {
   const rootPoint = ContainerOffsets.getRootPoint(component, origin, anchorInfo);
 
   return anchorInfo.node
     // Ensure the node is still attached, otherwise we can't get a valid client rect for a detached node
     .filter(SugarBody.inBody)
     .bind((target) => {
+      const cappingViewport = Origins.viewport(origin, getBounds);
       const rect = target.dom.getBoundingClientRect();
-      const nodeBox = ContentAnchorCommon.capRect(rect.left, rect.top, rect.width, rect.height);
+      const nodeBox = ContentAnchorCommon.capRect(rect.left, rect.top, rect.width, rect.height, Optional.some(cappingViewport));
       const elem = anchorInfo.node.getOr(component.element);
       return ContentAnchorCommon.calcNewAnchor(nodeBox, rootPoint, anchorInfo, origin, elem);
     });

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -41,7 +41,7 @@ const placement = (component: AlloyComponent, anchorInfo: SelectionAnchor, origi
         return rect;
       });
     });
-    return optRect.bind((rawRect) => ContentAnchorCommon.capRect(rawRect.left, rawRect.top, rawRect.width, rawRect.height));
+    return optRect.bind((rawRect) => ContentAnchorCommon.capRect(rawRect.left, rawRect.top, rawRect.width, rawRect.height, Optional.none()));
   });
 
   const targetElement: Optional<SugarElement> = getAnchorSelection(win, anchorInfo)


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Previously the area designed for the context toolbar was cropped on the top to prevent the toolbar from moving off-screen during placement, while no such treatment was given to the bottom area. This crops the area appropriately, allowing for the context toolbar to stick to the bottom of the screen instead of always going for the top.

Pre-checks:
* [x] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
