### PR TITLE
TINY-7358: Fixed a regression in the Tools.create() API

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added HTML5 `audio` and `video` elements to the default alignment formats #TINY-6633
 - The Oxide button text transform variable was incorrectly using `capitalize` instead of `none`. Patch contributed by dakur #GH-6341
 - Fix dialog button text that was using title-style capitalization #TINY-6816
+- Fixed a regression in the `tinymce.create()` API that caused issues when multiple objects were created #TINY-7358
 
 ## 5.7.1 - 2021-03-17
 

--- a/modules/tinymce/src/core/main/ts/api/util/Tools.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Tools.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun } from '@ephox/katamari';
 import * as ArrUtils from '../../util/ArrUtils';
 import Env from '../Env';
 
@@ -196,7 +195,8 @@ const create = function (s, p, root?) {
 
   // Create default constructor
   if (!p[cn]) {
-    p[cn] = Fun.noop;
+    // eslint-disable-next-line @tinymce/prefer-fun,prefer-arrow/prefer-arrow-functions
+    p[cn] = function () {};
     de = 1;
   }
 

--- a/modules/tinymce/src/core/test/ts/browser/util/ToolsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ToolsTest.ts
@@ -1,4 +1,5 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Global } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import Tools from 'tinymce/core/api/util/Tools';
@@ -7,5 +8,21 @@ describe('browser.tinymce.core.util.ToolsTest', () => {
   it('extend', () => {
     assert.deepEqual({ a: 1, b: 2, c: 3 }, Tools.extend({ a: 1 }, { b: 2 }, { c: 3 }));
     assert.deepEqual({ a: 1, c: 3 }, Tools.extend({ a: 1 }, null, { c: 3 }));
+  });
+
+  context('create', () => {
+    it('TINY-7358: Multiple calls to create should create different objects', () => {
+      Tools.create('tinymce.temp.class1', { init: () => 'obj1' });
+      Tools.create('tinymce.temp.class2', { init: () => 'obj2' });
+
+      const instance1 = new Global.tinymce.temp.class1();
+      const instance2 = new Global.tinymce.temp.class2();
+
+      assert.equal(instance1.init(), 'obj1');
+      assert.equal(instance2.init(), 'obj2');
+
+      // Cleanup
+      delete Global.tinymce.temp;
+    });
   });
 });


### PR DESCRIPTION
This regression caused all the create calls to use the same constructor, as it was reusing the `Fun.noop` function.

Related Ticket: TINY-7358

Description of Changes:
* Fixed a regression causing issues with the `tinymce.create` API.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
