### PR TITLE
TINY-6263: Fix `editor.insertContent` incorrectly handling nested style spans

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The color picker dialog will now show an alert if it is submitted with an invalid hex color code #TINY-2814
 - Fixed a bug where the `TableModified` event was not fired when adding a table row via the Tab key #TINY-7006
 - Added missing type for `images_file_types` setting #GH-6607
+- The `editor.insertContent` API was incorrectly handling nested matching style `span` elements #TINY-6263
 - The HTML5 `small` element could not be removed when clearing text formatting #TINY-6633
 - Added HTML5 `audio` and `video` elements to the default alignment formats #TINY-6633
 - The Oxide button text transform variable was incorrectly using `capitalize` instead of `none`. Patch contributed by dakur #GH-6341

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The color picker dialog will now show an alert if it is submitted with an invalid hex color code #TINY-2814
 - Fixed a bug where the `TableModified` event was not fired when adding a table row via the Tab key #TINY-7006
 - Added missing type for `images_file_types` setting #GH-6607
-- The `editor.insertContent` API was incorrectly handling nested matching style `span` elements #TINY-6263
+- The `editor.insertContent` API was incorrectly handling nested `span` elements with matching styles #TINY-6263
 - The HTML5 `small` element could not be removed when clearing text formatting #TINY-6633
 - Added HTML5 `audio` and `video` elements to the default alignment formats #TINY-6633
 - The Oxide button text transform variable was incorrectly using `capitalize` instead of `none`. Patch contributed by dakur #GH-6341

--- a/modules/tinymce/src/core/main/ts/api/html/StyleUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/StyleUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import { Arr, Obj, Strings } from '@ephox/katamari';
-import DOMUtils from '../api/dom/DOMUtils';
+import DOMUtils from '../dom/DOMUtils';
 
 const nonInheritableStyles: Set<string> = new Set();
 (() => {

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -14,12 +14,12 @@ import Editor from '../api/Editor';
 import Env from '../api/Env';
 import AstNode from '../api/html/Node';
 import HtmlSerializer from '../api/html/Serializer';
+import * as StyleUtils from '../api/html/StyleUtils';
 import * as Settings from '../api/Settings';
 import Tools from '../api/util/Tools';
 import CaretPosition from '../caret/CaretPosition';
 import { CaretWalker } from '../caret/CaretWalker';
 import * as TableDelete from '../delete/TableDelete';
-import * as NodeStyleUtils from '../dom/NodeStyleUtils';
 import * as NodeType from '../dom/NodeType';
 import * as PaddingBr from '../dom/PaddingBr';
 import * as RangeNormalizer from '../selection/RangeNormalizer';
@@ -70,11 +70,11 @@ const reduceInlineTextElements = (editor: Editor, merge: boolean) => {
 
     Tools.each(dom.select('*[data-mce-fragment]'), (node) => {
       const isInline = Type.isNonNullable(textInlineElements[node.nodeName.toLowerCase()]);
-      if (isInline && NodeStyleUtils.hasInheritableStyles(dom, node)) {
+      if (isInline && StyleUtils.hasInheritableStyles(dom, node)) {
         for (let parentNode = node.parentNode; Type.isNonNullable(parentNode) && parentNode !== root; parentNode = parentNode.parentNode) {
           // Check if the parent has a style conflict that would prevent the child node from being safely removed,
           // even if a exact node match could be found further up the tree
-          const styleConflict = NodeStyleUtils.hasStyleConflict(dom, node, parentNode);
+          const styleConflict = StyleUtils.hasStyleConflict(dom, node, parentNode);
           if (styleConflict) {
             break;
           }

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -59,8 +59,8 @@ const trimBrsFromTableCell = (dom: DOMUtils, elm: Element) => {
 };
 
 const hasInheritableStyles = (styles: string[]): boolean => {
-  // TODO: <Jira> Figure out what else should go in the nonInheritableStyles list
-  // spans which have these styles should not get merged as they have non-inherited properties
+  // TINY-7326: Figure out what else should go in the nonInheritableStyles list
+  // Elements which have these styles should not get merged as they have non-inherited properties
   const nonInheritableStyles = [ 'margin', 'padding', 'border', 'background' ];
   return Arr.forall(styles, (nodeStyle) => Arr.forall(nonInheritableStyles, (nonInheritableStyle) => !Strings.startsWith(nodeStyle, nonInheritableStyle)));
 };
@@ -69,7 +69,7 @@ const hasInheritableStyles = (styles: string[]): boolean => {
 const reduceInlineTextElements = (editor: Editor, merge: boolean) => {
   const textInlineElements = editor.schema.getTextInlineElements();
   const dom = editor.dom;
-  // TODO: <Jira> Figure out what else should be added
+  // TINY-7326: Figure out what else should be added
   const shorthandCssProps = [ 'font', 'text-decoration', 'text-emphasis' ];
 
   if (merge) {

--- a/modules/tinymce/src/core/main/ts/dom/NodeStyleUtils.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeStyleUtils.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Arr, Obj, Strings } from '@ephox/katamari';
+import DOMUtils from '../api/dom/DOMUtils';
+
+const nonInheritableStyles: Set<string> = new Set();
+(() => {
+  // TODO: TINY-7326 Figure out what else should go in the nonInheritableStyles list
+  const nonInheritableStylesArr = [
+    'margin', 'margin-left', 'margin-right', 'margin-top', 'margin-bottom',
+    'padding', 'padding-left', 'padding-right', 'padding-top', 'padding-bottom',
+    'border', 'border-width', 'border-style', 'border-color',
+    'background', 'background-attachment', 'background-clip', 'background-color',
+    'background-image', 'background-origin', 'background-position', 'background-repeat', 'background-size',
+    'float', 'position', 'left', 'right', 'top', 'bottom',
+    'z-index', 'display', 'transform',
+    'width', 'max-width', 'min-width', 'height', 'max-height', 'min-height',
+    'overflow', 'overflow-x', 'overflow-y', 'text-overflow', 'vertical-align',
+    'transition', 'transition-delay', 'transition-duration', 'transition-property', 'transition-timing-function'
+  ];
+  Arr.each(nonInheritableStylesArr, (style) => {
+    nonInheritableStyles.add(style);
+  });
+})();
+
+// TODO: TINY-7326 Figure out what else should be added to the shorthandStyleProps list
+// Does not include non-inherited shorthand style properties
+const shorthandStyleProps = [ 'font', 'text-decoration', 'text-emphasis' ];
+
+const getStyleProps = (dom: DOMUtils, node: Node) =>
+  Obj.keys(dom.parseStyle(dom.getAttrib(node, 'style')));
+
+const isNonInheritableStyle = (style: string) => nonInheritableStyles.has(style);
+
+const hasInheritableStyles = (dom: DOMUtils, node: Node): boolean =>
+  Arr.forall(getStyleProps(dom, node), (style) => !isNonInheritableStyle(style));
+
+const getLonghandStyleProps = (styles: string[]): string[] =>
+  Arr.filter(styles, (style) => Arr.exists(shorthandStyleProps, (prop) => Strings.startsWith(style, prop)));
+
+const hasStyleConflict = (dom: DOMUtils, node: Node, parentNode: Node): boolean => {
+  const nodeStyleProps = getStyleProps(dom, node);
+  const parentNodeStyleProps = getStyleProps(dom, parentNode);
+
+  const valueMismatch = (prop: string) => {
+    const nodeValue = dom.getStyle(node, prop);
+    const parentValue = dom.getStyle(parentNode, prop);
+    return Strings.isNotEmpty(nodeValue) && Strings.isNotEmpty(parentValue) && nodeValue !== parentValue;
+  };
+
+  return Arr.exists(nodeStyleProps, (nodeStyleProp) => {
+    const propExists = (props: string[]) => Arr.exists(props, (prop) => prop === nodeStyleProp);
+    // If parent has a longhand property e.g. margin-left but the child (node) style is margin, need to get the margin-left value of node to be able to do a proper comparison
+    // This is because getting the style using the key of 'margin' on a 'margin-left' parent would give a string of space separated values or empty string depending on the browser
+    if (!propExists(parentNodeStyleProps) && propExists(shorthandStyleProps)) {
+      const longhandProps = getLonghandStyleProps(parentNodeStyleProps);
+      return Arr.exists(longhandProps, valueMismatch);
+    } else {
+      return valueMismatch(nodeStyleProp);
+    }
+  });
+};
+
+export {
+  hasInheritableStyles,
+  hasStyleConflict
+};

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -14,7 +14,8 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     disable_nodechange: true,
     entities: 'raw',
     indent: false,
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    content_style: '.red { color: red; background-color: red; } .blue { color: blue; background-color: blue; }'
   }, [ Theme ]);
 
   it('TBA: insertAtCaret - i inside text, converts to em', () => {
@@ -429,5 +430,149 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     '</span>' +
     '</span>' +
     '</p>');
+  });
+
+  it('TINY-6263: insertAtCaret - spans with non-inheritable styles should not merge', () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    InsertContent.insertAtCaret(editor, {
+      content: '<p>' +
+        '<span style="margin: 5px;">' +
+        '<span style="margin-left: 5px; margin-right: 5px;">' +
+        '<span style="margin: 5px;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>' +
+        '<p>' +
+        '<span style="border-style: solid;">' +
+        '<span style="border: solid red;">' +
+        '<span style="border-style: solid;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>',
+      merge: true
+    });
+    TinyAssertions.assertContent(editor, '<p>' +
+    '<span style="margin: 5px;">' +
+    '<span style="margin-left: 5px; margin-right: 5px;">' +
+    '<span style="margin: 5px;">test</span>' +
+    '</span>' +
+    '</span>' +
+    '</p>' +
+    '<p>' +
+    '<span style="border-style: solid;">' +
+    '<span style="border: solid red;">' +
+    '<span style="border-style: solid;">test</span>' +
+    '</span>' +
+    '</span>' +
+    '</p>');
+  });
+
+  it('TINY-6263: insertAtCaret - shorthand styles with longhand properties in-between', () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    InsertContent.insertAtCaret(editor, {
+      content: '<p>' +
+        '<span style="text-decoration: underline dotted;">' +
+        '<span style="text-decoration-style: dotted;">' +
+        '<span style="text-decoration: underline dotted;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>' +
+        '<p>' +
+        '<span style="text-decoration: underline dotted;">' +
+        '<span style="text-decoration-style: dashsed;">' +
+        '<span style="text-decoration: underline dotted;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>',
+      merge: true
+    });
+    TinyAssertions.assertContent(editor, '<p>' +
+      '<span style="text-decoration: underline dotted;">' +
+      '<span style="text-decoration-style: dotted;">test</span>' +
+      '</span>' +
+      '</p>' +
+      '<p>' +
+      '<span style="text-decoration: underline dotted;">' +
+      '<span style="text-decoration-style: dashsed;">' +
+      '<span style="text-decoration: underline dotted;">test</span>' +
+      '</span>' +
+      '</span>' +
+      '</p>');
+  });
+
+  it('TINY-6263: insertAtCaret - longhand style spans with shorthand style span in-between', () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    InsertContent.insertAtCaret(editor, {
+      content: '<p>' +
+        '<span style="font-style: italic;">' +
+        '<span style="font: italic 12px sans-serif;">' +
+        '<span style="font-style: italic;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>' +
+        '<p>' +
+        '<span style="font-size: 10px;">' +
+        '<span style="font: italic 12px sans-serif;">' +
+        '<span style="font-size: 10px;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>',
+      merge: true
+    });
+    TinyAssertions.assertContent(editor, '<p>' +
+      '<span style="font-style: italic;">' +
+      '<span style="font: italic 12px sans-serif;">test</span>' +
+      '</span>' +
+      '</p>' +
+      '<p>' +
+      '<span style="font-size: 10px;">' +
+      '<span style="font: italic 12px sans-serif;">' +
+      '<span style="font-size: 10px;">test</span>' +
+      '</span>' +
+      '</span>' +
+      '</p>');
+  });
+
+  it('TINY-6263: insertAtCaret - merge spans with class style in-between (check computed style detects style from class)', () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    InsertContent.insertAtCaret(editor, {
+      content: '<p>' +
+        '<span style="color: red; font-size: 9pt;">' +
+        '<span class="red">' +
+        '<span style="color: red; font-size: 9pt;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>' +
+        '<p>' +
+        '<span style="color: red; font-size: 9pt;">' +
+        '<span class="blue">' +
+        '<span style="color: red; font-size: 9pt;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>',
+      merge: true
+    });
+    TinyAssertions.assertContent(editor, '<p>' +
+      '<span style="color: red; font-size: 9pt;">' +
+      '<span class="red">test</span>' +
+      '</span>' +
+      '</p>' +
+      '<p>' +
+      '<span style="color: red; font-size: 9pt;">' +
+      '<span class="blue">' +
+      '<span style="color: red; font-size: 9pt;">test</span>' +
+      '</span>' +
+      '</span>' +
+      '</p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -14,8 +14,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     disable_nodechange: true,
     entities: 'raw',
     indent: false,
-    base_url: '/project/tinymce/js/tinymce',
-    content_style: '.red { color: red; background-color: red; } .blue { color: blue; background-color: blue; }'
+    base_url: '/project/tinymce/js/tinymce'
   }, [ Theme ]);
 
   it('TBA: insertAtCaret - i inside text, converts to em', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -475,30 +475,30 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     TinySelections.setCursor(editor, [ 0 ], 0);
     InsertContent.insertAtCaret(editor, {
       content: '<p>' +
-        '<span style="text-decoration: underline dotted;">' +
-        '<span style="text-decoration-style: dotted;">' +
-        '<span style="text-decoration: underline dotted;">test</span>' +
+        '<span style="font: italic 10px sans-serif;">' +
+        '<span style="font-size: 10px;">' +
+        '<span style="font: italic 10px sans-serif;">test</span>' +
         '</span>' +
         '</span>' +
         '</p>' +
         '<p>' +
-        '<span style="text-decoration: underline dotted;">' +
-        '<span style="text-decoration-style: dashsed;">' +
-        '<span style="text-decoration: underline dotted;">test</span>' +
+        '<span style="font: italic 10px sans-serif;">' +
+        '<span style="font-size: 12px;">' +
+        '<span style="font: italic 10px sans-serif;">test</span>' +
         '</span>' +
         '</span>' +
         '</p>',
       merge: true
     });
     TinyAssertions.assertContent(editor, '<p>' +
-      '<span style="text-decoration: underline dotted;">' +
-      '<span style="text-decoration-style: dotted;">test</span>' +
+      '<span style="font: italic 10px sans-serif;">' +
+      '<span style="font-size: 10px;">test</span>' +
       '</span>' +
       '</p>' +
       '<p>' +
-      '<span style="text-decoration: underline dotted;">' +
-      '<span style="text-decoration-style: dashsed;">' +
-      '<span style="text-decoration: underline dotted;">test</span>' +
+      '<span style="font: italic 10px sans-serif;">' +
+      '<span style="font-size: 12px;">' +
+      '<span style="font: italic 10px sans-serif;">test</span>' +
       '</span>' +
       '</span>' +
       '</p>');
@@ -536,41 +536,6 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       '<span style="font-size: 10px;">' +
       '<span style="font: italic 12px sans-serif;">' +
       '<span style="font-size: 10px;">test</span>' +
-      '</span>' +
-      '</span>' +
-      '</p>');
-  });
-
-  it('TINY-6263: insertAtCaret - merge spans with class style in-between (check computed style detects style from class)', () => {
-    const editor = hook.editor();
-    editor.setContent('');
-    TinySelections.setCursor(editor, [ 0 ], 0);
-    InsertContent.insertAtCaret(editor, {
-      content: '<p>' +
-        '<span style="color: red; font-size: 9pt;">' +
-        '<span class="red">' +
-        '<span style="color: red; font-size: 9pt;">test</span>' +
-        '</span>' +
-        '</span>' +
-        '</p>' +
-        '<p>' +
-        '<span style="color: red; font-size: 9pt;">' +
-        '<span class="blue">' +
-        '<span style="color: red; font-size: 9pt;">test</span>' +
-        '</span>' +
-        '</span>' +
-        '</p>',
-      merge: true
-    });
-    TinyAssertions.assertContent(editor, '<p>' +
-      '<span style="color: red; font-size: 9pt;">' +
-      '<span class="red">test</span>' +
-      '</span>' +
-      '</p>' +
-      '<p>' +
-      '<span style="color: red; font-size: 9pt;">' +
-      '<span class="blue">' +
-      '<span style="color: red; font-size: 9pt;">test</span>' +
       '</span>' +
       '</span>' +
       '</p>');

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -351,4 +351,83 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     InsertContent.insertAtCaret(editor, ' <strong> a </strong> ');
     TinyAssertions.assertContent(editor, '<pre> <strong> a </strong> </pre>');
   });
+
+  it('TINY-6263: insertAtCaret - merge font-size spans', () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    InsertContent.insertAtCaret(editor, {
+      content: '<p>' +
+        '<span style="font-size: 9pt;">' +
+        '<span style="font-size: 14pt;">' +
+        '<span style="font-size: 9pt;">' +
+        '<span style="font-size: 9pt;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>',
+      merge: true
+    });
+    TinyAssertions.assertContent(editor, '<p>' +
+      '<span style="font-size: 9pt;">' +
+      '<span style="font-size: 14pt;">' +
+      '<span style="font-size: 9pt;">test</span>' +
+      '</span>' +
+      '</span>' +
+      '</p>');
+  });
+
+  it('TINY-6263: insertAtCaret - merge spans with similar node in-between', () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    InsertContent.insertAtCaret(editor, {
+      content: '<p>' +
+        '<span style="color: red; font-size: 9pt;">' +
+        '<span style="background-color: red; color: red;">' +
+        '<span style="color: red; font-size: 9pt;">test</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>',
+      merge: true
+    });
+    TinyAssertions.assertContent(editor, '<p>' +
+      '<span style="color: red; font-size: 9pt;">' +
+      '<span style="background-color: red; color: red;">test</span>' +
+      '</span>' +
+      '</p>');
+  });
+
+  it('TINY-6263: insertAtCaret - merge font colors with other surrounding inline elements in-between', () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    InsertContent.insertAtCaret(editor, {
+      content: '<p>' +
+        '<span style="color: yellow;">' +
+        '<span style="background-color: red;">' +
+        '<span style="color: yellow;">' +
+        '<span style="color: red;">red</span>' +
+        'yellow' +
+        '<span style="color: blue;">' +
+        '<strong>' +
+        '<span style="color: blue;">blue</span>' +
+        '</strong>' +
+        '</span>' +
+        '</span>' +
+        '</span>' +
+        '</span>' +
+        '</p>',
+      merge: true
+    });
+    TinyAssertions.assertContent(editor, '<p>' +
+    '<span style="color: yellow;">' +
+    '<span style="background-color: red;">' +
+    '<span style="color: red;">red</span>' +
+    'yellow' +
+    '<span style="color: blue;"><strong>blue</strong></span>' +
+    '</span>' +
+    '</span>' +
+    '</p>');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6263

Description of Changes:
* Fix an issue where `editor.insertContent` merged matching style spans without checking if another in-between node had the same style, but a different value

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)
* [X] License headers added on new files (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
