### PR TITLE
TINY-7258: redirected unsupported api calls to rtc plugin

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -27,6 +27,8 @@ import { addVisualInternal } from './view/VisualAidsImpl';
 /** API implemented by the RTC plugin */
 interface RtcRuntimeApi {
   undoManager: {
+    beforeChange: () => void;
+    add: () => UndoLevel;
     undo: () => UndoLevel;
     redo: () => UndoLevel;
     hasUndo: () => boolean;
@@ -40,6 +42,8 @@ interface RtcRuntimeApi {
   formatter: {
     canApply: (format: string) => boolean;
     match: (format: string, vars: Record<string, string>) => boolean;
+    matchAll: () => string[];
+    matchNode: () => boolean;
     closest: (formats: string) => string;
     apply: (format: string, vars: Record<string, string>) => void;
     remove: (format: string, vars: Record<string, string>) => void;
@@ -50,6 +54,7 @@ interface RtcRuntimeApi {
     getContent: (args: GetContentArgs) => Content;
     setContent: (content: Content, args: SetContentArgs) => Content;
     insertContent: (content: Content) => void;
+    addVisual: () => void;
   };
   selection: {
     getContent: (args: GetSelectionContentArgs) => Content;
@@ -66,7 +71,7 @@ interface RtcRuntimeApi {
 interface RtcAdaptor {
   undoManager: {
     beforeChange: (locks: Locks, beforeBookmark: UndoBookmark) => void;
-    addUndoLevel: (
+    add: (
       undoManager: UndoManager,
       index: Index,
       locks: Locks,
@@ -121,7 +126,7 @@ interface RtcEditor extends Editor {
 const makePlainAdaptor = (editor: Editor): RtcAdaptor => ({
   undoManager: {
     beforeChange: (locks, beforeBookmark) => Operations.beforeChange(editor, locks, beforeBookmark),
-    addUndoLevel: (undoManager, index, locks, beforeBookmark, level, event) =>
+    add: (undoManager, index, locks, beforeBookmark, level, event) =>
       Operations.addUndoLevel(editor, undoManager, index, locks, beforeBookmark, level, event),
     undo: (undoManager, locks, index) => Operations.undo(editor, undoManager, locks, index),
     redo: (index, data) => Operations.redo(editor, index, data),
@@ -161,28 +166,26 @@ const makePlainAdaptor = (editor: Editor): RtcAdaptor => ({
 
 const makeRtcAdaptor = (rtcEditor: RtcRuntimeApi): RtcAdaptor => {
   const defaultVars = (vars: Record<string, string>) => Type.isObject(vars) ? vars : {};
-  const unsupported = Fun.die('Unimplemented feature for rtc');
   const { undoManager, formatter, editor, selection, raw } = rtcEditor;
-  const ignore = Fun.noop;
 
   return {
     undoManager: {
-      beforeChange: ignore,
-      addUndoLevel: unsupported,
-      undo: () => undoManager.undo(),
-      redo: () => undoManager.redo(),
-      clear: () => undoManager.clear(),
-      reset: () => undoManager.reset(),
-      hasUndo: () => undoManager.hasUndo(),
-      hasRedo: () => undoManager.hasRedo(),
+      beforeChange: undoManager.beforeChange,
+      add: undoManager.add,
+      undo: undoManager.undo,
+      redo: undoManager.redo,
+      clear: undoManager.clear,
+      reset: undoManager.reset,
+      hasUndo: undoManager.hasUndo,
+      hasRedo: undoManager.hasRedo,
       transact: (_undoManager, _locks, fn) => undoManager.transact(fn),
       ignore: (_locks, callback) => undoManager.ignore(callback),
       extra: (_undoManager, _index, callback1, callback2) => undoManager.extra(callback1, callback2)
     },
     formatter: {
       match: (name, vars?, _node?) => formatter.match(name, defaultVars(vars)),
-      matchAll: unsupported,
-      matchNode: unsupported,
+      matchAll: formatter.matchAll,
+      matchNode: formatter.matchNode,
       canApply: (name) => formatter.canApply(name),
       closest: (names) => formatter.closest(names),
       apply: (name, vars, _node) => formatter.apply(name, defaultVars(vars)),
@@ -194,7 +197,7 @@ const makeRtcAdaptor = (rtcEditor: RtcRuntimeApi): RtcAdaptor => {
       getContent: (args, _format) => editor.getContent(args),
       setContent: (content, args) => editor.setContent(content, args),
       insertContent: (content, _details) => editor.insertContent(content),
-      addVisual: ignore
+      addVisual: editor.addVisual
     },
     selection: {
       getContent: (_format, args) => selection.getContent(args)
@@ -212,7 +215,7 @@ const makeNoopAdaptor = (): RtcAdaptor => {
   return {
     undoManager: {
       beforeChange: Fun.noop,
-      addUndoLevel: nul,
+      add: nul,
       undo: nul,
       redo: nul,
       clear: Fun.noop,
@@ -304,7 +307,7 @@ export const addUndoLevel = (
   level?: UndoLevel,
   event?: Event
 ): UndoLevel =>
-  getRtcInstanceWithError(editor).undoManager.addUndoLevel(undoManager, index, locks, beforeBookmark, level, event);
+  getRtcInstanceWithError(editor).undoManager.add(undoManager, index, locks, beforeBookmark, level, event);
 
 export const undo = (editor: Editor, undoManager: UndoManager, locks: Locks, index: Index): UndoLevel =>
   getRtcInstanceWithError(editor).undoManager.undo(undoManager, locks, index);


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This redirects more things to the rtc plugin so that it has the responsibility to display errors/log/ignore things. Doesn't need to be in 5.8 but it wouldn't hurt.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] License headers added on new files (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
