### PR TITLE
Treat the default/undefined `schema` as 'html5', as specified by docs.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents. #TINY-7249
 
 ### Fixed
+- The `schema` correctly defaults to 'html5', as documented. <b> and <i> aren't converted.
 - Flash of unstyled content while loading the editor because the content css was loaded after the editor content was rendered #TINY-7249
 - Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
 - Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -456,7 +456,8 @@ const Schema = (settings?: SchemaSettings): Schema => {
   };
 
   settings = settings || {};
-  const schemaItems = compileSchema(settings.schema);
+  const schema = settings.schema ?? 'html5';
+  const schemaItems = compileSchema(schema);
 
   // Allow all elements and attributes if verify_html is set to false
   if (settings.verify_html === false) {
@@ -710,7 +711,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
     const childRuleRegExp = /^([+\-]?)([A-Za-z0-9_\-.\u00b7\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u037d\u037f-\u1fff\u200c-\u200d\u203f-\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]+)\[([^\]]+)]$/; // from w3c's custom grammar (above)
 
     // Invalidate the schema cache if the schema is mutated
-    mapCache[settings.schema] = null;
+    mapCache[schema] = null;
 
     if (validChildren) {
       each(split(validChildren, ','), (rule) => {
@@ -772,7 +773,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
     });
 
     // Switch these on HTML4
-    if (settings.schema !== 'html5') {
+    if (schema !== 'html5') {
       each(split('strong/b em/i'), (item) => {
         const items = split(item, '/');
         elements[items[1]].outputName = items[0];

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
@@ -312,7 +312,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '';
     editor.execCommand('mceInsertContent', false, 'test<b>123</b><!-- a -->');
     // Opera adds an extra paragraph since it adds a BR at the end of the contents pass though this for now since it's an minority browser
-    assert.equal(editor.getContent().replace(/<p>\u00a0<\/p>/g, ''), '<p>test<strong>123</strong></p><!-- a -->');
+    assert.equal(editor.getContent().replace(/<p>\u00a0<\/p>/g, ''), '<p>test<b>123</b></p><!-- a -->');
   });
 
   it('mceInsertContent - mixed inline content inside td', () => {
@@ -321,7 +321,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<table><tr><td>X</td></tr></table>';
     LegacyUnit.setSelection(editor, 'td', 0, 'td', 0);
     editor.execCommand('mceInsertContent', false, 'test<b>123</b><!-- a -->');
-    assert.equal(editor.getContent(), '<table><tbody><tr><td>test<strong>123</strong><!-- a -->X</td></tr></tbody></table>');
+    assert.equal(editor.getContent(), '<table><tbody><tr><td>test<b>123</b><!-- a -->X</td></tr></tbody></table>');
   });
 
   it('mceInsertContent - invalid insertion with spans on page', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -17,15 +17,6 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme ]);
 
-  it('TBA: insertAtCaret - i inside text, converts to em', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>1234</p>');
-    editor.focus();
-    TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 0, 0 ], 2);
-    InsertContent.insertAtCaret(editor, '<i>a</i>');
-    TinyAssertions.assertContent(editor, '<p>12<em>a</em>34</p>');
-  });
-
   it('TBA: insertAtCaret - ul at beginning of li', () => {
     const editor = hook.editor();
     editor.setContent('<ul><li>12</li></ul>');

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -408,7 +408,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const root = parser.parse('<ul><li>1<li><b>2</b><li><em><b>3</b></em></ul>');
     assert.equal(
       serializer.serialize(root),
-      '<ul><li>1</li><li><strong>2</strong></li><li><em><strong>3</strong></em></li></ul>',
+      '<ul><li>1</li><li><b>2</b></li><li><em><b>3</b></em></li></ul>',
       'Split out LI elements in LI elements.'
     );
   });
@@ -486,7 +486,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     );
     assert.equal(
       serializer.serialize(root),
-      '<!-- a --><p>b<strong>c</strong></p><p>d</p><p>e</p><p>f<strong>g</strong>h</p>',
+      '<!-- a --><p>b<b>c</b></p><p>d</p><p>e</p><p>f<b>g</b>h</p>',
       'Mixed text nodes, inline elements and blocks.'
     );
   });
@@ -506,10 +506,10 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       'h'
     );
     assert.equal(serializer.serialize(root), '<!-- a -->' +
-      '<p class="class1">b<strong>c</strong></p>' +
+      '<p class="class1">b<b>c</b></p>' +
       '<p>d</p>' +
       '<p>e</p>' +
-      '<p class="class1">f<strong>g</strong>h</p>',
+      '<p class="class1">f<b>g</b>h</p>',
     'Mixed text nodes, inline elements and blocks.');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
@@ -12,7 +12,7 @@ describe('browser.tinymce.core.html.SerializerTest', () => {
     assert.equal(serializer.serialize(DomParser().parse('text<text&')), 'text&lt;text&amp;');
     assert.equal(
       serializer.serialize(DomParser().parse('<B>text</B><IMG src="1.gif">')),
-      '<strong>text</strong><img src="1.gif" />'
+      '<b>text</b><img src="1.gif" />'
     );
     assert.equal(serializer.serialize(DomParser().parse('<!-- comment -->')), '<!-- comment -->');
     assert.equal(serializer.serialize(DomParser().parse('<![CDATA[cdata]]>', { format: 'xml' })), '<![CDATA[cdata]]>');
@@ -25,7 +25,7 @@ describe('browser.tinymce.core.html.SerializerTest', () => {
 
     assert.equal(
       serializer.serialize(DomParser().parse('<b class="class" id="id">x</b>')),
-      '<strong id="id" class="class">x</strong>'
+      '<b id="id" class="class">x</b>'
     );
   });
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
@@ -397,7 +397,7 @@ describe('browser.tinymce.plugins.paste.PasteTest', () => {
       )
     });
 
-    TinyAssertions.assertContent(editor, '<p><strong>bold</strong><em>italic</em><strong><em>bold + italic</em></strong><strong><span style="color: red;">bold + color</span></strong></p>');
+    TinyAssertions.assertContent(editor, '<p><b>bold</b><i>italic</i><b><i>bold + italic</i></b><b><span style="color: red;">bold + color</span></b></p>');
   });
 
   it('TBA: paste track changes comment', () => {


### PR DESCRIPTION
Description of Changes:
The documentation claims that [the default schema is 'html5'](https://www.tiny.cloud/docs/configure/content-filtering/#schema) but nowhere is this default actually specified so the default value ends up being `undefined`. This is fine for code like `schema !== 'html4'` but doesn't work for `schema !== 'html5'` since it will evaluate to true when the schema is undefined.

The impact of this problem is that `schema: 'html5'` actually differs from omitting the schema. Only an explicit 'html5' actually disables the conversion from <b> => <strong> and <i> => <em>.

This change defaults the schema to 'html5' when `undefined`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable) => Tests corrected.

Review:
* [ ] Milestone set
* [ ] Review comments resolved