### PR TITLE
TINY-7480: Split out colour transformation logic to acid

### DIFF
--- a/modules/acid/CHANGELOG.md
+++ b/modules/acid/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- Added a new `anyToHex` API to the `Transformations` module. This uses a canvas to convert any value to a hex colour #TINY-7480

--- a/modules/acid/CHANGELOG.md
+++ b/modules/acid/CHANGELOG.md
@@ -8,3 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added a new `anyToHex` API to the `Transformations` module. This uses a canvas to convert any value to a hex colour #TINY-7480
+
+### Changed
+- `HexColour.fromString` will now normalize the hex value to strip the leading `#` if present and uppercase the values #TINY-7480

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/HexColour.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/HexColour.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import { Strings, Optional } from '@ephox/katamari';
 import { Hex, Rgba } from './ColourTypes';
 
 const hexColour = (value: string): Hex => ({
@@ -10,7 +10,9 @@ const longformRegex = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i;
 
 const isHexString = (hex: string): boolean => shorthandRegex.test(hex) || longformRegex.test(hex);
 
-const fromString = (hex: string): Optional<Hex> => isHexString(hex) ? Optional.some({ value: hex }) : Optional.none();
+const normalizeHex = (hex: string): string => Strings.removeLeading(hex, '#').toUpperCase();
+
+const fromString = (hex: string): Optional<Hex> => isHexString(hex) ? Optional.some({ value: normalizeHex(hex) }) : Optional.none();
 
 // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
 const getLongForm = (hex: Hex): Hex => {

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/Transformations.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/Transformations.ts
@@ -7,7 +7,7 @@ const hexToHsv = (hex: Hex): Hsv => HsvColour.fromRgb(RgbaColour.fromHex(hex));
 const hsvToHex = (hsv: Hsv): Hex => HexColour.fromRgba(RgbaColour.fromHsv(hsv));
 
 const anyToHex = (color: string): Hex =>
-  HexColour.fromString(color.replace('#', '').toUpperCase())
+  HexColour.fromString(color)
     .orThunk(() => RgbaColour.fromString(color).map((color) => HexColour.fromRgba(color)))
     .getOrThunk(() => {
       // Not dealing with Hex or RGBA so use a canvas to parse the color

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/Transformations.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/Transformations.ts
@@ -6,7 +6,34 @@ import * as RgbaColour from './RgbaColour';
 const hexToHsv = (hex: Hex): Hsv => HsvColour.fromRgb(RgbaColour.fromHex(hex));
 const hsvToHex = (hsv: Hsv): Hex => HexColour.fromRgba(RgbaColour.fromHsv(hsv));
 
+const anyToHex = (color: string): Hex =>
+  HexColour.fromString(color.replace('#', '').toUpperCase())
+    .orThunk(() => RgbaColour.fromString(color).map((color) => HexColour.fromRgba(color)))
+    .getOrThunk(() => {
+      // Not dealing with Hex or RGBA so use a canvas to parse the color
+      const canvas = document.createElement('canvas');
+      canvas.height = 1;
+      canvas.width = 1;
+      const canvasContext = canvas.getContext('2d') as CanvasRenderingContext2D;
+
+      // all valid colors after this point
+      canvasContext.clearRect(0, 0, canvas.width, canvas.height);
+      // invalid colors will be shown as white - the first assignment will pass and the second may be ignored
+      canvasContext.fillStyle = '#FFFFFF'; // lgtm[js/useless-assignment-to-property]
+      canvasContext.fillStyle = color;
+      canvasContext.fillRect(0, 0, 1, 1);
+
+      const rgba = canvasContext.getImageData(0, 0, 1, 1).data;
+      const r = rgba[0];
+      const g = rgba[1];
+      const b = rgba[2];
+      const a = rgba[3];
+
+      return HexColour.fromRgba(RgbaColour.rgbaColour(r, g, b, a));
+    });
+
 export {
+  anyToHex,
   hexToHsv,
   hsvToHex
 };

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/Transformations.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/Transformations.ts
@@ -8,7 +8,7 @@ const hsvToHex = (hsv: Hsv): Hex => HexColour.fromRgba(RgbaColour.fromHsv(hsv));
 
 const anyToHex = (color: string): Hex =>
   HexColour.fromString(color)
-    .orThunk(() => RgbaColour.fromString(color).map((color) => HexColour.fromRgba(color)))
+    .orThunk(() => RgbaColour.fromString(color).map(HexColour.fromRgba))
     .getOrThunk(() => {
       // Not dealing with Hex or RGBA so use a canvas to parse the color
       const canvas = document.createElement('canvas');

--- a/modules/acid/src/test/ts/atomic/HexColourTest.ts
+++ b/modules/acid/src/test/ts/atomic/HexColourTest.ts
@@ -72,22 +72,22 @@ describe('atomic.acid.HexColourTest', () => {
   context('fromString', () => {
     it('TINY-6952: gets a Hex from a string', () => {
       // with #
-      assertHexFromString('#FFF', '#FFF');
-      assertHexFromString('#0ED', '#0ED');
-      assertHexFromString('#0ed', '#0ed');
-      assertHexFromString('#FFFFFF', '#FFFFFF');
-      assertHexFromString('#00EEDD', '#00EEDD');
-      assertHexFromString('#00eedd', '#00eedd');
-      assertHexFromString('#00eeDD', '#00eeDD');
+      assertHexFromString('#FFF', 'FFF');
+      assertHexFromString('#0ED', '0ED');
+      assertHexFromString('#0ed', '0ED');
+      assertHexFromString('#FFFFFF', 'FFFFFF');
+      assertHexFromString('#00EEDD', '00EEDD');
+      assertHexFromString('#00eedd', '00EEDD');
+      assertHexFromString('#00eeDD', '00EEDD');
 
       // without #
       assertHexFromString('FFF', 'FFF');
       assertHexFromString('0ED', '0ED');
-      assertHexFromString('0ed', '0ed');
+      assertHexFromString('0ed', '0ED');
       assertHexFromString('FFFFFF', 'FFFFFF');
       assertHexFromString('00EEDD', '00EEDD');
-      assertHexFromString('00eedd', '00eedd');
-      assertHexFromString('00eeDD', '00eeDD');
+      assertHexFromString('00eedd', '00EEDD');
+      assertHexFromString('00eeDD', '00EEDD');
     });
 
     it('TINY-6952: fails for invalid hex strings', () => {

--- a/modules/acid/src/test/ts/browser/TransformationsTest.ts
+++ b/modules/acid/src/test/ts/browser/TransformationsTest.ts
@@ -50,5 +50,10 @@ describe('TransformationsTest', () => {
         assert.equal(result.value, hex);
       });
     });
+
+    it('TINY-7480: falls back to white for unknown colors', () => {
+      const result = Transformations.anyToHex('unknowncolor');
+      assert.equal(result.value, 'FFFFFF');
+    });
   });
 });

--- a/modules/acid/src/test/ts/browser/TransformationsTest.ts
+++ b/modules/acid/src/test/ts/browser/TransformationsTest.ts
@@ -15,7 +15,7 @@ describe('TransformationsTest', () => {
       }));
     });
 
-    it('TINY-7480: transform rgb colours', () => {
+    it('TINY-7480: transform rgb colors', () => {
       Obj.each({
         'rgb(155, 89, 182)': '9B59B6', // Purple
         'rgb(0,0,255)': '0000FF', // Blue
@@ -40,7 +40,7 @@ describe('TransformationsTest', () => {
       });
     });
 
-    it('TINY-7480: transform hsl colours', () => {
+    it('TINY-7480: transform hsl colors', () => {
       Obj.each({
         'hsl(145, 63.2%, 49.0%)': '2ECC70',
         'hsl(25,100%,60%)': 'FF8833',

--- a/modules/acid/src/test/ts/browser/TransformationsTest.ts
+++ b/modules/acid/src/test/ts/browser/TransformationsTest.ts
@@ -1,0 +1,54 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Obj } from '@ephox/katamari';
+import { assert } from 'chai';
+import * as fc from 'fast-check';
+import * as Transformations from 'ephox/acid/api/colour/Transformations';
+
+describe('TransformationsTest', () => {
+  context('anyToHex', () => {
+    it('TINY-7480: keep hex colors as is', () => {
+      fc.assert(fc.property(fc.hexaString(6, 6), (hex) => {
+        const result1 = Transformations.anyToHex(hex);
+        const result2 = Transformations.anyToHex('#' + hex);
+        assert.equal(result1.value, hex.toUpperCase(), 'without hash');
+        assert.equal(result2.value, hex.toUpperCase(), 'with hash');
+      }));
+    });
+
+    it('TINY-7480: transform rgb colours', () => {
+      Obj.each({
+        'rgb(155, 89, 182)': '9B59B6', // Purple
+        'rgb(0,0,255)': '0000FF', // Blue
+        'rgb(50,205,50)': '32CD32', // Lime green
+        'rgba(255, 99, 71, 0.5)': 'FF6347', // Pale tomato
+        'rgb(244,164,96)': 'F4A460', // Sandy brown
+      }, (hex, rgb) => {
+        const result = Transformations.anyToHex(rgb);
+        assert.equal(result.value, hex);
+      });
+    });
+
+    it('TINY-7480: transform named based colors', () => {
+      Obj.each({
+        darkviolet: '9400D3',
+        red: 'FF0000',
+        deeppink: 'FF1493',
+        silver: 'C0C0C0'
+      }, (hex, rgb) => {
+        const result = Transformations.anyToHex(rgb);
+        assert.equal(result.value, hex);
+      });
+    });
+
+    it('TINY-7480: transform hsl colours', () => {
+      Obj.each({
+        'hsl(145, 63.2%, 49.0%)': '2ECC70',
+        'hsl(25,100%,60%)': 'FF8833',
+        'hsl(340,79%,59%)': 'E9447B',
+      }, (hex, rgb) => {
+        const result = Transformations.anyToHex(rgb);
+        assert.equal(result.value, hex);
+      });
+    });
+  });
+});

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Flash of unstyled content while loading the editor because the content css was loaded after the editor content was rendered #TINY-7249
 - Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
 - Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
+- Fixed RGBA values provided in the `color_map` setting given the wrong hex value when containing some transparency #TINY-7163
 
 ## 5.8.1 - 2021-05-20
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Flash of unstyled content while loading the editor because the content css was loaded after the editor content was rendered #TINY-7249
 - Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
 - Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
-- Fixed RGBA values provided in the `color_map` setting given the wrong hex value when containing some transparency #TINY-7163
+- Partially transparent RGBA values provided in the `color_map` setting were given the wrong hex value #TINY-7163
 
 ## 5.8.1 - 2021-05-20
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Settings.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Transformations } from '@ephox/acid';
 import { Arr } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
@@ -44,40 +45,12 @@ const defaultColors = [
 const colorCache = ColorCache(10);
 
 const mapColors = (colorMap: string[]): Menu.ChoiceMenuItemSpec[] => {
-  const colors = [];
-
-  const canvas = document.createElement('canvas');
-  canvas.height = 1;
-  canvas.width = 1;
-  const ctx = canvas.getContext('2d');
-
-  const byteAsHex = (colorByte: number, alphaByte: number) => {
-    const bg = 255;
-    const alpha = (alphaByte / 255);
-    const colorByteWithWhiteBg = Math.round((colorByte * alpha) + (bg * (1 - alpha)));
-    return ('0' + colorByteWithWhiteBg.toString(16)).slice(-2).toUpperCase();
-  };
-
-  const asHexColor = (color: string) => {
-    // backwards compatibility
-    if (/^[0-9A-Fa-f]{6}$/.test(color)) {
-      return '#' + color.toUpperCase();
-    }
-    // all valid colors after this point
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    // invalid colors will be shown as white - the first assignment will pass and the second may be ignored
-    ctx.fillStyle = '#FFFFFF'; // lgtm[js/useless-assignment-to-property]
-    ctx.fillStyle = color;
-    ctx.fillRect(0, 0, 1, 1);
-    const rgba = ctx.getImageData(0, 0, 1, 1).data;
-    const r = rgba[0], g = rgba[1], b = rgba[2], a = rgba[3];
-    return '#' + byteAsHex(r, a) + byteAsHex(g, a) + byteAsHex(b, a);
-  };
+  const colors: Menu.ChoiceMenuItemSpec[] = [];
 
   for (let i = 0; i < colorMap.length; i += 2) {
     colors.push({
       text: colorMap[i + 1],
-      value: asHexColor(colorMap[i]),
+      value: '#' + Transformations.anyToHex(colorMap[i]).value,
       type: 'choiceitem'
     });
   }

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
@@ -98,7 +98,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorSettingsTest', () => {
     },
     {
       text: 'Pale tomato',
-      value: '#FFB0A2',
+      value: '#FF6347',
       type: 'choiceitem',
       delta: 1
     }

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,7 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 
+acid@3.1.0
 agar@5.4.0
 alloy@8.3.0
 mcagar@6.2.0


### PR DESCRIPTION
Related Ticket: TINY-7480/TINY-7163

Description of Changes:
This splits out the color parsing/transformation logic from Silver to Acid that @HAFRMO and I came up with for https://github.com/tinymce/tinymce/pull/6761/, as it's going to be needed in multiple places and not just in TinyMCE. This also adds the acid changelog/tests.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
