### PR TITLE
TINY-3254: Fixed EventDispatcher mutating the original event data

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `mceTableCellToggleClass` command which toggles the provided class on the currently selected table cells #TINY-7476
 
 ### Fixed
+- `editor.fire` was incorrectly mutating the original custom data provided #TINY-3254
 - The editor content could be edited after calling `setProgressState(true)` in iframe mode #TINY-7373
 - Tabbing out of the editor after calling `setProgressState(true)` was inconsistent in iframe mode #TINY-7373
 - Flash of unstyled content while loading the editor because the content css was loaded after the editor content was rendered #TINY-7249

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `mceTableCellToggleClass` command which toggles the provided class on the currently selected table cells #TINY-7476
 
 ### Fixed
-- `editor.fire` was incorrectly mutating the original custom data provided #TINY-3254
+- `editor.fire` was incorrectly mutating the original `args` provided #TINY-3254
 - The `SetContent` event contained the incorrect `content` when using the `editor.selection.setContent()` API #TINY-3254
 - The editor content could be edited after calling `setProgressState(true)` in iframe mode #TINY-7373
 - Tabbing out of the editor after calling `setProgressState(true)` was inconsistent in iframe mode #TINY-7373

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `editor.fire` was incorrectly mutating the original custom data provided #TINY-3254
+- The `SetContent` event contained the incorrect `content` when using the `editor.selection.setContent()` API #TINY-3254
 - The editor content could be edited after calling `setProgressState(true)` in iframe mode #TINY-7373
 - Tabbing out of the editor after calling `setProgressState(true)` was inconsistent in iframe mode #TINY-7373
 - Flash of unstyled content while loading the editor because the content css was loaded after the editor content was rendered #TINY-7249

--- a/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
@@ -6,6 +6,7 @@
  */
 
 import { Arr, Fun, Obj } from '@ephox/katamari';
+import * as EventUtils from '../../events/EventUtils';
 import Tools from './Tools';
 
 export type MappedEvent<T, K extends string> = K extends keyof T ? T[K] : any;
@@ -53,16 +54,7 @@ export interface NativeEventMap {
   'wheel': WheelEvent;
 }
 
-export type EditorEvent<T> = T & {
-  target: any;
-  type: string;
-  preventDefault: () => void;
-  isDefaultPrevented: () => boolean;
-  stopPropagation: () => void;
-  isPropagationStopped: () => boolean;
-  stopImmediatePropagation: () => void;
-  isImmediatePropagationStopped: () => boolean;
-};
+export type EditorEvent<T> = EventUtils.NormalizedEvent<T>;
 
 export interface EventDispatcherSettings {
   scope?: any;
@@ -142,48 +134,19 @@ class EventDispatcher<T> {
    * @example
    * instance.fire('event', {...});
    */
-  public fire <K extends string, U extends MappedEvent<T, K>>(nameIn: K, argsIn?: U): EditorEvent<U> {
-    const name = nameIn.toLowerCase();
-    const args = argsIn || {} as any;
-    args.type = name;
-
-    // Setup target is there isn't one
-    if (!args.target) {
-      args.target = this.scope;
-    }
-
-    // Add event delegation methods if they are missing
-    if (!args.preventDefault) {
-      // Add preventDefault method
-      args.preventDefault = () => {
-        args.isDefaultPrevented = Fun.always;
-      };
-
-      // Add stopPropagation
-      args.stopPropagation = () => {
-        args.isPropagationStopped = Fun.always;
-      };
-
-      // Add stopImmediatePropagation
-      args.stopImmediatePropagation = () => {
-        args.isImmediatePropagationStopped = Fun.always;
-      };
-
-      // Add event delegation states
-      args.isDefaultPrevented = Fun.never;
-      args.isPropagationStopped = Fun.never;
-      args.isImmediatePropagationStopped = Fun.never;
-    }
+  public fire <K extends string, U extends MappedEvent<T, K>>(name: K, args?: U): EditorEvent<U> {
+    const lcName = name.toLowerCase();
+    const event = EventUtils.normalize<U>(lcName, args || {} as U, this.scope);
 
     if (this.settings.beforeFire) {
-      this.settings.beforeFire(args);
+      this.settings.beforeFire(event);
     }
 
     // Don't clone the array here as this is a hot code path, so instead the handlers
     // array is recreated and the this.bindings[name] reference is updated in the `on`
     // and `off` functions. This is done to avoid the handlers array being mutated while
     // we're iterating over it below.
-    const handlers = this.bindings[name];
+    const handlers = this.bindings[lcName];
     if (handlers) {
       for (let i = 0, l = handlers.length; i < l; i++) {
         const callback = handlers[i];
@@ -195,24 +158,23 @@ class EventDispatcher<T> {
 
         // Unbind handlers marked with "once"
         if (callback.once) {
-          this.off(name, callback.func);
+          this.off(lcName, callback.func);
         }
 
         // Stop immediate propagation if needed
-        if (args.isImmediatePropagationStopped()) {
-          args.stopPropagation();
-          return args;
+        if (event.isImmediatePropagationStopped()) {
+          return event;
         }
 
         // If callback returns false then prevent default and stop all propagation
-        if (callback.func.call(this.scope, args) === false) {
-          args.preventDefault();
-          return args;
+        if (callback.func.call(this.scope, event) === false) {
+          event.preventDefault();
+          return event;
         }
       }
     }
 
-    return args;
+    return event;
   }
 
   /**

--- a/modules/tinymce/src/core/main/ts/content/GetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/GetContentImpl.ts
@@ -23,38 +23,36 @@ const trimEmptyContents = (editor: Editor, html: string): string => {
 };
 
 const getContentFromBody = (editor: Editor, args: GetContentArgs, format: ContentFormat, body: HTMLElement): Content => {
-  let content;
+  const updatedArgs = args.no_events ? args : editor.fire('BeforeGetContent', {
+    ...args,
+    format,
+    get: true,
+    getInner: true
+  });
 
-  args.format = format;
-  args.get = true;
-  args.getInner = true;
-
-  if (!args.no_events) {
-    editor.fire('BeforeGetContent', args);
-  }
-
-  if (args.format === 'raw') {
+  let content: string;
+  if (updatedArgs.format === 'raw') {
     content = Tools.trim(TrimHtml.trimExternal(editor.serializer, body.innerHTML));
-  } else if (args.format === 'text') {
+  } else if (updatedArgs.format === 'text') {
     // return empty string for text format when editor is empty to avoid bogus elements being returned in content
     content = editor.dom.isEmpty(body) ? '' : Zwsp.trim(body.innerText || body.textContent);
-  } else if (args.format === 'tree') {
-    content = editor.serializer.serialize(body, args);
+  } else if (updatedArgs.format === 'tree') {
+    content = editor.serializer.serialize(body, updatedArgs);
   } else {
-    content = trimEmptyContents(editor, editor.serializer.serialize(body, args));
+    content = trimEmptyContents(editor, editor.serializer.serialize(body, updatedArgs));
   }
 
-  if (!Arr.contains([ 'text', 'tree' ], args.format) && !isWsPreserveElement(SugarElement.fromDom(body))) {
-    args.content = Tools.trim(content);
+  if (!Arr.contains([ 'text', 'tree' ], updatedArgs.format) && !isWsPreserveElement(SugarElement.fromDom(body))) {
+    updatedArgs.content = Tools.trim(content);
   } else {
-    args.content = content;
+    updatedArgs.content = content;
   }
 
-  if (!args.no_events) {
-    editor.fire('GetContent', args);
+  if (updatedArgs.no_events) {
+    return updatedArgs.content;
+  } else {
+    return editor.fire('GetContent', updatedArgs).content;
   }
-
-  return args.content;
 };
 
 export const getContentInternal = (editor: Editor, args: GetContentArgs, format): Content => Optional.from(editor.getBody())

--- a/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
@@ -104,20 +104,19 @@ const setContentTree = (editor: Editor, body: HTMLElement, content: AstNode, arg
 };
 
 export const setContentInternal = (editor: Editor, content: Content, args: SetContentArgs): Content => {
-  args.format = args.format ? args.format : defaultFormat;
-  args.set = true;
-  args.content = isTreeNode(content) ? '' : content;
-
-  if (!args.no_events) {
-    editor.fire('BeforeSetContent', args);
-  }
+  const updatedArgs = args.no_events ? args : editor.fire('BeforeSetContent', {
+    format: defaultFormat,
+    ...args,
+    set: true,
+    content: isTreeNode(content) ? '' : content
+  });
 
   if (!isTreeNode(content)) {
-    content = args.content;
+    content = updatedArgs.content;
   }
 
   return Optional.from(editor.getBody()).fold(
     Fun.constant(content),
-    (body) => isTreeNode(content) ? setContentTree(editor, body, content, args) : setContentString(editor, body, content, args)
+    (body) => isTreeNode(content) ? setContentTree(editor, body, content, updatedArgs) : setContentString(editor, body, content, updatedArgs)
   );
 };

--- a/modules/tinymce/src/core/main/ts/events/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/events/EventUtils.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Fun, Obj, Type } from '@ephox/katamari';
+
+export interface PartialEvent {
+  readonly type?: string;
+  readonly target?: any;
+  readonly srcElement?: any;
+  readonly isDefaultPrevented?: () => boolean;
+  readonly preventDefault?: () => void;
+  readonly isPropagationStopped?: () => boolean;
+  readonly stopPropagation?: () => void;
+  readonly isImmediatePropagationStopped?: () => boolean;
+  readonly stopImmediatePropagation?: () => void;
+  readonly composedPath?: () => EventTarget[];
+  returnValue?: boolean;
+  defaultPrevented?: boolean;
+  cancelBubble?: boolean;
+}
+
+export type NormalizedEvent<E, T = any> = E & {
+  readonly type: string;
+  readonly target: T;
+  readonly isDefaultPrevented: () => boolean;
+  readonly preventDefault: () => void;
+  readonly isPropagationStopped: () => boolean;
+  readonly stopPropagation: () => void;
+  readonly isImmediatePropagationStopped: () => boolean;
+  readonly stopImmediatePropagation: () => void;
+};
+
+// Note: The values here aren't used. This is just used as a hash map to see if the key exists
+const deprecated: Record<string, boolean> = {
+  keyLocation: true,
+  layerX: true,
+  layerY: true,
+  returnValue: true,
+  webkitMovementX: true,
+  webkitMovementY: true,
+  keyIdentifier: true,
+  mozPressure: true
+};
+
+// Note: We can't rely on `instanceof` here as it won't work if the event was fired from another window.
+// Additionally, the constructor name might be `MouseEvent` or similar so we can't rely on the constructor name.
+const isNativeEvent = (event: PartialEvent) =>
+  event instanceof Event || Type.isFunction((event as any).initEvent);
+
+// Checks if it is our own isDefaultPrevented function
+const hasIsDefaultPrevented = (event: PartialEvent) =>
+  event.isDefaultPrevented === Fun.always || event.isDefaultPrevented === Fun.never;
+
+// An event needs normalizing if it doesn't have the prevent default function or if it's a native event
+const needsNormalizing = (event: PartialEvent) =>
+  Type.isNullable(event.preventDefault) || isNativeEvent(event);
+
+const clone = <T extends PartialEvent>(originalEvent: T, data?: T): T => {
+  const event: any = data ?? {};
+
+  // Copy all properties from the original event
+  for (const name in originalEvent) {
+    // Some properties are deprecated and produces a warning so don't include them
+    if (!Obj.has(deprecated, name)) {
+      event[name] = originalEvent[name];
+    }
+  }
+
+  // The composed path can't be cloned, so delegate instead
+  if (Type.isNonNullable(event.composedPath)) {
+    event.composedPath = () => originalEvent.composedPath();
+  }
+
+  return event as T;
+};
+
+const normalize = <T extends PartialEvent>(type: string, originalEvent: T, fallbackTarget: any, data?: T): NormalizedEvent<T> => {
+  const event: any = clone(originalEvent, data);
+  event.type = type;
+
+  // Normalize target IE uses srcElement
+  if (Type.isNullable(event.target)) {
+    event.target = event.srcElement ?? fallbackTarget;
+  }
+
+  if (needsNormalizing(originalEvent)) {
+    // Add preventDefault method
+    event.preventDefault = () => {
+      event.defaultPrevented = true;
+      event.isDefaultPrevented = Fun.always;
+
+      // Execute preventDefault on the original event object
+      if (Type.isFunction(originalEvent.preventDefault)) {
+        originalEvent.preventDefault();
+      } else if (isNativeEvent(originalEvent)) {
+        originalEvent.returnValue = false; // IE
+      }
+    };
+
+    // Add stopPropagation
+    event.stopPropagation = () => {
+      event.cancelBubble = true;
+      event.isPropagationStopped = Fun.always;
+
+      // Execute stopPropagation on the original event object
+      if (Type.isFunction(originalEvent.stopPropagation)) {
+        originalEvent.stopPropagation();
+      } else if (isNativeEvent(originalEvent)) {
+        originalEvent.cancelBubble = true; // IE
+      }
+    };
+
+    // Add stopImmediatePropagation
+    event.stopImmediatePropagation = () => {
+      event.isImmediatePropagationStopped = Fun.always;
+      event.stopPropagation();
+    };
+
+    // Add event delegation states
+    if (!hasIsDefaultPrevented(event)) {
+      event.isDefaultPrevented = event.defaultPrevented === true ? Fun.always : Fun.never;
+      event.isPropagationStopped = event.cancelBubble === true ? Fun.always : Fun.never;
+      event.isImmediatePropagationStopped = Fun.never;
+    }
+  }
+
+  return event as NormalizedEvent<T>;
+};
+
+export {
+  clone,
+  normalize
+};

--- a/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
@@ -86,28 +86,30 @@ const getSerializedContent = (editor: Editor, args: GetSelectionContentArgs): Co
 };
 
 export const getSelectedContentInternal = (editor: Editor, format: ContentFormat, args: GetSelectionContentArgs = {}): Content => {
-  args.get = true;
-  args.format = format;
-  args.selection = true;
+  const updatedArgs = editor.fire('BeforeGetContent', {
+    ...args,
+    format,
+    get: true,
+    selection: true
+  });
 
-  args = editor.fire('BeforeGetContent', args);
-  if (args.isDefaultPrevented()) {
-    editor.fire('GetContent', args);
-    return args.content;
+  if (updatedArgs.isDefaultPrevented()) {
+    editor.fire('GetContent', updatedArgs);
+    return updatedArgs.content;
   }
 
-  if (args.format === 'text') {
+  if (updatedArgs.format === 'text') {
     return getTextContent(editor);
   } else {
-    args.getInner = true;
-    const content = getSerializedContent(editor, args);
+    updatedArgs.getInner = true;
+    const content = getSerializedContent(editor, updatedArgs);
 
-    if (args.format === 'tree') {
+    if (updatedArgs.format === 'tree') {
       return content;
     } else {
-      args.content = editor.selection.isCollapsed() ? '' : content as string;
-      editor.fire('GetContent', args);
-      return args.content;
+      updatedArgs.content = editor.selection.isCollapsed() ? '' : content as string;
+      editor.fire('GetContent', updatedArgs);
+      return updatedArgs.content;
     }
   }
 };

--- a/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
@@ -126,10 +126,10 @@ const setContent = (editor: Editor, content: string, args: SelectionSetContentAr
   }
 
   // Sanitize the content
-  args.content = cleanContent(editor, updatedArgs);
+  updatedArgs.content = cleanContent(editor, updatedArgs);
 
   const rng = editor.selection.getRng();
-  rngSetContent(rng, rng.createContextualFragment(args.content));
+  rngSetContent(rng, rng.createContextualFragment(updatedArgs.content));
   editor.selection.setRng(rng);
 
   ScrollIntoView.scrollRangeIntoView(editor, rng);

--- a/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
@@ -1,6 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { SetContentEvent } from 'tinymce/core/api/EventTypes';
@@ -279,5 +280,18 @@ describe('browser.tinymce.selection.SetSelectionContentTest', () => {
         ]
       }))
     );
+  });
+
+  it('TINY-3254: The SetContent event should contain the cleaned content', () => {
+    const editor = hook.editor();
+
+    let lastSetContent: SetContentEvent;
+    editor.on('SetContent', (e) => {
+      lastSetContent = e;
+    });
+
+    SetSelectionContent.setContent(editor, '<img src="" onload="alert(1)">');
+
+    assert.equal(lastSetContent.content, '<img src="" />');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/EventDispatcherTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/EventDispatcherTest.ts
@@ -349,4 +349,21 @@ describe('browser.tinymce.core.util.EventDispatcherTest', () => {
     dispatcher.fire('run');
     assert.deepEqual(logs, [ 'func1' ]);
   });
+
+  it('TINY-3254: Does not mutate the original event args when firing', () => {
+    const dispatcher = new EventDispatcher();
+    const original = { type: 'custom' };
+
+    dispatcher.on('run', (e) => {
+      e.new = true;
+    });
+    const result = dispatcher.fire<'run', any>('run', original);
+
+    assert.notDeepEqual(result, original);
+    assert.equal(original.type, 'custom');
+    assert.notProperty(original, 'new');
+    assert.notProperty(original, 'preventDefault');
+    assert.equal(result.type, 'run');
+    assert.isTrue(result.new);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-3254

Description of Changes:
* Fixed `EventDispatcher` mutating the data provided
* Reworked the logic to share the clone/normalize functionality between `EventUtils` and `EventDispatcher`
* Fixed a small bug in `SetSelectionContent` I found when cleaning up the incorrect reliance on mutation when getting and setting content.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
