### PR TITLE
TINY-6870: Convert the searchreplace plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogCyclingTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogCyclingTest.ts
@@ -1,7 +1,7 @@
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
-import { Class, SelectorFilter, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { Class, SelectorFilter } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -22,7 +22,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogCyclingTest',
   }, [ Theme, Plugin ]);
 
   const assertMatchFound = (editor: Editor, index: number) => {
-    const matches = SelectorFilter.descendants(SugarElement.fromDom(editor.getBody()), '.mce-match-marker');
+    const matches = SelectorFilter.descendants(TinyDom.body(editor), '.mce-match-marker');
     const elem = matches[index];
     assert.isTrue(Class.has(elem, 'mce-match-marker-selected'), `Check match ${index} is marked as selected`);
   };
@@ -40,7 +40,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogCyclingTest',
         editor.setContent('<p>fish fish fish</p>');
         TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
         await Utils.pOpenDialog(editor);
-        Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
+        await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
         Utils.clickFind(editor);
         assertMatchFound(editor, 0);
         cycle(editor);

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogCyclingTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogCyclingTest.ts
@@ -1,111 +1,109 @@
-import { Assertions, Log, Pipeline, Step } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { Class, SelectorFilter, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
 
-import SearchreplacePlugin from 'tinymce/plugins/searchreplace/Plugin';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/searchreplace/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
-
 import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplaceDialogCyclingTest', (success, failure) => {
-  Theme();
-  SearchreplacePlugin();
+enum Direction {
+  FORWARDS,
+  BACKWARDS
+}
 
-  enum Direction {
-    FORWARDS,
-    BACKWARDS
-  }
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    const sFind = Utils.sClickFind(tinyUi);
-    const sNext = Utils.sClickNext(tinyUi);
-    const sPrev = Utils.sClickPrev(tinyUi);
-    const sSelectPreference = (name: string) => Utils.sSelectPreference(tinyUi, name);
-
-    const sAssertMatchFound = (index: number) => Step.sync(() => {
-      const matches = SelectorFilter.descendants(SugarElement.fromDom(editor.getBody()), '.mce-match-marker');
-      const elem = matches[index];
-      Assertions.assertEq(`Check match ${index} is marked as selected`, true, Class.has(elem, 'mce-match-marker-selected'));
-    });
-
-    const sTestCycling = (sCycle: Step<any, any>, dir: Direction) => [
-      Log.stepsAsStep('TINY-4506', 'SearchReplace: Test cycling through results without any preferences', [
-        tinyApis.sSetContent('<p>fish fish fish</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 4),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', 'fish'),
-        sFind,
-        sAssertMatchFound(0),
-        sCycle,
-        sAssertMatchFound(dir === Direction.FORWARDS ? 1 : 2),
-        sCycle,
-        sAssertMatchFound(dir === Direction.FORWARDS ? 2 : 1),
-        sCycle,
-        sAssertMatchFound(0),
-        Utils.sCloseDialog(tinyUi)
-      ]),
-      Log.stepsAsStep('TINY-4506', 'SearchReplace: Test cycling through results with matchcase enabled', [
-        tinyApis.sSetContent('<p>fish Fish fish Fish</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 5, [ 0, 0 ], 9),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', 'Fish'),
-        sSelectPreference('Match case'),
-        sFind,
-        sAssertMatchFound(0),
-        sCycle,
-        sAssertMatchFound(1),
-        sCycle,
-        sAssertMatchFound(0),
-        sSelectPreference('Match case'),
-        Utils.sCloseDialog(tinyUi)
-      ]),
-      Log.stepsAsStep('TINY-4506', 'SearchReplace: Test cycling through results with wholewords enabled', [
-        tinyApis.sSetContent('<p>ttt TTT ttt ttttt</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 3),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', 'ttt'),
-        sSelectPreference('Find whole words only'),
-        sFind,
-        sAssertMatchFound(0),
-        sCycle,
-        sAssertMatchFound(dir === Direction.FORWARDS ? 1 : 2),
-        sCycle,
-        sAssertMatchFound(dir === Direction.FORWARDS ? 2 : 1),
-        sCycle,
-        sAssertMatchFound(0),
-        sSelectPreference('Find whole words only'),
-        Utils.sCloseDialog(tinyUi)
-      ]),
-      Log.stepsAsStep('TINY-4506', 'SearchReplace: Test cycling through results with special characters', [
-        tinyApis.sSetContent('<p>^^ ^^ ^^ fish</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 2),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', '^^'),
-        sFind,
-        sAssertMatchFound(0),
-        sCycle,
-        sAssertMatchFound(dir === Direction.FORWARDS ? 1 : 2),
-        sCycle,
-        sAssertMatchFound(dir === Direction.FORWARDS ? 2 : 1),
-        sCycle,
-        sAssertMatchFound(0),
-        Utils.sCloseDialog(tinyUi)
-      ])
-    ];
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TINY-4506', 'SearchReplace: Test cycling using find', sTestCycling(sFind, Direction.FORWARDS)),
-      Log.stepsAsStep('TINY-4506', 'SearchReplace: Test cycling using next', sTestCycling(sNext, Direction.FORWARDS)),
-      Log.stepsAsStep('TINY-4506', 'SearchReplace: Test cycling using previous', sTestCycling(sPrev, Direction.BACKWARDS))
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogCyclingTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'searchreplace',
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
-    theme: 'silver'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  const assertMatchFound = (editor: Editor, index: number) => {
+    const matches = SelectorFilter.descendants(SugarElement.fromDom(editor.getBody()), '.mce-match-marker');
+    const elem = matches[index];
+    assert.isTrue(Class.has(elem, 'mce-match-marker-selected'), `Check match ${index} is marked as selected`);
+  };
+
+  Arr.each([
+    { label: 'Test cycling using find', scenario: { cycle: Utils.clickFind, dir: Direction.FORWARDS }},
+    { label: 'Test cycling using next', scenario: { cycle: Utils.clickNext, dir: Direction.FORWARDS }},
+    { label: 'Test cycling using previous', scenario: { cycle: Utils.clickPrev, dir: Direction.BACKWARDS }},
+  ], (testCase) => {
+    context(testCase.label, () => {
+      const { dir, cycle } = testCase.scenario;
+
+      it('TINY-4506: Test cycling through results without any preferences', async () => {
+        const editor = hook.editor();
+        editor.setContent('<p>fish fish fish</p>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
+        await Utils.pOpenDialog(editor);
+        Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
+        Utils.clickFind(editor);
+        assertMatchFound(editor, 0);
+        cycle(editor);
+        assertMatchFound(editor, dir === Direction.FORWARDS ? 1 : 2);
+        cycle(editor);
+        assertMatchFound(editor, dir === Direction.FORWARDS ? 2 : 1);
+        cycle(editor);
+        assertMatchFound(editor, 0);
+        TinyUiActions.closeDialog(editor);
+      });
+
+      it('TINY-4506: Test cycling through results with matchcase enabled', async () => {
+        const editor = hook.editor();
+        editor.setContent('<p>fish Fish fish Fish</p>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 5, [ 0, 0 ], 9);
+        await Utils.pOpenDialog(editor);
+        await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'Fish');
+        await Utils.pSelectPreference(editor, 'Match case');
+        Utils.clickFind(editor);
+        assertMatchFound(editor, 0);
+        cycle(editor);
+        assertMatchFound(editor, 1);
+        cycle(editor);
+        assertMatchFound(editor, 0);
+        await Utils.pSelectPreference(editor, 'Match case');
+        TinyUiActions.closeDialog(editor);
+      });
+
+      it('TINY-4506: Test cycling through results with wholewords enabled', async () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ttt TTT ttt ttttt</p>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+        await Utils.pOpenDialog(editor);
+        await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'ttt');
+        await Utils.pSelectPreference(editor, 'Find whole words only');
+        Utils.clickFind(editor);
+        assertMatchFound(editor, 0);
+        cycle(editor);
+        assertMatchFound(editor, dir === Direction.FORWARDS ? 1 : 2);
+        cycle(editor);
+        assertMatchFound(editor, dir === Direction.FORWARDS ? 2 : 1);
+        cycle(editor);
+        assertMatchFound(editor, 0);
+        await Utils.pSelectPreference(editor, 'Find whole words only');
+        TinyUiActions.closeDialog(editor);
+      });
+
+      it('TINY-4506: Test cycling through results with special characters', async () => {
+        const editor = hook.editor();
+        editor.setContent('<p>^^ ^^ ^^ fish</p>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        await Utils.pOpenDialog(editor);
+        await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', '^^');
+        Utils.clickFind(editor);
+        assertMatchFound(editor, 0);
+        cycle(editor);
+        assertMatchFound(editor, dir === Direction.FORWARDS ? 1 : 2);
+        cycle(editor);
+        assertMatchFound(editor, dir === Direction.FORWARDS ? 2 : 1);
+        cycle(editor);
+        assertMatchFound(editor, 0);
+        TinyUiActions.closeDialog(editor);
+      });
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
@@ -1,100 +1,102 @@
-import { GeneralSteps, Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 
-import SearchreplacePlugin from 'tinymce/plugins/searchreplace/Plugin';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/searchreplace/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
-
 import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplaceDialogTest', (success, failure) => {
-  Theme();
-  SearchreplacePlugin();
-  const browser = PlatformDetection.detect().browser;
-
-  TinyLoader.setupInBodyAndShadowRoot((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    const sAssertFound = (count: number) => tinyApis.sAssertContentPresence({
-      '.mce-match-marker': count
-    });
-
-    const sFindAndAssertFound = (count: number) => GeneralSteps.sequence([
-      Utils.sClickFind(tinyUi),
-      sAssertFound(count)
-    ]);
-
-    Pipeline.async({}, [
-      Log.stepsAsStep('TBA', 'SearchReplace: Test no content selected', [
-        tinyApis.sSetContent('<p>fish fish fish</p>'),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', ''),
-        Utils.sCloseDialog(tinyUi)
-      ]),
-      Log.stepsAsStep('TBA', 'SearchReplace: Test some content selected', [
-        tinyApis.sSetContent('<p>fish fish fish</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 5, [ 0, 0 ], 9),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', 'fish'),
-        sFindAndAssertFound(3),
-        Utils.sCloseDialog(tinyUi)
-      ]),
-      Log.stepsAsStep('TBA', 'SearchReplace: Test some content selected with matchcase enabled', [
-        tinyApis.sSetContent('<p>fish Fish fish</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 5, [ 0, 0 ], 9),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', 'Fish'),
-        Utils.sSelectPreference(tinyUi, 'Match case'),
-        sFindAndAssertFound(1),
-        Utils.sSelectPreference(tinyUi, 'Match case'),
-        Utils.sCloseDialog(tinyUi)
-      ]),
-      Log.stepsAsStep('TBA', 'SearchReplace: Test some content selected with wholewords enabled', [
-        tinyApis.sSetContent('<p>ttt TTT ttt ttttt</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 3),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', 'ttt'),
-        Utils.sSelectPreference(tinyUi, 'Find whole words only'),
-        sFindAndAssertFound(3),
-        Utils.sSelectPreference(tinyUi, 'Find whole words only'),
-        Utils.sCloseDialog(tinyUi)
-      ]),
-      Log.stepsAsStep('TINY-4549', 'SearchReplace: Test some content selected with in selection enabled', [
-        tinyApis.sSetContent('<p>ttt TTT ttt ttttt</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 0, [ 0, 0 ], 7),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', 'ttt TTT'),
-        Utils.sSetFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', 'ttt'),
-        Utils.sSelectPreference(tinyUi, 'Find in selection'),
-        sFindAndAssertFound(2),
-        browser.isIE() ? // TODO: Look into what to do with IE as it has a single selection model which causes some different behaviour
-          tinyApis.sAssertSelection([ 0, 0 ], 0, [ 0, 0 ], 0) :
-          tinyApis.sAssertSelection([ 0 ], 0, [ 0 ], 4),
-        Utils.sSelectPreference(tinyUi, 'Find in selection'),
-        Utils.sCloseDialog(tinyUi)
-      ]),
-      Log.stepsAsStep('TBA', 'SearchReplace: Test some content selected while changing preferences', [
-        tinyApis.sSetContent('<p>fish fish Fish fishy</p>'),
-        tinyApis.sSetSelection([ 0, 0 ], 5, [ 0, 0 ], 9),
-        Utils.sOpenDialog(tinyUi),
-        Utils.sAssertFieldValue(tinyUi, 'input.tox-textfield[placeholder="Find"]', 'fish'),
-        sFindAndAssertFound(4),
-        Utils.sSelectPreference(tinyUi, 'Match case'),
-        sAssertFound(0),
-        sFindAndAssertFound(3),
-        Utils.sSelectPreference(tinyUi, 'Find whole words only'),
-        sAssertFound(0),
-        sFindAndAssertFound(2),
-        Utils.sCloseDialog(tinyUi)
-      ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogTest', () => {
+  const hook = TinyHooks.bddSetupInShadowRoot<Editor>({
     plugins: 'searchreplace',
     menubar: false,
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
-    theme: 'silver'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  const browser = PlatformDetection.detect().browser;
+
+  const assertFound = (editor: Editor, count: number) => TinyAssertions.assertContentPresence(editor, {
+    '.mce-match-marker': count
+  });
+
+  const findAndAssertFound = (editor: Editor, count: number) => {
+    Utils.clickFind(editor);
+    assertFound(editor, count);
+  };
+
+  it('TBA: Test no content selected', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>fish fish fish</p>');
+    await Utils.pOpenDialog(editor);
+    await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', '');
+    TinyUiActions.closeDialog(editor);
+  });
+
+  it('TBA: Test some content selected', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>fish fish fish</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 5, [ 0, 0 ], 9);
+    await Utils.pOpenDialog(editor);
+    await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
+    findAndAssertFound(editor, 3);
+    TinyUiActions.closeDialog(editor);
+  });
+
+  it('TBA: Test some content selected with matchcase enabled', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>fish Fish fish</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 5, [ 0, 0 ], 9);
+    await Utils.pOpenDialog(editor);
+    await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'Fish');
+    await Utils.pSelectPreference(editor, 'Match case');
+    findAndAssertFound(editor, 1);
+    await Utils.pSelectPreference(editor, 'Match case');
+    TinyUiActions.closeDialog(editor);
+  });
+
+  it('TBA: Test some content selected with wholewords enabled', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>ttt TTT ttt ttttt</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+    await Utils.pOpenDialog(editor);
+    await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'ttt');
+    await Utils.pSelectPreference(editor, 'Find whole words only');
+    findAndAssertFound(editor, 3);
+    await Utils.pSelectPreference(editor, 'Find whole words only');
+    TinyUiActions.closeDialog(editor);
+  });
+
+  it('TINY-4549: Test some content selected with in selection enabled', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>ttt TTT ttt ttttt</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 7);
+    await Utils.pOpenDialog(editor);
+    await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'ttt TTT');
+    await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'ttt');
+    await Utils.pSelectPreference(editor, 'Find in selection');
+    findAndAssertFound(editor, 2);
+    browser.isIE() ? // TODO: Look into what to do with IE as it has a single selection model which causes some different behaviour
+      TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 0) :
+      TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 4);
+    await Utils.pSelectPreference(editor, 'Find in selection');
+    TinyUiActions.closeDialog(editor);
+  });
+
+  it('TBA: Test some content selected while changing preferences', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>fish fish Fish fishy</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 5, [ 0, 0 ], 9);
+    await Utils.pOpenDialog(editor);
+    await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
+    findAndAssertFound(editor, 4);
+    await Utils.pSelectPreference(editor, 'Match case');
+    assertFound(editor, 0);
+    findAndAssertFound(editor, 3);
+    await Utils.pSelectPreference(editor, 'Find whole words only');
+    assertFound(editor, 0);
+    findAndAssertFound(editor, 2);
+    TinyUiActions.closeDialog(editor);
+  });
 });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceInSelectionTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceInSelectionTest.ts
@@ -1,207 +1,221 @@
-import { Assertions, Log, Pipeline, Step } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
-import Editor from 'tinymce/core/api/Editor';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { assert } from 'chai';
 
-import SearchreplacePlugin from 'tinymce/plugins/searchreplace/Plugin';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/searchreplace/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplaceInSelectionTest', (success, failure) => {
-  Theme();
-  SearchreplacePlugin();
+interface FindScenario {
+  readonly content: string;
+  readonly find: string;
+  readonly matches: number;
+  readonly sel?: {
+    readonly sPath: number[];
+    readonly sOffset: number;
+    readonly fPath?: number[];
+    readonly fOffset?: number;
+  };
+  readonly wholeWords?: boolean;
+  readonly matchCase?: boolean;
+}
 
-  interface FindScenario {
-    content: string;
-    find: string;
-    matches: number;
-    sel?: {
-      sPath: number[];
-      sOffset: number;
-      fPath?: number[];
-      fOffset?: number;
-    };
-    wholeWords?: boolean;
-    matchCase?: boolean;
-  }
+interface ReplaceScenario extends FindScenario {
+  readonly replace: string;
+  readonly replaceAll?: boolean;
+  readonly backwards?: boolean;
+  readonly moreMatches: boolean;
+  readonly expectedContent: string;
+}
 
-  interface ReplaceScenario extends FindScenario {
-    replace: string;
-    replaceAll?: boolean;
-    backwards?: boolean;
-    moreMatches: boolean;
-    expectedContent: string;
-  }
+describe('browser.tinymce.plugins.searchreplace.SearchReplaceInSelectionTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'searchreplace',
+    base_url: '/project/tinymce/js/tinymce',
+    extended_valid_elements: 'b,i'
+  }, [ Theme, Plugin ], true);
 
   const isReplaceScenario = (scenario: FindScenario | ReplaceScenario): scenario is ReplaceScenario => Obj.has(scenario as Record<string, any>, 'replace');
 
-  const sReplaceStep = (editor: Editor, scenario: ReplaceScenario) => Step.sync(() => {
+  const testReplace = (editor: Editor, scenario: ReplaceScenario) => {
     const moreMatches = editor.plugins.searchreplace.replace(scenario.replace, scenario.backwards || true, scenario.replaceAll || false);
-    Assertions.assertEq('More matches found', scenario.moreMatches, moreMatches);
-    Assertions.assertHtml('Replaced content successfully', scenario.expectedContent, editor.getContent());
-  });
+    assert.equal(scenario.moreMatches, moreMatches);
+    TinyAssertions.assertContent(editor, scenario.expectedContent);
+  };
 
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
+  const testInSelection = (scenario: FindScenario | ReplaceScenario) => () => {
+    const editor = hook.editor();
+    editor.setContent(scenario.content);
+    if (scenario.sel) {
+      TinySelections.setSelection(editor, scenario.sel.sPath, scenario.sel.sOffset, scenario.sel.fPath || scenario.sel.sPath, scenario.sel.fOffset || scenario.sel.fOffset);
+    }
+    const matches = editor.plugins.searchreplace.find(scenario.find, scenario.matchCase || false, scenario.wholeWords || false, true);
+    assert.equal(scenario.matches, matches);
 
-    const sTestInSelection = (label: string, scenario: FindScenario | ReplaceScenario) => Log.stepsAsStep('TINY-4549', 'SearchReplace: ' + label, [
-      tinyApis.sSetContent(scenario.content),
-      scenario.sel ? tinyApis.sSetSelection(scenario.sel.sPath, scenario.sel.sOffset, scenario.sel.fPath || scenario.sel.sPath, scenario.sel.fOffset || scenario.sel.fOffset) : Step.pass,
-      Step.sync(() => {
-        const matches = editor.plugins.searchreplace.find(scenario.find, scenario.matchCase || false, scenario.wholeWords || false, true);
-        Assertions.assertEq('Check the correct number of matches were found', scenario.matches, matches);
-      }),
-      isReplaceScenario(scenario) ? sReplaceStep(editor, scenario) : Step.pass
-    ]);
+    if (isReplaceScenario(scenario)) {
+      testReplace(editor, scenario);
+    }
+  };
 
-    Pipeline.async({}, Log.steps('TINY-4549', 'SearchReplace: Find and replace in selection matches', [
-      tinyApis.sFocus(),
-      sTestInSelection('Find no match', { content: 'a', find: 'x', matches: 0, sel: { sPath: [ 0, 0 ], sOffset: 0, fOffset: 1 }}),
-      sTestInSelection('Find single match', { content: 'a a', find: 'a', matches: 1, sel: { sPath: [ 0, 0 ], sOffset: 0, fOffset: 1 }}),
-      sTestInSelection('Find multiple matches', { content: 'a A a', find: 'a', matches: 2, sel: { sPath: [ 0, 0 ], sOffset: 0, fOffset: 3 }}),
-      sTestInSelection('Find single match in fragmented text', {
-        content: 't<b>e</b><i>xt</i> t<b>e</b><i>xt</i>',
-        find: 'text',
-        matches: 1,
-        sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 3 ], fOffset: 0 }
-      }),
-      sTestInSelection('Find multiple matches in table', {
-        content: '<table><tbody><tr><th data-mce-selected="1">a</th><th>a</th></tr><tr><td data-mce-selected="1">a</td><td>a</td></tr></tbody></table>',
-        find: 'a',
-        matches: 2
-      }),
-      sTestInSelection('Find match ignores content editable false elements', {
-        content: 'a<span contenteditable="false">a</span>a',
-        find: 'a',
-        matches: 2,
-        sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 2 ], fOffset: 1 }
-      }),
-      sTestInSelection('Find matches on either side of an image', {
-        content: 'ab ab<img src=""/>ab abab',
-        find: 'ab',
-        matches: 2,
-        sel: { sPath: [ 0, 0 ], sOffset: 3, fPath: [ 0, 2 ], fOffset: 2 }
-      }),
-      sTestInSelection('Find no match spread across image', {
-        content: 'abab ab<img src=""/>ab abab',
-        find: 'abab',
-        matches: 0,
-        sel: { sPath: [ 0, 0 ], sOffset: 4, fPath: [ 0, 2 ], fOffset: 3 }
-      }),
-      sTestInSelection('Find no match spread across new lines', {
-        content: 'abab<br>ab<br>ab<br>abab',
-        find: 'abab',
-        matches: 0,
-        sel: { sPath: [ 0, 2 ], sOffset: 0, fPath: [ 0, 4 ], fOffset: 2 }
-      }),
-      sTestInSelection('Find single match, match case: true', {
-        content: 'a A a A',
-        find: 'A',
-        matches: 1,
-        matchCase: true,
-        sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 3 }
-      }),
-      sTestInSelection('Find single match, whole words: true', {
-        content: 'a Ax a Ax',
-        find: 'a',
-        matches: 1,
-        wholeWords: true,
-        sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 4 }
-      }),
-      sTestInSelection('Find special characters match', {
-        content: '^^ ^^ ^^^^',
-        find: '^^',
-        matches: 3,
-        sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 8 }
-      }),
-      sTestInSelection('Find special characters match, whole words: true', {
-        content: '^^ ^^ ^^^^',
-        find: '^^',
-        matches: 2,
-        wholeWords: true,
-        sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 8 }
-      }),
-      sTestInSelection('Find and replace single match', {
-        content: 'a a a',
-        find: 'a',
-        matches: 1,
-        replace: 'x',
-        expectedContent: '<p>a x a</p>',
-        moreMatches: false,
-        sel: { sPath: [ 0, 0 ], sOffset: 2, fPath: [ 0, 0 ], fOffset: 3 }
-      }),
-      sTestInSelection('Find and replace first in multiple matches', {
-        content: 'a b a b ab',
-        find: 'a',
-        matches: 2,
-        replace: 'x',
-        expectedContent: '<p>a b x b ab</p>',
-        moreMatches: true,
-        sel: { sPath: [ 0, 0 ], sOffset: 1, fPath: [ 0, 0 ], fOffset: 10 }
-      }),
-      sTestInSelection('Find and replace two consecutive spaces', {
-        content: 'ab a&nbsp; b a&nbsp; &nbsp;',
-        find: 'a  ',
-        matches: 1,
-        replace: 'x',
-        expectedContent: '<p>ab xb a&nbsp; &nbsp;</p>',
-        moreMatches: false,
-        sel: { sPath: [ 0, 0 ], sOffset: 2, fPath: [ 0, 0 ], fOffset: 8 }
-      }),
-      sTestInSelection('Find and replace consecutive spaces', {
-        content: 'ab a&nbsp; &nbsp;b a&nbsp; &nbsp;',
-        find: 'a   ',
-        matches: 1,
-        replace: 'x',
-        expectedContent: '<p>ab a&nbsp; &nbsp;b x</p>',
-        moreMatches: false,
-        sel: { sPath: [ 0, 0 ], sOffset: 6, fPath: [ 0, 0 ], fOffset: 13 }
-      }),
-      sTestInSelection('Find and replace all in multiple matches', {
-        content: 'a b a b a',
-        find: 'a',
-        matches: 2,
-        replace: 'x',
-        replaceAll: true,
-        expectedContent: '<p>x b x b a</p>',
-        moreMatches: false,
-        sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 7 }
-      }),
-      sTestInSelection('Find and replace all in multiple matches', {
-        content: 'a&nbsp; &nbsp;b<br/><br/>ab&nbsp;c',
-        find: ' ',
-        matches: 2,
-        replace: 'x',
-        replaceAll: true,
-        expectedContent: '<p>a&nbsp; xb<br /><br />abxc</p>',
-        moreMatches: false,
-        sel: { sPath: [ 0, 0 ], sOffset: 3, fPath: [ 0, 3 ], fOffset: 4 }
-      }),
-      sTestInSelection('Find and replace fragmented match', {
-        content: '<b>te<i>s</i>t</b><b>te<i>s</i>t</b>',
-        find: 'test',
-        matches: 1,
-        replace: 'abc',
-        expectedContent: '<p><b>te<i>s</i>t</b><b>abc</b></p>',
-        moreMatches: false,
-        sel: { sPath: [ 0, 0, 1 ], sOffset: 0, fPath: [ 0, 1, 2 ], fOffset: 1 }
-      }),
-      sTestInSelection('Find and replace all fragmented matches', {
-        content: '<b>te<i>s</i>t</b><b>te<i>s</i>t</b><b>te<i>s</i>t</b>',
-        find: 'test',
-        matches: 2,
-        replace: 'abc',
-        replaceAll: true,
-        expectedContent: '<p><b>te<i>s</i>t</b><b>abc</b><b>abc</b></p>',
-        moreMatches: false,
-        sel: { sPath: [ 0, 1, 0 ], sOffset: 0, fPath: [ 0, 2, 2 ], fOffset: 1 }
-      })
-    ]), onSuccess, onFailure);
-  }, {
-    plugins: 'searchreplace',
-    base_url: '/project/tinymce/js/tinymce',
-    theme: 'silver',
-    extended_valid_elements: 'b,i'
-  }, success, failure);
-}
-);
+  it('TINY-4549: Find no match', testInSelection({ content: 'a', find: 'x', matches: 0, sel: { sPath: [ 0, 0 ], sOffset: 0, fOffset: 1 }}));
+
+  it('TINY-4549: Find single match', testInSelection({ content: 'a a', find: 'a', matches: 1, sel: { sPath: [ 0, 0 ], sOffset: 0, fOffset: 1 }}));
+
+  it('TINY-4549: Find multiple matches', testInSelection({ content: 'a A a', find: 'a', matches: 2, sel: { sPath: [ 0, 0 ], sOffset: 0, fOffset: 3 }}));
+
+  it('TINY-4549: Find single match in fragmented text', testInSelection({
+    content: 't<b>e</b><i>xt</i> t<b>e</b><i>xt</i>',
+    find: 'text',
+    matches: 1,
+    sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 3 ], fOffset: 0 }
+  }));
+
+  it('TINY-4549: Find multiple matches in table', testInSelection({
+    content: '<table><tbody><tr><th data-mce-selected="1">a</th><th>a</th></tr><tr><td data-mce-selected="1">a</td><td>a</td></tr></tbody></table>',
+    find: 'a',
+    matches: 2
+  }));
+
+  it('TINY-4549: Find match ignores content editable false elements', testInSelection({
+    content: 'a<span contenteditable="false">a</span>a',
+    find: 'a',
+    matches: 2,
+    sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 2 ], fOffset: 1 }
+  }));
+
+  it('TINY-4549: Find matches on either side of an image', testInSelection({
+    content: 'ab ab<img src=""/>ab abab',
+    find: 'ab',
+    matches: 2,
+    sel: { sPath: [ 0, 0 ], sOffset: 3, fPath: [ 0, 2 ], fOffset: 2 }
+  }));
+
+  it('TINY-4549: Find no match spread across image', testInSelection({
+    content: 'abab ab<img src=""/>ab abab',
+    find: 'abab',
+    matches: 0,
+    sel: { sPath: [ 0, 0 ], sOffset: 4, fPath: [ 0, 2 ], fOffset: 3 }
+  }));
+
+  it('TINY-4549: Find no match spread across new lines', testInSelection({
+    content: 'abab<br>ab<br>ab<br>abab',
+    find: 'abab',
+    matches: 0,
+    sel: { sPath: [ 0, 2 ], sOffset: 0, fPath: [ 0, 4 ], fOffset: 2 }
+  }));
+
+  it('TINY-4549: Find single match, match case: true', testInSelection({
+    content: 'a A a A',
+    find: 'A',
+    matches: 1,
+    matchCase: true,
+    sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 3 }
+  }));
+
+  it('TINY-4549: Find single match, whole words: true', testInSelection({
+    content: 'a Ax a Ax',
+    find: 'a',
+    matches: 1,
+    wholeWords: true,
+    sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 4 }
+  }));
+
+  it('TINY-4549: Find special characters match', testInSelection({
+    content: '^^ ^^ ^^^^',
+    find: '^^',
+    matches: 3,
+    sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 8 }
+  }));
+
+  it('TINY-4549: Find special characters match, whole words: true', testInSelection({
+    content: '^^ ^^ ^^^^',
+    find: '^^',
+    matches: 2,
+    wholeWords: true,
+    sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 8 }
+  }));
+
+  it('TINY-4549: Find and replace single match', testInSelection({
+    content: 'a a a',
+    find: 'a',
+    matches: 1,
+    replace: 'x',
+    expectedContent: '<p>a x a</p>',
+    moreMatches: false,
+    sel: { sPath: [ 0, 0 ], sOffset: 2, fPath: [ 0, 0 ], fOffset: 3 }
+  }));
+
+  it('TINY-4549: Find and replace first in multiple matches', testInSelection({
+    content: 'a b a b ab',
+    find: 'a',
+    matches: 2,
+    replace: 'x',
+    expectedContent: '<p>a b x b ab</p>',
+    moreMatches: true,
+    sel: { sPath: [ 0, 0 ], sOffset: 1, fPath: [ 0, 0 ], fOffset: 10 }
+  }));
+
+  it('TINY-4549: Find and replace two consecutive spaces', testInSelection({
+    content: 'ab a&nbsp; b a&nbsp; &nbsp;',
+    find: 'a  ',
+    matches: 1,
+    replace: 'x',
+    expectedContent: '<p>ab xb a&nbsp; &nbsp;</p>',
+    moreMatches: false,
+    sel: { sPath: [ 0, 0 ], sOffset: 2, fPath: [ 0, 0 ], fOffset: 8 }
+  }));
+
+  it('TINY-4549: Find and replace consecutive spaces', testInSelection({
+    content: 'ab a&nbsp; &nbsp;b a&nbsp; &nbsp;',
+    find: 'a   ',
+    matches: 1,
+    replace: 'x',
+    expectedContent: '<p>ab a&nbsp; &nbsp;b x</p>',
+    moreMatches: false,
+    sel: { sPath: [ 0, 0 ], sOffset: 6, fPath: [ 0, 0 ], fOffset: 13 }
+  }));
+
+  it('TINY-4549: Find and replace all in multiple matches', testInSelection({
+    content: 'a b a b a',
+    find: 'a',
+    matches: 2,
+    replace: 'x',
+    replaceAll: true,
+    expectedContent: '<p>x b x b a</p>',
+    moreMatches: false,
+    sel: { sPath: [ 0, 0 ], sOffset: 0, fPath: [ 0, 0 ], fOffset: 7 }
+  }));
+
+  it('TINY-4549: Find and replace all in multiple matches with nbsp', testInSelection({
+    content: 'a&nbsp; &nbsp;b<br/><br/>ab&nbsp;c',
+    find: ' ',
+    matches: 2,
+    replace: 'x',
+    replaceAll: true,
+    expectedContent: '<p>a&nbsp; xb<br /><br />abxc</p>',
+    moreMatches: false,
+    sel: { sPath: [ 0, 0 ], sOffset: 3, fPath: [ 0, 3 ], fOffset: 4 }
+  }));
+
+  it('TINY-4549: Find and replace fragmented match', testInSelection({
+    content: '<b>te<i>s</i>t</b><b>te<i>s</i>t</b>',
+    find: 'test',
+    matches: 1,
+    replace: 'abc',
+    expectedContent: '<p><b>te<i>s</i>t</b><b>abc</b></p>',
+    moreMatches: false,
+    sel: { sPath: [ 0, 0, 1 ], sOffset: 0, fPath: [ 0, 1, 2 ], fOffset: 1 }
+  }));
+
+  it('TINY-4549: Find and replace all fragmented matches', testInSelection({
+    content: '<b>te<i>s</i>t</b><b>te<i>s</i>t</b><b>te<i>s</i>t</b>',
+    find: 'test',
+    matches: 2,
+    replace: 'abc',
+    replaceAll: true,
+    expectedContent: '<p><b>te<i>s</i>t</b><b>abc</b><b>abc</b></p>',
+    moreMatches: false,
+    sel: { sPath: [ 0, 1, 0 ], sOffset: 0, fPath: [ 0, 2, 2 ], fOffset: 1 }
+  }));
+});

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
@@ -1,10 +1,9 @@
-import { FocusTools, Keyboard, Keys } from '@ephox/agar';
+import { FocusTools, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Tools from 'tinymce/core/api/util/Tools';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 import * as Utils from '../module/test/Utils';
@@ -23,21 +22,13 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
 
   const doc = SugarDocument.getDocument();
 
-  const pressTab = () => Keyboard.activeKeydown(doc, Keys.tab());
-  const pressEsc = () => Keyboard.activeKeydown(doc, Keys.escape());
-  const pressDown = () => Keyboard.activeKeydown(doc, Keys.down());
-  const pressRight = () => Keyboard.activeKeydown(doc, Keys.right());
-  const pressEnter = () => Keyboard.activeKeydown(doc, Keys.enter());
+  const pressTab = (editor: Editor) => TinyUiActions.keydown(editor, Keys.tab());
+  const pressEsc = (editor: Editor) => TinyUiActions.keydown(editor, Keys.escape());
+  const pressDown = (editor: Editor) => TinyUiActions.keydown(editor, Keys.down());
+  const pressRight = (editor: Editor) => TinyUiActions.keydown(editor, Keys.right());
+  const pressEnter = (editor: Editor) => TinyUiActions.keydown(editor, Keys.enter());
 
-  const focusToolbar = (editor: Editor) => {
-    const args = Tools.extend({
-      ctrlKey: false,
-      altKey: false,
-      shiftKey: false,
-      metaKey: false
-    }, { altKey: true, keyCode: 120 });
-    editor.fire('keydown', args);
-  };
+  const focusToolbar = (editor: Editor) => TinyContentActions.keydown(editor, 120, { altKey: true });
 
   const pAssertFocused = (name: string, selector: string) => FocusTools.pTryOnSelector(name, doc, selector);
 
@@ -45,14 +36,14 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     const editor = hook.editor();
     focusToolbar(editor);
     await pAssertFocused('File', '.tox-mbtn:contains("File")');
-    pressRight();
+    pressRight(editor);
     await pAssertFocused('Edit', '.tox-mbtn:contains("Edit")');
-    pressDown(); // select all
+    pressDown(editor); // select all
     await TinyUiActions.pWaitForPopup(editor, '.tox-menu');
-    pressDown(); // find and replace
+    pressDown(editor); // find and replace
     await pAssertFocused('Find and replace edit menu item', '.tox-collection__item:contains("Find and replace")'); // Menu item can be reached by keyboard
-    pressEsc();
-    pressTab();
+    pressEsc(editor);
+    pressTab(editor);
     await pAssertFocused('Find and replace button', '.tox-tbtn'); // Button can be reached by keyboard
   });
 
@@ -60,17 +51,17 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     const editor = hook.editor();
     await Utils.pOpenDialog(editor);
     await pAssertFocused('Find input', '.tox-textfield[placeholder="Find"]');
-    pressTab();
+    pressTab(editor);
     await pAssertFocused('Replace with input', '.tox-textfield[placeholder="Replace with"]');
-    pressTab();
+    pressTab(editor);
     await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[title="Preferences"]');
-    pressDown();
+    pressDown(editor);
     await pAssertFocused('Match case menu item', '.tox-collection__item:contains("Match case")'); // Menu items can be reached by keyboard
-    pressEnter();
+    pressEnter(editor);
     await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[title="Preferences"]');
-    pressTab();
+    pressTab(editor);
     await pAssertFocused('Find button', '.tox-button[title="Find"]');
-    pressEsc();
+    pressEsc(editor);
   });
 
   it('TINY-3961: Dialog keyboard focus is returned to find input', async () => {
@@ -78,21 +69,21 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     editor.setContent('<p>fish fish fish</p>');
     await Utils.pOpenDialog(editor);
     await pAssertFocused('Find input', '.tox-textfield[placeholder="Find"]');
-    pressTab();
+    pressTab(editor);
     await pAssertFocused('Replace with input', '.tox-textfield[placeholder="Replace with"]');
-    pressTab();
+    pressTab(editor);
     await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[title="Preferences"]');
-    pressTab();
+    pressTab(editor);
     await pAssertFocused('Find button', '.tox-button[title="Find"]');
     await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
-    pressEnter();
-    pressTab();
+    pressEnter(editor);
+    pressTab(editor);
     await pAssertFocused('Find button', '.tox-button[title="Replace"]');
-    pressTab();
+    pressTab(editor);
     await pAssertFocused('Find button', '.tox-button[title="Replace all"]');
-    pressEnter();
+    pressEnter(editor);
     await pAssertFocused('Find input', '.tox-textfield[placeholder="Find"]');
-    pressEsc();
+    pressEsc(editor);
   });
 
   it('TINY-4014: Dialog keyboard focus is returned to find input after displaying an alert', async () => {
@@ -101,10 +92,10 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     await Utils.pOpenDialog(editor);
     await pAssertFocused('Find input', '.tox-textfield[placeholder="Find"]');
     await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'notfound');
-    pressEnter();
+    pressEnter(editor);
     await pAssertFocused('Alert dialog OK button', '.tox-alert-dialog .tox-button[title="OK"]');
-    pressEnter();
+    pressEnter(editor);
     await pAssertFocused('Find input', '.tox-textfield[placeholder="Find"]');
-    pressEsc();
+    pressEsc(editor);
   });
 });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
@@ -1,202 +1,214 @@
-import { Log, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import SearchreplacePlugin from 'tinymce/plugins/searchreplace/Plugin';
+import Plugin from 'tinymce/plugins/searchreplace/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
-
 import * as HtmlUtils from '../module/test/HtmlUtils';
 
-UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplacePluginTest', (success, failure) => {
-  const suite = LegacyUnit.createSuite<Editor>();
+describe('browser.tinymce.plugins.searchreplace.SearchReplacePluginTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'searchreplace',
+    valid_elements: 'p,b,i,br,span[contenteditable]',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+  }, [ Plugin, Theme ], true);
 
-  Theme();
-  SearchreplacePlugin();
-
-  suite.test('TestCase-TBA: SearchReplace: Find no match', (editor) => {
-    editor.focus();
+  it('TBA: SearchReplace: Find no match', () => {
+    const editor = hook.editor();
     editor.setContent('a');
-    LegacyUnit.equal(0, editor.plugins.searchreplace.find('x'));
+    assert.equal(editor.plugins.searchreplace.find('x'), 0);
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find single match', (editor) => {
+  it('TBA: SearchReplace: Find single match', () => {
+    const editor = hook.editor();
     editor.setContent('a');
-    LegacyUnit.equal(1, editor.plugins.searchreplace.find('a'));
+    assert.equal(editor.plugins.searchreplace.find('a'), 1);
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find single match in multiple elements', (editor) => {
+  it('TBA: SearchReplace: Find single match in multiple elements', () => {
+    const editor = hook.editor();
     editor.setContent('t<b>e</b><i>xt</i>');
-    LegacyUnit.equal(1, editor.plugins.searchreplace.find('text'));
+    assert.equal(editor.plugins.searchreplace.find('text'), 1);
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find single match, match case: true', (editor) => {
+  it('TBA: SearchReplace: Find single match, match case: true', () => {
+    const editor = hook.editor();
     editor.setContent('a A');
-    LegacyUnit.equal(1, editor.plugins.searchreplace.find('A', true));
+    assert.equal(editor.plugins.searchreplace.find('A', true), 1);
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find single match, whole words: true', (editor) => {
+  it('TBA: SearchReplace: Find single match, whole words: true', () => {
+    const editor = hook.editor();
     editor.setContent('a Ax');
-    LegacyUnit.equal(1, editor.plugins.searchreplace.find('a', false, true));
+    assert.equal(editor.plugins.searchreplace.find('a', false, true), 1);
   });
 
-  suite.test('TestCase-TINY-4522: SearchReplace: Find special characters match', (editor) => {
+  it('TINY-4522: SearchReplace: Find special characters match', () => {
+    const editor = hook.editor();
     editor.setContent('^^ ^^ ^^^^');
-    LegacyUnit.equal(4, editor.plugins.searchreplace.find('^^'));
+    assert.equal(editor.plugins.searchreplace.find('^^'), 4);
     editor.setContent('50$ 50$50$');
-    LegacyUnit.equal(3, editor.plugins.searchreplace.find('50$'));
+    assert.equal(editor.plugins.searchreplace.find('50$'), 3);
   });
 
-  suite.test('TestCase-TINY-4522: SearchReplace: Find special characters match, whole words: true', (editor) => {
+  it('TINY-4522: SearchReplace: Find special characters match, whole words: true', () => {
+    const editor = hook.editor();
     editor.setContent('^^ ^^ ^^^^');
-    LegacyUnit.equal(2, editor.plugins.searchreplace.find('^^', false, true));
+    assert.equal(editor.plugins.searchreplace.find('^^', false, true), 2);
     editor.setContent('50$ 50$50$');
-    LegacyUnit.equal(1, editor.plugins.searchreplace.find('50$', false, true));
+    assert.equal(editor.plugins.searchreplace.find('50$', false, true), 1);
   });
 
-  suite.test('TestCase-TINY-4522: SearchReplace: Find word with punctuation, whole words: true', (editor) => {
+  it('TINY-4522: SearchReplace: Find word with punctuation, whole words: true', () => {
+    const editor = hook.editor();
     editor.setContent(`'test' "test" \u2018test\u2019 test: test; test! test. test? test,`);
-    LegacyUnit.equal(9, editor.plugins.searchreplace.find('test', false, true));
-    LegacyUnit.equal(1, editor.plugins.searchreplace.find('test!', false, true));
+    assert.equal(editor.plugins.searchreplace.find('test', false, true), 9);
+    assert.equal(editor.plugins.searchreplace.find('test!', false, true), 1);
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find multiple matches', (editor) => {
+  it('TBA: SearchReplace: Find multiple matches', () => {
+    const editor = hook.editor();
     editor.setContent('a b A');
-    LegacyUnit.equal(2, editor.plugins.searchreplace.find('a'));
+    assert.equal(editor.plugins.searchreplace.find('a'), 2);
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find and replace single match', (editor) => {
+  it('TBA: SearchReplace: Find and replace single match', () => {
+    const editor = hook.editor();
     editor.setContent('a');
     editor.plugins.searchreplace.find('a');
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('x'), false);
-    LegacyUnit.equal('<p>x</p>', editor.getContent());
+    assert.isFalse(editor.plugins.searchreplace.replace('x'));
+    TinyAssertions.assertContent(editor, '<p>x</p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find and replace first in multiple matches', (editor) => {
+  it('TBA: SearchReplace: Find and replace first in multiple matches', () => {
+    const editor = hook.editor();
     editor.setContent('a b a');
     editor.plugins.searchreplace.find('a');
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('x'), true);
-    LegacyUnit.equal('<p>x b a</p>', editor.getContent());
+    assert.isTrue(editor.plugins.searchreplace.replace('x'));
+    TinyAssertions.assertContent(editor, '<p>x b a</p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find and replace two consecutive spaces', (editor) => {
+  it('TBA: SearchReplace: Find and replace two consecutive spaces', () => {
+    const editor = hook.editor();
     editor.setContent('a&nbsp; b');
     editor.plugins.searchreplace.find('a  ');
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('x'), false);
-    LegacyUnit.equal('<p>xb</p>', editor.getContent());
+    assert.isFalse(editor.plugins.searchreplace.replace('x'));
+    TinyAssertions.assertContent(editor, '<p>xb</p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find and replace consecutive spaces', (editor) => {
+  it('TBA: SearchReplace: Find and replace consecutive spaces', () => {
+    const editor = hook.editor();
     editor.setContent('a&nbsp; &nbsp;b');
     editor.plugins.searchreplace.find('a   ');
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('x'), false);
-    LegacyUnit.equal('<p>xb</p>', editor.getContent());
+    assert.isFalse(editor.plugins.searchreplace.replace('x'));
+    TinyAssertions.assertContent(editor, '<p>xb</p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find and replace all in multiple matches', (editor) => {
+  it('TBA: SearchReplace: Find and replace all in multiple matches', () => {
+    const editor = hook.editor();
     editor.setContent('a b a');
     editor.plugins.searchreplace.find('a');
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('x', true, true), false);
-    LegacyUnit.equal('<p>x b x</p>', editor.getContent());
+    assert.isFalse(editor.plugins.searchreplace.replace('x', true, true));
+    TinyAssertions.assertContent(editor, '<p>x b x</p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find and replace all spaces with new lines', (editor) => {
+  it('TBA: SearchReplace: Find and replace all spaces with new lines', () => {
+    const editor = hook.editor();
     editor.setContent('a&nbsp; &nbsp;b<br/><br/>ab&nbsp;c');
     editor.plugins.searchreplace.find(' ');
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('x', true, true), false);
-    LegacyUnit.equal('<p>axxxb<br /><br />abxc</p>', editor.getContent());
+    assert.isFalse(editor.plugins.searchreplace.replace('x', true, true));
+    TinyAssertions.assertContent(editor, '<p>axxxb<br /><br />abxc</p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find multiple matches, move to next and replace', (editor) => {
+  it('TBA: SearchReplace: Find multiple matches, move to next and replace', () => {
+    const editor = hook.editor();
     editor.setContent('a a');
-    LegacyUnit.equal(2, editor.plugins.searchreplace.find('a'));
+    assert.equal(editor.plugins.searchreplace.find('a'), 2);
     editor.plugins.searchreplace.next();
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('x'), true);
-    LegacyUnit.equal('<p>a x</p>', editor.getContent());
+    assert.isTrue(editor.plugins.searchreplace.replace('x'));
+    TinyAssertions.assertContent(editor, '<p>a x</p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find and replace fragmented match', (editor) => {
+  it('TBA: SearchReplace: Find and replace fragmented match', () => {
+    const editor = hook.editor();
     editor.setContent('<b>te<i>s</i>t</b><b>te<i>s</i>t</b>');
     editor.plugins.searchreplace.find('test');
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('abc'), true);
-    LegacyUnit.equal(editor.getContent(), '<p><b>abc</b><b>te<i>s</i>t</b></p>');
+    assert.isTrue(editor.plugins.searchreplace.replace('abc'));
+    TinyAssertions.assertContent(editor, '<p><b>abc</b><b>te<i>s</i>t</b></p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find and replace all fragmented matches', (editor) => {
+  it('TBA: SearchReplace: Find and replace all fragmented matches', () => {
+    const editor = hook.editor();
     editor.setContent('<b>te<i>s</i>t</b><b>te<i>s</i>t</b>');
     editor.plugins.searchreplace.find('test');
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('abc', true, true), false);
-    LegacyUnit.equal(editor.getContent(), '<p><b>abc</b><b>abc</b></p>');
+    assert.isFalse(editor.plugins.searchreplace.replace('abc', true, true));
+    TinyAssertions.assertContent(editor, '<p><b>abc</b><b>abc</b></p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find multiple matches, move to next and replace backwards', (editor) => {
+  it('TBA: SearchReplace: Find multiple matches, move to next and replace backwards', () => {
+    const editor = hook.editor();
     editor.setContent('a a');
-    LegacyUnit.equal(2, editor.plugins.searchreplace.find('a'));
+    assert.equal(editor.plugins.searchreplace.find('a'), 2);
     editor.plugins.searchreplace.next();
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('x', false), true);
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('y', false), false);
-    LegacyUnit.equal('<p>y x</p>', editor.getContent());
+    assert.isTrue(editor.plugins.searchreplace.replace('x', false));
+    assert.isFalse(editor.plugins.searchreplace.replace('y', false));
+    TinyAssertions.assertContent(editor, '<p>y x</p>');
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find multiple matches and unmark them', (editor) => {
+  it('TBA: SearchReplace: Find multiple matches and unmark them', () => {
+    const editor = hook.editor();
     editor.setContent('a b a');
-    LegacyUnit.equal(2, editor.plugins.searchreplace.find('a'));
+    assert.equal(editor.plugins.searchreplace.find('a'), 2);
     editor.plugins.searchreplace.done();
-    LegacyUnit.equal('a', editor.selection.getContent());
-    LegacyUnit.equal(0, editor.getBody().getElementsByTagName('span').length);
+    assert.equal(editor.selection.getContent(), 'a');
+    assert.lengthOf(editor.getBody().getElementsByTagName('span'), 0);
   });
 
-  suite.test('TestCase-TBA: SearchReplace: Find multiple matches with pre blocks', (editor) => {
+  it('TBA: SearchReplace: Find multiple matches with pre blocks', () => {
+    const editor = hook.editor();
     editor.getBody().innerHTML = 'abc<pre>  abc  </pre>abc';
-    LegacyUnit.equal(3, editor.plugins.searchreplace.find('b'));
-    LegacyUnit.equal(HtmlUtils.normalizeHtml(editor.getBody().innerHTML), (
+    assert.equal(editor.plugins.searchreplace.find('b'), 3);
+    assert.equal(HtmlUtils.normalizeHtml(editor.getBody().innerHTML), (
       'a<span class="mce-match-marker mce-match-marker-selected" data-mce-bogus="1" data-mce-index="0">b</span>c' +
         '<pre>  a<span class="mce-match-marker" data-mce-bogus="1" data-mce-index="1">b</span>c  </pre>' +
         'a<span class="mce-match-marker" data-mce-bogus="1" data-mce-index="2">b</span>c'
     ));
   });
 
-  suite.test('TestCase-TINY-5967: SearchReplace: Find and replace all in nested contenteditable elements', (editor) => {
+  it('TINY-5967: SearchReplace: Find and replace all in nested contenteditable elements', () => {
+    const editor = hook.editor();
     editor.setContent('<p>Editable ' +
       '<span contenteditable="false">NonEditable <span contenteditable="true">Editable ' +
       '<span contenteditable="false">NonEditable <span contenteditable="true">Editable </span>NonEditable </span>' +
       'Editable </span>NonEditable </span>' +
       'Editable</p>');
-    LegacyUnit.equal(5, editor.plugins.searchreplace.find('Editable', true, true));
-    LegacyUnit.equal(HtmlUtils.normalizeHtml(editor.getBody().innerHTML), (
+    assert.equal(editor.plugins.searchreplace.find('Editable', true, true), 5);
+    assert.equal(HtmlUtils.normalizeHtml(editor.getBody().innerHTML), (
       '<p><span class="mce-match-marker mce-match-marker-selected" data-mce-bogus="1" data-mce-index="0">Editable</span> ' +
       '<span contenteditable="false">NonEditable <span contenteditable="true"><span class="mce-match-marker" data-mce-bogus="1" data-mce-index="1">Editable</span> ' +
       '<span contenteditable="false">NonEditable <span contenteditable="true"><span class="mce-match-marker" data-mce-bogus="1" data-mce-index="2">Editable</span> </span>NonEditable </span>' +
       '<span class="mce-match-marker" data-mce-bogus="1" data-mce-index="3">Editable</span> </span>NonEditable </span>' +
       '<span class="mce-match-marker" data-mce-bogus="1" data-mce-index="4">Editable</span></p>'
     ));
-    LegacyUnit.equal(editor.plugins.searchreplace.replace('x', true, true), false);
-    LegacyUnit.equal(editor.getContent(), '<p>x ' +
+    assert.isFalse(editor.plugins.searchreplace.replace('x', true, true));
+    TinyAssertions.assertContent(editor, '<p>x ' +
       '<span contenteditable="false">NonEditable <span contenteditable="true">x ' +
       '<span contenteditable="false">NonEditable <span contenteditable="true">x </span>NonEditable </span>' +
       'x </span>NonEditable </span>' +
       'x</p>');
   });
 
-  suite.test('TestCase-TINY-4599: SearchReplace: Excludes zwsp characters', (editor) => {
+  it('TINY-4599: SearchReplace: Excludes zwsp characters', () => {
     const content = `<p>a${Unicode.zeroWidth} b${Unicode.zeroWidth} a</p>`;
+    const editor = hook.editor();
     editor.setContent(content, { format: 'raw' });
-    LegacyUnit.equal(2, editor.plugins.searchreplace.find(' '));
-    LegacyUnit.equal(2, editor.getBody().getElementsByTagName('span').length);
+    assert.equal(editor.plugins.searchreplace.find(' '), 2);
+    assert.lengthOf(editor.getBody().getElementsByTagName('span'), 2);
     editor.plugins.searchreplace.done();
-    LegacyUnit.equal(0, editor.getBody().getElementsByTagName('span').length);
-    LegacyUnit.equal(editor.getBody().innerHTML, content);
+    assert.lengthOf(editor.getBody().getElementsByTagName('span'), 0);
+    assert.equal(editor.getBody().innerHTML, content);
   });
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    Pipeline.async({}, Log.steps('TBA', 'SearchReplace: Find and replace matches', suite.toSteps(editor)), onSuccess, onFailure);
-  }, {
-    plugins: 'searchreplace',
-    valid_elements: 'p,b,i,br,span[contenteditable]',
-    indent: false,
-    base_url: '/project/tinymce/js/tinymce',
-    theme: 'silver'
-  }, success, failure);
-}
-);
+});

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
@@ -1,85 +1,64 @@
-import { Chain, Log, Mouse, Pipeline, UiControls, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
 
-import SearchreplacePlugin from 'tinymce/plugins/searchreplace/Plugin';
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/searchreplace/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
-
 import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', (success, failure) => {
-
-  Theme();
-  SearchreplacePlugin();
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    const cAssertButtonsEnabled = Chain.fromParent(Chain.identity, [
-      UiFinder.cWaitFor('wait for next button to be enabled', 'button[title="Next"]:not([disabled])'),
-      UiFinder.cWaitFor('wait for prev button to be enabled', 'button[title="Previous"]:not([disabled])'),
-      UiFinder.cWaitFor('wait for replace button to be enabled', 'button[title="Replace"]:not([disabled])')
-    ]);
-
-    const cAssertNextPrevButtonsDisabled = Chain.fromParent(Chain.identity, [
-      UiFinder.cWaitFor('wait for next button to be disabled', 'button[title="Next"][disabled]'),
-      UiFinder.cWaitFor('wait for prev button to be disabled', 'button[title="Previous"][disabled]')
-    ]);
-
-    const cClickButton = (name: string) => Chain.fromChains([
-      UiFinder.cFindIn('button[title="' + name + '"]:not([disabled])'),
-      Mouse.cClick
-    ]);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'SearchReplace: Test Prev and Next buttons become enabled and disabled at right places when multiple matches exist', [
-        tinyApis.sSetContent('<p>fish fish fish</p>'),
-        Utils.sOpenDialog(tinyUi),
-        Chain.asStep({}, [
-          Chain.fromParent(tinyUi.cWaitForPopup('wait for dialog', 'div[role="dialog"]'), [
-            Chain.fromChains([
-              UiFinder.cFindIn('input.tox-textfield[placeholder="Find"]'),
-              UiControls.cSetValue('fish')
-            ]),
-            cClickButton('Find'),
-
-            // Initial button states for first match
-            cAssertButtonsEnabled,
-
-            // Click next and assert states for second match
-            cClickButton('Next'),
-            cAssertButtonsEnabled,
-
-            // Click next and assert states for third/final match
-            cClickButton('Next'),
-            cAssertButtonsEnabled,
-
-            // Click next and cycle back to first match
-            cClickButton('Next'),
-            cAssertButtonsEnabled,
-
-            // replace all but one value and assert next/previous are disabled
-            Chain.fromChains([
-              UiFinder.cFindIn('input.tox-textfield[placeholder="Replace with"]'),
-              UiControls.cSetValue('squid')
-            ]),
-            cClickButton('Replace'),
-            cAssertButtonsEnabled,
-            cClickButton('Replace'),
-            cAssertNextPrevButtonsDisabled,
-
-            // Ensure the replace button is still enabled, for the last match
-            UiFinder.cWaitFor('wait for replace button to be enabled', 'button[title="Replace"]:not([disabled])')
-          ])
-        ]),
-        tinyApis.sAssertContent('<p>squid squid fish</p>')
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'searchreplace',
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
-    theme: 'silver'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  const body = SugarBody.body();
+
+  const pAssertButtonsEnabled = async () => {
+    await UiFinder.pWaitFor('next button enabled', body, 'button[title="Next"]:not([disabled])');
+    await UiFinder.pWaitFor('prev button enabled', body, 'button[title="Previous"]:not([disabled])');
+    await UiFinder.pWaitFor('replace button enabled', body, 'button[title="Replace"]:not([disabled])');
+  };
+
+  const pAssertNextPrevButtonsDisabled = async () => {
+    await UiFinder.pWaitFor('next button disabled', body, 'button[title="Next"][disabled]');
+    await UiFinder.pWaitFor('prev button disabled', body, 'button[title="Previous"][disabled]');
+  };
+
+  it('TBA: Test Prev and Next buttons become enabled and disabled at right places when multiple matches exist', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>fish fish fish</p>');
+    await Utils.pOpenDialog(editor);
+    await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
+    Utils.clickFind(editor);
+
+    // Initial button states for first match
+    await pAssertButtonsEnabled();
+
+    // Click next and assert states for second match
+    Utils.clickNext(editor);
+    await pAssertButtonsEnabled();
+
+    // Click next and assert states for third/final match
+    Utils.clickNext(editor);
+    await pAssertButtonsEnabled();
+
+    // Click next and cycle back to first match
+    Utils.clickNext(editor);
+    await pAssertButtonsEnabled();
+
+    // replace all but one value and assert next/previous are disabled
+    await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Replace with"]', 'squid');
+    Utils.clickReplace(editor);
+    await pAssertButtonsEnabled();
+    Utils.clickReplace(editor);
+    await pAssertNextPrevButtonsDisabled();
+
+    // Ensure the replace button is still enabled, for the last match
+    UiFinder.pWaitFor('wait for replace button to be enabled', body, 'button[title="Replace"]:not([disabled])');
+    TinyAssertions.assertContent(editor, '<p>squid squid fish</p>');
+  });
 });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
@@ -58,7 +58,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', () =
     await pAssertNextPrevButtonsDisabled();
 
     // Ensure the replace button is still enabled, for the last match
-    UiFinder.pWaitFor('wait for replace button to be enabled', body, 'button[title="Replace"]:not([disabled])');
+    await UiFinder.pWaitFor('wait for replace button to be enabled', body, 'button[title="Replace"]:not([disabled])');
     TinyAssertions.assertContent(editor, '<p>squid squid fish</p>');
   });
 });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
@@ -19,7 +19,6 @@ describe('browser.tinymce.plugins.searchreplace.UndoReplaceSpanTest', () => {
     const editor = hook.editor();
     editor.setContent('<p>cats cats cats</p>');
 
-    // TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Find and replace"]');
     await Utils.pOpenDialog(editor);
     await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'cats');
     await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Replace with"]', 'dogs');

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
@@ -1,74 +1,36 @@
-import { Chain, Log, Logger, Mouse, Pipeline, Step, UiControls, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
+
 import Editor from 'tinymce/core/api/Editor';
-
-import SearchreplacePlugin from 'tinymce/plugins/searchreplace/Plugin';
+import Plugin from 'tinymce/plugins/searchreplace/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
+import * as Utils from '../module/test/Utils';
 
-UnitTest.asynctest('browser.tinymce.plugins.searchreplace.UndoReplaceSpanTest', (success, failure) => {
-
-  Theme();
-  SearchreplacePlugin();
-
-  const sUndo = (editor: Editor) => {
-    return Logger.t('Undo', Step.sync(() => {
-      editor.undoManager.undo();
-    }));
-  };
-
-  const sRedo = (editor: Editor) => {
-    return Logger.t('Redo', Step.sync(() => {
-      editor.undoManager.redo();
-    }));
-  };
-
-  TinyLoader.setupLight((editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-    const tinyUi = TinyUi(editor);
-
-    Pipeline.async({},
-      Log.steps('TBA', 'SearchReplace: replace one of three found, undo and redo and assert there is no matcher spans in editor', [
-        tinyApis.sSetContent('<p>cats cats cats</p>'),
-        tinyUi.sClickOnToolbar('click on searchreplace button', 'button[aria-label="Find and replace"]'),
-        Chain.asStep({}, [
-          Chain.fromParent(tinyUi.cWaitForPopup('wait for dialog', 'div[role="dialog"]'), [
-            Chain.fromChains([
-              UiFinder.cFindIn('input.tox-textfield[placeholder="Find"]'),
-              UiControls.cSetValue('cats')
-            ]),
-            Chain.fromChains([
-              UiFinder.cFindIn('input.tox-textfield[placeholder="Replace with"]'),
-              UiControls.cSetValue('dogs')
-            ]),
-            Chain.fromChains([
-              UiFinder.cFindIn('button:contains("Find")'),
-              Mouse.cClick
-            ]),
-            Chain.fromChains([
-              UiFinder.cWaitFor('wait for button to be enabled', 'button[disabled!="disabled"]:contains("Replace")')
-            ]),
-            Chain.fromChains([
-              UiFinder.cFindIn('button:contains("Replace")'),
-              Mouse.cClick
-            ]),
-            Chain.fromChains([
-              UiFinder.cFindIn('button[aria-label="Close"]'),
-              Mouse.cClick
-            ])
-          ])
-        ]),
-        sUndo(editor),
-        tinyApis.sAssertContent('<p>cats cats cats</p>'),
-        sRedo(editor),
-        tinyApis.sAssertContentPresence({ 'span.mce-match-marker': 0 }),
-        tinyApis.sAssertContent('<p>dogs cats cats</p>')
-      ])
-      , onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.searchreplace.UndoReplaceSpanTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'searchreplace',
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
-    theme: 'silver'
-  }, success, failure);
+  }, [ Theme, Plugin ]);
+
+  it('TBA: replace one of three found, undo and redo and assert there is no matcher spans in editor', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>cats cats cats</p>');
+
+    // TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Find and replace"]');
+    await Utils.pOpenDialog(editor);
+    await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'cats');
+    await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Replace with"]', 'dogs');
+    Utils.clickFind(editor);
+    await UiFinder.pWaitFor('wait for button to be enabled', SugarBody.body(), 'button[disabled!="disabled"]:contains("Replace")');
+    Utils.clickReplace(editor);
+    Utils.clickClose(editor);
+    editor.undoManager.undo();
+    TinyAssertions.assertContent(editor, '<p>cats cats cats</p>');
+    editor.undoManager.redo();
+    TinyAssertions.assertContentPresence(editor, { 'span.mce-match-marker': 0 });
+    TinyAssertions.assertContent(editor, '<p>dogs cats cats</p>');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
Convert the `searchreplace` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
