### PR TITLE
TINY-7661: Add cursor: pointer to 'a' tags in notifications

### DIFF
--- a/modules/oxide/src/less/theme/components/notification/notification.less
+++ b/modules/oxide/src/less/theme/components/notification/notification.less
@@ -63,6 +63,7 @@
     }
 
     a {
+      cursor: pointer;
       text-decoration: underline;
     }
   }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
 - Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
 - Partially transparent RGBA values provided in the `color_map` setting were given the wrong hex value #TINY-7163
+- Links in notification text did not show the correct mouse pointer #TINY-7661
 
 ## 5.8.2 - 2021-06-23
 


### PR DESCRIPTION
Related Ticket: TINY-7661

Description of Changes:
* Added a `cursor: pointer` style entry to `a` tags inside notifications. Without this they default to the text cursor.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved