### PR TITLE
TINY-6870: Switch Quickbars plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/quickbars/test/ts/atomic/EditorSettingsTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/atomic/EditorSettingsTest.ts
@@ -1,106 +1,105 @@
-import { Logger } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
+import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as Settings from 'tinymce/plugins/quickbars/api/Settings';
 
-UnitTest.test('DialogChanges', () => {
-  Logger.sync(
-    'Quick Toolbars plugin: Quick Toolbars Editor Settings and default values',
-    () => {
+describe('Quick Toolbars Editor Settings and default values', () => {
+  const test = (method: (editor: Editor) => string, settings: any, expected: string) => {
+    const mockEditor = {
+      getParam: (name: string, defaultValue: any) => Obj.get(settings, name).getOr(defaultValue),
+      settings
+    } as Editor;
 
-      const test = (label: string, method: (editor: Editor) => string, settings: any, expected: string) => {
-        const mockEditor = {
-          getParam: (name, defaultValue) => Obj.get(settings, name).getOr(defaultValue),
-          settings
-        } as any;
+    const result = method(mockEditor);
+    assert.equal(result, expected);
+  };
 
-        Logger.sync(label, () => {
-          const result = method(mockEditor);
-          Assert.eq(label, expected, result);
-        });
-      };
-
-      test('getTextSelectionToolbarItems: testing for empty string should return empty string',
+  context('getTextSelectionToolbarItems', () => {
+    it('TBA: testing for empty string should return empty string', () => {
+      test(
         Settings.getTextSelectionToolbarItems,
-        {
-          quickbars_selection_toolbar: ''
-        },
+        { quickbars_selection_toolbar: '' },
         ''
       );
+    });
 
-      test('getTextSelectionToolbarItems: testing for boolean false should return empty string',
+    it('TBA: testing for boolean false should return empty string', () => {
+      test(
         Settings.getTextSelectionToolbarItems,
-        {
-          quickbars_selection_toolbar: false
-        },
+        { quickbars_selection_toolbar: false },
         ''
       );
+    });
 
-      test('getTextSelectionToolbarItems: testing for boolean true should fallback to defaults',
+    it('TBA: testing for boolean true should fallback to defaults', () => {
+      test(
         Settings.getTextSelectionToolbarItems,
-        {
-          quickbars_selection_toolbar: true
-        },
+        { quickbars_selection_toolbar: true },
         'bold italic | quicklink h2 h3 blockquote'
       );
+    });
 
-      test('getTextSelectionToolbarItems: testing for undefined should fallback to defaults',
+    it('TBA: testing for undefined should fallback to defaults', () => {
+      test(
         Settings.getTextSelectionToolbarItems,
         {
           // intentionally blank undefined
         },
         'bold italic | quicklink h2 h3 blockquote'
       );
+    });
 
-      test('getTextSelectionToolbarItems: testing for custom config string',
+    it('TBA: testing for custom config string', () => {
+      test(
         Settings.getTextSelectionToolbarItems,
-        {
-          quickbars_selection_toolbar: 'hello | friend'
-        },
+        { quickbars_selection_toolbar: 'hello | friend' },
         'hello | friend'
       );
+    });
+  });
 
-      test('getInsertToolbarItems: testing for empty string should return empty string',
+  context('getInsertToolbarItems', () => {
+    it('TBA: testing for empty string should return empty string', () => {
+      test(
         Settings.getInsertToolbarItems,
-        {
-          quickbars_insert_toolbar: ''
-        },
+        { quickbars_insert_toolbar: '' },
         ''
       );
+    });
 
-      test('getInsertToolbarItems: testing for boolean false should return empty string',
+    it('TBA: testing for boolean false should return empty string', () => {
+      test(
         Settings.getInsertToolbarItems,
-        {
-          quickbars_insert_toolbar: false
-        },
+        { quickbars_insert_toolbar: false },
         ''
       );
+    });
 
-      test('getInsertToolbarItems: testing for boolean true should fallback to defaults',
+    it('TBA: testing for boolean true should fallback to defaults', () => {
+      test(
         Settings.getInsertToolbarItems,
-        {
-          quickbars_insert_toolbar: true
-        },
+        { quickbars_insert_toolbar: true },
         'quickimage quicktable'
       );
+    });
 
-      test('getInsertToolbarItems: testing for undefined should fallback to defaults',
+    it('TBA: testing for undefined should fallback to defaults', () => {
+      test(
         Settings.getInsertToolbarItems,
         {
           // intentionally blank undefined
         },
         'quickimage quicktable'
       );
+    });
 
-      test('getInsertToolbarItems: testing for custom config string',
+    it('TBA: testing for custom config string', () => {
+      test(
         Settings.getInsertToolbarItems,
-        {
-          quickbars_insert_toolbar: 'bye | now'
-        },
+        { quickbars_insert_toolbar: 'bye | now' },
         'bye | now'
       );
-
-    }
-  );
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
@@ -1,60 +1,61 @@
-import { Log, Pipeline, UiFinder, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
-import QuickbarsPlugin from 'tinymce/plugins/quickbars/Plugin';
+import Plugin from 'tinymce/plugins/quickbars/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.quickbars.ContentEditableTest', (success, failure) => {
-
-  Theme();
-  QuickbarsPlugin();
-
-  TinyLoader.setup((editor: Editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    const sAssertToolbarVisible = tinyUi.sWaitForUi('wait for toolbar to show', '.tox-toolbar');
-    const sAssertToolbarNotVisible = Waiter.sTryUntil('toolbar should not exist', UiFinder.sNotExists(SugarBody.body(), '.tox-toolbar'));
-
-    Pipeline.async({}, [
-      tinyApis.sFocus(),
-      Log.stepsAsStep('TBA', 'Text selection toolbar is not shown with contenteditable=false', [
-        tinyApis.sSetContent('<p>abc</p><p contenteditable="false">cab</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 1),
-        sAssertToolbarVisible,
-        tinyApis.sSelect('p[contenteditable=false]', []),
-        sAssertToolbarNotVisible
-      ]),
-      Log.stepsAsStep('TBA', 'Text selection toolbar is not shown with contenteditable=false parent, select parent', [
-        tinyApis.sSetContent('<div><p>abc</p></div><div contenteditable="false"><p>cab</p></div>'),
-        tinyApis.sSelect('div', []),
-        sAssertToolbarVisible,
-        tinyApis.sSelect('div[contenteditable=false]', []),
-        sAssertToolbarNotVisible
-      ]),
-      Log.stepsAsStep('TBA', 'Text selection toolbar is not shown with contenteditable=false parent, select child of parent', [
-        tinyApis.sSetContent('<div><p>abc</p></div><div contenteditable="false"><p>cab</p></div>'),
-        tinyApis.sSelect('div p', []),
-        sAssertToolbarVisible,
-        tinyApis.sSelect('div[contenteditable=false] p', []),
-        sAssertToolbarNotVisible
-      ]),
-      Log.stepsAsStep('TBA', 'Text selection toolbar is not shown with contenteditable=false span, select span', [
-        tinyApis.sSetContent('<p>abc</p><p>abc <span contenteditable="false">click on me</span> 123</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 1),
-        sAssertToolbarVisible,
-        tinyApis.sSelect('p span', []),
-        sAssertToolbarNotVisible
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.quickbars.ContentEditableTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'quickbars link',
     inline: true,
     toolbar: false,
     menubar: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Theme, Plugin ], true);
+
+  const pAssertToolbarVisible = async () => Waiter.pTryUntil('toolbar should not exist', () => UiFinder.sNotExists(SugarBody.body(), '.tox-toolbar'));
+
+  const pAssertToolbarNotVisible = async () => {
+    await Waiter.pWait(300);
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog .tox-toolbar');
+  };
+
+  it('TBA: Text selection toolbar is not shown with contenteditable=false', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>abc</p><p contenteditable="false">cab</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+    await pAssertToolbarVisible();
+    TinySelections.select(editor, 'p[contenteditable=false]', []);
+    await pAssertToolbarNotVisible();
+  });
+
+  it('TBA: Text selection toolbar is not shown with contenteditable=false parent, select parent', async () => {
+    const editor = hook.editor();
+    editor.setContent('<div><p>abc</p></div><div contenteditable="false"><p>cab</p></div>');
+    TinySelections.select(editor, 'div', []);
+    await pAssertToolbarVisible();
+    TinySelections.select(editor, 'div[contenteditable=false]', []);
+    await pAssertToolbarNotVisible();
+  });
+
+  it('TBA: Text selection toolbar is not shown with contenteditable=false parent, select child of parent', async () => {
+    const editor = hook.editor();
+    editor.setContent('<div><p>abc</p></div><div contenteditable="false"><p>cab</p></div>');
+    TinySelections.select(editor, 'div p', []);
+    await pAssertToolbarVisible();
+    TinySelections.select(editor, 'div[contenteditable=false] p', []);
+    await pAssertToolbarNotVisible();
+  });
+
+  it('Text selection toolbar is not shown with contenteditable=false span, select span', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>abc</p><p>abc <span contenteditable="false">click on me</span> 123</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+    await pAssertToolbarVisible();
+    TinySelections.select(editor, 'p span', []);
+    await pAssertToolbarNotVisible();
+  });
 });

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
@@ -1,53 +1,51 @@
-import { ApproxStructure, Assertions, Chain, GeneralSteps, Guard, Log, Pipeline, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import QuickbarsPlugin from 'tinymce/plugins/quickbars/Plugin';
+import Plugin from 'tinymce/plugins/quickbars/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.quickbars.SelectionToolbarTest', (success, failure) => {
+enum Alignment {
+  Left = 'left',
+  Right = 'right',
+  Center = 'center'
+}
+
+describe('browser.tinymce.plugins.quickbars.SelectionToolbarTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'quickbars link',
+    inline: true,
+    toolbar: false,
+    menubar: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Theme, LinkPlugin, Plugin ], true);
 
   const imgSrc = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-  Theme();
-  LinkPlugin();
-  QuickbarsPlugin();
+  const pAssertButtonToggledState = async (name: string, state: boolean) => {
+    const button = await UiFinder.pWaitForVisible('Wait for button', SugarBody.body(), `.tox-toolbar button[aria-label="${name}"]`);
+    await Waiter.pTryUntil('Wait for toolbar button state', () => {
+      return Assertions.assertStructure('', ApproxStructure.build((s, _str, arr) => s.element('button', {
+        classes: [ state ? arr.has('tox-tbtn--enabled') : arr.not('tox-tbtn--enabled') ]
+      })), button);
+    });
+  };
 
-  enum Alignment {
-    Left = 'left',
-    Right = 'right',
-    Center = 'center'
-  }
+  const pWaitForTextToolbarAndAssertState = async (bold: boolean, italic: boolean, heading2: boolean, heading3: boolean, link: boolean, blockquote: boolean) => {
+    await pAssertButtonToggledState('Bold', bold);
+    await pAssertButtonToggledState('Italic', italic);
+    await pAssertButtonToggledState('Link', link);
+    await pAssertButtonToggledState('Heading 2', heading2);
+    await pAssertButtonToggledState('Heading 3', heading3);
+    await pAssertButtonToggledState('Blockquote', blockquote);
+  };
 
-  const sAssertButtonToggledState = (name: string, state: boolean) => Chain.asStep(SugarBody.body(), [
-    Chain.control(
-      Chain.fromChains( [
-        UiFinder.cFindIn(`.tox-toolbar button[aria-label="${name}"]`),
-        Assertions.cAssertStructure(`Check ${name} button is ${state ? 'active' : 'inactive'}`,
-          ApproxStructure.build((s, str, arr) => s.element('button', {
-            classes: [ state ? arr.has('tox-tbtn--enabled') : arr.not('tox-tbtn--enabled') ]
-          }))
-        )
-      ]),
-      Guard.tryUntil('wait for toolbar button state')
-    )
-  ]);
-
-  const sWaitForTextToolbarAndAssertState = (tinyUi: TinyUi, bold: boolean, italic: boolean, heading2: boolean, heading3: boolean, link: boolean, blockquote: boolean) => GeneralSteps.sequence([
-    tinyUi.sWaitForUi('wait for text selection toolbar to show', '.tox-toolbar'),
-    sAssertButtonToggledState('Bold', bold),
-    sAssertButtonToggledState('Italic', italic),
-    sAssertButtonToggledState('Link', link),
-    sAssertButtonToggledState('Heading 2', heading2),
-    sAssertButtonToggledState('Heading 3', heading3),
-    sAssertButtonToggledState('Blockquote', blockquote)
-  ]);
-
-  const sSetImageAndAssertToolbarState = (tinyApis: TinyApis, tinyUi: TinyUi, useFigure: boolean, alignment?: Alignment) => {
-    let attrs, imageHtml;
+  const pSetImageAndAssertToolbarState = async (editor: Editor, useFigure: boolean, alignment?: Alignment) => {
+    let attrs: string;
+    let imageHtml: string;
     if (alignment === undefined) {
       attrs = useFigure ? 'class="image"' : '';
     } else if (alignment === Alignment.Center) {
@@ -62,49 +60,132 @@ UnitTest.asynctest('browser.tinymce.plugins.quickbars.SelectionToolbarTest', (su
       imageHtml = `<p><img src="${imgSrc}" ${attrs}></p>`;
     }
 
-    return GeneralSteps.sequence([
-      tinyApis.sSetContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p>' + imageHtml),
-      tinyApis.sSelect(useFigure ? 'figure' : 'img', []),
-      tinyUi.sWaitForUi('wait for image selection toolbar to show', '.tox-toolbar'),
-      sAssertButtonToggledState('Align left', alignment === Alignment.Left),
-      sAssertButtonToggledState('Align center', alignment === Alignment.Center),
-      sAssertButtonToggledState('Align right', alignment === Alignment.Right)
-    ]);
+    editor.setContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p>' + imageHtml);
+    TinySelections.select(editor, useFigure ? 'figure' : 'img', []);
+    await pAssertButtonToggledState('Align left', alignment === Alignment.Left);
+    await pAssertButtonToggledState('Align center', alignment === Alignment.Center);
+    await pAssertButtonToggledState('Align right', alignment === Alignment.Right);
   };
 
-  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
+  it.skip('TBA: Text selection toolbar', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><blockquote><p>Some quoted content</p></blockquote>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
+    await pWaitForTextToolbarAndAssertState(false, false, false, false, false, false);
+    TinySelections.setSelection(editor, [ 0, 1, 0 ], 0, [ 0, 1, 0 ], 3);
+    await pWaitForTextToolbarAndAssertState(true, false, false, false, false, false);
+    TinySelections.setSelection(editor, [ 0, 3, 0 ], 1, [ 0, 3, 0 ], 4);
+    await pWaitForTextToolbarAndAssertState(false, true, false, false, false, false);
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 1);
+    await pWaitForTextToolbarAndAssertState(false, false, false, false, false, true);
+  });
 
-    Pipeline.async({}, [
-      tinyApis.sFocus(),
-      Log.stepsAsStep('TBA', 'Text selection toolbar', [
-        tinyApis.sSetContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><blockquote><p>Some quoted content</p></blockquote>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 4),
-        sWaitForTextToolbarAndAssertState(tinyUi, false, false, false, false, false, false),
-        tinyApis.sSetSelection([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 3),
-        sWaitForTextToolbarAndAssertState(tinyUi, true, false, false, false, false, false),
-        tinyApis.sSetSelection([ 0, 3, 0 ], 1, [ 0, 3, 0 ], 4),
-        sWaitForTextToolbarAndAssertState(tinyUi, false, true, false, false, false, false),
-        tinyApis.sSetSelection([ 1, 0 ], 0, [ 1, 0 ], 1),
-        sWaitForTextToolbarAndAssertState(tinyUi, false, false, false, false, false, true)
-      ]),
-      Log.stepsAsStep('TBA', 'Image selection toolbar', [
-        sSetImageAndAssertToolbarState(tinyApis, tinyUi, false),
-        sSetImageAndAssertToolbarState(tinyApis, tinyUi, false, Alignment.Left),
-        sSetImageAndAssertToolbarState(tinyApis, tinyUi, false, Alignment.Center),
-        sSetImageAndAssertToolbarState(tinyApis, tinyUi, false, Alignment.Right),
-        sSetImageAndAssertToolbarState(tinyApis, tinyUi, true),
-        sSetImageAndAssertToolbarState(tinyApis, tinyUi, true, Alignment.Left),
-        sSetImageAndAssertToolbarState(tinyApis, tinyUi, true, Alignment.Center),
-        sSetImageAndAssertToolbarState(tinyApis, tinyUi, true, Alignment.Right)
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    plugins: 'quickbars link',
-    inline: true,
-    toolbar: false,
-    menubar: false,
-    base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  it('TBA: Image selection toolbar', async () => {
+    const editor = hook.editor();
+    await pSetImageAndAssertToolbarState(editor, false);
+    await pSetImageAndAssertToolbarState(editor, false, Alignment.Left);
+    await pSetImageAndAssertToolbarState(editor, false, Alignment.Center);
+    await pSetImageAndAssertToolbarState(editor, false, Alignment.Right);
+    await pSetImageAndAssertToolbarState(editor, true);
+    await pSetImageAndAssertToolbarState(editor, true, Alignment.Left);
+    await pSetImageAndAssertToolbarState(editor, true, Alignment.Center);
+    await pSetImageAndAssertToolbarState(editor, true, Alignment.Right);
+  });
 });
+
+// UnitTest.asynctest('browser.tinymce.plugins.quickbars.SelectionToolbarTest', (success, failure) => {
+
+//   const imgSrc = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+//   Theme();
+//   LinkPlugin();
+//   QuickbarsPlugin();
+
+
+
+//   const sAssertButtonToggledState = (name: string, state: boolean) => Chain.asStep(SugarBody.body(), [
+//     Chain.control(
+//       Chain.fromChains( [
+//         UiFinder.cFindIn(`.tox-toolbar button[aria-label="${name}"]`),
+//         Assertions.cAssertStructure(`Check ${name} button is ${state ? 'active' : 'inactive'}`,
+//           ApproxStructure.build((s, str, arr) => s.element('button', {
+//             classes: [ state ? arr.has('tox-tbtn--enabled') : arr.not('tox-tbtn--enabled') ]
+//           }))
+//         )
+//       ]),
+//       Guard.tryUntil('wait for toolbar button state')
+//     )
+//   ]);
+
+//   const sWaitForTextToolbarAndAssertState = (tinyUi: TinyUi, bold: boolean, italic: boolean, heading2: boolean, heading3: boolean, link: boolean, blockquote: boolean) => GeneralSteps.sequence([
+//     tinyUi.sWaitForUi('wait for text selection toolbar to show', '.tox-toolbar'),
+//     sAssertButtonToggledState('Bold', bold),
+//     sAssertButtonToggledState('Italic', italic),
+//     sAssertButtonToggledState('Link', link),
+//     sAssertButtonToggledState('Heading 2', heading2),
+//     sAssertButtonToggledState('Heading 3', heading3),
+//     sAssertButtonToggledState('Blockquote', blockquote)
+//   ]);
+
+//   const sSetImageAndAssertToolbarState = (tinyApis: TinyApis, tinyUi: TinyUi, useFigure: boolean, alignment?: Alignment) => {
+//     let attrs, imageHtml;
+//     if (alignment === undefined) {
+//       attrs = useFigure ? 'class="image"' : '';
+//     } else if (alignment === Alignment.Center) {
+//       attrs = useFigure ? `class="image align-${alignment}"` : 'style="margin-left: auto; margin-right: auto; display: block;"';
+//     } else {
+//       attrs = useFigure ? `class="image align-${alignment}"` : `style="float: ${alignment};"`;
+//     }
+
+//     if (useFigure) {
+//       imageHtml = `<figure ${attrs} contenteditable="false"><img src="${imgSrc}"><figcaption contenteditable="true">Caption</figcaption></figure>`;
+//     } else {
+//       imageHtml = `<p><img src="${imgSrc}" ${attrs}></p>`;
+//     }
+
+//     return GeneralSteps.sequence([
+//       tinyApis.sSetContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p>' + imageHtml),
+//       tinyApis.sSelect(useFigure ? 'figure' : 'img', []),
+//       tinyUi.sWaitForUi('wait for image selection toolbar to show', '.tox-toolbar'),
+//       sAssertButtonToggledState('Align left', alignment === Alignment.Left),
+//       sAssertButtonToggledState('Align center', alignment === Alignment.Center),
+//       sAssertButtonToggledState('Align right', alignment === Alignment.Right)
+//     ]);
+//   };
+
+//   TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
+//     const tinyApis = TinyApis(editor);
+//     const tinyUi = TinyUi(editor);
+
+//     Pipeline.async({}, [
+//       tinyApis.sFocus(),
+//       Log.stepsAsStep('TBA', 'Text selection toolbar', [
+//         tinyApis.sSetContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><blockquote><p>Some quoted content</p></blockquote>'),
+//         TinySelections.setSelection([ 0, 0 ], 0, [ 0, 0 ], 4),
+//         sWaitForTextToolbarAndAssertState(tinyUi, false, false, false, false, false, false),
+//         TinySelections.setSelection([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 3),
+//         sWaitForTextToolbarAndAssertState(tinyUi, true, false, false, false, false, false),
+//         TinySelections.setSelection([ 0, 3, 0 ], 1, [ 0, 3, 0 ], 4),
+//         sWaitForTextToolbarAndAssertState(tinyUi, false, true, false, false, false, false),
+//         TinySelections.setSelection([ 1, 0 ], 0, [ 1, 0 ], 1),
+//         sWaitForTextToolbarAndAssertState(tinyUi, false, false, false, false, false, true)
+//       ]),
+//       Log.stepsAsStep('TBA', 'Image selection toolbar', [
+//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, false),
+//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, false, Alignment.Left),
+//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, false, Alignment.Center),
+//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, false, Alignment.Right),
+//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, true),
+//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, true, Alignment.Left),
+//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, true, Alignment.Center),
+//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, true, Alignment.Right)
+//       ])
+//     ], onSuccess, onFailure);
+//   }, {
+//     plugins: 'quickbars link',
+//     inline: true,
+//     toolbar: false,
+//     menubar: false,
+//     base_url: '/project/tinymce/js/tinymce'
+//   }, success, failure);
+// });

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
@@ -62,12 +62,14 @@ describe('browser.tinymce.plugins.quickbars.SelectionToolbarTest', () => {
 
     editor.setContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p>' + imageHtml);
     TinySelections.select(editor, useFigure ? 'figure' : 'img', []);
+    // A short wait to ensure the button state has been updated before running assertions
+    await Waiter.pWait(50);
     await pAssertButtonToggledState('Align left', alignment === Alignment.Left);
     await pAssertButtonToggledState('Align center', alignment === Alignment.Center);
     await pAssertButtonToggledState('Align right', alignment === Alignment.Right);
   };
 
-  it.skip('TBA: Text selection toolbar', async () => {
+  it('TBA: Text selection toolbar', async () => {
     const editor = hook.editor();
     editor.setContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><blockquote><p>Some quoted content</p></blockquote>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
@@ -92,100 +94,3 @@ describe('browser.tinymce.plugins.quickbars.SelectionToolbarTest', () => {
     await pSetImageAndAssertToolbarState(editor, true, Alignment.Right);
   });
 });
-
-// UnitTest.asynctest('browser.tinymce.plugins.quickbars.SelectionToolbarTest', (success, failure) => {
-
-//   const imgSrc = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-
-//   Theme();
-//   LinkPlugin();
-//   QuickbarsPlugin();
-
-
-
-//   const sAssertButtonToggledState = (name: string, state: boolean) => Chain.asStep(SugarBody.body(), [
-//     Chain.control(
-//       Chain.fromChains( [
-//         UiFinder.cFindIn(`.tox-toolbar button[aria-label="${name}"]`),
-//         Assertions.cAssertStructure(`Check ${name} button is ${state ? 'active' : 'inactive'}`,
-//           ApproxStructure.build((s, str, arr) => s.element('button', {
-//             classes: [ state ? arr.has('tox-tbtn--enabled') : arr.not('tox-tbtn--enabled') ]
-//           }))
-//         )
-//       ]),
-//       Guard.tryUntil('wait for toolbar button state')
-//     )
-//   ]);
-
-//   const sWaitForTextToolbarAndAssertState = (tinyUi: TinyUi, bold: boolean, italic: boolean, heading2: boolean, heading3: boolean, link: boolean, blockquote: boolean) => GeneralSteps.sequence([
-//     tinyUi.sWaitForUi('wait for text selection toolbar to show', '.tox-toolbar'),
-//     sAssertButtonToggledState('Bold', bold),
-//     sAssertButtonToggledState('Italic', italic),
-//     sAssertButtonToggledState('Link', link),
-//     sAssertButtonToggledState('Heading 2', heading2),
-//     sAssertButtonToggledState('Heading 3', heading3),
-//     sAssertButtonToggledState('Blockquote', blockquote)
-//   ]);
-
-//   const sSetImageAndAssertToolbarState = (tinyApis: TinyApis, tinyUi: TinyUi, useFigure: boolean, alignment?: Alignment) => {
-//     let attrs, imageHtml;
-//     if (alignment === undefined) {
-//       attrs = useFigure ? 'class="image"' : '';
-//     } else if (alignment === Alignment.Center) {
-//       attrs = useFigure ? `class="image align-${alignment}"` : 'style="margin-left: auto; margin-right: auto; display: block;"';
-//     } else {
-//       attrs = useFigure ? `class="image align-${alignment}"` : `style="float: ${alignment};"`;
-//     }
-
-//     if (useFigure) {
-//       imageHtml = `<figure ${attrs} contenteditable="false"><img src="${imgSrc}"><figcaption contenteditable="true">Caption</figcaption></figure>`;
-//     } else {
-//       imageHtml = `<p><img src="${imgSrc}" ${attrs}></p>`;
-//     }
-
-//     return GeneralSteps.sequence([
-//       tinyApis.sSetContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p>' + imageHtml),
-//       tinyApis.sSelect(useFigure ? 'figure' : 'img', []),
-//       tinyUi.sWaitForUi('wait for image selection toolbar to show', '.tox-toolbar'),
-//       sAssertButtonToggledState('Align left', alignment === Alignment.Left),
-//       sAssertButtonToggledState('Align center', alignment === Alignment.Center),
-//       sAssertButtonToggledState('Align right', alignment === Alignment.Right)
-//     ]);
-//   };
-
-//   TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
-//     const tinyApis = TinyApis(editor);
-//     const tinyUi = TinyUi(editor);
-
-//     Pipeline.async({}, [
-//       tinyApis.sFocus(),
-//       Log.stepsAsStep('TBA', 'Text selection toolbar', [
-//         tinyApis.sSetContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><blockquote><p>Some quoted content</p></blockquote>'),
-//         TinySelections.setSelection([ 0, 0 ], 0, [ 0, 0 ], 4),
-//         sWaitForTextToolbarAndAssertState(tinyUi, false, false, false, false, false, false),
-//         TinySelections.setSelection([ 0, 1, 0 ], 0, [ 0, 1, 0 ], 3),
-//         sWaitForTextToolbarAndAssertState(tinyUi, true, false, false, false, false, false),
-//         TinySelections.setSelection([ 0, 3, 0 ], 1, [ 0, 3, 0 ], 4),
-//         sWaitForTextToolbarAndAssertState(tinyUi, false, true, false, false, false, false),
-//         TinySelections.setSelection([ 1, 0 ], 0, [ 1, 0 ], 1),
-//         sWaitForTextToolbarAndAssertState(tinyUi, false, false, false, false, false, true)
-//       ]),
-//       Log.stepsAsStep('TBA', 'Image selection toolbar', [
-//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, false),
-//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, false, Alignment.Left),
-//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, false, Alignment.Center),
-//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, false, Alignment.Right),
-//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, true),
-//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, true, Alignment.Left),
-//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, true, Alignment.Center),
-//         sSetImageAndAssertToolbarState(tinyApis, tinyUi, true, Alignment.Right)
-//       ])
-//     ], onSuccess, onFailure);
-//   }, {
-//     plugins: 'quickbars link',
-//     inline: true,
-//     toolbar: false,
-//     menubar: false,
-//     base_url: '/project/tinymce/js/tinymce'
-//   }, success, failure);
-// });

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarFalseTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarFalseTest.ts
@@ -1,52 +1,46 @@
-import { GeneralSteps, Log, Pipeline, Step, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
-import QuickbarsPlugin from 'tinymce/plugins/quickbars/Plugin';
+import Plugin from 'tinymce/plugins/quickbars/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.quickbars.ToolbarFalseTest', (success, failure) => {
-
-  Theme();
-  QuickbarsPlugin();
-
-  TinyLoader.setup((editor: Editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-
-    const sAssertToolbarNotVisible = GeneralSteps.sequence([
-      // We can't wait for something to happen, as nothing will change. So instead, just wait some time for when the toolbar would have normally shown
-      Step.wait(200),
-      UiFinder.sNotExists(SugarBody.body(), '.tox-pop__dialog .tox-toolbar')
-    ]);
-
-    Pipeline.async({}, [
-      tinyApis.sFocus(),
-      Log.stepsAsStep('TBA', 'Text selection toolbar is not shown', [
-        tinyApis.sSetContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><blockquote><p>Some quoted content</p></blockquote>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 4),
-        sAssertToolbarNotVisible
-      ]),
-      Log.stepsAsStep('TBA', 'Insert toolbar is not shown', [
-        tinyApis.sSetContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><p></p>'),
-        tinyApis.sSetSelection([ 1 ], 0, [ 1 ], 0),
-        sAssertToolbarNotVisible
-      ]),
-      Log.stepsAsStep('TBA', 'Image toolbar is not shown', [
-        tinyApis.sSetContent('<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"></p>'),
-        tinyApis.sSetSelection([ 0 ], 0, [ 0 ], 0),
-        sAssertToolbarNotVisible
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.quickbars.ToolbarFalseTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'quickbars link',
     inline: true,
-    toolbar: false,
-    menubar: false,
     quickbars_insert_toolbar: false,
     quickbars_selection_toolbar: false,
     quickbars_image_toolbar: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  const assertToolbarNotVisible = async () => {
+    // We can't wait for something to happen, as nothing will change. So instead, just wait some time for when the toolbar would have normally shown
+    await Waiter.pWait(300);
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog .tox-toolbar');
+  };
+
+  it('TBA: Text selection toolbar is not shown', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><blockquote><p>Some quoted content</p></blockquote>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
+    await assertToolbarNotVisible();
+  });
+
+  it('TBA: Insert toolbar is not shown', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><p></p>');
+    TinySelections.setCursor(editor, [ 1 ], 0);
+    await assertToolbarNotVisible();
+  });
+
+  it('TBA: Image toolbar is not shown', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"></p>');
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    await assertToolbarNotVisible();
+  });
 });

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarFalseTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarFalseTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.plugins.quickbars.ToolbarFalseTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme, Plugin ]);
 
-  const assertToolbarNotVisible = async () => {
+  const pAssertToolbarNotVisible = async () => {
     // We can't wait for something to happen, as nothing will change. So instead, just wait some time for when the toolbar would have normally shown
     await Waiter.pWait(300);
     UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog .tox-toolbar');
@@ -27,20 +27,20 @@ describe('browser.tinymce.plugins.quickbars.ToolbarFalseTest', () => {
     const editor = hook.editor();
     editor.setContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><blockquote><p>Some quoted content</p></blockquote>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
-    await assertToolbarNotVisible();
+    await pAssertToolbarNotVisible();
   });
 
   it('TBA: Insert toolbar is not shown', async () => {
     const editor = hook.editor();
     editor.setContent('<p>Some <strong>bold</strong> and <em>italic</em> content.</p><p></p>');
     TinySelections.setCursor(editor, [ 1 ], 0);
-    await assertToolbarNotVisible();
+    await pAssertToolbarNotVisible();
   });
 
   it('TBA: Image toolbar is not shown', async () => {
     const editor = hook.editor();
     editor.setContent('<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"></p>');
     TinySelections.setCursor(editor, [ 0 ], 0);
-    await assertToolbarNotVisible();
+    await pAssertToolbarNotVisible();
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
Converts tests in the `quickbars` plugin to BDD.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
