### PR TITLE
Move caret behind newly inserted links

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the performance when rendering UI components #TINY-7572
 - When scrolling, the context toolbar will stick to where it was previously for large elements, such as tables #TINY-7545
 - The context toolbar will now move out of the way when it overlaps with the selection, such as in table cells #TINY-7192
+- The caret is now positioned behind newly inserted links, so that the user can carry on typing #6711
 
 ### Changed
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents. #TINY-7249

--- a/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
@@ -518,6 +518,9 @@ class EditorCommands {
         if (value.href) {
           editor.formatter.apply('link', value, anchor);
         }
+
+        // Move the selection behind the new link, so the user can go on typing.
+        editor.selection.setStart(editor.selection.getEnd());
       },
 
       'selectAll': () => {

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -85,6 +85,7 @@ interface EditorSelection {
   setRng: (rng: Range, forward?: boolean) => void;
   getRng: () => Range;
   getStart: (real?: boolean) => Element;
+  setStart: (elm: Element) => void;
   getEnd: (real?: boolean) => Element;
   getSelectedBlocks: (startElm?: Element, endElm?: Element) => Element[];
   normalize: () => Range;
@@ -181,6 +182,18 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
    * @return {Element} Start element of selection range.
    */
   const getStart = (real?: boolean): Element => ElementSelection.getStart(editor.getBody(), getRng(), real);
+
+  /**
+   * Changes the selection to start behind the given element.
+   *
+   * @method setStart
+   * @param {Element} elm Start element of selection range.
+   */
+  const setStart = (elm: Element): void => {
+    const rng = dom.createRng();
+    rng.setStartAfter(elm);
+    setRng(rng);
+  };
 
   /**
    * Returns the end element of a selection range. If the end is in a text
@@ -575,6 +588,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
     setRng,
     getRng,
     getStart,
+    setStart,
     getEnd,
     getSelectedBlocks,
     normalize,

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -228,10 +228,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'test');
     assert.equal(editor.getContent(), '<p><a href="test">test 123</a></p>');
-    // Assert selection is this:                         <---------------)
-    // The <--) refers to the content string in the line above
-    // The `<` is inclusive but the `)` is not.
-    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
+    TinyAssertions.assertCursor(editor, [ ], 1); // Cursor should be at the end.
   });
 
   it('mceInsertLink (link absolute)', () => {
@@ -240,7 +237,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'http://www.site.com');
     assert.equal(editor.getContent(), '<p><a href="http://www.site.com">test 123</a></p>');
-    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
+    TinyAssertions.assertCursor(editor, [ ], 1); // Cursor should be at the end.
   });
 
   it('mceInsertLink (link encoded)', () => {
@@ -273,8 +270,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link"><img style="float: right;" src="about:blank" /></a></p>');
-    // Assert selection is this:       <------------------------------------------------------------------------)
-    TinyAssertions.assertSelection(editor, [ ], 0, [ ], 1);
+    TinyAssertions.assertCursor(editor, [ ], 1); // Cursor should be at the end.
   });
 
   it('mceInsertLink (link adjacent text)', () => {
@@ -288,19 +284,29 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="#">a</a><a href="link">b</a></p>');
-    // Assert selection is this:                                          <----)
-    TinyAssertions.assertSelection(editor, [ 0, 1, 0 ], 0, [ 0, 1 ], 1);
+    TinyAssertions.assertCursor(editor, [ 0 ], 2); // Cursor should be here:       ^
   });
 
-  it('mceInsertLink (link text inside text)', () => {
+  it('mceInsertLink (link inside text then type)', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><em>abc</em></p>');
+    LegacyUnit.setSelection(editor, 'em', 1, 'em', 2); // Select `b`
+
+    editor.execCommand('mceInsertLink', false, 'link');
+    editor.insertContent('d');
+    // Note that the `d` is inserted *behind* the newly inserted link.
+    assert.equal(editor.getContent(), '<p><em>a<a href="link">b</a>dc</em></p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0, 2 ], 1); // Cursor: ...d|c...
+  });
+
+  it('mceInsertLink (link inside link)', () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="#"><em>abc</em></a></p>');
-    LegacyUnit.setSelection(editor, 'em', 1, 'em', 2);
+    LegacyUnit.setSelection(editor, 'em', 1, 'em', 2); // Select `b`
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link"><em>abc</em></a></p>');
-    // Assert selection is this (same as before):             <)
-    TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 1, [ 0, 0, 0, 0 ], 2);
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 1); //                ^
   });
 
   it('mceInsertLink (link around existing links)', () => {
@@ -310,8 +316,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link">12</a></p>');
-    // Assert selection is this:                         <---------)
-    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
+    TinyAssertions.assertCursor(editor, [ ], 1); // Cursor should be at the end.
   });
 
   it('mceInsertLink (link around existing links with different attrs)', () => {
@@ -321,8 +326,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link">12</a></p>');
-    // Assert selection is this:                         <---------)
-    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
+    TinyAssertions.assertCursor(editor, [ ], 1); // Cursor should be at the end.
   });
 
   it('mceInsertLink (link around existing complex contents with links)', () => {
@@ -339,8 +343,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       '<p><a href="link"><span id="s1"><strong><em>1</em>' +
         '</strong></span><span id="s2"><em><strong>2</strong></em></span></a></p>'
     );
-    // Selection goes from the 1 inside the first <em> all the way to the end.
-    TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ ], 1);
+    TinyAssertions.assertCursor(editor, [ ], 1); // Cursor should be at the end.
   });
 
   it('mceInsertLink (link text inside link)', () => {
@@ -351,8 +354,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link">test</a></p>');
-    // Assert selection is this:                         <-----------)
-    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
+    TinyAssertions.assertCursor(editor, [ ], 1); // Cursor should be at the end.
   });
 
   it('mceInsertLink bug #7331', () => {

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -228,6 +228,10 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'test');
     assert.equal(editor.getContent(), '<p><a href="test">test 123</a></p>');
+    // Assert selection is this:                         <---------------)
+    // The <--) refers to the content string in the line above
+    // The `<` is inclusive but the `)` is not.
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
   });
 
   it('mceInsertLink (link absolute)', () => {
@@ -236,6 +240,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'http://www.site.com');
     assert.equal(editor.getContent(), '<p><a href="http://www.site.com">test 123</a></p>');
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
   });
 
   it('mceInsertLink (link encoded)', () => {
@@ -268,6 +273,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link"><img style="float: right;" src="about:blank" /></a></p>');
+    // Assert selection is this:       <------------------------------------------------------------------------)
+    TinyAssertions.assertSelection(editor, [ ], 0, [ ], 1);
   });
 
   it('mceInsertLink (link adjacent text)', () => {
@@ -281,6 +288,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="#">a</a><a href="link">b</a></p>');
+    // Assert selection is this:                                          <----)
+    TinyAssertions.assertSelection(editor, [ 0, 1, 0 ], 0, [ 0, 1 ], 1);
   });
 
   it('mceInsertLink (link text inside text)', () => {
@@ -290,6 +299,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link"><em>abc</em></a></p>');
+    // Assert selection is this (same as before):             <)
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 1, [ 0, 0, 0, 0 ], 2);
   });
 
   it('mceInsertLink (link around existing links)', () => {
@@ -299,6 +310,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link">12</a></p>');
+    // Assert selection is this:                         <---------)
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
   });
 
   it('mceInsertLink (link around existing links with different attrs)', () => {
@@ -308,6 +321,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link">12</a></p>');
+    // Assert selection is this:                         <---------)
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
   });
 
   it('mceInsertLink (link around existing complex contents with links)', () => {
@@ -324,6 +339,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       '<p><a href="link"><span id="s1"><strong><em>1</em>' +
         '</strong></span><span id="s2"><em><strong>2</strong></em></span></a></p>'
     );
+    // Selection goes from the 1 inside the first <em> all the way to the end.
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ ], 1);
   });
 
   it('mceInsertLink (link text inside link)', () => {
@@ -334,6 +351,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
 
     editor.execCommand('mceInsertLink', false, 'link');
     assert.equal(editor.getContent(), '<p><a href="link">test</a></p>');
+    // Assert selection is this:                         <-----------)
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ ], 1);
   });
 
   it('mceInsertLink bug #7331', () => {


### PR DESCRIPTION
Fixes #6711.

Description of Changes:
* Add unit test that succeeds _before_ the changes, for documentation purposes.
* Change behavior to move caret behind newly inserted links.
* Update the unit tests accordingly. Add a new test case to illustrate with an extreme case (adding a link on `b` within `abc`, then typing `d`, which should result in `a<a>b</a>dc` -- note how the `d` is _not_ inside the link).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [ ] ~~Branch prefixed with `feature/` for new features (if applicable)~~

Review:
* [ ] Milestone set
* [ ] Review comments resolved