### PR TITLE
TINY-7588: Fixed new `prefer-fun` errors for `Fun.identity` usage

### DIFF
--- a/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
+++ b/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
@@ -1,5 +1,5 @@
 import { Channels, Debugging, Gui, GuiFactory } from '@ephox/alloy';
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { Class, DomEvent, Insert, SugarElement } from '@ephox/sugar';
 import * as ColourPicker from 'ephox/acid/gui/ColourPicker';
 import { strings } from '../../../../i18n/en';
@@ -24,9 +24,7 @@ const fakeTranslate = (key: string): string =>
     return key;
   });
 
-const fakeGetClass = (key: string): string => key;
-
-const colourPickerFactory = ColourPicker.makeFactory(fakeTranslate, fakeGetClass);
+const colourPickerFactory = ColourPicker.makeFactory(fakeTranslate, Fun.identity);
 
 const colourPicker = GuiFactory.build(colourPickerFactory.sketch({
   dom: {

--- a/modules/agar/src/main/ts/ephox/agar/api/NamedChain.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/NamedChain.ts
@@ -1,4 +1,4 @@
-import { Arr, Id, Obj, Result } from '@ephox/katamari';
+import { Arr, Fun, Id, Obj, Result } from '@ephox/katamari';
 
 import { DieFn, NextFn } from '../pipe/Pipe';
 import { Chain } from './Chain';
@@ -109,11 +109,11 @@ const pipeline = (namedChains: NamedChain[], onSuccess: NextFn<any>, onFailure: 
   Chain.pipeline([ asChain(namedChains) ], onSuccess, onFailure, initLogs);
 };
 
-const inputName = (): string => inputNameId;
+const inputName = Fun.constant(inputNameId);
 
 // tests need these values but other users should not
-export const _outputName = (): string => outputNameId;
-export const _outputUnset = (): string => outputUnset;
+export const _outputName = Fun.constant(outputNameId);
+export const _outputUnset = Fun.constant(outputUnset);
 
 export const NamedChain = {
   inputName,

--- a/modules/agar/src/test/ts/atomic/api/ChainTest.ts
+++ b/modules/agar/src/test/ts/atomic/api/ChainTest.ts
@@ -1,4 +1,5 @@
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { Chain } from 'ephox/agar/api/Chain';
 import * as Logger from 'ephox/agar/api/Logger';
 import { Pipeline } from 'ephox/agar/api/Pipeline';
@@ -183,7 +184,7 @@ UnitTest.asynctest('ChainTest', (success, failure) => {
     {},
     [
       Chain.asStep({}, [
-        Chain.injectThunked(() => 'cat'),
+        Chain.injectThunked(Fun.constant('cat')),
         cIsEqual('cat')
       ])
     ]

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/Component.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/Component.ts
@@ -86,7 +86,7 @@ const build = (spec: ComponentDetail): AlloyComponent => {
     // INVESTIGATE: Not sure about how to handle text nodes here.
     const subs = Arr.bind(children, (child) => systemApi.get().getByDom(child).fold(
       () => [ ],
-      (c) => [ c ]
+      Arr.pure
     ));
     subcomponents.set(subs);
   };

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
@@ -94,14 +94,14 @@ const isSimpleOrSketchSpec = (spec: AlloySpec): spec is SimpleOrSketchSpec =>
   Obj.has(spec as SimpleOrSketchSpec, 'uid');
 
 // INVESTIGATE: A better way to provide 'meta-specs'
-const build = (spec: AlloySpec): AlloyComponent => GuiTypes.getPremade(spec).fold(() => {
+const build = (spec: AlloySpec): AlloyComponent => GuiTypes.getPremade(spec).getOrThunk(() => {
   // EFFICIENCY: Consider not merging here, and passing uid through separately
   const userSpecWithUid = isSimpleOrSketchSpec(spec) ? spec : {
     uid: uids(''),
     ...spec
   } as SimpleOrSketchSpec;
   return buildFromSpec(userSpecWithUid).getOrDie();
-}, (prebuilt) => prebuilt);
+});
 
 const premade = GuiTypes.premade;
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyEvents.ts
@@ -120,7 +120,7 @@ const runWithTarget = <T extends EventFormat>(name: string, f: (component: Alloy
   return run(name, (component, simulatedEvent) => {
     const ev: T = simulatedEvent.event;
 
-    const target = component.getSystem().getByDom(ev.target).fold(
+    const target = component.getSystem().getByDom(ev.target).getOrThunk(
       // If we don't find an alloy component for the target, I guess we go up the tree
       // until we find an alloy component? Performance concern?
       // TODO: Write tests for this.
@@ -129,8 +129,7 @@ const runWithTarget = <T extends EventFormat>(name: string, f: (component: Alloy
 
         // If we still found nothing ... fire on component itself;
         return closest.getOr(component);
-      },
-      (c) => c
+      }
     );
 
     f(component, target, simulatedEvent);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Dropdown.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Dropdown.ts
@@ -31,24 +31,24 @@ const factory: CompositeSketchFactory<DropdownDetail, DropdownSpec> = (detail, c
 
   const action = (component: AlloyComponent): void => {
     const onOpenSync = switchToMenu;
-    DropdownUtils.togglePopup(detail, (x) => x, component, externals, onOpenSync, DropdownUtils.HighlightOnOpen.HighlightFirst).get(Fun.noop);
+    DropdownUtils.togglePopup(detail, Fun.identity, component, externals, onOpenSync, DropdownUtils.HighlightOnOpen.HighlightFirst).get(Fun.noop);
   };
 
   const apis: DropdownApis = {
     expand: (comp) => {
       if (!Toggling.isOn(comp)) {
-        DropdownUtils.togglePopup(detail, (x) => x, comp, externals, Fun.noop, DropdownUtils.HighlightOnOpen.HighlightNone).get(Fun.noop);
+        DropdownUtils.togglePopup(detail, Fun.identity, comp, externals, Fun.noop, DropdownUtils.HighlightOnOpen.HighlightNone).get(Fun.noop);
       }
     },
     open: (comp) => {
       if (!Toggling.isOn(comp)) {
-        DropdownUtils.togglePopup(detail, (x) => x, comp, externals, Fun.noop, DropdownUtils.HighlightOnOpen.HighlightFirst).get(Fun.noop);
+        DropdownUtils.togglePopup(detail, Fun.identity, comp, externals, Fun.noop, DropdownUtils.HighlightOnOpen.HighlightFirst).get(Fun.noop);
       }
     },
     isOpen: Toggling.isOn,
     close: (comp) => {
       if (Toggling.isOn(comp)) {
-        DropdownUtils.togglePopup(detail, (x) => x, comp, externals, Fun.noop, DropdownUtils.HighlightOnOpen.HighlightFirst).get(Fun.noop);
+        DropdownUtils.togglePopup(detail, Fun.identity, comp, externals, Fun.noop, DropdownUtils.HighlightOnOpen.HighlightFirst).get(Fun.noop);
       }
     },
     // If we are open, refresh the menus in the tiered menu system

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Form.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Form.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Optional, Result } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Result } from '@ephox/katamari';
 
 import * as AlloyLogger from '../../log/AlloyLogger';
 import * as AlloyParts from '../../parts/AlloyParts';
@@ -31,7 +31,7 @@ const sketch = (fSpec: FormSpecBuilder): SketchSpec => {
 
     return {
       field,
-      record: () => record
+      record: Fun.constant(record)
     };
   })();
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SlotContainer.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SlotContainer.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj } from '@ephox/katamari';
+import { Arr, Fun, Obj } from '@ephox/katamari';
 import { Attribute, Css } from '@ephox/sugar';
 
 import * as AlloyParts from '../../parts/AlloyParts';
@@ -33,7 +33,7 @@ const sketch = (sSpec: SlotContainerSpecBuilder): SketchSpec => {
 
     return {
       slot,
-      record: () => record
+      record: Fun.constant(record)
     };
   })();
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitDropdown.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitDropdown.ts
@@ -31,7 +31,7 @@ const factory: CompositeSketchFactory<SplitDropdownDetail, SplitDropdownSpec> = 
 
   const action = (component: AlloyComponent) => {
     const onOpenSync = switchToMenu;
-    DropdownUtils.togglePopup(detail, (x) => x, component, externals, onOpenSync, DropdownUtils.HighlightOnOpen.HighlightFirst).get(Fun.noop);
+    DropdownUtils.togglePopup(detail, Fun.identity, component, externals, onOpenSync, DropdownUtils.HighlightOnOpen.HighlightFirst).get(Fun.noop);
   };
 
   const openMenu = (comp: AlloyComponent) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaVoice.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaVoice.ts
@@ -1,4 +1,4 @@
-import { Id } from '@ephox/katamari';
+import { Fun, Id } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute, Css, Insert, Remove, SugarElement, Traverse } from '@ephox/sugar';
 
@@ -7,7 +7,7 @@ const offscreen = {
   left: '-9999px'
 };
 
-const tokenSelector = (): string => 'span[id^="ephox-alloy-aria-voice"]';
+const tokenSelector = Fun.constant('span[id^="ephox-alloy-aria-voice"]');
 
 // INVESTIGATE: Aria is special for insertion. Think about it more.
 const create = (doc: SugarElement<HTMLDocument>, text: string): SugarElement => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourBlob.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourBlob.ts
@@ -1,5 +1,6 @@
 import { FieldProcessor, FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Arr, Obj, Optional } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
+
 import { BehaviourState, BehaviourStateInitialiser, NoState } from './BehaviourState';
 import { AlloyBehaviour, BehaviourConfigDetail, BehaviourConfigSpec, BehaviourRecord } from './BehaviourTypes';
 
@@ -52,7 +53,7 @@ const generateFrom = (spec: { behaviours?: BehaviourRecord }, all: Array<AlloyBe
         config: blob.config,
         state: blob.state.init(blob.config)
       }));
-      return () => output;
+      return Fun.constant(output);
     })
   };
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourBlob.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourBlob.ts
@@ -44,7 +44,7 @@ const generateFrom = (spec: { behaviours?: BehaviourRecord }, all: Array<AlloyBe
       StructureSchema.formatError(errInfo) + '\nComplete spec:\n' +
         JSON.stringify(spec, null, 2)
     );
-  }, (v) => v);
+  }, Fun.identity);
 
   return {
     list: all,

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourState.ts
@@ -1,3 +1,5 @@
+import { Fun } from '@ephox/katamari';
+
 export interface BehaviourState {
   /** This is for debug purposes only, and only used by the Alloy Inspector Chrome Plugin */
   readState: () => any;
@@ -9,9 +11,7 @@ export interface BehaviourStateInitialiser<C, S extends BehaviourState> {
 
 const NoState: BehaviourStateInitialiser<any, BehaviourState> = {
   init: () => nu({
-    readState: () => {
-      return 'No State required';
-    }
+    readState: Fun.constant('No State required')
   })
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/reflecting/ReflectingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/reflecting/ReflectingState.ts
@@ -1,4 +1,4 @@
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional } from '@ephox/katamari';
 
 import { ReflectingState } from './ReflectingTypes';
 
@@ -9,7 +9,7 @@ const init = <S>(): ReflectingState<S> => {
   const clear = () => cell.set(Optional.none<S>());
   const get = () => cell.get();
 
-  const readState = (): any => cell.get().fold<any>(() => 'none', (x) => x);
+  const readState = (): any => cell.get().fold<any>(Fun.constant('none'), Fun.identity);
 
   return {
     readState,

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/DatasetStore.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/DatasetStore.ts
@@ -19,7 +19,7 @@ const setValue = (component: AlloyComponent, repConfig: DatasetRepresentingConfi
 const getValue = (component: AlloyComponent, repConfig: DatasetRepresentingConfig, repState: DatasetRepresentingState) => {
   const store = repConfig.store;
   const key = store.getDataKey(component);
-  return repState.lookup(key).fold(() => store.getFallbackEntry(key), (data) => data);
+  return repState.lookup(key).getOrThunk(() => store.getFallbackEntry(key));
 };
 
 const onLoad = (component: AlloyComponent, repConfig: DatasetRepresentingConfig, repState: DatasetRepresentingState) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/dom/DomModification.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dom/DomModification.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { DomDefinitionDetail } from './DomDefinition';
 
 export interface DomModification {
@@ -22,7 +23,7 @@ const modToStr = (mod: DomModification): string => {
   return JSON.stringify(raw, null, 2);
 };
 
-const modToRaw = (mod: DomModification): any => mod;
+const modToRaw: (mod: DomModification) => any = Fun.identity;
 
 const merge = (defnA: DomDefinitionDetail, mod: DomModification): DomDefinitionDetail => ({
   ...defnA,

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragMovement.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragMovement.ts
@@ -1,4 +1,4 @@
-import { Num, Optional, Optionals } from '@ephox/katamari';
+import { Fun, Num, Optional, Optionals } from '@ephox/katamari';
 import { Css, Scroll, SugarElement, SugarLocation, SugarPosition, Traverse } from '@ephox/sugar';
 
 import * as OffsetOrigin from '../../alien/OffsetOrigin';
@@ -35,7 +35,7 @@ const clampCoords = (component: AlloyComponent, coords: DragCoord.CoordAdt, scro
       return DragCoord.offset(offset.left, offset.top);
     },
     // absolute
-    () => newCoords,
+    Fun.constant(newCoords),
     // fixed
     () => {
       const fixed = DragCoord.asFixed(newCoords, scroll, origin);

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { SimRange, SugarElement } from '@ephox/sugar';
 
 import { Bounds } from '../../alien/Boxes';
@@ -135,7 +135,7 @@ export interface Anchoring {
   placer: Optional<AnchorPlacement>;
 }
 
-const nu: (spec: Anchoring) => Anchoring = (x) => x;
+const nu: (spec: Anchoring) => Anchoring = Fun.identity;
 
 export {
   nu

--- a/modules/alloy/src/main/ts/ephox/alloy/registry/Registry.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/registry/Registry.ts
@@ -22,10 +22,10 @@ export const Registry = (): Registry => {
 
   const readOrTag = (component: AlloyComponent): string => {
     const elem = component.element;
-    return Tagger.read(elem).fold(() =>
+    return Tagger.read(elem).getOrThunk(() =>
       // No existing tag, so add one.
       Tagger.write('uid-', component.element)
-    , (uid) => uid);
+    );
   };
 
   const failOnDuplicate = (component: AlloyComponent, tagId: string): void => {

--- a/modules/alloy/src/test/ts/atomic/api/DomDefinitionTest.ts
+++ b/modules/alloy/src/test/ts/atomic/api/DomDefinitionTest.ts
@@ -1,5 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Arr, Obj, Optional } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import Jsc from '@ephox/wrap-jsverify';
 
@@ -36,7 +36,7 @@ UnitTest.test('DomDefinitionTest', () => {
       (v) => [ true, v ]
     ),
     (opt: Optional<string>) => opt.fold(
-      () => 'None',
+      Fun.constant('None'),
       (v) => 'Some(' + v + ')'
     )
   );

--- a/modules/alloy/src/test/ts/browser/api/ComponentApisTest.ts
+++ b/modules/alloy/src/test/ts/browser/api/ComponentApisTest.ts
@@ -1,5 +1,6 @@
 import { Step, GeneralSteps, Logger, Assertions } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 
 import * as GuiFactory from 'ephox/alloy/api/component/GuiFactory';
 import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
@@ -18,7 +19,7 @@ UnitTest.asynctest('ComponentApisTest', (success, failure) => {
     apis: {
       doFirstThing: store.adder('doFirstThing'),
       doSecondThing: store.adder('doSecondThing'),
-      doThirdThing: () => 'thirdThing'
+      doThirdThing: Fun.constant('thirdThing')
     }
   }), (_doc, _body, _gui, component, store) => [
     Logger.t('Testing "doFirstThing"', GeneralSteps.sequence([

--- a/modules/alloy/src/test/ts/browser/parts/PartGenerateTest.ts
+++ b/modules/alloy/src/test/ts/browser/parts/PartGenerateTest.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { FieldSchema, Objects } from '@ephox/boulder';
-import { Obj } from '@ephox/katamari';
+import { Fun, Obj } from '@ephox/katamari';
 
 import * as AlloyParts from 'ephox/alloy/parts/AlloyParts';
 import * as PartType from 'ephox/alloy/parts/PartType';
@@ -9,7 +9,7 @@ import * as PartType from 'ephox/alloy/parts/PartType';
 UnitTest.test('Atomic Test: parts.GenerateTest', () => {
   const schema = [
     FieldSchema.required('test-data'),
-    FieldSchema.customField('state', () => 'state')
+    FieldSchema.customField('state', Fun.constant('state'))
   ];
 
   const internal = PartType.required({

--- a/modules/alloy/src/test/ts/module/ephox/alloy/log/AlloyLogger.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/log/AlloyLogger.ts
@@ -1,7 +1,8 @@
+import { Fun } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 // Used for atomic testing where window is not available.
-const element = (elem: SugarElement): SugarElement => elem;
+const element: (elem: SugarElement) => SugarElement = Fun.identity;
 
 export {
   element

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, Step, Waiter } from '@ephox/agar';
-import { Merger } from '@ephox/katamari';
+import { Fun, Merger } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
 
 import { Representing } from 'ephox/alloy/api/behaviour/Representing';
@@ -104,7 +104,7 @@ const assertLazySinkArgs = (expectedTag: string, expectedClass: string, comp: Al
   );
 };
 
-const itemMarkers = {
+const itemMarkers: TieredMenuSpec['markers'] = {
   item: 'item',
   selectedItem: 'selected-item',
   menu: 'menu',
@@ -112,7 +112,7 @@ const itemMarkers = {
   backgroundMenu: 'background-menu'
 };
 
-const markers = (): TieredMenuSpec['markers'] => itemMarkers;
+const markers = Fun.constant(itemMarkers);
 
 export {
   assertLazySinkArgs,

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/toolbar/TestPartialToolbarGroup.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/toolbar/TestPartialToolbarGroup.ts
@@ -22,7 +22,7 @@ const mungeItem = (itemSpec: AlloySpec) => Merger.deepMerge(
   }
 );
 
-const itemMarkers = {
+const itemMarkers: ToolbarGroupSpec['markers'] = {
   itemSelector: 'toolbar-item'
 };
 
@@ -46,7 +46,7 @@ const setGroups = (tb: AlloyComponent, gs: Array<{ items: AlloySpec[] }>): void 
 const createGroups = (gs: Array<{ items: AlloySpec[] }>): SketchSpec[] =>
   Arr.map(gs, Fun.compose(ToolbarGroup.sketch, munge));
 
-const markers = (): ToolbarGroupSpec['markers'] => itemMarkers;
+const markers = Fun.constant(itemMarkers);
 
 export {
   markers,

--- a/modules/boulder/src/main/ts/ephox/boulder/core/Utils.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/Utils.ts
@@ -1,3 +1,5 @@
+import { Fun } from '@ephox/katamari';
+
 import { SimpleResult } from '../alien/SimpleResult';
 import * as SchemaError from './SchemaError';
 import { StructureProcessor, ValueValidator } from './StructureProcessor';
@@ -10,7 +12,7 @@ const value = (validator: ValueValidator): StructureProcessor => {
     );
   };
 
-  const toString = () => 'val';
+  const toString = Fun.constant('val');
 
   return {
     extract,

--- a/modules/boulder/src/main/ts/ephox/boulder/format/PrettyPrinter.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/format/PrettyPrinter.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Type } from '@ephox/katamari';
 
 const formatObj = (input: any): string => {
   return Type.isObject(input) && Obj.keys(input).length > 100 ? ' removed due to size' : JSON.stringify(input, null, 2);
@@ -8,9 +8,7 @@ const formatErrors = (errors: Array<{ path: string[]; getErrorInfo: () => string
   const es = errors.length > 10 ? errors.slice(0, 10).concat([
     {
       path: [ ],
-      getErrorInfo: () => {
-        return '... (only showing first ten failures)';
-      }
+      getErrorInfo: Fun.constant('... (only showing first ten failures)')
     }
   ]) : errors;
 

--- a/modules/bridge/src/demo/ts/buttons/DemoRegistry.ts
+++ b/modules/bridge/src/demo/ts/buttons/DemoRegistry.ts
@@ -1,9 +1,10 @@
+import { Fun } from '@ephox/katamari';
 import * as Registry from '../../../main/ts/ephox/bridge/api/Registry';
 
 const editorButtons = Registry.create();
 
 // This would be exposed as a public api in tinymce as something like editor.ui or similar
-const getDemoRegistry = (): Registry.Registry => editorButtons;
+const getDemoRegistry = Fun.constant(editorButtons);
 
 export {
   getDemoRegistry

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -108,7 +108,7 @@ const toggleOrNormal = StructureSchema.choose('type', {
 
 const contextFormSchema = StructureSchema.objOf([
   FieldSchema.defaulted('type', 'contextform'),
-  FieldSchema.defaultedFunction('initValue', () => ''),
+  FieldSchema.defaultedFunction('initValue', Fun.constant('')),
   FieldSchema.optionString('label'),
   FieldSchema.requiredArrayOf('commands', toggleOrNormal),
   FieldSchema.optionOf('launch', StructureSchema.choose('type', {

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/Blocker.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/Blocker.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { Attribute, Class, Css, Remove, SugarElement } from '@ephox/sugar';
 import * as Styles from '../style/Styles';
 
@@ -29,9 +30,7 @@ export const Blocker = (options: Partial<BlockerOptions>): Blocker => {
   Class.add(div, Styles.resolve('blocker'));
   Class.add(div, settings.layerClass);
 
-  const element = () => {
-    return div;
-  };
+  const element = Fun.constant(div);
 
   const destroy = () => {
     Remove.remove(div);

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
@@ -82,9 +82,7 @@ export const find = <T>(obj: T, pred: (value: T[keyof T], key: string, obj: T) =
 };
 
 export const values = <T>(obj: T): Array<T[keyof T]> => {
-  return mapToArray(obj, (v) => {
-    return v;
-  });
+  return mapToArray(obj, Fun.identity);
 };
 
 export const size = (obj: {}): number => {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Optional.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Optional.ts
@@ -70,7 +70,7 @@ const none = <T = never>(): Optional<T> => NONE;
 const NONE: Optional<never> = (() => {
   // inlined from peanut, maybe a micro-optimisation?
   const call = (thunk) => thunk();
-  const id = (n) => n;
+  const id = Fun.identity;
   const me: Optional<never> = {
     fold: (n, _s) => n(),
     isSome: Fun.never,

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Result.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Result.ts
@@ -112,9 +112,7 @@ const error = <T = any, E = any>(message: E): Result<T, E> => {
     return Fun.die(String(message))();
   };
 
-  const or = (opt: Result<T, E>) => {
-    return opt;
-  };
+  const or = Fun.identity;
 
   const orThunk = (f: () => Result<T, E>) => {
     return f();

--- a/modules/katamari/src/main/ts/ephox/katamari/api/StringMatch.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/StringMatch.ts
@@ -43,9 +43,7 @@ const caseInsensitive = (val: string): string => {
   return val.toLowerCase();
 };
 
-const caseSensitive = (val: string): string => {
-  return val;
-};
+const caseSensitive: (val: string) => string = Fun.identity;
 
 /** matches :: (StringMatch, String) -> Boolean */
 const matches = (subject: StringMatch, str: string): boolean => {

--- a/modules/katamari/src/test/ts/atomic/api/arr/GroupByTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/GroupByTest.ts
@@ -2,12 +2,13 @@ import { describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 import fc from 'fast-check';
 import * as Arr from 'ephox/katamari/api/Arr';
+import * as Fun from 'ephox/katamari/api/Fun';
 
 describe('atomic.katamari.api.arr.GroupByTest', () => {
 
   it('unit tests', () => {
     const check = (input: unknown[], expected) => {
-      const f = (b) => b;
+      const f = Fun.identity;
       assert.deepEqual(Arr.groupBy(input, f), expected);
       assert.deepEqual(Arr.groupBy(Object.freeze(input.slice()), f), expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/data/ResultErrorTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/data/ResultErrorTest.ts
@@ -15,7 +15,7 @@ describe('atomic.katamari.api.data.ResultErrorTest', () => {
     assert.isFalse(s.isValue());
     assert.isTrue(s.isError());
     assert.equal(s.getOr(6), 6);
-    assert.equal(s.getOrThunk(() => 6), 6);
+    assert.equal(s.getOrThunk(Fun.constant(6)), 6);
     assert.throws(() => {
       s.getOrDie();
     });

--- a/modules/katamari/src/test/ts/atomic/api/data/ResultErrorTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/data/ResultErrorTest.ts
@@ -40,7 +40,7 @@ describe('atomic.katamari.api.data.ResultErrorTest', () => {
     assertNone(Result.error(4).toOptional());
   });
 
-  const getErrorOrDie = (res) => res.fold((err) => err, Fun.die('Was not an error!'));
+  const getErrorOrDie = (res) => res.fold(Fun.identity, Fun.die('Was not an error!'));
 
   it('error.is === false', () => {
     fc.assert(fc.property(fc.integer(), fc.string(), (i, s) => {

--- a/modules/katamari/src/test/ts/atomic/api/data/ResultValueTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/data/ResultValueTest.ts
@@ -13,7 +13,7 @@ describe('atomic.katamari.api.arr.ResultValueTest', () => {
     assert.isTrue(s.isValue());
     assert.isFalse(s.isError());
     assert.equal(s.getOr(6), 5);
-    assert.equal(s.getOrThunk(() => 6), 5);
+    assert.equal(s.getOrThunk(Fun.constant(6)), 5);
     assert.equal(s.getOrDie(), 5);
     assert.equal(s.or(Result.value(6)).getOrDie(), 5);
     assert.equal(s.orThunk(() => Result.error('Should not get here.')).getOrDie(), 5);

--- a/modules/katamari/src/test/ts/atomic/api/maybe/ComparatorTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/maybe/ComparatorTest.ts
@@ -55,8 +55,8 @@ describe('atomic.katamari.maybe.ComparatorTest', () => {
 
       fc.assert(fc.property(fc.string(), (thing) => {
         const matches = Fun.pipe(
-          Maybes.just(() => thing),
-          Maybes.is(() => thing, thunkEq)
+          Maybes.just(Fun.constant(thing)),
+          Maybes.is(Fun.constant(thing), thunkEq)
         );
 
         assert.isTrue(matches);
@@ -64,7 +64,7 @@ describe('atomic.katamari.maybe.ComparatorTest', () => {
 
       fc.assert(fc.property(fc.string(), (thing) => {
         const matches = Fun.pipe(
-          Maybes.just(() => thing),
+          Maybes.just(Fun.constant(thing)),
           Maybes.is(() => thing + 'foo', thunkEq)
         );
 

--- a/modules/katamari/src/test/ts/atomic/api/optional/OptionalNoneTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/optional/OptionalNoneTest.ts
@@ -28,7 +28,7 @@ describe('atomic.katamari.api.optional.OptionalNoneTest', () => {
 
     assert.deepEqual(Optional.none().toArray(), []);
 
-    assert.equal(Optional.none().fold(() => 'zz', Fun.die('boom')), 'zz');
+    assert.equal(Optional.none().fold(Fun.constant('zz'), Fun.die('boom')), 'zz');
     assert.deepEqual(Optional.none().fold((...args: any[]) => {
       return args;
     }, Fun.die('boom')), []);

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
@@ -1,4 +1,4 @@
-import { Arr, Global, Obj } from '@ephox/katamari';
+import { Arr, Fun, Global, Obj } from '@ephox/katamari';
 import { Editor } from '../alien/EditorTypes';
 
 const isSilver = (): boolean => {
@@ -21,7 +21,7 @@ export interface ThemeSelectors {
 }
 
 const ModernThemeSelectors: ThemeSelectors = {
-  toolBarSelector: () => '.mce-toolbar-grp',
+  toolBarSelector: Fun.constant('.mce-toolbar-grp'),
   menuBarSelector: '.mce-menubar',
   dialogSelector: '.mce-window',
   dialogCancelSelector: 'div[role="button"]:contains(Cancel)',

--- a/modules/mcagar/src/test/ts/browser/api/TinySetAndDeleteSettingTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinySetAndDeleteSettingTest.ts
@@ -1,5 +1,6 @@
 import { Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { Editor } from 'ephox/mcagar/alien/EditorTypes';
 import { TinyApis } from 'ephox/mcagar/api/pipeline/TinyApis';
 import * as TinyLoader from 'ephox/mcagar/api/pipeline/TinyLoader';
@@ -34,9 +35,7 @@ UnitTest.asynctest('TinySetAndDeleteSettingTest', (success, failure) => {
       ])),
 
       Logger.t('set setting to function', GeneralSteps.sequence([
-        apis.sSetSetting('a', (a: any) => {
-          return a;
-        }),
+        apis.sSetSetting('a', Fun.identity),
         sAssertSettingType(editor, 'a', 'function')
       ])),
 

--- a/modules/phoenix/src/test/ts/browser/DomExtractTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomExtractTest.ts
@@ -64,15 +64,12 @@ UnitTest.test('DomExtractTest', () => {
     const check = (expected: string, input: SugarElement) => {
       const rawActual = DomExtract.from(input, optimise);
       const actual = Arr.map(rawActual, (x) => {
-        return x.fold(() => {
-          return '\\w';
-        }, () => {
-          return '-';
-        }, (t) => {
-          return SugarText.get(t);
-        }, (t) => {
-          return SugarText.get(t);
-        });
+        return x.fold(
+          Fun.constant('\\w'),
+          Fun.constant('-'),
+          (t) => SugarText.get(t),
+          (t) => SugarText.get(t)
+        );
       }).join('');
       Assert.eq('eq', expected, actual);
     };

--- a/modules/phoenix/src/test/ts/browser/FamilyGroupTest.ts
+++ b/modules/phoenix/src/test/ts/browser/FamilyGroupTest.ts
@@ -8,15 +8,12 @@ import * as Family from 'ephox/phoenix/api/general/Family';
 UnitTest.test('FamilyGroupTest', () => {
   const universe = DomUniverse();
   const toStr = (subject: TypedItem<SugarElement, Document>) => {
-    return subject.fold(() => {
-      return '|';
-    }, () => {
-      return '/';
-    }, (text) => {
-      return '"' + SugarText.get(text) + '"';
-    }, (_text) => {
-      return '\\';
-    });
+    return subject.fold(
+      Fun.constant('|'),
+      Fun.constant('/'),
+      (text) => '"' + SugarText.get(text) + '"',
+      Fun.constant('\\')
+    );
   };
 
   // Family.group is used to break a list of elements in a list of list of elements, where each sublist

--- a/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Outlaw.ts
+++ b/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Outlaw.ts
@@ -1,4 +1,4 @@
-import { Singleton } from '@ephox/katamari';
+import { Fun, Singleton } from '@ephox/katamari';
 import { Bindable, Event } from 'ephox/porkbun/Event';
 import * as Events from 'ephox/porkbun/Events';
 import { DieEvent, Outlaw, Saloon, ShootEvent } from './Types';
@@ -37,9 +37,7 @@ const create = (name: string): Outlaw => {
   character.append(img, caption);
   container.append(character);
 
-  const getElement = () => {
-    return container;
-  };
+  const getElement = Fun.constant(container);
 
   const addAction = (text: string, action: () => void) => {
     const button = $('<button />');

--- a/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Saloon.ts
+++ b/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Saloon.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import * as Binder from 'ephox/porkbun/Binder';
 import { Bindable, Event } from 'ephox/porkbun/Event';
 import * as Events from 'ephox/porkbun/Events';
@@ -24,9 +25,7 @@ const create = (): Saloon => {
     float: 'left'
   });
 
-  const getElement = () => {
-    return saloon;
-  };
+  const getElement = Fun.constant(saloon);
 
   const events: SaloonEvents = Events.create({
     shooting: Event([ 'shooter', 'target' ])

--- a/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Sheriff.ts
+++ b/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Sheriff.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { Saloon, Sherif, ShootingEvent } from './Types';
 
 declare const $: any;
@@ -25,9 +26,7 @@ const create = (): Sherif => {
   caption.append(actions);
   container.append(img, caption);
 
-  const getElement = () => {
-    return container;
-  };
+  const getElement = Fun.constant(container);
 
   const watch = (establishment: Saloon) => {
     establishment.events.shooting.bind(shooting);

--- a/modules/robin/src/test/ts/browser/api/DomParentTest.ts
+++ b/modules/robin/src/test/ts/browser/api/DomParentTest.ts
@@ -221,7 +221,7 @@ UnitTest.test(
         const subset = DomParent.subset(parent, child);
 
         const actual = subset.map((ss) => Arr.map(ss, (x) => Attribute.get(x, 'class')));
-        const expected_ = expected.map((ss) => Arr.map<string | undefined>((ss), (x) => x));
+        const expected_ = expected.map((ss) => Arr.map<string | undefined>((ss), Fun.identity));
 
         KAssert.eqOptional('eq', expected_, actual);
       };

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
@@ -33,6 +33,7 @@ const replace = <K extends keyof HTMLElementTagNameMap>(cell: SugarElement, tag:
   return replica;
 };
 
+// eslint-disable-next-line @tinymce/prefer-fun
 const pasteReplace = (cell: SugarElement) => {
   // TODO: check for empty content and don't return anything
   return cell;

--- a/modules/snooker/src/main/ts/ephox/snooker/model/TableGrid.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/TableGrid.ts
@@ -21,11 +21,7 @@ const findDiff = (xs: ElementNew[], comp: (a: SugarElement, b: SugarElement) => 
   const index = Arr.findIndex(xs, (x) => {
     return !comp(first.element, x.element);
   });
-  return index.fold(() => {
-    return xs.length;
-  }, (ind) => {
-    return ind;
-  });
+  return index.getOr(xs.length);
 };
 
 /*

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
@@ -11,10 +11,8 @@ import * as Sizes from './Sizes';
 const isCol = SugarNode.isTag('col');
 
 const getRaw = (cell: SugarElement, property: string, getter: (e: SugarElement) => number): string => {
-  return Css.getRaw(cell, property).fold(() => {
+  return Css.getRaw(cell, property).getOrThunk(() => {
     return getter(cell) + 'px';
-  }, (raw) => {
-    return raw;
   });
 };
 

--- a/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
@@ -28,13 +28,11 @@ UnitTest.test('FitmentIVTest', () => {
       return r;
     };
 
-    const replace = (name: string) => name;
-
     return {
       cell,
       gap: Fun.constant('*'),
       row: Fun.constant('tr'),
-      replace
+      replace: Fun.identity
     } as any;
   };
 

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Optional, Optionals } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Optionals } from '@ephox/katamari';
 import { Attribute, Css, Hierarchy, Insert, Replication, SugarElement, SugarNode, TextContent } from '@ephox/sugar';
 import { Generators, SimpleGenerators } from 'ephox/snooker/api/Generators';
 import * as Structs from 'ephox/snooker/api/Structs';
@@ -60,6 +60,8 @@ const createCell = (): SugarElement<HTMLTableCellElement> => {
   return tag;
 };
 
+const replace = Fun.identity as <T extends HTMLElement>(cell: SugarElement<HTMLTableCellElement>) => SugarElement<T>;
+
 // This is used for testing pasting as the real paste generator (TableFill.ts) differs from the standard generator
 // e.g. creates a cell that does not rely on the previous cell
 const pasteGenerators: SimpleGenerators = {
@@ -67,7 +69,7 @@ const pasteGenerators: SimpleGenerators = {
   colgroup: () => SugarElement.fromTag('colgroup'),
   row: () => SugarElement.fromTag('tr'),
   cell: createCell,
-  replace: (cell: SugarElement) => cell,
+  replace,
   gap: createCell
 };
 

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/CreateTableUtils.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/CreateTableUtils.ts
@@ -1,4 +1,4 @@
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 
 interface TableConfig {
   readonly numCols: number;
@@ -10,7 +10,7 @@ const generateTestTable = (bodyContent: string[], headerContent: string[], foote
   const numCols = config.numCols;
   const theadContent = headerContent.length > 0 ? `<thead><tr>${headerContent.join('')}</tr></thead>` : ``;
   const tfootContent = footerContent.length > 0 ? `<tfoot><tr>${footerContent.join('')}</tr></tfoot>` : ``;
-  const colgroupContent = config.colgroup ? `<colgroup>${Arr.range(numCols, () => `<col>`).join('')}</colgroup>` : ``;
+  const colgroupContent = config.colgroup ? `<colgroup>${Arr.range(numCols, Fun.constant('<col>')).join('')}</colgroup>` : ``;
 
   return `<table${config.lockedColumns.length > 0 ? ` data-snooker-locked-cols="${config.lockedColumns.join(',')}"` : ''}>` +
     colgroupContent +

--- a/modules/sugar/src/test/ts/browser/DimensionTest.ts
+++ b/modules/sugar/src/test/ts/browser/DimensionTest.ts
@@ -1,4 +1,5 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as SugarBody from 'ephox/sugar/api/node/SugarBody';
@@ -178,9 +179,9 @@ UnitTest.test('DimensionTest', () => {
   Insert.append(SugarBody.body(), bounds);
 
   // Aggregator test
-  // Dimension.agregate takes an element and a list of propeties that return measurement values.
-  // it will accumulatively add all the properties and return a cumulative total.
-  const dim = Dimension('internal', () => 1);
+  // Dimension.aggregate takes an element and a list of properties that return measurement values.
+  // it will accumulative add all the properties and return a cumulative total.
+  const dim = Dimension('internal', Fun.constant(1));
   const ctotal = dim.aggregate(container, [ 'padding-top', 'margin-bottom', 'border-top-width', 'border-bottom-width' ]);
   assert.eq( ( paddingTop + marginBottom + borderWidth + borderWidth ), ctotal);
 

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Focus, SugarElement } from '@ephox/sugar';
 import * as EditorView from '../EditorView';
 import { NotificationManagerImpl } from '../ui/NotificationManagerImpl';
@@ -139,9 +139,7 @@ const NotificationManager = (editor: Editor): NotificationManager => {
     });
   };
 
-  const getNotifications = (): NotificationApi[] => {
-    return notifications;
-  };
+  const getNotifications = Fun.constant(notifications);
 
   const registerEvents = (editor: Editor) => {
     editor.on('SkinLoaded', () => {

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1909,7 +1909,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     dumpRng
   };
 
-  const attrHooks = setupAttrHooks(styles, settings, () => self);
+  const attrHooks = setupAttrHooks(styles, settings, Fun.constant(self));
 
   return self;
 };

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Obj } from '@ephox/katamari';
+import { Fun, Obj } from '@ephox/katamari';
 import Tools from '../util/Tools';
 
 export type SchemaType = 'html4' | 'html5' | 'html5-strict';
@@ -434,7 +434,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
   const customElementsMap = {}, specialElements = {} as SchemaRegExpMap;
 
   // Creates an lookup table map object for the specified option or the default value
-  const createLookupTable = (option: string, defaultValue?: string, extendWith?: string) => {
+  const createLookupTable = (option: string, defaultValue?: string, extendWith?: SchemaMap): SchemaMap => {
     let value = settings[option];
 
     if (!value) {
@@ -866,7 +866,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getValidStyles
    * @type Object
    */
-  const getValidStyles = (): SchemaMap => validStyles;
+  const getValidStyles = Fun.constant(validStyles);
 
   /**
    * Name/value map object with valid styles for each element.
@@ -874,7 +874,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getInvalidStyles
    * @type Object
    */
-  const getInvalidStyles = (): SchemaMap => invalidStyles;
+  const getInvalidStyles = Fun.constant(invalidStyles);
 
   /**
    * Name/value map object with valid classes for each element.
@@ -882,7 +882,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getValidClasses
    * @type Object
    */
-  const getValidClasses = (): SchemaMap => validClasses;
+  const getValidClasses = Fun.constant(validClasses);
 
   /**
    * Returns a map with boolean attributes.
@@ -890,7 +890,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getBoolAttrs
    * @return {Object} Name/value lookup map for boolean attributes.
    */
-  const getBoolAttrs = (): SchemaMap => boolAttrMap;
+  const getBoolAttrs = Fun.constant(boolAttrMap);
 
   /**
    * Returns a map with block elements.
@@ -898,7 +898,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getBlockElements
    * @return {Object} Name/value lookup map for block elements.
    */
-  const getBlockElements = (): SchemaMap => blockElementsMap;
+  const getBlockElements = Fun.constant(blockElementsMap);
 
   /**
    * Returns a map with text block elements. For example: <code>&#60;p&#62;</code>, <code>&#60;h1&#62;</code> to <code>&#60;h6&#62;</code>, <code>&#60;div&#62;</code> or <code>&#60;address&#62;</code>.
@@ -906,7 +906,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getTextBlockElements
    * @return {Object} Name/value lookup map for block elements.
    */
-  const getTextBlockElements = (): SchemaMap => textBlockElementsMap;
+  const getTextBlockElements = Fun.constant(textBlockElementsMap);
 
   /**
    * Returns a map of inline text format nodes. For example: <code>&#60;strong&#62;</code>, <code>&#60;span&#62;</code> or <code>&#60;ins&#62;</code>.
@@ -914,7 +914,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getTextInlineElements
    * @return {Object} Name/value lookup map for text format elements.
    */
-  const getTextInlineElements = (): SchemaMap => textInlineElementsMap;
+  const getTextInlineElements = Fun.constant(textInlineElementsMap);
 
   /**
    * Returns a map with short ended elements. For example: <code>&#60;br&#62;</code> or <code>&#60;img&#62;</code>.
@@ -922,7 +922,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getShortEndedElements
    * @return {Object} Name/value lookup map for short ended elements.
    */
-  const getShortEndedElements = (): SchemaMap => shortEndedElementsMap;
+  const getShortEndedElements = Fun.constant(shortEndedElementsMap);
 
   /**
    * Returns a map with self closing tags. For example: <code>&#60;li&#62;</code>.
@@ -930,7 +930,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getSelfClosingElements
    * @return {Object} Name/value lookup map for self closing tags elements.
    */
-  const getSelfClosingElements = (): SchemaMap => selfClosingElementsMap;
+  const getSelfClosingElements = Fun.constant(selfClosingElementsMap);
 
   /**
    * Returns a map with elements that should be treated as contents regardless if it has text
@@ -939,7 +939,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getNonEmptyElements
    * @return {Object} Name/value lookup map for non empty elements.
    */
-  const getNonEmptyElements = (): SchemaMap => nonEmptyElementsMap;
+  const getNonEmptyElements = Fun.constant(nonEmptyElementsMap);
 
   /**
    * Returns a map with elements that the caret should be moved in front of after enter is
@@ -948,7 +948,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getMoveCaretBeforeOnEnterElements
    * @return {Object} Name/value lookup map for elements to place the caret in front of.
    */
-  const getMoveCaretBeforeOnEnterElements = (): SchemaMap => moveCaretBeforeOnEnterElementsMap;
+  const getMoveCaretBeforeOnEnterElements = Fun.constant(moveCaretBeforeOnEnterElementsMap);
 
   /**
    * Returns a map with elements where white space is to be preserved. For example: <code>&#60;pre&#62;</code> or <code>&#60;script&#62;</code>.
@@ -956,7 +956,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getWhiteSpaceElements
    * @return {Object} Name/value lookup map for white space elements.
    */
-  const getWhiteSpaceElements = (): SchemaMap => whiteSpaceElementsMap;
+  const getWhiteSpaceElements = Fun.constant(whiteSpaceElementsMap);
 
   /**
    * Returns a map with special elements. These are elements that needs to be parsed
@@ -966,7 +966,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getSpecialElements
    * @return {Object} Name/value lookup map for special elements.
    */
-  const getSpecialElements = (): SchemaRegExpMap => specialElements;
+  const getSpecialElements = Fun.constant(specialElements);
 
   /**
    * Returns true/false if the specified element and it's child is valid or not
@@ -1037,7 +1037,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * @method getCustomElements
    * @return {Object} Name/value map object of all custom elements.
    */
-  const getCustomElements = (): SchemaMap => customElementsMap;
+  const getCustomElements = Fun.constant(customElementsMap);
 
   /**
    * Parses a valid elements string and adds it to the schema. The valid elements

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -17,7 +17,7 @@ import * as Parents from '../dom/Parents';
 const getChildrenUntilBlockBoundary = (block: SugarElement) => {
   const children = Traverse.children(block);
   return Arr.findIndex(children, ElementType.isBlock).fold(
-    () => children,
+    Fun.constant(children),
     (index) => children.slice(0, index)
   );
 };

--- a/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.caret.FakeCaretTest', () => {
 
   before(() => {
     const mockEditor: any = {
-      getParam: () => 'p'
+      getParam: Fun.constant('p')
     };
     fakeCaret = FakeCaret(mockEditor, getRoot(), isBlock, Fun.always);
   });

--- a/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
@@ -484,9 +484,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
 
   it('isDefaultPrevented', () => {
     const testObj: any = {};
-    const testCallback = () => {
-      return 'hello';
-    };
+    const testCallback = Fun.constant('hello');
     testObj.isDefaultPrevented = testCallback;
     eventUtils.fire(window, 'testEvent', testObj);
 

--- a/modules/tinymce/src/core/test/ts/browser/util/ToolsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ToolsTest.ts
@@ -12,7 +12,9 @@ describe('browser.tinymce.core.util.ToolsTest', () => {
 
   context('create', () => {
     it('TINY-7358: Multiple calls to create should create different objects', () => {
+      // eslint-disable-next-line @tinymce/prefer-fun
       Tools.create('tinymce.temp.class1', { init: () => 'obj1' });
+      // eslint-disable-next-line @tinymce/prefer-fun
       Tools.create('tinymce.temp.class2', { init: () => 'obj2' });
 
       const instance1 = new Global.tinymce.temp.class1();

--- a/modules/tinymce/src/core/test/ts/module/test/ViewBlock.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/ViewBlock.ts
@@ -1,4 +1,5 @@
 import { after, afterEach, before } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 
 interface ViewBlock {
@@ -28,9 +29,7 @@ const ViewBlock = (): ViewBlock => {
     DOMUtils.DOM.setHTML(domElm, html);
   };
 
-  const get = (): HTMLElement => {
-    return domElm;
-  };
+  const get = Fun.constant(domElm);
 
   return {
     attach,

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/CodeSample.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/CodeSample.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import * as Utils from '../util/Utils';
@@ -41,7 +41,7 @@ const insertCodeSample = (editor: Editor, language: string, code: string) => {
 
 const getCurrentCode = (editor: Editor): string => {
   const node = getSelectedCodeSample(editor);
-  return node.fold(() => '', (n) => n.textContent);
+  return node.fold(Fun.constant(''), (n) => n.textContent);
 };
 
 export {

--- a/modules/tinymce/src/plugins/codesample/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/ui/Dialog.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import * as CodeSample from '../core/CodeSample';
 import * as Languages from '../core/Languages';
@@ -14,7 +14,7 @@ type LanguageSpec = Languages.LanguageSpec;
 
 const open = (editor: Editor) => {
   const languages: LanguageSpec[] = Languages.getLanguages(editor);
-  const defaultLanguage: string = Arr.head(languages).fold(() => '', (l) => l.value);
+  const defaultLanguage: string = Arr.head(languages).fold(Fun.constant(''), (l) => l.value);
   const currentLanguage: string = Languages.getCurrentLanguage(editor, defaultLanguage);
   const currentCode: string = CodeSample.getCurrentCode(editor);
 

--- a/modules/tinymce/src/plugins/help/test/ts/module/test/FakePlugin.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/test/FakePlugin.ts
@@ -1,15 +1,14 @@
+import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import PluginManager from 'tinymce/core/api/PluginManager';
 
 export default () => {
   const Plugin = (_editor: Editor, _url: string) => {
     return {
-      getMetadata: () => {
-        return {
-          name: 'Fake',
-          url: 'http://www.fake.com'
-        };
-      }
+      getMetadata: Fun.constant({
+        name: 'Fake',
+        url: 'http://www.fake.com'
+      })
     };
   };
 

--- a/modules/tinymce/src/plugins/imagetools/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/core/Actions.ts
@@ -215,10 +215,10 @@ const selectedImageOperation = (editor: Editor, imageUploadTimerState: Cell<numb
 const rotate = (editor: Editor, imageUploadTimerState: Cell<number>, angle: number) => {
   return () => {
     const imgOpt = getSelectedImage(editor);
-    const flippedSize = imgOpt.fold(() => null, (img) => {
+    const flippedSize = imgOpt.map((img) => {
       const size = ImageSize.getImageSize(img.dom);
       return size ? { w: size.h, h: size.w } : null;
-    });
+    }).getOrNull();
 
     return selectedImageOperation(editor, imageUploadTimerState, (imageResult) => {
       return ImageTransformations.rotate(imageResult, angle);

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
@@ -64,12 +64,11 @@ const register = (editor: Editor) => {
   editor.ui.registry.addContextMenu('imagetools', {
     update: (element) =>
       // since there's no menu item available, this has to be it's own thing
-      Actions.getEditableImage(editor, element).fold(() => [], (_) => [{
+      Actions.getEditableImage(editor, element).map((_) => ({
         text: 'Edit image',
         icon: 'edit-image',
         onAction: cmd('mceEditImage')
-      }])
-
+      })).toArray()
   });
 };
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/InternalHtml.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/InternalHtml.ts
@@ -5,6 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Fun } from '@ephox/katamari';
+
 const internalMimeType = 'x-tinymce/html';
 const internalMark = '<!-- ' + internalMimeType + ' -->';
 
@@ -20,7 +22,7 @@ const isMarked = (html: string) => {
   return html.indexOf(internalMark) !== -1;
 };
 
-const internalHtmlMime = () => internalMimeType;
+const internalHtmlMime = Fun.constant(internalMimeType);
 
 export {
   mark,

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Fun } from '@ephox/katamari';
 import { SugarNode } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
@@ -90,7 +91,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipbo
   const row: Menu.NestedMenuItemSpec = {
     type: 'nestedmenuitem',
     text: 'Row',
-    getSubmenuItems: () => 'tableinsertrowbefore tableinsertrowafter tabledeleterow tablerowprops | tablecutrow tablecopyrow tablepasterowbefore tablepasterowafter'
+    getSubmenuItems: Fun.constant('tableinsertrowbefore tableinsertrowafter tabledeleterow tablerowprops | tablecutrow tablecopyrow tablepasterowbefore tablepasterowafter')
   };
 
   editor.ui.registry.addMenuItem('tableinsertcolumnbefore', {
@@ -140,7 +141,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipbo
   const column: Menu.NestedMenuItemSpec = {
     type: 'nestedmenuitem',
     text: 'Column',
-    getSubmenuItems: () => 'tableinsertcolumnbefore tableinsertcolumnafter tabledeletecolumn | tablecutcolumn tablecopycolumn tablepastecolumnbefore tablepastecolumnafter'
+    getSubmenuItems: Fun.constant('tableinsertcolumnbefore tableinsertcolumnafter tabledeletecolumn | tablecutcolumn tablecopycolumn tablepastecolumnbefore tablepastecolumnafter')
   };
 
   editor.ui.registry.addMenuItem('tablecellprops', {
@@ -165,7 +166,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipbo
   const cell: Menu.NestedMenuItemSpec = {
     type: 'nestedmenuitem',
     text: 'Cell',
-    getSubmenuItems: () => 'tablecellprops tablemergecells tablesplitcells'
+    getSubmenuItems: Fun.constant('tablecellprops tablemergecells tablesplitcells')
   };
 
   if (hasTableGrid(editor) === false) {
@@ -202,7 +203,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipbo
       // context menu fires before node change, so check the selection here first
       selectionTargets.resetTargets();
       // ignoring element since it's monitored elsewhere
-      return selectionTargets.targets().fold(() => '', (targets) => {
+      return selectionTargets.targets().fold(Fun.constant(''), (targets) => {
         // If clicking in a caption, then we shouldn't show the cell/row/column options
         if (SugarNode.name(targets.element) === 'caption') {
           return 'tableprops deletetable';

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
@@ -1,5 +1,5 @@
 import { Assertions, Keys, Waiter } from '@ephox/agar';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import { TinyAssertions, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 
@@ -51,9 +51,7 @@ const assertStructureIsRestoredToDefault = (editor: Editor, rows: number, column
         Arr.range(rows, () => {
           return (
             '<tr>' +
-                Arr.range(columns, () => {
-                  return '<td>Filler</td>';
-                }).join('') +
+                Arr.range(columns, Fun.constant('<td>Filler</td>')).join('') +
             '</tr>'
           );
         }).join('') +

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextSearchTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextSearchTest.ts
@@ -27,18 +27,16 @@ describe('browser.tinymce.plugins.textpattern.TextSearchTest', () => {
 
   const repeatLeftUntil = (editor: Editor, content: string) => {
     const rng = editor.selection.getRng();
-    return TextSearch.repeatLeft(editor.dom, rng.startContainer, rng.startOffset, process(content), editor.getBody()).fold(
-      () => null,
-      (spot) => spot.container
-    );
+    return TextSearch.repeatLeft(editor.dom, rng.startContainer, rng.startOffset, process(content), editor.getBody())
+      .map((spot) => spot.container)
+      .getOrNull();
   };
 
   const repeatRightUntil = (editor: Editor, content: string) => {
     const rng = editor.selection.getRng();
-    return TextSearch.repeatRight(editor.dom, rng.startContainer, rng.startOffset, process(content), editor.getBody()).fold(
-      () => null,
-      (spot) => spot.container
-    );
+    return TextSearch.repeatRight(editor.dom, rng.startContainer, rng.startOffset, process(content), editor.getBody())
+      .map((spot) => spot.container)
+      .getOrNull();
   };
 
   const assertSpot = (label: string, spotOpt: Optional<SpotPoint<Text>>, elementText: string, offset: number) => {

--- a/modules/tinymce/src/themes/mobile/main/ts/ui/ColorSlider.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/ui/ColorSlider.ts
@@ -6,6 +6,7 @@
  */
 
 import { Behaviour, SketchSpec, Slider, Toggling } from '@ephox/alloy';
+import { Fun } from '@ephox/katamari';
 import { Css } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
@@ -103,10 +104,8 @@ const sketch = (realm: MobileRealm, editor: Editor) => {
         editor.nodeChanged();
       });
     },
-    getInitialValue: (/* slider */) => {
-      // Return black
-      return BLACK;
-    }
+    // Return black
+    getInitialValue: Fun.constant(BLACK)
   };
 
   return ToolbarWidgets.button(realm, 'color-levels', () => makeItems(spec), editor);

--- a/modules/tinymce/src/themes/mobile/main/ts/util/CssUrls.ts
+++ b/modules/tinymce/src/themes/mobile/main/ts/util/CssUrls.ts
@@ -16,10 +16,8 @@ export interface CssUrls {
 }
 
 const derive = (editor: Editor): CssUrls => {
-  const base = Optional.from(Settings.getSkinUrl(editor)).fold(
-    () => EditorManager.baseURL + '/skins/ui/oxide',
-    (url) => url
-  );
+  const base = Optional.from(Settings.getSkinUrl(editor))
+    .getOrThunk(() => EditorManager.baseURL + '/skins/ui/oxide');
 
   return {
     content: base + '/content.mobile.min.css',

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestFrameEditor.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/ui/TestFrameEditor.ts
@@ -19,9 +19,7 @@ export default () => {
   );
 
   const config = {
-    getFrame: () => {
-      return frame;
-    },
+    getFrame: Fun.constant(frame),
     onDomChanged: () => {
       return { unbind: Fun.noop };
     }

--- a/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/components/DemoHelpers.ts
@@ -107,7 +107,7 @@ const setupDemo = () => {
         isDisabled: Fun.never,
         getSetting: (_settingName: string, defaultVal: any) => defaultVal
       },
-      interpreter: (x) => x,
+      interpreter: Fun.identity,
       getSink: () => Result.value(sink),
       anchors: {
         inlineDialog: () =>

--- a/modules/tinymce/src/themes/silver/demo/ts/components/DialogComponentsDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/components/DialogComponentsDemo.ts
@@ -1,7 +1,7 @@
 import { AlloyEvents, DomFactory, GuiFactory, Input as AlloyInput, Memento, Representing, SimpleSpec } from '@ephox/alloy';
 import { StructureSchema } from '@ephox/boulder';
 import { Dialog } from '@ephox/bridge';
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { UiFactoryBackstage, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderBodyPanel } from 'tinymce/themes/silver/ui/dialog/BodyPanel';
 import { renderCollection } from 'tinymce/themes/silver/ui/dialog/Collection';
@@ -31,7 +31,7 @@ export default () => {
   const sharedBackstage: UiFactoryBackstageShared = {
     getSink: helpers.extras.backstage.shared.getSink,
     providers: helpers.extras.backstage.shared.providers,
-    interpreter: (x) => x
+    interpreter: Fun.identity
   };
 
   const iframeSpec = renderIFrame({

--- a/modules/tinymce/src/themes/silver/main/ts/autocomplete/Autocompleters.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/autocomplete/Autocompleters.ts
@@ -7,7 +7,7 @@
 
 import { StructureSchema } from '@ephox/boulder';
 import { InlineContent } from '@ephox/bridge';
-import { Arr, Obj, Unique } from '@ephox/katamari';
+import { Arr, Fun, Obj, Unique } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 export interface AutocompleterDatabase {
@@ -22,7 +22,7 @@ const register = (editor: Editor): AutocompleterDatabase => {
     (err) => {
       throw new Error(StructureSchema.formatError(err));
     },
-    (x) => x
+    Fun.identity
   ));
 
   const triggerChars = Unique.stringArray(

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
@@ -6,11 +6,11 @@
  */
 
 import { AlloyComponent, AlloyTriggers } from '@ephox/alloy';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import { updateMenuIcon } from '../../dropdown/CommonDropdown';
-import { createMenuItems, createSelectButton, FormatItem, FormatterFormatItem, PreviewSpec, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, FormatItem, FormatterFormatItem, SelectSpec } from './BespokeSelect';
 import { buildBasicStaticDataset } from './SelectDatasets';
 import { IsSelectedForType } from './utils/FormatRegister';
 
@@ -26,11 +26,11 @@ const getSpec = (editor: Editor): SelectSpec => {
 
   const isSelectedFor: IsSelectedForType = (format: string) => () => editor.formatter.match(format);
 
-  const getPreviewFor = (_format: string) => () => Optional.none<PreviewSpec>();
+  const getPreviewFor = (_format: string) => Optional.none;
 
   const updateSelectMenuIcon = (comp: AlloyComponent) => {
     const match = getMatchingValue();
-    const alignment = match.fold(() => 'left', (item) => item.title.toLowerCase());
+    const alignment = match.fold(Fun.constant('left'), (item) => item.title.toLowerCase());
     AlloyTriggers.emitWith(comp, updateMenuIcon, {
       icon: `align-${alignment}`
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
@@ -100,7 +100,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 
   const updateSelectMenuText = (comp: AlloyComponent) => {
     const { matchOpt, font } = getMatchingValue();
-    const text = matchOpt.fold(() => font, (item) => item.title);
+    const text = matchOpt.fold(Fun.constant(font), (item) => item.title);
     AlloyTriggers.emitWith(comp, updateMenuText, {
       text
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
@@ -10,7 +10,7 @@ import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
-import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, FormatterFormatItem, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as FormatRegister from './utils/FormatRegister';
 
@@ -79,7 +79,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     return matchOpt;
   };
 
-  const getPreviewFor: FormatRegister.GetPreviewForType = Fun.constant(Optional.none as () => Optional<PreviewSpec>);
+  const getPreviewFor: FormatRegister.GetPreviewForType = Fun.constant(Optional.none);
 
   const onAction = (rawItem: FormatterFormatItem) => () => {
     editor.undoManager.transact(() => {
@@ -91,7 +91,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const updateSelectMenuText = (comp: AlloyComponent) => {
     const { matchOpt, size } = getMatchingValue();
 
-    const text = matchOpt.fold(() => size, (match) => match.title);
+    const text = matchOpt.fold(Fun.constant(size), (match) => match.title);
     AlloyTriggers.emitWith(comp, updateMenuText, {
       text
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, AlloyTriggers } from '@ephox/alloy';
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
@@ -40,7 +40,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 
   const updateSelectMenuText = (comp: AlloyComponent) => {
     const detectedFormat = findNearest(editor, () => dataset.data);
-    const text = detectedFormat.fold(() => 'Paragraph', (fmt) => fmt.title);
+    const text = detectedFormat.fold(Fun.constant('Paragraph'), (fmt) => fmt.title);
     AlloyTriggers.emitWith(comp, updateMenuText, {
       text
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleSelect.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, AlloyTriggers } from '@ephox/alloy';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
@@ -34,8 +34,8 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
       return subs !== undefined && subs.length > 0 ? Arr.bind(subs, getFormatItems) : [{ title: fmt.title, format: fmt.format }];
     };
     const flattenedItems = Arr.bind(getStyleFormats(editor), getFormatItems);
-    const detectedFormat = findNearest(editor, () => flattenedItems);
-    const text = detectedFormat.fold(() => 'Paragraph', (fmt) => fmt.title);
+    const detectedFormat = findNearest(editor, Fun.constant(flattenedItems));
+    const text = detectedFormat.fold(Fun.constant('Paragraph'), (fmt) => fmt.title);
     AlloyTriggers.emitWith(comp, updateMenuText, {
       text
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Id, Merger, Obj, Optional, Type } from '@ephox/katamari';
+import { Arr, Fun, Id, Merger, Obj, Optional, Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { StyleFormat } from 'tinymce/core/api/fmt/StyleFormat';
 import { FormatItem, FormatterFormatItem, PreviewSpec, SubMenuFormatItem } from '../BespokeSelect';
@@ -62,7 +62,7 @@ const register = (editor: Editor, formats, isSelectedFor: IsSelectedForType, get
       return Merger.deepMerge(
         enrichMenu(item),
         {
-          getStyleItems: () => newItems
+          getStyleItems: Fun.constant(newItems)
         }
       ) as FormatItem;
     } else if (Obj.hasNonNullableKey(item, 'format')) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
@@ -60,7 +60,7 @@ const renderBodyPanel = (spec: BodyPanelSpec, backstage: UiFactoryBackstage): Si
             console.error(err);
             return { };
           },
-          (vals) => vals
+          Fun.identity
         )
       })
     ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/state/ImageToolsState.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/state/ImageToolsState.ts
@@ -31,7 +31,7 @@ const makeState = (initialState: BlobState) => {
     blobState.set(state);
   };
 
-  const getTempState = (): BlobState => tempState.get().fold(() => blobState.get(), (temp) => temp);
+  const getTempState = (): BlobState => tempState.get().getOrThunk(blobState.get);
 
   const updateTempState = (blob: Blob): string => {
     const newTempState = createState(blob);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, Boxes, Channels, Docking, VerticalDir } from '@ephox/alloy';
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional } from '@ephox/katamari';
 import { Attribute, Css, Height, SugarBody, SugarElement, SugarLocation, Traverse, Width } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -48,7 +48,7 @@ export const InlineHeader = (editor: Editor, targetElm: SugarElement, uiComponen
 
   // Calculate the toolbar offset when using a split toolbar drawer
   const calcToolbarOffset = (toolbar: Optional<AlloyComponent>) => isSplitToolbar ?
-    toolbar.fold(() => 0, (tbar) =>
+    toolbar.fold(Fun.constant(0), (tbar) =>
       // If we have an overflow toolbar, we need to offset the positioning by the height of the overflow toolbar
       tbar.components().length > 1 ? Height.get(tbar.components()[1].element) : 0
     ) : 0;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -7,7 +7,7 @@
 
 import { AlloyComponent, Composing, ModalDialog } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderModalBody } from './SilverDialogBody';
@@ -68,7 +68,7 @@ const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverD
     };
 
     return {
-      getRoot: () => dialog,
+      getRoot: Fun.constant(dialog),
       getBody: () => ModalDialog.getBody(dialog),
       getFooter: () => ModalDialog.getFooter(dialog),
       getFormWrapper: getForm

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -11,7 +11,7 @@ import {
   Receiving, Reflecting, Replacing, SimpleSpec, SystemEvents
 } from '@ephox/alloy';
 import { DialogManager } from '@ephox/bridge';
-import { Id, Optional } from '@ephox/katamari';
+import { Fun, Id, Optional } from '@ephox/katamari';
 import { Attribute, SugarNode } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
@@ -128,7 +128,7 @@ const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: S
 
   // TODO: Clean up the dupe between this (InlineDialog) and SilverDialog
   const instanceApi = getDialogApi<T>({
-    getRoot: () => dialog,
+    getRoot: Fun.constant(dialog),
     getFooter: () => memFooter.get(dialog),
     getBody: () => memBody.get(dialog),
     getFormWrapper: () => {

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/context/ContextMenuTriggerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/context/ContextMenuTriggerTest.ts
@@ -1,4 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -10,7 +11,7 @@ describe('atomic.tinymce.themes.silver.context.ContextMenuTriggerTest', () => {
     const node = 'node';
 
     const fakeEditor = {
-      getBody: () => body
+      getBody: Fun.constant(body)
     } as unknown as Editor;
 
     const createFakeEvent = (type: string, button: number, target: any, pointerType?: string) => ({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { Arr, Type } from '@ephox/katamari';
+import { Arr, Fun, Type } from '@ephox/katamari';
 import { McEditor, TinyDom } from '@ephox/mcagar';
 import { Css, Scroll, SugarBody, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
@@ -73,7 +73,7 @@ describe('browser.tinymce.themes.silver.editor.SilverInlineEditorWidthTest', () 
 
     structureTest(editor, uiContainer, expectedWidth);
     assertWidth(uiContainer, expectedWidth, expectedWidth - 100);
-    editor.setContent(Arr.range(100, () => '<p></p>').join(''));
+    editor.setContent(Arr.range(100, Fun.constant('<p></p>')).join(''));
     Scroll.to(0, 500);
     await UiFinder.pWaitForVisible('Wait to be docked', SugarBody.body(), '.tox-tinymce--toolbar-sticky-on .tox-editor-header');
     assertWidth(uiContainer, expectedWidth, expectedWidth - 100);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
@@ -1,5 +1,6 @@
 import { Keyboard, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 
@@ -27,7 +28,7 @@ describe('browser.tinymce.themes.silver.editor.contextmenu.CustomContextMenuTest
         text: 'Custom Context Menu',
       });
       editor.ui.registry.addContextMenu('customContextMenu', {
-        update: () => 'customMenuItem'
+        update: Fun.constant('customMenuItem')
       });
     });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
 
   const createForm = (): InlineContent.ContextForm => ({
     type: 'contextform',
-    initValue: () => 'test',
+    initValue: Fun.constant('test'),
     label: Optional.none(),
     launch: Optional.none(),
     commands: [{

--- a/modules/tinymce/src/themes/silver/test/ts/phantom/components/colorinput/ColorInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/phantom/components/colorinput/ColorInputTest.ts
@@ -34,7 +34,7 @@ describe('phantom.tinymce.themes.silver.components.colorinput.ColorInputTest', (
             { type: 'choiceitem', text: 'Purple', value: '#9B59B6' },
             { type: 'choiceitem', text: 'Navy Blue', value: '#34495E' }
           ],
-          getColorCols: () => 3
+          getColorCols: Fun.constant(3)
         })
       ]
     })


### PR DESCRIPTION
Related Ticket: TINY-7588

Description of Changes:
* Fix places where `Fun.identity` should have been used in existing code.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
