### PR TITLE
TINY-7572: Minor toolbar button setup performance improvement and cleanup

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/AlignmentButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/AlignmentButtons.ts
@@ -5,10 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import Editor from 'tinymce/core/api/Editor';
-import Tools from 'tinymce/core/api/util/Tools';
+import { Arr } from '@ephox/katamari';
 
-import { onSetupFormatToggle } from './complex/utils/Utils';
+import Editor from 'tinymce/core/api/Editor';
+
+import { onActionExecCommand, onSetupFormatToggle } from './ControlUtils';
 
 const register = (editor: Editor) => {
   const alignToolbarButtons = [
@@ -18,20 +19,19 @@ const register = (editor: Editor) => {
     { name: 'alignjustify', text: 'Justify', cmd: 'JustifyFull', icon: 'align-justify' }
   ];
 
-  Tools.each(alignToolbarButtons, (item) => {
+  Arr.each(alignToolbarButtons, (item) => {
     editor.ui.registry.addToggleButton(item.name, {
       tooltip: item.text,
-      onAction: () => editor.execCommand(item.cmd),
       icon: item.icon,
+      onAction: onActionExecCommand(editor, item.cmd),
       onSetup: onSetupFormatToggle(editor, item.name)
     });
   });
 
-  const alignNoneToolbarButton = { name: 'alignnone', text: 'No alignment', cmd: 'JustifyNone', icon: 'align-none' };
-  editor.ui.registry.addButton(alignNoneToolbarButton.name, {
-    tooltip: alignNoneToolbarButton.text,
-    onAction: () => editor.execCommand(alignNoneToolbarButton.cmd),
-    icon: alignNoneToolbarButton.icon
+  editor.ui.registry.addButton('alignnone', {
+    tooltip: 'No alignment',
+    icon: 'align-none',
+    onAction: onActionExecCommand(editor, 'JustifyNone')
   });
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/IndentOutdent.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/IndentOutdent.ts
@@ -8,29 +8,25 @@
 import Editor from 'tinymce/core/api/Editor';
 import { Toolbar } from 'tinymce/core/api/ui/Ui';
 
-const toggleOutdentState = (api: Toolbar.ToolbarButtonInstanceApi, editor: Editor) => {
-  api.setDisabled(!editor.queryCommandState('outdent'));
+import { onActionExecCommand, onSetupEvent } from './ControlUtils';
 
-  const onNodeChange = () => {
+const onSetupOutdentState = (editor: Editor) =>
+  onSetupEvent(editor, 'NodeChange', (api: Toolbar.ToolbarButtonInstanceApi) => {
     api.setDisabled(!editor.queryCommandState('outdent'));
-  };
-
-  editor.on('NodeChange', onNodeChange);
-  return () => editor.off('NodeChange', onNodeChange);
-};
+  });
 
 const registerButtons = (editor: Editor) => {
   editor.ui.registry.addButton('outdent', {
     tooltip: 'Decrease indent',
     icon: 'outdent',
-    onSetup: (api) => toggleOutdentState(api, editor),
-    onAction: () => editor.execCommand('outdent')
+    onSetup: onSetupOutdentState(editor),
+    onAction: onActionExecCommand(editor, 'outdent')
   });
 
   editor.ui.registry.addButton('indent', {
     tooltip: 'Increase indent',
     icon: 'indent',
-    onAction: () => editor.execCommand('indent')
+    onAction: onActionExecCommand(editor, 'indent')
   });
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
@@ -8,9 +8,9 @@
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 
-import { onSetupFormatToggle } from './complex/utils/Utils';
+import { onActionExecCommand, onSetupFormatToggle } from './ControlUtils';
 
-const toggleFormat = (editor: Editor, fmt: string) => () => {
+const onActionToggleFormat = (editor: Editor, fmt: string) => () => {
   editor.execCommand('mceToggleFormat', false, fmt);
 };
 
@@ -27,7 +27,7 @@ const registerFormatButtons = (editor: Editor) => {
       tooltip: btn.text,
       icon: btn.icon,
       onSetup: onSetupFormatToggle(editor, btn.name),
-      onAction: toggleFormat(editor, btn.name)
+      onAction: onActionToggleFormat(editor, btn.name)
     });
   });
 
@@ -37,7 +37,7 @@ const registerFormatButtons = (editor: Editor) => {
       text: name.toUpperCase(),
       tooltip: 'Heading ' + i,
       onSetup: onSetupFormatToggle(editor, name),
-      onAction: toggleFormat(editor, name)
+      onAction: onActionToggleFormat(editor, name)
     });
   }
 };
@@ -57,7 +57,7 @@ const registerCommandButtons = (editor: Editor) => {
     editor.ui.registry.addButton(btn.name, {
       tooltip: btn.text,
       icon: btn.icon,
-      onAction: () => editor.execCommand(btn.action)
+      onAction: onActionExecCommand(editor, btn.action)
     });
   });
 };
@@ -69,7 +69,7 @@ const registerCommandToggleButtons = (editor: Editor) => {
     editor.ui.registry.addToggleButton(btn.name, {
       tooltip: btn.text,
       icon: btn.icon,
-      onAction: () => editor.execCommand(btn.action),
+      onAction: onActionExecCommand(editor, btn.action),
       onSetup: onSetupFormatToggle(editor, btn.name)
     });
   });
@@ -100,14 +100,14 @@ const registerMenuItems = (editor: Editor) => {
       text: btn.text,
       icon: btn.icon,
       shortcut: btn.shortcut,
-      onAction: () => editor.execCommand(btn.action)
+      onAction: onActionExecCommand(editor, btn.action)
     });
   });
 
   editor.ui.registry.addMenuItem('codeformat', {
     text: 'Code',
     icon: 'sourcecode',
-    onAction: toggleFormat(editor, 'code')
+    onAction: onActionToggleFormat(editor, 'code')
   });
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/UndoRedo.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/UndoRedo.ts
@@ -6,52 +6,50 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
-const toggleUndoRedoState = (api: Menu.MenuItemInstanceApi, editor: Editor, type: 'hasUndo' | 'hasRedo') => {
-  const checkState = () => editor.undoManager ? editor.undoManager[type]() : false;
+import { onActionExecCommand, onSetupEvent } from './ControlUtils';
 
-  const onUndoStateChange = () => {
-    api.setDisabled(editor.mode.isReadOnly() || !checkState());
-  };
-
-  api.setDisabled(!checkState());
-
-  editor.on('Undo Redo AddUndo TypingUndo ClearUndos SwitchMode', onUndoStateChange);
-  return () => editor.off('Undo Redo AddUndo TypingUndo ClearUndos SwitchMode', onUndoStateChange);
-};
+const onSetupUndoRedoState = (editor: Editor, type: 'hasUndo' | 'hasRedo') =>
+  onSetupEvent(editor, 'Undo Redo AddUndo TypingUndo ClearUndos SwitchMode', (api: Menu.MenuItemInstanceApi | Toolbar.ToolbarButtonInstanceApi) => {
+    api.setDisabled(editor.mode.isReadOnly() || !editor.undoManager[type]());
+  });
 
 const registerMenuItems = (editor: Editor) => {
   editor.ui.registry.addMenuItem('undo', {
     text: 'Undo',
     icon: 'undo',
     shortcut: 'Meta+Z',
-    onSetup: (api) => toggleUndoRedoState(api, editor, 'hasUndo'),
-    onAction: () => editor.execCommand('undo')
+    onSetup: onSetupUndoRedoState(editor, 'hasUndo'),
+    onAction: onActionExecCommand(editor, 'undo')
   });
 
   editor.ui.registry.addMenuItem('redo', {
     text: 'Redo',
     icon: 'redo',
     shortcut: 'Meta+Y',
-    onSetup: (api) => toggleUndoRedoState(api, editor, 'hasRedo'),
-    onAction: () => editor.execCommand('redo')
+    onSetup: onSetupUndoRedoState(editor, 'hasRedo'),
+    onAction: onActionExecCommand(editor, 'redo')
   });
 };
 
+// Note: The undo/redo buttons are disabled by default here, as they'll be rendered
+// on init generally and it won't haven't any undo levels at that stage.
 const registerButtons = (editor: Editor) => {
   editor.ui.registry.addButton('undo', {
     tooltip: 'Undo',
     icon: 'undo',
-    onSetup: (api) => toggleUndoRedoState(api, editor, 'hasUndo'),
-    onAction: () => editor.execCommand('undo')
+    disabled: true,
+    onSetup: onSetupUndoRedoState(editor, 'hasUndo'),
+    onAction: onActionExecCommand(editor, 'undo')
   });
 
   editor.ui.registry.addButton('redo', {
     tooltip: 'Redo',
     icon: 'redo',
-    onSetup: (api) => toggleUndoRedoState(api, editor, 'hasRedo'),
-    onAction: () => editor.execCommand('redo')
+    disabled: true,
+    onSetup: onSetupUndoRedoState(editor, 'hasRedo'),
+    onAction: onActionExecCommand(editor, 'redo')
   });
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/UndoRedo.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/UndoRedo.ts
@@ -34,7 +34,7 @@ const registerMenuItems = (editor: Editor) => {
 };
 
 // Note: The undo/redo buttons are disabled by default here, as they'll be rendered
-// on init generally and it won't haven't any undo levels at that stage.
+// on init generally and it won't have any undo levels at that stage.
 const registerButtons = (editor: Editor) => {
   editor.ui.registry.addButton('undo', {
     tooltip: 'Undo',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/VisualAid.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/VisualAid.ts
@@ -8,23 +8,18 @@
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
 
-const toggleVisualAidState = (api: Menu.ToggleMenuItemInstanceApi, editor: Editor) => {
-  api.setActive(editor.hasVisual);
+import { onActionExecCommand, onSetupEvent } from './ControlUtils';
 
-  const onVisualAid = (e) => {
-    api.setActive(e.hasVisual);
-  };
-  editor.on('VisualAid', onVisualAid);
-  return () => editor.off('VisualAid', onVisualAid);
-};
+const onSetupVisualAidState = (editor: Editor) =>
+  onSetupEvent(editor, 'VisualAid', (api: Menu.ToggleMenuItemInstanceApi) => {
+    api.setActive(editor.hasVisual);
+  });
 
 const registerMenuItems = (editor: Editor) => {
   editor.ui.registry.addToggleMenuItem('visualaid', {
     text: 'Visual aids',
-    onSetup: (api) => toggleVisualAidState(api, editor),
-    onAction: () => {
-      editor.execCommand('mceToggleVisualAid');
-    }
+    onSetup: onSetupVisualAidState(editor),
+    onAction: onActionExecCommand(editor, 'mceToggleVisualAid')
   });
 };
 
@@ -32,7 +27,7 @@ const registerToolbarButton = (editor: Editor) => {
   editor.ui.registry.addButton('visualaid', {
     tooltip: 'Visual aids',
     text: 'Visual aids',
-    onAction: () => editor.execCommand('mceToggleVisualAid')
+    onAction: onActionExecCommand(editor, 'mceToggleVisualAid')
   });
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignSelect.ts
@@ -46,6 +46,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 
   return {
     tooltip: 'Align',
+    text: Optional.none(),
     icon: Optional.some('align-left'),
     isSelectedFor,
     getCurrentValue: Optional.none,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -16,6 +16,7 @@ import { renderCommonDropdown } from '../../dropdown/CommonDropdown';
 import ItemResponse from '../../menus/item/ItemResponse';
 import * as NestedMenus from '../../menus/menu/NestedMenus';
 import { ToolbarButtonClasses } from '../../toolbar/button/ButtonClasses';
+import { onSetupEvent } from '../ControlUtils';
 import { SelectDataset } from './SelectDatasets';
 import * as FormatRegister from './utils/FormatRegister';
 
@@ -48,6 +49,7 @@ export type FormatItem = FormatterFormatItem | SubMenuFormatItem | SeparatorForm
 
 export interface SelectSpec {
   tooltip: string;
+  text: Optional<string>;
   icon: Optional<string>;
   // This is used for determining if an item gets a tick in the menu
   isSelectedFor: FormatRegister.IsSelectedForType;
@@ -158,24 +160,15 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({ getComponent: Fun.constant(comp) });
 
-  const onSetup = (api: BespokeSelectApi): () => void => {
-    const updateText = () => {
-      const comp = api.getComponent();
-      spec.updateText(comp);
-    };
-
-    // Set the initial text when the component is attached and then update on node changes
-    updateText();
-    editor.on('NodeChange', updateText);
-
-    return () => {
-      editor.off('NodeChange', updateText);
-    };
-  };
+  // Set the initial text when the component is attached and then update on node changes
+  const onSetup = onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {
+    const comp = api.getComponent();
+    spec.updateText(comp);
+  });
 
   return renderCommonDropdown(
     {
-      text: spec.icon.isSome() ? Optional.none() : Optional.some(''),
+      text: spec.icon.isSome() ? Optional.none() : spec.text,
       icon: spec.icon,
       tooltip: Optional.from(spec.tooltip),
       role: Optional.none(),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, AlloyTriggers } from '@ephox/alloy';
-import { Arr, Fun, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
@@ -57,6 +57,8 @@ const isSystemFontStack = (fontFamily: string): boolean => {
 };
 
 const getSpec = (editor: Editor): SelectSpec => {
+  const systemFont = 'System Font';
+
   const getMatchingValue = () => {
     const getFirstFont = (fontFamily) => fontFamily ? splitFonts(fontFamily)[0] : '';
 
@@ -68,14 +70,10 @@ const getSpec = (editor: Editor): SelectSpec => {
       const format = item.format;
       return (format.toLowerCase() === font) || (getFirstFont(format).toLowerCase() === getFirstFont(font).toLowerCase());
     }).orThunk(() => {
-      if (isSystemFontStack(font)) {
-        return Optional.from({
-          title: 'System Font',
-          format: font
-        });
-      } else {
-        return Optional.none();
-      }
+      return Optionals.someIf(isSystemFontStack(font), {
+        title: systemFont,
+        format: font
+      });
     });
 
     return { matchOpt, font: fontFamily };
@@ -112,6 +110,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 
   return {
     tooltip: 'Fonts',
+    text: Optional.some(systemFont),
     icon: Optional.none(),
     isSelectedFor,
     getCurrentValue,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
@@ -103,6 +103,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 
   return {
     tooltip: 'Font sizes',
+    text: Optional.some('12pt'),
     icon: Optional.none(),
     isSelectedFor,
     getPreviewFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
@@ -13,10 +13,10 @@ import { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
 
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
+import { onActionToggleFormat } from '../ControlUtils';
 import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
-import { onActionToggleFormat } from './utils/Utils';
 
 const defaultBlocks = (
   'Paragraph=p;' +
@@ -30,6 +30,8 @@ const defaultBlocks = (
 );
 
 const getSpec = (editor: Editor): SelectSpec => {
+  const fallbackFormat = 'Paragraph';
+
   const isSelectedFor = (format: string) => () => editor.formatter.match(format);
 
   const getPreviewFor = (format: string) => () => {
@@ -42,7 +44,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 
   const updateSelectMenuText = (comp: AlloyComponent) => {
     const detectedFormat = findNearest(editor, () => dataset.data);
-    const text = detectedFormat.fold(Fun.constant('Paragraph'), (fmt) => fmt.title);
+    const text = detectedFormat.fold(Fun.constant(fallbackFormat), (fmt) => fmt.title);
     AlloyTriggers.emitWith(comp, updateMenuText, {
       text
     });
@@ -52,6 +54,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 
   return {
     tooltip: 'Blocks',
+    text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,
     getCurrentValue: Optional.none,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleSelect.ts
@@ -13,13 +13,15 @@ import { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
 
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
+import { onActionToggleFormat } from '../ControlUtils';
 import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { AdvancedSelectDataset, SelectDataset } from './SelectDatasets';
 import { getStyleFormats } from './StyleFormat';
 import { findNearest } from './utils/FormatDetection';
-import { onActionToggleFormat } from './utils/Utils';
 
 const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
+  const fallbackFormat = 'Paragraph';
+
   const isSelectedFor = (format: string) => () => editor.formatter.match(format);
 
   const getPreviewFor = (format: string) => () => {
@@ -37,7 +39,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
     };
     const flattenedItems = Arr.bind(getStyleFormats(editor), getFormatItems);
     const detectedFormat = findNearest(editor, Fun.constant(flattenedItems));
-    const text = detectedFormat.fold(Fun.constant('Paragraph'), (fmt) => fmt.title);
+    const text = detectedFormat.fold(Fun.constant(fallbackFormat), (fmt) => fmt.title);
     AlloyTriggers.emitWith(comp, updateMenuText, {
       text
     });
@@ -45,6 +47,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
 
   return {
     tooltip: 'Formats',
+    text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,
     getCurrentValue: Optional.none,


### PR DESCRIPTION
Related Ticket: TINY-7572

Description of Changes:
The bespoke toolbar buttons where running a number of times before init and this didn't do anything meaningful as they need the initial location set during init. Additionally, these aren't the fastest lookups so this just makes the bespoke and other core buttons only start listening to events once the editor is initialized. I also did some code cleanup to remove duplicate code which made this easier to implement. Doing all this ends up saving another ~20-25ms during init time for the full feature demo.

Pre-checks:
* [x] ~Changelog entry added~ (Already have a changelog from the previous PR)
* [x] ~Tests have been added (if applicable)~ (Covered by existing tests)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
