### PR TITLE
TINY-6816: Fix title-case dialog buttons

### DIFF
--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -29,7 +29,7 @@
 @button-text-align: center;
 @button-text-color: contrast(@button-background-color, @color-black, @color-white);
 @button-text-decoration: none;
-@button-text-transform: capitalize;
+@button-text-transform: none;
 
 @button-disabled-background-color: @button-background-color;
 @button-disabled-background-image: @button-background-image;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The color picker dialog will now show an alert if it is submitted with an invalid hex color code #TINY-2814
 - Fixed a bug where the `TableModified` event was not fired when adding a table row via the Tab key #TINY-7006
 - Added missing type for `images_file_types` setting #GH-6607
+- The Oxide button text transform variable was incorrectly using `capitalize` instead of `none`. Patch contributed by dakur #GH-6341
+- Fix dialog button text that was using title-style capitalization #TINY-6816
 
 ## 5.7.1 - 2021-03-17
 

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
@@ -190,7 +190,7 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>) => 
       {
         type: 'custom',
         name: 'replaceall',
-        text: 'Replace All',
+        text: 'Replace all',
         disabled: true
       }
     ],

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
@@ -87,7 +87,7 @@ UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardN
         sPressTab,
         sAssertFocused('Find button', '.tox-button[title="Replace"]'),
         sPressTab,
-        sAssertFocused('Find button', '.tox-button[title="Replace All"]'),
+        sAssertFocused('Find button', '.tox-button[title="Replace all"]'),
         sPressEnter,
         sAssertFocused('Find input', '.tox-textfield[placeholder="Find"]'),
         sPressEsc

--- a/modules/tinymce/src/themes/silver/demo/ts/components/searchreplace/SearchReplace.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/components/searchreplace/SearchReplace.ts
@@ -56,7 +56,7 @@ export const SearchReplaceDialogSpec: Dialog.DialogSpec<any> = {
     {
       type: 'custom',
       name: 'replaceall',
-      text: 'Replace All',
+      text: 'Replace all',
       align: 'start'
     },
     {


### PR DESCRIPTION
Related Ticket: TINY-6816

Description of Changes:
* Make sure dialog buttons use sentence case for their text.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
