### PR TITLE
Add copyright-header.js to dev archive

### DIFF
--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -436,6 +436,7 @@ module.exports = function (grunt) {
               'modules/*/.stylelintignore',
               'modules/*/.stylelintrc',
               'modules/tinymce/tools',
+              'modules/tinymce/copyright-header.js',
               '.yarnrc',
               'LICENSE.TXT',
               'README.md',


### PR DESCRIPTION
modules/tinymce/copyright-header.js needs to be included in
tinymce_5.*_dev.zip for it to build cleanly.

Related Ticket:

Description of Changes:
* Adding inclusion of modules/tinymce/copyright-header.js in the Gruntfile, so it will be added to the archive.

Pre-checks:
* ~[ ] Changelog entry added~
* ~[ ] Tests have been added (if applicable)~
* ~[ ] Branch prefixed with `feature/` for new features (if applicable)~

Review:
* ~[ ] Milestone set~
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #6867