### PR TITLE
Fixed a test flake on Firefox

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/ImagePanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/ImagePanel.ts
@@ -117,34 +117,39 @@ const renderImagePanel = (initialUrl: string) => {
     });
   };
 
-  const updateSrc = (anyInSystem: AlloyComponent, url: string): Promise<Optional<SugarElement>> => {
+  const updateSrc = (anyInSystem: AlloyComponent, url: string): Promise<void> => {
     const img = SugarElement.fromTag('img');
     Attribute.set(img, 'src', url);
-    return loadImage(img.dom).then(() => memContainer.getOpt(anyInSystem).map((panel) => {
-      const aImg = GuiFactory.external({
-        element: img
-      });
+    return loadImage(img.dom).then(() => {
+      // Ensure the component hasn't been removed while the image was loading
+      // if it has, then just do nothing
+      if (anyInSystem.getSystem().isConnected()) {
+        memContainer.getOpt(anyInSystem).map((panel) => {
+          const aImg = GuiFactory.external({
+            element: img
+          });
 
-      Replacing.replaceAt(panel, 1, Optional.some(aImg));
+          Replacing.replaceAt(panel, 1, Optional.some(aImg));
 
-      const lastViewRect = viewRectState.get();
-      const viewRect = {
-        x: 0,
-        y: 0,
-        w: img.dom.naturalWidth,
-        h: img.dom.naturalHeight
-      };
-      viewRectState.set(viewRect);
-      const rect = Rect.inflate(viewRect, -20, -20);
-      rectState.set(rect);
+          const lastViewRect = viewRectState.get();
+          const viewRect = {
+            x: 0,
+            y: 0,
+            w: img.dom.naturalWidth,
+            h: img.dom.naturalHeight
+          };
+          viewRectState.set(viewRect);
+          const rect = Rect.inflate(viewRect, -20, -20);
+          rectState.set(rect);
 
-      if (lastViewRect.w !== viewRect.w || lastViewRect.h !== viewRect.h) {
-        zoomFit(panel, img);
+          if (lastViewRect.w !== viewRect.w || lastViewRect.h !== viewRect.h) {
+            zoomFit(panel, img);
+          }
+
+          repaintImg(panel, img);
+        });
       }
-
-      repaintImg(panel, img);
-      return img;
-    }));
+    });
   };
 
   const zoom = (anyInSystem: AlloyComponent, direction: number): void => {


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
This should fix a long-standing Firefox test flake. I haven't been able to verify it, as it's quite random, however what I believe was happening was that the `loadImage` promise would resolve, however the alloy components had been removed in the very short time that the image was attempting to load. Given the timing required to trigger this, it's possible a user could run into it, but the chances would be extremely unlikely and if it did nothing is going to fail.

Note: This also does some minor cleanup as we never used the `Optional` passed all the way up from `updateSrc` and it didn't make sense to be returning the temporary image.

For reference, here's what we'd see as the test failure:
```
12:42:36  Current test: browser.tinymce.plugins.imagetools.ContextToolbarTest - TBA:
12:42:36  Session: 60970374, Status: RUNNING, Progress: 3357/4982, Failed: 0, Skipped: 49 ... 
12:42:36  Current test: browser.tinymce.plugins.imagetools.ContextToolbarTest - TBA:
12:42:36  Session: 60970374, Status: STOPPED, Progress: 3357/4982, Failed: 0, Skipped: 49 
12:42:36  ********** Unexpected Bedrock Error -> Server Quitting **********
12:42:36  Unexpected runner error: Error: Unhandled promise rejection: The component must be in a context to execute: getByUid
12:42:36  <div role="presentation" class="tox-image-tools__image"></div> is not in context.
```

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
