### PR TITLE
TINY-6870: Added APIs and fixed issues found in Agar while converting tests to BDD

### DIFF
--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## Added
+- Added new `pasteDataTransfer`, `pasteItems`, `pasteFiles`, `cut` and `copy` helpers to the `Clipboard` module.
+
+### Fixed
+- The `DataTransfer.clearData` API threw an exception when no format was provided.
+- The `Keyboard` module generated fake keys was missing the `charCode` property for `keypress` events.
+
+## 5.3.0 - 2021-05-06
+
+### Added
 - Added `pageUp` and `pageDown` constants to the `Keys` API
 
 ## 4.13.1 - 2019-05-20

--- a/modules/agar/src/main/ts/ephox/agar/datatransfer/DataTransfer.ts
+++ b/modules/agar/src/main/ts/ephox/agar/datatransfer/DataTransfer.ts
@@ -108,14 +108,13 @@ const createDataTransfer = (): DataTransfer => {
 
     clearData: (format?: string) => {
       if (isInReadWriteMode(dataTransfer)) {
-        const normalizedFormat = normalize(format);
-
-        if (Type.isString(normalizedFormat)) {
+        if (Type.isString(format)) {
+          const normalizedFormat = normalize(format);
           Arr.findIndex(Arr.from(items), (item) => item.type === normalizedFormat).each((idx) => {
             items.remove(idx);
           });
         } else {
-          for (let i = items.length; i >= 0; i--) {
+          for (let i = items.length - 1; i >= 0; i--) {
             if (items[i].kind === 'string') {
               items.remove(i);
             }

--- a/modules/agar/src/main/ts/ephox/agar/dragndrop/DndEvents.ts
+++ b/modules/agar/src/main/ts/ephox/agar/dragndrop/DndEvents.ts
@@ -42,7 +42,7 @@ const createDragEvent = createDndEvent('drag');
 
 const isDefaultPrevented = (evt: DragEvent): boolean => evt.defaultPrevented || evt.hasOwnProperty('ieDefaultPrevented');
 
-const dispatchDndEvent = (event: DragEvent, target: SugarElement<any>): DragEvent => {
+const dispatchDndEvent = (event: DragEvent, target: SugarElement<Node>): DragEvent => {
   if (event.type === 'dragstart') {
     setReadWriteMode(event.dataTransfer);
   } else if (event.type === 'drop') {
@@ -56,7 +56,7 @@ const dispatchDndEvent = (event: DragEvent, target: SugarElement<any>): DragEven
   return event;
 };
 
-const getWindowFromElement = (element: SugarElement<any>): Window => element.dom.ownerDocument.defaultView;
+const getWindowFromElement = (element: SugarElement<Element>): Window => element.dom.ownerDocument.defaultView;
 
 export {
   createDndEvent,

--- a/modules/agar/src/main/ts/ephox/agar/keyboard/FakeKeys.ts
+++ b/modules/agar/src/main/ts/ephox/agar/keyboard/FakeKeys.ts
@@ -41,6 +41,9 @@ const keyevent = (type: string, doc: SugarElement<Document>, value: number, modi
   } else {
 
     if (platform.browser.isChrome() || platform.browser.isEdge() || platform.browser.isFirefox()) {
+      if (type === 'keypress') {
+        defineGetter(oEvent, 'charCode', getter);
+      }
       defineGetter(oEvent, 'keyCode', getter);
       defineGetter(oEvent, 'which', getter);
       defineGetter(oEvent, 'shiftKey', () => mod.shiftKey === true);
@@ -72,6 +75,9 @@ const safari = (type: string, doc: SugarElement<Document>, value: number, modifi
   const oEvent = doc.dom.createEvent('Events');
   oEvent.initEvent(type, true, true);
 
+  if (type === 'keypress') {
+    (oEvent as any).charCode = value;
+  }
   (oEvent as any).which = value;
   (oEvent as any).keyCode = value;
   (oEvent as any).shiftKey = modifiers.shiftKey === true;

--- a/modules/agar/src/test/ts/browser/KeyboardTest.ts
+++ b/modules/agar/src/test/ts/browser/KeyboardTest.ts
@@ -12,25 +12,30 @@ import * as DomContainers from 'ephox/agar/test/DomContainers';
 
 UnitTest.asynctest('KeyboardTest', (success, failure) => {
 
-  const sAssertEvent = (type, code, modifiers, raw) =>
-    Assertions.sAssertEq(
-      'Checking ' + type + ' event',
-      {
-        which: code,
-        ctrlKey: modifiers.ctrlKey || false,
-        shiftKey: modifiers.shiftKey || false,
-        altKey: modifiers.altKey || false,
-        metaKey: modifiers.metaKey || false,
-        type
-      }, {
-        which: raw.which,
-        ctrlKey: raw.ctrlKey,
-        shiftKey: raw.shiftKey,
-        altKey: raw.altKey,
-        metaKey: raw.metaKey,
-        type: raw.type
-      }
-    );
+  const sAssertEvent = (type: string, code: number, modifiers: Record<string, boolean>, raw: KeyboardEvent) => {
+    const expected: Record<string, any> = {
+      which: code,
+      ctrlKey: modifiers.ctrlKey || false,
+      shiftKey: modifiers.shiftKey || false,
+      altKey: modifiers.altKey || false,
+      metaKey: modifiers.metaKey || false,
+      type
+    };
+    const actual: Record<string, any> = {
+      which: raw.which,
+      ctrlKey: raw.ctrlKey,
+      shiftKey: raw.shiftKey,
+      altKey: raw.altKey,
+      metaKey: raw.metaKey,
+      type: raw.type
+    };
+    // Keypress events should also include a charCode
+    if (type === 'keypress') {
+      expected.charCode = code;
+      actual.charCode = raw.charCode;
+    }
+    return Assertions.sAssertEq('Checking ' + type + ' event', expected, actual);
+  };
 
   const listenOn = (type, f, code, modifiers) =>
     Step.control(

--- a/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
+++ b/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
@@ -15,11 +15,13 @@ if (!/phantom/i.test(navigator.userAgent)) {
 
     const cutUnbinder = DomEvent.bind(pastebin, 'cut', (evt) => {
       const dataTransfer = evt.raw.clipboardData;
+      dataTransfer.clearData();
       dataTransfer.setData('text/plain', 'cut-data');
     });
 
     const copyUnbinder = DomEvent.bind(pastebin, 'copy', (evt) => {
       const dataTransfer = evt.raw.clipboardData;
+      dataTransfer.clearData();
       dataTransfer.setData('text/plain', 'copy-data');
     });
 
@@ -77,14 +79,14 @@ if (!/phantom/i.test(navigator.userAgent)) {
       Logger.t('Cut', Chain.isolate(pastebin, ChainSequence.sequence([
         cCut,
         Chain.op((dataTransfer: DataTransfer) => {
-          Assert.eq('Should be extected cut data', 'cut-data', dataTransfer.getData('text/plain'));
+          Assert.eq('Should be extracted cut data', 'cut-data', dataTransfer.getData('text/plain'));
         })
       ]))),
 
       Logger.t('Copy', Chain.isolate(pastebin, ChainSequence.sequence([
         cCopy,
         Chain.op((dataTransfer: DataTransfer) => {
-          Assert.eq('Should be extected copy data', 'copy-data', dataTransfer.getData('text/plain'));
+          Assert.eq('Should be extracted copy data', 'copy-data', dataTransfer.getData('text/plain'));
         })
       ])))
     ]), () => {


### PR DESCRIPTION
Related Ticket: TINY-6870

Description of Changes:
* Added new BDD clipboard helpers
* Fixed issues found in the mocked DataTransfer and FakeKeys implementations.

Note: This was split out from the other conversions to make it easier to review.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
