### PR TITLE
Fix disappearing letters and words from lists pasted from Word

### DIFF
--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
@@ -159,6 +159,41 @@ UnitTest.asynctest('browser.tinymce.plugins.paste.PasteTest', (success, failure)
     LegacyUnit.equal(editor.getContent(), '<ol><li>Version 7.0:</li></ol>');
   });
 
+  suite.test('TestCase-TBA: Paste: Paste Word fake list with font changes', (editor) => {
+    editor.setContent('');
+
+    editor.execCommand('mceInsertClipboardContent', false, {
+      content: `<p class=MsoListParagraph style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><![if !supportLists]><span lang=EN-US style='font-family:Symbol;mso-fareast-font-family:Symbol;mso-bidi-font-family:Symbol;mso-ansi-language:EN-US'><span style='mso-list:Ignore'>·<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span lang=EN-US style='mso-ansi-language:EN-US'>Hello </span><span lang=EN-US style='font-size:20.0pt;line-height:107%;mso-ansi-language:EN-US'>world.</span><span lang=EN-US style='mso-ansi-language:EN-US'> What?<o:p></o:p></span></p>` });
+
+    LegacyUnit.equal(editor.getContent(), '<ul><li>Hello world. What?</li></ul>');
+  });
+
+  suite.test('TestCase-TBA: Paste: Paste Word fake list with single words ending in dot.', (editor) => {
+    editor.setContent('');
+
+    editor.execCommand('mceInsertClipboardContent', false, {
+      content:
+        `<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><![if !supportLists]><span
+        lang=en-FI style='mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin'><span
+        style='mso-list:Ignore'>1.<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        </span></span></span><![endif]><span lang=EN-US style='mso-ansi-language:EN-US'>First.</span><span
+        lang=en-FI><o:p></o:p></span></p>
+      
+        <p class=MsoListParagraphCxSpMiddle style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><![if !supportLists]><span
+        lang=en-FI style='mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin'><span
+        style='mso-list:Ignore'>2.<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        </span></span></span><![endif]><span lang=EN-US style='mso-ansi-language:EN-US'>Second.</span><span
+        lang=en-FI><o:p></o:p></span></p>
+      
+        <p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><![if !supportLists]><span
+        lang=en-FI style='mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin'><span
+        style='mso-list:Ignore'>3.<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        </span></span></span><![endif]><span lang=EN-US style='mso-ansi-language:EN-US'>Third.</span><span
+        lang=en-FI><o:p></o:p></span></p>` });
+
+    LegacyUnit.equal(editor.getContent(), '<ol><li>First.</li><li>Second.</li><li>Third.</li></ol>');
+  });
+
   suite.test('TestCase-TBA: Paste: Paste Word fake list before BR', (editor) => {
     let rng = editor.dom.createRng();
 


### PR DESCRIPTION
This pull request replaces #6621 as agreed with @JamesToohey.

Fixes #2810, Fixes #3017, Fixes #3480, Fixes #5474

This commit includes fixes to multiple subtle errors in MS Word list
cleanups. The bugs caused any characters ending with a dot to disappear
from the lists under certain circumstances:

Font/style -changes cause multiple text nodes to appear as siblings in
the AST.

Function `filterStyles` marked only the first node with `_listIgnore` and
thus missed the nodes with roman numerals. This was fixed.

The `removeIgnoredNodes`-function used `node.remove()` to delete nodes
from the AST. The method sets `node.next` to `null` and thus recursion
did not proceed further. Sibling text nodes with `_listIgnore` would
not be deleted. This was fixed by avoiding `node.remove()`.

The `trimListStart` -function did not trim the beginning of the
paragraph. It trimmed all text nodes instead and removed the ones with
words ending with dot. This was fixed by merging the paragraph
text nodes before trimming the first text node.

Regex for cleaning up the beginning is now safe. It no longer removes
any letters (with` \w`). Instead it only looks for bullets. One
regex is enough to filter those as the text nodes have been merged
before matching.

Added a couple of test cases as a proof that the fixes work correctly.

Pre-checks:
* [x] Tests have been added (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
- #2933
- #3017
- #3480
- #5474
- possibly others as well