### PR TITLE
Added default label to feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for TinyMCE
+labels: 'type: feature'
 
 ---
 


### PR DESCRIPTION
GitHub allows setting default labels when issues are created via templates, so this is just a small change to have the `feature` label set by default.