### PR TITLE
Fixed the ToolbarButtonsTest flaking when not run in a specific order

### DIFF
--- a/modules/tinymce/src/themes/silver/test/ts/phantom/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/toolbar/ToolbarButtonsTest.ts
@@ -168,7 +168,6 @@ describe('phantom.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
   };
 
   afterEach(() => {
-    hook.store().clear();
     shouldDisable.set(false);
     shouldActivate.set(false);
   });
@@ -181,6 +180,8 @@ describe('phantom.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
   it('First button (button1): normal button', () => {
     const component = hook.component();
     const store = hook.store();
+    hook.store().clear();
+
     const button1 = getButton('.button1-container .tox-tbtn');
     Assertions.assertStructure(
       'Checking initial structure',
@@ -216,8 +217,9 @@ describe('phantom.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
   it('Second button (button2): toggle button', () => {
     const component = hook.component();
     const store = hook.store();
-    const button2 = getButton('.button2-container .tox-tbtn');
+    hook.store().clear();
 
+    const button2 = getButton('.button2-container .tox-tbtn');
     Mouse.clickOn(component.element, '.button2-container .tox-tbtn');
     store.assertEq('Store should have action2', [ 'onToggleAction.2' ]);
     store.clear();
@@ -250,8 +252,9 @@ describe('phantom.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
     const body = hook.body();
     const component = hook.component();
     const store = hook.store();
-    const button3 = getButton('.button3-container .tox-split-button');
+    hook.store().clear();
 
+    const button3 = getButton('.button3-container .tox-split-button');
     Assertions.assertStructure(
       'Checking initial structure',
       ApproxStructure.build((s, str, arr) => s.element('div', {
@@ -334,8 +337,9 @@ describe('phantom.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
     const body = hook.body();
     const component = hook.component();
     const store = hook.store();
-    const button4 = getButton('.button4-container .tox-mbtn');
+    hook.store().clear();
 
+    const button4 = getButton('.button4-container .tox-mbtn');
     Assertions.assertStructure(
       'Checking initial structure',
       ApproxStructure.build((s, str, arr) => s.element('button', {

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/toolbar/ToolbarButtonsTest.ts
@@ -180,7 +180,7 @@ describe('phantom.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
   it('First button (button1): normal button', () => {
     const component = hook.component();
     const store = hook.store();
-    hook.store().clear();
+    store.clear();
 
     const button1 = getButton('.button1-container .tox-tbtn');
     Assertions.assertStructure(
@@ -217,7 +217,7 @@ describe('phantom.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
   it('Second button (button2): toggle button', () => {
     const component = hook.component();
     const store = hook.store();
-    hook.store().clear();
+    store.clear();
 
     const button2 = getButton('.button2-container .tox-tbtn');
     Mouse.clickOn(component.element, '.button2-container .tox-tbtn');
@@ -252,7 +252,7 @@ describe('phantom.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
     const body = hook.body();
     const component = hook.component();
     const store = hook.store();
-    hook.store().clear();
+    store.clear();
 
     const button3 = getButton('.button3-container .tox-split-button');
     Assertions.assertStructure(
@@ -337,7 +337,7 @@ describe('phantom.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
     const body = hook.body();
     const component = hook.component();
     const store = hook.store();
-    hook.store().clear();
+    store.clear();
 
     const button4 = getButton('.button4-container .tox-mbtn');
     Assertions.assertStructure(


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* If the very first test in `ToolbarButtonsTest` didn't run, then all subsequent tests would fail. As such, this moves the clear store call before each other test.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
