### PR TITLE
TINY-6633: Add HTML5 elements to default formats

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The color picker dialog will now show an alert if it is submitted with an invalid hex color code #TINY-2814
 - Fixed a bug where the `TableModified` event was not fired when adding a table row via the Tab key #TINY-7006
 - Added missing type for `images_file_types` setting #GH-6607
+- The HTML5 `small` element could not be removed when clearing text formatting #TINY-6633
 
 ## 5.7.1 - 2021-03-17
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where the `TableModified` event was not fired when adding a table row via the Tab key #TINY-7006
 - Added missing type for `images_file_types` setting #GH-6607
 - The HTML5 `small` element could not be removed when clearing text formatting #TINY-6633
+- Added HTML5 `audio` and `video` elements to the default alignment formats #TINY-6633
 
 ## 5.7.1 - 2021-03-17
 

--- a/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
@@ -42,7 +42,7 @@ const get = (dom: DOMUtils) => {
         defaultBlock: 'div'
       },
       {
-        selector: 'img,table',
+        selector: 'img,table,audio,video',
         collapsed: false,
         styles: {
           float: 'left'
@@ -69,7 +69,7 @@ const get = (dom: DOMUtils) => {
         preview: 'font-family font-size'
       },
       {
-        selector: 'img',
+        selector: 'img,audio,video',
         collapsed: false,
         styles: {
           display: 'block',
@@ -107,7 +107,7 @@ const get = (dom: DOMUtils) => {
         defaultBlock: 'div'
       },
       {
-        selector: 'img,table',
+        selector: 'img,table,audio,video',
         collapsed: false,
         styles: {
           float: 'right'

--- a/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
@@ -177,7 +177,7 @@ const get = (dom: DOMUtils) => {
 
     removeformat: [
       {
-        selector: 'b,strong,em,i,font,u,strike,s,sub,sup,dfn,code,samp,kbd,var,cite,mark,q,del,ins',
+        selector: 'b,strong,em,i,font,u,strike,s,sub,sup,dfn,code,samp,kbd,var,cite,mark,q,del,ins,small',
         remove: 'all',
         split: true,
         expand: false,
@@ -189,7 +189,7 @@ const get = (dom: DOMUtils) => {
     ]
   };
 
-  Tools.each('p h1 h2 h3 h4 h5 h6 div address pre div dt dd samp'.split(/\s/), (name) => {
+  Tools.each('p h1 h2 h3 h4 h5 h6 div address pre dt dd samp'.split(/\s/), (name) => {
     formats[name] = { block: name, remove: 'all' };
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -460,10 +460,10 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent(
       '<p><dfn>dfn tag </dfn> <code>code tag </code> <samp>samp tag</samp> ' +
       '<kbd> kbd tag</kbd> <var> var tag</var> <cite> cite tag</cite> <mark> mark tag</mark> <q> q tag</q> ' +
-      '<strike>strike tag</strike> <s>s tag</s></p>'
+      '<strike>strike tag</strike> <s>s tag</s> <small>small tag</small></p>'
     );
     editor.execCommand('SelectAll');
     editor.execCommand('RemoveFormat');
-    assert.equal(editor.getContent(), '<p>dfn tag code tag samp tag kbd tag var tag cite tag mark tag q tag strike tag s tag</p>');
+    assert.equal(editor.getContent(), '<p>dfn tag code tag samp tag kbd tag var tag cite tag mark tag q tag strike tag s tag small tag</p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
@@ -14,12 +14,17 @@ describe('browser.tinymce.core.delete.MediaAlignTest', () => {
   }, [ Theme ], true);
 
   const mediaApproxStructure = (tag: string, alignment: Alignment) => {
-    const alignStyles = (str: ApproxStructure.StringApi) => ({
-      left: { float: str.is('left') },
-      center: { 'display': str.is('block'), 'margin-left': str.is('auto'), 'margin-right': str.is('auto') },
-      right: { float: str.is('right') },
-      justify: {}
-    });
+    const alignStyles = (str: ApproxStructure.StringApi) => {
+      if (alignment === 'left') {
+        return { float: str.is('left') };
+      } else if (alignment === 'center') {
+        return { 'display': str.is('block'), 'margin-left': str.is('auto'), 'margin-right': str.is('auto') };
+      } else if (alignment === 'right') {
+        return { float: str.is('right') };
+      } else {
+        return {};
+      }
+    };
 
     return ApproxStructure.build((s, str) => s.element('body', {
       children: [
@@ -27,7 +32,7 @@ describe('browser.tinymce.core.delete.MediaAlignTest', () => {
           styles: alignment === 'justify' ? { 'text-align': str.is('justify') } : {},
           children: [
             s.element(tag, {
-              styles: alignStyles(str)[alignment]
+              styles: alignStyles(str)
             })
           ]
         }),

--- a/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
@@ -8,7 +8,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 
 type Alignment = 'left' | 'center' | 'right' | 'justify';
 
-describe('browser.tinymce.core.delete.MediaAlignTest', () => {
+describe('browser.tinymce.core.fmt.MediaAlignTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme ], true);

--- a/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
@@ -1,0 +1,77 @@
+import { ApproxStructure } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
+
+type Alignment = 'left' | 'center' | 'right' | 'justify';
+
+describe('browser.tinymce.core.delete.MediaAlignTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Theme ], true);
+
+  const mediaApproxStructure = (tag: string, alignment: Alignment) => {
+    const alignStyles = (str: ApproxStructure.StringApi) => ({
+      left: { float: str.is('left') },
+      center: { 'display': str.is('block'), 'margin-left': str.is('auto'), 'margin-right': str.is('auto') },
+      right: { float: str.is('right') },
+      justify: {}
+    });
+
+    return ApproxStructure.build((s, str) => s.element('body', {
+      children: [
+        s.element('p', {
+          styles: alignment === 'justify' ? { 'text-align': str.is('justify') } : {},
+          children: [
+            s.element(tag, {
+              styles: alignStyles(str)[alignment]
+            })
+          ]
+        }),
+        s.theRest()
+      ]
+    }));
+  };
+
+  Arr.each([
+    { type: 'video', content: '<p><video controls="controls"><source src="custom/video.mp4" /></video></p>' },
+    { type: 'audio', content: '<p><audio controls="controls"><source src="custom/audio.mp3" /></audio></p>' },
+  ], (test) => {
+    const { type, content } = test;
+
+    context(`${type} media`, () => {
+      it('TINY-6633: Align left', () => {
+        const editor = hook.editor();
+        editor.setContent(content);
+        TinySelections.select(editor, type, []);
+        editor.formatter.apply('alignleft');
+        TinyAssertions.assertContentStructure(editor, mediaApproxStructure(type, 'left'));
+        editor.formatter.remove('alignleft');
+        TinyAssertions.assertContent(editor, content);
+      });
+
+      it('TINY-6633: Align center', () => {
+        const editor = hook.editor();
+        editor.setContent(content);
+        TinySelections.select(editor, type, []);
+        editor.formatter.apply('aligncenter');
+        TinyAssertions.assertContentStructure(editor, mediaApproxStructure(type, 'center'));
+        editor.formatter.remove('aligncenter');
+        TinyAssertions.assertContent(editor, content);
+      });
+
+      it('TINY-6633: Align right', () => {
+        const editor = hook.editor();
+        editor.setContent(content);
+        TinySelections.select(editor, type, []);
+        editor.formatter.apply('alignright');
+        TinyAssertions.assertContentStructure(editor, mediaApproxStructure(type, 'right'));
+        editor.formatter.remove('alignright');
+        TinyAssertions.assertContent(editor, content);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-6633

Description of Changes:
* Allow the `small` element to be removed when clearing text formatting
* Add `video` and `audio` to align formats. Worth noting that if the media plugin is enabled, the alignments won't work on them which needs to be looked into in a separate ticket.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* ~~[ ] Branch prefixed with `feature/` for new features (if applicable)~~
* ~~[ ] License headers added on new files (if applicable)~~

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
