### PR TITLE
Migrate some plugins to use the Maybe API

### DIFF
--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional } from '@ephox/katamari';
+import { Maybe, Maybes } from '@ephox/katamari';
 
 const isChildOfBody = (editor, elm) => {
   return editor.$.contains(editor.getBody(), elm);
@@ -21,10 +21,10 @@ const isListNode = (editor) => {
   };
 };
 
-const getSelectedStyleType = (editor): Optional<string> => {
+const getSelectedStyleType = (editor): Maybe<string> => {
   const listElm = editor.dom.getParent(editor.selection.getNode(), 'ol,ul');
   const style = editor.dom.getStyle(listElm, 'listStyleType');
-  return Optional.from(style);
+  return Maybes.from(style);
 };
 
 export {

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Maybes } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
 import Tools from 'tinymce/core/api/util/Tools';
@@ -69,7 +70,7 @@ const addSplitButton = (editor: Editor, id: string, tooltip: string, cmd: string
     },
     select: (value) => {
       const listStyleType = ListUtils.getSelectedStyleType(editor);
-      return listStyleType.map((listStyle) => value === listStyle).getOr(false);
+      return Maybes.exists((listStyle) => listStyle === value)(listStyleType);
     },
     onSetup: (api) => {
       const nodeChangeHandler = (e) => {

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/Languages.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/Languages.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Maybes } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../api/Settings';
 import * as CodeSample from './CodeSample';
@@ -35,10 +36,12 @@ const getLanguages = (editor: Editor): LanguageSpec[] => {
 const getCurrentLanguage = (editor: Editor, fallback: string): string => {
   const node = CodeSample.getSelectedCodeSample(editor);
 
-  return node.fold(() => fallback, (n) => {
-    const matches = n.className.match(/language-(\w+)/);
+  if (Maybes.isNothing(node)) {
+    return fallback;
+  } else {
+    const matches = node.value.className.match(/language-(\w+)/);
     return matches ? matches[1] : fallback;
-  });
+  }
 };
 
 export {

--- a/modules/tinymce/src/plugins/emoticons/main/ts/core/Lookup.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/core/Lookup.ts
@@ -5,16 +5,16 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Optional, Strings } from '@ephox/katamari';
+import { Arr, Maybe, Maybes, Strings } from '@ephox/katamari';
 
 import { EmojiEntry } from './EmojiDatabase';
 
 const emojiMatches = (emoji: EmojiEntry, lowerCasePattern: string): boolean => Strings.contains(emoji.title.toLowerCase(), lowerCasePattern) || Arr.exists(emoji.keywords, (k) => Strings.contains(k.toLowerCase(), lowerCasePattern));
 
-const emojisFrom = (list: EmojiEntry[], pattern: string, maxResults: Optional<number>): Array<{value: string; icon: string; text: string }> => {
+const emojisFrom = (list: EmojiEntry[], pattern: string, maxResults: Maybe<number>): Array<{value: string; icon: string; text: string }> => {
   const matches = [];
   const lowerCasePattern = pattern.toLowerCase();
-  const reachedLimit = maxResults.fold(() => Fun.never, (max) => (size) => size >= max);
+  const reachedLimit = (size: number) => Maybes.exists<number>((max) => size >= max)(maxResults);
   for (let i = 0; i < list.length; i++) {
     // TODO: more intelligent search by showing title matches at the top, keyword matches after that (use two arrays and concat at the end)
     if (pattern.length === 0 || emojiMatches(list[i], lowerCasePattern)) {

--- a/modules/tinymce/src/plugins/emoticons/main/ts/ui/Autocompletion.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/ui/Autocompletion.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional } from '@ephox/katamari';
+import { Maybes } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { EmojiDatabase } from '../core/EmojiDatabase';
 
@@ -18,7 +18,7 @@ const init = (editor: Editor, database: EmojiDatabase): void => {
     minChars: 2,
     fetch: (pattern, maxResults) => database.waitForLoad().then(() => {
       const candidates = database.listAll();
-      return emojisFrom(candidates, pattern, Optional.some(maxResults));
+      return emojisFrom(candidates, pattern, Maybes.just(maxResults));
     }),
     onAction: (autocompleteApi, rng, value) => {
       editor.selection.setRng(rng);

--- a/modules/tinymce/src/plugins/emoticons/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/ui/Dialog.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Cell, Optional, Throttler } from '@ephox/katamari';
+import { Arr, Cell, Maybes, Throttler } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 import { insertEmoticon } from '../core/Actions';
@@ -18,7 +18,7 @@ const open = (editor: Editor, database: EmojiDatabase) => {
 
   const initialState = {
     pattern: '',
-    results: emojisFrom(database.listAll(), '', Optional.some(300))
+    results: emojisFrom(database.listAll(), '', Maybes.just(300))
   };
 
   const currentTab = Cell(ALL_CATEGORY);
@@ -27,7 +27,7 @@ const open = (editor: Editor, database: EmojiDatabase) => {
     const dialogData = dialogApi.getData();
     const category = currentTab.get();
     const candidates = database.listCategory(category);
-    const results = emojisFrom(candidates, dialogData[patternName], category === ALL_CATEGORY ? Optional.some(300) : Optional.none());
+    const results = emojisFrom(candidates, dialogData[patternName], category === ALL_CATEGORY ? Maybes.just(300) : Maybes.nothing());
     dialogApi.setData({
       results
     });

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell, Fun, Optional, Singleton } from '@ephox/katamari';
+import { Cell, Fun, Maybes, Singleton } from '@ephox/katamari';
 import { Css, DomEvent, EventUnbinder, SugarElement, SugarShadowDom, Traverse, WindowVisualViewport } from '@ephox/sugar';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -132,7 +132,10 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
     handleClasses(DOM.removeClass);
 
     viewportUpdate.unbind();
-    Optional.from(fullscreenState.get()).each((info) => info.fullscreenChangeHandler.unbind());
+    const info = Maybes.from(fullscreenState.get());
+    if (Maybes.isJust(info)) {
+      info.value.fullscreenChangeHandler.unbind();
+    }
   };
 
   if (!fullscreenInfo) {

--- a/modules/tinymce/src/plugins/imagetools/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/api/Settings.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional } from '@ephox/katamari';
+import { Maybes } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 const getToolbarItems = (editor: Editor): string => editor.getParam('imagetools_toolbar', 'rotateleft rotateright flipv fliph editimage imageoptions');
@@ -16,7 +16,7 @@ const getCorsHosts = (editor: Editor) => editor.getParam('imagetools_cors_hosts'
 
 const getCredentialsHosts = (editor: Editor) => editor.getParam('imagetools_credentials_hosts', [], 'string[]');
 
-const getFetchImage = (editor: Editor) => Optional.from(editor.getParam('imagetools_fetch_image', null, 'function'));
+const getFetchImage = (editor: Editor) => Maybes.from(editor.getParam('imagetools_fetch_image', null, 'function'));
 
 const getApiKey = (editor: Editor) => editor.getParam('api_key', editor.getParam('imagetools_api_key', '', 'string'), 'string');
 

--- a/modules/tinymce/src/plugins/imagetools/main/ts/core/UploadSelectedImage.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/core/UploadSelectedImage.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell } from '@ephox/katamari';
+import { Cell, Maybes } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as Actions from './Actions';
 
@@ -17,14 +17,16 @@ const setup = (editor: Editor, imageUploadTimerState: Cell<number>, lastSelected
     // If the last node we selected was an image
     // And had a source that doesn't match the current blob url
     // We need to attempt to upload it
-    if (lastSelectedImage && !selectedImage.exists((img) => lastSelectedImage.src === img.src)) {
+    if (lastSelectedImage && !Maybes.exists<HTMLImageElement>((img) => lastSelectedImage.src === img.src)(selectedImage)) {
       Actions.cancelTimedUpload(imageUploadTimerState);
       editor.editorUpload.uploadImagesAuto();
       lastSelectedImageState.set(null);
     }
 
     // Set up the lastSelectedImage
-    selectedImage.each(lastSelectedImageState.set);
+    if (Maybes.isJust(selectedImage)) {
+      lastSelectedImageState.set(selectedImage.value);
+    }
   });
 };
 

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Fun, Maybes } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as Actions from '../core/Actions';
 
@@ -41,9 +42,10 @@ const register = (editor: Editor) => {
     onAction: cmd('mceEditImage'),
     onSetup: (buttonApi) => {
       const setDisabled = () => {
-        const disabled = Actions.getSelectedImage(editor).forall((element) => {
-          return Actions.getEditableImage(editor, element.dom).isNone();
-        });
+        const disabled = Fun.pipe(
+          Actions.getSelectedImage(editor),
+          Maybes.forall((element) => Maybes.isNothing(Actions.getEditableImage(editor, element.dom)))
+        );
         buttonApi.setDisabled(disabled);
       };
 
@@ -62,14 +64,16 @@ const register = (editor: Editor) => {
   });
 
   editor.ui.registry.addContextMenu('imagetools', {
-    update: (element) =>
+    update: (element) => Fun.pipe(
       // since there's no menu item available, this has to be it's own thing
-      Actions.getEditableImage(editor, element).fold(() => [], (_) => [{
+      Actions.getEditableImage(editor, element),
+      Maybes.map(() => ({
         text: 'Edit image',
         icon: 'edit-image',
         onAction: cmd('mceEditImage')
-      }])
-
+      })),
+      Maybes.toArr
+    )
   });
 };
 

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/ContextToolbar.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/ContextToolbar.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Maybes } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../api/Settings';
 import * as Actions from '../core/Actions';
@@ -12,7 +13,7 @@ import * as Actions from '../core/Actions';
 const register = (editor: Editor) => {
   editor.ui.registry.addContextToolbar('imagetools', {
     items: Settings.getToolbarItems(editor),
-    predicate: (elem) => Actions.getEditableImage(editor, elem).isSome(),
+    predicate: (elem) => Maybes.isJust(Actions.getEditableImage(editor, elem)),
     position: 'node',
     scope: 'node'
   });

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCustomFetchTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCustomFetchTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { BlobConversions } from '@ephox/imagetools';
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Maybes } from '@ephox/katamari';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { assert } from 'chai';
 
@@ -13,7 +13,7 @@ import * as ImageUtils from '../module/test/ImageUtils';
 describe('browser.tinymce.plugins.imagetools.ImageToolsCustomFetchTest', () => {
   const uploadHandlerState = ImageUtils.createStateContainer();
   const srcUrl = '/project/tinymce/src/plugins/imagetools/demo/img/dogleft.jpg';
-  const fetchState = Cell(Optional.none());
+  const fetchState = Cell(Maybes.nothing());
 
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'imagetools',
@@ -26,7 +26,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsCustomFetchTest', () => {
   it('TBA: flip image with custom fetch image', async () => {
     const editor = hook.editor();
     editor.settings.imagetools_fetch_image = (img: HTMLImageElement) => {
-      fetchState.set(Optional.some(img.src));
+      fetchState.set(Maybes.just(img.src));
       return BlobConversions.imageToBlob(img);
     };
     await ImageUtils.pLoadImage(editor, srcUrl);
@@ -34,7 +34,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsCustomFetchTest', () => {
     editor.execCommand('mceImageFlipHorizontal');
     await ImageUtils.pWaitForBlobImage(editor);
 
-    const actualSrc = fetchState.get().getOrDie('Could not get fetch state');
+    const actualSrc = Maybes.getOrDie(fetchState.get());
     const expectedSrc = document.location.protocol + '//' + document.location.host + '/project/tinymce/src/plugins/imagetools/demo/img/dogleft.jpg';
     assert.equal(actualSrc, expectedSrc, 'Should be the expected input image');
   });


### PR DESCRIPTION
Related Ticket: TINY-7444

Description of Changes:
* Each plugin I migrated was a separate commit, so
  * It should be easier to review
  * We can revert any one plugin individually
* The plugins themselves that have been converted so far
  * advlist
  * imagetools
  * fullscreen
  * codesample
  * emoticons
* Images was considered, but it ended up being too messy at this point. It'll need to wait until more of the underlying libraries have been migrated.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
