### PR TITLE
TINY-7486: Restructure the OpenNotification event fields

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where block elements containing a pagebreak could be removed from the editor content #TINY-3388
 - Fixed a bug where the `list-style-type: none;` style on nested list items was incorrectly removed when clearing formatting #TINY-6264
 - URLs were not always detected when pasting over a selection. Patch contributed by jwcooper #TINY-6997
-- Properties on `OpenNotification` event were incorrectly namespaced #TINY-7486
+- Properties on the `OpenNotification` event were incorrectly namespaced #TINY-7486
 
 ## 5.8.0 - 2021-05-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where block elements containing a pagebreak could be removed from the editor content #TINY-3388
 - Fixed a bug where the `list-style-type: none;` style on nested list items was incorrectly removed when clearing formatting #TINY-6264
 - URLs were not always detected when pasting over a selection. Patch contributed by jwcooper #TINY-6997
+- Properties on `OpenNotification` event were incorrectly namespaced #TINY-7486
 
 ## 5.8.0 - 2021-05-06
 

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -126,7 +126,7 @@ const NotificationManager = (editor: Editor): NotificationManager => {
       reposition();
 
       // Ensure notification is not passed by reference to prevent mutation
-      editor.fire('OpenNotification', { ...notification });
+      editor.fire('OpenNotification', { notification: { ...notification }});
       return notification;
     });
   };

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -52,6 +52,9 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
         assert.equal(unmodified.text, 'service notification text', 'Should have unmodified text');
         assert.equal(unmodified.type, 'warning', 'Should have unmodified type');
         assert.equal(unmodified.timeout, 0, 'Should have unmodified timeout');
+
+        // Notification event should have "notification" field
+        assert.property(openEvents[0], 'notification');
       });
 
       it('TBA: Should not add duplicate text message', () => {


### PR DESCRIPTION
Related Ticket: TINY-7486

Description of Changes:
* Restructure the OpenNotification event fields

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
