### PR TITLE
TINY-6870: Switch Nonbreaking plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingForceTabTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingForceTabTest.ts
@@ -9,7 +9,7 @@ import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.nonbreaking.NonbreakingForceTabTest', () => {
-  const hook = TinyHooks.bddSetup<Editor>({
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'nonbreaking',
     toolbar: 'nonbreaking',
     nonbreaking_force_tab: 5,
@@ -19,7 +19,6 @@ describe('browser.tinymce.plugins.nonbreaking.NonbreakingForceTabTest', () => {
 
   it('TBA: Undo level on insert tab', () => {
     const editor = hook.editor();
-    editor.focus();
     Keyboard.activeKeystroke(TinyDom.document(editor), Keys.tab());
     TinyAssertions.assertContent(editor, '<p><span class="mce-nbsp-wrap" contenteditable="false">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></p>');
     editor.undoManager.undo();

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingForceTabTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingForceTabTest.ts
@@ -1,42 +1,35 @@
-import { Keys, Log, Pipeline, Step } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
+import { Keyboard, Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
 import VK from 'tinymce/core/api/util/VK';
-import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.nonbreaking.NonbreakingForceTabTest', (success, failure) => {
-
-  NonbreakingPlugin();
-  SilverTheme();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyActions = TinyActions(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'NonBreaking: Undo level on insert tab', [
-        tinyActions.sContentKeystroke(Keys.tab(), {}),
-        tinyApis.sAssertContent('<p><span class="mce-nbsp-wrap" contenteditable="false">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></p>'),
-        Step.sync(() => {
-          editor.undoManager.undo();
-        }),
-        tinyApis.sAssertContent('')
-      ]),
-      Log.step('TBA', 'NonBreaking: Prevent default and other handlers on insert tab',
-        Step.sync(() => {
-          const args = editor.fire('keydown', { keyCode: VK.TAB });
-          Assert.eq('Default should be prevented', true, args.isDefaultPrevented());
-          Assert.eq('Should not propagate', true, args.isImmediatePropagationStopped());
-        })
-      )
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.nonbreaking.NonbreakingForceTabTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'nonbreaking',
     toolbar: 'nonbreaking',
     nonbreaking_force_tab: 5,
     theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
-}
-);
+  }, [ Theme, Plugin ], true);
+
+  it('TBA: Undo level on insert tab', () => {
+    const editor = hook.editor();
+    editor.focus();
+    Keyboard.activeKeystroke(TinyDom.document(editor), Keys.tab());
+    TinyAssertions.assertContent(editor, '<p><span class="mce-nbsp-wrap" contenteditable="false">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></p>');
+    editor.undoManager.undo();
+    TinyAssertions.assertContent(editor, '');
+  });
+
+  it('TBA: Prevent default and other handlers on insert tab', () => {
+    const editor = hook.editor();
+    const args = editor.fire('keydown', { keyCode: VK.TAB } as KeyboardEvent);
+    assert.isTrue(args.isDefaultPrevented());
+    assert.isTrue(args.isImmediatePropagationStopped());
+  });
+});

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSanityTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSanityTest.ts
@@ -1,43 +1,38 @@
-import { ApproxStructure, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { ApproxStructure } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
-import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';
-import theme from 'tinymce/themes/silver/Theme';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.nonbreaking.NonbreakingSanityTest', (success, failure) => {
-
-  theme();
-  NonbreakingPlugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-    const tinyApis = TinyApis(editor);
-
-    Pipeline.async({}, Log.steps('TBA', 'NonBreaking: Click on the nbsp button and assert nonbreaking space is inserted', [
-      tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-      tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => {
-        return s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth))
-              ]
-            })
-          ]
-        });
-      }))
-    ]), onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.nonbreaking.NonbreakingSanityTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'nonbreaking',
     toolbar: 'nonbreaking',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  it('TBA: Click on the nbsp button and assert nonbreaking space is inserted', () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Nonbreaking space"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.element('span', {
+                classes: [ arr.has('mce-nbsp-wrap') ],
+                children: [
+                  s.text(str.is(Unicode.nbsp))
+                ]
+              }),
+              s.text(str.is(Unicode.zeroWidth))
+            ]
+          })
+        ]
+      });
+    }));
+  });
 });

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSettingsTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSettingsTest.ts
@@ -5,7 +5,7 @@ import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import * as Settings from 'tinymce/plugins/nonbreaking/api/Settings';
 
-describe('browser.tinymce.plugins.nonbreaking.SettingsTest', () => {
+describe('browser.tinymce.plugins.nonbreaking.NonbreakingSettingsTest', () => {
   it('TBA: Should be 0 as default', () => {
     assert.equal(Settings.getKeyboardSpaces(new Editor('x', {}, EditorManager)), 0);
   });

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSettingsTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSettingsTest.ts
@@ -1,12 +1,24 @@
-import { Assertions } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import * as Settings from 'tinymce/plugins/nonbreaking/api/Settings';
 
-UnitTest.test('browser.tinymce.plugins.nonbreaking.SettingsTest', () => {
-  Assertions.assertEq('TestCase-TBA: NonBreaking: Should be 0 as default', 0, Settings.getKeyboardSpaces(new Editor('x', {}, EditorManager)));
-  Assertions.assertEq('TestCase-TBA: NonBreaking: Should return 3 if set to true', 3, Settings.getKeyboardSpaces(new Editor('x', { nonbreaking_force_tab: true }, EditorManager)));
-  Assertions.assertEq('TestCase-TBA: NonBreaking: Should return 0 if set to false', 0, Settings.getKeyboardSpaces(new Editor('x', { nonbreaking_force_tab: false }, EditorManager)));
-  Assertions.assertEq('TestCase-TBA: NonBreaking: Should return number if set', 4, Settings.getKeyboardSpaces(new Editor('x', { nonbreaking_force_tab: 4 }, EditorManager)));
+describe('browser.tinymce.plugins.nonbreaking.SettingsTest', () => {
+  it('TBA: Should be 0 as default', () => {
+    assert.equal(Settings.getKeyboardSpaces(new Editor('x', {}, EditorManager)), 0);
+  });
+
+  it('TBA: Should return 3 if set to true', () => {
+    assert.equal(Settings.getKeyboardSpaces(new Editor('x', { nonbreaking_force_tab: true }, EditorManager)), 3);
+  });
+
+  it('TBA: Should return 0 if set to false', () => {
+    assert.equal(Settings.getKeyboardSpaces(new Editor('x', { nonbreaking_force_tab: false }, EditorManager)), 0);
+  });
+
+  it('TBA: Should return number if set', () => {
+    assert.equal(Settings.getKeyboardSpaces(new Editor('x', { nonbreaking_force_tab: 4 }, EditorManager)), 4);
+  });
 });

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingVisualCharsTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingVisualCharsTest.ts
@@ -1,70 +1,70 @@
-import { ApproxStructure, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { ApproxStructure } from '@ephox/agar';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
 import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';
 import VisualCharsPlugin from 'tinymce/plugins/visualchars/Plugin';
-import theme from 'tinymce/themes/silver/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.nonbreaking.NonbreakingVisualCharsTest', (success, failure) => {
-
-  theme();
-  NonbreakingPlugin();
-  VisualCharsPlugin();
-
-  TinyLoader.setup((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-    const tinyApis = TinyApis(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TINY-3647', 'NonBreaking+VisualChars: Click on the nbsp button and assert nonbreaking space is inserted', [
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => {
-          return s.element('body', {
-            children: [
-              s.element('p', {
-                children: [
-                  s.element('span', {
-                    classes: [ arr.has('mce-nbsp-wrap') ],
-                    children: [
-                      s.text(str.is(Unicode.nbsp))
-                    ]
-                  }),
-                  s.text(str.is(Unicode.zeroWidth))
-                ]
-              })
-            ]
-          });
-        }))
-      ]),
-
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', 'NonBreaking+VisualChars: Enable VisualChars then click on the nbsp button and assert nonbreaking span is inserted', [
-        tinyUi.sClickOnToolbar('click on visualchars button', 'button[aria-label="Show invisible characters"]'),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => {
-          return s.element('body', {
-            children: [
-              s.element('p', {
-                children: [
-                  s.element('span', {
-                    classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                    children: [
-                      s.text(str.is(Unicode.nbsp))
-                    ]
-                  }),
-                  s.text(str.is(Unicode.zeroWidth))
-                ]
-              })
-            ]
-          });
-        }))
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.nonbreaking.NonbreakingVisualCharsTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'nonbreaking visualchars',
     toolbar: 'nonbreaking visualchars',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Theme, NonbreakingPlugin, VisualCharsPlugin ]);
+
+  beforeEach(() => {
+    const editor = hook.editor();
+    editor.setContent('');
+  });
+
+  it('TINY-3647: Click on the nbsp button and assert nonbreaking space is inserted', () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Nonbreaking space"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.element('span', {
+                classes: [ arr.has('mce-nbsp-wrap') ],
+                children: [
+                  s.text(str.is(Unicode.nbsp))
+                ]
+              }),
+              s.text(str.is(Unicode.zeroWidth))
+            ]
+          })
+        ]
+      });
+    }));
+  });
+
+  it('TINY-3647: Enable VisualChars then click on the nbsp button and assert nonbreaking span is inserted', () => {
+    const editor = hook.editor();
+    // click visual chars
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Show invisible characters"]');
+    // click nonbreaking
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Nonbreaking space"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.element('span', {
+                classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
+                children: [
+                  s.text(str.is(Unicode.nbsp))
+                ]
+              }),
+              s.text(str.is(Unicode.zeroWidth))
+            ]
+          })
+        ]
+      });
+    }));
+  });
 });
+

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingTypingTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingTypingTest.ts
@@ -1,140 +1,118 @@
-import { ApproxStructure, Log, Pipeline, RealKeys } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { ApproxStructure, RealKeys } from '@ephox/agar';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';
-import theme from 'tinymce/themes/silver/Theme';
+import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('webdriver.tinymce.plugins.nonbreaking.NonbreakingTypingTest', (success, failure) => {
+describe('webdriver.tinymce.plugins.nonbreaking.NonbreakingTypingTest', () => {
   // Note: Uses RealKeys, so needs a browser. Headless won't work.
-
-  theme();
-  NonbreakingPlugin();
-
-  const isGecko = Env.browser.isFirefox();
-  const isGeckoOrIE = isGecko || Env.browser.isIE();
-
-  TinyLoader.setup((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-    const tinyApis = TinyApis(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', '1. NonBreaking: Click on the nbsp button then type some text, and assert content is correct', [
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str) => {
-          return s.element('body', {
-            children: [
-              s.element('p', {
-                children: [
-                  s.text(str.is('\u00a0test'))
-                ]
-              })
-            ]
-          });
-        }))
-      ]),
-
-      tinyApis.sSetContent(''),
-
-      Log.stepsAsStep('TBA', '2. NonBreaking: Add text to editor, click on the nbsp button, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str) => {
-          return s.element('body', {
-            children: [
-              s.element('p', {
-                children: [
-                  s.text(str.is('test\u00a0'))
-                ]
-              })
-            ]
-          });
-        }))
-      ]),
-
-      tinyApis.sSetContent(''),
-
-      Log.stepsAsStep('TBA', '3. NonBreaking: Add content to editor, click on the nbsp button then type some text, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str) => {
-          return s.element('body', {
-            children: [
-              s.element('p', {
-                children: [
-                  s.text(str.is('test test'))
-                ]
-              })
-            ]
-          });
-        }))
-      ]),
-
-      tinyApis.sSetContent(''),
-
-      Log.stepsAsStep('TBA', '4. NonBreaking: Click on the nbsp button then type a space, and assert content is correct', [
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text(' ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str) => {
-          return s.element('body', {
-            children: [
-              s.element('p', {
-                children: [
-                  s.text(str.is(isGeckoOrIE ? '\u00a0 ' : '\u00a0\u00a0'))
-                ].concat(isGecko ? [ s.element('br', {}) ] : [])
-              })
-            ]
-          });
-        }))
-      ]),
-
-      Log.stepsAsStep('TBA', '5. NonBreaking: Add text to editor, click on the nbsp button and add content plus a space, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str) => {
-          return s.element('body', {
-            children: [
-              s.element('p', {
-                children: [
-                  s.text(str.is(isGeckoOrIE ? 'test test ' : 'test test\u00a0'))
-                ].concat(isGecko ? [ s.element('br', {}) ] : [])
-              })
-            ]
-          });
-        }))
-      ])
-
-    ], onSuccess, onFailure);
-  }, {
+  const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'nonbreaking',
     toolbar: 'nonbreaking',
     nonbreaking_wrap: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const isGecko = Env.browser.isFirefox();
+  const isGeckoOrIE = isGecko || Env.browser.isIE();
+
+  const clickNbspToolbarButton = (editor: Editor) => TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Nonbreaking space"]');
+
+  beforeEach(() => {
+    const editor = hook.editor();
+    editor.setContent('');
+  });
+
+  it('TBA: Click on the nbsp button then type some text, and assert content is correct', async () => {
+    const editor = hook.editor();
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.text(str.is('\u00a0test'))
+            ]
+          })
+        ]
+      });
+    }));
+  });
+
+  it('TBA: Add text to editor, click on the nbsp button, and assert content is correct', () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.text(str.is('test\u00a0'))
+            ]
+          })
+        ]
+      });
+    }));
+  });
+
+  it('TBA: Add content to editor, click on the nbsp button then type some text, and assert content is correct', async () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.text(str.is('test test'))
+            ]
+          })
+        ]
+      });
+    }));
+  });
+
+  it('TBA: Click on the nbsp button then type a space, and assert content is correct', async () => {
+    const editor = hook.editor();
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text(' ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.text(str.is(isGeckoOrIE ? '\u00a0 ' : '\u00a0\u00a0'))
+            ].concat(isGecko ? [ s.element('br', {}) ] : [])
+          })
+        ]
+      });
+    }));
+  });
+
+  it('TBA: Add text to editor, click on the nbsp button and add content plus a space, and assert content is correct', async () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.text(str.is(isGeckoOrIE ? 'test test ' : 'test test\u00a0'))
+            ].concat(isGecko ? [ s.element('br', {}) ] : [])
+          })
+        ]
+      });
+    }));
+  });
 });

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingVisualCharsTypingTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingVisualCharsTypingTest.ts
@@ -1,25 +1,24 @@
-import { ApproxStructure, Log, Pipeline, RealKeys } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { ApproxStructure, RealKeys } from '@ephox/agar';
+import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+
+import Editor from 'tinymce/core/api/Editor';
 import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';
 import VisualCharsPlugin from 'tinymce/plugins/visualchars/Plugin';
-import theme from 'tinymce/themes/silver/Theme';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('webdriver.tinymce.plugins.nonbreaking.NonbreakingVisualCharsTypingTest', (success, failure) => {
+describe('webdriver.tinymce.plugins.nonbreaking.NonbreakingVisualCharsTypingTest', () => {
   // Note: Uses RealKeys, so needs a browser. Headless won't work.
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'nonbreaking visualchars',
+    toolbar: 'nonbreaking visualchars',
+    visualchars_default_state: true,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Theme, NonbreakingPlugin, VisualCharsPlugin ]);
 
   const detection = PlatformDetection.detect();
-
-  // TODO TINY-4129: this currently fails on IE 11 and Edge 18 or above and needs to be investigated
-  if (detection.browser.isIE() || detection.browser.isEdge()) {
-    return success();
-  }
-
-  theme();
-  NonbreakingPlugin();
-  VisualCharsPlugin();
 
   const isIE = detection.browser.isIE();
   const getNbspText = (text: string) => {
@@ -32,236 +31,203 @@ UnitTest.asynctest('webdriver.tinymce.plugins.nonbreaking.NonbreakingVisualChars
     }
   };
 
-  TinyLoader.setup((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-    const tinyApis = TinyApis(editor);
+  const clickNbspToolbarButton = (editor: Editor) => TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Nonbreaking space"]');
 
-    Pipeline.async({}, [
-      Log.stepsAsStep('TINY-3647', '1. NonBreaking: Click on the nbsp button then type some text, and assert content is correct', [
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
+  before(function () {
+    // TODO TINY-4129: this currently fails on IE 11 and Edge 18 or above and needs to be investigated
+    if (detection.browser.isIE() || detection.browser.isEdge()) {
+      this.skip();
+    }
+  });
+
+  beforeEach(() => {
+    const editor = hook.editor();
+    editor.setContent('');
+  });
+
+  it('TINY-3647: Click on the nbsp button then type some text, and assert content is correct', async () => {
+    const editor = hook.editor();
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
           children: [
-            s.element('p', {
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
               children: [
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth + 'test'))
+                s.text(str.is(Unicode.nbsp))
               ]
-            })
+            }),
+            s.text(str.is(Unicode.zeroWidth + 'test'))
           ]
-        })))
-      ]),
+        })
+      ]
+    })));
+  });
 
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '2. NonBreaking: Add text to editor, click on the nbsp button, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
+  it('TINY-3647: Add text to editor, click on the nbsp button, and assert content is correct', () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
           children: [
-            s.element('p', {
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
               children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth))
+                s.text(str.is(Unicode.nbsp))
               ]
-            })
+            }),
+            s.text(str.is(Unicode.zeroWidth))
           ]
-        })))
-      ]),
+        })
+      ]
+    })));
+  });
 
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '3. NonBreaking: Add content to editor, click on the nbsp button then type some text, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
+  it('TINY-3647: Add content to editor, click on the nbsp button then type some text, and assert content is correct', async () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
           children: [
-            s.element('p', {
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
               children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(isIE ? 'test' : Unicode.zeroWidth + 'test'))
+                s.text(str.is(Unicode.nbsp))
               ]
-            })
+            }),
+            s.text(str.is(isIE ? 'test' : Unicode.zeroWidth + 'test'))
           ]
-        })))
-      ]),
+        })
+      ]
+    })));
+  });
 
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '4. NonBreaking: Click on the nbsp button then type a space, and assert content is correct', [
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text(' ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
+  it('TINY-3647: Click on the nbsp button then type a space, and assert content is correct', async () => {
+    const editor = hook.editor();
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text(' ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
           children: [
-            s.element('p', {
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
               children: [
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(getNbspText('')))
-              ].concat(detection.browser.isFirefox() ? [ s.element('br', {}) ] : [])
-            })
-          ]
-        })))
-      ]),
-
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '5. NonBreaking: Add text to editor, click on the nbsp button and add content plus a space, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth))
+                s.text(str.is(Unicode.nbsp))
               ]
-            })
-          ]
-        }))),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(getNbspText('test')))
-              ].concat(detection.browser.isFirefox() ? [ s.element('br', {}) ] : [])
-            })
-          ]
-        })))
-      ]),
+            }),
+            s.text(str.is(getNbspText('')))
+          ].concat(detection.browser.isFirefox() ? [ s.element('br', {}) ] : [])
+        })
+      ]
+    })));
+  });
 
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '6. NonBreaking: Add text to editor, click on the nbsp button and add content plus a space, repeat, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
+  it('TINY-3647: Add text to editor, click on the nbsp button and add content plus a space, and assert content is correct', async () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
           children: [
-            s.element('p', {
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
               children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth))
+                s.text(str.is(Unicode.nbsp))
               ]
-            })
+            }),
+            s.text(str.is(Unicode.zeroWidth))
           ]
-        }))),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
+        })
+      ]
+    })));
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
           children: [
-            s.element('p', {
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
               children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(getNbspText('test')))
-              ].concat(detection.browser.isFirefox() ? [ s.element('br', {}) ] : [])
-            })
-          ]
-        }))),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(getNbspText('test test')))
-              ].concat(detection.browser.isFirefox() ? [ s.element('br', {}) ] : [])
-            })
-          ]
-        })))
-      ])
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(getNbspText('test')))
+          ].concat(detection.browser.isFirefox() ? [ s.element('br', {}) ] : [])
+        })
+      ]
+    })));
+  });
 
-    ], onSuccess, onFailure);
-  }, {
-    plugins: 'nonbreaking visualchars',
-    toolbar: 'nonbreaking visualchars',
-    visualchars_default_state: true,
-    base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  it('TINY-3647: Add text to editor, click on the nbsp button and add content plus a space, repeat, and assert content is correct', async () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(Unicode.zeroWidth))
+          ]
+        })
+      ]
+    })));
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(getNbspText('test')))
+          ].concat(detection.browser.isFirefox() ? [ s.element('br', {}) ] : [])
+        })
+      ]
+    })));
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap'), arr.has('mce-nbsp') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(getNbspText('test test')))
+          ].concat(detection.browser.isFirefox() ? [ s.element('br', {}) ] : [])
+        })
+      ]
+    })));
+  });
 });

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingWrapTypingTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingWrapTypingTest.ts
@@ -1,250 +1,218 @@
-import { ApproxStructure, Log, Pipeline, RealKeys } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { ApproxStructure, RealKeys } from '@ephox/agar';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';
-import theme from 'tinymce/themes/silver/Theme';
+import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('webdriver.tinymce.plugins.nonbreaking.NonbreakingWrapTypingTest', (success, failure) => {
+describe('webdriver.tinymce.plugins.nonbreaking.NonbreakingWrapTypingTest', () => {
   // Note: Uses RealKeys, so needs a browser. Headless won't work.
-
-  theme();
-  NonbreakingPlugin();
-
-  const isGecko = Env.browser.isFirefox();
-  const isGeckoOrIE = isGecko || Env.browser.isIE();
-
-  TinyLoader.setup((editor, onSuccess, onFailure) => {
-    const tinyUi = TinyUi(editor);
-    const tinyApis = TinyApis(editor);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TINY-3647', '1. NonBreaking: Click on the nbsp button then type some text, and assert content is correct', [
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth + 'test'))
-              ]
-            })
-          ]
-        })))
-      ]),
-
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '2. NonBreaking: Add text to editor, click on the nbsp button, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth))
-              ]
-            })
-          ]
-        })))
-      ]),
-
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '3. NonBreaking: Add content to editor, click on the nbsp button then type some text, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth + 'test'))
-              ]
-            })
-          ]
-        })))
-      ]),
-
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '4. NonBreaking: Click on the nbsp button then type a space, and assert content is correct', [
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text(' ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(isGeckoOrIE ? Unicode.zeroWidth + ' ' : Unicode.zeroWidth + Unicode.nbsp))
-              ].concat(isGecko ? [ s.element('br', {}) ] : [])
-            })
-          ]
-        })))
-      ]),
-
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '5. NonBreaking: Add text to editor, click on the nbsp button and add content plus a space, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth))
-              ]
-            })
-          ]
-        }))),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(isGeckoOrIE ? Unicode.zeroWidth + 'test ' : Unicode.zeroWidth + 'test\u00a0'))
-              ].concat(isGecko ? [ s.element('br', {}) ] : [])
-            })
-          ]
-        })))
-      ]),
-
-      tinyApis.sSetContent(''), // reset content
-
-      Log.stepsAsStep('TINY-3647', '6. NonBreaking: Add text to editor, click on the nbsp button and add content plus a space, repeat, and assert content is correct', [
-        tinyApis.sSetContent('test'),
-        tinyApis.sSetCursor([ 0, 0 ], 4),
-        tinyUi.sClickOnToolbar('click on nbsp button', 'button[aria-label="Nonbreaking space"]'),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(Unicode.zeroWidth))
-              ]
-            })
-          ]
-        }))),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(isGeckoOrIE ? Unicode.zeroWidth + 'test ' : Unicode.zeroWidth + 'test\u00a0'))
-              ].concat(isGecko ? [ s.element('br', {}) ] : [])
-            })
-          ]
-        }))),
-        RealKeys.sSendKeysOn(
-          'iframe => body => p',
-          [
-            RealKeys.text('test ')
-          ]
-        ),
-        tinyApis.sAssertContentStructure(ApproxStructure.build((s, str, arr) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                s.text(str.is('test')),
-                s.element('span', {
-                  classes: [ arr.has('mce-nbsp-wrap') ],
-                  children: [
-                    s.text(str.is(Unicode.nbsp))
-                  ]
-                }),
-                s.text(str.is(isGeckoOrIE ? Unicode.zeroWidth + 'test test ' : Unicode.zeroWidth + 'test test\u00a0'))
-              ].concat(isGecko ? [ s.element('br', {}) ] : [])
-            })
-          ]
-        })))
-      ])
-
-    ], onSuccess, onFailure);
-  }, {
+  const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'nonbreaking',
     toolbar: 'nonbreaking',
     nonbreaking_wrap: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  const isGecko = Env.browser.isFirefox();
+  const isGeckoOrIE = isGecko || Env.browser.isIE();
+
+  const clickNbspToolbarButton = (editor: Editor) => TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Nonbreaking space"]');
+
+  beforeEach(() => {
+    const editor = hook.editor();
+    editor.setContent('');
+  });
+
+  it('TINY-3647: Click on the nbsp button then type some text, and assert content is correct', async () => {
+    const editor = hook.editor();
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(Unicode.zeroWidth + 'test'))
+          ]
+        })
+      ]
+    })));
+  });
+
+  it('TINY-3647: Add text to editor, click on the nbsp button, and assert content is correct', () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(Unicode.zeroWidth))
+          ]
+        })
+      ]
+    })));
+  });
+
+  it('TINY-3647: Add content to editor, click on the nbsp button then type some text, and assert content is correct', async () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(Unicode.zeroWidth + 'test'))
+          ]
+        })
+      ]
+    })));
+  });
+
+  it('TINY-3647: Click on the nbsp button then type a space, and assert content is correct', async () => {
+    const editor = hook.editor();
+    clickNbspToolbarButton(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text(' ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(isGeckoOrIE ? Unicode.zeroWidth + ' ' : Unicode.zeroWidth + Unicode.nbsp))
+          ].concat(isGecko ? [ s.element('br', {}) ] : [])
+        })
+      ]
+    })));
+  });
+
+  it('TINY-3647: Add text to editor, click on the nbsp button and add content plus a space, and assert content is correct', async () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(Unicode.zeroWidth))
+          ]
+        })
+      ]
+    })));
+
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(isGeckoOrIE ? Unicode.zeroWidth + 'test ' : Unicode.zeroWidth + 'test\u00a0'))
+          ].concat(isGecko ? [ s.element('br', {}) ] : [])
+        })
+      ]
+    })));
+  });
+
+  it('TINY-3647: Add text to editor, click on the nbsp button and add content plus a space, repeat, and assert content is correct', async () => {
+    const editor = hook.editor();
+    editor.setContent('test');
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    clickNbspToolbarButton(editor);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(Unicode.zeroWidth))
+          ]
+        })
+      ]
+    })));
+
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(isGeckoOrIE ? Unicode.zeroWidth + 'test ' : Unicode.zeroWidth + 'test\u00a0'))
+          ].concat(isGecko ? [ s.element('br', {}) ] : [])
+        })
+      ]
+    })));
+
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('test ') ]);
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => s.element('body', {
+      children: [
+        s.element('p', {
+          children: [
+            s.text(str.is('test')),
+            s.element('span', {
+              classes: [ arr.has('mce-nbsp-wrap') ],
+              children: [
+                s.text(str.is(Unicode.nbsp))
+              ]
+            }),
+            s.text(str.is(isGeckoOrIE ? Unicode.zeroWidth + 'test test ' : Unicode.zeroWidth + 'test test\u00a0'))
+          ].concat(isGecko ? [ s.element('br', {}) ] : [])
+        })
+      ]
+    })));
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
Switch `nonbreaking` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
