### PR TITLE
  TINY-6997: Paste plugin with smart_paste not pasting url over highlighted text

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An unexpected exception was thrown when switching to readonly mode and adjusting the editor width #TINY-6383
 - Fixed a bug where block elements containing a pagebreak could be removed from the editor content #TINY-3388
 - Fixed a bug where the `list-style-type: none;` style on nested list items was incorrectly removed when clearing formatting #TINY-6264
+- URLs were not always detected when pasting over a selection. Patch contributed by jwcooper #TINY-6997
 
 ## 5.8.0 - 2021-05-06
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -326,17 +326,16 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
     pasteBin.remove();
 
     const isPlainTextHtml = (internal === false && Newlines.isPlainText(content));
-    const isImage = SmartPaste.isImageUrl(editor, content);
     const isAbsoluteUrl = SmartPaste.isAbsoluteUrl(content);
 
     // If we got nothing from clipboard API and pastebin or the content is a plain text (with only
     // some BRs, Ps or DIVs as newlines) then we fallback to plain/text
-    if (!content.length || (isPlainTextHtml && !isImage && !isAbsoluteUrl)) {
+    if (!content.length || (isPlainTextHtml && !isAbsoluteUrl)) {
       plainTextMode = true;
     }
 
     // Grab plain text from Clipboard API or convert existing HTML to plain text
-    if (plainTextMode || isImage) {
+    if (plainTextMode || isAbsoluteUrl) {
       // Use plain text contents from Clipboard API unless the HTML contains paragraphs then
       // we should convert the HTML to plain text since works better when pasting HTML/Word contents as plain text
       if (hasContentType(clipboardContent, 'text/plain') && isPlainTextHtml) {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -327,10 +327,11 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
 
     const isPlainTextHtml = (internal === false && Newlines.isPlainText(content));
     const isImage = SmartPaste.isImageUrl(editor, content);
+    const isAbsoluteUrl = SmartPaste.isAbsoluteUrl(content);
 
     // If we got nothing from clipboard API and pastebin or the content is a plain text (with only
     // some BRs, Ps or DIVs as newlines) then we fallback to plain/text
-    if (!content.length || (isPlainTextHtml && !isImage)) {
+    if (!content.length || (isPlainTextHtml && !isImage && !isAbsoluteUrl)) {
       plainTextMode = true;
     }
 


### PR DESCRIPTION
Related Ticket: TINY-6493

Description of Changes:
* Fixes to paste plugin (see title)

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ This will need manual testing.
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

Before merge:
* [x] Merge commit or rebase merge (to retain contributor commit)
* [x] Neil needs to squash the fixup! commits

GitHub issues (if applicable): Fixes #6493