### PR TITLE
TINY-7572: Various little UI performance improvements

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a new `preserve` option to `LayoutInside` which will preserve the previous placement inside the component.
 - Added the `alwaysFit` layout property which allows for the layout to specify if it should always claim to fit, no matter what.
 
+### Improved
+- Improved the performance of constructing event handlers and components.
+- Improved the performance of split toolbars when there were no groups to render.
+
 ### Changed
 - Changed disconnected components to log a warning instead of throwing an error when triggering or broadcasting events.
 - Changed `LayoutInside` rendering behaviour, as it was inconsistent with other layouts. It will now mirror the `Layout` logic for each direction.

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/Behaviour.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/Behaviour.ts
@@ -1,5 +1,5 @@
 import { StructureProcessor, FieldSchema, StructureSchema, FieldProcessor } from '@ephox/boulder';
-import { Fun, Obj, Optional, Thunk } from '@ephox/katamari';
+import { Fun, Obj, Optional, Optionals, Thunk } from '@ephox/katamari';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
@@ -120,7 +120,9 @@ const doCreate = <
     schema: Fun.constant(schemaSchema),
 
     exhibit: (info: BehaviourInfo<D, S>, base: DomDefinitionDetail) => {
-      return getConfig(info).bind((behaviourInfo) => Obj.get(active, 'exhibit').map((exhibitor) => exhibitor(base, behaviourInfo.config, behaviourInfo.state))).getOr(DomModification.nu({ }));
+      return Optionals.lift2(getConfig(info), Obj.get(active, 'exhibit'), (behaviourInfo, exhibitor) => {
+        return exhibitor(base, behaviourInfo.config, behaviourInfo.state);
+      }).getOrThunk(() => DomModification.nu({ }));
     },
 
     name: Fun.constant(name),

--- a/modules/alloy/src/main/ts/ephox/alloy/construct/CustomDefinition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/construct/CustomDefinition.ts
@@ -25,7 +25,7 @@ export interface CustomDetail<A> {
 
 const baseBehaviour = 'alloy.base.behaviour';
 
-const toInfo = <A>(spec: ComponentDetail): Result<CustomDetail<A>, any> => StructureSchema.asRaw('custom.definition', StructureSchema.objOf([
+const schema = StructureSchema.objOf([
   FieldSchema.field('dom', 'dom', FieldPresence.required(), StructureSchema.objOf([
     // Note, no children.
     FieldSchema.required('tag'),
@@ -39,7 +39,7 @@ const toInfo = <A>(spec: ComponentDetail): Result<CustomDetail<A>, any> => Struc
   FieldSchema.required('uid'),
 
   FieldSchema.defaulted('events', {}),
-  FieldSchema.defaulted('apis', { }),
+  FieldSchema.defaulted('apis', {}),
 
   // Use mergeWith in the future when pre-built behaviours conflict
   FieldSchema.field(
@@ -61,7 +61,9 @@ const toInfo = <A>(spec: ComponentDetail): Result<CustomDetail<A>, any> => Struc
   ),
 
   FieldSchema.option('domModification')
-]), spec);
+]);
+
+const toInfo = <A>(spec: ComponentDetail): Result<CustomDetail<A>, any> => StructureSchema.asRaw('custom.definition', schema, spec);
 
 const toDefinition = (detail: CustomDetail<any>): DomDefinitionDetail =>
   // EFFICIENCY: Consider not merging here.

--- a/modules/alloy/src/main/ts/ephox/alloy/construct/EventHandler.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/construct/EventHandler.ts
@@ -1,8 +1,13 @@
-import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Arr, Fun, Obj, Type } from '@ephox/katamari';
 
 import { AlloyEventHandler, EventRunHandler } from '../api/events/AlloyEvents';
 import { EventFormat, SimulatedEvent } from '../events/SimulatedEvent';
+
+const defaultEventHandler = {
+  can: Fun.always,
+  abort: Fun.never,
+  run: Fun.noop
+};
 
 const nu = <T extends EventFormat>(parts: Partial<AlloyEventHandler<T>>): AlloyEventHandler<T> => {
   if (!Obj.hasNonNullableKey(parts, 'can') && !Obj.hasNonNullableKey(parts, 'abort') && !Obj.hasNonNullableKey(parts, 'run')) {
@@ -10,11 +15,10 @@ const nu = <T extends EventFormat>(parts: Partial<AlloyEventHandler<T>>): AlloyE
       'EventHandler defined by: ' + JSON.stringify(parts, null, 2) + ' does not have can, abort, or run!'
     );
   }
-  return StructureSchema.asRawOrDie('Extracting event.handler', StructureSchema.objOfOnly([
-    FieldSchema.defaulted('can', Fun.always),
-    FieldSchema.defaulted('abort', Fun.never),
-    FieldSchema.defaulted('run', Fun.noop)
-  ]), parts);
+  return {
+    ...defaultEventHandler,
+    ...parts
+  };
 };
 
 const all = <T extends EventFormat>(handlers: Array<AlloyEventHandler<T>>, f: (handler: AlloyEventHandler<T>) => any) => (...args: any[]) =>
@@ -42,11 +46,11 @@ const fuse = <T extends EventFormat>(handlers: Array<AlloyEventHandler<T>>): All
     });
   };
 
-  return nu<T>({
+  return {
     can,
     abort,
     run
-  });
+  };
 };
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/dom/DomModification.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dom/DomModification.ts
@@ -1,4 +1,5 @@
-import { Fun } from '@ephox/katamari';
+import { Fun, Type } from '@ephox/katamari';
+
 import { DomDefinitionDetail } from './DomDefinition';
 
 export interface DomModification {
@@ -13,9 +14,9 @@ export interface DomModificationSpec extends Partial<DomModification> {
 
 // Maybe we'll need to allow add/remove
 const nu = (s: DomModificationSpec): DomModification => ({
-  classes: s.classes !== undefined ? s.classes : [ ],
-  attributes: s.attributes !== undefined ? s.attributes : { },
-  styles: s.styles !== undefined ? s.styles : { }
+  classes: Type.isUndefined(s.classes) ? [ ] : s.classes,
+  attributes: Type.isUndefined(s.attributes) ? { } : s.attributes,
+  styles: Type.isUndefined(s.styles) ? { } : s.styles
 });
 
 const modToStr = (mod: DomModification): string => {

--- a/modules/alloy/src/main/ts/ephox/alloy/toolbar/SplitToolbarUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/toolbar/SplitToolbarUtils.ts
@@ -20,13 +20,19 @@ const findFocusedComp = (comps: AlloyComponent[]): Optional<AlloyComponent> =>
   Arr.findMap(comps, (comp) => Focus.search(comp.element).bind((focusedElm) => comp.getSystem().getByDom(focusedElm).toOptional()));
 
 const refresh = (toolbar: AlloyComponent, detail: SplitToolbarBaseDetail, setOverflow: (groups: AlloyComponent[]) => void): void => {
+  // Ensure we have toolbar groups to render
+  const builtGroups = detail.builtGroups.get();
+  if (builtGroups.length === 0) {
+    return;
+  }
+
   const primary = AlloyParts.getPartOrDie(toolbar, detail, 'primary');
   const overflowGroup = Coupling.getCoupled(toolbar, 'overflowGroup');
 
   // Set the primary toolbar to have visibility hidden;
   Css.set(primary.element, 'visibility', 'hidden');
 
-  const groups = detail.builtGroups.get().concat([ overflowGroup ]);
+  const groups = builtGroups.concat([ overflowGroup ]);
 
   // Store the current focus state
   const focusedComp = findFocusedComp(groups);

--- a/modules/boulder/CHANGELOG.md
+++ b/modules/boulder/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- Improved the performance of the `StructureProcessor.objOf` and `StructureProcessor.objOfOnly` functions #TINY-7572
+
 ### Changed
 - Replaced `FieldPresenceAdt` with the native TypeScript equivalent, and renamed to `FieldPresence`  #TINY-7549
 - Replaced `ValueProcessorAdt` (and its alias `FieldProcessorAdt`) with the native TypeScript equivalent, and renamed to `FieldProcessor` #TINY-7549

--- a/modules/boulder/src/main/ts/ephox/boulder/core/StructureProcessor.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/StructureProcessor.ts
@@ -141,7 +141,7 @@ const objOfOnly = (fields: FieldProcessor[]): StructureProcessor => {
     );
   }, {} as Record<string, boolean>);
 
-  const extract = (path: string[], o: Record<string, any>) => {
+  const extract = (path: string[], o: Record<string, any> | boolean) => {
     const keys = Type.isBoolean(o) ? [] : getSetKeys(o);
     const extra = Arr.filter(keys, (k) => !Obj.hasNonNullableKey(fieldNames, k));
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504
+- Improved the performance when rendering UI components #TINY-7572
 - When scrolling, the context toolbar will stick to where it was previously for large elements, such as tables #TINY-7545
 
 ### Changed

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -20,7 +20,7 @@ import * as Iframe from './modes/Iframe';
 import * as Inline from './modes/Inline';
 import * as ReadOnly from './ReadOnly';
 import * as FormatControls from './ui/core/FormatControls';
-import OuterContainer, { OuterContainerSketchSpec } from './ui/general/OuterContainer';
+import OuterContainer from './ui/general/OuterContainer';
 import * as StaticHeader from './ui/header/StaticHeader';
 import * as StickyHeader from './ui/header/StickyHeader';
 import * as SilverContextMenu from './ui/menus/contextmenu/SilverContextMenu';
@@ -333,7 +333,7 @@ const setup = (editor: Editor): RenderInfo => {
           selector: '.tox-menubar, .tox-toolbar, .tox-toolbar__primary, .tox-toolbar__overflow--open, .tox-sidebar__overflow--open, .tox-statusbar__path, .tox-statusbar__wordcount, .tox-statusbar__branding a, .tox-statusbar__resize-handle'
         })
       ])
-    } as OuterContainerSketchSpec)
+    })
   );
 
   lazyOuterContainer = Optional.some(outerContainer);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
@@ -8,7 +8,7 @@
 import {
   AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Focusing, ItemTypes, NativeEvents, Replacing
 } from '@ephox/alloy';
-import { Arr, Cell, Fun, Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional, Optionals } from '@ephox/katamari';
 import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import * as ReadOnly from 'tinymce/themes/silver/ReadOnly';
 
@@ -18,8 +18,7 @@ import { menuItemEventOrder, onMenuItemExecute } from '../ItemEvents';
 import ItemResponse from '../ItemResponse';
 import { ItemStructure } from '../structure/ItemStructure';
 
-export const componentRenderPipeline = (xs: Array<Optional<AlloySpec>>) =>
-  Arr.bind(xs, (o) => o.toArray());
+export const componentRenderPipeline: (xs: Array<Optional<AlloySpec>>) => AlloySpec[] = Optionals.cat;
 
 export interface CommonMenuItemSpec<T> {
   onAction: (itemApi: T) => void;


### PR DESCRIPTION
Related Ticket: TINY-7572

Description of Changes:
* Improves the boulder validation so that a lot less objects are created. This saves in construction time and also reduces the amount of garbage collection needed. It also reduces the amount of looping going on, as it was previously was looping at least twice for every field being validated.
* Removes the boulder validation from alloy event handler construction, as it's not needed with TypeScript and only slows things down setting up the event processing.
* Stores a constant copy of the component schema, which saves having to construct it for every Alloy component generated.
* A couple of other very minor cleanup tasks.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
