### PR TITLE
TINY-6625: Table plugin tries to perform operations on tables that contain the (inline) editor

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing type for `images_file_types` setting #GH-6607
 - The Oxide button text transform variable was incorrectly using `capitalize` instead of `none`. Patch contributed by dakur #GH-6341
 - Fix dialog button text that was using title-style capitalization #TINY-6816
+- Table plugin could perform operations on tables containing the inline editor #TINY-6625
 
 ## 5.7.1 - 2021-03-17
 

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -25,8 +25,8 @@ import * as RowDialog from '../ui/RowDialog';
 import * as TableDialog from '../ui/TableDialog';
 import { isPercentagesForced, isPixelsForced, isResponsiveForced } from './Settings';
 
-const getSelectionStartCellOrCaption = (editor: Editor) => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor));
-const getSelectionStartCell = (editor: Editor) => TableSelection.getSelectionStartCell(Util.getSelectionStart(editor));
+const getSelectionStartCellOrCaption = (editor: Editor) => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor), Util.getIsRoot(editor));
+const getSelectionStartCell = (editor: Editor) => TableSelection.getSelectionStartCell(Util.getSelectionStart(editor), Util.getIsRoot(editor));
 
 const registerCommands = (editor: Editor, actions: TableActions, cellSelection: CellSelectionApi, selections: Selections, clipboard: Clipboard) => {
   const isRoot = Util.getIsRoot(editor);
@@ -191,8 +191,7 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
     if (!Type.isObject(args)) {
       return;
     }
-
-    const cells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections);
+    const cells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, Util.getIsRoot(editor));
     if (cells.length === 0) {
       return;
     }

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -191,7 +191,7 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
     if (!Type.isObject(args)) {
       return;
     }
-    const cells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, Util.getIsRoot(editor));
+    const cells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, isRoot);
     if (cells.length === 0) {
       return;
     }

--- a/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
@@ -47,9 +47,8 @@ export const getSelectionTargets = (editor: Editor, selections: Selections): Sel
 
   const isCaption = SugarNode.isTag('caption');
   const isDisabledForSelection = (key: keyof ExtractedSelectionDetails) => selectionDetails.forall((details) => !details[key]);
-  const isRoot = Util.getIsRoot(editor);
 
-  const findTargets = (): Optional<RunOperation.CombinedTargets> => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor), isRoot)
+  const findTargets = (): Optional<RunOperation.CombinedTargets> => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor),  Util.getIsRoot(editor))
     .bind((cellOrCaption) => {
       const table = TableLookup.table(cellOrCaption);
       return table.map((table) => {

--- a/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
@@ -48,7 +48,7 @@ export const getSelectionTargets = (editor: Editor, selections: Selections): Sel
   const isCaption = SugarNode.isTag('caption');
   const isDisabledForSelection = (key: keyof ExtractedSelectionDetails) => selectionDetails.forall((details) => !details[key]);
 
-  const findTargets = (): Optional<RunOperation.CombinedTargets> => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor),  Util.getIsRoot(editor))
+  const findTargets = (): Optional<RunOperation.CombinedTargets> => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor), Util.getIsRoot(editor))
     .bind((cellOrCaption) => {
       const table = TableLookup.table(cellOrCaption);
       return table.map((table) => {

--- a/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
@@ -47,8 +47,9 @@ export const getSelectionTargets = (editor: Editor, selections: Selections): Sel
 
   const isCaption = SugarNode.isTag('caption');
   const isDisabledForSelection = (key: keyof ExtractedSelectionDetails) => selectionDetails.forall((details) => !details[key]);
+  const isRoot = Util.getIsRoot(editor);
 
-  const findTargets = (): Optional<RunOperation.CombinedTargets> => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor))
+  const findTargets = (): Optional<RunOperation.CombinedTargets> => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor), isRoot)
     .bind((cellOrCaption) => {
       const table = TableLookup.table(cellOrCaption);
       return table.map((table) => {

--- a/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
@@ -16,10 +16,10 @@ const getSelectionStartCellFallback = (start: SugarElement<Node>) =>
     TableSelection.retrieve(table, ephemera.firstSelectedSelector)
   ).fold(() => start, (cells) => cells[0]);
 
-const getSelectionStartFromSelector = <T extends Element>(selector: string) => (start: SugarElement<Node>) => {
+const getSelectionStartFromSelector = <T extends Element>(selector: string) => (start: SugarElement<Node>, isRoot?: (el: SugarElement<Node>) => boolean) => {
   const startCellName = SugarNode.name(start);
   const startCell = startCellName === 'col' || startCellName === 'colgroup' ? getSelectionStartCellFallback(start) : start;
-  return SelectorFind.closest<T>(startCell, selector);
+  return SelectorFind.closest<T>(startCell, selector, isRoot);
 };
 
 const getSelectionStartCaption = getSelectionStartFromSelector<HTMLTableCaptionElement>('caption');

--- a/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
@@ -28,8 +28,8 @@ const getSelectionStartCell = getSelectionStartFromSelector<HTMLTableCellElement
 
 const getSelectionStartCellOrCaption = getSelectionStartFromSelector<HTMLTableCellElement | HTMLTableCaptionElement>('th,td,caption');
 
-const getCellsFromSelection = (start: SugarElement<Node>, selections: Selections): SugarElement<HTMLTableCellElement>[] =>
-  getSelectionStartCell(start)
+const getCellsFromSelection = (start: SugarElement<Node>, selections: Selections, isRoot?: (el: SugarElement<Node>) => boolean): SugarElement<HTMLTableCellElement>[] =>
+  getSelectionStartCell(start, isRoot)
     .map((_cell) => CellOpSelection.selection(selections))
     .getOr([]);
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -157,7 +157,7 @@ const open = (editor: Editor, insertNewTable: boolean) => {
   // 3. isNew == false && selection parent isn't a table - open dialog with default values and insert a table
 
   if (insertNewTable === false) {
-    tableElm = dom.getParent(editor.selection.getStart(), 'table');
+    tableElm = dom.getParent(editor.selection.getStart(), 'table', editor.getBody());
     if (tableElm) {
       // Case 2 - isNew == false && table parent
       data = Helpers.extractDataFromTableElement(editor, tableElm, hasAdvancedTableTab(editor));

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -2,14 +2,14 @@ import { Mouse, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Html, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
-import {assert} from 'chai';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as EditorFocus from 'tinymce/core/focus/EditorFocus';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-const count = (selector: string) => UiFinder.findAllIn(SugarBody.body(), selector).length
+const count = (selector: string) => UiFinder.findAllIn(SugarBody.body(), selector).length;
 
 describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
   const setupElement = () => {
@@ -79,9 +79,9 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
     it('TINY-6625: mceTableInsertRowBefore', () => {
       const editor = hook.editor();
       focusEditor(editor);
-      const beforeCount = count('tr')
+      const beforeCount = count('tr');
       editor.execCommand('mceTableInsertRowBefore');
-      assert.equal(count('tr'), beforeCount)
+      assert.equal(count('tr'), beforeCount);
     });
 
     it('TINY-6625: mceTableInsertRowAfter', () => {
@@ -89,7 +89,7 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
       focusEditor(editor);
       const beforeCount = count('tr');
       editor.execCommand('mceTableInsertRowAfter');
-      assert.equal(count('tr'), beforeCount)
+      assert.equal(count('tr'), beforeCount);
     });
 
     it('TINY-6625: mceTableInsertColBefore', () => {
@@ -97,7 +97,7 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
       focusEditor(editor);
       const beforeCount = count('td');
       editor.execCommand('mceTableInsertColBefore');
-      assert.equal(count('td'), beforeCount)
+      assert.equal(count('td'), beforeCount);
     });
 
     it('TINY-6625: mceTableInsertColAfter', () => {
@@ -105,7 +105,7 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
       focusEditor(editor);
       const beforeCount = count('td');
       editor.execCommand('mceTableInsertColAfter');
-      assert.equal(count('td'), beforeCount)
+      assert.equal(count('td'), beforeCount);
     });
 
     it('TINY-6625: mceTableDeleteCol', () => {
@@ -113,7 +113,7 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
       focusEditor(editor);
       const beforeCount = count('td');
       editor.execCommand('mceTableDeleteCol');
-      assert.equal(count('td'), beforeCount)
+      assert.equal(count('td'), beforeCount);
     });
 
     it('TINY-6625: mceTableDeleteRow', () => {
@@ -121,7 +121,7 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
       focusEditor(editor);
       const beforeCount = count('tr');
       editor.execCommand('mceTableDeleteRow');
-      assert.equal(count('tr'), beforeCount)
+      assert.equal(count('tr'), beforeCount);
     });
 
     it('TINY-6625: mceTableDelete', () => {
@@ -129,7 +129,7 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
       focusEditor(editor);
       const beforeCount = count('table');
       editor.execCommand('mceTableDelete');
-      assert.equal(count('table'), beforeCount)
+      assert.equal(count('table'), beforeCount);
     });
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -1,9 +1,10 @@
 import { Mouse, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Html, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
+import * as EditorFocus from 'tinymce/core/focus/EditorFocus';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
@@ -35,13 +36,31 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
     inline: true,
     base_url: '/project/tinymce/js/tinymce',
     plugins: 'table',
-    menubar: false,
+    menubar: 'table',
     statusbar: false
   }, setupElement, [ Plugin, Theme ]);
+
+  const focusEditor = (editor: Editor) => {
+    EditorFocus.focus(editor, false);
+  };
+
+  const pWaitForMenuBar = (editor: Editor) => TinyUiActions.pWaitForUi(editor, '.tox-menubar');
+
+  const pAssertMenuButtonDisabled = (editor: Editor, selector: string, disabled: boolean) =>
+    TinyUiActions.pWaitForUi(editor, `div.tox-collection__item[title="${selector}"][aria-disabled="${disabled}"]`);
 
   it('TBA: Table outside of inline editor should not become resizable', () => {
     const editor = hook.editor();
     Mouse.mouseOver(TinyDom.targetElement(editor));
     UiFinder.notExists(SugarBody.body(), 'div[data-row="0"]');
+  });
+
+  it('TINY-6625: Table outside of inline editor should not be accessible for deleting', async () => {
+    const editor = hook.editor();
+    focusEditor(editor);
+    await pWaitForMenuBar(editor);
+    TinyUiActions.clickOnMenu(editor, 'span:contains("Table")');
+    // Expect "Delete table" menu button to be disabled
+    await pAssertMenuButtonDisabled(editor, "Delete table", true);
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -61,6 +61,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
     await pWaitForMenuBar(editor);
     TinyUiActions.clickOnMenu(editor, 'span:contains("Table")');
     // Expect "Delete table" menu button to be disabled
-    await pAssertMenuButtonDisabled(editor, "Delete table", true);
+    await pAssertMenuButtonDisabled(editor, 'Delete table', true);
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -1,11 +1,10 @@
 import { Mouse, UiFinder } from '@ephox/agar';
-import { context, describe, it } from '@ephox/bedrock-client';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Html, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import * as EditorFocus from 'tinymce/core/focus/EditorFocus';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
@@ -43,9 +42,10 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
     statusbar: false
   }, setupElement, [ Plugin, Theme ]);
 
-  const focusEditor = (editor: Editor) => {
-    EditorFocus.focus(editor, false);
-  };
+  beforeEach(() => {
+    const editor = hook.editor();
+    editor.focus();
+  });
 
   const pWaitForMenuBar = (editor: Editor) => TinyUiActions.pWaitForUi(editor, '.tox-menubar');
 
@@ -60,7 +60,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
 
   it('TINY-6625: Table menu items of inline editor shoud be disabled', async () => {
     const editor = hook.editor();
-    focusEditor(editor);
     await pWaitForMenuBar(editor);
     TinyUiActions.clickOnMenu(editor, 'span:contains("Table")');
     await pAssertMenuButtonDisabled(editor, 'Delete table', true);
@@ -70,7 +69,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
   context('TINY-6625: Table outside of inline editor should not be affected by table plugin commands', () => {
     it('TINY-6625: mceTableApplyCellStyle', () => {
       const editor = hook.editor();
-      focusEditor(editor);
       editor.execCommand('mceTableApplyCellStyle', false, { 'background-color': 'pink' });
       const td = editor.getBody().parentElement;
       assert.notEqual(td.style.backgroundColor, 'pink');
@@ -78,7 +76,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
 
     it('TINY-6625: mceTableInsertRowBefore', () => {
       const editor = hook.editor();
-      focusEditor(editor);
       const beforeCount = count('tr');
       editor.execCommand('mceTableInsertRowBefore');
       assert.equal(count('tr'), beforeCount);
@@ -86,7 +83,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
 
     it('TINY-6625: mceTableInsertRowAfter', () => {
       const editor = hook.editor();
-      focusEditor(editor);
       const beforeCount = count('tr');
       editor.execCommand('mceTableInsertRowAfter');
       assert.equal(count('tr'), beforeCount);
@@ -94,7 +90,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
 
     it('TINY-6625: mceTableInsertColBefore', () => {
       const editor = hook.editor();
-      focusEditor(editor);
       const beforeCount = count('td');
       editor.execCommand('mceTableInsertColBefore');
       assert.equal(count('td'), beforeCount);
@@ -102,7 +97,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
 
     it('TINY-6625: mceTableInsertColAfter', () => {
       const editor = hook.editor();
-      focusEditor(editor);
       const beforeCount = count('td');
       editor.execCommand('mceTableInsertColAfter');
       assert.equal(count('td'), beforeCount);
@@ -110,7 +104,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
 
     it('TINY-6625: mceTableDeleteCol', () => {
       const editor = hook.editor();
-      focusEditor(editor);
       const beforeCount = count('td');
       editor.execCommand('mceTableDeleteCol');
       assert.equal(count('td'), beforeCount);
@@ -118,7 +111,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
 
     it('TINY-6625: mceTableDeleteRow', () => {
       const editor = hook.editor();
-      focusEditor(editor);
       const beforeCount = count('tr');
       editor.execCommand('mceTableDeleteRow');
       assert.equal(count('tr'), beforeCount);
@@ -126,7 +118,6 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
 
     it('TINY-6625: mceTableDelete', () => {
       const editor = hook.editor();
-      focusEditor(editor);
       const beforeCount = count('table');
       editor.execCommand('mceTableDelete');
       assert.equal(count('table'), beforeCount);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -58,7 +58,7 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
     UiFinder.notExists(SugarBody.body(), 'div[data-row="0"]');
   });
 
-  it('TINY-6625: Table menu items shoud be disabled', async () => {
+  it('TINY-6625: Table menu items of inline editor shoud be disabled', async () => {
     const editor = hook.editor();
     focusEditor(editor);
     await pWaitForMenuBar(editor);
@@ -67,7 +67,7 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
     await pAssertMenuButtonDisabled(editor, 'Table properties', true);
   });
 
-  context('TINY-6625: Table plugin commands should not affect outside table', () => {
+  context('TINY-6625: Table outside of inline editor should not be affected by table plugin commands', () => {
     it('TINY-6625: mceTableApplyCellStyle', () => {
       const editor = hook.editor();
       focusEditor(editor);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -1,12 +1,15 @@
 import { Mouse, UiFinder } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Html, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import {assert} from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as EditorFocus from 'tinymce/core/focus/EditorFocus';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
+
+const count = (selector: string) => UiFinder.findAllIn(SugarBody.body(), selector).length
 
 describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
   const setupElement = () => {
@@ -55,12 +58,78 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
     UiFinder.notExists(SugarBody.body(), 'div[data-row="0"]');
   });
 
-  it('TINY-6625: Table outside of inline editor should not be accessible for deleting', async () => {
+  it('TINY-6625: Table menu items shoud be disabled', async () => {
     const editor = hook.editor();
     focusEditor(editor);
     await pWaitForMenuBar(editor);
     TinyUiActions.clickOnMenu(editor, 'span:contains("Table")');
-    // Expect "Delete table" menu button to be disabled
     await pAssertMenuButtonDisabled(editor, 'Delete table', true);
+    await pAssertMenuButtonDisabled(editor, 'Table properties', true);
+  });
+
+  context('TINY-6625: Table plugin commands should not affect outside table', () => {
+    it('TINY-6625: mceTableApplyCellStyle', () => {
+      const editor = hook.editor();
+      focusEditor(editor);
+      editor.execCommand('mceTableApplyCellStyle', false, { 'background-color': 'pink' });
+      const td = editor.getBody().parentElement;
+      assert.notEqual(td.style.backgroundColor, 'pink');
+    });
+
+    it('TINY-6625: mceTableInsertRowBefore', () => {
+      const editor = hook.editor();
+      focusEditor(editor);
+      const beforeCount = count('tr')
+      editor.execCommand('mceTableInsertRowBefore');
+      assert.equal(count('tr'), beforeCount)
+    });
+
+    it('TINY-6625: mceTableInsertRowAfter', () => {
+      const editor = hook.editor();
+      focusEditor(editor);
+      const beforeCount = count('tr');
+      editor.execCommand('mceTableInsertRowAfter');
+      assert.equal(count('tr'), beforeCount)
+    });
+
+    it('TINY-6625: mceTableInsertColBefore', () => {
+      const editor = hook.editor();
+      focusEditor(editor);
+      const beforeCount = count('td');
+      editor.execCommand('mceTableInsertColBefore');
+      assert.equal(count('td'), beforeCount)
+    });
+
+    it('TINY-6625: mceTableInsertColAfter', () => {
+      const editor = hook.editor();
+      focusEditor(editor);
+      const beforeCount = count('td');
+      editor.execCommand('mceTableInsertColAfter');
+      assert.equal(count('td'), beforeCount)
+    });
+
+    it('TINY-6625: mceTableDeleteCol', () => {
+      const editor = hook.editor();
+      focusEditor(editor);
+      const beforeCount = count('td');
+      editor.execCommand('mceTableDeleteCol');
+      assert.equal(count('td'), beforeCount)
+    });
+
+    it('TINY-6625: mceTableDeleteRow', () => {
+      const editor = hook.editor();
+      focusEditor(editor);
+      const beforeCount = count('tr');
+      editor.execCommand('mceTableDeleteRow');
+      assert.equal(count('tr'), beforeCount)
+    });
+
+    it('TINY-6625: mceTableDelete', () => {
+      const editor = hook.editor();
+      focusEditor(editor);
+      const beforeCount = count('table');
+      editor.execCommand('mceTableDelete');
+      assert.equal(count('table'), beforeCount)
+    });
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -8,7 +8,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-const count = (selector: string) => UiFinder.findAllIn(SugarBody.body(), selector).length;
+const findAll = (selector: string) => UiFinder.findAllIn(SugarBody.body(), selector);
 
 describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
   const setupElement = () => {
@@ -76,51 +76,44 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
 
     it('TINY-6625: mceTableInsertRowBefore', () => {
       const editor = hook.editor();
-      const beforeCount = count('tr');
       editor.execCommand('mceTableInsertRowBefore');
-      assert.equal(count('tr'), beforeCount);
+      assert.lengthOf(findAll('tr'), 1);
     });
 
     it('TINY-6625: mceTableInsertRowAfter', () => {
       const editor = hook.editor();
-      const beforeCount = count('tr');
       editor.execCommand('mceTableInsertRowAfter');
-      assert.equal(count('tr'), beforeCount);
+      assert.lengthOf(findAll('tr'), 1);
     });
 
     it('TINY-6625: mceTableInsertColBefore', () => {
       const editor = hook.editor();
-      const beforeCount = count('td');
       editor.execCommand('mceTableInsertColBefore');
-      assert.equal(count('td'), beforeCount);
+      assert.lengthOf(findAll('td'), 1);
     });
 
     it('TINY-6625: mceTableInsertColAfter', () => {
       const editor = hook.editor();
-      const beforeCount = count('td');
       editor.execCommand('mceTableInsertColAfter');
-      assert.equal(count('td'), beforeCount);
+      assert.lengthOf(findAll('td'), 1);
     });
 
     it('TINY-6625: mceTableDeleteCol', () => {
       const editor = hook.editor();
-      const beforeCount = count('td');
       editor.execCommand('mceTableDeleteCol');
-      assert.equal(count('td'), beforeCount);
+      assert.lengthOf(findAll('td'), 1);
     });
 
     it('TINY-6625: mceTableDeleteRow', () => {
       const editor = hook.editor();
-      const beforeCount = count('tr');
       editor.execCommand('mceTableDeleteRow');
-      assert.equal(count('tr'), beforeCount);
+      assert.lengthOf(findAll('tr'), 1);
     });
 
     it('TINY-6625: mceTableDelete', () => {
       const editor = hook.editor();
-      const beforeCount = count('table');
       editor.execCommand('mceTableDelete');
-      assert.equal(count('table'), beforeCount);
+      assert.lengthOf(findAll('table'), 1);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-6625

Description of Changes:
* Placeholder text

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
