### PR TITLE
TINY-3551: Fixed the forecolor/backcolor color indicator being blurry

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarSplitButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarSplitButton.ts
@@ -44,7 +44,7 @@ export interface ToolbarSplitButtonInstanceApi {
   isDisabled: () => boolean;
   setDisabled: (state: boolean) => void;
   setIconFill: (id: string, value: string) => void;
-  setIconStroke: (id: string, value: string) => void;
+  setIconStroke: (id: string, value: string) => void; // Deprecated as of TinyMCE 5.8 (see TINY-3551)
   isActive: () => boolean;
   setActive: (state: boolean) => void;
 }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the `image` dialog to display the class list dropdown as full-width if the caption checkbox is not present #TINY-6400
 - Renamed the "H Align" and "V Align" input labels in the Table Cell Properties dialog to "Horizontal align" and "Vertical align" respectively #TINY-7285
 
+### Deprecated
+- The undocumented `setIconStroke` Split Toolbar Button API has been deprecated and will be removed in a future release #TINY-3551
+
 ### Fixed
 - The RGB fields in the color picker dialog were not staying in sync with the color palette and hue slider #TINY-6952
 - The color preview box in the color picker dialog was not correctly displaying the saturation and value of the chosen color #TINY-6952
@@ -33,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix dialog button text that was using title-style capitalization #TINY-6816
 - Table plugin could perform operations on tables containing the inline editor #TINY-6625
 - Fixed Tab key navigation inside table cells with a ranged selection #TINY-6638
+- The foreground and background toolbar button color indicator is no longer blurry #TINY-3551
 - Fixed a regression in the `tinymce.create()` API that caused issues when multiple objects were created #TINY-7358
 
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -112,13 +112,8 @@ const getFetch = (colors: Menu.ChoiceMenuItemSpec[], hasCustom: boolean) => (cal
 };
 
 const setIconColor = (splitButtonApi: Toolbar.ToolbarSplitButtonInstanceApi, name: string, newColor: string) => {
-  const setIconFillAndStroke = (pathId, color) => {
-    splitButtonApi.setIconFill(pathId, color);
-    splitButtonApi.setIconStroke(pathId, color);
-  };
-
   const id = name === 'forecolor' ? 'tox-icon-text-color__color' : 'tox-icon-highlight-bg-color__color';
-  setIconFillAndStroke(id, newColor);
+  splitButtonApi.setIconFill(id, newColor);
 };
 
 const registerTextColorButton = (editor: Editor, name: string, format: string, tooltip: string, lastColor: Cell<string>) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -273,6 +273,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
         Attribute.set(underlinePath, 'fill', value);
       });
     },
+    // Deprecated as of TinyMCE 5.8 (see TINY-3551)
     setIconStroke: (id, value) => {
       SelectorFind.descendant(comp.element, 'svg path[id="' + id + '"], rect[id="' + id + '"]').each((underlinePath) => {
         Attribute.set(underlinePath, 'stroke', value);


### PR DESCRIPTION
Related Ticket: TINY-3551

Description of Changes:
* Fixed the `forecolor`/`backcolor` color indicator ending up blurry due to incorrectly setting the `stroke` attribute when changing the color.
* Deprecated the undocumented `setIconStroke` Split Toolbar button API.

Before:
![image](https://user-images.githubusercontent.com/1575550/116841010-2af92e80-ac1b-11eb-851f-9a3d045f5724.png)

After:
![image](https://user-images.githubusercontent.com/1575550/116840988-1ae14f00-ac1b-11eb-8909-8ce80f719871.png)

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ No color swatch tests exist, so have logged TINY-7376 to get them added
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
