### PR TITLE
TINY-3388_2: Allow optional getContent args in TinyAssertions.assertContent

### DIFF
--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -6,5 +6,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Changed
+### Added
 - Added optional `args` parameter to `TinyAssertions.assertContent` to be passed to `editor.getContent()` #TINY-3388

--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Changed
+- Added optional `args` parameter to `TinyAssertions.assertContent` to be passed to `editor.getContent()` #TINY-3388

--- a/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
@@ -10,6 +10,17 @@ export interface Selection {
   isCollapsed: () => boolean;
 }
 
+export type ContentFormat = 'raw' | 'text' | 'html' | 'tree';
+
+export interface GetContentArgs {
+  format?: ContentFormat;
+  get?: boolean;
+  content?: string;
+  getInner?: boolean;
+  no_events?: boolean;
+  [key: string]: any;
+}
+
 export interface Editor {
   id: string;
   settings: Record<string, any>;
@@ -30,7 +41,7 @@ export interface Editor {
   getContentAreaContainer: () => HTMLElement;
   getElement: () => HTMLElement;
 
-  getContent: () => string;
+  getContent: (args?: GetContentArgs) => string;
   setContent: (content: string) => void;
 
   execCommand: (command: string, ui?: boolean, value?: any, args?: any) => boolean;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyAssertions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyAssertions.ts
@@ -1,7 +1,7 @@
 import { Assertions, Cursors, StructAssert } from '@ephox/agar';
 import { Optional } from '@ephox/katamari';
 import { Hierarchy, Html, SugarElement } from '@ephox/sugar';
-import { Editor } from '../../alien/EditorTypes';
+import { Editor, GetContentArgs } from '../../alien/EditorTypes';
 import { Presence } from '../pipeline/TinyApis';
 import { TinyDom } from '../TinyDom';
 
@@ -16,7 +16,7 @@ const assertPath = (label: string, root: SugarElement, expPath: number[], expOff
   Assertions.assertEq(() => 'Offset mismatch for ' + label + ' in :\n' + Html.getOuter(expected), expOffset, actOffset);
 };
 
-const assertContent = (editor: Editor, expected: string, args?: object): void => {
+const assertContent = (editor: Editor, expected: string, args?: GetContentArgs): void => {
   const content = editor.getContent(args);
   Assertions.assertHtml('Checking TinyMCE content', expected, content);
 };

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyAssertions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyAssertions.ts
@@ -16,8 +16,8 @@ const assertPath = (label: string, root: SugarElement, expPath: number[], expOff
   Assertions.assertEq(() => 'Offset mismatch for ' + label + ' in :\n' + Html.getOuter(expected), expOffset, actOffset);
 };
 
-const assertContent = (editor: Editor, expected: string): void => {
-  const content = editor.getContent();
+const assertContent = (editor: Editor, expected: string, args?: object): void => {
+  const content = editor.getContent(args);
   Assertions.assertHtml('Checking TinyMCE content', expected, content);
 };
 

--- a/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
+++ b/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
@@ -69,21 +69,21 @@ describe('browser.tinymce.plugins.fullpage.FullPagePluginTest', () => {
     const editor = hook.editor();
     editor.settings.fullpage_hide_in_source_view = false;
     editor.setContent('<html><body><p>1</p></body></html>');
-    assert.equal(editor.getContent({ source_view: true }), '<html><body>\n<p>1</p>\n</body></html>');
+    TinyAssertions.assertContent(editor, '<html><body>\n<p>1</p>\n</body></html>', { source_view: true });
   });
 
   it('TBA: fullpage_hide_in_source_view: true', () => {
     const editor = hook.editor();
     editor.settings.fullpage_hide_in_source_view = true;
     editor.setContent('<html><body><p>1</p></body></html>');
-    assert.equal(editor.getContent({ source_view: true }), '<p>1</p>');
+    TinyAssertions.assertContent(editor, '<p>1</p>', { source_view: true });
   });
 
   it('TBA: link elements', () => {
     const editor = hook.editor();
     editor.setContent('<html><head><link rel="stylesheet" href="a.css"><link rel="something"></head><body><p>c</p></body></html>');
-    assert.equal(
-      editor.getContent(),
+    TinyAssertions.assertContent(
+      editor,
       '<html><head><link rel="stylesheet" href="a.css"><link rel="something"></head><body>\n<p>c</p>\n</body></html>'
     );
   });
@@ -183,6 +183,6 @@ describe('browser.tinymce.plugins.fullpage.FullPagePluginTest', () => {
   it('TINY-6541: Text content should not be modified', () => {
     const editor = hook.editor();
     editor.setContent('some plain text');
-    assert.equal(editor.getContent({ format: 'text' }), 'some plain text', 'should return plain text content');
+    TinyAssertions.assertContent(editor, 'some plain text', { format: 'text' });
   });
 });

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 
-
+mcagar@6.2.0


### PR DESCRIPTION
Related Ticket: TINY-3388

Description of Changes:
Note: This couldn't go through with #6792 because it's a `minor` bump to mcagar.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
