### PR TITLE
TINY-4589: Rtl/ltl attributes sometimes gets applied to list items

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents. #TINY-7249
 
 ### Fixed
+- Rtl/ltl attributes sometimes gets applied to list items #TINY-4589
 - `editor.fire` was incorrectly mutating the original `args` provided #TINY-3254
 - The `SetContent` event contained the incorrect `content` when using the `editor.selection.setContent()` API #TINY-3254
 - The editor content could be edited after calling `setProgressState(true)` in iframe mode #TINY-7373

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents. #TINY-7249
 
 ### Fixed
-- Rtl/ltl attributes sometimes gets applied to list items #TINY-4589
+- The `dir` attribute was being incorrectly applied to list items #TINY-4589
 - `editor.fire` was incorrectly mutating the original `args` provided #TINY-3254
 - The `SetContent` event contained the incorrect `content` when using the `editor.selection.setContent()` API #TINY-3254
 - The editor content could be edited after calling `setProgressState(true)` in iframe mode #TINY-7373

--- a/modules/tinymce/src/plugins/directionality/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/directionality/demo/ts/demo/Demo.ts
@@ -2,8 +2,8 @@ declare let tinymce: any;
 
 tinymce.init({
   selector: 'textarea.tinymce',
-  plugins: 'directionality code',
-  toolbar: 'ltr rtl code',
+  plugins: 'directionality code lists',
+  toolbar: 'ltr rtl code | bullist numlist',
   height: 600
 });
 

--- a/modules/tinymce/src/plugins/directionality/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/api/Commands.ts
@@ -9,11 +9,11 @@ import * as Direction from '../core/Direction';
 
 const register = (editor) => {
   editor.addCommand('mceDirectionLTR', () => {
-    Direction.setDir(editor, 'ltr');
+    Direction.setDir(editor, 'ltr' as Direction.Dir);
   });
 
   editor.addCommand('mceDirectionRTL', () => {
-    Direction.setDir(editor, 'rtl');
+    Direction.setDir(editor, 'rtl' as Direction.Dir);
   });
 };
 

--- a/modules/tinymce/src/plugins/directionality/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/api/Commands.ts
@@ -9,11 +9,11 @@ import * as Direction from '../core/Direction';
 
 const register = (editor) => {
   editor.addCommand('mceDirectionLTR', () => {
-    Direction.setDir(editor, 'ltr' as Direction.Dir);
+    Direction.setDir(editor, 'ltr');
   });
 
   editor.addCommand('mceDirectionRTL', () => {
-    Direction.setDir(editor, 'rtl' as Direction.Dir);
+    Direction.setDir(editor, 'rtl');
   });
 };
 

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -10,7 +10,7 @@ import { Traverse, Attribute, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-type Dir = 'rtl' | 'ltl';
+type Dir = 'rtl' | 'ltr';
 
 const setDir = (editor: Editor, dir: Dir) => {
   const selectedBlocks = editor.selection.getSelectedBlocks();
@@ -43,5 +43,5 @@ const setDirAttr = (editor: Editor, element: SugarElement, dir: Dir): void => {
 const isListItem = (element: SugarElement<Element>): boolean => element.dom.nodeName === 'LI';
 
 export {
-  setDir, Dir
+  setDir
 };

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -36,7 +36,7 @@ const setDir = (editor: Editor, dir: Dir) => {
 
 const isListItem = SugarNode.isTag('li');
 
-const setDirAttr = (editor: Editor, element: SugarElement, dir: Dir): void => {
+const setDirAttr = (editor: Editor, element: SugarElement<Element>, dir: Dir): void => {
   if (isListItem(element)) {
     const list = getParentElement(element);
     list.each((l) => Attribute.set(l, 'dir', dir));

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -17,7 +17,7 @@ const setDir = (editor: Editor, dir: Dir) => {
   Arr.each(selectedBlocks, (block) => {
     const sugarBlock = SugarElement.fromDom(block);
     const blockParent = Traverse.parent(sugarBlock);
-    blockParent.map((blockParent: SugarElement<Element>) => {
+    blockParent.each((blockParent: SugarElement<Element>) => {
       const blockParentDirection = Attribute.get(blockParent, 'dir');
       if ((blockParentDirection === undefined) || (blockParentDirection !== dir)) {
         setDirAttr(editor, sugarBlock, dir);
@@ -32,7 +32,7 @@ const setDir = (editor: Editor, dir: Dir) => {
 const setDirAttr = (editor: Editor, element: SugarElement, dir: Dir): void => {
   if (isListItem(element)) {
     const list = Traverse.parent(element);
-    list.map((l: SugarElement<Element>) => Attribute.set(l, 'dir', dir));
+    list.each((l: SugarElement<Element>) => Attribute.set(l, 'dir', dir));
   } else {
     Attribute.set(element, 'dir', dir);
   }

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -25,7 +25,7 @@ const setDir = (editor: Editor, dir: Dir) => {
         Type.isNull(blockParentDirection) ||
         blockParentDirection.trim() === '' ||
         blockParentDirection !== dir) {
-        setDirAttr(editor, sugarBlock, dir);
+        setDirAttr(editor, sugarBlock, blockParent, dir);
       } else { // if parent and child dir are going to be the same then remove it from child
         Attribute.remove(sugarBlock, 'dir');
         editor.nodeChanged();
@@ -36,17 +36,10 @@ const setDir = (editor: Editor, dir: Dir) => {
 
 const isListItem = SugarNode.isTag('li');
 
-const setDirAttr = (editor: Editor, element: SugarElement<Element>, dir: Dir): void => {
-  if (isListItem(element)) {
-    const list = getParentElement(element);
-    list.each((l) => Attribute.set(l, 'dir', dir));
-  } else {
-    Attribute.set(element, 'dir', dir);
-  }
-
+const setDirAttr = (editor: Editor, element: SugarElement<Element>, parent: SugarElement<Element>, dir: Dir): void => {
+  Attribute.set(isListItem(element) ? parent : element, 'dir', dir);
   editor.nodeChanged();
 };
-
 
 export {
   setDir

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -12,9 +12,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 type Dir = 'rtl' | 'ltr';
 
-const getParentElement = (element: SugarElement<Element>): Optional<SugarElement<Element>> => {
-  return Traverse.parent(element).filter(SugarNode.isElement);
-};
+const getParentElement = (element: SugarElement<Element>): Optional<SugarElement<Element>> => Traverse.parent(element).filter(SugarNode.isElement);
 
 // if the block is a list item, we need to get the parent of the list itself
 const getNormalizedBlock = (element: SugarElement<Element>, isListItem: boolean): SugarElement<Element> => {
@@ -28,9 +26,9 @@ const setDir = (editor: Editor, dir: Dir): void => {
   const selectedBlocks = editor.selection.getSelectedBlocks();
   if (selectedBlocks.length > 0) {
     Arr.each(selectedBlocks, (block) => {
-      const sugarBlock = SugarElement.fromDom(block);
-      const isSugarBlockListItem = isListItem(sugarBlock);
-      const normalizedBlock = getNormalizedBlock(sugarBlock, isSugarBlockListItem);
+      const blockElement = SugarElement.fromDom(block);
+      const isBlockElementListItem = isListItem(blockElement);
+      const normalizedBlock = getNormalizedBlock(blockElement, isBlockElementListItem);
       const normalizedBlockParent = getParentElement(normalizedBlock);
       normalizedBlockParent.each((parent) => {
         const parentDirection = Direction.getDirection(parent);
@@ -41,7 +39,7 @@ const setDir = (editor: Editor, dir: Dir): void => {
         }
 
         // remove dir attr from list children
-        if (isSugarBlockListItem) {
+        if (isBlockElementListItem) {
           const listItems = SelectorFilter.children(normalizedBlock, 'li[dir]');
           Arr.each(listItems, (listItem) => Attribute.remove(listItem, 'dir'));
         }

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -12,7 +12,8 @@ import Editor from 'tinymce/core/api/Editor';
 
 type Dir = 'rtl' | 'ltr';
 
-const getParentElement = (element: SugarElement<Element>): Optional<SugarElement<Element>> => Traverse.parent(element).filter(SugarNode.isElement);
+const getParentElement = (element: SugarElement<Element>): Optional<SugarElement<Element>> =>
+  Traverse.parent(element).filter(SugarNode.isElement);
 
 // if the block is a list item, we need to get the parent of the list itself
 const getNormalizedBlock = (element: SugarElement<Element>, isListItem: boolean): SugarElement<Element> => {

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -42,12 +42,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
 
   it('TINY-4589: should set parent dir when element is a list item', () => {
     const editor = hook.editor();
-    editor.setContent(`
-    <ul>
-      <li>foo</li>
-      <li>bar</li>
-    </ul>
-    `);
+    editor.setContent('<ul><li>foo</li><li>bar</li></ul>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContent(editor, `<ul dir="rtl">\n<li>foo</li>\n<li>bar</li>\n</ul>`);
@@ -58,12 +53,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
 
   it('TINY-4589: should remove dir from list item', () => {
     const editor = hook.editor();
-    editor.setContent(`
-    <ul>
-      <li dir="ltr">foo</li>
-      <li>bar</li>
-    </ul>
-    `);
+    editor.setContent('<ul><li dir="ltr">foo</li><li>bar</li></ul>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContent(editor, `<ul dir="rtl">\n<li>foo</li>\n<li>bar</li>\n</ul>`);

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -81,7 +81,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     );
   });
 
-  it('TINY-4589: should consider list item dir', () => {
+  it('TINY-4589: applying the same dir makes no changes', () => {
     const editor = hook.editor();
     editor.setContent(
       '<ul dir="rtl">' +
@@ -105,7 +105,21 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
         '</li>' +
       '</ul>'
     );
+  });
 
+  it('TINY-4589: should consider list item dir', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ul dir="rtl">' +
+        '<li dir="ltr">ini' +
+          '<ul>' +
+            '<li>foo</li>' +
+            '<li>bar</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>'
+    );
+    TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1); // foo
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContent(editor,
       '<ul dir="rtl">' +

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -47,4 +47,139 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       });
     }));
   });
+
+  it('should set two paragraphs to rtl and ltl', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>foo</p><p>bar</p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            attrs: {
+              dir: str.is('rtl')
+            }
+          }),
+          s.element('p', {
+            attrs: {
+              dir: str.is('rtl')
+            }
+          })
+        ]
+      });
+    }));
+
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            attrs: {
+              dir: str.is('ltr')
+            }
+          }),
+          s.element('p', {
+            attrs: {
+              dir: str.is('ltr')
+            }
+          })
+        ]
+      });
+    }));
+  });
+
+  it('should set parent dir when element is a list item', () => {
+    const editor = hook.editor();
+    editor.setContent(`
+    <ul>
+      <li>foo</li>
+      <li>bar</li>
+    </ul>
+    `);
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('ul', {
+            attrs: {
+              dir: str.is('rtl')
+            },
+            children: [
+              s.element('li', {}),
+              s.element('li', {}),
+            ]
+          }),
+        ]
+      });
+    }));
+
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('ul', {
+            attrs: {
+              dir: str.is('ltr')
+            },
+            children: [
+              s.element('li', {}),
+              s.element('li', {}),
+            ]
+          }),
+        ]
+      });
+    }));
+  });
+
+  it('should remove dir attr if parent has same dir', () => {
+    const editor = hook.editor();
+    editor.setContent(`
+    <div dir="ltr">
+      <p>foo</p>
+      <p>bar</p>
+    </div>
+    `);
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('div', {
+            attrs: {
+              dir: str.is('ltr')
+            },
+            children: [
+              s.element('p', {
+                attrs: {
+                  dir: str.is('rtl')
+                }
+              }),
+              s.element('p', {}),
+            ]
+          }),
+        ]
+      });
+    }));
+
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('div', {
+            attrs: {
+              dir: str.is('ltr')
+            },
+            children: [
+              s.element('p', {}),
+              s.element('p', {}),
+            ]
+          }),
+        ]
+      });
+    }));
+  });
+
 });

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -17,17 +17,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('a');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('p', {
-            attrs: {
-              dir: str.is('rtl')
-            }
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor, '<p dir="rtl">a</p>');
   });
 
   it('TBA: Set and select content, click on the Left to right toolbar button and assert direction is left to right', () => {
@@ -35,17 +25,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<p dir="rtl">a</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('p', {
-            attrs: {
-              dir: str.is('ltr')
-            }
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor, '<p dir="ltr">a</p>');
   });
 
   it('TINY-4589: should set two paragraphs to rtl and ltl', () => {
@@ -53,41 +33,11 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<p>foo</p><p>bar</p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('p', {
-            attrs: {
-              dir: str.is('rtl')
-            }
-          }),
-          s.element('p', {
-            attrs: {
-              dir: str.is('rtl')
-            }
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor, `<p dir="rtl">foo</p>\n<p dir="rtl">bar</p>`);
 
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('p', {
-            attrs: {
-              dir: str.is('ltr')
-            }
-          }),
-          s.element('p', {
-            attrs: {
-              dir: str.is('ltr')
-            }
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor, `<p dir="ltr">foo</p>\n<p dir="ltr">bar</p>`);
   });
 
   it('TINY-4589: should set parent dir when element is a list item', () => {
@@ -100,6 +50,40 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     `);
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyAssertions.assertContent(editor, `<ul dir="rtl">\n<li>foo</li>\n<li>bar</li>\n</ul>`);
+
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyAssertions.assertContent(editor, `<ul dir="ltr">\n<li>foo</li>\n<li>bar</li>\n</ul>`);
+  });
+
+  it('TINY-4589: should remove dir from list item', () => {
+    const editor = hook.editor();
+    editor.setContent(`
+    <ul>
+      <li dir="ltr">foo</li>
+      <li>bar</li>
+    </ul>
+    `);
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyAssertions.assertContent(editor, `<ul dir="rtl">\n<li>foo</li>\n<li>bar</li>\n</ul>`);
+  });
+
+  it('TINY-4589: should consider list parent dir if it is a list item', () => {
+    const editor = hook.editor();
+    editor.setContent(`
+    <ul dir="rtl">
+      <li dir="ltr">
+        ini
+        <ul>
+          <li>foo</li>
+          <li>bar</li>
+        </ul>
+      </li>
+    </ul>
+    `);
+    TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
     TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
       return s.element('body', {
         children: [
@@ -108,27 +92,54 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
               dir: str.is('rtl')
             },
             children: [
-              s.element('li', {}),
-              s.element('li', {}),
+              s.element('li', {
+                attrs: {
+                  dir: str.is('ltr')
+                },
+                children: [
+                  s.anything(),
+                  s.element('ul', {
+                    attrs: {
+                      dir: str.is('ltr')
+                    },
+                    children: [
+                      s.element('li', {}),
+                      s.element('li', {})
+                    ]
+                  }),
+                ]
+              })
             ]
-          }),
+          })
         ]
       });
     }));
 
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
       return s.element('body', {
         children: [
           s.element('ul', {
             attrs: {
-              dir: str.is('ltr')
+              dir: str.is('rtl')
             },
             children: [
-              s.element('li', {}),
-              s.element('li', {}),
+              s.element('li', {
+                attrs: {
+                  dir: str.is('ltr')
+                },
+                children: [
+                  s.anything(),
+                  s.element('ul', { // remove dir cause parent ul has rtl already
+                    children: [
+                      s.element('li', {}),
+                      s.element('li', {})
+                    ]
+                  }),
+                ]
+              })
             ]
-          }),
+          })
         ]
       });
     }));
@@ -138,48 +149,16 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent(`
     <div dir="ltr">
-      <p>foo</p>
-      <p>bar</p>
+    <p>foo</p>
+    <p>bar</p>
     </div>
     `);
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('div', {
-            attrs: {
-              dir: str.is('ltr')
-            },
-            children: [
-              s.element('p', {
-                attrs: {
-                  dir: str.is('rtl')
-                }
-              }),
-              s.element('p', {}),
-            ]
-          }),
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor, `<div dir="ltr">\n<p dir="rtl">foo</p>\n<p>bar</p>\n</div>`);
 
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('div', {
-            attrs: {
-              dir: str.is('ltr')
-            },
-            children: [
-              s.element('p', {}),
-              s.element('p', {}),
-            ]
-          }),
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor, `<div dir="ltr">\n<p>foo</p>\n<p>bar</p>\n</div>`);
   });
 
   it('TINY-4589: should not remove dir attr if parent has dir empty', () => {
@@ -192,22 +171,74 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     `);
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyAssertions.assertContent(editor, `<div dir="">\n<p dir="rtl">foo</p>\n<p>bar</p>\n</div>`);
+
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyAssertions.assertContent(editor, `<div dir="">\n<p dir="ltr">foo</p>\n<p>bar</p>\n</div>`);
+  });
+
+  it('TINY-4589: should use first correct parent dir', () => {
+    const editor = hook.editor();
+    editor.setContent(`
+    <div dir="rtl">
+      <div dir="ltr">
+        <div dir>
+          <div dir="x">
+            <div dir=" ">
+              <p>foo</p>
+              <p>bar</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    `);
+    TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
       return s.element('body', {
         children: [
           s.element('div', {
             attrs: {
-              dir: str.is('')
+              dir: str.is('rtl')
             },
             children: [
-              s.element('p', {
+              s.element('div', {
                 attrs: {
-                  dir: str.is('rtl')
-                }
-              }),
-              s.element('p', {}),
+                  dir: str.is('ltr')
+                },
+                children: [
+                  s.element('div', {
+                    attrs: {
+                      dir: str.is('')
+                    },
+                    children: [
+                      s.element('div', {
+                        attrs: {
+                          dir: str.is('x')
+                        },
+                        children: [
+                          s.element('div', {
+                            attrs: {
+                              dir: str.is(' ')
+                            },
+                            children: [
+                              s.element('p', {
+                                attrs: {
+                                  dir: str.is('rtl')
+                                }
+                              }),
+                              s.element('p', {})
+                            ]
+                          })
+                        ]
+                      })
+                    ]
+                  })
+                ]
+              })
             ]
-          }),
+          })
         ]
       });
     }));
@@ -218,17 +249,41 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
         children: [
           s.element('div', {
             attrs: {
-              dir: str.is('')
+              dir: str.is('rtl')
             },
             children: [
-              s.element('p', {
+              s.element('div', {
                 attrs: {
                   dir: str.is('ltr')
-                }
-              }),
-              s.element('p', {}),
+                },
+                children: [
+                  s.element('div', {
+                    attrs: {
+                      dir: str.is('')
+                    },
+                    children: [
+                      s.element('div', {
+                        attrs: {
+                          dir: str.is('x')
+                        },
+                        children: [
+                          s.element('div', {
+                            attrs: {
+                              dir: str.is(' ')
+                            },
+                            children: [
+                              s.element('p', {}), // doesn't add ltr cause parent has
+                              s.element('p', {})
+                            ]
+                          })
+                        ]
+                      })
+                    ]
+                  })
+                ]
+              })
             ]
-          }),
+          })
         ]
       });
     }));

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -33,11 +33,11 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<p>foo</p><p>bar</p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContent(editor, `<p dir="rtl">foo</p>\n<p dir="rtl">bar</p>`);
+    TinyAssertions.assertContent(editor, '<p dir="rtl">foo</p>\n<p dir="rtl">bar</p>');
 
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContent(editor, `<p dir="ltr">foo</p>\n<p dir="ltr">bar</p>`);
+    TinyAssertions.assertContent(editor, '<p dir="ltr">foo</p>\n<p dir="ltr">bar</p>');
   });
 
   it('TINY-4589: should set parent dir when element is a list item', () => {
@@ -45,10 +45,10 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<ul><li>foo</li><li>bar</li></ul>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContent(editor, `<ul dir="rtl">\n<li>foo</li>\n<li>bar</li>\n</ul>`);
+    TinyAssertions.assertContent(editor, '<ul dir="rtl">\n<li>foo</li>\n<li>bar</li>\n</ul>');
 
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContent(editor, `<ul dir="ltr">\n<li>foo</li>\n<li>bar</li>\n</ul>`);
+    TinyAssertions.assertContent(editor, '<ul dir="ltr">\n<li>foo</li>\n<li>bar</li>\n</ul>');
   });
 
   it('TINY-4589: should remove dir from list item', () => {
@@ -56,7 +56,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<ul><li dir="ltr">foo</li><li>bar</li></ul>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContent(editor, `<ul dir="rtl">\n<li>foo</li>\n<li>bar</li>\n</ul>`);
+    TinyAssertions.assertContent(editor, '<ul dir="rtl">\n<li>foo</li>\n<li>bar</li>\n</ul>');
   });
 
   it('TINY-4589: should consider list parent dir if it is a list item', () => {
@@ -144,10 +144,10 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<div dir="ltr"><p>foo</p><p>bar</p></div>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContent(editor, `<div dir="ltr">\n<p dir="rtl">foo</p>\n<p>bar</p>\n</div>`);
+    TinyAssertions.assertContent(editor, '<div dir="ltr">\n<p dir="rtl">foo</p>\n<p>bar</p>\n</div>');
 
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContent(editor, `<div dir="ltr">\n<p>foo</p>\n<p>bar</p>\n</div>`);
+    TinyAssertions.assertContent(editor, '<div dir="ltr">\n<p>foo</p>\n<p>bar</p>\n</div>');
   });
 
   it('TINY-4589: should not remove dir attr if parent has dir empty', () => {
@@ -155,10 +155,10 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<div dir=""><p>foo</p><p>bar</p></div>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContent(editor, `<div dir="">\n<p dir="rtl">foo</p>\n<p>bar</p>\n</div>`);
+    TinyAssertions.assertContent(editor, '<div dir="">\n<p dir="rtl">foo</p>\n<p>bar</p>\n</div>');
 
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContent(editor, `<div dir="">\n<p dir="ltr">foo</p>\n<p>bar</p>\n</div>`);
+    TinyAssertions.assertContent(editor, '<div dir="">\n<p dir="ltr">foo</p>\n<p>bar</p>\n</div>');
   });
 
   it('TINY-4589: should use first correct parent dir', () => {

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -120,12 +120,16 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
                 },
                 children: [
                   s.anything(),
-                  s.element('ul', { // remove dir cause parent ul has rtl already
-                    children: [
-                      s.element('li', {}),
-                      s.element('li', {})
-                    ]
-                  }),
+                  s.element('ul',
+                    {
+                      attrs: {
+                        dir: str.none()
+                      },
+                      children: [
+                        s.element('li', {}),
+                        s.element('li', {})
+                      ]
+                    }),
                 ]
               })
             ]
@@ -137,12 +141,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
 
   it('TINY-4589: should remove dir attr if parent has same dir', () => {
     const editor = hook.editor();
-    editor.setContent(`
-    <div dir="ltr">
-    <p>foo</p>
-    <p>bar</p>
-    </div>
-    `);
+    editor.setContent('<div dir="ltr"><p>foo</p><p>bar</p></div>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContent(editor, `<div dir="ltr">\n<p dir="rtl">foo</p>\n<p>bar</p>\n</div>`);
@@ -153,12 +152,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
 
   it('TINY-4589: should not remove dir attr if parent has dir empty', () => {
     const editor = hook.editor();
-    editor.setContent(`
-    <div dir="">
-      <p>foo</p>
-      <p>bar</p>
-    </div>
-    `);
+    editor.setContent('<div dir=""><p>foo</p><p>bar</p></div>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContent(editor, `<div dir="">\n<p dir="rtl">foo</p>\n<p>bar</p>\n</div>`);
@@ -262,7 +256,11 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
                               dir: str.is(' ')
                             },
                             children: [
-                              s.element('p', {}), // doesn't add ltr cause parent has
+                              s.element('p', {
+                                attrs: {
+                                  dir: str.none()
+                                }
+                              }),
                               s.element('p', {})
                             ]
                           })

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -48,7 +48,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     }));
   });
 
-  it('should set two paragraphs to rtl and ltl', () => {
+  it('TINY-4589: should set two paragraphs to rtl and ltl', () => {
     const editor = hook.editor();
     editor.setContent('<p>foo</p><p>bar</p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
@@ -90,7 +90,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     }));
   });
 
-  it('should set parent dir when element is a list item', () => {
+  it('TINY-4589: should set parent dir when element is a list item', () => {
     const editor = hook.editor();
     editor.setContent(`
     <ul>
@@ -134,7 +134,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     }));
   });
 
-  it('should remove dir attr if parent has same dir', () => {
+  it('TINY-4589: should remove dir attr if parent has same dir', () => {
     const editor = hook.editor();
     editor.setContent(`
     <div dir="ltr">
@@ -182,7 +182,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     }));
   });
 
-  it('should not remove dir attr if parent has dir empty', () => {
+  it('TINY-4589: should not remove dir attr if parent has dir empty', () => {
     const editor = hook.editor();
     editor.setContent(`
     <div dir="">

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -1,4 +1,3 @@
-import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 
@@ -9,7 +8,8 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
   const hook = TinyHooks.bddSetupLight({
     plugins: 'directionality',
     toolbar: 'ltr rtl',
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    indent: false
   }, [ Plugin, Theme ]);
 
   it('TBA: Set and select content, click on the Right to left toolbar button and assert direction is right to left', () => {
@@ -33,11 +33,11 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<p>foo</p><p>bar</p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContent(editor, '<p dir="rtl">foo</p>\n<p dir="rtl">bar</p>');
+    TinyAssertions.assertContent(editor, '<p dir="rtl">foo</p><p dir="rtl">bar</p>');
 
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContent(editor, '<p>foo</p>\n<p>bar</p>');
+    TinyAssertions.assertContent(editor, '<p>foo</p><p>bar</p>');
   });
 
   it('TINY-4589: should set parent dir when element is a list item', () => {
@@ -45,157 +45,78 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<ul><li>foo</li><li>bar</li></ul>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContent(editor, '<ul dir="rtl">\n<li>foo</li>\n<li>bar</li>\n</ul>');
+    TinyAssertions.assertContent(editor, '<ul dir="rtl"><li>foo</li><li>bar</li></ul>');
 
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContent(editor, '<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>');
+    TinyAssertions.assertContent(editor, '<ul><li>foo</li><li>bar</li></ul>');
   });
 
   it('TINY-4589: should remove dir from selected list item and children', () => {
     const editor = hook.editor();
-    editor.setContent(`
-    <ul>
-      <li dir="ltr">
-        foo
-        <ul>
-          <li dir="ltr">a</li>
-          <li dir="rtl">b</li>
-          <li>c</li>
-        </ul>
-      </li>
-      <li dir="xyz">bar</li>
-    </ul>
-    `);
+    editor.setContent(
+      '<ul>' +
+        '<li dir="ltr">foo' +
+          '<ul>' +
+            '<li dir="ltr">a</li>' +
+            '<li dir="rtl">b</li>' +
+            '<li>c</li>' +
+          '</ul>' +
+        '</li>' +
+        '<li dir="xyz">bar</li>' +
+      '</ul>'
+    );
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('ul', {
-            attrs: {
-              dir: str.is('rtl')
-            },
-            children: [
-              s.element('li', {
-                attrs: {
-                  dir: str.none()
-                },
-                children: [
-                  s.anything(),
-                  s.element('ul', {
-                    attrs: {
-                      dir: str.none()
-                    },
-                    children: [
-                      s.element('li', {
-                        attrs: {
-                          dir: str.is('ltr')
-                        }
-                      }),
-                      s.element('li', {
-                        attrs: {
-                          dir: str.is('rtl')
-                        }
-                      }),
-                      s.element('li', {
-                        attrs: {
-                          dir: str.none()
-                        }
-                      }),
-                    ]
-                  }),
-                ]
-              }),
-              s.element('li', {
-                attrs: {
-                  dir: str.none()
-                },
-              })
-            ]
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor,
+      '<ul dir="rtl">' +
+        '<li>foo' +
+          '<ul>' +
+            '<li dir="ltr">a</li>' +
+            '<li dir="rtl">b</li>' +
+            '<li>c</li>' +
+          '</ul>' +
+        '</li>' +
+        '<li>bar</li>' +
+      '</ul>'
+    );
   });
 
   it('TINY-4589: should consider list item dir', () => {
     const editor = hook.editor();
-    editor.setContent(`
-    <ul dir="rtl">
-      <li dir="ltr">
-        ini
-        <ul>
-          <li>foo</li>
-          <li>bar</li>
-        </ul>
-      </li>
-    </ul>
-    `);
+    editor.setContent(
+      '<ul dir="rtl">' +
+        '<li dir="ltr">ini' +
+          '<ul>' +
+            '<li>foo</li>' +
+            '<li>bar</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>'
+    );
     TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1); // foo
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('ul', {
-            attrs: {
-              dir: str.is('rtl')
-            },
-            children: [
-              s.element('li', {
-                attrs: {
-                  dir: str.is('ltr')
-                },
-                children: [
-                  s.anything(),
-                  s.element('ul', {
-                    attrs: {
-                      dir: str.none()
-                    },
-                    children: [
-                      s.element('li', {}),
-                      s.element('li', {})
-                    ]
-                  }),
-                ]
-              })
-            ]
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor,
+      '<ul dir="rtl">' +
+        '<li dir="ltr">ini' +
+          '<ul>' +
+            '<li>foo</li>' +
+            '<li>bar</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>'
+    );
 
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('ul', {
-            attrs: {
-              dir: str.is('rtl')
-            },
-            children: [
-              s.element('li', {
-                attrs: {
-                  dir: str.is('ltr')
-                },
-                children: [
-                  s.anything(),
-                  s.element('ul',
-                    {
-                      attrs: {
-                        dir: str.is('rtl')
-                      },
-                      children: [
-                        s.element('li', {}),
-                        s.element('li', {})
-                      ]
-                    }),
-                ]
-              })
-            ]
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor,
+      '<ul dir="rtl">' +
+        '<li dir="ltr">ini' +
+          '<ul dir="rtl">' +
+            '<li>foo</li>' +
+            '<li>bar</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>'
+    );
   });
 
   it('TINY-4589: should remove dir attr if parent has same dir', () => {
@@ -203,125 +124,59 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent('<div dir="ltr"><p>foo</p><p>bar</p></div>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContent(editor, '<div dir="ltr">\n<p dir="rtl">foo</p>\n<p>bar</p>\n</div>');
+    TinyAssertions.assertContent(editor, '<div dir="ltr"><p dir="rtl">foo</p><p>bar</p></div>');
 
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContent(editor, '<div dir="ltr">\n<p>foo</p>\n<p>bar</p>\n</div>');
+    TinyAssertions.assertContent(editor, '<div dir="ltr"><p>foo</p><p>bar</p></div>');
   });
 
   it('TINY-4589: should get computed dir from #target', () => {
     const editor = hook.editor();
-    editor.setContent(`
-    <div dir="rtl">
-      <div dir="ltr" id="target">
-        <div dir>
-          <div dir="x">
-            <div dir=" ">
-              <p>foo</p>
-              <p>bar</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    `);
+    editor.setContent(
+      '<div dir="rtl">' +
+        '<div id="target" dir="ltr">' +
+          '<div dir>' +
+            '<div dir="x">' +
+              '<div dir=" ">' +
+                '<p>foo</p>' +
+                '<p>bar</p>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>'
+    );
     TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1); // foo
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('div', {
-            attrs: {
-              dir: str.is('rtl')
-            },
-            children: [
-              s.element('div', {
-                attrs: {
-                  dir: str.is('ltr')
-                },
-                children: [
-                  s.element('div', {
-                    attrs: {
-                      dir: str.is('')
-                    },
-                    children: [
-                      s.element('div', {
-                        attrs: {
-                          dir: str.is('x')
-                        },
-                        children: [
-                          s.element('div', {
-                            attrs: {
-                              dir: str.is(' ')
-                            },
-                            children: [
-                              s.element('p', {
-                                attrs: {
-                                  dir: str.is('rtl')
-                                }
-                              }),
-                              s.element('p', {})
-                            ]
-                          })
-                        ]
-                      })
-                    ]
-                  })
-                ]
-              })
-            ]
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor,
+      '<div dir="rtl">' +
+        '<div id="target" dir="ltr">' +
+          '<div dir="">' +
+            '<div dir="x">' +
+              '<div dir=" ">' +
+                '<p dir="rtl">foo</p>' +
+                '<p>bar</p>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>'
+    );
 
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('div', {
-            attrs: {
-              dir: str.is('rtl')
-            },
-            children: [
-              s.element('div', {
-                attrs: {
-                  dir: str.is('ltr')
-                },
-                children: [
-                  s.element('div', {
-                    attrs: {
-                      dir: str.is('')
-                    },
-                    children: [
-                      s.element('div', {
-                        attrs: {
-                          dir: str.is('x')
-                        },
-                        children: [
-                          s.element('div', {
-                            attrs: {
-                              dir: str.is(' ')
-                            },
-                            children: [
-                              s.element('p', {
-                                attrs: {
-                                  dir: str.none()
-                                }
-                              }),
-                              s.element('p', {})
-                            ]
-                          })
-                        ]
-                      })
-                    ]
-                  })
-                ]
-              })
-            ]
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertContent(editor,
+      '<div dir="rtl">' +
+        '<div id="target" dir="ltr">' +
+          '<div dir="">' +
+            '<div dir="x">' +
+              '<div dir=" ">' +
+                '<p>foo</p>' +
+                '<p>bar</p>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>'
+    );
   });
 });

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -34,8 +34,6 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContent(editor, '<p dir="rtl">foo</p><p dir="rtl">bar</p>');
-
-    TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
     TinyAssertions.assertContent(editor, '<p>foo</p><p>bar</p>');
   });
@@ -46,7 +44,6 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContent(editor, '<ul dir="rtl"><li>foo</li><li>bar</li></ul>');
-
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
     TinyAssertions.assertContent(editor, '<ul><li>foo</li><li>bar</li></ul>');
   });
@@ -83,28 +80,19 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
 
   it('TINY-4589: applying the same dir makes no changes', () => {
     const editor = hook.editor();
-    editor.setContent(
-      '<ul dir="rtl">' +
-        '<li dir="ltr">ini' +
-          '<ul>' +
-            '<li>foo</li>' +
-            '<li>bar</li>' +
-          '</ul>' +
-        '</li>' +
-      '</ul>'
-    );
+    const editorContent =
+    '<ul dir="rtl">' +
+      '<li dir="ltr">ini' +
+        '<ul>' +
+          '<li>foo</li>' +
+          '<li>bar</li>' +
+        '</ul>' +
+      '</li>' +
+    '</ul>';
+    editor.setContent(editorContent);
     TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1); // foo
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
-    TinyAssertions.assertContent(editor,
-      '<ul dir="rtl">' +
-        '<li dir="ltr">ini' +
-          '<ul>' +
-            '<li>foo</li>' +
-            '<li>bar</li>' +
-          '</ul>' +
-        '</li>' +
-      '</ul>'
-    );
+    TinyAssertions.assertContent(editor, editorContent);
   });
 
   it('TINY-4589: should consider list item dir', () => {
@@ -139,7 +127,6 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContent(editor, '<div dir="ltr"><p dir="rtl">foo</p><p>bar</p></div>');
-
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
     TinyAssertions.assertContent(editor, '<div dir="ltr"><p>foo</p><p>bar</p></div>');
   });
@@ -149,45 +136,32 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     editor.setContent(
       '<div dir="rtl">' +
         '<div id="target" dir="ltr">' +
-          '<div dir>' +
-            '<div dir="x">' +
-              '<div dir=" ">' +
-                '<p>foo</p>' +
-                '<p>bar</p>' +
-              '</div>' +
-            '</div>' +
+          '<div dir="x">' +
+            '<p>foo</p>' +
+            '<p>bar</p>' +
           '</div>' +
         '</div>' +
       '</div>'
     );
-    TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1); // foo
+    TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1); // foo
     TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
     TinyAssertions.assertContent(editor,
       '<div dir="rtl">' +
         '<div id="target" dir="ltr">' +
-          '<div dir="">' +
-            '<div dir="x">' +
-              '<div dir=" ">' +
-                '<p dir="rtl">foo</p>' +
-                '<p>bar</p>' +
-              '</div>' +
-            '</div>' +
+          '<div dir="x">' +
+            '<p dir="rtl">foo</p>' +
+            '<p>bar</p>' +
           '</div>' +
         '</div>' +
       '</div>'
     );
-
     TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
     TinyAssertions.assertContent(editor,
       '<div dir="rtl">' +
         '<div id="target" dir="ltr">' +
-          '<div dir="">' +
-            '<div dir="x">' +
-              '<div dir=" ">' +
-                '<p>foo</p>' +
-                '<p>bar</p>' +
-              '</div>' +
-            '</div>' +
+          '<div dir="x">' +
+            '<p>foo</p>' +
+            '<p>bar</p>' +
           '</div>' +
         '</div>' +
       '</div>'

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -182,4 +182,55 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     }));
   });
 
+  it('should not remove dir attr if parent has dir empty', () => {
+    const editor = hook.editor();
+    editor.setContent(`
+    <div dir="">
+      <p>foo</p>
+      <p>bar</p>
+    </div>
+    `);
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('div', {
+            attrs: {
+              dir: str.is('')
+            },
+            children: [
+              s.element('p', {
+                attrs: {
+                  dir: str.is('rtl')
+                }
+              }),
+              s.element('p', {}),
+            ]
+          }),
+        ]
+      });
+    }));
+
+    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('div', {
+            attrs: {
+              dir: str.is('')
+            },
+            children: [
+              s.element('p', {
+                attrs: {
+                  dir: str.is('ltr')
+                }
+              }),
+              s.element('p', {}),
+            ]
+          }),
+        ]
+      });
+    }));
+  });
 });


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* when `rtl` or `ltr` is clicked on a list item (li) it applies `dir` to parent (`ul` or `ol`).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
