### PR TITLE
TINY-7048: Fixed the `LineHeight` command causing the `change` event to be fired inconsistently

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Table plugin could perform operations on tables containing the inline editor #TINY-6625
 - Fixed Tab key navigation inside table cells with a ranged selection #TINY-6638
 - Fixed a regression in the `tinymce.create()` API that caused issues when multiple objects were created #TINY-7358
-
+- Fixed the `LineHeight` command causing the `change` event to be fired inconsistently #TINY-7048
 
 ## 5.7.1 - 2021-03-17
 

--- a/modules/tinymce/src/core/main/ts/commands/LineHeight.ts
+++ b/modules/tinymce/src/core/main/ts/commands/LineHeight.ts
@@ -25,8 +25,6 @@ export const lineHeightQuery = (editor: Editor) => mapRange(editor, (elm) => {
 }).getOr('');
 
 export const lineHeightAction = (editor: Editor, lineHeight: number) => {
-  editor.undoManager.transact(() => {
-    editor.formatter.toggle('lineheight', { value: String(lineHeight) });
-    editor.nodeChanged();
-  });
+  editor.formatter.toggle('lineheight', { value: String(lineHeight) });
+  editor.nodeChanged();
 };

--- a/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
@@ -72,4 +72,19 @@ describe('browser.tinymce.core.commands.LineHeightTest', () => {
     editor.execCommand('LineHeight', false, '1.4');
     TinyAssertions.assertContent(editor, '<p>Hello</p>');
   });
+
+  it('TINY-7048: LineHeight event order is correct', () => {
+    const events = [];
+    const editor = hook.editor();
+    editor.setContent('<p>Hello</p>');
+    const logEvents = (e) => events.push(e.type.toLowerCase());
+    // Note: It's important that we prepend these events, otherwise the UndoManager `ExecCommand` event handler
+    // will execute first and make it looks like `change` is fired second.
+    editor.on('BeforeExecCommand change ExecCommand', logEvents, true);
+
+    editor.execCommand('LineHeight', false, '2');
+    TinyAssertions.assertContent(editor, '<p style="line-height: 2;">Hello</p>');
+    assert.deepEqual(events, [ 'beforeexeccommand', 'execcommand', 'change' ]);
+    editor.off('BeforeExecCommand change ExecCommand', logEvents);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7048

Description of Changes:
* Fixes the `LineHeight` command incorrectly being wrapped in an UndoManager transaction (commands are already wrapped via the command manager). This then caused an UndoLevel to be created too early, which in turn caused the `change` event to fire inconsistently.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #6549