### PR TITLE
TINY-6870: Switch save plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/save/test/ts/browser/SaveSanityTest.ts
+++ b/modules/tinymce/src/plugins/save/test/ts/browser/SaveSanityTest.ts
@@ -1,6 +1,6 @@
-import { Keyboard, Keys } from '@ephox/agar';
+import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/save/Plugin';
@@ -13,13 +13,17 @@ describe('browser.tinymce.plugins.save.SaveSanityTest', () => {
     base_url: '/project/tinymce/js/tinymce',
   }, [ Theme, Plugin ]);
 
-  it('TBA: Assert Save button is disabled when editor is opened. Add content and assert Save button is enabled', async () => {
+  it('TBA: Assert Save button is disabled when editor is opened.', async () => {
     const editor = hook.editor();
     // button is disabled
     await TinyUiActions.pWaitForUi(editor, 'button.tox-tbtn--disabled[aria-label="Save"]');
+  });
+
+  it('TBA: Add content and assert Save button is enabled.', async () => {
+    const editor = hook.editor();
     editor.setContent('<p>a</p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    Keyboard.activeKeystroke(TinyDom.document(editor), Keys.enter());
+    TinyContentActions.keystroke(editor, Keys.enter());
     // button no longer disabled
     await TinyUiActions.pWaitForUi(editor, 'button[aria-label="Save"]:not(.tox-tbtn--disabled)');
   });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
Switch `save` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
