### PR TITLE
TINY-6638: Allow table tab navigation with ranged selections

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added HTML5 `audio` and `video` elements to the default alignment formats #TINY-6633
 - The Oxide button text transform variable was incorrectly using `capitalize` instead of `none`. Patch contributed by dakur #GH-6341
 - Fix dialog button text that was using title-style capitalization #TINY-6816
+- Fixed Tab key navigation inside table cells with a ranged selection #TINY-6638
 
 ## 5.7.1 - 2021-03-17
 

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -50,7 +50,7 @@ const Plugin = (editor: Editor) => {
 
   if (hasTabNavigation(editor)) {
     editor.on('keydown', (e: KeyboardEvent) => {
-      TabContext.handle(e, editor);
+      TabContext.handle(e, editor, cellSelection);
     });
   }
 

--- a/modules/tinymce/src/plugins/table/main/ts/queries/TabContext.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/TabContext.ts
@@ -13,6 +13,7 @@ import Editor from 'tinymce/core/api/Editor';
 import VK from 'tinymce/core/api/util/VK';
 
 import * as Util from '../core/Util';
+import { CellSelectionApi } from '../selection/CellSelection';
 
 const forward = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: SugarElement<HTMLTableCellElement>) => {
   return go(editor, isRoot, CellNavigation.next(cell));
@@ -51,7 +52,7 @@ const go = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: CellLoca
 
 const rootElements = [ 'table', 'li', 'dl' ];
 
-const handle = (event: KeyboardEvent, editor: Editor) => {
+const handle = (event: KeyboardEvent, editor: Editor, cellSelection: CellSelectionApi) => {
   if (event.keyCode === VK.TAB) {
     const body = Util.getBody(editor);
     const isRoot = (element) => {
@@ -60,17 +61,18 @@ const handle = (event: KeyboardEvent, editor: Editor) => {
     };
 
     const rng = editor.selection.getRng();
-    if (rng.collapsed) {
-      const start = SugarElement.fromDom(rng.startContainer);
-      TableLookup.cell(start, isRoot).each((cell) => {
-        event.preventDefault();
-        const navigation = event.shiftKey ? backward : forward;
-        const rng = navigation(editor, isRoot, cell);
-        rng.each((range) => {
-          editor.selection.setRng(range);
-        });
+    // If navigating backwards, use the start of the ranged selection
+    const container = SugarElement.fromDom(event.shiftKey ? rng.startContainer : rng.endContainer);
+    TableLookup.cell(container, isRoot).each((cell) => {
+      event.preventDefault();
+      // Clear fake ranged selection because our new selection will always be collapsed
+      TableLookup.table(cell, isRoot).each(cellSelection.clear);
+      const navigation = event.shiftKey ? backward : forward;
+      const rng = navigation(editor, isRoot, cell);
+      rng.each((range) => {
+        editor.selection.setRng(range);
       });
-    }
+    });
   }
 };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
@@ -75,7 +75,7 @@ describe('browser.tinymce.plugins.table.TabKeyNavigationTest', () => {
     editor.off('TableModified', logEvent);
   });
 
-  context('TINY-6683: Tab navigation with ranged selection', () => {
+  context('Tab navigation with ranged selection', () => {
     it('TINY-6638: Navigates to next cell', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr><td>cell 1</td></tr><tr><td>cell 2</td></tr></tbody></table>');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
-import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks } from '@ephox/mcagar';
+import { afterEach, context, describe, it } from '@ephox/bedrock-client';
+import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -73,5 +73,115 @@ describe('browser.tinymce.plugins.table.TabKeyNavigationTest', () => {
     assert.lengthOf(events, 2);
     assert.equal(events[1].type, 'tablemodified');
     editor.off('TableModified', logEvent);
+  });
+
+  context('TINY-6683: Tab navigation with ranged selection', () => {
+    it('TINY-6638: Navigates to next cell', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>cell 1</td></tr><tr><td>cell 2</td></tr></tbody></table>');
+
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 6);
+      assert.equal(editor.selection.getStart().innerHTML, 'cell 1');
+      TinyContentActions.keystroke(editor, Keys.tab());
+
+      // Cursor moves to next cell
+      TinyAssertions.assertSelection(editor, [ 0, 0, 1, 0, 0 ], 0, [ 0, 0, 1, 0, 0 ], 0);
+    });
+
+    it('TINY-6638: Shift + Tab navigates to previous cell', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>cell 1</td></tr><tr><td>cell 2</td></tr></tbody></table>');
+
+      TinySelections.setSelection(editor, [ 0, 0, 1, 0, 0 ], 0, [ 0, 0, 1, 0, 0 ], 6);
+      assert.equal(editor.selection.getStart().innerHTML, 'cell 2');
+      TinyContentActions.keystroke(editor, Keys.tab(), { shiftKey: true });
+
+      // Cursor moves to previous cell
+      TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 0);
+    });
+
+    it('TINY-6638: Tabbing in last row creates a new row', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>cell 1</td></tr><tr><td>cell 2</td></tr></tbody></table>');
+      TinyAssertions.assertContentPresence(editor, { tr: 2, td: 2 });
+
+      TinySelections.setSelection(editor, [ 0, 0, 1, 0, 0 ], 0, [ 0, 0, 1, 0, 0 ], 6);
+      assert.equal(editor.selection.getStart().innerHTML, 'cell 2');
+      TinyContentActions.keystroke(editor, Keys.tab());
+
+      // Creates a new cell + row and moves to it
+      TinyAssertions.assertContentPresence(editor, { tr: 3, td: 3 });
+      TinyAssertions.assertSelection(editor, [ 0, 0, 2, 0 ], 0, [ 0, 0, 2, 0 ], 0);
+    });
+
+    it('TINY-6638: Shift+Tab does nothing on first cell', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>cell 1</td></tr><tr><td>cell 2</td></tr></tbody></table>');
+      TinyAssertions.assertContentPresence(editor, { tr: 2, td: 2 });
+
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 6);
+      assert.equal(editor.selection.getStart().innerHTML, 'cell 1');
+      TinyContentActions.keystroke(editor, Keys.tab(), { shiftKey: true });
+
+      // Selection stays the same, table stays the same
+      TinyAssertions.assertContentPresence(editor, { tr: 2, td: 2 });
+      TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 6);
+    });
+
+    it('TINY-6683: Selection starts inside table, ends outside table', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>cell 1</td></tr><tr><td>cell 2</td></tr></tbody></table><p>outside</p>');
+
+      TinySelections.setSelection(editor, [ 0, 0, 1, 0, 0 ], 0, [ 1, 0 ], 2);
+      TinyContentActions.keystroke(editor, Keys.tab());
+      // Selection does not move within editor
+      TinySelections.setSelection(editor, [ 0, 0, 1, 0, 0 ], 0, [ 1, 0 ], 2);
+
+      // Shift + Tab navigates to first cell
+      TinySelections.setSelection(editor, [ 0, 0, 1, 0, 0 ], 0, [ 1, 0 ], 2);
+      TinyContentActions.keystroke(editor, Keys.tab(), { shiftKey: true });
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+    });
+
+    it('TINY-6683: (From top) Selection starts outside table, ends inside table', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>outside</p><table><tbody><tr><td>cell 1</td></tr><tr><td>cell 2</td></tr></tbody></table>');
+
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0, 0, 0, 0 ], 2);
+      TinyContentActions.keystroke(editor, Keys.tab());
+      TinyAssertions.assertCursor(editor, [ 1, 0, 1, 0, 0 ], 0);
+
+      // Shift + Tab does nothing
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0, 0, 0, 0 ], 2);
+      TinyContentActions.keystroke(editor, Keys.tab(), { shiftKey: true });
+      TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0, 0, 0, 0 ], 2);
+    });
+
+    it('TINY-6683: Tab clears fake selection', () => {
+      const editor = hook.editor();
+      editor.setContent(`
+        <table data-mce-selected="1">
+          <tbody>
+            <tr>
+              <td data-mce-selected="1" data-mce-first-selected="1">cell 1</td>
+              <td data-mce-selected="1">cell 2</td>
+            </tr>
+            <tr>
+              <td data-mce-selected="1">cell 3</td>
+              <td data-mce-selected="1" data-mce-last-selected="1">cell 4</td>
+            </tr>
+          </tbody>
+        </table>
+      `);
+      TinyAssertions.assertContentPresence(editor, { tr: 2, td: 4 });
+      TinyAssertions.assertContentPresence(editor, { '[data-mce-selected="1"]': 5 });
+
+      TinySelections.setCursor(editor, [ 0, 0, 1, 1, 0 ], 6);
+      TinyContentActions.keystroke(editor, Keys.tab());
+
+      TinyAssertions.assertContentPresence(editor, { tr: 3, td: 6 });
+      // Tab clears fake selection on cells
+      TinyAssertions.assertContentPresence(editor, { '[data-mce-selected="1"]': 1 });
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-6638

Description of Changes:
Allow table tab navigation with ranged selections

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
