### PR TITLE
TINY-7619: Ensure all dialogs have the ability to be opened by a command

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `initData` property to `fancymenuitem` to allow custom initialization data #TINY-7480
 - Added a new `language` menu item and toolbar button to add `lang` attributes to content, with an accompanying `content_langs` setting to specify the languages available #TINY-6149
 - A new `lang` format is now available that can be used with `editor.formatter`, or applied with the `Lang` editor command #TINY-6149
-- Added new commands: `mceEmoticons` (emoticons plugin), `mceWordCount` (wordcount), and `mceCreateTemplateList` (template) #TINY-7619
+- Added new commands: `mceEmoticons` (emoticons plugin), `mceWordCount` (wordcount), and `mceTemplate` (template) #TINY-7619
 
 ### Improved
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `initData` property to `fancymenuitem` to allow custom initialization data #TINY-7480
 - Added a new `language` menu item and toolbar button to add `lang` attributes to content, with an accompanying `content_langs` setting to specify the languages available #TINY-6149
 - A new `lang` format is now available that can be used with `editor.formatter`, or applied with the `Lang` editor command #TINY-6149
+- Added new commands: `mceEmoticons` (emoticons plugin), `mceWordCount` (wordcount), and `mceCreateTemplateList` (template) #TINY-7619
 
 ### Improved
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents #TINY-7249
-- Changed emoticons, wordcount, code, and codesample plugins to open dialogs using commands #TINY-7619
+- Changed emoticons, wordcount, code, codesample, and template plugins to open dialogs using commands #TINY-7619
 
 ### Fixed
 - `editor.fire` was incorrectly mutating the original `args` provided #TINY-3254

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `initData` property to `fancymenuitem` to allow custom initialization data #TINY-7480
 - Added a new `language` menu item and toolbar button to add `lang` attributes to content, with an accompanying `content_langs` setting to specify the languages available #TINY-6149
 - A new `lang` format is now available that can be used with `editor.formatter`, or applied with the `Lang` editor command #TINY-6149
-- Added new commands: `mceEmoticons` (emoticons plugin), `mceWordCount` (wordcount), and `mceTemplate` (template) #TINY-7619
+- Added new plugin commands: `mceEmoticons` (emoticons), `mceWordCount` (wordcount), and `mceTemplate` (template) #TINY-7619
 
 ### Improved
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The context toolbar will now move out of the way when it overlaps with the selection, such as in table cells #TINY-7192
 
 ### Changed
-- Changed the load order so that the content css gets loaded before the editor gets populated with contents. #TINY-7249
+- Changed the load order so that the content css gets loaded before the editor gets populated with contents #TINY-7249
+- Changed emoticons, wordcount, code, and codesample plugins to open dialogs using commands #TINY-7619
 
 ### Fixed
 - `editor.fire` was incorrectly mutating the original `args` provided #TINY-3254

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents #TINY-7249
-- Changed emoticons, wordcount, code, codesample, and template plugins to open dialogs using commands #TINY-7619
+- Changed `emoticons`, `wordcount`, `code`, `codesample`, and `template` plugins to open dialogs using commands #TINY-7619
 
 ### Fixed
 - `editor.fire` was incorrectly mutating the original `args` provided #TINY-3254

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Buttons.ts
@@ -8,16 +8,19 @@
 import Editor from 'tinymce/core/api/Editor';
 
 const register = (editor: Editor) => {
+
+  const onAction = () => editor.execCommand('mceCodeEditor');
+
   editor.ui.registry.addButton('code', {
     icon: 'sourcecode',
     tooltip: 'Source code',
-    onAction: () => editor.execCommand('mceCodeEditor')
+    onAction
   });
 
   editor.ui.registry.addMenuItem('code', {
     icon: 'sourcecode',
     text: 'Source code',
-    onAction: () => editor.execCommand('mceCodeEditor')
+    onAction
   });
 };
 

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Buttons.ts
@@ -7,19 +7,17 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-import * as Dialog from './Dialog';
-
 const register = (editor: Editor) => {
   editor.ui.registry.addButton('code', {
     icon: 'sourcecode',
     tooltip: 'Source code',
-    onAction: () => Dialog.open(editor)
+    onAction: () => editor.execCommand('mceCodeEditor')
   });
 
   editor.ui.registry.addMenuItem('code', {
     icon: 'sourcecode',
     text: 'Source code',
-    onAction: () => Dialog.open(editor)
+    onAction: () => editor.execCommand('mceCodeEditor')
   });
 };
 

--- a/modules/tinymce/src/plugins/codesample/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/ui/Buttons.ts
@@ -7,8 +7,6 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-import * as Dialog from './Dialog';
-
 const isCodeSampleSelection = (editor: Editor) => {
   const node = editor.selection.getStart();
   return editor.dom.is(node, 'pre[class*="language-"]');
@@ -18,7 +16,7 @@ const register = (editor: Editor) => {
   editor.ui.registry.addToggleButton('codesample', {
     icon: 'code-sample',
     tooltip: 'Insert/edit code sample',
-    onAction: () => Dialog.open(editor),
+    onAction: () => editor.execCommand('codesample'),
     onSetup: (api) => {
       const nodeChangeHandler = () => {
         api.setActive(isCodeSampleSelection(editor));
@@ -31,7 +29,7 @@ const register = (editor: Editor) => {
   editor.ui.registry.addMenuItem('codesample', {
     text: 'Code sample...',
     icon: 'code-sample',
-    onAction: () => Dialog.open(editor)
+    onAction: () => editor.execCommand('codesample')
   });
 };
 

--- a/modules/tinymce/src/plugins/codesample/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/ui/Buttons.ts
@@ -13,10 +13,13 @@ const isCodeSampleSelection = (editor: Editor) => {
 };
 
 const register = (editor: Editor) => {
+
+  const onAction = () => editor.execCommand('codesample');
+
   editor.ui.registry.addToggleButton('codesample', {
     icon: 'code-sample',
     tooltip: 'Insert/edit code sample',
-    onAction: () => editor.execCommand('codesample'),
+    onAction,
     onSetup: (api) => {
       const nodeChangeHandler = () => {
         api.setActive(isCodeSampleSelection(editor));
@@ -29,7 +32,7 @@ const register = (editor: Editor) => {
   editor.ui.registry.addMenuItem('codesample', {
     text: 'Code sample...',
     icon: 'code-sample',
-    onAction: () => editor.execCommand('codesample')
+    onAction
   });
 };
 

--- a/modules/tinymce/src/plugins/emoticons/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/Plugin.ts
@@ -7,6 +7,7 @@
 
 import PluginManager from 'tinymce/core/api/PluginManager';
 
+import * as Commands from './api/Commands';
 import * as Settings from './api/Settings';
 import { initDatabase } from './core/EmojiDatabase';
 import * as Filters from './core/Filters';
@@ -27,7 +28,8 @@ export default () => {
 
     const database = initDatabase(editor, databaseUrl, databaseId);
 
-    Buttons.register(editor, database);
+    Commands.register(editor, database);
+    Buttons.register(editor);
     Autocompletion.init(editor, database);
     Filters.setup(editor);
   });

--- a/modules/tinymce/src/plugins/emoticons/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/api/Commands.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import Editor from 'tinymce/core/api/Editor';
+
+import { EmojiDatabase } from '../core/EmojiDatabase';
+import * as Dialog from '../ui/Dialog';
+
+const register = (editor: Editor, database: EmojiDatabase): void => {
+  editor.addCommand('mceEmoticons', () => Dialog.open(editor, database));
+};
+
+export {
+  register
+};

--- a/modules/tinymce/src/plugins/emoticons/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/ui/Buttons.ts
@@ -7,11 +7,8 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-import { EmojiDatabase } from '../core/EmojiDatabase';
-import * as Dialog from './Dialog';
-
-const register = (editor: Editor, database: EmojiDatabase): void => {
-  const onAction = () => Dialog.open(editor, database);
+const register = (editor: Editor): void => {
+  const onAction = () => editor.execCommand('mceEmoticons');
 
   editor.ui.registry.addButton('emoticons', {
     tooltip: 'Emoticons',

--- a/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
@@ -7,10 +7,20 @@
 
 import { Fun } from '@ephox/katamari';
 
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Templates from '../core/Templates';
+import * as Dialog from '../ui/Dialog';
+
+const showDialog = (editor: Editor) => {
+  return (templates) => {
+    Dialog.open(editor, templates);
+  };
+};
 
 const register = (editor) => {
   editor.addCommand('mceInsertTemplate', Fun.curry(Templates.insertTemplate, editor));
+  editor.addCommand('mceCreateTemplateList', Templates.createTemplateList(editor, showDialog(editor)));
 };
 
 export {

--- a/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
@@ -20,7 +20,7 @@ const showDialog = (editor: Editor) => {
 
 const register = (editor) => {
   editor.addCommand('mceInsertTemplate', Fun.curry(Templates.insertTemplate, editor));
-  editor.addCommand('mceCreateTemplateList', Templates.createTemplateList(editor, showDialog(editor)));
+  editor.addCommand('mceTemplate', Templates.createTemplateList(editor, showDialog(editor)));
 };
 
 export {

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 const register = (editor: Editor) => {
 
-  const onAction = () => editor.execCommand('mceCreateTemplateList');
+  const onAction = () => editor.execCommand('mceTemplate');
 
   editor.ui.registry.addButton('template', {
     icon: 'template',

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
@@ -7,26 +7,20 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-import * as Templates from '../core/Templates';
-import * as Dialog from './Dialog';
-
-const showDialog = (editor: Editor) => {
-  return (templates) => {
-    Dialog.open(editor, templates);
-  };
-};
-
 const register = (editor: Editor) => {
+
+  const onAction = () => editor.execCommand('mceCreateTemplateList');
+
   editor.ui.registry.addButton('template', {
     icon: 'template',
     tooltip: 'Insert template',
-    onAction: Templates.createTemplateList(editor, showDialog(editor))
+    onAction
   });
 
   editor.ui.registry.addMenuItem('template', {
     icon: 'template',
     text: 'Insert template...',
-    onAction: Templates.createTemplateList(editor, showDialog(editor))
+    onAction
   });
 };
 

--- a/modules/tinymce/src/plugins/wordcount/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/Plugin.ts
@@ -8,6 +8,7 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 
 import * as Api from './api/Api';
+import * as Commands from './api/Commands';
 import * as Wordcounter from './core/WordCounter';
 import * as Buttons from './ui/Buttons';
 
@@ -15,6 +16,7 @@ export default (delay: number = 300) => {
   PluginManager.add('wordcount', (editor) => {
     const api = Api.get(editor);
 
+    Commands.register(editor, api);
     Buttons.register(editor, api);
     Wordcounter.setup(editor, api, delay);
     return api;

--- a/modules/tinymce/src/plugins/wordcount/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/Plugin.ts
@@ -17,7 +17,7 @@ export default (delay: number = 300) => {
     const api = Api.get(editor);
 
     Commands.register(editor, api);
-    Buttons.register(editor, api);
+    Buttons.register(editor);
     Wordcounter.setup(editor, api, delay);
     return api;
   });

--- a/modules/tinymce/src/plugins/wordcount/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/api/Commands.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import Editor from 'tinymce/core/api/Editor';
+
+import { WordCountApi } from '../api/Api';
+import * as Dialog from '../ui/Dialog';
+
+const register = (editor: Editor, api: WordCountApi): void => {
+  editor.addCommand('mceWordCount', () => Dialog.open(editor, api));
+};
+
+export {
+  register
+};

--- a/modules/tinymce/src/plugins/wordcount/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/ui/Buttons.ts
@@ -8,16 +8,19 @@
 import Editor from 'tinymce/core/api/Editor';
 
 const register = (editor: Editor) => {
+
+  const onAction = () => editor.execCommand('mceWordCount');
+
   editor.ui.registry.addButton('wordcount', {
     tooltip: 'Word count',
     icon: 'character-count',
-    onAction: () => editor.execCommand('mceWordCount')
+    onAction
   });
 
   editor.ui.registry.addMenuItem('wordcount', {
     text: 'Word count',
     icon: 'character-count',
-    onAction: () => editor.execCommand('mceWordCount')
+    onAction
   });
 };
 

--- a/modules/tinymce/src/plugins/wordcount/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/ui/Buttons.ts
@@ -8,19 +8,18 @@
 import Editor from 'tinymce/core/api/Editor';
 
 import { WordCountApi } from '../api/Api';
-import * as Dialog from './Dialog';
 
 const register = (editor: Editor, api: WordCountApi) => {
   editor.ui.registry.addButton('wordcount', {
     tooltip: 'Word count',
     icon: 'character-count',
-    onAction: () => Dialog.open(editor, api)
+    onAction: () => editor.execCommand('mceWordCount')
   });
 
   editor.ui.registry.addMenuItem('wordcount', {
     text: 'Word count',
     icon: 'character-count',
-    onAction: () => Dialog.open(editor, api)
+    onAction: () => editor.execCommand('mceWordCount')
   });
 };
 

--- a/modules/tinymce/src/plugins/wordcount/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/ui/Buttons.ts
@@ -7,9 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-import { WordCountApi } from '../api/Api';
-
-const register = (editor: Editor, api: WordCountApi) => {
+const register = (editor: Editor) => {
   editor.ui.registry.addButton('wordcount', {
     tooltip: 'Word count',
     icon: 'character-count',


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Changed emoticons, wordcount, code, and codesample plugins to open dialogs using commands

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] ~Review comments resolved~

GitHub issues (if applicable):
