### PR TITLE
TINY-6870: Switch Preview plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
@@ -1,41 +1,34 @@
-import { Log, Logger, Pipeline, Step } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
+import { assert } from 'chai';
+
 import Editor from 'tinymce/core/api/Editor';
 import * as IframeContent from 'tinymce/plugins/preview/core/IframeContent';
+import Plugin from 'tinymce/plugins/preview/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-import PreviewPlugin from 'tinymce/plugins/preview/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
-
-UnitTest.asynctest('browser.tinymce.plugins.preview.PreviewContentCssTest', (success, failure) => {
-
-  PreviewPlugin();
-  SilverTheme();
-
-  const sAssertIframeHtmlContains = (editor: Editor, text: string) => Logger.t('Assert Iframe Html contains ' + text, Step.sync(() => {
-    const actual = IframeContent.getPreviewHtml(editor);
-    const regexp = new RegExp(text);
-
-    Assert.eq('Should be same html', true, regexp.test(actual));
-  }));
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const contentCssUrl = editor.documentBaseURI.toAbsolute('/project/tinymce/js/tinymce/skins/content/default/content.css');
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Preview: Set content, set content_css_cors and assert link elements. Delete setting and assert crossOrigin attr is removed', [
-        tinyApis.sSetContent('<p>hello world</p>'),
-        tinyApis.sSetSetting('content_css_cors', true),
-        sAssertIframeHtmlContains(editor, `<link type="text/css" rel="stylesheet" href="${contentCssUrl}" crossorigin="anonymous">`),
-        tinyApis.sSetSetting('content_css_cors', false),
-        sAssertIframeHtmlContains(editor, `<link type="text/css" rel="stylesheet" href="${contentCssUrl}">`)
-      ])
-      , onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.preview.PreviewContentCssTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'preview',
     base_url: '/project/tinymce/js/tinymce',
     content_css: '/project/tinymce/js/tinymce/skins/content/default/content.css'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  const assertIframeHtmlContains = (editor: Editor, text: string) => {
+    const actual = IframeContent.getPreviewHtml(editor);
+    const regexp = new RegExp(text);
+
+    assert.isTrue(regexp.test(actual), 'Should be the same html');
+  };
+
+  it('TBA: Set content, set content_css_cors and assert link elements. Delete setting and assert crossOrigin attr is removed', () => {
+    const editor = hook.editor();
+    const contentCssUrl = editor.documentBaseURI.toAbsolute('/project/tinymce/js/tinymce/skins/content/default/content.css');
+
+    editor.setContent('<p>hello world</p>');
+    editor.settings.content_css_cors = true;
+    assertIframeHtmlContains(editor, `<link type="text/css" rel="stylesheet" href="${contentCssUrl}" crossorigin="anonymous">`);
+    editor.settings.content_css_cors = false;
+    assertIframeHtmlContains(editor, `<link type="text/css" rel="stylesheet" href="${contentCssUrl}">`);
+  });
 });

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.plugins.preview.PreviewContentCssTest', () => {
     const actual = IframeContent.getPreviewHtml(editor);
     const regexp = new RegExp(text);
 
-    assert.isTrue(regexp.test(actual), 'Should be the same html');
+    assert.match(actual, regexp, 'Should be the same html');
   };
 
   it('TBA: Set content, set content_css_cors and assert link elements. Delete setting and assert crossOrigin attr is removed', () => {

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
@@ -1,56 +1,47 @@
-import { Log, Logger, Pipeline, Step } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
 import * as IframeContent from 'tinymce/plugins/preview/core/IframeContent';
+import Plugin from 'tinymce/plugins/preview/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-import PreviewPlugin from 'tinymce/plugins/preview/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+describe('browser.tinymce.plugins.preview.PreviewContentStyleTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'preview',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Theme, Plugin ]);
 
-UnitTest.asynctest('browser.tinymce.plugins.preview.PreviewContentStyleTest', (success, failure) => {
-
-  PreviewPlugin();
-  SilverTheme();
-
-  const sAssertIframeContains = (editor, text, expected) => Step.sync(() => {
+  const assertIframeContains = (editor: Editor, text: string, expected: boolean) => {
     const actual = IframeContent.getPreviewHtml(editor);
     const regexp = new RegExp(text);
 
-    Assert.eq('Should be same html', expected, regexp.test(actual));
+    assert.equal(regexp.test(actual), expected, `Should${expected ? '' : ' not'} be the same html`);
+  };
+
+  const assertIframeHtmlContains = (editor: Editor, text: string) => assertIframeContains(editor, text, true);
+
+  const assertIframeHtmlNotContains = (editor: Editor, text: string) => assertIframeContains(editor, text, false);
+
+  it('TBA: Set content, set style setting and assert content and style. Delete style and assert style is removed', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>hello world</p>');
+    editor.settings.content_style = 'p {color: blue;}';
+    assertIframeHtmlContains(editor, '<style type="text/css">p {color: blue;}</style>');
+    delete editor.settings.content_style;
+    assertIframeHtmlNotContains(editor, '<style type="text/css">p {color: blue;}</style>');
   });
 
-  const sAssertIframeHtmlContains = (editor, text) => {
-    return Logger.t('Assert Iframe Html contains ' + text, sAssertIframeContains(editor, text, true));
-  };
-
-  const sAssertIframeHtmlNotContains = (editor, text) => {
-    return Logger.t('Assert Iframe Html does not contain ' + text, sAssertIframeContains(editor, text, false));
-  };
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
+  it('TINY-6529: Set content, set style settings and assert content and styles. content_style should take precedence. Delete style and assert style is removed', () => {
+    const editor = hook.editor();
     const contentCssUrl = editor.documentBaseURI.toAbsolute('/project/tinymce/js/tinymce/skins/content/default/content.css');
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'Preview: Set content, set style setting and assert content and style. Delete style and assert style is removed', [
-        tinyApis.sSetContent('<p>hello world</p>'),
-        tinyApis.sSetSetting('content_style', 'p {color: blue;}'),
-        sAssertIframeHtmlContains(editor, '<style type="text/css">p {color: blue;}</style>'),
-        tinyApis.sDeleteSetting('content_style'),
-        sAssertIframeHtmlNotContains(editor, '<style type="text/css">p {color: blue;}</style>')
-      ]),
-      Log.stepsAsStep('TINY-6529', 'Preview: Set content, set style settings and assert content and styles. content_style should take precedence. Delete style and assert style is removed', [
-        tinyApis.sSetContent('<p>hello world</p>'),
-        tinyApis.sSetSetting('content_css_cors', true),
-        tinyApis.sSetSetting('content_style', 'p {color: blue;}'),
-        sAssertIframeHtmlContains(editor, `<link type="text/css" rel="stylesheet" href="${contentCssUrl}" crossorigin="anonymous"><style type="text/css">p {color: blue;}</style>`),
-        tinyApis.sSetSetting('content_css_cors', false),
-        tinyApis.sDeleteSetting('content_style'),
-        sAssertIframeHtmlNotContains(editor, '<style type="text/css">p {color: blue;}</style>')
-      ])
-    ], onSuccess, onFailure);
-  }, {
-    theme: 'silver',
-    plugins: 'preview',
-    base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+    editor.setContent('<p>hello world</p>');
+    editor.settings.content_css_cors = true;
+    editor.settings.content_style = 'p {color: blue;}';
+    assertIframeHtmlContains(editor, `<link type="text/css" rel="stylesheet" href="${contentCssUrl}" crossorigin="anonymous"><style type="text/css">p {color: blue;}</style>`);
+    editor.settings.content_css_cors = false;
+    delete editor.settings.content_style;
+    assertIframeHtmlNotContains(editor, '<style type="text/css">p {color: blue;}</style>');
+  });
 });

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
@@ -13,11 +13,15 @@ describe('browser.tinymce.plugins.preview.PreviewContentStyleTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme, Plugin ]);
 
-  const assertIframeContains = (editor: Editor, text: string, expected: boolean) => {
+  const assertIframeContains = (editor: Editor, text: string, shouldMatch: boolean) => {
     const actual = IframeContent.getPreviewHtml(editor);
     const regexp = new RegExp(text);
 
-    assert.equal(regexp.test(actual), expected, `Should${expected ? '' : ' not'} be the same html`);
+    if (shouldMatch) {
+      assert.match(actual, regexp, 'Should be the same html');
+    } else {
+      assert.notMatch(actual, regexp, 'Should not be the same html');
+    }
   };
 
   const assertIframeHtmlContains = (editor: Editor, text: string) => assertIframeContains(editor, text, true);
@@ -33,15 +37,12 @@ describe('browser.tinymce.plugins.preview.PreviewContentStyleTest', () => {
     assertIframeHtmlNotContains(editor, '<style type="text/css">p {color: blue;}</style>');
   });
 
-  it('TINY-6529: Set content, set style settings and assert content and styles. content_style should take precedence. Delete style and assert style is removed', () => {
+  it('TINY-6529: Set content, set style settings and assert content and styles. content_style should take precedence.', () => {
     const editor = hook.editor();
     const contentCssUrl = editor.documentBaseURI.toAbsolute('/project/tinymce/js/tinymce/skins/content/default/content.css');
     editor.setContent('<p>hello world</p>');
     editor.settings.content_css_cors = true;
     editor.settings.content_style = 'p {color: blue;}';
     assertIframeHtmlContains(editor, `<link type="text/css" rel="stylesheet" href="${contentCssUrl}" crossorigin="anonymous"><style type="text/css">p {color: blue;}</style>`);
-    editor.settings.content_css_cors = false;
-    delete editor.settings.content_style;
-    assertIframeHtmlNotContains(editor, '<style type="text/css">p {color: blue;}</style>');
   });
 });

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewSanityTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewSanityTest.ts
@@ -1,7 +1,7 @@
-import { Keyboard, Keys, UiFinder, Waiter } from '@ephox/agar';
+import { Keys, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
-import { SugarElement } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/preview/Plugin';
@@ -15,25 +15,27 @@ describe('browser.tinymce.plugins.preview.PreviewSanityTest', () => {
   }, [ Theme, Plugin ]);
 
   const dialogSelector = 'div[role="dialog"]';
-  const docBody = SugarElement.fromDom(document.body);
+  const docBody = SugarBody.body();
 
-  const openDialog = async (editor: Editor) => {
+  const pOpenDialog = async (editor: Editor) => {
     TinyUiActions.clickOnToolbar(editor, 'button');
-    await TinyUiActions.pWaitForPopup(editor, '[role="dialog"] iframe');
+    await TinyUiActions.pWaitForDialog(editor, '[role="dialog"] iframe');
   };
 
-  it('TBA: Set content, open dialog, click Close to close dialog. Open dialog, press escape and assert dialog closes', async () => {
+  it('TBA: Open dialog, click Close to close dialog', async () => {
     const editor = hook.editor();
     editor.setContent('<strong>a</strong>');
-
-    await openDialog(editor);
-    // Close dialog with button
-    TinyUiActions.clickOnUi(editor, '.tox-button:not(.tox-button--secondary)');
+    await pOpenDialog(editor);
+    TinyUiActions.closeDialog(editor);
     await Waiter.pTryUntil('Dialog should close', () => UiFinder.notExists(docBody, dialogSelector));
 
-    await openDialog(editor);
-    // Close dialog with escape key
-    Keyboard.keydown(Keys.escape(), { }, TinyDom.fromDom(document));
+  });
+
+  it('TBA: Open dialog, press escape to close dialog', async () => {
+    const editor = hook.editor();
+    editor.setContent('<strong>a</strong>');
+    await pOpenDialog(editor);
+    TinyUiActions.keydown(editor, Keys.escape());
     await Waiter.pTryUntil('Dialog should close on esc', () => UiFinder.notExists(docBody, dialogSelector));
   });
 });

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewSanityTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewSanityTest.ts
@@ -1,46 +1,39 @@
-import { GeneralSteps, Keyboard, Keys, Log, Logger, Pipeline, UiFinder, Waiter } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyDom, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { Keyboard, Keys, UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
 
-import PreviewPlugin from 'tinymce/plugins/preview/Plugin';
-import SilverTheme from 'tinymce/themes/silver/Theme';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/preview/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.preview.PreviewSanityTest', (success, failure) => {
-
-  PreviewPlugin();
-  SilverTheme();
-
-  const dialogSelector = 'div[role="dialog"]';
-  const docBody = SugarElement.fromDom(document.body);
-  const doc = TinyDom.fromDom(document);
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    const sOpenDialog = () => GeneralSteps.sequence(Logger.ts('Open dialog and wait for it to be visible', [
-      tinyUi.sClickOnToolbar('click on preview toolbar', 'button'),
-      tinyUi.sWaitForPopup('wait for preview popup', '[role="dialog"] iframe')
-    ]));
-
-    Pipeline.async({},
-      Log.steps('TBA', 'Preview: Set content, open dialog, click Close to close dialog. Open dialog, press escape and assert dialog closes', [
-        tinyApis.sSetContent('<strong>a</strong>'),
-
-        sOpenDialog(),
-        tinyUi.sClickOnUi('Click on Close button', '.tox-button:not(.tox-button--secondary)'),
-        Waiter.sTryUntil('Dialog should close', UiFinder.sNotExists(docBody, dialogSelector)),
-
-        sOpenDialog(),
-        Keyboard.sKeydown(doc, Keys.escape(), { }),
-        Waiter.sTryUntil('Dialog should close on esc', UiFinder.sNotExists(docBody, dialogSelector))
-      ])
-      , onSuccess, onFailure);
-  }, {
-    theme: 'silver',
+describe('browser.tinymce.plugins.preview.PreviewSanityTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'preview',
     toolbar: 'preview',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  const dialogSelector = 'div[role="dialog"]';
+  const docBody = SugarElement.fromDom(document.body);
+
+  const openDialog = async (editor: Editor) => {
+    TinyUiActions.clickOnToolbar(editor, 'button');
+    await TinyUiActions.pWaitForPopup(editor, '[role="dialog"] iframe');
+  };
+
+  it('TBA: Set content, open dialog, click Close to close dialog. Open dialog, press escape and assert dialog closes', async () => {
+    const editor = hook.editor();
+    editor.setContent('<strong>a</strong>');
+
+    await openDialog(editor);
+    // Close dialog with button
+    TinyUiActions.clickOnUi(editor, '.tox-button:not(.tox-button--secondary)');
+    await Waiter.pTryUntil('Dialog should close', () => UiFinder.notExists(docBody, dialogSelector));
+
+    await openDialog(editor);
+    // Close dialog with escape key
+    Keyboard.keydown(Keys.escape(), { }, TinyDom.fromDom(document));
+    await Waiter.pTryUntil('Dialog should close on esc', () => UiFinder.notExists(docBody, dialogSelector));
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
Switch `preview` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
