### PR TITLE
TINY-3388: Fix block elements containing pagebreaks being removed when `pagebreak_split_block=true`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed a bug where block elements could be removed from the editor content when containing a pagebreak #TINY-3388
+
 ## 5.8.0 - 2021-05-06
 
 ### Added

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Fixed a bug where block elements could be removed from the editor content when containing a pagebreak #TINY-3388
+- Fixed a bug where block elements containing a pagebreak could be removed from the editor content #TINY-3388
 
 ## 5.8.0 - 2021-05-06
 

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 import * as FilterContent from '../core/FilterContent';
-import * as Settings from '../api/Settings';
+import * as Settings from './Settings';
 
 const register = (editor: Editor) => {
   editor.addCommand('mcePageBreak', () => {

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/api/Commands.ts
@@ -7,15 +7,11 @@
 
 import Editor from 'tinymce/core/api/Editor';
 import * as FilterContent from '../core/FilterContent';
-import * as Settings from './Settings';
+import * as Settings from '../api/Settings';
 
 const register = (editor: Editor) => {
   editor.addCommand('mcePageBreak', () => {
-    if (Settings.shouldSplitBlock(editor)) {
-      editor.insertContent('<p>' + FilterContent.getPlaceholderHtml() + '</p>');
-    } else {
-      editor.insertContent(FilterContent.getPlaceholderHtml());
-    }
+    editor.insertContent(FilterContent.getPlaceholderHtml(Settings.shouldSplitBlock(editor)));
   });
 };
 

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
@@ -5,24 +5,31 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import * as Settings from '../api/Settings';
 
-const getPageBreakClass = () => 'mce-pagebreak';
+const pageBreakClass = 'mce-pagebreak';
 
-const getPlaceholderHtml = () => {
-  return '<img src="' + Env.transparentSrc + '" class="' + getPageBreakClass() + '" data-mce-resize="false" data-mce-placeholder />';
+const getPlaceholderHtml = (shouldSplitBlock: boolean) => {
+  const html = `<img src="${Env.transparentSrc}" class="${pageBreakClass}" data-mce-resize="false" data-mce-placeholder />`;
+  if (shouldSplitBlock) {
+    return `<p>${html}</p>`;
+  } else {
+    return html;
+  }
 };
 
-const setup = (editor) => {
+const setup = (editor: Editor) => {
   const separatorHtml = Settings.getSeparatorHtml(editor);
+  const shouldSplitBlock = () => Settings.shouldSplitBlock(editor);
 
   const pageBreakSeparatorRegExp = new RegExp(separatorHtml.replace(/[\?\.\*\[\]\(\)\{\}\+\^\$\:]/g, (a) => {
     return '\\' + a;
   }), 'gi');
 
   editor.on('BeforeSetContent', (e) => {
-    e.content = e.content.replace(pageBreakSeparatorRegExp, getPlaceholderHtml());
+    e.content = e.content.replace(pageBreakSeparatorRegExp, getPlaceholderHtml(shouldSplitBlock()));
   });
 
   editor.on('PreInit', () => {
@@ -35,7 +42,7 @@ const setup = (editor) => {
         if (className && className.indexOf('mce-pagebreak') !== -1) {
           // Replace parent block node if pagebreak_split_block is enabled
           const parentNode = node.parent;
-          if (editor.schema.getBlockElements()[parentNode.name] && Settings.shouldSplitBlock(editor)) {
+          if (editor.schema.getBlockElements()[parentNode.name] && shouldSplitBlock()) {
             parentNode.type = 3;
             parentNode.value = separatorHtml;
             parentNode.raw = true;
@@ -53,7 +60,7 @@ const setup = (editor) => {
 };
 
 export {
-  setup,
+  pageBreakClass,
   getPlaceholderHtml,
-  getPageBreakClass
+  setup,
 };

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
@@ -13,11 +13,7 @@ const pageBreakClass = 'mce-pagebreak';
 
 const getPlaceholderHtml = (shouldSplitBlock: boolean) => {
   const html = `<img src="${Env.transparentSrc}" class="${pageBreakClass}" data-mce-resize="false" data-mce-placeholder />`;
-  if (shouldSplitBlock) {
-    return `<p>${html}</p>`;
-  } else {
-    return html;
-  }
+  return shouldSplitBlock ? `<p>${html}</p>` : html;
 };
 
 const setup = (editor: Editor) => {

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
@@ -39,7 +39,7 @@ const setup = (editor: Editor) => {
       while (i--) {
         node = nodes[i];
         className = node.attr('class');
-        if (className && className.indexOf('mce-pagebreak') !== -1) {
+        if (className && className.indexOf(pageBreakClass) !== -1) {
           // Replace parent block node if pagebreak_split_block is enabled
           const parentNode = node.parent;
           if (editor.schema.getBlockElements()[parentNode.name] && shouldSplitBlock()) {

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/core/FilterContent.ts
@@ -58,5 +58,5 @@ const setup = (editor: Editor) => {
 export {
   pageBreakClass,
   getPlaceholderHtml,
-  setup,
+  setup
 };

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/core/ResolveName.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/core/ResolveName.ts
@@ -9,7 +9,7 @@ import * as FilterContent from './FilterContent';
 
 const setup = (editor) => {
   editor.on('ResolveName', (e) => {
-    if (e.target.nodeName === 'IMG' && editor.dom.hasClass(e.target, FilterContent.getPageBreakClass())) {
+    if (e.target.nodeName === 'IMG' && editor.dom.hasClass(e.target, FilterContent.pageBreakClass)) {
       e.name = 'pagebreak';
     }
   });

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/core/ResolveName.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/core/ResolveName.ts
@@ -5,9 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
 import * as FilterContent from './FilterContent';
 
-const setup = (editor) => {
+const setup = (editor: Editor) => {
   editor.on('ResolveName', (e) => {
     if (e.target.nodeName === 'IMG' && editor.dom.hasClass(e.target, FilterContent.pageBreakClass)) {
       e.name = 'pagebreak';

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSanityTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSanityTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSanityTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme, Plugin ]);
 
-  it('TBA: PageBreak: Click on the pagebreak toolbar button and assert pagebreak is inserted', () => {
+  it('TBA: Click on the pagebreak toolbar button and assert pagebreak is inserted', () => {
     const editor = hook.editor();
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Page break"]');
     TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => {

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSanityTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSanityTest.ts
@@ -1,40 +1,35 @@
-import { ApproxStructure, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { ApproxStructure } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
-import PageBreakPlugin from 'tinymce/plugins/pagebreak/Plugin';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/pagebreak/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.pagebreak.PageBreakSanityTest', (success, failure) => {
-
-  Theme();
-  PageBreakPlugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-    const tinyApis = TinyApis(editor);
-
-    Pipeline.async({}, Log.steps('TBA', 'PageBreak: Click on the pagebreak toolbar button and assert pagebreak is inserted', [
-      tinyUi.sClickOnToolbar('click on pagebreak button', 'button[aria-label="Page break"]'),
-      tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => {
-        return s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.element('img', {
-                  classes: [
-                    arr.has('mce-pagebreak')
-                  ]
-                })
-              ]
-            })
-          ]
-        });
-      }))
-    ]), onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.pagebreak.PageBreakSanityTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'pagebreak',
     toolbar: 'pagebreak',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  it('TBA: PageBreak: Click on the pagebreak toolbar button and assert pagebreak is inserted', () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Page break"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.element('img', {
+                classes: [
+                  arr.has('mce-pagebreak')
+                ]
+              })
+            ]
+          })
+        ]
+      });
+    }));
+  });
 });

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
@@ -1,0 +1,108 @@
+import { ApproxStructure } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/pagebreak/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'pagebreak',
+    toolbar: 'pagebreak',
+    pagebreak_split_block: false, // default
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Theme, Plugin ]);
+
+  const clickPageBreak = (editor: Editor) => TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Page break"]');
+
+  it('TINY-3388: Pagebreak should insert inline when `pagebreak_split_block` is `false`', () => {
+    const editor = hook.editor();
+    editor.settings.pagebreak_split_block = false;
+
+    editor.setContent('<p>sometext</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickPageBreak(editor);
+
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.text(str.is('some')),
+              s.element('img', {
+                classes: [
+                  arr.has('mce-pagebreak')
+                ]
+              }),
+              s.text(str.is('text')),
+            ]
+          })
+        ]
+      });
+    }));
+  });
+
+  it('TINY-3388: Pagebreak should split block element when `pagebreak_split_block` is `true`', () => {
+    const editor = hook.editor();
+    editor.settings.pagebreak_split_block = true;
+
+    editor.setContent('<p>sometext</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickPageBreak(editor);
+
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.text(str.is('some')),
+            ]
+          }),
+          s.element('p', {
+            children: [
+              s.element('img', {
+                classes: [
+                  arr.has('mce-pagebreak')
+                ]
+              }),
+            ]
+          }),
+          s.element('p', {
+            children: [
+              s.text(str.is('text')),
+            ]
+          })
+        ]
+      });
+    }));
+  });
+
+  context('Source view', () => {
+    it('TINY-3388: `pagebreak_split_block` is `true`', () => {
+      const editor = hook.editor();
+      editor.settings.pagebreak_split_block = true;
+
+      editor.setContent('<p>sometext</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 4);
+      clickPageBreak(editor);
+
+      const content = editor.getContent({ source_view: true });
+      // NOTE: p that wraps pagebreak is stripped
+      assert.equal(content, `<p>some</p>\n<!-- pagebreak -->\n<p>text</p>`)
+    });
+
+    it('TINY-3388: `pagebreak_split_block` is `false`', () => {
+      const editor = hook.editor();
+      editor.settings.pagebreak_split_block = false;
+
+      editor.setContent('<p>sometext</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 4);
+      clickPageBreak(editor);
+
+      const content = editor.getContent({ source_view: true });
+      assert.equal(content, `<p>some<!-- pagebreak -->text</p>`)
+    });
+  });
+});

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
@@ -79,8 +79,8 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
     }));
   });
 
-  context('Source view', () => {
-    it('TINY-3388: `pagebreak_split_block` is `true`', () => {
+  context('Editor content', () => {
+    it('TINY-3388: source_view with `pagebreak_split_block=true`', () => {
       const editor = hook.editor();
       editor.settings.pagebreak_split_block = true;
 
@@ -93,7 +93,7 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
       assert.equal(content, `<p>some</p>\n<!-- pagebreak -->\n<p>text</p>`)
     });
 
-    it('TINY-3388: `pagebreak_split_block` is `false`', () => {
+    it('TINY-3388: source_view with `pagebreak_split_block=false`', () => {
       const editor = hook.editor();
       editor.settings.pagebreak_split_block = false;
 
@@ -103,6 +103,28 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
 
       const content = editor.getContent({ source_view: true });
       assert.equal(content, `<p>some<!-- pagebreak -->text</p>`)
+    });
+
+    it('TINY-3388: getContent with `pagebreak_split_block=true`', () => {
+      const editor = hook.editor();
+      editor.settings.pagebreak_split_block = true;
+
+      editor.setContent('<p>sometext</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 4);
+      clickPageBreak(editor);
+
+      TinyAssertions.assertContent(editor, `<p>some</p>\n<!-- pagebreak -->\n<p>text</p>`);
+    });
+
+    it('TINY-3388: getContent with `pagebreak_split_block=false`', () => {
+      const editor = hook.editor();
+      editor.settings.pagebreak_split_block = false;
+
+      editor.setContent('<p>sometext</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 4);
+      clickPageBreak(editor);
+
+      TinyAssertions.assertContent(editor, '<p>some<!-- pagebreak -->text</p>');
     });
   });
 });

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
@@ -90,7 +90,7 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
 
       const content = editor.getContent({ source_view: true });
       // NOTE: p that wraps pagebreak is stripped
-      assert.equal(content, `<p>some</p>\n<!-- pagebreak -->\n<p>text</p>`)
+      assert.equal(content, `<p>some</p>\n<!-- pagebreak -->\n<p>text</p>`);
     });
 
     it('TINY-3388: source_view with `pagebreak_split_block=false`', () => {
@@ -102,7 +102,7 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
       clickPageBreak(editor);
 
       const content = editor.getContent({ source_view: true });
-      assert.equal(content, `<p>some<!-- pagebreak -->text</p>`)
+      assert.equal(content, `<p>some<!-- pagebreak -->text</p>`);
     });
 
     it('TINY-3388: getContent with `pagebreak_split_block=true`', () => {


### PR DESCRIPTION
Related Ticket: TINY-3388

Description of Changes:

Fixed the bug by ensuring all code paths add the wrapping `p` element around the pagebreak

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): https://github.com/tinymce/tinymce/issues/4844
