### PR TITLE
feature/TINY-6400: Image dialog incorrectly renders class/caption in grid

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Updated the image dialog to show a grid with two columns only if `hasImageCaption` is true, `image` plugin #TINY-6400
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891
 
 ### Fixed

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,12 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-<<<<<<< HEAD
 - Updated the image dialog to display the class list dropdown as full-width if the caption checkbox is not present #TINY-6400
-=======
 - The `inline_boundaries` feature now supports the `home`, `end`, `pageup` and `pagedown` keys #TINY-4612
 - Added new `PAGE_UP` and `PAGE_DOWN` key code constants to the `VK` API
->>>>>>> edf347999fcf9581bfe9ecbc50b1f03eb14f0bba
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891
 - The editor resize handle can now be controlled using the keyboard #TINY-4823
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Updated the image dialog to display the class list dropdown as full-width if the caption checkbox is not present #TINY-6400
 - The `inline_boundaries` feature now supports the `home`, `end`, `pageup` and `pagedown` keys #TINY-4612
 - Added new `PAGE_UP` and `PAGE_DOWN` key code constants to the `VK` API
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891
 - The editor resize handle can now be controlled using the keyboard #TINY-4823
 
 ### Changed
+- Updated the `image` dialog to display the class list dropdown as full-width if the caption checkbox is not present #TINY-6400
 - Renamed the "H Align" and "V Align" input labels in the Table Cell Properties dialog to "Horizontal align" and "Vertical align" respectively #TINY-7285
 
 ### Fixed

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Updated the image dialog to show a grid with two columns only if `hasImageCaption` is true, `image` plugin #TINY-6400
+- Updated the image dialog to display the class list dropdown as full-width if the caption checkbox is not present #TINY-6400
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891
 
 ### Fixed

--- a/modules/tinymce/src/plugins/image/main/ts/ui/MainTab.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/MainTab.ts
@@ -71,6 +71,8 @@ const makeItems = (info: ImageDialogInfo) => {
     ]
   };
 
+  const dialogType = (hasColumns: boolean) => hasColumns ? { type: 'grid', columns: 2 } : { type: 'panel' };
+
   return Arr.flatten<any>([
     [ imageUrl ],
     imageList.toArray(),
@@ -79,8 +81,7 @@ const makeItems = (info: ImageDialogInfo) => {
     info.hasImageTitle ? [ imageTitle ] : [],
     info.hasDimensions ? [ imageDimensions ] : [],
     [{
-      type: 'grid',
-      columns: 2,
+      ...dialogType(info.hasImageCaption),
       items: Arr.flatten([
         classList.toArray(),
         info.hasImageCaption ? [ caption ] : []

--- a/modules/tinymce/src/plugins/image/main/ts/ui/MainTab.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/MainTab.ts
@@ -71,7 +71,7 @@ const makeItems = (info: ImageDialogInfo) => {
     ]
   };
 
-  const dialogType = (hasColumns: boolean) => hasColumns ? { type: 'grid', columns: 2 } : { type: 'panel' };
+  const getDialogContainerType = (useColumns: boolean) => useColumns ? { type: 'grid', columns: 2 } : { type: 'panel' };
 
   return Arr.flatten<any>([
     [ imageUrl ],
@@ -81,7 +81,7 @@ const makeItems = (info: ImageDialogInfo) => {
     info.hasImageTitle ? [ imageTitle ] : [],
     info.hasDimensions ? [ imageDimensions ] : [],
     [{
-      ...dialogType(info.hasImageCaption),
+      ...getDialogContainerType(info.classList.isSome() && info.hasImageCaption),
       items: Arr.flatten([
         classList.toArray(),
         info.hasImageCaption ? [ caption ] : []

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
@@ -1,3 +1,4 @@
+import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
@@ -46,5 +47,30 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
       '<figcaption>Caption</figcaption>' +
       '</figure>'
     ));
+  });
+
+  it('TINY-6400: render image_class_list as Dialog type "panel"', async () => {
+    const editor = hook.editor();
+    editor.settings.image_caption = false;
+    editor.execCommand('mceImage');
+
+    const dialog = await TinyUiActions.pWaitForDialog(editor);
+    const expected = {
+      ['.tox-form__group button[aria-label="Class"]']: 1,
+      ['.tox-form__grid--2col button[aria-label="Class"]']: 0
+    };
+    Assertions.assertPresence('Asserting presence', expected, dialog);
+  });
+
+  it('TINY-6400: render image_class_list and image_caption as Dialog type "group"', async () => {
+    const editor = hook.editor();
+    editor.execCommand('mceImage');
+
+    const dialog = await TinyUiActions.pWaitForDialog(editor);
+    const expected = {
+      ['.tox-form__grid--2col button[aria-label="Class"]']: 1,
+      ['.tox-form__grid--2col .tox-checkbox']: 1
+    };
+    Assertions.assertPresence('Asserting presence', expected, dialog);
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
@@ -49,19 +49,6 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
     ));
   });
 
-  it('TINY-6400: render image_class_list as Dialog type "panel"', async () => {
-    const editor = hook.editor();
-    editor.settings.image_caption = false;
-    editor.execCommand('mceImage');
-    const dialog = await TinyUiActions.pWaitForDialog(editor);
-    const expected = {
-      ['.tox-form__group button[aria-label="Class"]']: 1,
-      ['.tox-form__grid--2col button[aria-label="Class"]']: 0
-    };
-    Assertions.assertPresence('Does not have columns for the class', expected, dialog);
-    delete editor.settings.image_caption;
-  });
-
   it('TINY-6400: render image_class_list and image_caption as Dialog type "group"', async () => {
     const editor = hook.editor();
     editor.execCommand('mceImage');
@@ -72,5 +59,20 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
     };
 
     Assertions.assertPresence('Does have columns for the class', expected, dialog);
+    TinyUiActions.clickOnUi(editor, 'button.tox-button:contains(Cancel)');
+  });
+
+  it('TINY-6400: render image_class_list as Dialog type "panel"', async () => {
+    const editor = hook.editor();
+    editor.settings.image_caption = false;
+    editor.execCommand('mceImage');
+    const dialog = await TinyUiActions.pWaitForDialog(editor);
+    const expected = {
+      ['.tox-form__group button[aria-label="Class"]']: 1,
+      ['.tox-form__grid--2col button[aria-label="Class"]']: 0
+    };
+    Assertions.assertPresence('Does not have columns for the class', expected, dialog);
+    TinyUiActions.clickOnUi(editor, 'button.tox-button:contains(Cancel)');
+    delete editor.settings.image_caption;
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
@@ -73,6 +73,6 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
     };
     Assertions.assertPresence('Does not have columns for the class', expected, dialog);
     TinyUiActions.clickOnUi(editor, 'button.tox-button:contains(Cancel)');
-    delete editor.settings.image_caption;
+    editor.settings.image_caption = true;
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
@@ -53,24 +53,24 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
     const editor = hook.editor();
     editor.settings.image_caption = false;
     editor.execCommand('mceImage');
-
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     const expected = {
       ['.tox-form__group button[aria-label="Class"]']: 1,
       ['.tox-form__grid--2col button[aria-label="Class"]']: 0
     };
-    Assertions.assertPresence('Asserting presence', expected, dialog);
+    Assertions.assertPresence('Does not have columns for the class', expected, dialog);
+    delete editor.settings.image_caption;
   });
 
   it('TINY-6400: render image_class_list and image_caption as Dialog type "group"', async () => {
     const editor = hook.editor();
     editor.execCommand('mceImage');
-
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     const expected = {
       ['.tox-form__grid--2col button[aria-label="Class"]']: 1,
       ['.tox-form__grid--2col .tox-checkbox']: 1
     };
-    Assertions.assertPresence('Asserting presence', expected, dialog);
+
+    Assertions.assertPresence('Does have columns for the class', expected, dialog);
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
@@ -49,7 +49,7 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
     ));
   });
 
-  it('TINY-6400: render image_class_list and image_caption as Dialog type "group"', async () => {
+  it('TINY-6400: render image_class_list and image_caption as Dialog type "grid"', async () => {
     const editor = hook.editor();
     editor.execCommand('mceImage');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
@@ -58,7 +58,7 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
       ['.tox-form__grid--2col .tox-checkbox']: 1
     };
 
-    Assertions.assertPresence('Does have columns for the class', expected, dialog);
+    Assertions.assertPresence('Does have columns for the class and checkbox', expected, dialog);
     TinyUiActions.clickOnUi(editor, 'button.tox-button:contains(Cancel)');
   });
 
@@ -69,10 +69,31 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     const expected = {
       ['.tox-form__group button[aria-label="Class"]']: 1,
-      ['.tox-form__grid--2col button[aria-label="Class"]']: 0
+      ['.tox-form__grid--2col .tox-checkbox']: 0
     };
-    Assertions.assertPresence('Does not have columns for the class', expected, dialog);
+
+    Assertions.assertPresence('Does not have columns for the class but a group', expected, dialog);
     TinyUiActions.clickOnUi(editor, 'button.tox-button:contains(Cancel)');
     editor.settings.image_caption = true;
+  });
+
+  it('TINY-6400: render image_caption as Dialog type "panel"', async () => {
+    const editor = hook.editor();
+    delete editor.settings.image_class_list;
+
+    editor.execCommand('mceImage');
+    const dialog = await TinyUiActions.pWaitForDialog(editor);
+    const expected = {
+      ['.tox-form__grid--2col button[aria-label="Class"]']: 0,
+      ['.tox-form__group .tox-checkbox']: 1,
+    };
+
+    Assertions.assertPresence('Does not have columns but a checkbox group', expected, dialog);
+    TinyUiActions.clickOnUi(editor, 'button.tox-button:contains(Cancel)');
+    editor.settings.image_class_list = [
+      { title: 'None', value: '' },
+      { title: 'class1', value: 'class1' },
+      { title: 'class2', value: 'class2' }
+    ];
   });
 });


### PR DESCRIPTION
Related Ticket: [TINY-6400](https://ephocks.atlassian.net/secure/RapidBoard.jspa?rapidView=116&modal=detail&selectedIssue=TINY-6400)

Description of Changes:
* Update tap config to forcing it into a 2 column grid if both a class list and caption are enabled

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
