### PR TITLE
TINY-7227: Support formatting multiple classes on same element

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Update `MatchFormat` to match multiple values on same element #TINY-7227
 - The `inline_boundaries` feature now supports the `home`, `end`, `pageup` and `pagedown` keys #TINY-4612
 - Added new `PAGE_UP` and `PAGE_DOWN` key code constants to the `VK` API
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891
 - The editor resize handle can now be controlled using the keyboard #TINY-4823
 
 ### Changed
+- Updated `formatter.matchFormat` to support for matching formats with variables in the classes property #TINY-7227
 - Updated the `image` dialog to display the class list dropdown as full-width if the caption checkbox is not present #TINY-6400
 - Renamed the "H Align" and "V Align" input labels in the Table Cell Properties dialog to "Horizontal align" and "Vertical align" respectively #TINY-7285
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Update `MatchFormat` to match multiple classes on same element #TINY-7227
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891
 - The editor resize handle can now be controlled using the keyboard #TINY-4823
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Update `MatchFormat` to match multiple classes on same element #TINY-7227
+- Update `MatchFormat` to match multiple values on same element #TINY-7227
 - The `inline_boundaries` feature now supports the `home`, `end`, `pageup` and `pagedown` keys #TINY-4612
 - Added new `PAGE_UP` and `PAGE_DOWN` key code constants to the `VK` API
 - Added support for alpha list numbering to the `lists` plugin #TINY-6891

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The editor resize handle can now be controlled using the keyboard #TINY-4823
 - Added a new `fixed_toolbar_container_target` setting which renders the toolbar in the specified `HTMLElement`. Patch contributed by pvrobays
 
+### Improved
+- Updated the `formatter.matchFormat` API to support matching formats with variables in the `classes` property #TINY-7227
+
 ### Changed
-- Updated `formatter.matchFormat` to support for matching formats with variables in the classes property #TINY-7227
 - Updated the `image` dialog to display the class list dropdown as full-width if the caption checkbox is not present #TINY-6400
 - Renamed the "H Align" and "V Align" input labels in the Table Cell Properties dialog to "Horizontal align" and "Vertical align" respectively #TINY-7285
 

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Compare, SugarElement, TransformFind } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
@@ -92,7 +92,11 @@ const matchItems = (dom: DOMUtils, node: Node, format, itemName: string, similar
             return;
           }
 
-          if ((!similar || format.exact) && !isEq(value, FormatUtils.normalizeStyleValue(dom, FormatUtils.replaceVars(items[key], vars), key))) {
+          const normalizedStyle = FormatUtils.normalizeStyleValue(dom, FormatUtils.replaceVars(items[key], vars), key);
+          // TINY-7227 multiple classes on same element
+          const matchAttribute = Arr.exists(value.split(' '), Fun.curry(isEq, normalizedStyle));
+
+          if ((!similar || format.exact) && !matchAttribute) {
             return;
           }
         }

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Optional } from '@ephox/katamari';
+import { Arr, Optional } from '@ephox/katamari';
 import { Compare, SugarElement, TransformFind } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
@@ -92,11 +92,7 @@ const matchItems = (dom: DOMUtils, node: Node, format, itemName: string, similar
             return;
           }
 
-          const normalizedStyle = FormatUtils.normalizeStyleValue(dom, FormatUtils.replaceVars(items[key], vars), key);
-          // TINY-7227 multiple classes on same element
-          const matchAttribute = isEq(normalizedStyle, value) || Arr.exists(value.split(' '), Fun.curry(isEq, normalizedStyle));
-
-          if ((!similar || format.exact) && !matchAttribute) {
+          if ((!similar || format.exact) && !isEq(value, FormatUtils.normalizeStyleValue(dom, FormatUtils.replaceVars(items[key], vars), key))) {
             return;
           }
         }
@@ -129,7 +125,7 @@ const matchNode = (ed: Editor, node: Node, name: string, vars?: FormatVars, simi
         // Match classes
         if ((classes = format.classes)) {
           for (x = 0; x < classes.length; x++) {
-            if (!ed.dom.hasClass(node, classes[x])) {
+            if (!ed.dom.hasClass(node, FormatUtils.replaceVars(classes[x], vars))) {
               return;
             }
           }

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -94,7 +94,7 @@ const matchItems = (dom: DOMUtils, node: Node, format, itemName: string, similar
 
           const normalizedStyle = FormatUtils.normalizeStyleValue(dom, FormatUtils.replaceVars(items[key], vars), key);
           // TINY-7227 multiple classes on same element
-          const matchAttribute = Arr.exists(value.split(' '), Fun.curry(isEq, normalizedStyle));
+          const matchAttribute = isEq(normalizedStyle, value) || Arr.exists(value.split(' '), Fun.curry(isEq, normalizedStyle));
 
           if ((!similar || format.exact) && !matchAttribute) {
             return;

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -2308,4 +2308,17 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.formatter.apply('bold');
     assert.equal(getContent(editor), '<p><strong>test</strong></p><table><tbody><tr><td><strong>cell 1</strong></td><td>cell 2</td></tr><tr><td><strong>cell 3</strong></td><td>cell 4</td></tr></tbody></table>');
   });
+
+  it('TINY-7227: Apply classes with variables', () => {
+    const editor = hook.editor();
+    editor.focus();
+    editor.formatter.register('formatA', { selector: 'p', classes: [ '%value' ] });
+
+    editor.setContent('<p>test</p>');
+    LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
+
+    editor.formatter.apply('formatA', { value: 'a' });
+    editor.formatter.apply('formatA', { value: 'b' });
+    assert.equal(getContent(editor), '<p class="a b">test</p>');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
@@ -278,12 +278,13 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.setContent('<p class="a b c">test</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
 
-    assert.isTrue(editor.formatter.match('formatA', { value: 'a' }), 'Should match since the onmatch matches on "A" value.');
-    assert.isTrue(editor.formatter.match('formatA', { value: 'b' }), 'Should match since the onmatch matches on "B" value.');
-    assert.isTrue(editor.formatter.match('formatA', { value: 'c' }), 'Should match since the onmatch matches on "C" value.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'a' }), 'Should match since the onmatch matches on "a" value.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'b' }), 'Should match since the onmatch matches on "b" value.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'c' }), 'Should match since the onmatch matches on "c" value.');
+    assert.isFalse(editor.formatter.match('formatA', { value: 'd' }), 'Should not match since the "d" class does not exist.');
   });
 
-  it('TINY-7227: mach whole value with spaces', () => {
+  it('TINY-7227: match whole value with spaces', () => {
     const editor = hook.editor();
     editor.formatter.register('format', { selector: 'p', classes: [ '%value' ] });
 

--- a/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
@@ -263,31 +263,31 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
 
   it('TINY-7227: match one class on an element with multiple classes', () => {
     const editor = hook.editor();
-    editor.formatter.register('formatB', { selector: 'p', attributes: { class: '%value' }});
+    editor.formatter.register('formatA', { selector: 'p', classes: [ '%value' ] });
 
     editor.setContent('<p class="a b c">test</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
 
-    assert.isTrue(editor.formatter.match('formatB', { value: 'b' }), 'Should match since the onmatch matches on "b" class.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'b' }), 'Should match since the onmatch matches on "b" class.');
   });
 
-  it('TINY-7227: match multiple values on an element with multiple attributes values', () => {
+  it('TINY-7227: match multiple values on an element with multiple classes', () => {
     const editor = hook.editor();
-    editor.formatter.register('formatA', { selector: 'p', attributes: { 'data-label': '%value' }});
+    editor.formatter.register('formatA', { selector: 'p', classes: [ '%value' ] });
 
-    editor.setContent('<p data-label="A B C">test</p>');
+    editor.setContent('<p class="a b c">test</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
 
-    assert.isTrue(editor.formatter.match('formatA', { value: 'A' }), 'Should match since the onmatch matches on "A" value.');
-    assert.isTrue(editor.formatter.match('formatA', { value: 'B' }), 'Should match since the onmatch matches on "B" value.');
-    assert.isTrue(editor.formatter.match('formatA', { value: 'C' }), 'Should match since the onmatch matches on "C" value.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'a' }), 'Should match since the onmatch matches on "A" value.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'b' }), 'Should match since the onmatch matches on "B" value.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'c' }), 'Should match since the onmatch matches on "C" value.');
   });
 
   it('TINY-7227: mach whole value with spaces', () => {
     const editor = hook.editor();
-    editor.formatter.register('format', { selector: 'p', attributes: { 'data-label': '%value' }});
+    editor.formatter.register('format', { selector: 'p', classes: [ '%value' ] });
 
-    editor.setContent('<p data-label="format plus">test</p>');
+    editor.setContent('<p class="format plus">test</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
 
     assert.isTrue(editor.formatter.match('format', { value: 'format plus' }), 'Should match since the onmatch matches on "format plus" value.');

--- a/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
@@ -271,17 +271,25 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     assert.isTrue(editor.formatter.match('formatB', { value: 'b' }), 'Should match since the onmatch matches on "b" class.');
   });
 
-  it('TINY-7227: match multiple classes on an element with multiple classes', () => {
+  it('TINY-7227: match multiple values on an element with multiple attributes values', () => {
     const editor = hook.editor();
-    editor.formatter.register('formatA', { selector: 'p', attributes: { class: '%value' }});
-    editor.formatter.register('formatB', { selector: 'p', attributes: { class: '%value' }});
-    editor.formatter.register('formatC', { selector: 'p', attributes: { class: '%value' }});
+    editor.formatter.register('formatA', { selector: 'p', attributes: { 'data-label': '%value' }});
 
-    editor.setContent('<p class="A B C">test</p>');
+    editor.setContent('<p data-label="A B C">test</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
 
-    assert.isTrue(editor.formatter.match('formatA', { value: 'A' }), 'Should match since the onmatch matches on "A" class.');
-    assert.isTrue(editor.formatter.match('formatB', { value: 'B' }), 'Should match since the onmatch matches on "B" class.');
-    assert.isTrue(editor.formatter.match('formatC', { value: 'C' }), 'Should match since the onmatch matches on "C" class.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'A' }), 'Should match since the onmatch matches on "A" value.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'B' }), 'Should match since the onmatch matches on "B" value.');
+    assert.isTrue(editor.formatter.match('formatA', { value: 'C' }), 'Should match since the onmatch matches on "C" value.');
+  });
+
+  it('TINY-7227: mach whole value with spaces', () => {
+    const editor = hook.editor();
+    editor.formatter.register('format', { selector: 'p', attributes: { 'data-label': '%value' }});
+
+    editor.setContent('<p data-label="format plus">test</p>');
+    LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
+
+    assert.isTrue(editor.formatter.match('format', { value: 'format plus' }), 'Should match since the onmatch matches on "format plus" value.');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
@@ -260,4 +260,28 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.selection.setRng(rng);
     assert.isFalse(editor.formatter.match('link'), 'No match on named anchor');
   });
+
+  it('TINY-7227: match one class on an element with multiple classes', () => {
+    const editor = hook.editor();
+    editor.formatter.register('formatB', { selector: 'p', attributes: { class: '%value' }});
+
+    editor.setContent('<p class="a b c">test</p>');
+    LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
+
+    assert.isTrue(editor.formatter.match('formatB', { value: 'b' }), 'Should match since the onmatch matches on "b" class.');
+  });
+
+  it('TINY-7227: match multiple classes on an element with multiple classes', () => {
+    const editor = hook.editor();
+    editor.formatter.register('formatA', { selector: 'p', attributes: { class: '%value' }});
+    editor.formatter.register('formatB', { selector: 'p', attributes: { class: '%value' }});
+    editor.formatter.register('formatC', { selector: 'p', attributes: { class: '%value' }});
+
+    editor.setContent('<p class="A B C">test</p>');
+    LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
+
+    assert.isTrue(editor.formatter.match('formatA', { value: 'A' }), 'Should match since the onmatch matches on "A" class.');
+    assert.isTrue(editor.formatter.match('formatB', { value: 'B' }), 'Should match since the onmatch matches on "B" class.');
+    assert.isTrue(editor.formatter.match('formatC', { value: 'C' }), 'Should match since the onmatch matches on "C" class.');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -593,4 +593,13 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.remove('underline');
     assert.equal(getContent(editor), '<p>test test</p>', 'Formatting on the space should not have been removed');
   });
+
+  it('TINY-7227: Remove classes with variables', () => {
+    const editor = hook.editor();
+    editor.formatter.register('formatA', { selector: 'p', classes: [ '%value' ] });
+    editor.setContent('<p class="a b">test</p>');
+    LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
+    editor.formatter.remove('formatA', { value: 'a' });
+    assert.equal(getContent(editor), '<p class="b">test</p>');
+  });
 });


### PR DESCRIPTION
Related Ticket: [7227](https://ephocks.atlassian.net/secure/RapidBoard.jspa?rapidView=116&modal=detail&selectedIssue=TINY-7227)

Description of Changes:
* Match multiple classes on the same element

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
