### PR TITLE
TINY-7387: Update the help dialog to mention keyboard resizing of the editor

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardNavTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardNavTab.ts
@@ -33,6 +33,7 @@ const description = `<h1>Editor UI keyboard navigation</h1>
   <li>the element path in the footer </li>
   <li>the wordcount toggle button in the footer </li>
   <li>the branding link in the footer </li>
+  <li>the editor resize handle in the footer</li>
 </ul>
 
 <p>Pressing shift + tab will move backwards through the same sections, except when moving from the footer to the toolbar. Focusing the element path then pressing shift + tab will move focus to the first toolbar group, not the last.</p>


### PR DESCRIPTION
Related Ticket: TINY-7387

Description of Changes:
* Update the help dialog to mention that the editor resize handle is in the list of things selectable via keyboard navigation now

Pre-checks:
* [x] ~Changelog entry added~ Not added as there's already a changelog entry for this feature as a whole, and this is shipping as part of the same release
* [x] ~Tests have been added (if applicable)~ This is just a change to copy text, doesn't involve any code.
* [x] Branch prefixed with `feature/` for new features (if applicable)
* [x] ~License headers added on new files (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
