### PR TITLE
TINY-7545: Attempt to preserve the previous position of context toolbars when rendering over top of the element

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added new `focus` property to the `Blocking` behaviour config.
+- Added a new `preserve` option to `LayoutInside` which will preserve the previous placement inside the component.
+- Added the `alwaysFit` layout property which allows for the layout to specify if it should always fit, no matter what.
 
 ### Changed
 - Changed disconnected components to log a warning instead of throwing an error when triggering or broadcasting events.

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added new `focus` property to the `Blocking` behaviour config.
 - Added a new `preserve` option to `LayoutInside` which will preserve the previous placement inside the component.
-- Added the `alwaysFit` layout property which allows for the layout to specify if it should always fit, no matter what.
+- Added the `alwaysFit` layout property which allows for the layout to specify if it should always claim to fit, no matter what.
 
 ### Changed
 - Changed disconnected components to log a warning instead of throwing an error when triggering or broadcasting events.

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
@@ -3,7 +3,7 @@ import { Bubble } from './Bubble';
 import * as Direction from './Direction';
 import { boundsRestriction, AnchorBoxBounds } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
-import * as Placement from './Placement';
+import { Placement } from './Placement';
 
 /*
   Layout for menus and inline context dialogs;
@@ -40,7 +40,7 @@ const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   southY(anchor),
   bubbles.southeast(),
   Direction.southeast(),
-  Placement.southeast,
+  Placement.Southeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.BottomEdge }),
   labelPrefix
 );
@@ -50,7 +50,7 @@ const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   southY(anchor),
   bubbles.southwest(),
   Direction.southwest(),
-  Placement.southwest,
+  Placement.Southwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.BottomEdge }),
   labelPrefix
 );
@@ -60,7 +60,7 @@ const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   northY(anchor, element),
   bubbles.northeast(),
   Direction.northeast(),
-  Placement.northeast,
+  Placement.Northeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.TopEdge }),
   labelPrefix
 );
@@ -70,7 +70,7 @@ const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   northY(anchor, element),
   bubbles.northwest(),
   Direction.northwest(),
-  Placement.northwest,
+  Placement.Northwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.TopEdge }),
   labelPrefix
 );
@@ -80,7 +80,7 @@ const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   northY(anchor, element),
   bubbles.north(),
   Direction.north(),
-  Placement.north,
+  Placement.North,
   boundsRestriction(anchor, { bottom: AnchorBoxBounds.TopEdge }),
   labelPrefix
 );
@@ -90,7 +90,7 @@ const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   southY(anchor),
   bubbles.south(),
   Direction.south(),
-  Placement.south,
+  Placement.South,
   boundsRestriction(anchor, { top: AnchorBoxBounds.BottomEdge }),
   labelPrefix
 );
@@ -100,7 +100,7 @@ const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   centreY(anchor, element),
   bubbles.east(),
   Direction.east(),
-  Placement.east,
+  Placement.East,
   boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge }),
   labelPrefix
 );
@@ -110,7 +110,7 @@ const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   centreY(anchor, element),
   bubbles.west(),
   Direction.west(),
-  Placement.west,
+  Placement.West,
   boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge }),
   labelPrefix
 );

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
@@ -3,12 +3,15 @@ import { Bubble } from './Bubble';
 import * as Direction from './Direction';
 import { boundsRestriction, AnchorBoxBounds } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
+import * as Placement from './Placement';
 
 /*
   Layout for menus and inline context dialogs;
   Either above or below. Never left or right.
   Aligned to the left or right of the anchor as appropriate.
  */
+
+const labelPrefix = 'layout';
 
 // display element to the right, left edge against the anchor
 const eastX = (anchor: AnchorBox): number => anchor.x;
@@ -37,16 +40,19 @@ const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   southY(anchor),
   bubbles.southeast(),
   Direction.southeast(),
+  Placement.southeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.BottomEdge }),
-  'layout-se');
+  labelPrefix
+);
 
 const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   westX(anchor, element),
   southY(anchor),
   bubbles.southwest(),
   Direction.southwest(),
+  Placement.southwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.BottomEdge }),
-  'layout-sw'
+  labelPrefix
 );
 
 const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -54,8 +60,9 @@ const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   northY(anchor, element),
   bubbles.northeast(),
   Direction.northeast(),
+  Placement.northeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.TopEdge }),
-  'layout-ne'
+  labelPrefix
 );
 
 const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -63,8 +70,9 @@ const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   northY(anchor, element),
   bubbles.northwest(),
   Direction.northwest(),
+  Placement.northwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.TopEdge }),
-  'layout-nw'
+  labelPrefix
 );
 
 const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -72,8 +80,9 @@ const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   northY(anchor, element),
   bubbles.north(),
   Direction.north(),
+  Placement.north,
   boundsRestriction(anchor, { bottom: AnchorBoxBounds.TopEdge }),
-  'layout-n'
+  labelPrefix
 );
 
 const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -81,8 +90,9 @@ const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   southY(anchor),
   bubbles.south(),
   Direction.south(),
+  Placement.south,
   boundsRestriction(anchor, { top: AnchorBoxBounds.BottomEdge }),
-  'layout-s'
+  labelPrefix
 );
 
 const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -90,8 +100,9 @@ const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   centreY(anchor, element),
   bubbles.east(),
   Direction.east(),
+  Placement.east,
   boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge }),
-  'layout-e'
+  labelPrefix
 );
 
 const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -99,8 +110,9 @@ const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   centreY(anchor, element),
   bubbles.west(),
   Direction.west(),
+  Placement.west,
   boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge }),
-  'layout-w'
+  labelPrefix
 );
 
 const all = (): AnchorLayout[] => [ southeast, southwest, northeast, northwest, south, north, east, west ];

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
@@ -4,7 +4,7 @@ import { Bubble } from './Bubble';
 import * as Direction from './Direction';
 import { AnchorBoxBounds, boundsRestriction } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
-import * as Placement from './Placement';
+import { Placement, getPlacement } from './Placement';
 
 /*
   Layouts for things that overlay over the anchor element/box. These are designed to mirror
@@ -40,7 +40,7 @@ const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   southY(anchor, element),
   bubbles.innerSouthwest(),
   Direction.northwest(),
-  Placement.southwest,
+  Placement.Southwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.BottomEdge }),
   labelPrefix
 );
@@ -51,7 +51,7 @@ const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   southY(anchor, element),
   bubbles.innerSoutheast(),
   Direction.northeast(),
-  Placement.southeast,
+  Placement.Southeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.BottomEdge }),
   labelPrefix
 );
@@ -62,7 +62,7 @@ const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   northY(anchor),
   bubbles.innerNorthwest(),
   Direction.southwest(),
-  Placement.northwest,
+  Placement.Northwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.TopEdge }),
   labelPrefix
 );
@@ -73,7 +73,7 @@ const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   northY(anchor),
   bubbles.innerNortheast(),
   Direction.southeast(),
-  Placement.northeast,
+  Placement.Northeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.TopEdge }),
   labelPrefix
 );
@@ -84,7 +84,7 @@ const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   northY(anchor),
   bubbles.innerNorth(),
   Direction.south(),
-  Placement.north,
+  Placement.North,
   boundsRestriction(anchor, { top: AnchorBoxBounds.TopEdge }),
   labelPrefix
 );
@@ -95,7 +95,7 @@ const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   southY(anchor, element),
   bubbles.innerSouth(),
   Direction.north(),
-  Placement.south,
+  Placement.South,
   boundsRestriction(anchor, { bottom: AnchorBoxBounds.BottomEdge }),
   labelPrefix
 );
@@ -106,7 +106,7 @@ const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   centreY(anchor, element),
   bubbles.innerEast(),
   Direction.west(),
-  Placement.east,
+  Placement.East,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge }),
   labelPrefix
 );
@@ -117,7 +117,7 @@ const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   centreY(anchor, element),
   bubbles.innerWest(),
   Direction.east(),
-  Placement.west,
+  Placement.West,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge }),
   labelPrefix
 );
@@ -125,23 +125,23 @@ const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
 const all = (): AnchorLayout[] => [ southeast, southwest, northeast, northwest, south, north, east, west ];
 const allRtl = (): AnchorLayout[] => [ southwest, southeast, northwest, northeast, south, north, east, west ];
 
-const lookupPreserveLayout = (lastPlacement: Placement.Placement) => {
+const lookupPreserveLayout = (lastPlacement: Placement) => {
   switch (lastPlacement) {
-    case Placement.north:
+    case Placement.North:
       return north;
-    case Placement.northeast:
+    case Placement.Northeast:
       return northeast;
-    case Placement.northwest:
+    case Placement.Northwest:
       return northwest;
-    case Placement.south:
+    case Placement.South:
       return south;
-    case Placement.southeast:
+    case Placement.Southeast:
       return southeast;
-    case Placement.southwest:
+    case Placement.Southwest:
       return southwest;
-    case Placement.east:
+    case Placement.East:
       return east;
-    case Placement.west:
+    case Placement.West:
       return west;
   }
 };
@@ -152,7 +152,7 @@ const preserve: AnchorLayout = (
   bubbles: Bubble,
   placee: SugarElement<HTMLElement>
 ) => {
-  const lastPlacement = Placement.getPlacement(placee).getOr(Placement.north);
+  const lastPlacement = getPlacement(placee).getOr(Placement.North);
   const layout = lookupPreserveLayout(lastPlacement);
   return layout(anchor, element, bubbles, placee);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
@@ -1,8 +1,10 @@
+import { SugarElement } from '@ephox/sugar';
 import { nu as NuSpotInfo } from '../view/SpotInfo';
 import { Bubble } from './Bubble';
 import * as Direction from './Direction';
 import { AnchorBoxBounds, boundsRestriction } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
+import * as Placement from './Placement';
 
 /*
   Layouts for things that overlay over the anchor element/box. These are designed to mirror
@@ -11,6 +13,8 @@ import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
   As an example `Layout.north` will appear horizontally centered above the anchor, whereas
   `LayoutInside.north` will appear horizontally centered overlapping the top of the anchor.
  */
+
+const labelPrefix = 'layout-inner';
 
 // returns left edge of anchor - used to display element to the left, left edge against the anchor
 const westEdgeX = (anchor: AnchorBox): number => anchor.x;
@@ -36,8 +40,9 @@ const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   southY(anchor, element),
   bubbles.innerSouthwest(),
   Direction.northwest(),
+  Placement.southwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.BottomEdge }),
-  'layout-inner-sw'
+  labelPrefix
 );
 
 // positions element relative to the bottom left of the anchor
@@ -46,8 +51,9 @@ const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   southY(anchor, element),
   bubbles.innerSoutheast(),
   Direction.northeast(),
+  Placement.southeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.BottomEdge }),
-  'layout-inner-se'
+  labelPrefix
 );
 
 // positions element relative to the top right of the anchor
@@ -56,8 +62,9 @@ const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   northY(anchor),
   bubbles.innerNorthwest(),
   Direction.southwest(),
+  Placement.northwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.TopEdge }),
-  'layout-inner-nw'
+  labelPrefix
 );
 
 // positions element relative to the top left of the anchor
@@ -66,8 +73,9 @@ const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   northY(anchor),
   bubbles.innerNortheast(),
   Direction.southeast(),
+  Placement.northeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.TopEdge }),
-  'layout-inner-ne'
+  labelPrefix
 );
 
 // positions element relative to the top of the anchor, horizontally centered
@@ -76,8 +84,10 @@ const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   northY(anchor),
   bubbles.innerNorth(),
   Direction.south(),
+  Placement.north,
   boundsRestriction(anchor, { top: AnchorBoxBounds.TopEdge }),
-  'layout-inner-n');
+  labelPrefix
+);
 
 // positions element relative to the bottom of the anchor, horizontally centered
 const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -85,8 +95,9 @@ const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   southY(anchor, element),
   bubbles.innerSouth(),
   Direction.north(),
+  Placement.south,
   boundsRestriction(anchor, { bottom: AnchorBoxBounds.BottomEdge }),
-  'layout-inner-s'
+  labelPrefix
 );
 
 // positions element with the right edge against the anchor, vertically centered
@@ -95,8 +106,10 @@ const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   centreY(anchor, element),
   bubbles.innerEast(),
   Direction.west(),
+  Placement.east,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge }),
-  'layout-inner-e');
+  labelPrefix
+);
 
 // positions element with the left each against the anchor, vertically centered
 const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -104,13 +117,45 @@ const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   centreY(anchor, element),
   bubbles.innerWest(),
   Direction.east(),
+  Placement.west,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge }),
-  'layout-inner-w'
+  labelPrefix
 );
 
 const all = (): AnchorLayout[] => [ southeast, southwest, northeast, northwest, south, north, east, west ];
-
 const allRtl = (): AnchorLayout[] => [ southwest, southeast, northwest, northeast, south, north, east, west ];
+
+const lookupPreserveLayout = (lastPlacement: Placement.Placement) => {
+  switch (lastPlacement) {
+    case Placement.north:
+      return north;
+    case Placement.northeast:
+      return northeast;
+    case Placement.northwest:
+      return northwest;
+    case Placement.south:
+      return south;
+    case Placement.southeast:
+      return southeast;
+    case Placement.southwest:
+      return southwest;
+    case Placement.east:
+      return east;
+    case Placement.west:
+      return west;
+  }
+};
+
+const preserve: AnchorLayout = (
+  anchor: AnchorBox,
+  element: AnchorElement,
+  bubbles: Bubble,
+  placee: SugarElement<HTMLElement>
+) => {
+  const lastPlacement = Placement.getPlacement(placee).getOr(Placement.north);
+  const layout = lookupPreserveLayout(lastPlacement);
+  return layout(anchor, element, bubbles, placee);
+};
 
 export {
   southeast,
@@ -122,5 +167,6 @@ export {
   east,
   west,
   all,
-  allRtl
+  allRtl,
+  preserve
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutTypes.ts
@@ -1,3 +1,4 @@
+import { SugarElement } from '@ephox/sugar';
 import { SpotInfo } from '../view/SpotInfo';
 import { Bubble } from './Bubble';
 
@@ -16,5 +17,6 @@ export interface AnchorElement {
 export type AnchorLayout = (
   anchor: AnchorBox,
   element: AnchorElement,
-  bubbles: Bubble
+  bubbles: Bubble,
+  placee: SugarElement<HTMLElement>
 ) => SpotInfo;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
@@ -2,12 +2,15 @@ import { nu as NuSpotInfo } from '../view/SpotInfo';
 import * as Direction from './Direction';
 import { AnchorBoxBounds, boundsRestriction } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
+import * as Placement from './Placement';
 
 /*
   Layout for submenus;
   Either left or right of the anchor menu item. Never above or below.
   Aligned to the top or bottom of the anchor as appropriate.
  */
+
+const labelPrefix = 'link-layout';
 
 // display element to the right, left edge against the right of the menu
 const eastX = (anchor: AnchorBox): number => anchor.x + anchor.width;
@@ -26,16 +29,19 @@ const southeast: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   southY(anchor),
   bubbles.southeast(),
   Direction.southeast(),
+  Placement.southeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.TopEdge }),
-  'link-layout-se');
+  labelPrefix
+);
 
 const southwest: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   westX(anchor, element),
   southY(anchor),
   bubbles.southwest(),
   Direction.southwest(),
+  Placement.southwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.TopEdge }),
-  'link-layout-sw'
+  labelPrefix
 );
 
 const northeast: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
@@ -43,8 +49,9 @@ const northeast: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   northY(anchor, element),
   bubbles.northeast(),
   Direction.northeast(),
+  Placement.northeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.BottomEdge }),
-  'link-layout-ne'
+  labelPrefix
 );
 
 const northwest: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
@@ -52,12 +59,12 @@ const northwest: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   northY(anchor, element),
   bubbles.northwest(),
   Direction.northwest(),
+  Placement.northwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.BottomEdge }),
-  'link-layout-nw'
+  labelPrefix
 );
 
 const all = (): AnchorLayout[] => [ southeast, southwest, northeast, northwest ];
-
 const allRtl = (): AnchorLayout[] => [ southwest, southeast, northwest, northeast ];
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
@@ -2,7 +2,7 @@ import { nu as NuSpotInfo } from '../view/SpotInfo';
 import * as Direction from './Direction';
 import { AnchorBoxBounds, boundsRestriction } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
-import * as Placement from './Placement';
+import { Placement } from './Placement';
 
 /*
   Layout for submenus;
@@ -29,7 +29,7 @@ const southeast: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   southY(anchor),
   bubbles.southeast(),
   Direction.southeast(),
-  Placement.southeast,
+  Placement.Southeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.TopEdge }),
   labelPrefix
 );
@@ -39,7 +39,7 @@ const southwest: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   southY(anchor),
   bubbles.southwest(),
   Direction.southwest(),
-  Placement.southwest,
+  Placement.Southwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.TopEdge }),
   labelPrefix
 );
@@ -49,7 +49,7 @@ const northeast: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   northY(anchor, element),
   bubbles.northeast(),
   Direction.northeast(),
-  Placement.northeast,
+  Placement.Northeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.BottomEdge }),
   labelPrefix
 );
@@ -59,7 +59,7 @@ const northwest: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   northY(anchor, element),
   bubbles.northwest(),
   Direction.northwest(),
-  Placement.northwest,
+  Placement.Northwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.BottomEdge }),
   labelPrefix
 );

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Placement.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Placement.ts
@@ -1,16 +1,16 @@
 import { Optional } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
-export type Placement = 'north' | 'northeast' | 'northwest' | 'south' | 'southeast' | 'southwest' | 'east' | 'west';
-
-const north = 'north' as const;
-const northeast = 'northeast' as const;
-const northwest = 'northwest' as const;
-const south = 'south' as const;
-const southeast = 'southeast' as const;
-const southwest = 'southwest' as const;
-const east = 'east' as const;
-const west = 'west' as const;
+export const enum Placement {
+  North = 'north',
+  Northeast = 'northeast',
+  Northwest = 'northwest',
+  South = 'south',
+  Southeast = 'southeast',
+  Southwest = 'southwest',
+  East = 'east',
+  West = 'west'
+}
 
 const placementAttribute = 'data-alloy-placement';
 
@@ -22,15 +22,6 @@ const getPlacement = (element: SugarElement<HTMLElement>): Optional<Placement> =
   Attribute.getOpt(element, placementAttribute) as Optional<Placement>;
 
 export {
-  north,
-  northeast,
-  northwest,
-  south,
-  southeast,
-  southwest,
-  east,
-  west,
-
   setPlacement,
   getPlacement
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Placement.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Placement.ts
@@ -1,0 +1,36 @@
+import { Optional } from '@ephox/katamari';
+import { Attribute, SugarElement } from '@ephox/sugar';
+
+export type Placement = 'north' | 'northeast' | 'northwest' | 'south' | 'southeast' | 'southwest' | 'east' | 'west';
+
+const north = 'north' as const;
+const northeast = 'northeast' as const;
+const northwest = 'northwest' as const;
+const south = 'south' as const;
+const southeast = 'southeast' as const;
+const southwest = 'southwest' as const;
+const east = 'east' as const;
+const west = 'west' as const;
+
+const placementAttribute = 'data-alloy-placement';
+
+const setPlacement = (element: SugarElement<HTMLElement>, placement: Placement): void => {
+  Attribute.set(element, placementAttribute, placement);
+};
+
+const getPlacement = (element: SugarElement<HTMLElement>): Optional<Placement> =>
+  Attribute.getOpt(element, placementAttribute) as Optional<Placement>;
+
+export {
+  north,
+  northeast,
+  northwest,
+  south,
+  southeast,
+  southwest,
+  east,
+  west,
+
+  setPlacement,
+  getPlacement
+};

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
@@ -45,6 +45,7 @@ const go = (anchorBox: LayoutTypes.AnchorBox, element: SugarElement, bubble: Bub
   const decision = Callouts.layout(anchorBox, element, bubble, options);
 
   Callouts.position(element, decision, options);
+  Callouts.setPlacement(element, decision);
   Callouts.setClasses(element, decision);
   Callouts.setHeight(element, decision, options);
   Callouts.setWidth(element, decision, options);

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
@@ -6,7 +6,7 @@ import { Bubble } from '../layout/Bubble';
 import * as Direction from '../layout/Direction';
 import * as LayoutBounds from '../layout/LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from '../layout/LayoutTypes';
-import * as Placement from '../layout/Placement';
+import { Placement } from '../layout/Placement';
 import { RepositionDecision } from './Reposition';
 import { SpotInfo } from './SpotInfo';
 
@@ -225,7 +225,7 @@ const attempts = (element: SugarElement<HTMLElement>, candidates: AnchorLayout[]
       maxHeight: elementBox.height,
       maxWidth: elementBox.width,
       direction: Direction.southeast(),
-      placement: Placement.southeast,
+      placement: Placement.Southeast,
       classes: {
         on: [],
         off: []

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
@@ -1,10 +1,12 @@
 import { Adt, Arr, Fun, Num } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 
 import * as Boxes from '../../alien/Boxes';
 import { Bubble } from '../layout/Bubble';
 import * as Direction from '../layout/Direction';
 import * as LayoutBounds from '../layout/LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from '../layout/LayoutTypes';
+import * as Placement from '../layout/Placement';
 import { RepositionDecision } from './Reposition';
 import { SpotInfo } from './SpotInfo';
 
@@ -150,6 +152,7 @@ const attempt = (candidate: SpotInfo, width: number, height: number, bounds: Box
     maxHeight,
     maxWidth,
     direction: candidate.direction,
+    placement: candidate.placement,
     classes: {
       on: bubble.classesOn,
       off: bubble.classesOff
@@ -183,7 +186,7 @@ const attempt = (candidate: SpotInfo, width: number, height: number, bounds: Box
 
   // Take special note that we don't use the futz values in the nofit case; whether this position is a good fit is separate
   // to ensuring that if we choose it the popup is actually on screen properly.
-  return fits ? adt.fit(reposition) : adt.nofit(reposition, visibleW, visibleH, isPartlyVisible);
+  return fits || candidate.alwaysFit ? adt.fit(reposition) : adt.nofit(reposition, visibleW, visibleH, isPartlyVisible);
 };
 
 /**
@@ -195,11 +198,11 @@ const attempt = (candidate: SpotInfo, width: number, height: number, bounds: Box
  * bubbles: the bubbles for the popup (see api.Bubble)
  * bounds: the screen
  */
-const attempts = (candidates: AnchorLayout[], anchorBox: AnchorBox, elementBox: AnchorElement, bubbles: Bubble, bounds: Boxes.Bounds): RepositionDecision => {
+const attempts = (element: SugarElement<HTMLElement>, candidates: AnchorLayout[], anchorBox: AnchorBox, elementBox: AnchorElement, bubbles: Bubble, bounds: Boxes.Bounds): RepositionDecision => {
   const panelWidth = elementBox.width;
   const panelHeight = elementBox.height;
   const attemptBestFit = (layout: AnchorLayout, reposition: RepositionDecision, visibleW: number, visibleH: number, isVisible: boolean) => {
-    const next: SpotInfo = layout(anchorBox, elementBox, bubbles);
+    const next: SpotInfo = layout(anchorBox, elementBox, bubbles, element);
     const attemptLayout = attempt(next, panelWidth, panelHeight, bounds);
 
     return attemptLayout.fold(Fun.constant(attemptLayout), (newReposition, newVisibleW, newVisibleH, newIsVisible) => {
@@ -222,6 +225,7 @@ const attempts = (candidates: AnchorLayout[], anchorBox: AnchorBox, elementBox: 
       maxHeight: elementBox.height,
       maxWidth: elementBox.width,
       direction: Direction.southeast(),
+      placement: Placement.southeast,
       classes: {
         on: [],
         off: []

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
@@ -3,6 +3,7 @@ import { Classes, Css, Height, SugarElement, Width } from '@ephox/sugar';
 import { Bubble } from '../layout/Bubble';
 import { AnchorBox, AnchorElement } from '../layout/LayoutTypes';
 import * as Origins from '../layout/Origins';
+import * as Placement from '../layout/Placement';
 import { ReparteeOptions } from '../layout/SimpleLayout';
 import * as Bounder from './Bounder';
 import { applyPositionCss } from './PositionCss';
@@ -24,7 +25,7 @@ const layout = (anchorBox: AnchorBox, element: SugarElement, bubbles: Bubble, op
   Css.remove(element, 'max-width');
 
   const elementBox = elementSize(element);
-  return Bounder.attempts(options.preference, anchorBox, elementBox, bubbles, options.bounds);
+  return Bounder.attempts(element, options.preference, anchorBox, elementBox, bubbles, options.bounds);
 };
 
 const setClasses = (element: SugarElement, decision: RepositionDecision): void => {
@@ -57,10 +58,15 @@ const position = (element: SugarElement, decision: RepositionDecision, options: 
   applyPositionCss(element, Origins.reposition(options.origin, decision));
 };
 
+const setPlacement = (element: SugarElement, decision: RepositionDecision): void => {
+  Placement.setPlacement(element, decision.placement);
+};
+
 export {
   layout,
   setClasses,
   setHeight,
   setWidth,
-  position
+  position,
+  setPlacement
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Reposition.ts
@@ -1,11 +1,13 @@
 import * as Boxes from '../../alien/Boxes';
 import { DirectionAdt } from '../layout/Direction';
+import { Placement } from '../layout/Placement';
 
 export interface RepositionDecision {
   readonly rect: Boxes.Rect;
   readonly maxHeight: number;
   readonly maxWidth: number;
   readonly direction: DirectionAdt;
+  readonly placement: Placement;
   readonly classes: {
     off: string[];
     on: string[];

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
@@ -1,6 +1,7 @@
 import { BubbleInstance } from '../layout/Bubble';
 import { DirectionAdt } from '../layout/Direction';
 import { BoundsRestriction } from '../layout/LayoutBounds';
+import { Placement } from '../layout/Placement';
 
 export interface SpotInfo {
   readonly x: number;
@@ -9,6 +10,8 @@ export interface SpotInfo {
   readonly direction: DirectionAdt;
   readonly label: string;
   readonly restriction: BoundsRestriction;
+  readonly placement: Placement;
+  readonly alwaysFit: boolean;
 }
 
 const nu = (
@@ -16,15 +19,19 @@ const nu = (
   y: number,
   bubble: BubbleInstance,
   direction: DirectionAdt,
-  restriction: BoundsRestriction,
-  label: string
+  placement: Placement,
+  boundsRestriction: BoundsRestriction,
+  labelPrefix: string,
+  alwaysFit: boolean = false
 ): SpotInfo => ({
   x,
   y,
   bubble,
   direction,
-  restriction,
-  label
+  placement,
+  restriction: boundsRestriction,
+  label: `${labelPrefix}-${placement}`,
+  alwaysFit
 });
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
@@ -11,6 +11,7 @@ export interface SpotInfo {
   readonly label: string;
   readonly restriction: BoundsRestriction;
   readonly placement: Placement;
+  // This flag will pretend that this spot fits within the bounds, no matter whether it does or not
   readonly alwaysFit: boolean;
 }
 

--- a/modules/alloy/src/test/ts/browser/position/layout/LayoutInsidePreserveTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/layout/LayoutInsidePreserveTest.ts
@@ -1,0 +1,32 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+import * as fc from 'fast-check';
+
+import * as Boxes from 'ephox/alloy/alien/Boxes';
+import * as Bubble from 'ephox/alloy/positioning/layout/Bubble';
+import * as LayoutInside from 'ephox/alloy/positioning/layout/LayoutInside';
+import * as Placement from 'ephox/alloy/positioning/layout/Placement';
+import { boxArb } from 'ephox/alloy/test/BoundsUtils';
+
+describe('LayoutInsidePreserveTest', () => {
+  const placements = [
+    Placement.north, Placement.south, Placement.northeast, Placement.southeast,
+    Placement.northwest, Placement.southwest, Placement.east, Placement.west
+  ];
+
+  it('TINY-7545: the new layout placement should always match the previous placement', () => {
+    const element = SugarElement.fromTag('div');
+    fc.assert(fc.property(boxArb(), fc.constantFrom(...placements), (box, placement) => {
+      Placement.setPlacement(element, placement);
+      const newLayout = LayoutInside.preserve(box, { width: 10, height: 10 }, Bubble.fallback(), element);
+      assert.equal(newLayout.placement, placement);
+    }));
+  });
+
+  it('TINY-7545: falls back to north if no previous placement is found', () => {
+    const element = SugarElement.fromTag('div');
+    const newLayout = LayoutInside.preserve(Boxes.bounds(0, 0, 50, 50), { width: 10, height: 10 }, Bubble.fallback(), element);
+    assert.equal(newLayout.placement, Placement.north);
+  });
+});

--- a/modules/alloy/src/test/ts/browser/position/layout/LayoutInsidePreserveTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/layout/LayoutInsidePreserveTest.ts
@@ -6,19 +6,19 @@ import * as fc from 'fast-check';
 import * as Boxes from 'ephox/alloy/alien/Boxes';
 import * as Bubble from 'ephox/alloy/positioning/layout/Bubble';
 import * as LayoutInside from 'ephox/alloy/positioning/layout/LayoutInside';
-import * as Placement from 'ephox/alloy/positioning/layout/Placement';
+import { Placement, setPlacement } from 'ephox/alloy/positioning/layout/Placement';
 import { boxArb } from 'ephox/alloy/test/BoundsUtils';
 
 describe('LayoutInsidePreserveTest', () => {
   const placements = [
-    Placement.north, Placement.south, Placement.northeast, Placement.southeast,
-    Placement.northwest, Placement.southwest, Placement.east, Placement.west
+    Placement.North, Placement.South, Placement.Northeast, Placement.Southeast,
+    Placement.Northwest, Placement.Southwest, Placement.East, Placement.West
   ];
 
   it('TINY-7545: the new layout placement should always match the previous placement', () => {
     const element = SugarElement.fromTag('div');
     fc.assert(fc.property(boxArb(), fc.constantFrom(...placements), (box, placement) => {
-      Placement.setPlacement(element, placement);
+      setPlacement(element, placement);
       const newLayout = LayoutInside.preserve(box, { width: 10, height: 10 }, Bubble.fallback(), element);
       assert.equal(newLayout.placement, placement);
     }));
@@ -27,6 +27,6 @@ describe('LayoutInsidePreserveTest', () => {
   it('TINY-7545: falls back to north if no previous placement is found', () => {
     const element = SugarElement.fromTag('div');
     const newLayout = LayoutInside.preserve(Boxes.bounds(0, 0, 50, 50), { width: 10, height: 10 }, Bubble.fallback(), element);
-    assert.equal(newLayout.placement, Placement.north);
+    assert.equal(newLayout.placement, Placement.North);
   });
 });

--- a/modules/alloy/src/test/ts/browser/position/view/BounderCursorTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/view/BounderCursorTest.ts
@@ -1,4 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
+import { SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { Bounds, bounds } from 'ephox/alloy/alien/Boxes';
@@ -16,7 +17,8 @@ interface TestDecisionSpec {
 
 describe('BounderCursorTest', () => {
   const check = (expected: TestDecisionSpec, preference: AnchorLayout[], anchor: AnchorBox, panel: AnchorElement, bubbles: Bubble.Bubble, bounds: Bounds) => {
-    const actual = Bounder.attempts(preference, anchor, panel, bubbles, bounds);
+    const placee = SugarElement.fromTag('div');
+    const actual = Bounder.attempts(placee, preference, anchor, panel, bubbles, bounds);
     assert.equal(actual.label, expected.label, 'label');
     assert.equal(actual.rect.x, expected.x, 'X');
     assert.equal(actual.rect.y, expected.y, 'Y');
@@ -56,7 +58,7 @@ describe('BounderCursorTest', () => {
   it('southeast', () => {
     const anchor = bounds(100, 55, 2, 2);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x,                                // 100
       y: anchor.bottom,                           // 57
     }, four, anchor, panelBox, bubb, view);
@@ -65,7 +67,7 @@ describe('BounderCursorTest', () => {
   it('southwest', () => {
     const anchor = bounds(320, 55, 2, 2);
     check({
-      label: 'layout-sw',
+      label: 'layout-southwest',
       x: anchor.right - panelBox.width,           // 222
       y: anchor.bottom,                           // 57
     }, four, anchor, panelBox, bubb, view);
@@ -74,7 +76,7 @@ describe('BounderCursorTest', () => {
   it('northeast', () => {
     const anchor = bounds(140, 235, 2, 2);
     check({
-      label: 'layout-ne',
+      label: 'layout-northeast',
       x: anchor.x,                                // 140
       y: anchor.y - panelBox.height               // 160
     }, four, anchor, panelBox, bubb, view);
@@ -83,7 +85,7 @@ describe('BounderCursorTest', () => {
   it('northwest', () => {
     const anchor = bounds(320, 235, 2, 2);
     check({
-      label: 'layout-nw',
+      label: 'layout-northwest',
       x: anchor.right - panelBox.width,           // 222
       y: anchor.y - panelBox.height,              // 160
     }, four, anchor, panelBox, bubb, view);
@@ -92,7 +94,7 @@ describe('BounderCursorTest', () => {
   it('all fit -> southeast because of order of preference', () => {
     const anchor = bounds(270, 100, 2, 2);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x,                                // 270
       y: anchor.bottom                            // 102
     }, four, anchor, panelBox, bubb, view);
@@ -101,7 +103,7 @@ describe('BounderCursorTest', () => {
   it('none near top left -> best fit is southeast', () => {
     const anchor = bounds(55, 55, 2, 2);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x,                                // 55
       y: anchor.bottom,                           // 57
     }, four, anchor, bigPanel, bubb, view);
@@ -110,7 +112,7 @@ describe('BounderCursorTest', () => {
   it('none near top right -> best fit is southwest', () => {
     const anchor = bounds(350, 55, 2, 2);
     check({
-      label: 'layout-sw',
+      label: 'layout-southwest',
       x: anchor.right - bigPanel.width,           // 277
       y: anchor.bottom,                           // 57
     }, four, anchor, bigPanel, bubb, view);
@@ -119,7 +121,7 @@ describe('BounderCursorTest', () => {
   it('none near bottom left -> best fit is northeast', () => {
     const anchor = bounds(55, 200, 2, 2);
     check({
-      label: 'layout-ne',
+      label: 'layout-northeast',
       x: anchor.x,                                // 55
       y: view.y,                                  // 50 - constrained within viewport
       candidateY: anchor.y - bigPanel.height,     // -300
@@ -129,7 +131,7 @@ describe('BounderCursorTest', () => {
   it('none near bottom right -> best fit is northwest', () => {
     const anchor = bounds(350, 200, 2, 2);
     check({
-      label: 'layout-nw',
+      label: 'layout-northwest',
       x: anchor.right - bigPanel.width,           // 277
       y: view.y,                                  // 50 - constrained within viewport
       candidateY: anchor.y - bigPanel.height,     // -300
@@ -140,7 +142,7 @@ describe('BounderCursorTest', () => {
     // Southwest
     const anchorSW = bounds(300, 50, 2, 2);
     check({
-      label: 'layout-sw',
+      label: 'layout-southwest',
       x: view.x,                                  // 50 - constrained within viewport
       y: anchorSW.bottom                          // 52
     }, four, anchorSW, widePanel, bubb, view);
@@ -148,7 +150,7 @@ describe('BounderCursorTest', () => {
     // northwest
     const anchorNW = bounds(300, 200, 2, 2);
     check({
-      label: 'layout-nw',
+      label: 'layout-northwest',
       x: view.x,                                  // 50 - constrained within viewport
       y: view.y,                                  // 50 - constrained within viewport
       candidateY: anchorNW.y - widePanel.height,  // -300
@@ -158,7 +160,7 @@ describe('BounderCursorTest', () => {
   it('southeast (1px short on x and y)', () => {
     const anchor = bounds(view.right - panelBox.width - 1, view.bottom - panelBox.height - 2 - 1, 2, 2);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x,                                // 299
       y: anchor.bottom,                           // 194
     }, four, anchor, panelBox, bubb, view);
@@ -167,7 +169,7 @@ describe('BounderCursorTest', () => {
   it('southeast (exactly for x and y)', () => {
     const anchor = bounds(view.right - panelBox.width, view.bottom - panelBox.height - 2, 2, 2);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x,                                // 300
       y: anchor.bottom,                           // 195
     }, four, anchor, panelBox, bubb, view);
@@ -176,7 +178,7 @@ describe('BounderCursorTest', () => {
   it('southeast -> southwest (1px too far on x)', () => {
     const anchor = bounds(view.right - panelBox.width + 1, view.bottom - panelBox.height - 2, 2, 2);
     check({
-      label: 'layout-sw',
+      label: 'layout-southwest',
       x: anchor.right - panelBox.width,           // 203
       y: anchor.bottom,                           // 195
     }, four, anchor, panelBox, bubb, view);
@@ -185,7 +187,7 @@ describe('BounderCursorTest', () => {
   it('southeast -> northeast (1px too far on y)', () => {
     const anchor = bounds(view.right - panelBox.width, view.bottom - panelBox.height - 2 + 1, 2, 2);
     check({
-      label: 'layout-ne',
+      label: 'layout-northeast',
       x: anchor.x,                                // 300
       y: anchor.y - panelBox.height,              // 119
     }, four, anchor, panelBox, bubb, view);
@@ -194,7 +196,7 @@ describe('BounderCursorTest', () => {
   it('southeast -> northwest (1px too far on x and y)', () => {
     const anchor = bounds(view.right - panelBox.width + 1, view.bottom - panelBox.height - 2 + 1, 2, 2);
     check({
-      label: 'layout-nw',
+      label: 'layout-northwest',
       x: anchor.right - panelBox.width,           // 203
       y: anchor.y - panelBox.height,              // 119
     }, four, anchor, panelBox, bubb, view);
@@ -203,7 +205,7 @@ describe('BounderCursorTest', () => {
   it('east', () => {
     const anchor = bounds(55, 150, 10, 10);
     check({
-      label: 'layout-e',
+      label: 'layout-east',
       x: anchor.right,                                            // 65
       y: anchor.y + (anchor.height / 2) - (panelBox.height / 2),  // 117.5
     }, two, anchor, panelBox, bubb, view);
@@ -212,7 +214,7 @@ describe('BounderCursorTest', () => {
   it('none near bottom left -> best fit is east (limited to bottom bounds)', () => {
     const anchor = bounds(55, 240, 10, 10);
     check({
-      label: 'layout-e',
+      label: 'layout-east',
       x: anchor.right,                            // 65
       y: view.bottom - panelBox.height            // 195 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);
@@ -221,7 +223,7 @@ describe('BounderCursorTest', () => {
   it('none near top left -> best fit is east (limited to top bounds)', () => {
     const anchor = bounds(55, 80, 10, 10);
     check({
-      label: 'layout-e',
+      label: 'layout-east',
       x: anchor.right,                            // 65
       y: view.y,                                  // 50 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);
@@ -230,7 +232,7 @@ describe('BounderCursorTest', () => {
   it('west', () => {
     const anchor = bounds(350, 150, 10, 10);
     check({
-      label: 'layout-w',
+      label: 'layout-west',
       x: anchor.x - panelBox.width,                               // 250
       y: anchor.y + (anchor.height / 2) - (panelBox.height / 2),  // 117.5
     }, two, anchor, panelBox, bubb, view);
@@ -239,7 +241,7 @@ describe('BounderCursorTest', () => {
   it('none near bottom right -> best fit is west (limited to bottom bounds)', () => {
     const anchor = bounds(350, 240, 10, 10);
     check({
-      label: 'layout-w',
+      label: 'layout-west',
       x: anchor.x - panelBox.width,               // 250
       y: view.bottom - panelBox.height            // 195 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);
@@ -248,7 +250,7 @@ describe('BounderCursorTest', () => {
   it('none near top right -> best fit is west (limited to top bounds)', () => {
     const anchor = bounds(350, 80, 10, 10);
     check({
-      label: 'layout-w',
+      label: 'layout-west',
       x: anchor.x - panelBox.width,               // 250
       y: view.y,                                  // 50 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);

--- a/modules/alloy/src/test/ts/browser/position/view/BounderMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/view/BounderMenuTest.ts
@@ -1,4 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
+import { SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { Bounds, bounds } from 'ephox/alloy/alien/Boxes';
@@ -16,7 +17,8 @@ interface TestDecisionSpec {
 
 describe('BounderMenuTest', () => {
   const check = (expected: TestDecisionSpec, preference: AnchorLayout[], anchor: AnchorBox, panel: AnchorElement, bubbles: Bubble.Bubble, bounds: Bounds) => {
-    const actual = Bounder.attempts(preference, anchor, panel, bubbles, bounds);
+    const placee = SugarElement.fromTag('div');
+    const actual = Bounder.attempts(placee, preference, anchor, panel, bubbles, bounds);
     assert.equal(actual.label, expected.label, 'label');
     assert.equal(actual.rect.x, expected.x, 'X');
     assert.equal(actual.rect.y, expected.y, 'Y');
@@ -54,7 +56,7 @@ describe('BounderMenuTest', () => {
   it('southeast', () => {
     const anchor = bounds(100, 55, 2, 2);
     check({
-      label: 'link-layout-se',
+      label: 'link-layout-southeast',
       x: anchor.right,                            // 102
       y: anchor.y,                                // 55
     }, four, anchor, panelBox, bubb, view);
@@ -63,7 +65,7 @@ describe('BounderMenuTest', () => {
   it('southwest', () => {
     const anchor = bounds(320, 55, 2, 2);
     check({
-      label: 'link-layout-sw',
+      label: 'link-layout-southwest',
       x: anchor.x - panelBox.width,               // 220
       y: anchor.y,                                // 55
     }, four, anchor, panelBox, bubb, view);
@@ -72,7 +74,7 @@ describe('BounderMenuTest', () => {
   it('northeast', () => {
     const anchor = bounds(140, 235, 2, 2);
     check({
-      label: 'link-layout-ne',
+      label: 'link-layout-northeast',
       x: anchor.right,                            // 142
       y: anchor.bottom - panelBox.height,         // 162
     }, four, anchor, panelBox, bubb, view);
@@ -81,7 +83,7 @@ describe('BounderMenuTest', () => {
   it('northwest', () => {
     const anchor = bounds(320, 235, 2, 2);
     check({
-      label: 'link-layout-nw',
+      label: 'link-layout-northwest',
       x: anchor.x - panelBox.width,               // 220
       y: anchor.bottom - panelBox.height,         // 162
     }, four, anchor, panelBox, bubb, view);
@@ -90,7 +92,7 @@ describe('BounderMenuTest', () => {
   it('all fit -> southeast because of order of preference', () => {
     const anchor = bounds(270, 100, 2, 2);
     check({
-      label: 'link-layout-se',
+      label: 'link-layout-southeast',
       x: anchor.right,                            // 272
       y: anchor.y,                                // 100
     }, four, anchor, panelBox, bubb, view);
@@ -99,7 +101,7 @@ describe('BounderMenuTest', () => {
   it('none near top left -> best fit is southeast', () => {
     const anchor = bounds(55, 55, 2, 2);
     check({
-      label: 'link-layout-se',
+      label: 'link-layout-southeast',
       x: anchor.right,                            // 57
       y: anchor.y,                                // 55
     }, four, anchor, bigPanel, bubb, view);
@@ -108,7 +110,7 @@ describe('BounderMenuTest', () => {
   it('none near top right -> best fit is southwest', () => {
     const anchor = bounds(350, 55, 2, 2);
     check({
-      label: 'link-layout-sw',
+      label: 'link-layout-southwest',
       x: anchor.x - bigPanel.width,               // 275
       y: anchor.y,                                // 55
     }, four, anchor, bigPanel, bubb, view);
@@ -117,7 +119,7 @@ describe('BounderMenuTest', () => {
   it('none near bottom left -> best fit is northeast', () => {
     const anchor = bounds(55, 200, 2, 2);
     check({
-      label: 'link-layout-ne',
+      label: 'link-layout-northeast',
       x: anchor.right,                            // 57
       y: view.y,                                  // 50 - constrained within viewport
       candidateY: anchor.bottom - bigPanel.height // -298
@@ -127,7 +129,7 @@ describe('BounderMenuTest', () => {
   it('none near bottom right -> best fit is northwest', () => {
     const anchor = bounds(350, 200, 2, 2);
     check({
-      label: 'link-layout-nw',
+      label: 'link-layout-northwest',
       x: anchor.x - bigPanel.width,               // 275
       y: view.y,                                  // 50 - constrained within viewport
       candidateY: anchor.bottom - bigPanel.height // -298
@@ -137,7 +139,7 @@ describe('BounderMenuTest', () => {
   it('southeast (1px short on x and y)', () => {
     const anchor = bounds(view.right - panelBox.width - 2 - 1, view.bottom - panelBox.height - 1, 2, 2);
     check({
-      label: 'link-layout-se',
+      label: 'link-layout-southeast',
       x: anchor.right,                            // 299
       y: anchor.y,                                // 194
     }, four, anchor, panelBox, bubb, view);
@@ -146,7 +148,7 @@ describe('BounderMenuTest', () => {
   it('southeast (exactly for x and y)', () => {
     const anchor = bounds(view.right - panelBox.width - 2, view.bottom - panelBox.height, 2, 2);
     check({
-      label: 'link-layout-se',
+      label: 'link-layout-southeast',
       x: anchor.right,                            // 300
       y: anchor.y,                                // 195
     }, four, anchor, panelBox, bubb, view);
@@ -155,7 +157,7 @@ describe('BounderMenuTest', () => {
   it('southeast -> southwest (1px too far on x)', () => {
     const anchor = bounds(view.right - panelBox.width - 2 + 1, view.bottom - panelBox.height, 2, 2);
     check({
-      label: 'link-layout-sw',
+      label: 'link-layout-southwest',
       x: anchor.x - panelBox.width,               // 199
       y: anchor.y,                                // 195
     }, four, anchor, panelBox, bubb, view);
@@ -164,7 +166,7 @@ describe('BounderMenuTest', () => {
   it('southeast -> northeast (1px too far on y)', () => {
     const anchor = bounds(view.right - panelBox.width - 2, view.bottom - panelBox.height + 1, 2, 2);
     check({
-      label: 'link-layout-ne',
+      label: 'link-layout-northeast',
       x: anchor.right,                            // 300
       y: anchor.bottom - panelBox.height          // 123
     }, four, anchor, panelBox, bubb, view);
@@ -173,7 +175,7 @@ describe('BounderMenuTest', () => {
   it('southeast -> northwest (1px too far on x and y)', () => {
     const anchor = bounds(view.right - panelBox.width - 2 + 1, view.bottom - panelBox.height + 1, 2, 2);
     check({
-      label: 'link-layout-nw',
+      label: 'link-layout-northwest',
       x: anchor.x - panelBox.width,               // 199
       y: anchor.bottom - panelBox.height          // 123
     }, four, anchor, panelBox, bubb, view);

--- a/modules/alloy/src/test/ts/browser/position/view/BounderOverlappingTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/view/BounderOverlappingTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { SugarPosition } from '@ephox/sugar';
+import { SugarElement, SugarPosition } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { Bounds, bounds } from 'ephox/alloy/alien/Boxes';
@@ -18,7 +18,8 @@ interface TestDecisionSpec {
 
 describe('BounderOverlappingTest', () => {
   const check = (expected: TestDecisionSpec, preference: AnchorLayout[], anchor: AnchorBox, panel: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
-    const actual = Bounder.attempts(preference, anchor, panel, bubbles, bounds);
+    const placee = SugarElement.fromTag('div');
+    const actual = Bounder.attempts(placee, preference, anchor, panel, bubbles, bounds);
     assert.equal(actual.label, expected.label, 'label');
     assert.equal(actual.rect.x, expected.x, 'X');
     assert.equal(actual.rect.y, expected.y, 'Y');
@@ -128,7 +129,7 @@ describe('BounderOverlappingTest', () => {
   it('southeast', () => {
     const anchor = bounds(340, 45, 80, 80);
     check({
-      label: 'layout-inner-se',
+      label: 'layout-inner-southeast',
       x: anchor.x + 1,                            // 341
       y: anchor.bottom - panelBox.height + 2      // 117
     }, four, anchor, panelBox, bubb, view);
@@ -137,7 +138,7 @@ describe('BounderOverlappingTest', () => {
   it('southwest', () => {
     const anchor = bounds(40, 45, 50, 50);
     check({
-      label: 'layout-inner-sw',
+      label: 'layout-inner-southwest',
       x: anchor.right - panelBox.width - 1,       // 74
       y: anchor.bottom - panelBox.height + 2      // 87
     }, four, anchor, panelBox, bubb, view);
@@ -146,7 +147,7 @@ describe('BounderOverlappingTest', () => {
   it('northeast', () => {
     const anchor = bounds(340, 235, 80, 80);
     check({
-      label: 'layout-inner-ne',
+      label: 'layout-inner-northeast',
       x: anchor.x + 1,                            // 341
       y: anchor.y - 1                             // 234
     }, four, anchor, panelBox, bubb, view);
@@ -155,7 +156,7 @@ describe('BounderOverlappingTest', () => {
   it('northwest', () => {
     const anchor = bounds(40, 235, 50, 50);
     check({
-      label: 'layout-inner-nw',
+      label: 'layout-inner-northwest',
       x: anchor.right - panelBox.width - 1,       // 74
       y: anchor.y - 1                             // 234
     }, four, anchor, panelBox, bubb, view);
@@ -164,7 +165,7 @@ describe('BounderOverlappingTest', () => {
   it('all fit -> southeast because of order of preference', () => {
     const anchor = bounds(270, 100, 100, 100);
     check({
-      label: 'layout-inner-se',
+      label: 'layout-inner-southeast',
       x: anchor.x + 1,                            // 271
       y: anchor.bottom - panelBox.height + 2      // 192
     }, four, anchor, panelBox, bubb, view);
@@ -173,7 +174,7 @@ describe('BounderOverlappingTest', () => {
   it('none -> best fit is southeast', () => {
     const anchor = bounds(60, 40, view.width, view.height + 15);
     check({
-      label: 'layout-inner-se',
+      label: 'layout-inner-southeast',
       x: anchor.x + 1,                            // 61
       y: view.bottom - bigPanel.height,           // 170 - Constrained within viewport
       candidateY: anchor.bottom - bigPanel.height + 2, // 177
@@ -183,7 +184,7 @@ describe('BounderOverlappingTest', () => {
   it('none -> best fit is southwest', () => {
     const anchor = bounds(40, 40, view.width + 15, view.height);
     check({
-      label: 'layout-inner-sw',
+      label: 'layout-inner-southwest',
       x: view.right - bigPanel.width - 1,         // 299 - Constrained within viewport
       y: anchor.bottom - bigPanel.height + 2,     // 177
     }, four, anchor, bigPanel, bubb, view);
@@ -192,7 +193,7 @@ describe('BounderOverlappingTest', () => {
   it('none -> best fit is northeast', () => {
     const anchor = bounds(45, 55, view.width + 15, view.height);
     check({
-      label: 'layout-inner-ne',
+      label: 'layout-inner-northeast',
       x: view.x + 1,                              // 51 - Constrained within viewport
       y: anchor.y - 1,                            // 54
     }, four, anchor, bigPanel, bubb, view);
@@ -201,7 +202,7 @@ describe('BounderOverlappingTest', () => {
   it('none -> best fit is northwest', () => {
     const anchor = bounds(40, 45, view.width, view.height + 15);
     check({
-      label: 'layout-inner-nw',
+      label: 'layout-inner-northwest',
       x: anchor.right - bigPanel.width - 1,       // 289
       y: view.y,                                  // 50 - constrained within viewport
       candidateY: anchor.y - 1,                   // 44
@@ -212,7 +213,7 @@ describe('BounderOverlappingTest', () => {
     // Note: The additional -2 here is to account for the southeast bubble y offsets
     const anchor = bounds(view.y + 1, view.bottom - 20 - 2 - 1, 20, 20);
     check({
-      label: 'layout-inner-se',
+      label: 'layout-inner-southeast',
       x: anchor.x + 1,                            // 51
       y: anchor.bottom - panelBox.height + 2,     // 259
     }, four, anchor, panelBox, bubb, view);
@@ -222,7 +223,7 @@ describe('BounderOverlappingTest', () => {
     // Note: The additional -2 here is to account for the southeast bubble y offsets
     const anchor = bounds(view.y, view.bottom - 20 - 2, 20, 20);
     check({
-      label: 'layout-inner-se',
+      label: 'layout-inner-southeast',
       x: anchor.x + 1,                            // 50
       y: anchor.bottom - panelBox.height + 2,     // 260
     }, four, anchor, panelBox, bubb, view);
@@ -232,7 +233,7 @@ describe('BounderOverlappingTest', () => {
     // Note: The additional -2 here is to account for the southeast bubble y offsets
     const anchor = bounds(view.y - 1, view.bottom - 30 - 2, 30, 30);
     check({
-      label: 'layout-inner-sw',
+      label: 'layout-inner-southwest',
       x: anchor.right - panelBox.width - 1,       // 63
       y: anchor.bottom - panelBox.height + 2,     // 260
     }, four, anchor, panelBox, bubb, view);
@@ -242,7 +243,7 @@ describe('BounderOverlappingTest', () => {
     // Note: The additional -2 here is to account for the southeast bubble y offsets
     const anchor = bounds(view.y, view.bottom - 30 - 2 + 1, 30, 30);
     check({
-      label: 'layout-inner-ne',
+      label: 'layout-inner-northeast',
       x: anchor.x + 1,                            // 50
       y: anchor.y - 1                             // 238
     }, four, anchor, panelBox, bubb, view);
@@ -252,7 +253,7 @@ describe('BounderOverlappingTest', () => {
     // Note: The additional -2 here is to account for the southeast bubble y offsets
     const anchor = bounds(view.y - 1, view.bottom - 30 - 2 + 1, 30, 30);
     check({
-      label: 'layout-inner-nw',
+      label: 'layout-inner-northwest',
       x: anchor.right - panelBox.width - 1,       // 63
       y: anchor.y - 1                             // 238
     }, four, anchor, panelBox, bubb, view);
@@ -261,7 +262,7 @@ describe('BounderOverlappingTest', () => {
   it('east', () => {
     const anchor = bounds(55, 150, 100, 100);
     check({
-      label: 'layout-inner-e',
+      label: 'layout-inner-east',
       x: anchor.right - panelBox.width + 1,                         // 141
       y: anchor.y + (anchor.height / 2) - (panelBox.height / 2) + 1 // 196
     }, two, anchor, panelBox, bubb, view);
@@ -270,7 +271,7 @@ describe('BounderOverlappingTest', () => {
   it('none near bottom left -> best fit is east (limited to bottom bounds)', () => {
     const anchor = bounds(55, 240, 100, 100);
     check({
-      label: 'layout-inner-e',
+      label: 'layout-inner-east',
       x: anchor.right - panelBox.width + 1,       // 141
       y: view.bottom - panelBox.height            // 260 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);
@@ -279,7 +280,7 @@ describe('BounderOverlappingTest', () => {
   it('none near top left -> best fit is east (limited to top bounds)', () => {
     const anchor = bounds(55, 0, 100, 100);
     check({
-      label: 'layout-inner-e',
+      label: 'layout-inner-east',
       x: anchor.right - panelBox.width + 1,       // 141
       y: view.y,                                  // 50 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);
@@ -288,7 +289,7 @@ describe('BounderOverlappingTest', () => {
   it('west', () => {
     const anchor = bounds(320, 150, 100, 100);
     check({
-      label: 'layout-inner-w',
+      label: 'layout-inner-west',
       x: anchor.x + 1,                                              // 321
       y: anchor.y + (anchor.height / 2) - (panelBox.height / 2) + 1 // 196
     }, two, anchor, panelBox, bubb, view);
@@ -297,7 +298,7 @@ describe('BounderOverlappingTest', () => {
   it('none near bottom right -> best fit is west (limited to bottom bounds)', () => {
     const anchor = bounds(320, 240, 100, 100);
     check({
-      label: 'layout-inner-w',
+      label: 'layout-inner-west',
       x: anchor.x + 1,                            // 321
       y: view.bottom - panelBox.height            // 260 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);
@@ -306,7 +307,7 @@ describe('BounderOverlappingTest', () => {
   it('none near top right -> best fit is west (limited to top bounds)', () => {
     const anchor = bounds(320, 0, 100, 100);
     check({
-      label: 'layout-inner-w',
+      label: 'layout-inner-west',
       x: anchor.x + 1,                            // 321
       y: view.y,                                  // 50 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);

--- a/modules/alloy/src/test/ts/browser/position/view/BounderToolbuttonTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/view/BounderToolbuttonTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { SugarPosition } from '@ephox/sugar';
+import { SugarElement, SugarPosition } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { Bounds, bounds } from 'ephox/alloy/alien/Boxes';
@@ -18,7 +18,8 @@ interface TestDecisionSpec {
 
 describe('BounderToolbuttonTest', () => {
   const check = (expected: TestDecisionSpec, preference: AnchorLayout[], anchor: AnchorBox, panel: AnchorElement, bubbles: Bubble, bounds: Bounds) => {
-    const actual = Bounder.attempts(preference, anchor, panel, bubbles, bounds);
+    const placee = SugarElement.fromTag('div');
+    const actual = Bounder.attempts(placee, preference, anchor, panel, bubbles, bounds);
     assert.equal(actual.label, expected.label, 'label');
     assert.equal(actual.rect.x, expected.x, 'X');
     assert.equal(actual.rect.y, expected.y, 'Y');
@@ -129,7 +130,7 @@ describe('BounderToolbuttonTest', () => {
   it('southeast', () => {
     const anchor = bounds(100, 55, 10, 10);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x - 1,                            // 99
       y: anchor.bottom - 2                        // 63
     }, four, anchor, panelBox, bubb, view);
@@ -138,7 +139,7 @@ describe('BounderToolbuttonTest', () => {
   it('southwest', () => {
     const anchor = bounds(320, 55, 30, 10);
     check({
-      label: 'layout-sw',
+      label: 'layout-southwest',
       x: anchor.right - panelBox.width + 31,      // 281
       y: anchor.bottom - 2                        // 63
     }, four, anchor, panelBox, bubb, view);
@@ -147,7 +148,7 @@ describe('BounderToolbuttonTest', () => {
   it('northeast', () => {
     const anchor = bounds(140, 235, 10, 10);
     check({
-      label: 'layout-ne',
+      label: 'layout-northeast',
       x: anchor.x - 1,                            // 139
       y: anchor.y - panelBox.height + 1           // 161
     }, four, anchor, panelBox, bubb, view);
@@ -156,7 +157,7 @@ describe('BounderToolbuttonTest', () => {
   it('northwest', () => {
     const anchor = bounds(320, 235, 10, 10);
     check({
-      label: 'layout-nw',
+      label: 'layout-northwest',
       x: anchor.right - panelBox.width + 31,      // 261
       y: anchor.y - panelBox.height + 1           // 161
     }, four, anchor, panelBox, bubb, view);
@@ -165,7 +166,7 @@ describe('BounderToolbuttonTest', () => {
   it('all fit -> southeast because of order of preference', () => {
     const anchor = bounds(270, 100, 10, 10);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x - 1,                            // 269
       y: anchor.bottom - 2                        // 108
     }, four, anchor, panelBox, bubb, view);
@@ -174,7 +175,7 @@ describe('BounderToolbuttonTest', () => {
   it('none near top left -> best fit is southeast', () => {
     const anchor = bounds(55, 55, 10, 10);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x - 1,                            // 54
       y: anchor.bottom - 2                        // 63
     }, four, anchor, bigPanel, bubb, view);
@@ -183,7 +184,7 @@ describe('BounderToolbuttonTest', () => {
   it('none near top right -> best fit is southwest', () => {
     const anchor = bounds(350, 55, 10, 10);
     check({
-      label: 'layout-sw',
+      label: 'layout-southwest',
       x: anchor.right - bigPanel.width + 31,      // 316
       y: anchor.bottom - 2                        // 63
     }, four, anchor, bigPanel, bubb, view);
@@ -192,7 +193,7 @@ describe('BounderToolbuttonTest', () => {
   it('none near bottom left -> best fit is northeast', () => {
     const anchor = bounds(55, 200, 10, 10);
     check({
-      label: 'layout-ne',
+      label: 'layout-northeast',
       x: anchor.x - 1,                            // 54
       y: view.y,                                  // 50 - constrained within viewport
       candidateY: anchor.y - bigPanel.height + 1, // -299
@@ -202,7 +203,7 @@ describe('BounderToolbuttonTest', () => {
   it('none near bottom right -> best fit is northwest', () => {
     const anchor = bounds(350, 200, 10, 10);
     check({
-      label: 'layout-nw',
+      label: 'layout-northwest',
       x: anchor.right - bigPanel.width + 31,      // 316
       y: view.y,                                  // 50 - constrained within viewport
       candidateY: anchor.y - bigPanel.height + 1, // -299
@@ -213,7 +214,7 @@ describe('BounderToolbuttonTest', () => {
     // Note: The additional +1/+2 here is to account for the southeast bubble x/y offsets
     const anchor = bounds(view.right - panelBox.width + 1 - 1, view.bottom - panelBox.height - 10 + 2 - 1, 10, 10);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x - 1,                            // 299
       y: anchor.bottom - 2,                       // 194
     }, four, anchor, panelBox, bubb, view);
@@ -223,7 +224,7 @@ describe('BounderToolbuttonTest', () => {
     // Note: The additional +1/+2 here is to account for the southeast bubble x/y offsets
     const anchor = bounds(view.right - panelBox.width + 1, view.bottom - panelBox.height - 10 + 2, 10, 10);
     check({
-      label: 'layout-se',
+      label: 'layout-southeast',
       x: anchor.x - 1,                            // 300
       y: anchor.bottom - 2,                       // 195
     }, four, anchor, panelBox, bubb, view);
@@ -233,7 +234,7 @@ describe('BounderToolbuttonTest', () => {
     // Note: The additional +1/+2 here is to account for the southeast bubble x/y offsets
     const anchor = bounds(view.right - panelBox.width + 1 + 1, view.bottom - panelBox.height - 10 + 2, 10, 10);
     check({
-      label: 'layout-sw',
+      label: 'layout-southwest',
       x: anchor.right - panelBox.width + 31,      // 243
       y: anchor.bottom - 2,                       // 195
     }, four, anchor, panelBox, bubb, view);
@@ -243,7 +244,7 @@ describe('BounderToolbuttonTest', () => {
     // Note: The additional +1/+2 here is to account for the southeast bubble x/y offsets
     const anchor = bounds(view.right - panelBox.width + 1, view.bottom - panelBox.height - 10 + 2 + 1, 10, 10);
     check({
-      label: 'layout-ne',
+      label: 'layout-northeast',
       x: anchor.x - 1,                            // 300
       y: anchor.y - panelBox.height + 1           // 114
     }, four, anchor, panelBox, bubb, view);
@@ -253,7 +254,7 @@ describe('BounderToolbuttonTest', () => {
     // Note: The additional +1/+2 here is to account for the southeast bubble x/y offsets
     const anchor = bounds(view.right - panelBox.width + 1 + 1, view.bottom - panelBox.height - 10 + 2 + 1, 10, 10);
     check({
-      label: 'layout-nw',
+      label: 'layout-northwest',
       x: anchor.right - panelBox.width + 31,      // 243
       y: anchor.y - panelBox.height + 1           // 114
     }, four, anchor, panelBox, bubb, view);
@@ -262,7 +263,7 @@ describe('BounderToolbuttonTest', () => {
   it('east', () => {
     const anchor = bounds(55, 150, 10, 10);
     check({
-      label: 'layout-e',
+      label: 'layout-east',
       x: anchor.right - 1,                                          // 64
       y: anchor.y + (anchor.height / 2) - (panelBox.height / 2) + 1 // 118.5
     }, two, anchor, panelBox, bubb, view);
@@ -271,7 +272,7 @@ describe('BounderToolbuttonTest', () => {
   it('none near bottom left -> best fit is east (limited to bottom bounds)', () => {
     const anchor = bounds(55, 240, 10, 10);
     check({
-      label: 'layout-e',
+      label: 'layout-east',
       x: anchor.right - 1,                        // 64
       y: view.bottom - panelBox.height            // 195 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);
@@ -280,7 +281,7 @@ describe('BounderToolbuttonTest', () => {
   it('none near top left -> best fit is east (limited to top bounds)', () => {
     const anchor = bounds(55, 80, 10, 10);
     check({
-      label: 'layout-e',
+      label: 'layout-east',
       x: anchor.right - 1,                        // 64
       y: view.y,                                  // 50 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);
@@ -289,7 +290,7 @@ describe('BounderToolbuttonTest', () => {
   it('west', () => {
     const anchor = bounds(350, 150, 10, 10);
     check({
-      label: 'layout-w',
+      label: 'layout-west',
       x: anchor.x - panelBox.width - 1,                             // 249
       y: anchor.y + (anchor.height / 2) - (panelBox.height / 2) + 1 // 118.5
     }, two, anchor, panelBox, bubb, view);
@@ -298,7 +299,7 @@ describe('BounderToolbuttonTest', () => {
   it('none near bottom right -> best fit is west (limited to bottom bounds)', () => {
     const anchor = bounds(350, 240, 10, 10);
     check({
-      label: 'layout-w',
+      label: 'layout-west',
       x: anchor.x - panelBox.width - 1,           // 249
       y: view.bottom - panelBox.height            // 195 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);
@@ -307,7 +308,7 @@ describe('BounderToolbuttonTest', () => {
   it('none near top right -> best fit is west (limited to top bounds)', () => {
     const anchor = bounds(350, 80, 10, 10);
     check({
-      label: 'layout-w',
+      label: 'layout-west',
       x: anchor.x - panelBox.width - 1,           // 249
       y: view.y,                                  // 50 - constrained within viewport
     }, two, anchor, panelBox, bubb, view);

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504
-- When scrolling the context toolbar will stick to where it was previously for large elements, such as tables #TINY-7545
+- When scrolling, the context toolbar will stick to where it was previously for large elements, such as tables #TINY-7545
 
 ### Changed
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents. #TINY-7249

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504
+- When scrolling the context toolbar will stick to where it was previously for large elements, such as tables #TINY-7545
 
 ### Changed
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents. #TINY-7249

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
@@ -101,14 +101,6 @@ export default () => {
     setup: (ed: Editor) => {
       ButtonSetupDemo.setup(ed);
 
-      ed.on('skinLoaded', () => {
-        // Notification fields for equality: type, text, progressBar, timeout
-        ed.notificationManager.open({
-          text: 'You will not see this because the mobile theme has no notifications',
-          type: 'info'
-        });
-      });
-
       ed.ui.registry.addButton('MagicButton', {
         text: 'yeah button text',
         onAction: () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -219,4 +219,32 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     await UiFinder.pWaitForHidden('Waiting for toolbar to be hidden', SugarBody.body(), '.tox-pop');
     Css.remove(TinyDom.container(editor), 'margin-bottom');
   });
+
+  it('TINY-7545: Context toolbar preserves the previous position when scrolling top to bottom and back', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<p style="padding-top: 200px"></p>' +
+      `<p><img src="${getGreenImageDataUrl()}" style="height: 500px; width: 100px"></p>` +
+      '<p style="padding-top: 200px"></p>'
+    );
+    TinySelections.select(editor, 'img', []);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top outside content', SugarBody.body(), '.tox-pop.tox-pop--bottom');
+    await pAssertPosition('bottom', 111);
+
+    scrollTo(editor, 0, 400);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), '.tox-pop.tox-pop--top');
+    await pAssertPosition('top', -309);
+
+    // Note: Can't wait for the anchor classes here as they will remain the same
+    scrollTo(editor, 0, 700);
+    await pAssertPosition('top', -234);
+
+    scrollTo(editor, 0, 400);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the bottom inside content', SugarBody.body(), '.tox-pop.tox-pop--bottom');
+    await pAssertPosition('bottom', 12);
+
+    // Note: Can't wait for the anchor classes here as they will remain the same
+    scrollTo(editor, 0, 0);
+    await pAssertPosition('bottom', 111);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7545

Description of Changes:
This is part 3 of 3 PRs to get this working. This finally adds in the new `preserve` functionality to `LayoutInside` which will attempt to preserve the previous layout that was used for the component. This is done by storing the placement of the layout as chosen by `Bounder` via the `data-alloy-placement` attribute and then looking this up when repositioning.

This also cleans up the `ContextToolbar` logic a little, mainly just removing the duplicate `debounce` implementation we had going on.

**Note:** This builds on and does some reworking of the work done by @HAFRMO in https://github.com/tinymce/tinymce/pull/6725

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
