### PR TITLE
TINY-6504: Use pre-existing editor schema in fullpage plugin when parsing editor contents

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `toolbar_sticky_offset` setting to allow the toolbar to be offset from the top of the page #TINY-7337
 - Added a new `mceFocus` command that focuses the editor. Equivalent to using `editor.focus()` #TINY-7373
 
+### Improved
+- Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504
+
 ### Changed
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents. #TINY-7249
 - Added a new `mceTableToggleClass` command which toggles the provided class on the currently selected table #TINY-7476

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/FilterContent.ts
@@ -62,7 +62,7 @@ const handleSetContent = (editor: Editor, headState, footState, evt) => {
   }
 
   // Parse header and update iframe
-  const headerFragment = Parser.parseHeader(headState.get());
+  const headerFragment = Parser.parseHeader(editor, headState.get());
   each(headerFragment.getAll('style'), (node) => {
     if (node.firstChild) {
       styles += node.firstChild.value;

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
@@ -29,17 +29,17 @@ interface Data {
   active_color?: string;
 }
 
-const parseHeader = (head: string) => {
+const parseHeader = (editor: Editor, head: string) => {
   // Parse the contents with a DOM parser
   return DomParser({
     validate: false,
     root_name: '#document'
   // Parse as XHTML to allow for inclusion of the XML processing instruction
-  }).parse(head, { format: 'xhtml' });
+  }, editor.schema).parse(head, { format: 'xhtml' });
 };
 
 const htmlToData = (editor: Editor, head: string) => {
-  const headerFragment = parseHeader(head);
+  const headerFragment = parseHeader(editor, head);
   const data: Data = {};
   let elm, matches;
 
@@ -136,7 +136,7 @@ const dataToHtml = (editor: Editor, data: Data, head) => {
     }
   };
 
-  const headerFragment = parseHeader(head);
+  const headerFragment = parseHeader(editor, head);
   headElement = headerFragment.getAll('head')[0];
   if (!headElement) {
     elm = headerFragment.getAll('html')[0];


### PR DESCRIPTION
Related Ticket: TINY-6504

Description of Changes:
- Rather than building a new schema, this just uses the existing editor schema. Shaves ~4-5ms off the script load time.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
