### PR TITLE
TINY-6297: Push editor rendering on focus into another event loop

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
 - Partially transparent RGBA values provided in the `color_map` setting were given the wrong hex value #TINY-7163
 - Fixed an issue when pasting cells from tables containing `colgroup`s into tables without `colgroup`s #TINY-6675
+- Fixed an issue that could cause invalid toolbar button state when multiple inline editors were on a single page #TINY-6297
 
 ## 5.8.1 - 2021-05-20
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -126,7 +126,7 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
 
   editor.on('init', () => {
     if (editor.hasFocus() || toolbarPersist) {
-      render();
+      delayedRender();
     }
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -112,11 +112,15 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     editor.nodeChanged();
   };
 
+  // In certain circumstances we need to delay the render function until the next
+  // event loop to ensure things like the current selection are correct.
+  const delayedRender = () => Delay.setEditorTimeout(editor, render, 0);
+
   editor.on('show', render);
   editor.on('hide', ui.hide);
 
   if (!toolbarPersist) {
-    editor.on('focus', render);
+    editor.on('focus', delayedRender);
     editor.on('blur', ui.hide);
   }
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
@@ -6,7 +6,7 @@ import { SugarBody } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../module/TestUtils';
+import * as TestUtils from '../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
   const base_url = '/project/tinymce/js/tinymce';
@@ -37,7 +37,7 @@ describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
     ]
   });
 
-  const pFocusEditor = async (editor: Editor) => {
+  const pActivateEditor = async (editor: Editor) => {
     editor.focus();
     await TestUtils.pWaitForEditorToRender();
   };
@@ -45,7 +45,7 @@ describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
   it('TINY-6048: Inline editor should hide UI on editor hide', async () => {
     const editor = await McEditor.pFromSettings<Editor>({ base_url, inline: true });
     // Bring out the UI
-    await pFocusEditor(editor);
+    await pActivateEditor(editor);
     await pWaitForVisible('UI should be on the screen', '.tox-toolbar');
     // Hide the editor
     editor.hide();
@@ -69,7 +69,7 @@ describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
   it('TINY-6048: Inline editor should close dialogs on editor hide', async () => {
     const editor = await McEditor.pFromSettings<Editor>({ base_url, inline: true });
     // Bring out the UI
-    await pFocusEditor(editor);
+    await pActivateEditor(editor);
     openDialog(editor);
     await pWaitForVisible('Dialog should be on the screen', '.tox-dialog');
     // Hide the editor

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
@@ -6,6 +6,8 @@ import { SugarBody } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
+import * as TestUtils from '../../module/TestUtils';
+
 describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
   const base_url = '/project/tinymce/js/tinymce';
 
@@ -35,10 +37,15 @@ describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
     ]
   });
 
+  const pFocusEditor = async (editor: Editor) => {
+    editor.focus();
+    await TestUtils.pWaitForEditorToRender();
+  };
+
   it('TINY-6048: Inline editor should hide UI on editor hide', async () => {
     const editor = await McEditor.pFromSettings<Editor>({ base_url, inline: true });
     // Bring out the UI
-    editor.focus();
+    await pFocusEditor(editor);
     await pWaitForVisible('UI should be on the screen', '.tox-toolbar');
     // Hide the editor
     editor.hide();
@@ -62,7 +69,7 @@ describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
   it('TINY-6048: Inline editor should close dialogs on editor hide', async () => {
     const editor = await McEditor.pFromSettings<Editor>({ base_url, inline: true });
     // Bring out the UI
-    editor.focus();
+    await pFocusEditor(editor);
     openDialog(editor);
     await pWaitForVisible('Dialog should be on the screen', '.tox-dialog');
     // Hide the editor

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
@@ -6,7 +6,7 @@ import { SugarBody } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../module/UiUtils';
+import * as UiUtils from '../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
   const base_url = '/project/tinymce/js/tinymce';
@@ -39,7 +39,7 @@ describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
 
   const pActivateEditor = async (editor: Editor) => {
     editor.focus();
-    await TestUtils.pWaitForEditorToRender();
+    await UiUtils.pWaitForEditorToRender();
   };
 
   it('TINY-6048: Inline editor should hide UI on editor hide', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
@@ -6,7 +6,7 @@ import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../module/UiUtils';
+import * as UiUtils from '../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTest', () => {
   let toolbar: SugarElement<HTMLDivElement>;
@@ -31,7 +31,7 @@ describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTest',
     const editor = hook.editor();
     editor.setContent('fixed_toolbar_container test');
     editor.focus();
-    await TestUtils.pWaitForEditorToRender();
+    await UiUtils.pWaitForEditorToRender();
     Assertions.assertStructure(
       'Container structure',
       ApproxStructure.build((s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
@@ -6,6 +6,8 @@ import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
+import * as TestUtils from '../../module/TestUtils';
+
 describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTest', () => {
   let toolbar: SugarElement<HTMLDivElement>;
   before(() => {
@@ -25,10 +27,11 @@ describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTest',
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme ]);
 
-  it('Check basic structure', () => {
+  it('Check basic structure', async () => {
     const editor = hook.editor();
     editor.setContent('fixed_toolbar_container test');
     editor.focus();
+    await TestUtils.pWaitForEditorToRender();
     Assertions.assertStructure(
       'Container structure',
       ApproxStructure.build((s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
@@ -6,7 +6,7 @@ import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../module/TestUtils';
+import * as TestUtils from '../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTest', () => {
   let toolbar: SugarElement<HTMLDivElement>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -10,6 +10,8 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Theme from 'tinymce/themes/silver/Theme';
 
+import * as TestUtils from '../../module/TestUtils';
+
 describe('browser.tinymce.themes.silver.editor.SilverInlineEditorTest', () => {
   const store = Cell([ ]);
   const hook = TinyHooks.bddSetup<Editor>({
@@ -132,8 +134,9 @@ describe('browser.tinymce.themes.silver.editor.SilverInlineEditorTest', () => {
     }
   }, [ Theme ]);
 
-  beforeEach(() => {
+  beforeEach(async () => {
     hook.editor().focus();
+    await TestUtils.pWaitForEditorToRender();
   });
 
   it('Check basic container structure and actions', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../module/TestUtils';
+import * as TestUtils from '../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.SilverInlineEditorTest', () => {
   const store = Cell([ ]);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../module/UiUtils';
+import * as UiUtils from '../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.SilverInlineEditorTest', () => {
   const store = Cell([ ]);
@@ -136,7 +136,7 @@ describe('browser.tinymce.themes.silver.editor.SilverInlineEditorTest', () => {
 
   beforeEach(async () => {
     hook.editor().focus();
-    await TestUtils.pWaitForEditorToRender();
+    await UiUtils.pWaitForEditorToRender();
   });
 
   it('Check basic container structure and actions', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -9,7 +9,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 import { getContextToolbarBounds } from 'tinymce/themes/silver/ui/context/ContextToolbarBounds';
 
 import TestBackstage from '../../../module/TestBackstage';
-import * as TestUtils from '../../../module/UiUtils';
+import * as UiUtils from '../../../module/UiUtils';
 
 interface TestBounds {
   readonly header: Bounds;
@@ -97,7 +97,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
       });
       backstage.shared.header.setDockingMode(editor.settings.toolbar_location);
       editor.focus();
-      await TestUtils.pWaitForEditorToRender();
+      await UiUtils.pWaitForEditorToRender();
       scrollRelativeEditorContainer(editor, scenario.scroll.relativeTop, scenario.scroll.delta);
       assertToolbarBounds(editor, scenario);
       McEditor.remove(editor);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -9,7 +9,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 import { getContextToolbarBounds } from 'tinymce/themes/silver/ui/context/ContextToolbarBounds';
 
 import TestBackstage from '../../../module/TestBackstage';
-import * as TestUtils from '../../../module/TestUtils';
+import * as TestUtils from '../../../module/UiUtils';
 
 interface TestBounds {
   readonly header: Bounds;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -9,6 +9,7 @@ import Theme from 'tinymce/themes/silver/Theme';
 import { getContextToolbarBounds } from 'tinymce/themes/silver/ui/context/ContextToolbarBounds';
 
 import TestBackstage from '../../../module/TestBackstage';
+import * as TestUtils from '../../../module/TestUtils';
 
 interface TestBounds {
   readonly header: Bounds;
@@ -96,6 +97,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
       });
       backstage.shared.header.setDockingMode(editor.settings.toolbar_location);
       editor.focus();
+      await TestUtils.pWaitForEditorToRender();
       scrollRelativeEditorContainer(editor, scenario.scroll.relativeTop, scenario.scroll.delta);
       assertToolbarBounds(editor, scenario);
       McEditor.remove(editor);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -7,6 +7,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings, ToolbarMode } from 'tinymce/core/api/SettingsTypes';
 import Theme from 'tinymce/themes/silver/Theme';
 
+import * as TestUtils from '../../../module/TestUtils';
+
 describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest', () => {
   before(() => {
     Theme();
@@ -27,6 +29,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       base_url: '/project/tinymce/js/tinymce'
     });
     editor.focus();
+    await TestUtils.pWaitForEditorToRender();
     assertToolbarToggleState(editor, false);
     editor.execCommand('ToggleToolbarDrawer');
     assertToolbarToggleState(editor, shouldToggle);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -7,7 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings, ToolbarMode } from 'tinymce/core/api/SettingsTypes';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../../module/UiUtils';
+import * as UiUtils from '../../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest', () => {
   before(() => {
@@ -29,7 +29,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       base_url: '/project/tinymce/js/tinymce'
     });
     editor.focus();
-    await TestUtils.pWaitForEditorToRender();
+    await UiUtils.pWaitForEditorToRender();
     assertToolbarToggleState(editor, false);
     editor.execCommand('ToggleToolbarDrawer');
     assertToolbarToggleState(editor, shouldToggle);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -7,7 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings, ToolbarMode } from 'tinymce/core/api/SettingsTypes';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../../module/TestUtils';
+import * as TestUtils from '../../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest', () => {
   before(() => {

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestUtils.ts
@@ -1,0 +1,9 @@
+import { UiFinder, Waiter } from '@ephox/agar';
+import { SugarBody } from '@ephox/sugar';
+
+const pWaitForEditorToRender = () =>
+  Waiter.pTryUntil('Editor has rendered', () => UiFinder.exists(SugarBody.body(), '.tox-editor-header'));
+
+export {
+  pWaitForEditorToRender
+};

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestUtils.ts
@@ -1,9 +1,0 @@
-import { UiFinder, Waiter } from '@ephox/agar';
-import { SugarBody } from '@ephox/sugar';
-
-const pWaitForEditorToRender = () =>
-  Waiter.pTryUntil('Editor has rendered', () => UiFinder.exists(SugarBody.body(), '.tox-editor-header'));
-
-export {
-  pWaitForEditorToRender
-};

--- a/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
@@ -1,4 +1,4 @@
-import { Mouse, UiFinder } from '@ephox/agar';
+import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { Arr } from '@ephox/katamari';
 import { TinyDom } from '@ephox/mcagar';
 import { Scroll, SugarBody, SugarElement } from '@ephox/sugar';
@@ -42,9 +42,13 @@ const scrollRelativeEditor = (editor: Editor, relative: 'top' | 'bottom' = 'top'
   Scroll.to(0, window.pageYOffset + deltaY);
 };
 
+const pWaitForEditorToRender = () =>
+  Waiter.pTryUntil('Editor has rendered', () => UiFinder.exists(SugarBody.body(), '.tox-editor-header'));
+
 export {
   countNumber,
   extractOnlyOne,
   resizeToPos,
-  scrollRelativeEditor
+  scrollRelativeEditor,
+  pWaitForEditorToRender
 };

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
@@ -7,14 +7,16 @@ import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.core.SimpleControlsInlineTest', () => {
-  before(() => Theme());
+  before(() => {
+    Theme();
+  });
 
   const settings = {
     inline: true,
     base_url: '/project/tinymce/js/tinymce'
   };
 
-  const pAssertToolbarButtonPressed = (title: string, pressed: boolean = true) =>
+  const pAssertToolbarButtonPressed = (title: string, pressed: boolean) =>
     Waiter.pTryUntil('button pressed', () => UiFinder.exists(SugarBody.body(), `button[title="${title}"][aria-pressed="${pressed ? 'true' : 'false'}"]`));
 
   it('TINY-6675: Button state on multiple inline editors is correct', async () => {
@@ -23,7 +25,7 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsInlineTest', (
     editorOne.setContent('<p id="number1"><strong>blarg</strong></p>');
     editorTwo.setContent('<p id="number2">blarg</p>');
     await RealMouse.pClickOn('#number1');
-    await pAssertToolbarButtonPressed('Bold');
+    await pAssertToolbarButtonPressed('Bold', true);
     await RealMouse.pClickOn('#number2');
     await pAssertToolbarButtonPressed('Bold', false);
     McEditor.remove(editorOne);

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
@@ -1,0 +1,32 @@
+import { RealMouse, UiFinder, Waiter } from '@ephox/agar';
+import { before, describe, it } from '@ephox/bedrock-client';
+import { McEditor } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
+
+describe('browser.tinymce.themes.silver.editor.core.SimpleControlsInlineTest', () => {
+  before(() => Theme());
+
+  const settings = {
+    inline: true,
+    base_url: '/project/tinymce/js/tinymce'
+  };
+
+  const pAssertToolbarButtonPressed = (title: string, pressed: boolean = true) =>
+    Waiter.pTryUntil('button pressed', () => UiFinder.exists(SugarBody.body(), `button[title="${title}"][aria-pressed="${pressed ? 'true' : 'false'}"]`));
+
+  it('TINY-6675: Button state on multiple inline editors is correct', async () => {
+    const editorOne = await McEditor.pFromSettings<Editor>(settings);
+    const editorTwo = await McEditor.pFromSettings<Editor>(settings);
+    editorOne.setContent('<p id="number1"><strong>blarg</strong></p>');
+    editorTwo.setContent('<p id="number2">blarg</p>');
+    await RealMouse.pClickOn('#number1');
+    await pAssertToolbarButtonPressed('Bold');
+    await RealMouse.pClickOn('#number2');
+    await pAssertToolbarButtonPressed('Bold', false);
+    McEditor.remove(editorOne);
+    McEditor.remove(editorTwo);
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../module/UiUtils';
+import * as UiUtils from '../../module/UiUtils';
 
 describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -60,7 +60,7 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
 
   const pFocusAndWaitForRender = async (selector: string) => {
     FocusTools.setFocus(SugarBody.body(), selector);
-    await TestUtils.pWaitForEditorToRender();
+    await UiUtils.pWaitForEditorToRender();
   };
 
   it('TINY-7373: should be able to tab into editor if throbber is disabled', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
@@ -9,6 +9,8 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Theme from 'tinymce/themes/silver/Theme';
 
+import * as TestUtils from '../../module/TestUtils';
+
 describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
@@ -56,9 +58,14 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
     await pAssertFocus();
   };
 
+  const pSetFocus = async (selector: string) => {
+    FocusTools.setFocus(SugarBody.body(), selector);
+    await TestUtils.pWaitForEditorToRender();
+  };
+
   it('TINY-7373: should be able to tab into editor if throbber is disabled', async () => {
     const editor = hook.editor();
-    FocusTools.setFocus(SugarBody.body(), '#beforeInput');
+    await pSetFocus('#beforeInput');
     await pPressTab('#beforeInput');
     await pAssertEditorFocus(editor)();
     assert.isTrue(editor.hasFocus());
@@ -66,7 +73,7 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
 
   it('TINY-7373: should take focus if editor is tabbed into and throbber is enabled', async () => {
     const editor = hook.editor();
-    FocusTools.setFocus(SugarBody.body(), '#beforeInput');
+    await pSetFocus('#beforeInput');
     await pEnableThrobber(editor, pAssertInputFocus(true));
 
     // Make sure throbber gets focus if the editor is tabbed into
@@ -79,7 +86,7 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
 
   it('TINY-7373: should be able to Tab out of the throbber if it has focus', async () => {
     const editor = hook.editor();
-    FocusTools.setFocus(SugarBody.body(), '#beforeInput');
+    await pSetFocus('#beforeInput');
     await pEnableThrobber(editor, pAssertInputFocus(true));
 
     await pPressTab('#beforeInput');
@@ -99,7 +106,7 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
     }
 
     const editor = hook.editor();
-    FocusTools.setFocus(SugarBody.body(), '#afterInput');
+    await pSetFocus('#afterInput');
     await pEnableThrobber(editor, pAssertInputFocus(false));
 
     await pPressTab('#afterInput', true);

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import * as TestUtils from '../../module/TestUtils';
+import * as TestUtils from '../../module/UiUtils';
 
 describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -58,14 +58,14 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
     await pAssertFocus();
   };
 
-  const pSetFocus = async (selector: string) => {
+  const pFocusAndWaitForRender = async (selector: string) => {
     FocusTools.setFocus(SugarBody.body(), selector);
     await TestUtils.pWaitForEditorToRender();
   };
 
   it('TINY-7373: should be able to tab into editor if throbber is disabled', async () => {
     const editor = hook.editor();
-    await pSetFocus('#beforeInput');
+    await pFocusAndWaitForRender('#beforeInput');
     await pPressTab('#beforeInput');
     await pAssertEditorFocus(editor)();
     assert.isTrue(editor.hasFocus());
@@ -73,7 +73,7 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
 
   it('TINY-7373: should take focus if editor is tabbed into and throbber is enabled', async () => {
     const editor = hook.editor();
-    await pSetFocus('#beforeInput');
+    await pFocusAndWaitForRender('#beforeInput');
     await pEnableThrobber(editor, pAssertInputFocus(true));
 
     // Make sure throbber gets focus if the editor is tabbed into
@@ -86,7 +86,7 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
 
   it('TINY-7373: should be able to Tab out of the throbber if it has focus', async () => {
     const editor = hook.editor();
-    await pSetFocus('#beforeInput');
+    await pFocusAndWaitForRender('#beforeInput');
     await pEnableThrobber(editor, pAssertInputFocus(true));
 
     await pPressTab('#beforeInput');
@@ -106,7 +106,7 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
     }
 
     const editor = hook.editor();
-    await pSetFocus('#afterInput');
+    await pFocusAndWaitForRender('#afterInput');
     await pEnableThrobber(editor, pAssertInputFocus(false));
 
     await pPressTab('#afterInput', true);


### PR DESCRIPTION
Related Ticket: TINY-6297

Description of Changes:
This fixes certain operations performing on a selection that may not be valid yet (e.g. the selection could be in another editor on the same page).

The bug reported was when two inline editors are on the same page, the toolbar state does not update correctly when you move your selection to another editor.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): Fixes #5947
