### PR TITLE
TINY-6870: Switch Noneditable plugin to use BDD style tests 

### DIFF
--- a/modules/tinymce/src/plugins/noneditable/test/ts/browser/NonEditablePluginTest.ts
+++ b/modules/tinymce/src/plugins/noneditable/test/ts/browser/NonEditablePluginTest.ts
@@ -1,49 +1,45 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/noneditable/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.noneditable.NonEditablePluginTest', (success, failure) => {
-  const suite = LegacyUnit.createSuite<Editor>();
-
-  Plugin();
-  Theme();
-
-  suite.test('TestCase-TBA: NonEditable: noneditable class', (editor) => {
-    editor.setContent('<p><span class="mceNonEditable">abc</span></p>');
-    LegacyUnit.equal(editor.dom.select('span')[0].contentEditable, 'false');
-  });
-
-  suite.test('TestCase-TBA: NonEditable: editable class', (editor) => {
-    editor.setContent('<p><span class="mceEditable">abc</span></p>');
-    LegacyUnit.equal(editor.dom.select('span')[0].contentEditable, 'true');
-  });
-
-  suite.test('TestCase-TBA: NonEditable: noneditable regexp', (editor) => {
-    editor.setContent('<p>{test1}{test2}</p>');
-
-    LegacyUnit.equal(editor.dom.select('span').length, 2);
-    LegacyUnit.equal(editor.dom.select('span')[0].contentEditable, 'false');
-    LegacyUnit.equal(editor.dom.select('span')[1].contentEditable, 'false');
-    LegacyUnit.equal(editor.getContent(), '<p>{test1}{test2}</p>');
-  });
-
-  suite.test('TestCase-TBA: NonEditable: noneditable regexp inside cE=false', (editor) => {
-    editor.setContent('<span contenteditable="false">{test1}</span>');
-    LegacyUnit.equal(editor.dom.select('span').length, 1);
-  });
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    Pipeline.async({}, Log.steps('TBA', 'NonEditable: Test noneditable class and regexp', suite.toSteps(editor)), onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.noneditable.NonEditablePluginTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     indent: false,
     noneditable_regexp: [ /\{[^\}]+\}/g ],
     plugins: 'noneditable',
     entities: 'raw',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  it('TBA: noneditable class', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><span class="mceNonEditable">abc</span></p>');
+    assert.equal(editor.dom.select('span')[0].contentEditable, 'false');
+  });
+
+  it('TBA: editable class', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><span class="mceEditable">abc</span></p>');
+    assert.equal(editor.dom.select('span')[0].contentEditable, 'true');
+  });
+
+  it('TBA: noneditable regexp', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>{test1}{test2}</p>');
+    assert.equal(editor.dom.select('span').length, 2);
+    assert.equal(editor.dom.select('span')[0].contentEditable, 'false');
+    assert.equal(editor.dom.select('span')[1].contentEditable, 'false');
+    TinyAssertions.assertContent(editor, '<p>{test1}{test2}</p>');
+  });
+
+  it('TBA: noneditable regexp inside cE=false', () => {
+    const editor = hook.editor();
+    editor.setContent('<span contenteditable="false">{test1}</span>');
+    assert.equal(editor.dom.select('span').length, 1);
+  });
 });

--- a/modules/tinymce/src/plugins/noneditable/test/ts/browser/NonEditablePluginTest.ts
+++ b/modules/tinymce/src/plugins/noneditable/test/ts/browser/NonEditablePluginTest.ts
@@ -40,6 +40,6 @@ describe('browser.tinymce.plugins.noneditable.NonEditablePluginTest', () => {
   it('TBA: noneditable regexp inside cE=false', () => {
     const editor = hook.editor();
     editor.setContent('<span contenteditable="false">{test1}</span>');
-    assert.equal(editor.dom.select('span').length, 1);
+    assert.lengthOf(editor.dom.select('span'), 1);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
BDD style test for `noneditable` plugin

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
