### PR TITLE
Replace hasOwnProperty calls with Obj.has

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/NamedChain.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/NamedChain.ts
@@ -1,4 +1,4 @@
-import { Arr, Id, Result } from '@ephox/katamari';
+import { Arr, Id, Obj, Result } from '@ephox/katamari';
 
 import { DieFn, NextFn } from '../pipe/Pipe';
 import { Chain } from './Chain';
@@ -61,7 +61,7 @@ const combine = (input: NamedData, name: string, value: any): NamedData => ({ ..
 
 const process = (name: string, chain: Chain<any, any>): Chain<NamedData, NamedData> =>
   Chain.on((input, next, die, initLogs) => {
-    if (Object.prototype.hasOwnProperty.call(input, name)) {
+    if (Obj.has(input, name)) {
       const part = input[name];
       chain.runChain(part, (other, newLogs) => {
         const merged: NamedData = { ...input, ...other };

--- a/modules/agar/src/main/ts/ephox/agar/dragndrop/DndEvents.ts
+++ b/modules/agar/src/main/ts/ephox/agar/dragndrop/DndEvents.ts
@@ -1,6 +1,11 @@
+import { Obj } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarElement } from '@ephox/sugar';
 import { setProtectedMode, setReadOnlyMode, setReadWriteMode } from '../datatransfer/Mode';
+
+interface IeDragEvent extends DragEvent {
+  readonly ieDefaultPrevented?: boolean;
+}
 
 const platform = PlatformDetection.detect();
 
@@ -40,7 +45,7 @@ const createDragenterEvent = createDndEvent('dragenter');
 const createDropEvent = createDndEvent('drop');
 const createDragEvent = createDndEvent('drag');
 
-const isDefaultPrevented = (evt: DragEvent): boolean => evt.defaultPrevented || evt.hasOwnProperty('ieDefaultPrevented');
+const isDefaultPrevented = (evt: DragEvent): boolean => evt.defaultPrevented || Obj.has(evt as IeDragEvent, 'ieDefaultPrevented');
 
 const dispatchDndEvent = (event: DragEvent, target: SugarElement<Node>): DragEvent => {
   if (event.type === 'dragstart') {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
@@ -90,10 +90,13 @@ const external = (spec: ExternalElement): PremadeSpec => {
 // There are other solutions than this ... not sure if they are going to have better performance, though
 const uids = Tagger.generate;
 
+const isSimpleOrSketchSpec = (spec: AlloySpec): spec is SimpleOrSketchSpec =>
+  Obj.has(spec as SimpleOrSketchSpec, 'uid');
+
 // INVESTIGATE: A better way to provide 'meta-specs'
 const build = (spec: AlloySpec): AlloyComponent => GuiTypes.getPremade(spec).fold(() => {
   // EFFICIENCY: Consider not merging here, and passing uid through separately
-  const userSpecWithUid = spec.hasOwnProperty('uid') ? spec as SimpleOrSketchSpec : {
+  const userSpecWithUid = isSimpleOrSketchSpec(spec) ? spec : {
     uid: uids(''),
     ...spec
   } as SimpleOrSketchSpec;

--- a/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
@@ -77,7 +77,7 @@ export const EventRegistry = (): EventRegistry => {
   const unregisterId = (id: string): void => {
     // INVESTIGATE: Find a better way than mutation if we can.
     Obj.each(registry, (handlersById: Record<string, CurriedHandler>, _eventName) => {
-      if (handlersById.hasOwnProperty(id)) {
+      if (Obj.has(handlersById, id)) {
         delete handlersById[id];
       }
     });

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/MenuSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/MenuSchema.ts
@@ -1,5 +1,5 @@
 import { FieldProcessorAdt, FieldSchema, ValueSchema } from '@ephox/boulder';
-import { Fun } from '@ephox/katamari';
+import { Fun, Obj } from '@ephox/katamari';
 
 import { Composing } from '../../api/behaviour/Composing';
 import { Highlighting } from '../../api/behaviour/Highlighting';
@@ -14,7 +14,7 @@ import SeparatorType from '../../menu/build/SeparatorType';
 import WidgetType from '../../menu/build/WidgetType';
 import * as PartType from '../../parts/PartType';
 import * as Tagger from '../../registry/Tagger';
-import { ItemSpec } from '../types/ItemTypes';
+import { ItemSpec, WidgetItemSpec } from '../types/ItemTypes';
 import { MenuDetail, MenuGridMovement, MenuMatrixMovement, MenuNormalMovement } from '../types/MenuTypes';
 
 const itemSchema = ValueSchema.choose(
@@ -64,7 +64,7 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
     unit: 'item',
     defaults: (detail, u) => {
       // Switch this to a common library
-      return u.hasOwnProperty('uid') ? u : {
+      return Obj.has(u as WidgetItemSpec, 'uid') ? u : {
         ...u,
         uid: Tagger.generate('item')
       };

--- a/modules/alloy/src/test/ts/atomic/api/DomDefinitionTest.ts
+++ b/modules/alloy/src/test/ts/atomic/api/DomDefinitionTest.ts
@@ -109,7 +109,7 @@ UnitTest.test('DomDefinitionTest', () => {
         Assert.eq(
           () => 'Defn Style: ' + k + '=' + v + ' should appear in result: ' + JSON.stringify(result, null, 2) + '., unless modification changed it',
           true,
-          result.styles[k] === v || result.styles[k] === mod.styles[k] && mod.styles.hasOwnProperty(k)
+          result.styles[k] === v || result.styles[k] === mod.styles[k] && Obj.has(mod.styles, k)
         );
       });
 
@@ -123,7 +123,7 @@ UnitTest.test('DomDefinitionTest', () => {
         Assert.eq(
           () => 'Defn attribute: ' + k + '=' + v + ' should appear in result: ' + JSON.stringify(result, null, 2) + '., unless modification changed it',
           true,
-          result.attributes[k] === v || result.attributes[k] === mod.attributes[k] && mod.attributes.hasOwnProperty(k)
+          result.attributes[k] === v || result.attributes[k] === mod.attributes[k] && Obj.has(mod.attributes, k)
         );
       });
       return true;

--- a/modules/imagetools/src/main/ts/ephox/imagetools/transformations/ImageResizerWebgl.ts
+++ b/modules/imagetools/src/main/ts/ephox/imagetools/transformations/ImageResizerWebgl.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import { Obj, Optional } from '@ephox/katamari';
 import * as Canvas from '../util/Canvas';
 import * as ImageSize from '../util/ImageSize';
 import { Promise } from '../util/Promise';
@@ -175,7 +175,7 @@ const _createProgram = (gl: WebGLRenderingContext): WebGLProgram => {
   const program = gl.createProgram() as WebGLProgram;
 
   for (const type in shaders.bilinear) {
-    if (Object.hasOwnProperty.call(shaders.bilinear, type)) {
+    if (Obj.has(shaders.bilinear, type)) {
       _loadShader(gl, shaders.bilinear[type], type).each((shader) => gl.attachShader(program, shader));
     }
   }

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Merger.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Merger.ts
@@ -1,3 +1,4 @@
+import * as Obj from './Obj';
 import * as Type from './Type';
 
 type MergeStrategy = (old: any, nu: any) => any;
@@ -25,9 +26,6 @@ interface ShallowMergeFunc {
   (...objs: Array<Record<string, any>>): Record<string, any>;
 }
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const hasOwnProperty = Object.prototype.hasOwnProperty;
-
 const shallow = (old: Record<string, any>, nu: Record<string, any>) => {
   return nu;
 };
@@ -47,7 +45,7 @@ const baseMerge = (merger: MergeStrategy): (...objs: Array<Record<string, any>>)
     for (let j = 0; j < objects.length; j++) {
       const curObject = objects[j];
       for (const key in curObject) {
-        if (hasOwnProperty.call(curObject, key)) {
+        if (Obj.has(curObject, key)) {
           ret[key] = merger(ret[key], curObject[key]);
         }
       }

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
@@ -1,4 +1,4 @@
-import { Arr, Global } from '@ephox/katamari';
+import { Arr, Global, Obj } from '@ephox/katamari';
 import { Editor } from '../alien/EditorTypes';
 
 const isSilver = (): boolean => {
@@ -6,7 +6,7 @@ const isSilver = (): boolean => {
   if (!tinymce) {
     throw new Error('Failed to get global tinymce');
   }
-  return tinymce.activeEditor.hasOwnProperty('ui');
+  return Obj.has(tinymce.activeEditor, 'ui');
 };
 
 const isModern = (): boolean => !isSilver();

--- a/modules/porkbun/src/test/ts/atomic/EventsTest.ts
+++ b/modules/porkbun/src/test/ts/atomic/EventsTest.ts
@@ -1,4 +1,5 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Obj } from '@ephox/katamari';
 import { Bindable, Event } from 'ephox/porkbun/Event';
 import * as Events from 'ephox/porkbun/Events';
 import SourceEvent from 'ephox/porkbun/SourceEvent';
@@ -34,7 +35,7 @@ UnitTest.test('Events', () => {
     events.trigger.myEvent('something');
 
     assert.eq(true, called);
-    assert.eq(true, calledEvent.hasOwnProperty('name'));
+    assert.eq(true, Obj.has(calledEvent, 'name'));
     assert.eq('something', calledEvent.name);
 
     called = false;
@@ -44,7 +45,7 @@ UnitTest.test('Events', () => {
     events.trigger.myEvent('something');
 
     assert.eq(false, called);
-    assert.eq(false, calledEvent.hasOwnProperty('name'));
+    assert.eq(false, Obj.has(calledEvent, 'name'));
 
     // This should not throw an error
     events.registry.myEvent.unbind(handler);

--- a/modules/sand/src/test/ts/atomic/core/BrowserTest.ts
+++ b/modules/sand/src/test/ts/atomic/core/BrowserTest.ts
@@ -3,8 +3,10 @@ import { Fun } from '@ephox/katamari';
 import { PlatformDetection } from 'ephox/sand/core/PlatformDetection';
 import * as PlatformQuery from 'ephox/sand/test/PlatformQuery';
 
+type PlatformQuery = typeof PlatformQuery;
+
 UnitTest.test('BrowserTest', () => {
-  const check = (expectedQuery: string, expectedOs: string, expectedBrowser: string, expectedMajor: number, expectedMinor: number, userAgent: string) => {
+  const check = (expectedQuery: keyof PlatformQuery, expectedOs: string, expectedBrowser: string, expectedMajor: number, expectedMinor: number, userAgent: string) => {
     const platform = PlatformDetection.detect(userAgent, Fun.never);
     assert.eq(expectedBrowser, platform.browser.current);
     assert.eq(expectedOs, platform.os.current);
@@ -13,9 +15,6 @@ UnitTest.test('BrowserTest', () => {
     assert.eq(expectedMajor, actualBrowserVersion.major);
     assert.eq(expectedMinor, actualBrowserVersion.minor);
 
-    if (!PlatformQuery.hasOwnProperty(expectedQuery)) {
-      assert.fail('Platform query: ' + expectedQuery + ' not known');
-    }
     assert.eq(true, PlatformQuery[expectedQuery](platform), 'The query ' + expectedQuery + ' should match.\nUser Agent: ' + userAgent + '\nbrowser: ' + expectedBrowser);
   };
 

--- a/modules/tinymce/src/core/main/ts/EditorSettings.ts
+++ b/modules/tinymce/src/core/main/ts/EditorSettings.ts
@@ -66,12 +66,12 @@ const extractSections = (keys, settings) => {
 
 const getSection = (sectionResult: SectionResult, name: string, defaults: Partial<RawEditorSettings> = { }) => {
   const sections = sectionResult.sections();
-  const sectionSettings = sections.hasOwnProperty(name) ? sections[name] : { };
+  const sectionSettings = Obj.get(sections, name).getOr({});
   return Tools.extend({}, defaults, sectionSettings);
 };
 
 const hasSection = (sectionResult: SectionResult, name: string) => {
-  return sectionResult.sections().hasOwnProperty(name);
+  return Obj.has(sectionResult.sections(), name);
 };
 
 const isSectionTheme = (sectionResult: SectionResult, name: string, theme: string) => {

--- a/modules/tinymce/src/core/main/ts/ForceBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/ForceBlocks.ts
@@ -5,9 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun } from '@ephox/katamari';
+import { Arr, Fun, Obj } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import Editor from './api/Editor';
+import { SchemaMap } from './api/html/Schema';
 import * as Settings from './api/Settings';
 import * as Bookmarks from './bookmark/Bookmarks';
 import * as NodeType from './dom/NodeType';
@@ -21,9 +22,8 @@ import * as EditorFocus from './focus/EditorFocus';
  * @class tinymce.ForceBlocks
  */
 
-const isBlockElement = (blockElements, node) => {
-  return blockElements.hasOwnProperty(node.nodeName);
-};
+const isBlockElement = (blockElements: SchemaMap, node: Node) =>
+  Obj.has(blockElements, node.nodeName);
 
 const isValidTarget = (blockElements, node) => {
   if (NodeType.isText(node)) {

--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
@@ -40,7 +40,7 @@ const setup = (editor: Editor, _registry: AnnotationsRegistry): AnnotationChange
 
   const updateCallbacks = (name: string, f: (inputData: AnnotationListenerData) => AnnotationListenerData) => {
     const callbackMap = changeCallbacks.get();
-    const data = callbackMap.hasOwnProperty(name) ? callbackMap[name] : initData();
+    const data = Obj.get(callbackMap, name).getOrThunk(initData);
     const outputData = f(data);
     callbackMap[name] = outputData;
     changeCallbacks.set(callbackMap);

--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationsRegistry.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationsRegistry.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional } from '@ephox/katamari';
+import { Obj, Optional } from '@ephox/katamari';
 import { Decorator } from './Wrapping';
 
 export interface AnnotatorSettings {
@@ -18,8 +18,13 @@ export interface AnnotationsRegistry {
   lookup: (name: string) => Optional<AnnotatorSettings>;
 }
 
+interface Annotation {
+  readonly name: string;
+  readonly settings: AnnotatorSettings;
+}
+
 const create = (): AnnotationsRegistry => {
-  const annotations = { };
+  const annotations: Record<string, Annotation> = { };
 
   const register = (name: string, settings: AnnotatorSettings): void => {
     annotations[name] = {
@@ -28,7 +33,8 @@ const create = (): AnnotationsRegistry => {
     };
   };
 
-  const lookup = (name: string): Optional<AnnotatorSettings> => annotations.hasOwnProperty(name) ? Optional.from(annotations[name]).map((a) => a.settings) : Optional.none();
+  const lookup = (name: string): Optional<AnnotatorSettings> =>
+    Obj.get(annotations, name).map((a) => a.settings);
 
   return {
     register,

--- a/modules/tinymce/src/core/main/ts/annotate/Identification.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/Identification.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Obj, Optional } from '@ephox/katamari';
 import { Attribute, Class, Compare, SelectorFilter, SelectorFind, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import Editor from '../api/Editor';
 
@@ -60,7 +60,7 @@ const findAll = (editor: Editor, name: string): Record<string, SugarElement[]> =
   const directory: Record<string, SugarElement[]> = { };
   Arr.each(markers, (m) => {
     const uid = Attribute.get(m, Markings.dataAnnotationId());
-    const nodesAlready = directory.hasOwnProperty(uid) ? directory[uid] : [ ];
+    const nodesAlready = Obj.get(directory, uid).getOr([]);
     directory[uid] = nodesAlready.concat([ m ]);
   });
   return directory;

--- a/modules/tinymce/src/core/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/core/main/ts/api/Settings.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Strings, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Strings, Type } from '@ephox/katamari';
 import { UploadHandler } from '../file/Uploader';
 import DOMUtils from './dom/DOMUtils';
 import Editor from './Editor';
@@ -22,7 +22,7 @@ const getBodySetting = (editor: Editor, name: string, defaultValue: string) => {
 
   if (value.indexOf('=') !== -1) {
     const bodyObj = editor.getParam(name, '', 'hash');
-    return bodyObj.hasOwnProperty(editor.id) ? bodyObj[editor.id] : defaultValue;
+    return Obj.get(bodyObj, editor.id).getOr(defaultValue);
   } else {
     return value;
   }

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -736,7 +736,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     outHtml += '<' + name;
 
     for (key in attrs) {
-      if (attrs.hasOwnProperty(key) && attrs[key] !== null && typeof attrs[key] !== 'undefined') {
+      if (Obj.hasNonNullableKey(attrs, key)) {
         outHtml += ' ' + key + '="' + encode(attrs[key]) + '"';
       }
     }

--- a/modules/tinymce/src/core/main/ts/api/dom/ElementUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ElementUtils.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Obj } from '@ephox/katamari';
 import * as Bookmarks from '../../bookmark/Bookmarks';
 import Tools from '../util/Tools';
 import DOMUtils from './DOMUtils';
@@ -73,7 +74,7 @@ const ElementUtils = (dom: DOMUtils): ElementUtils => {
 
       for (name in obj1) {
         // Obj1 has item obj2 doesn't have
-        if (obj1.hasOwnProperty(name)) {
+        if (Obj.has(obj1, name)) {
           value = obj2[name];
 
           // Obj2 doesn't have obj1 item
@@ -94,7 +95,7 @@ const ElementUtils = (dom: DOMUtils): ElementUtils => {
       // Check if obj 2 has something obj 1 doesn't have
       for (name in obj2) {
         // Obj2 has item obj1 doesn't have
-        if (obj2.hasOwnProperty(name)) {
+        if (Obj.has(obj2, name)) {
           return false;
         }
       }

--- a/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
@@ -5,13 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr } from '@ephox/katamari';
+import { Arr, Obj } from '@ephox/katamari';
 import Editor from '../Editor';
 import Tools from '../util/Tools';
 import DOMUtils from './DOMUtils';
 
 const deleteFromCallbackMap = (callbackMap, selector, callback) => {
-  if (callbackMap && callbackMap.hasOwnProperty(selector)) {
+  if (callbackMap && Obj.has(callbackMap, selector)) {
     const newCallbacks = Arr.filter(callbackMap[selector], (cb) => cb !== callback);
 
     if (newCallbacks.length === 0) {

--- a/modules/tinymce/src/core/main/ts/api/util/Tools.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Tools.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Obj } from '@ephox/katamari';
 import * as ArrUtils from '../../util/ArrUtils';
 import Env from '../Env';
 
@@ -117,9 +118,7 @@ const makeMap = (items, delim?, map?) => {
  * @param {String} prop
  * @returns {Boolean}
  */
-const hasOwnProperty = (obj, prop) => {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-};
+const hasOwnProperty = Obj.has;
 
 /**
  * Creates a class, subclass or static singleton.
@@ -258,7 +257,7 @@ const extend = (obj, ...exts: any[]) => {
   for (let i = 0; i < exts.length; i++) {
     const ext = exts[i];
     for (const name in ext) {
-      if (ext.hasOwnProperty(name)) {
+      if (Obj.has(ext, name)) {
         const value = ext[name];
         if (value !== undefined) {
           obj[name] = value;

--- a/modules/tinymce/src/core/main/ts/bookmark/BookmarkTypes.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/BookmarkTypes.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Type } from '@ephox/katamari';
+import { Obj, Type } from '@ephox/katamari';
 import Tools from '../api/util/Tools';
 
 export interface StringPathBookmark {
@@ -36,11 +36,11 @@ export type Bookmark = StringPathBookmark | RangeBookmark | IdBookmark | IndexBo
 
 const isStringPathBookmark = (bookmark: Bookmark): bookmark is StringPathBookmark => Type.isString((bookmark as StringPathBookmark).start);
 
-const isRangeBookmark = (bookmark: Bookmark): bookmark is RangeBookmark => bookmark.hasOwnProperty('rng');
+const isRangeBookmark = (bookmark: Bookmark): bookmark is RangeBookmark => Obj.has(bookmark as RangeBookmark, 'rng');
 
-const isIdBookmark = (bookmark: Bookmark): bookmark is IdBookmark => bookmark.hasOwnProperty('id');
+const isIdBookmark = (bookmark: Bookmark): bookmark is IdBookmark => Obj.has(bookmark as IdBookmark, 'id');
 
-const isIndexBookmark = (bookmark: Bookmark): bookmark is IndexBookmark => bookmark.hasOwnProperty('name');
+const isIndexBookmark = (bookmark: Bookmark): bookmark is IndexBookmark => Obj.has(bookmark as IndexBookmark, 'name');
 
 const isPathBookmark = (bookmark: Bookmark): bookmark is PathBookmark => Tools.isArray((bookmark as PathBookmark).start);
 

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun } from '@ephox/katamari';
+import { Arr, Fun, Obj } from '@ephox/katamari';
 import { SugarElement, SugarNode } from '@ephox/sugar';
 
 const blocks = [
@@ -40,7 +40,7 @@ const lazyLookup = <T extends Node = HTMLElement>(items: string[]) => {
   let lookup;
   return (node: SugarElement<Node>): node is SugarElement<T> => {
     lookup = lookup ? lookup : Arr.mapToObject(items, Fun.always);
-    return lookup.hasOwnProperty(SugarNode.name(node));
+    return Obj.has(lookup, SugarNode.name(node));
   };
 };
 

--- a/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
@@ -349,7 +349,7 @@ const replaceWithCaretFormat = (targetNode: Node, formatNodes: Node[]) => {
 
 const isFormatElement = (editor: Editor, element: SugarElement) => {
   const inlineElements = editor.schema.getTextInlineElements();
-  return inlineElements.hasOwnProperty(SugarNode.name(element)) && !isCaretNode(element.dom) && !NodeType.isBogus(element.dom);
+  return Obj.has(inlineElements, SugarNode.name(element)) && !isCaretNode(element.dom) && !NodeType.isBogus(element.dom);
 };
 
 const isEmptyCaretFormatElement = (element: SugarElement) => {

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Obj, Optional } from '@ephox/katamari';
 import { Compare, SugarElement, TransformFind } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
@@ -81,7 +81,7 @@ const matchItems = (dom: DOMUtils, node: Node, format, itemName: string, similar
     // Non indexed object
     if (typeof items.length === 'undefined') {
       for (key in items) {
-        if (items.hasOwnProperty(key)) {
+        if (Obj.has(items, key)) {
           if (itemName === 'attributes') {
             value = dom.getAttrib(node, key);
           } else {

--- a/modules/tinymce/src/core/main/ts/html/FilterNode.ts
+++ b/modules/tinymce/src/core/main/ts/html/FilterNode.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr } from '@ephox/katamari';
+import { Arr, Obj } from '@ephox/katamari';
 import { ParserFilter, ParserFilterCallback } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
 
@@ -58,13 +58,13 @@ const findMatchingNodes = (nodeFilters: ParserFilter[], attributeFilters: Parser
   }
 
   for (const name in nodeMatches) {
-    if (nodeMatches.hasOwnProperty(name)) {
+    if (Obj.has(nodeMatches, name)) {
       matches.push(nodeMatches[name]);
     }
   }
 
   for (const name in attrMatches) {
-    if (attrMatches.hasOwnProperty(name)) {
+    if (Obj.has(attrMatches, name)) {
       matches.push(attrMatches[name]);
     }
   }

--- a/modules/tinymce/src/core/main/ts/init/Render.ts
+++ b/modules/tinymce/src/core/main/ts/init/Render.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Optional, Optionals, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Optionals, Type } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 import { UrlObject } from '../api/AddOnManager';
 import DOMUtils from '../api/dom/DOMUtils';
@@ -50,7 +50,7 @@ const loadTheme = (scriptLoader: ScriptLoader, editor: Editor, suffix, callback)
   const theme = Settings.getTheme(editor);
 
   if (Type.isString(theme)) {
-    if (!hasSkipLoadPrefix(theme) && !ThemeManager.urls.hasOwnProperty(theme)) {
+    if (!hasSkipLoadPrefix(theme) && !Obj.has(ThemeManager.urls, theme)) {
       const themeUrl = Settings.getThemeUrl(editor);
 
       if (themeUrl) {

--- a/modules/tinymce/src/core/main/ts/util/ArrUtils.ts
+++ b/modules/tinymce/src/core/main/ts/util/ArrUtils.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Type } from '@ephox/katamari';
+import { Obj, Type } from '@ephox/katamari';
 
 /**
  * Array utility class.
@@ -53,7 +53,7 @@ const each: {
   } else {
     // Hashtables
     for (n in o) {
-      if (o.hasOwnProperty(n)) {
+      if (Obj.has(o, n)) {
         if (cb.call(s, o[n], n, o) === false) {
           return false;
         }

--- a/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell } from '@ephox/katamari';
+import { Cell, Obj } from '@ephox/katamari';
 import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Resize from './core/Resize';
@@ -20,7 +20,7 @@ import * as Resize from './core/Resize';
 export default () => {
   PluginManager.add('autoresize', (editor) => {
     // If autoresize is enabled, disable resize if the user hasn't explicitly enabled it
-    if (!editor.settings.hasOwnProperty('resize')) {
+    if (!Obj.has(editor.settings, 'resize')) {
       editor.settings.resize = false;
     }
     if (!editor.inline) {

--- a/modules/tinymce/src/plugins/image/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/ListUtils.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional, Type } from '@ephox/katamari';
+import { Arr, Obj, Optional, Type } from '@ephox/katamari';
 import Tools from 'tinymce/core/api/util/Tools';
 import { ListGroup, ListItem, ListValue, UserListItem } from '../ui/DialogTypes';
 
@@ -48,7 +48,7 @@ const sanitizer = (extracter = getValue) => (list: UserListItem[]): Optional<Lis
 
 const sanitize = (list: UserListItem[]) => sanitizer(getValue)(list);
 
-const isGroup = (item: ListItem): item is ListGroup => Object.prototype.hasOwnProperty.call(item, 'items');
+const isGroup = (item: ListItem): item is ListGroup => Obj.has(item as ListGroup, 'items');
 
 const findEntryDelegate = (list: ListItem[], value: string): Optional<ListValue> => Arr.findMap(list, (item) => {
   if (isGroup(item)) {

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -129,7 +129,7 @@ const applyLinkOverrides = (editor: Editor, linkAttrs: Record<string, string>) =
 const updateLink = (editor: Editor, anchorElm: HTMLAnchorElement, text: Optional<string>, linkAttrs: Record<string, string>) => {
   // If we have text, then update the anchor elements text content
   text.each((text) => {
-    if (anchorElm.hasOwnProperty('innerText')) {
+    if (Obj.has(anchorElm, 'innerText')) {
       anchorElm.innerText = text;
     } else {
       anchorElm.textContent = text;

--- a/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
@@ -5,13 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Obj } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import Promise from 'tinymce/core/api/util/Promise';
 import * as Settings from '../api/Settings';
 import * as DataToHtml from './DataToHtml';
 import { MediaData } from './Types';
 
-const cache = {};
+const cache: Record<string, unknown> = {};
+
 const embedPromise = (data: MediaData, dataToHtml: DataToHtml.DataToHtmlCallback, handler) => {
   return new Promise<{url: string; html: string}>((res, rej) => {
     const wrappedResolve = (response) => {
@@ -49,9 +51,8 @@ const getEmbedHtml = (editor: Editor, data: MediaData) => {
   return embedHandler ? embedPromise(data, loadedData(editor), embedHandler) : defaultPromise(data, loadedData(editor));
 };
 
-const isCached = (url: string) => {
-  return cache.hasOwnProperty(url);
-};
+const isCached = (url: string): boolean =>
+  Obj.has(cache, url);
 
 export {
   getEmbedHtml,

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Newlines.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Newlines.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Obj } from '@ephox/katamari';
 import Entities from 'tinymce/core/api/html/Entities';
 import Tools from 'tinymce/core/api/util/Tools';
 
@@ -35,7 +36,7 @@ const openContainer = (rootTag: string, rootAttrs: RootAttrs) => {
 
   if (typeof rootAttrs === 'object') {
     for (key in rootAttrs) {
-      if (rootAttrs.hasOwnProperty(key)) {
+      if (Obj.has(rootAttrs, key)) {
         attrs.push(key + '="' + Entities.encodeAllRaw(rootAttrs[key]) + '"');
       }
     }

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputHistory.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputHistory.ts
@@ -53,7 +53,7 @@ const setAllHistory = (history: Record<string, string[]>) => {
 
 const getHistory = (fileType: string): string[] => {
   const history = getAllHistory();
-  return Object.prototype.hasOwnProperty.call(history, fileType) ? history[fileType] : [];
+  return Obj.get(history, fileType).getOr([]);
 };
 
 const addToHistory = (url: string, fileType: string) => {
@@ -61,7 +61,7 @@ const addToHistory = (url: string, fileType: string) => {
     return;
   }
   const history = getAllHistory();
-  const items = Object.prototype.hasOwnProperty.call(history, fileType) ? history[fileType] : [];
+  const items = Obj.get(history, fileType).getOr([]);
   const itemsWithoutUrl = Arr.filter(items, (item) => item !== url);
   history[fileType] = [ url ].concat(itemsWithoutUrl).slice(0, HISTORY_LENGTH);
   setAllHistory(history);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -7,7 +7,7 @@
 
 import { AddEventsBehaviour, AlloyEvents, Behaviour, Memento, Representing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Obj, Optional } from '@ephox/katamari';
 import Resource from 'tinymce/core/api/Resource';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -15,7 +15,8 @@ import { ComposingConfigs } from '../alien/ComposingConfigs';
 type CustomEditorSpec = Dialog.CustomEditor;
 type CustomEditorInitFn = Dialog.CustomEditorInitFn;
 
-const isOldCustomEditor = (spec: CustomEditorSpec): spec is Dialog.CustomEditorOld => Object.prototype.hasOwnProperty.call(spec, 'init');
+const isOldCustomEditor = (spec: CustomEditorSpec): spec is Dialog.CustomEditorOld =>
+  Obj.has(spec as Dialog.CustomEditorOld, 'init');
 
 export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
   const editorApi = Cell(Optional.none<Dialog.CustomEditorInit>());

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/FancyMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/FancyMenuItem.ts
@@ -7,7 +7,7 @@
 
 import { ItemTypes } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
-import { Optional } from '@ephox/katamari';
+import { Obj, Optional } from '@ephox/katamari';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderColorSwatchItem } from './ColorSwatchItem';
 import { renderInsertTableMenuItem } from './InsertTableMenuItem';
@@ -17,11 +17,8 @@ const fancyMenuItems: Record<keyof Menu.FancyActionArgsMap, (mi: Menu.FancyMenuI
   colorswatch: renderColorSwatchItem
 };
 
-const valueOpt = <T>(obj: Record<string, T>, key): Optional<T> => Object.prototype.hasOwnProperty.call(obj, key)
-  ? Optional.some(obj[key])
-  : Optional.none();
-
-const renderFancyMenuItem = (spec: Menu.FancyMenuItem, backstage: UiFactoryBackstage): Optional<ItemTypes.WidgetItemSpec> => valueOpt(fancyMenuItems, spec.fancytype).map((render) => render(spec, backstage));
+const renderFancyMenuItem = (spec: Menu.FancyMenuItem, backstage: UiFactoryBackstage): Optional<ItemTypes.WidgetItemSpec> =>
+  Obj.get(fancyMenuItems, spec.fancytype).map((render) => render(spec, backstage));
 
 export {
   renderFancyMenuItem

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
@@ -7,7 +7,7 @@
 
 import { AlloyEvents, FocusManagers, ItemTypes, Keying, MenuTypes, TieredMenu, TieredMenuTypes } from '@ephox/alloy';
 import { InlineContent, Menu as BridgeMenu, Toolbar } from '@ephox/bridge';
-import { Arr, Optional, Optionals } from '@ephox/katamari';
+import { Arr, Obj, Optional, Optionals } from '@ephox/katamari';
 import { UiFactoryBackstage, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { detectSize } from '../../alien/FlatgridAutodetect';
 import { SimpleBehaviours } from '../../alien/SimpleBehaviours';
@@ -171,7 +171,7 @@ export const createPartialMenu = (
       // Have to check each item for an icon, instead of as part of hasIcons above,
       // else in horizontal menus, items with an icon but without text will display
       // with neither
-      const itemHasIcon = (i: SingleMenuItemSpec) => isHorizontalMenu ? !i.hasOwnProperty('text') : hasIcons;
+      const itemHasIcon = (i: SingleMenuItemSpec) => isHorizontalMenu ? !Obj.has(i as Record<string, unknown>, 'text') : hasIcons;
       const createItem = (i: SingleMenuItemSpec) => createMenuItemFromBridge(
         i,
         itemResponse,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -10,15 +10,20 @@ import Editor from 'tinymce/core/api/Editor';
 import { getRemovedMenuItems } from 'tinymce/themes/silver/api/Settings';
 import { MenubarItemSpec } from './SilverMenubar';
 
+interface MenuSpec {
+  readonly title: string;
+  readonly items: string;
+}
+
 export interface MenuRegistry {
   menuItems: Record<string, any>;
   menubar: string | boolean;
-  menus: Record<string, any>;
+  menus: Record<string, MenuSpec>;
 }
 
 const defaultMenubar = 'file edit view insert format tools table help';
 
-const defaultMenus = {
+const defaultMenus: Record<string, MenuSpec> = {
   file: { title: 'File', items: 'newdocument restoredraft | preview | export print | deleteallconversations' },
   edit: { title: 'Edit', items: 'undo redo | cut copy paste pastetext | selectall | searchreplace' },
   view: { title: 'View', items: 'code | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
@@ -64,9 +69,14 @@ const identifyMenus = (editor: Editor, registry: MenuRegistry): MenubarItemSpec[
   const userDefinedMenus = Obj.keys(registry.menus).length > 0;
 
   const menubar: string[] = registry.menubar === undefined || registry.menubar === true ? parseItemsString(defaultMenubar) : parseItemsString(registry.menubar === false ? '' : registry.menubar);
-  const validMenus = Arr.filter(menubar, (menuName) => userDefinedMenus ? (registry.menus.hasOwnProperty(menuName) && registry.menus[menuName].hasOwnProperty('items')
-      || defaultMenus.hasOwnProperty(menuName))
-    : defaultMenus.hasOwnProperty(menuName));
+  const validMenus = Arr.filter(menubar, (menuName) => {
+    const isDefaultMenu = Obj.has(defaultMenus, menuName);
+    if (userDefinedMenus) {
+      return isDefaultMenu || Obj.get(registry.menus, menuName).exists((menu) => Obj.has(menu, 'items'));
+    } else {
+      return isDefaultMenu;
+    }
+  });
 
   const menus: MenubarItemSpec[] = Arr.map(validMenus, (menuName) => {
     const menuData = rawMenuData[menuName];

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInputModel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInputModel.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional, Optionals, Result } from '@ephox/katamari';
+import { Obj, Optional, Optionals, Result } from '@ephox/katamari';
 
 export type SizeUnit = '' | 'cm' | 'mm' | 'in' | 'px' | 'pt' | 'pc' | 'em' | 'ex' | 'ch' | 'rem' | 'vw' | 'vh' | 'vmin' | 'vmax' | '%';
 
@@ -54,7 +54,7 @@ export const parseSize = (sizeText: string): Result<Size, string> => {
 };
 
 export const convertUnit = (size: Size, unit: SizeUnit): Optional<number> => {
-  const inInch = {
+  const inInch: Record<string, number> = {
     '': 96,
     'px': 96,
     'pt': 72,
@@ -63,9 +63,8 @@ export const convertUnit = (size: Size, unit: SizeUnit): Optional<number> => {
     'mm': 25.4,
     'in': 1
   };
-  type ConvertableSizeUnit = keyof typeof inInch;
-  const supported = (u: SizeUnit): u is ConvertableSizeUnit =>
-    Object.prototype.hasOwnProperty.call(inInch, u);
+  const supported = (u: SizeUnit) => Obj.has(inInch, u);
+
   if (size.unit === unit) {
     return Optional.some(size.value);
   } else if (supported(size.unit) && supported(unit)) {


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Given the issue we found today, I went through and made sure all cases of `hasOwnProperty` use the appropriate Katamari API instead.

Note: This also saves a "massive" 400 bytes in the minified core/theme JS file since the old `hasOwnProperty` calls can't be minified.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
