### PR TITLE
TINY-6383: Fixed an exception thrown when switching to readonly mode and resizing the editor

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- An unexpected exception was thrown when switching to readonly mode and adjusting the editor width #TINY-6383
+
 ## 5.8.0 - 2021-05-06
 
 ### Added

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Mouse, UiFinder } from '@ephox/agar';
 import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Optional, OptionalInstances } from '@ephox/katamari';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Class, Css, Scroll, SelectorFind, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { assert } from 'chai';
 
@@ -9,7 +9,6 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Readonly from 'tinymce/core/mode/Readonly';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
-import { TinyAssertions, TinySelections } from '../../../../../../mcagar/src/main/ts/ephox/mcagar/api/Main';
 
 const tOptional = OptionalInstances.tOptional;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
@@ -36,10 +36,6 @@ const getSpec = (editor: Editor): SelectSpec => {
     });
   };
 
-  const nodeChangeHandler = Optional.some((comp: AlloyComponent) => () => updateSelectMenuIcon(comp));
-
-  const setInitialValue = Optional.some((comp: AlloyComponent) => updateSelectMenuIcon(comp));
-
   const dataset = buildBasicStaticDataset(alignMenuItems);
 
   const onAction = (rawItem: FormatterFormatItem) => () =>
@@ -53,8 +49,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     getCurrentValue: Optional.none,
     getPreviewFor,
     onAction,
-    setInitialValue,
-    nodeChangeHandler,
+    updateText: updateSelectMenuIcon,
     dataset,
     shouldHide: false,
     isInvalid: (item) => !editor.formatter.canApply(item.format)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
@@ -106,10 +106,6 @@ const getSpec = (editor: Editor): SelectSpec => {
     });
   };
 
-  const nodeChangeHandler = Optional.some((comp) => () => updateSelectMenuText(comp));
-
-  const setInitialValue = Optional.some((comp) => updateSelectMenuText(comp));
-
   const dataset = buildBasicSettingsDataset(editor, 'font_formats', defaultFontsFormats, Delimiter.SemiColon);
 
   return {
@@ -119,8 +115,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     getCurrentValue,
     getPreviewFor,
     onAction,
-    setInitialValue,
-    nodeChangeHandler,
+    updateText: updateSelectMenuText,
     dataset,
     shouldHide: false,
     isInvalid: Fun.never

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
@@ -97,10 +97,6 @@ const getSpec = (editor: Editor): SelectSpec => {
     });
   };
 
-  const nodeChangeHandler = Optional.some((comp: AlloyComponent) => () => updateSelectMenuText(comp));
-
-  const setInitialValue = Optional.some((comp: AlloyComponent) => updateSelectMenuText(comp));
-
   const dataset = buildBasicSettingsDataset(editor, 'fontsize_formats', defaultFontsizeFormats, Delimiter.Space);
 
   return {
@@ -110,8 +106,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     getPreviewFor,
     getCurrentValue,
     onAction,
-    setInitialValue,
-    nodeChangeHandler,
+    updateText: updateSelectMenuText,
     dataset,
     shouldHide: false,
     isInvalid: Fun.never

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
@@ -46,10 +46,6 @@ const getSpec = (editor: Editor): SelectSpec => {
     });
   };
 
-  const nodeChangeHandler = Optional.some((comp: AlloyComponent) => () => updateSelectMenuText(comp));
-
-  const setInitialValue = Optional.some((comp: AlloyComponent) => updateSelectMenuText(comp));
-
   const dataset = buildBasicSettingsDataset(editor, 'block_formats', defaultBlocks, Delimiter.SemiColon);
 
   return {
@@ -59,8 +55,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     getCurrentValue: Optional.none,
     getPreviewFor,
     onAction: onActionToggleFormat(editor),
-    setInitialValue,
-    nodeChangeHandler,
+    updateText: updateSelectMenuText,
     dataset,
     shouldHide: false,
     isInvalid: (item) => !editor.formatter.canApply(item.format)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleSelect.ts
@@ -41,10 +41,6 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
     });
   };
 
-  const nodeChangeHandler = Optional.some((comp: AlloyComponent) => () => updateSelectMenuText(comp));
-
-  const setInitialValue = Optional.some((comp: AlloyComponent) => updateSelectMenuText(comp));
-
   return {
     tooltip: 'Formats',
     icon: Optional.none(),
@@ -52,8 +48,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
     getCurrentValue: Optional.none,
     getPreviewFor,
     onAction: onActionToggleFormat(editor),
-    setInitialValue,
-    nodeChangeHandler,
+    updateText: updateSelectMenuText,
     shouldHide: editor.getParam('style_formats_autohide', false, 'boolean'),
     isInvalid: (item) => !editor.formatter.canApply(item.format),
     dataset

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
-import { SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { Css, SugarBody } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ToolbarMode } from 'tinymce/themes/silver/api/Settings';
@@ -13,7 +13,7 @@ import { resizeToPos } from '../../../module/UiUtils';
 describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-    toolbar: 'bold | italic | underline | strikethrough | cut | copy | paste | indent | subscript | superscript | removeformat',
+    toolbar: 'bold | italic | underline | strikethrough | cut | copy | paste | indent | subscript | superscript | removeformat | fontselect',
     toolbar_mode: 'floating',
     menubar: false,
     width: 300,
@@ -87,7 +87,19 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
     ]
   });
 
+  it('TINY-6383: No exception thrown when switching modes and resizing', () => {
+    const editor = hook.editor();
+    const container = TinyDom.container(editor);
+    Css.set(container, 'width', '200px');
+    editor.mode.set('design');
+
+    // Revert back to readonly mode
+    editor.mode.set('readonly');
+  });
+
   it('TBA: Test if the toolbar buttons are disabled in readonly mode when toolbar drawer is present', async () => {
+    const editor = hook.editor();
+    Css.set(TinyDom.container(editor), 'width', '300px');
     await pAssertToolbarButtonState('Assert the first toolbar button, Bold is disabled', true, (s, str, arr) => [
       disabledButtonStruct(s, str, arr, 'Bold'),
       s.theRest()
@@ -110,6 +122,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
 
   it('TINY-6014: Test buttons become enabled again when disabling readonly mode and resizing', async () => {
     const editor = hook.editor();
+    Css.set(TinyDom.container(editor), 'width', '400px');
     await pAssertToolbarButtonState('Assert the first toolbar button, Bold is disabled', true, (s, str, arr) => [
       disabledButtonStruct(s, str, arr, 'Bold'),
       s.theRest()
@@ -130,7 +143,8 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
     await pAssertToolbarDrawerButtonState('Assert the toolbar drawer buttons are enabled', (s, str, arr) => [
       enabledButtonStruct(s, str, arr, 'Subscript'),
       enabledButtonStruct(s, str, arr, 'Superscript'),
-      enabledButtonStruct(s, str, arr, 'Clear formatting')
+      enabledButtonStruct(s, str, arr, 'Clear formatting'),
+      s.theRest()
     ]);
 
     resizeTo(400, 400, 450, 400);
@@ -149,7 +163,8 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
     ]);
     await pAssertToolbarDrawerButtonState('Assert the toolbar drawer buttons are enabled', (s, str, arr) => [
       enabledButtonStruct(s, str, arr, 'Superscript'),
-      enabledButtonStruct(s, str, arr, 'Clear formatting')
+      enabledButtonStruct(s, str, arr, 'Clear formatting'),
+      s.theRest()
     ]);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-6383

Description of Changes:
* Fixed an exception thrown when switching to readonly mode and resizing the editor
* Cleaned up the bespoke logic, as it was overly complicated

Note: This is the low-risk version of this fix, however I'm going to create a more versatile fix for 5.9 that will follow this.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
