### PR TITLE
TINY-6870: Switch tabfocus plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
+++ b/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
@@ -1,7 +1,7 @@
-import { Keyboard, Keys, Waiter } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
-import { assert } from 'chai';
+import { FocusTools, Keys } from '@ephox/agar';
+import { after, before, describe, it } from '@ephox/bedrock-client';
+import { TinyContentActions, TinyHooks } from '@ephox/mcagar';
+import { SugarDocument } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/tabfocus/Plugin';
@@ -14,27 +14,23 @@ describe('browser.tinymce.plugins.tabfocus.TabfocusSanityTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme, Plugin ], true);
 
-  const addInputs = (editor: Editor) => {
+  before(() => {
+    const editor = hook.editor();
     const container = editor.getContainer();
     const input1 = document.createElement('input');
     input1.id = 'tempinput1';
     container.parentNode.insertBefore(input1, container);
-  };
+  });
 
-  const removeInputs = () => {
+  after(() => {
     const input1 = document.getElementById('tempinput1');
     input1.parentNode.removeChild(input1);
-  };
+  });
 
   it('TBA: Add an input field outside the editor, focus on the editor, press the tab key and assert focus shifts to the input field', async () => {
     const editor = hook.editor();
-    addInputs(editor);
-    assert.equal(document.activeElement.nodeName, 'IFRAME');
-    Keyboard.activeKeystroke(TinyDom.document(editor), Keys.tab());
-    await Waiter.pTryUntil('Wait for focus', () => {
-      const input = document.getElementById('tempinput1');
-      assert.equal(document.activeElement.outerHTML, input.outerHTML);
-    });
-    removeInputs();
+    FocusTools.isOnSelector('iframe is focused', SugarDocument.getDocument(), 'iframe');
+    TinyContentActions.keystroke(editor, Keys.tab());
+    await FocusTools.pTryOnSelector('Wait for focus to be on input', SugarDocument.getDocument(), '#tempinput1');
   });
 });

--- a/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
+++ b/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
@@ -1,54 +1,40 @@
-import { Keys, Log, Logger, Pipeline, Step, Waiter } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyActions, TinyApis, TinyLoader } from '@ephox/mcagar';
+import { Keyboard, Keys, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { assert } from 'chai';
 
-import TabfocusPlugin from 'tinymce/plugins/tabfocus/Plugin';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/tabfocus/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.tabfocus.TabfocusSanityTest', (success, failure) => {
-
-  Theme();
-  TabfocusPlugin();
-
-  const sAddInputs = (editor) => {
-    return Logger.t('Add inputs', Step.sync(() => {
-      const container = editor.getContainer();
-      const input1 = document.createElement('input');
-      input1.id = 'tempinput1';
-
-      container.parentNode.insertBefore(input1, container);
-    }));
-  };
-
-  const sRemoveInputs = Logger.t('Remove inputs', Step.sync(() => {
-    const input1 = document.getElementById('tempinput1');
-
-    input1.parentNode.removeChild(input1);
-  }));
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyActions = TinyActions(editor);
-    const tinyApis = TinyApis(editor);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'TabFocus: Add an input field outside the editor, focus on the editor, press the tab key and assert focus shifts to the input field', [
-        sAddInputs(editor),
-        tinyApis.sFocus(),
-        Step.sync(() => {
-          Assert.eq('should be same', 'IFRAME', document.activeElement.nodeName);
-        }),
-        tinyActions.sContentKeystroke(Keys.tab(), {}),
-        Waiter.sTryUntil('wait for focus',
-          Step.sync(() => {
-            const input = document.getElementById('tempinput1');
-            Assert.eq('should be same', input.outerHTML, document.activeElement.outerHTML);
-          })),
-        sRemoveInputs
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.tabfocus.TabfocusSanityTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'tabfocus',
     tabfocus_elements: 'tempinput1',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Theme, Plugin ], true);
+
+  const addInputs = (editor: Editor) => {
+    const container = editor.getContainer();
+    const input1 = document.createElement('input');
+    input1.id = 'tempinput1';
+    container.parentNode.insertBefore(input1, container);
+  };
+
+  const removeInputs = () => {
+    const input1 = document.getElementById('tempinput1');
+    input1.parentNode.removeChild(input1);
+  };
+
+  it('TBA: Add an input field outside the editor, focus on the editor, press the tab key and assert focus shifts to the input field', async () => {
+    const editor = hook.editor();
+    addInputs(editor);
+    assert.equal(document.activeElement.nodeName, 'IFRAME');
+    Keyboard.activeKeystroke(TinyDom.document(editor), Keys.tab());
+    await Waiter.pTryUntil('Wait for focus', () => {
+      const input = document.getElementById('tempinput1');
+      assert.equal(document.activeElement.outerHTML, input.outerHTML);
+    });
+    removeInputs();
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
Switch `tabfocus` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
