### PR TITLE
TINY-7249: changed loading order so content css gets loaded before loading contents

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Changed the load order so that the content css gets loaded before the editor gets populated with contents. #TINY-7249
+
 ### Fixed
-- Flash of unstyled content while loading the content css was shown. It will now load the content css first then populate the editor #TINY-7249
+- Flash of unstyled content while loading the editor because the content css was loaded after the editor content was rendered #TINY-7249
 - Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
 - Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Flash of unstyled content while loading the content css was shown. It will now load the content css first then populate the editor #TINY-7249
 - Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
 - Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
 

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -8,7 +8,6 @@
 import { Cell, Fun, Obj, Optional, Type } from '@ephox/katamari';
 import Editor from './api/Editor';
 import Formatter from './api/Formatter';
-import Promise from './api/util/Promise';
 import { Content, ContentFormat, GetContentArgs, SetContentArgs } from './content/ContentTypes';
 import { getContentInternal } from './content/GetContentImpl';
 import { insertHtmlAtCaret } from './content/InsertContentImpl';
@@ -257,23 +256,24 @@ const getRtcSetup = (editor: Editor): Optional<() => Promise<RtcRuntimeApi>> =>
     Optional.from(rtcPlugin.setup)
   );
 
-export const setup = (editor: Editor): Optional<Promise<boolean>> => {
+export const setup = (editor: Editor): Optional<() => Promise<boolean>> => {
   const editorCast = editor as RtcEditor;
   return getRtcSetup(editor).fold(
     () => {
       editorCast.rtcInstance = makePlainAdaptor(editor);
       return Optional.none();
     },
-    (setup) => Optional.some(
-      setup().then((rtcEditor) => {
-        editorCast.rtcInstance = makeRtcAdaptor(rtcEditor);
-        return rtcEditor.rtc.isRemote;
-      }, (err) => {
-        // We need to provide a noop adaptor on init failure since otherwise calls to hasUndo etc will continue to throw errors
-        editorCast.rtcInstance = makeNoopAdaptor();
-        return Promise.reject<boolean>(err);
-      })
-    )
+    (setup) => {
+      // We need to provide a noop adaptor while initializing since any call by the theme or plugins to say undoManager.hasUndo would throw errors
+      editorCast.rtcInstance = makeNoopAdaptor();
+
+      return Optional.some(
+        () => setup().then((rtcEditor) => {
+          editorCast.rtcInstance = makeRtcAdaptor(rtcEditor);
+          return rtcEditor.rtc.isRemote;
+        })
+      );
+    }
   );
 };
 

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -330,12 +330,16 @@ const loadContentCss = (editor: Editor) => {
 const preInit = (editor: Editor) => {
   const settings = editor.settings, doc = editor.getDoc(), body = editor.getBody();
 
+  Events.firePreInit(editor);
+
   if (!settings.browser_spellcheck && !settings.gecko_spellcheck) {
     doc.body.spellcheck = false; // Gecko
     DOM.setAttrib(body, 'spellcheck', 'false');
   }
 
   editor.quirks = Quirks(editor);
+
+  Events.firePostRender(editor);
 
   const directionality = Settings.getDirectionality(editor);
   if (directionality !== undefined) {
@@ -459,14 +463,13 @@ const initContentBody = (editor: Editor, skipWrite?: boolean) => {
   ForceBlocks.setup(editor);
   Placeholder.setup(editor);
 
-  Events.firePreInit(editor);
+  const setupRtcThunk = Rtc.setup(editor);
+
   preInit(editor);
 
-  Rtc.setup(editor).fold(() => {
-    Events.firePostRender(editor);
+  setupRtcThunk.fold(() => {
     loadContentCss(editor).then(() => initEditorWithInitialContent(editor));
   }, (setupRtc) => {
-    Events.firePostRender(editor);
     editor.setProgressState(true);
 
     loadContentCss(editor).then(() => {

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -38,7 +38,7 @@ describe('browser.tinymce.core.EditorRemoveTest', () => {
     await McEditor.pFromHtml('<textarea></textarea>', {
       ...settings,
       setup: (editor: Editor) => {
-        editor.on('LoadContent', () => {
+        editor.on('PreInit', () => {
           // Hook the function called when stylesheets are loaded
           // so we can remove the editor right after starting to load them.
           const realLoadAll = editor.ui.styleSheetLoader.loadAll;

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/theme/TestTheme.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/theme/TestTheme.ts
@@ -53,7 +53,9 @@ const setup = (info, onSuccess, onFailure) => {
   ThemeManager.add(strName, (editor) => {
     return {
       renderUI: () => {
-        editor.fire('SkinLoaded');
+        // Existing themes will delay firing the SkinLoaded until the editor has been initialized
+        editor.on('init', () => editor.fire('SkinLoaded'));
+
         return {
           iframeContainer: socket.element.dom,
           editorContainer: alloy.element.dom


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This changes the load order of things so that the content css gets loaded before the editor is filled with contents. This is to prevent a FOUC happening while loading the editor. It's extra visible with RTC but I think this happens on the non RTC version of tinymce as well. Not sure how to make a unit test for this though since just waiting for the events to fire is not enough to ensure that a flash doesn't occur.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
