### PR TITLE
TINY-7545: Fixed a bug with the context toolbar placement when switching anchors

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ContextToolbar.ts
@@ -260,12 +260,15 @@ const register = (editor: Editor, registryContextToolbars, sink: AlloyComponent,
     // ensures all toolbars returned by ContextToolbarLookup have the same position.
     // And everything else that gets toolbars from elsewhere only returns maximum 1 toolbar
     const anchor = getAnchor(toolbarApi[0].position, sElem);
-
     lastAnchor.set(Optional.some(anchor));
-    lastElement.set(sElem);
+
     const contextBarEle = contextbar.element;
     Css.remove(contextBarEle, 'display');
     InlineView.showWithinBounds(contextbar, anchor, wrapInPopDialog(toolbarSpec), () => Optional.some(getBounds()));
+
+    // IMPORTANT: This must be stored after the initial render, otherwise the lookup of the last element in the
+    // anchor placement will be incorrect as it'll reuse the new element as the anchor point.
+    lastElement.set(sElem);
 
     // It's possible we may have launched offscreen, if so then hide
     if (shouldContextToolbarHide()) {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -247,4 +247,23 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     scrollTo(editor, 0, 0);
     await pAssertPosition('bottom', 111);
   });
+
+  it('TINY-7545: Moving from different anchor points should reset the placement', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<p style="padding-top: 200px"></p>' +
+      '<div style="height: 25px;"></div>' +
+      `<p><img src="${getGreenImageDataUrl()}" style="height: 500px; width: 100px"></p>` +
+      '<p style="padding-top: 200px"></p>'
+    );
+
+    // Select the div and make sure the toolbar shows to the right
+    TinySelections.setCursor(editor, [ 1, 0 ], 0);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear', SugarBody.body(), '.tox-pop.tox-pop--left');
+
+    // Scroll to and select the image, then make sure the toolbar appears at the top
+    scrollTo(editor, 0, 400);
+    TinySelections.select(editor, 'img', []);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), '.tox-pop.tox-pop--top');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7545

Description of Changes:
* Fixed a bug @ltrouton found when doing team QA. The problem was the last anchor element was being updated before the element rendered, which caused it to always think it was rendering on the same anchor point.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
