### PR TITLE
Implement Optional<T> as a class to make construction faster

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
+++ b/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
@@ -132,7 +132,7 @@ const text = (s: StringAssert, combineSiblings = false): StructAssert => {
       }, (t: string) => {
         let text = t;
         if (combineSiblings) {
-          while (queue.peek().map(SugarNode.isText).is(true)) {
+          while (queue.peek().map(SugarNode.isText).getOr(false)) {
             text += queue.take().bind(SugarText.getOption).getOr('');
           }
         }

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/OffsetOrigin.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/OffsetOrigin.ts
@@ -1,11 +1,11 @@
-import { Optional } from '@ephox/katamari';
+import { Optional, Optionals } from '@ephox/katamari';
 import { Css, Insert, Remove, SugarElement, SugarLocation, SugarPosition, Traverse } from '@ephox/sugar';
 
 const getOffsetParent = (element: SugarElement): Optional<SugarElement<HTMLElement>> => {
   // Firefox sets the offsetParent to the body when fixed instead of null like
   // all other browsers. So we need to check if the element is fixed and if so then
   // disregard the elements offsetParent.
-  const isFixed = Css.getRaw(element, 'position').is('fixed');
+  const isFixed = Optionals.is(Css.getRaw(element, 'position'), 'fixed');
   const offsetParent = isFixed ? Optional.none<SugarElement<HTMLElement>>() : Traverse.offsetParent(element);
   return offsetParent.orThunk(() => {
     const marker = SugarElement.fromTag('span');

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/Dockables.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/Dockables.ts
@@ -1,4 +1,4 @@
-import { Adt, Arr, Obj, Optional } from '@ephox/katamari';
+import { Adt, Arr, Obj, Optional, Optionals } from '@ephox/katamari';
 import { Class, Css, Height, SugarBody, SugarElement, Width } from '@ephox/sugar';
 
 import * as Boxes from '../../alien/Boxes';
@@ -147,7 +147,7 @@ const morphToFixed = (elem: SugarElement<HTMLElement>, viewport: Boxes.Bounds, s
 
 const getMorph = (component: AlloyComponent, viewport: Boxes.Bounds, state: DockingState): Optional<MorphAdt> => {
   const elem = component.element;
-  const isDocked = Css.getRaw(elem, 'position').is('fixed');
+  const isDocked = Optionals.is(Css.getRaw(elem, 'position'), 'fixed');
   return isDocked ? morphToOriginal(elem, viewport, state) : morphToFixed(elem, viewport, state);
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
@@ -1,5 +1,5 @@
 import { ValueSchema } from '@ephox/boulder';
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, Optional, Optionals } from '@ephox/katamari';
 import { Css, SugarElement, SugarLocation } from '@ephox/sugar';
 
 import { Bounds, box } from '../../alien/Boxes';
@@ -81,7 +81,7 @@ const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningC
       Css.getRaw(placee.element, 'top').isNone() &&
       Css.getRaw(placee.element, 'right').isNone() &&
       Css.getRaw(placee.element, 'bottom').isNone() &&
-      Css.getRaw(placee.element, 'position').is('fixed')
+      Optionals.is(Css.getRaw(placee.element, 'position'), 'fixed')
     ) {
       Css.remove(placee.element, 'position');
     }

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
@@ -88,7 +88,7 @@ const init = (): LayeredState => {
       const triggers: Array<Optional<LayeredItemTrigger>> = Arr.bind(revPath, (menuValue, menuIndex) =>
         // finding menuValue, it should match the trigger
         getTriggerData(menuValue, getItemByValue, revPath.slice(0, menuIndex + 1)).fold(
-          () => primary.get().is(menuValue) ? [ ] : [ Optional.none() ],
+          () => Optionals.is(primary.get(), menuValue) ? [ ] : [ Optional.none() ],
           (data) => [ Optional.some(data) ]
         )
       );

--- a/modules/katamari/CHANGELOG.md
+++ b/modules/katamari/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added static `Optionals.is` and `Optionals.equals` methods.
+- Added `Type.isPlainObject` function to distinguish between classes and plain objects.
 
 ### Removed
 - Removed the `.is`, `.equals` and `.equals_` APIs from `Optional`.

--- a/modules/katamari/CHANGELOG.md
+++ b/modules/katamari/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added static `Optionals.is` and `Optionals.equals` methods.
+
+### Removed
+- Removed the `.is`, `.equals` and `.equals_` APIs from `Optional`.
+
+### Improved
+- The `Optional` type is now covariant with respect to its type argument.
+  - In particular, this means that if all `Cat`s are `Animal`s, then all `Optional<Cat>`s are now `Optional<Animal>`s.
+
 ## 7.2.0 - 2021-05-06
 
 ### Added

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Merger.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Merger.ts
@@ -31,7 +31,7 @@ const shallow = (old: Record<string, any>, nu: Record<string, any>) => {
 };
 
 const deep = (old: Record<string, any>, nu: Record<string, any>) => {
-  const bothObjects = Type.isObject(old) && Type.isObject(nu);
+  const bothObjects = Type.isPlainObject(old) && Type.isPlainObject(nu);
   return bothObjects ? deepMerge(old, nu) : nu;
 };
 

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Optional.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Optional.ts
@@ -1,142 +1,272 @@
-import * as Fun from './Fun';
+import * as Type from './Type';
 
-/** A value which may be Optional.some(a) or Optional.none().
- *  Useful for representing partiality or pass/fail conditions that produce a value when successful.
- *  Sometimes called a "type-safe alternative to null".
- *  Can be thought of as a list of exactly zero or 1 elements.
- */
-export interface Optional<T> {
-  /** If none, run whenNone; if some(a) run whenSome(a) */
-  readonly fold: <T2> (whenNone: () => T2, whenSome: (v: T) => T2) => T2;
+/**
+ The `Optional` type represents a value (of any type) that potentially does not
+ exist. Any `Optional<T>` can either be a `Some<T>` (in which case the value
+ does exist) or a `None` (in which case the value does not exist). This file
+ defines a whole lot of FP-inspired utility functions for dealing with
+ `Optional` objects. Note: Functions are grouped based on, primarily, their
+ Haskell roots. That said, I'm not a Haskell programmer so it might be
+ imperfect.
 
-  readonly isSome: () => boolean;
-  readonly isNone: () => boolean;
+ Comparison with null or undefined
+ - We don't get fancy null coalescing operators with `Optional`
+ - We do get fancy helper functions with `Optional`
+ - `Optional` support nesting, and allow for the type to still be nullable (or
+ another `Optional`)
+ - There is no option to turn off strict-optional-checks like there is for
+ strict-null-checks
+ - Try to use `Optional` instead of null or undefined where you can
+*/
 
-  /** If some(x) return x, otherwise return the specified default value */
-  readonly getOr: <T2>(value: T2) => T | T2;
+export class Optional<T> {
+  private readonly tag: boolean;
+  private readonly value?: T;
 
-  /** getOr with a thunked default value */
-  readonly getOrThunk: <T2>(makeValue: () => T2) => T | T2;
+  // Sneaky optimisation: every instance of Optional.none is identical, so just
+  // reuse the same object
+  private static singletonNone = new Optional<any>(false);
 
-  /** get the 'some' value; throw if none */
-  readonly getOrDie: (msg?: string) => T;
+  // The internal representation has an `tag` and a `value`, but both are
+  // private: able to be console.logged, but not able to be accessed by code
+  private constructor(tag: boolean, value?: T) {
+    this.tag = tag;
+    this.value = value;
+  }
 
-  readonly getOrNull: () => T | null;
-  readonly getOrUndefined: () => T | undefined;
+  // --- Identities ---
+
   /**
-  - if some: return self
-  - if none: return opt
+   Creates a new Optional<T> that **does** contain a value.
   */
-  readonly or: (opt: Optional<T>) => Optional<T>;
+  public static some<T>(this: void, value: T): Optional<T> {
+    return new Optional(true, value);
+  }
 
-  /** Same as "or", but uses a thunk instead of a value */
-  readonly orThunk: (makeOption: () => Optional<T>) => Optional<T>;
+  /**
+   Create a new Optional<T> that **does not** contain a value. T can be any type
+   (and defaults to the literal any type) because we don't actually have a T.
+  */
+  public static none<T = any>(this: void): Optional<T> {
+    return Optional.singletonNone;
+  }
 
-  /** Run a function over the 'some' value.
-   *  "map" operation on the Optional functor.
+  /**
+   Perform a transform on an Optional type. Similar to the fold method on a
+   number of ADTs in the TinyMCE codebase, you pass two functions into this - if
+   `self` **does not** contain a value then `onNone` will be called (with no
+   argument) but if `self` **does** contain a value then `onSome` will be
+   called (with the value as its argument).
+
+   For the FP enthusiasts in the room, this function:
+   1. Could be used to implement all of the functions below
+   2. Forms a catamorphism
+  */
+  public fold<U>(onNone: () => U, onSome: (value: T) => U): U {
+    if (this.tag) {
+      return onSome(this.value as T);
+    } else {
+      return onNone();
+    }
+  }
+
+  /**
+   Determine if this Optional object contains a value.
+  */
+  public isSome(): boolean {
+    return this.tag;
+  }
+
+  /**
+   Determine if this Optional object **does not** contain a value.
+  */
+  public isNone(): boolean {
+    return !this.tag;
+  }
+
+  // --- Functor ---
+
+  /**
+   Perform a transform on an Optional object, **if** there is a value. If you
+   provide a function to turn a T into a U, this is the function you use to turn
+   an `Optional<T>` into an `Optional<U>`. If self **does** contain a value then
+   the output will also contain a value (that value being the output of
+   `mapper(self.value)`), and if self **does not** contain a value then neither
+   will the output.
+  */
+  public map<U>(mapper: (value: T) => U): Optional<U> {
+    if (this.tag) {
+      return Optional.some(mapper(this.value as T));
+    } else {
+      return Optional.none();
+    }
+  }
+
+  // --- Monad ---
+
+  /**
+   Perform a transform on an Optional object, **if** there is a value. Unlike
+   the map function earlier in the piece, here the transform itself also returns
+   a Optional.
+  */
+  public bind<U>(binder: (value: T) => Optional<U>): Optional<U> {
+    if (this.tag) {
+      return binder(this.value as T);
+    } else {
+      return Optional.none();
+    }
+  }
+
+  // --- Traversable ---
+
+  /**
+   For a given predicate, this function finds out if there **exists** a value
+   inside this Optional object that meets the predicate. In practice, this means
+   that for empty objects it returns false (as no predicate-meeting object
+   exists).
    */
-  readonly map: <T2> (mapper: (x: T) => T2) => Optional<T2>;
+  public exists(predicate: (value: T) => boolean): boolean {
+    return this.tag && predicate(this.value as T);
+  }
 
-  /** Run a side effect over the 'some' value */
-  readonly each: (worker: (x: T) => void) => void;
-
-  /** "bind"/"flatMap" operation on the Optional Bind/Monad.
-   *  Equivalent to >>= in Haskell/PureScript; flatMap in Scala.
+  /**
+   For a given predicate, this function finds out if **all** the values inside
+   this maybe object meet the predicate. In practice, this means that for empty
+   objects it returns true (as all 0 objects do meet the predicate).
    */
-  readonly bind: <T2> (f: (x: T) => Optional<T2>) => Optional<T2>;
+  public forall(predicate: (value: T) => boolean): boolean {
+    return !this.tag || predicate(this.value as T);
+  }
 
-  /** Does this Optional contain a value that predicate? */
-  readonly exists: (f: (x: T) => boolean) => boolean;
-
-  /** Do all values contained in this option match this predicate? */
-  readonly forall: (f: (x: T) => boolean) => boolean;
-
-  /** Return all values in this Optional that match the predicate.
-   *  The predicate may refine the constituent type using TypeScript type predicates.
+  /**
+   For a given predicate, create a new Optional object that will retain all the
+   values inside the old Optional object that meet the predicate. In practice,
+   the Optional object contains either 0 or 1 objects, and the output will keep
+   the (single) input object (if it exists) as long as it passes the predicate.
    */
-  readonly filter: {
-    <Q extends T>(f: (x: T) => x is Q): Optional<Q>;
-    (f: (x: T) => boolean): Optional<T>;
-  };
+  public filter<U extends T>(predicate: (value: T) => value is U): Optional<U>;
+  public filter(predicate: (value: T) => boolean): Optional<T>;
+  public filter(predicate: (value: T) => boolean): Optional<T> {
+    if (!this.tag || predicate(this.value as T)) {
+      return this;
+    } else {
+      return Optional.none();
+    }
+  }
 
-  /** Returns all the values in this Optional as an array */
-  readonly toArray: () => T[];
+  // --- Getters ---
 
-  readonly toString: () => string;
+  /**
+   Get the value out of the inside of the Optional object, using a default
+   `replacement` value if the provided Optional object does not contain a value.
+  */
+  public getOr<U = T>(replacement: U): T | U {
+    return this.tag ? this.value as T : replacement;
+  }
+
+  /**
+   Get the value out of the inside of the Optional object, using a default
+   `replacement` value if the provided Optional object does not contain a value.
+   Unlike `getOr`, in this method the `replacement` object is also Optional -
+   meaning that this method will always return an Optional.
+  */
+  public or(replacement: Optional<T>): Optional<T> {
+    return this.tag ? this : replacement;
+  }
+
+  /**
+   Get the value out of the inside of the Optional object, using a default
+   `replacement` value if the provided Optional object does not contain a value.
+   Unlike `getOr`, in this method the `replacement` value is "thunked" - that is
+   to say that you don't pass a value to `getOrThunk`, you pass a function which
+   (if called) will **return** the `value` you want to use.
+   */
+  public getOrThunk<U = T>(thunk: () => U): T | U {
+    return this.tag ? this.value as T : thunk();
+  }
+
+  /**
+   Get the value out of the inside of the Optional object, using a default
+   `replacement` value if the provided Optional object does not contain a value.
+
+   Unlike `or`, in this method the `replacement` value is "thunked" - that is
+   to say that you don't pass a value to `getOrThunk`, you pass a function which
+   (if called) will **return** the `value` you want to use.
+
+   Unlike `getOrThunk`, in this method the `replacement` value is also Optional,
+   meaning that this method will always return an Optional.
+  */
+  public orThunk(thunk: () => Optional<T>): Optional<T> {
+    return this.tag ? this : thunk();
+  }
+
+  /**
+   Get the value out of the inside of the Optional object, throwing an exception
+   if the provided Optional object does not contain a value.
+
+   WARNING:
+   You should only be using this function if you know that the Optional
+   object **is not** empty (otherwise you're throwing exceptions in production
+   code, which is bad).
+
+   Prefer other methods to this, such as `.each`.
+   */
+  public getOrDie(message?: string): T {
+    if (!this.tag) {
+      throw new Error(message ?? 'Called getOrDie on None');
+    } else {
+      return this.value as T;
+    }
+  }
+
+  // --- Interop with null and undefined ---
+
+  /**
+   Creates an Optional value from a nullable (or undefined-able) input. Null, or
+   undefined, is converted to None, and anything else is converted to Some.
+  */
+  public static from<T>(this: void, value: T | null | undefined): Optional<NonNullable<T>> {
+    return Type.isNonNullable(value) ? Optional.some(value) : Optional.none();
+  }
+
+  /**
+   Converts an Optional to a nullable type.
+  */
+  public getOrNull(): T | null {
+    return this.tag ? this.value as T : null;
+  }
+
+  /**
+   Converts an Optional to an undefined-able type.
+  */
+  public getOrUndefined(): T | undefined {
+    return this.tag ? this.value as T : undefined;
+  }
+
+  // -- Utilities --
+
+  /**
+   If the Optional contains a value, perform an action on that value. Unlike
+   the rest of the methods on this type, `.each` has side-effects. If you want
+   to transform an Optional<T> **into** something, then this is not the method
+   for you. If you want to use an Optional<T> to **do** something, then this is
+   the method for you - provided you're okay with not doing anything in the
+   case where the Optional doesn't have a value inside it. If you're not sure
+   whether your use-case fits into transforming **into** something or **doing**
+   something, check whether it has a return value. If it does, you're looking
+   at a transform.
+  */
+  public each(worker: (value: T) => void): void {
+    if (this.tag) {
+      worker(this.value as T);
+    }
+  }
+
+  public toArray(): T[] {
+    return this.tag ? [ this.value as T ] : [];
+  }
+
+  public toString(): string {
+    return this.tag ? `some(${this.value})` : 'none()';
+  }
 }
-
-const none = <T>(): Optional<T> => NONE;
-
-const NONE: Optional<any> = (() => {
-  // inlined from peanut, maybe a micro-optimisation?
-  const call = (thunk) => thunk();
-  const id = (n) => n;
-  const me: Optional<any> = {
-    fold: (n, _s) => n(),
-    isSome: Fun.never,
-    isNone: Fun.always,
-    getOr: id,
-    getOrThunk: call,
-    getOrDie: (msg) => {
-      throw new Error(msg || 'error: getOrDie called on none.');
-    },
-    getOrNull: Fun.constant(null),
-    getOrUndefined: Fun.constant(undefined),
-    or: id,
-    orThunk: call,
-    map: none,
-    each: Fun.noop,
-    bind: none,
-    exists: Fun.never,
-    forall: Fun.always,
-    filter: none,
-    toArray: () => [],
-    toString: Fun.constant('none()')
-  };
-  return me;
-})();
-
-const some = <T>(a: T): Optional<T> => {
-  const constant_a = Fun.constant(a);
-
-  const self = () =>
-    // can't Fun.constant this one
-    me;
-
-  const bind = <T2> (f: (value: T) => T2) => {
-    return f(a);
-  };
-
-  const me: Optional<T> = {
-    fold: <T2> (n: () => T2, s: (v: T) => T2): T2 => s(a),
-    isSome: Fun.always,
-    isNone: Fun.never,
-    getOr: constant_a,
-    getOrThunk: constant_a,
-    getOrDie: constant_a,
-    getOrNull: constant_a,
-    getOrUndefined: constant_a,
-    or: self,
-    orThunk: self,
-    map: <T2> (f: (value: T) => T2) => some(f(a)),
-    each: (f: (value: T) => void): void => {
-      f(a);
-    },
-    bind,
-    exists: bind,
-    forall: bind,
-    filter: <Q extends T>(f: (value: T) => value is Q): Optional<Q> =>
-      f(a) ? me as Optional<Q> : NONE,
-    toArray: () => [ a ],
-    toString: () => 'some(' + a + ')'
-  };
-  return me;
-};
-
-const from = <T>(value: T | undefined | null): Optional<T> => value === null || value === undefined ? NONE : some(value);
-
-export const Optional = {
-  some,
-  none,
-  from
-};

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Optional.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Optional.ts
@@ -9,9 +9,6 @@ export interface Optional<T> {
   /** If none, run whenNone; if some(a) run whenSome(a) */
   readonly fold: <T2> (whenNone: () => T2, whenSome: (v: T) => T2) => T2;
 
-  /** is this value some(t)?  */
-  readonly is: (t: T) => boolean;
-
   readonly isSome: () => boolean;
   readonly isNone: () => boolean;
 
@@ -62,12 +59,6 @@ export interface Optional<T> {
     (f: (x: T) => boolean): Optional<T>;
   };
 
-  /** Compare two Options using === */
-  readonly equals: (opt: Optional<T>) => boolean;
-
-  /** Compare two Options using a specified comparator. */
-  readonly equals_: <T2> (opt: Optional<T2>, equality: (a: T, b: T2) => boolean) => boolean;
-
   /** Returns all the values in this Optional as an array */
   readonly toArray: () => T[];
 
@@ -77,16 +68,11 @@ export interface Optional<T> {
 const none = <T>(): Optional<T> => NONE;
 
 const NONE: Optional<any> = (() => {
-  const eq = (o) => {
-    return o.isNone();
-  };
-
   // inlined from peanut, maybe a micro-optimisation?
   const call = (thunk) => thunk();
   const id = (n) => n;
   const me: Optional<any> = {
     fold: (n, _s) => n(),
-    is: Fun.never,
     isSome: Fun.never,
     isNone: Fun.always,
     getOr: id,
@@ -104,8 +90,6 @@ const NONE: Optional<any> = (() => {
     exists: Fun.never,
     forall: Fun.always,
     filter: none,
-    equals: eq,
-    equals_: eq,
     toArray: () => [],
     toString: Fun.constant('none()')
   };
@@ -125,7 +109,6 @@ const some = <T>(a: T): Optional<T> => {
 
   const me: Optional<T> = {
     fold: <T2> (n: () => T2, s: (v: T) => T2): T2 => s(a),
-    is: (v: T): boolean => a === v,
     isSome: Fun.always,
     isNone: Fun.never,
     getOr: constant_a,
@@ -145,16 +128,7 @@ const some = <T>(a: T): Optional<T> => {
     filter: <Q extends T>(f: (value: T) => value is Q): Optional<Q> =>
       f(a) ? me as Optional<Q> : NONE,
     toArray: () => [ a ],
-    toString: () => 'some(' + a + ')',
-    equals: (o: Optional<T>) => {
-      return o.is(a);
-    },
-    equals_: <T2>(o: Optional<T2>, elementEq: (a: T, b: T2) => boolean) => {
-      return o.fold(
-        Fun.never,
-        (b) => elementEq(a, b)
-      );
-    }
+    toString: () => 'some(' + a + ')'
   };
   return me;
 };

--- a/modules/katamari/src/main/ts/ephox/katamari/api/OptionalInstances.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/OptionalInstances.ts
@@ -1,5 +1,6 @@
 import { Eq, Pnode, Pprint, Testable } from '@ephox/dispute';
 import { Optional } from './Optional';
+import * as Optionals from './Optionals';
 
 type Pprint<A> = Pprint.Pprint<A>;
 type Eq<A> = Eq.Eq<A>;
@@ -13,7 +14,7 @@ export const pprintOptional = <A> (pprintA: Pprint<A> = Pprint.pprintAny): Pprin
 );
 
 export const eqOptional = <A> (eqA: Eq<A> = Eq.eqAny): Eq<Optional<A>> =>
-  Eq.eq((oa, ob) => oa.equals_(ob, eqA.eq));
+  Eq.eq((oa, ob) => Optionals.equals(oa, ob, eqA.eq));
 
 export const tOptional = <A> (testableA: Testable<A> = Testable.tAny): Testable<Optional<A>> =>
   Testable.testable(eqOptional(testableA), pprintOptional(testableA));

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Optionals.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Optionals.ts
@@ -2,6 +2,22 @@ import * as Arr from './Arr';
 import * as Fun from './Fun';
 import { Optional } from './Optional';
 
+/**
+ **Is** the value stored inside this Optional object equal to `other`?
+ */
+export const is = <T>(lhs: Optional<T>, rhs: T, comparator: (a: T, b: T) => boolean = Fun.tripleEquals): boolean =>
+  lhs.exists((left) => comparator(left, rhs));
+
+/**
+ Are these two Optional objects equal? Equality here means either they're both
+ `Some` (and the values are equal under the comparator) or they're both `None`.
+ */
+export const equals: {
+  <A, B>(lhs: Optional<A>, rhs: Optional<B>, comparator: (a: A, b: B) => boolean);
+  <T>(lhs: Optional<T>, rhs: Optional<T>);
+} = <A, B>(lhs: Optional<A>, rhs: Optional<B>, comparator: (a: A, b: B) => boolean = Fun.tripleEquals as any): boolean =>
+  lift2(lhs, rhs, comparator).getOr(lhs.isNone() && rhs.isNone());
+
 export const cat = <A>(arr: Optional<A>[]): A[] => {
   const r: A[] = [];
   const push = (x: A) => {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -26,6 +26,9 @@ export const isString: (value: any) => value is string =
 export const isObject: (value: any) => value is Object =
   isType('object');
 
+export const isPlainObject = (value: unknown): value is Object =>
+  isObject(value) && value.constructor?.name === 'Object';
+
 export const isArray: (value: any) => value is Array<unknown> =
   isType('array');
 

--- a/modules/katamari/src/test/ts/atomic/api/optional/CovarianceAssertionTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/optional/CovarianceAssertionTest.ts
@@ -1,0 +1,33 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+import { Optional } from 'ephox/katamari/api/Optional';
+import * as Optionals from 'ephox/katamari/api/Optionals';
+
+interface Animal {
+  name: string;
+}
+
+interface Cat extends Animal {
+  length: number;
+}
+
+// Sorry for the maths, but really there's a large body of literature working
+// to describe exactly the problem that we're interested in here - and it all
+// comes from maths. There's no advantage in not leaning on that existing work.
+//
+// In particular, we're looking here:
+// https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)
+//
+// We need to make sure that Optional<T> is, and remains, covariant with
+// respect to T.
+describe('atomic.katamari.api.optional.CovarianceAssertionTest', () => {
+  it('is covariant', () => {
+    const cat: Cat = { name: 'Loki', length: 5 };
+    const optCat: Optional<Cat> = Optional.some(cat);
+    const optAnimal: Optional<Animal> = optCat;
+
+    // This assertion is just so that we can avoid the "unused variables" warnings
+    // This test is more about making sure that the above code compiles
+    assert.isTrue(Optionals.equals<Animal>(optCat, optAnimal));
+  });
+});

--- a/modules/katamari/src/test/ts/atomic/api/optional/OptionalNoneTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/optional/OptionalNoneTest.ts
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import fc from 'fast-check';
 import * as Fun from 'ephox/katamari/api/Fun';
 import { Optional } from 'ephox/katamari/api/Optional';
+import * as Optionals from 'ephox/katamari/api/Optionals';
 import { assertNone } from 'ephox/katamari/test/AssertOptional';
 
 describe('atomic.katamari.api.optional.OptionalNoneTest', () => {
@@ -22,8 +23,8 @@ describe('atomic.katamari.api.optional.OptionalNoneTest', () => {
     assertNone(Optional.from(null));
     assertNone(Optional.from(undefined));
 
-    assert.isTrue(Optional.none().or(Optional.some(7)).equals(Optional.some(7)));
-    assert.isTrue(Optional.none().or(Optional.none()).equals(Optional.none()));
+    assert.isTrue(Optionals.equals(Optional.none().or(Optional.some(7)), Optional.some(7)));
+    assert.isTrue(Optionals.equals(Optional.none().or(Optional.none()), Optional.none()));
 
     assert.deepEqual(Optional.none().toArray(), []);
 
@@ -51,7 +52,7 @@ describe('atomic.katamari.api.optional.OptionalNoneTest', () => {
 
   it('Checking none.is === false', () => {
     fc.assert(fc.property(fc.integer(), (v) => {
-      assert.equal(Optional.none<number>().is(v), false);
+      assert.isFalse(Optionals.is(Optional.none(), v));
     }));
   });
 
@@ -79,14 +80,14 @@ describe('atomic.katamari.api.optional.OptionalNoneTest', () => {
   it('Checking none.or(oSomeValue) === oSomeValue', () => {
     fc.assert(fc.property(fc.integer(), (i) => {
       const output = Optional.none().or(Optional.some(i));
-      assert.isTrue(output.is(i));
+      assert.isTrue(Optionals.is(output, i));
     }));
   });
 
   it('Checking none.orThunk(_ -> v) === v', () => {
     fc.assert(fc.property(fc.integer(), (i) => {
       const output = Optional.none().orThunk(() => Optional.some(i));
-      assert.isTrue(output.is(i));
+      assert.isTrue(Optionals.is(output, i));
     }));
   });
 });

--- a/modules/katamari/src/test/ts/atomic/api/optional/OptionalSomeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/optional/OptionalSomeTest.ts
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import fc from 'fast-check';
 import * as Fun from 'ephox/katamari/api/Fun';
 import { Optional } from 'ephox/katamari/api/Optional';
+import * as Optionals from 'ephox/katamari/api/Optionals';
 import * as ArbDataTypes from 'ephox/katamari/test/arb/ArbDataTypes';
 import { assertNone, assertOptional } from 'ephox/katamari/test/AssertOptional';
 
@@ -27,8 +28,8 @@ describe('atomic.katamari.api.optional.OptionalsSomeTest', () => {
     assert.deepEqual(Optional.some({ cat: 'dog' }).toArray(), [{ cat: 'dog' }]);
     assert.deepEqual(Optional.some([ 1 ]).toArray(), [[ 1 ]]);
 
-    assert.isTrue(Optional.some(6).or(Optional.some(7)).equals(Optional.some(6)));
-    assert.isTrue(Optional.some(3).or(Optional.none()).equals(Optional.some(3)));
+    assert.isTrue(Optionals.equals(Optional.some(6).or(Optional.some(7)), Optional.some(6)));
+    assert.isTrue(Optionals.equals(Optional.some(3).or(Optional.none()), Optional.some(3)));
 
     assert.deepEqual(s.fold(boom, (v) => v + 6), 11);
     assert.deepEqual(Optional.some('a').fold(Fun.die('boom'), Fun.identity), 'a');
@@ -52,7 +53,7 @@ describe('atomic.katamari.api.optional.OptionalsSomeTest', () => {
   it('Checking some(x).is(x) === true', () => {
     fc.assert(fc.property(fc.integer(), (json) => {
       const opt = Optional.some(json);
-      assert.isTrue(opt.is(json));
+      assert.isTrue(Optionals.is(opt, json));
     }));
   });
 
@@ -86,14 +87,14 @@ describe('atomic.katamari.api.optional.OptionalsSomeTest', () => {
   it('Checking some(x).or(oSomeValue) === some(x)', () => {
     fc.assert(fc.property(fc.integer(), arbOptionSome(fc.integer()), (json, other) => {
       const output = Optional.some(json).or(other);
-      assert.isTrue(output.is(json));
+      assert.isTrue(Optionals.is(output, json));
     }));
   });
 
   it('Checking some(x).orThunk(_ -> oSomeValue) === some(x)', () => {
     fc.assert(fc.property(fc.integer(), arbOptionSome(fc.integer()), (i, other) => {
       const output = Optional.some(i).orThunk(() => other);
-      assert.isTrue(output.is(i));
+      assert.isTrue(Optionals.is(output, i));
     }));
   });
 

--- a/modules/katamari/src/test/ts/atomic/api/optional/OptionalsEqualTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/optional/OptionalsEqualTest.ts
@@ -3,94 +3,95 @@ import { assert } from 'chai';
 import fc from 'fast-check';
 import * as Fun from 'ephox/katamari/api/Fun';
 import { Optional } from 'ephox/katamari/api/Optional';
+import * as Optionals from 'ephox/katamari/api/Optionals';
 import { arbOptionalSome as arbOptionSome } from 'ephox/katamari/test/arb/ArbDataTypes';
 
 const boom = Fun.die('boom');
 
 describe('atomic.katamari.api.optional.OptionalsEqualTest', () => {
   it('none === none', () => {
-    assert.isTrue(Optional.none().equals(Optional.none()));
+    assert.isTrue(Optionals.equals(Optional.none(), Optional.none()));
   });
 
   it('Optional.none() !== Optional.some(x)', () => {
     fc.assert(fc.property(fc.integer(), (i) => {
-      assert.isFalse(Optional.none().equals(Optional.some(i)));
+      assert.isFalse(Optionals.equals(Optional.none(), Optional.some(i)));
     }));
   });
 
   it('Optional.some(x) !== Optional.none()', () => {
     fc.assert(fc.property(fc.integer(), (i) => {
-      assert.isFalse((Optional.some(i).equals(Optional.none())));
+      assert.isFalse((Optionals.equals(Optional.some(i), Optional.none())));
     }));
   });
 
   it('Optional.some(x) === Optional.some(x)', () => {
-    fc.assert(fc.property(fc.integer(), (i) => assert.isTrue(Optional.some(i).equals(Optional.some(i)))));
+    fc.assert(fc.property(fc.integer(), (i) => assert.isTrue(Optionals.equals(Optional.some(i), Optional.some(i)))));
   });
 
   it('Optional.some(x) === Optional.some(x) (same ref)', () => {
     fc.assert(fc.property(fc.integer(), (i) => {
       const ob = Optional.some(i);
-      assert.isTrue(ob.equals(ob));
+      assert.isTrue(Optionals.equals(ob, ob));
     }));
   });
 
   it('Optional.some(x) !== Optional.some(x + y) where y is not identity', () => {
     fc.assert(fc.property(fc.string(), fc.string(1, 40), (a, b) => {
-      assert.isFalse(Optional.some(a).equals(Optional.some(a + b)));
+      assert.isFalse(Optionals.equals(Optional.some(a), Optional.some(a + b)));
     }));
   });
 
   it('unit tests', () => {
-    assert.isTrue(Optional.none().equals(Optional.none()));
-    assert.isFalse(Optional.none().equals(Optional.some(3)));
+    assert.isTrue(Optionals.equals(Optional.none(), Optional.none()));
+    assert.isFalse(Optionals.equals(Optional.none(), Optional.some(3)));
 
-    assert.isFalse(Optional.some(4).equals(Optional.none()));
-    assert.isFalse(Optional.some(2).equals(Optional.some(4)));
-    assert.isTrue(Optional.some(5).equals(Optional.some(5)));
-    assert.isFalse(Optional.some(5.1).equals(Optional.some(5.3)));
+    assert.isFalse(Optionals.equals(Optional.some(4), Optional.none()));
+    assert.isFalse(Optionals.equals(Optional.some(2), Optional.some(4)));
+    assert.isTrue(Optionals.equals(Optional.some(5), Optional.some(5)));
+    assert.isFalse(Optionals.equals(Optional.some(5.1), Optional.some(5.3)));
 
     const comparator = (a, b) => Math.round(a) === Math.round(b);
 
-    assert.isTrue(Optional.some(5.1).equals_(Optional.some(5.3), comparator));
-    assert.isFalse(Optional.some(5.1).equals_(Optional.some(5.9), comparator));
+    assert.isTrue(Optionals.equals(Optional.some(5.1), Optional.some(5.3), comparator));
+    assert.isFalse(Optionals.equals(Optional.some(5.1), Optional.some(5.9), comparator));
   });
 
-  it('Optionals.equals_', () => {
-    assert.isTrue(Optional.none().equals_(Optional.none(), boom));
+  it('Optionals.equals with comparator', () => {
+    assert.isTrue(Optionals.equals(Optional.none(), Optional.none(), boom));
   });
 
   it('some !== none, for any predicate', () => {
     fc.assert(fc.property(arbOptionSome(fc.integer()), (opt1) => {
-      assert.isFalse(opt1.equals_(Optional.none(), boom));
+      assert.isFalse(Optionals.equals(opt1, Optional.none(), boom));
     }));
   });
 
   it('none !== some, for any predicate', () => {
     fc.assert(fc.property(arbOptionSome(fc.integer()), (opt1) => {
-      assert.isFalse(Optional.none().equals_(opt1, boom));
+      assert.isFalse(Optionals.equals(Optional.none(), opt1, boom));
     }));
   });
 
-  it('Checking some(x).equals_(some(y), _, _ -> false) === false', () => {
+  it('Checking Optionals.equals(some(x), some(y), _, _ -> false) === false', () => {
     fc.assert(fc.property(arbOptionSome(fc.integer()), arbOptionSome(fc.integer()), (opt1, opt2) => {
-      assert.isFalse(opt1.equals_(opt2, Fun.never));
+      assert.isFalse(Optionals.equals(opt1, opt2, Fun.never));
     }));
   });
 
-  it('Checking some(x).equals_(some(y), _, _ -> true) === true', () => {
+  it('Checking Optionals.equals(some(x), some(y), _, _ -> true) === true', () => {
     fc.assert(fc.property(fc.integer(), fc.integer(), (a, b) => {
       const opt1 = Optional.some(a);
       const opt2 = Optional.some(b);
-      assert.isTrue(opt1.equals_(opt2, Fun.always));
+      assert.isTrue(Optionals.equals(opt1, opt2, Fun.always));
     }));
   });
 
-  it('Checking some(x).equals_(some(y), f) iff. f(x, y)', () => {
+  it('Checking Optionals.equals(some(x), some(y), f) iff. f(x, y)', () => {
     fc.assert(fc.property(arbOptionSome(fc.integer()), arbOptionSome(fc.integer()), fc.func(fc.boolean()), (a, b, f) => {
       const opt1 = Optional.some(a);
       const opt2 = Optional.some(b);
-      return f(a, b) === opt1.equals_(opt2, f);
+      return f(a, b) === Optionals.equals(opt1, opt2, f);
     }));
   });
 });

--- a/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
@@ -1,11 +1,12 @@
 // noinspection JSPrimitiveTypeWrapperUsage
 
-import { Assert, describe, it } from '@ephox/bedrock-client';
+import { Assert, context, describe, it } from '@ephox/bedrock-client';
 import { Pprint } from '@ephox/dispute';
 import { assert } from 'chai';
 import * as fc from 'fast-check';
 import * as Arr from 'ephox/katamari/api/Arr';
 import * as Fun from 'ephox/katamari/api/Fun';
+import { Optional } from 'ephox/katamari/api/Optional';
 import * as Type from 'ephox/katamari/api/Type';
 
 const check = (method: (u: unknown) => boolean, methodName: string) => (expected: boolean, input: unknown) => {
@@ -189,5 +190,31 @@ describe('atomic.katamari.api.struct.TypeTest', () => {
       const s: string = os;
       Assert.eq('s', s, os);
     }
+  });
+
+  context('Type.isPlainObject', () => {
+    it('returns false for null and undefined', () => {
+      assert.isFalse(Type.isPlainObject(null));
+      assert.isFalse(Type.isPlainObject(undefined));
+    });
+
+    it('returns false for things that are not even objects', () => {
+      assert.isFalse(Type.isPlainObject('hello'));
+      assert.isFalse(Type.isPlainObject(5));
+      assert.isFalse(Type.isPlainObject([ 1, 2, 4 ]));
+    });
+
+    it('returns true for actual plain objects', () => {
+      assert.isTrue(Type.isPlainObject({}));
+      assert.isTrue(Type.isPlainObject({ a: 3 }));
+      assert.isTrue(Type.isPlainObject({ field: 'more-fields', next: 'other-field' }));
+    });
+
+    it('returns false for classes', () => {
+      assert.isFalse(Type.isPlainObject(new Set()));
+      assert.isFalse(Type.isPlainObject(new Map()));
+      assert.isFalse(Type.isPlainObject(Optional.none()));
+      assert.isFalse(Type.isPlainObject(Optional.some(5)));
+    });
   });
 });

--- a/modules/robin/src/main/ts/ephox/robin/zone/LanguageZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/LanguageZones.ts
@@ -1,5 +1,5 @@
 import { Universe } from '@ephox/boss';
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, Optional, Optionals } from '@ephox/katamari';
 import { WordDecisionItem } from '../words/WordDecision';
 
 export interface ZoneDetails<E> {
@@ -138,7 +138,7 @@ const strictBounder = (envLang: string, onlyLang: string) => {
 const softBounder = (optLang: Optional<string>) => {
   return <E, D>(universe: Universe<E, D>, item: E): boolean => {
     const itemLang = calculate(universe, item);
-    return !optLang.equals(itemLang);
+    return !Optionals.equals(optLang, itemLang);
   };
 };
 

--- a/modules/robin/src/test/ts/atomic/util/WordSanitiserTest.ts
+++ b/modules/robin/src/test/ts/atomic/util/WordSanitiserTest.ts
@@ -1,5 +1,5 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
-import { Optional } from '@ephox/katamari';
+import { Optional, Optionals } from '@ephox/katamari';
 import { WordScope } from 'ephox/robin/data/WordScope';
 import * as WordSanitiser from 'ephox/robin/util/WordSanitiser';
 
@@ -13,8 +13,8 @@ UnitTest.test('Word Sanitiser', () => {
   const check = (expected: WordScope, input: WordScope) => {
     const actual = WordSanitiser.scope(input);
     assert.eq(expected.word, actual.word);
-    assert.eq(true, expected.left.equals(actual.left));
-    assert.eq(true, expected.right.equals(actual.right));
+    assert.eq(true, Optionals.equals(expected.left, actual.left));
+    assert.eq(true, Optionals.equals(expected.right, actual.right));
   };
 
   check(ss('one', '<', '>'), ss('one', '<', '>'));

--- a/modules/robin/src/test/ts/atomic/words/ClusteringTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/ClusteringTest.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Optional, Optionals } from '@ephox/katamari';
 import Jsc from '@ephox/wrap-jsverify';
 import { ArbTextIds, arbTextIds } from 'ephox/robin/test/Arbitraries';
 import * as Clustering from 'ephox/robin/words/Clustering';
@@ -26,7 +26,7 @@ UnitTest.test('ClusteringTest', () => {
         Assert.eq('start: ' + id + ', check right()', expRight, checkWords(universe, act.right));
         Assert.eq(
           () => 'start: ' + id + ', check lang(): expected: ' + expLang.toString() + ', actual: ' + act.lang.toString(),
-          true, expLang.equals(act.lang)
+          true, Optionals.equals(expLang, act.lang)
         );
         // .all() is:  tfel + middle + right
         Assert.eq('start: ' + id + ', check all()', Arr.reverse(expLeft).concat(expMiddle).concat(expRight), checkWords(universe, act.all));

--- a/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
@@ -1,5 +1,5 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Optional, Optionals } from '@ephox/katamari';
 import { WordScope } from 'ephox/robin/data/WordScope';
 import * as Identify from 'ephox/robin/words/Identify';
 
@@ -12,8 +12,8 @@ UnitTest.test('words :: Identify', () => {
     assert.eq(expected.length, actual.length);
     Arr.map(expected, (x, i) => {
       assert.eq(expected[i].word, actual[i].word);
-      assert.eq(true, expected[i].left.equals(actual[i].left));
-      assert.eq(true, expected[i].right.equals(actual[i].right));
+      assert.eq(true, Optionals.equals(expected[i].left, actual[i].left));
+      assert.eq(true, Optionals.equals(expected[i].right, actual[i].right));
     });
   };
 

--- a/modules/robin/src/test/ts/atomic/zone/InViewportTest.ts
+++ b/modules/robin/src/test/ts/atomic/zone/InViewportTest.ts
@@ -93,7 +93,7 @@ UnitTest.asyncTest('atomic.robin.zone.InViewportTest', (success, failure) => {
       if (isText && withinViewport && afterOrEqualsStart && beforeOrEqualsEnd) {
         Assertions.assertEq('Ensuring element ' + el.name + ' is reached by the walker', true, indexedZones.has(el.id));
       } else {
-        Assertions.assertEq('Ensuring element ' + JSON.stringify(el) + ' is not reached by the walker', false, indexedZones.has(el.id));
+        Assertions.assertEq('Ensuring element ' + el.name + ' is not reached by the walker', false, indexedZones.has(el.id));
       }
 
     });

--- a/modules/robin/src/test/ts/atomic/zone/LanguageGetTest.ts
+++ b/modules/robin/src/test/ts/atomic/zone/LanguageGetTest.ts
@@ -1,6 +1,6 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import { Optional, Optionals } from '@ephox/katamari';
 import { LanguageZones } from 'ephox/robin/zone/LanguageZones';
 
 UnitTest.test('LanguageGetTest', () => {
@@ -10,7 +10,7 @@ UnitTest.test('LanguageGetTest', () => {
     Assert.eq(
       () => 'check lang(). Expected: ' + lang.getOr('none') + ', actual: ' + itemLang.getOr('none'),
       true,
-      lang.equals(itemLang)
+      Optionals.equals(lang, itemLang)
     );
   };
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Optional, Strings, Type } from '@ephox/katamari';
+import { Arr, Obj, Optional, Optionals, Strings, Type } from '@ephox/katamari';
 import * as Style from '../../impl/Style';
 import * as SugarBody from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
@@ -126,7 +126,7 @@ const remove = (element: SugarElement<Node>, property: string): void => {
 
   internalRemove(dom, property);
 
-  if (Attribute.getOpt(element as SugarElement<Element>, 'style').map(Strings.trim).is('')) {
+  if (Optionals.is(Attribute.getOpt(element as SugarElement<Element>, 'style').map(Strings.trim), '')) {
     // No more styles left, remove the style attribute as well
     Attribute.remove(element as SugarElement<Element>, 'style');
   }

--- a/modules/sugar/src/test/ts/atomic/DimensionParseTest.ts
+++ b/modules/sugar/src/test/ts/atomic/DimensionParseTest.ts
@@ -1,4 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Optionals } from '@ephox/katamari';
 import fc from 'fast-check';
 import * as Dimension from 'ephox/sugar/api/view/Dimension';
 
@@ -26,10 +27,10 @@ UnitTest.test('All valid integers are valid', () => {
 });
 
 UnitTest.test('Accepts known units', () => {
-  Assert.succeeds('Accepts % in relative', () => Dimension.parse('1%', [ 'relative' ]).is({ value: 1, unit: '%' }));
-  Assert.succeeds('Accepts px in fixed', () => Dimension.parse('20px', [ 'fixed' ]).is({ value: 20, unit: 'px' }));
+  Assert.succeeds('Accepts % in relative', () => Optionals.is(Dimension.parse('1%', [ 'relative' ]), { value: 1, unit: '%' as const }));
+  Assert.succeeds('Accepts px in fixed', () => Optionals.is(Dimension.parse('20px', [ 'fixed' ]), { value: 20, unit: 'px' as const }));
   Assert.succeeds('Does not accept % in fixed', () => Dimension.parse('1%', [ 'fixed' ]).isNone());
-  Assert.succeeds('Accepts px in fixed/relative', () => Dimension.parse('20px', [ 'fixed', 'relative' ]).is({ value: 20, unit: 'px' }));
-  Assert.succeeds('Accepts unitless in unitless', () => Dimension.parse('1.4', [ 'empty' ]).is({ value: 1.4, unit: '' }));
+  Assert.succeeds('Accepts px in fixed/relative', () => Optionals.is(Dimension.parse('20px', [ 'fixed', 'relative' ]), { value: 20, unit: 'px' as const }));
+  Assert.succeeds('Accepts unitless in unitless', () => Optionals.is(Dimension.parse('1.4', [ 'empty' ]), { value: 1.4, unit: '' as const }));
   Assert.succeeds('Does not accept unitless without unitless', () => Dimension.parse('1.4', [ 'fixed', 'unsupportedLength', 'relative' ]).isNone());
 });

--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Cell, Obj, Optional, Throttler } from '@ephox/katamari';
+import { Arr, Cell, Obj, Optional, Optionals, Throttler } from '@ephox/katamari';
 import Editor from '../api/Editor';
 import { AnnotationsRegistry } from './AnnotationsRegistry';
 import { identify } from './Identification';
@@ -78,7 +78,7 @@ const setup = (editor: Editor, _registry: AnnotationsRegistry): AnnotationChange
           },
           ({ uid, name, elements }) => {
             // Changed from a different annotation (or nothing)
-            if (!prev.is(uid)) {
+            if (!Optionals.is(prev, uid)) {
               fireCallbacks(name, uid, elements);
               data.previous.set(Optional.some(uid));
             }

--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import { Compare, Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import Editor from '../api/Editor';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -41,7 +41,7 @@ const deleteCellContents = (editor: Editor, rng: Range, cell: SugarElement<HTMLT
   }
   // Clean up any additional leftover nodes. If the last block wasn't a direct child, then we also need to clean up siblings
   if (!Compare.eq(cell, lastBlock)) {
-    const additionalCleanupNodes = Traverse.parent(lastBlock).is(cell) ? [] : Traverse.siblings(lastBlock);
+    const additionalCleanupNodes = Optionals.is(Traverse.parent(lastBlock), cell) ? [] : Traverse.siblings(lastBlock);
     Arr.each(additionalCleanupNodes.concat(Traverse.children(cell)), (node) => {
       if (!Compare.eq(node, lastBlock) && !Compare.contains(node, lastBlock)) {
         Remove.remove(node);

--- a/modules/tinymce/src/core/main/ts/fmt/Preview.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/Preview.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Obj } from '@ephox/katamari';
+import { Obj, Optionals } from '@ephox/katamari';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import Schema from '../api/html/Schema';
@@ -215,7 +215,7 @@ const getCssText = (editor: Editor, format: any) => {
   // TODO: This should probably be further reduced by the previewStyles option
   if ('preview' in format) {
     const previewOpt = Obj.get(format, 'preview');
-    if (previewOpt.is(false)) {
+    if (Optionals.is(previewOpt, false)) {
       return '';
     } else {
       previewStyles = previewOpt.getOr(previewStyles);

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
@@ -15,7 +15,7 @@ import * as Utils from '../core/Utils';
 import { DialogChanges } from './DialogChanges';
 import { DialogConfirms } from './DialogConfirms';
 import { DialogInfo } from './DialogInfo';
-import { LinkDialogData, LinkDialogInfo } from './DialogTypes';
+import { LinkDialogData, LinkDialogInfo, LinkDialogKey } from './DialogTypes';
 
 const handleSubmit = (editor: Editor, info: LinkDialogInfo) => (api: Dialog.DialogInstanceApi<LinkDialogData>) => {
   const data: LinkDialogData = api.getData();
@@ -29,7 +29,7 @@ const handleSubmit = (editor: Editor, info: LinkDialogInfo) => (api: Dialog.Dial
 
   // Check if a key is defined, meaning it was a field in the dialog. If it is,
   // then check if it's changed and return none if nothing has changed.
-  const getChangedValue = (key: string) => Optional.from(data[key]).filter((value) => !info.anchor[key].is(value));
+  const getChangedValue = (key: LinkDialogKey) => Optional.from(data[key]).filter((value) => !Optionals.is(info.anchor[key], value));
 
   const changedData = {
     href: data.url.value,

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogTypes.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogTypes.ts
@@ -49,6 +49,8 @@ export interface LinkDialogUrlData {
   meta?: LinkUrlMeta;
 }
 
+export type LinkDialogKey = 'text' | 'target' | 'rel' | 'linkClass' | 'title';
+
 export interface LinkDialogData {
   url: LinkDialogUrlData;
   text: string;

--- a/modules/tinymce/src/plugins/link/main/ts/ui/sections/RelOptions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/sections/RelOptions.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional } from '@ephox/katamari';
+import { Optional, Optionals } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 import * as Settings from '../../api/Settings';
@@ -16,7 +16,7 @@ import { ListItem } from '../DialogTypes';
 const getRels = (editor: Editor, initialTarget: Optional<string>): Optional<ListItem[]> => {
   const list = Settings.getRelList(editor);
   if (list.length > 0) {
-    const isTargetBlank = initialTarget.is('_blank');
+    const isTargetBlank = Optionals.is(initialTarget, '_blank');
     const enforceSafe = Settings.allowUnsafeLinkTarget(editor) === false;
     const safeRelExtractor = (item) => Utils.applyRelTargetRules(ListOptions.getValue(item), isTargetBlank);
     const sanitizer = enforceSafe ? ListOptions.sanitizeWith(safeRelExtractor) : ListOptions.sanitize;

--- a/modules/tinymce/src/plugins/lists/main/ts/core/ListNumbering.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/ListNumbering.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional, Strings } from '@ephox/katamari';
+import { Arr, Optional, Optionals, Strings } from '@ephox/katamari';
 
 export interface ListDetail {
   readonly start: string;
@@ -100,9 +100,9 @@ const parseStartValue = (start: string): Optional<ListDetail> => {
 const parseDetail = (detail: ListDetail): string => {
   const start = parseInt(detail.start, 10);
 
-  if (detail.listStyleType.is('upper-alpha')) {
+  if (Optionals.is(detail.listStyleType, 'upper-alpha')) {
     return composeAlphabeticBase26(start);
-  } else if (detail.listStyleType.is('lower-alpha')) {
+  } else if (Optionals.is(detail.listStyleType, 'lower-alpha')) {
     return composeAlphabeticBase26(start).toLowerCase();
   } else {
     return detail.start;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -11,7 +11,7 @@ import {
 } from '@ephox/alloy';
 import { ValueSchema } from '@ephox/boulder';
 import { Sidebar as BridgeSidebar } from '@ephox/bridge';
-import { Arr, Cell, Fun, Id, Obj, Optional } from '@ephox/katamari';
+import { Arr, Cell, Fun, Id, Obj, Optional, Optionals } from '@ephox/katamari';
 import { Css, Width } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import { onControlAttached, onControlDetached } from 'tinymce/themes/silver/ui/controls/Controls';
@@ -27,7 +27,7 @@ const setup = (editor: Editor) => {
   // Setup each registered sidebar
   Arr.each(Obj.keys(sidebars), (name) => {
     const spec = sidebars[name];
-    const isActive = () => Optional.from(editor.queryCommandValue('ToggleSidebar')).is(name);
+    const isActive = () => Optionals.is(Optional.from(editor.queryCommandValue('ToggleSidebar')), name);
     editor.ui.registry.addToggleButton(name, {
       icon: spec.icon,
       tooltip: spec.tooltip,

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConvertTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConvertTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Optional, Optionals } from '@ephox/katamari';
 import { assert } from 'chai';
 import * as fc from 'fast-check';
 
@@ -10,7 +10,7 @@ describe('atomic.tinymce.themes.silver.components.sizeinput.SizeInputConvertTest
 
   const check = (expected: Optional<number>, size: Size, unit: SizeUnit) => {
     const result = convertUnit(size, unit);
-    assert.isTrue(expected.equals(result),
+    assert.isTrue(Optionals.equals(expected, result),
       'Expected conversion of ' + JSON.stringify(size) +
       ' to ' + unit + ' = ' + result.toString()
     );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Mouse, UiFinder } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
+import { Arr, Optionals } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Height, SelectorFind, SugarBody, SugarDocument, SugarElement, SugarLocation, Width } from '@ephox/sugar';
 import { assert } from 'chai';
@@ -61,9 +61,8 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
   const pAssertBlock = async (editor: Editor, blocked: boolean) => {
     const button = await TinyUiActions.pWaitForUi(editor, 'button:contains("Clickable?")');
     const parent = SelectorFind.closest(button, '[aria-busy]');
-    const isBlocked = parent
-      .bind((parent) => Attribute.getOpt(parent, 'aria-busy'))
-      .is('true');
+    const busyAttr = parent.bind((parent) => Attribute.getOpt(parent, 'aria-busy'));
+    const isBlocked = Optionals.is(busyAttr, 'true');
     assert.equal(isBlocked, blocked, 'Blocked state of the dialog');
   };
 

--- a/versions.txt
+++ b/versions.txt
@@ -5,3 +5,4 @@ acid@3.1.0
 agar@5.4.0
 alloy@8.3.0
 mcagar@6.2.0
+katamari@8.0.0


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Moved Optional<T> to be a class
* Ensured that we don't accidentally remove prototypes when using `Merger.deepMerge`
  * In particular, this was happening inside Boulder and Alloy
* Added a `Type.isPlainObject` method to facilitate ^

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved
* [ ] Merge #6884 and rebase on top of it

GitHub issues (if applicable): N/A