### PR TITLE
TINY-6264: Ensure list-style-type: none is not removed from nested lists when clearing formatting

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - An unexpected exception was thrown when switching to readonly mode and adjusting the editor width #TINY-6383
 - Fixed a bug where block elements containing a pagebreak could be removed from the editor content #TINY-3388
+- Fixed a bug where the `list-style-type: none;` style on nested list items was incorrectly removed when clearing formatting #TINY-6264
 
 ## 5.8.0 - 2021-05-06
 

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -306,6 +306,11 @@ const removeFormatInternal = (ed: Editor, format: RemoveFormatPartial, vars?: Fo
           }
         }
 
+        // Remove mce prefixed attributes (must clean before short circuit operations)
+        if (MCE_ATTR_RE.test(name)) {
+          elm.removeAttribute('data-mce-' + name);
+        }
+
         // keep style="list-style-type: none" on <li>s
         if (name === 'style' && NodeType.matchNodeNames([ 'li' ])(elm) && dom.getStyle(elm, 'list-style-type') === 'none') {
           elm.removeAttribute(name);
@@ -316,11 +321,6 @@ const removeFormatInternal = (ed: Editor, format: RemoveFormatPartial, vars?: Fo
         // IE6 has a bug where the attribute doesn't get removed correctly
         if (name === 'class') {
           elm.removeAttribute('className');
-        }
-
-        // Remove mce prefixed attributes
-        if (MCE_ATTR_RE.test(name)) {
-          elm.removeAttribute('data-mce-' + name);
         }
 
         elm.removeAttribute(name);

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -306,6 +306,13 @@ const removeFormatInternal = (ed: Editor, format: RemoveFormatPartial, vars?: Fo
           }
         }
 
+        // keep style="list-style-type: none" on <li>s
+        if (name === 'style' && NodeType.matchNodeNames([ 'li' ])(elm) && dom.getStyle(elm, 'list-style-type') === 'none') {
+          elm.removeAttribute(name);
+          dom.setStyle(elm, 'list-style-type', 'none');
+          return;
+        }
+
         // IE6 has a bug where the attribute doesn't get removed correctly
         if (name === 'class') {
           elm.removeAttribute('className');

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -30,6 +30,25 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
     editor.formatter.unregister('format');
   };
 
+  context('DefaultFormats remove format behavior', () => {
+    it('TINY-6264: Will not remove style="list-style-type: none" from list item elements', () => {
+      const editor = hook.editor();
+      const nestedListHtml = '<ul><li style="list-style-type: none;"><ul><li>hello</li></ul></li></ul>';
+      editor.setContent(nestedListHtml);
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 5);
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, nestedListHtml);
+    });
+
+    it('TINY-6264: Will remove other styles except for style="list-style-type: none" from list item elements', () => {
+      const editor = hook.editor();
+      editor.setContent('<ul><li style="list-style-type: none; background-color: #000000;"><ul><li>hello</li></ul></li></ul>');
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 5);
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, '<ul><li style="list-style-type: none;"><ul><li>hello</li></ul></li></ul>');
+    });
+  });
+
   context('Remove format with collapsed selection', () => {
     it('In middle of single word wrapped in strong', () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -31,9 +31,9 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
   };
 
   context('DefaultFormats remove format behavior', () => {
-    it('TINY-6264: Will not remove style="list-style-type: none" from list item elements', () => {
+    it('TINY-6264: Will not remove style="list-style-type: none" from list item elements (ol)', () => {
       const editor = hook.editor();
-      const nestedListHtml = '<ul><li style="list-style-type: none;"><ul><li>hello</li></ul></li></ul>';
+      const nestedListHtml = '<ol><li style="list-style-type: none;"><ol><li>hello</li></ol></li></ol>';
       editor.setContent(nestedListHtml);
       TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 5);
       editor.execCommand('RemoveFormat');
@@ -46,6 +46,14 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
       TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 5);
       editor.execCommand('RemoveFormat');
       TinyAssertions.assertContent(editor, '<ul><li style="list-style-type: none;"><ul><li>hello</li></ul></li></ul>');
+    });
+
+    it('TINY-6264: Removes data-mce-style attribute when short-circuiting for "list-style-type: none" retention', () => {
+      const editor = hook.editor();
+      editor.setContent('<ol><li data-mce-style="list-style-type: none;" style="list-style-type: none;"><ol><li>hello</li></ol></li></ol>');
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 5);
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, '<ol><li style="list-style-type: none;"><ol><li>hello</li></ol></li></ol>');
     });
   });
 


### PR DESCRIPTION
Related Ticket: TINY-6264

Description of Changes:
Ensure that nested list items do not have their `list-style-type: none;` style removed when clearing formatting. This resulted in a bug where the markers for each li would be revealed.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
