### PR TITLE
TINY-7678: Replace Cell<Optional<T>> with Singleton<T>

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
+++ b/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
@@ -1,4 +1,4 @@
-import { Cell, Optional } from '@ephox/katamari';
+import { Singleton } from '@ephox/katamari';
 
 import { Chain } from '../api/Chain';
 import * as GeneralSteps from '../api/GeneralSteps';
@@ -10,7 +10,7 @@ interface Props {
   click: () => void;
 }
 
-const inputPrototypeState = Cell(Optional.none<Props>());
+const inputPrototypeState = Singleton.value<Props>();
 
 const createChangeEvent = (win: Window): Event => {
   const event: any = document.createEvent('CustomEvent');
@@ -36,7 +36,7 @@ const cPatchInputElement = (files: File[]) => Chain.op<any>(() => {
     click: HTMLInputElement.prototype.click
   };
 
-  inputPrototypeState.set(Optional.some(currentProps));
+  inputPrototypeState.set(currentProps);
 
   Object.defineProperty(HTMLInputElement.prototype, 'files', {
     get: () => createFileList(files)
@@ -48,7 +48,7 @@ const cPatchInputElement = (files: File[]) => Chain.op<any>(() => {
 });
 
 const cUnpatchInputElement = Chain.op<any>(() => {
-  inputPrototypeState.get().each((props) => {
+  inputPrototypeState.on((props) => {
     Object.defineProperty(HTMLInputElement.prototype, 'files', props.files);
     HTMLInputElement.prototype.click = props.click;
   });

--- a/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
+++ b/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
@@ -1,5 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Cell, Optional } from '@ephox/katamari';
+import { Singleton } from '@ephox/katamari';
 import { DomEvent, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 import { Chain } from 'ephox/agar/api/Chain';
@@ -14,7 +14,7 @@ import * as StepSequence from 'ephox/agar/api/StepSequence';
 if (!/phantom/i.test(navigator.userAgent)) {
   UnitTest.asynctest('ClipboardTest', (success, failure) => {
     const pastebin = SugarElement.fromHtml('<div class="pastebin"></div>');
-    const pasteState = Cell(Optional.none<DataTransfer>());
+    const pasteState = Singleton.value<DataTransfer>();
 
     Insert.append(SugarBody.body(), pastebin);
 
@@ -32,7 +32,7 @@ if (!/phantom/i.test(navigator.userAgent)) {
 
     const pasteUnbinder = DomEvent.bind(pastebin, 'paste', (evt) => {
       const dataTransfer = evt.raw.clipboardData;
-      pasteState.set(Optional.some(dataTransfer));
+      pasteState.set(dataTransfer);
     });
 
     Pipeline.runStep({}, StepSequence.sequenceSame([

--- a/modules/agar/src/test/ts/browser/file/PatchFileInputTest.ts
+++ b/modules/agar/src/test/ts/browser/file/PatchFileInputTest.ts
@@ -1,5 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Cell, Optional } from '@ephox/katamari';
+import { Singleton } from '@ephox/katamari';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 import { Chain } from 'ephox/agar/api/Chain';
@@ -12,7 +12,7 @@ import { Step } from 'ephox/agar/api/Step';
 
 UnitTest.asynctest('PatchFileInputTest', (success, failure) => {
   const files = [ createFile('a.txt', 0, new Blob([ 'x' ])) ];
-  const filesState = Cell(Optional.none<FileList>());
+  const filesState = Singleton.value<FileList>();
 
   const pickFiles = (body: SugarElement<any>, next: (files: FileList) => void) => {
     const elm = SugarElement.fromHtml<HTMLInputElement>('<input type="file">');
@@ -26,7 +26,7 @@ UnitTest.asynctest('PatchFileInputTest', (success, failure) => {
 
   const cPickFiles = Chain.async<SugarElement, FileList>((input, next, _die) => pickFiles(input, next));
   const sPickFiles = Step.async((next, _die) => pickFiles(SugarBody.body(), (files) => {
-    filesState.set(Optional.some(files));
+    filesState.set(files);
     next();
   }));
 
@@ -42,7 +42,7 @@ UnitTest.asynctest('PatchFileInputTest', (success, failure) => {
       Step.sync(() => {
         const files = filesState.get().getOrDie('Failed to get files state');
         assetFiles(files);
-        filesState.set(Optional.none());
+        filesState.clear();
       })
     ])),
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
@@ -1,4 +1,4 @@
-import { Cell, Id, Optional } from '@ephox/katamari';
+import { Id, Singleton } from '@ephox/katamari';
 import { Traverse } from '@ephox/sugar';
 
 import * as AriaDescribe from '../../aria/AriaDescribe';
@@ -24,11 +24,11 @@ import { CompositeSketchFactory } from './UiSketcher';
 
 const factory: CompositeSketchFactory<ModalDialogDetail, ModalDialogSpec> = (detail, components, spec, externals) => {
 
-  const dialogComp = Cell(Optional.none<AlloyComponent>());
+  const dialogComp = Singleton.value<AlloyComponent>();
 
   // TODO IMPROVEMENT: Make close actually close the dialog by default!
   const showDialog = (dialog: AlloyComponent) => {
-    dialogComp.set(Optional.some(dialog));
+    dialogComp.set(dialog);
     const sink = detail.lazySink(dialog).getOrDie();
 
     const externalBlocker = externals.blocker();
@@ -54,7 +54,7 @@ const factory: CompositeSketchFactory<ModalDialogDetail, ModalDialogSpec> = (det
   };
 
   const hideDialog = (dialog: AlloyComponent) => {
-    dialogComp.set(Optional.none());
+    dialogComp.clear();
     Traverse.parent(dialog.element).each((blockerDom) => {
       dialog.getSystem().getByDom(blockerDom).each((blocker) => {
         Attachment.detach(blocker);

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/Dockables.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/Dockables.ts
@@ -5,7 +5,7 @@ import * as Boxes from '../../alien/Boxes';
 import * as OffsetOrigin from '../../alien/OffsetOrigin';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { NuPositionCss, PositionCss } from '../../positioning/view/PositionCss';
-import { DockingContext, DockingMode, DockingState, InitialDockingPosition } from './DockingTypes';
+import { DockingContext, DockingMode, DockingState } from './DockingTypes';
 
 type StaticMorph<T> = () => T;
 type AbsoluteMorph<T> = (pos: PositionCss) => T;
@@ -73,7 +73,7 @@ const isVisibleForModes = (modes: DockingMode[], box: Boxes.Bounds, viewport: Bo
   });
 
 const getPrior = (elem: SugarElement<HTMLElement>, state: DockingState): Optional<Boxes.Bounds> =>
-  state.getInitialPosition().map(
+  state.getInitialPos().map(
     // Only supports position absolute.
     (pos) => Boxes.bounds(
       pos.bounds.x,
@@ -84,16 +84,16 @@ const getPrior = (elem: SugarElement<HTMLElement>, state: DockingState): Optiona
   );
 
 const storePrior = (elem: SugarElement<HTMLElement>, box: Boxes.Bounds, state: DockingState): void => {
-  state.setInitialPosition(Optional.some<InitialDockingPosition>({
+  state.setInitialPos({
     style: Css.getAllRaw(elem),
     position: Css.get(elem, 'position') || 'static',
     bounds: box
-  }));
+  });
 };
 
 const revertToOriginal = (elem: SugarElement<HTMLElement>, box: Boxes.Bounds, state: DockingState): Optional<MorphAdt> =>
-  state.getInitialPosition().bind((position) => {
-    state.setInitialPosition(Optional.none());
+  state.getInitialPos().bind((position) => {
+    state.clearInitialPos();
 
     switch (position.position) {
       case 'static':

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingState.ts
@@ -1,4 +1,4 @@
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Singleton } from '@ephox/katamari';
 
 import { nuState } from '../common/BehaviourState';
 import { DockingConfig, DockingMode, DockingState, InitialDockingPosition } from './DockingTypes';
@@ -6,7 +6,7 @@ import { DockingConfig, DockingMode, DockingState, InitialDockingPosition } from
 const init = (spec: DockingConfig): DockingState => {
   const docked = Cell(false);
   const visible = Cell(true);
-  const initialBounds = Cell(Optional.none<InitialDockingPosition>());
+  const initialBounds = Singleton.value<InitialDockingPosition>();
   const modes = Cell<DockingMode[]>(spec.modes);
 
   const readState = () => `docked:  ${docked.get()}, visible: ${visible.get()}, modes: ${modes.get().join(',')}`;
@@ -14,8 +14,9 @@ const init = (spec: DockingConfig): DockingState => {
   return nuState({
     isDocked: docked.get,
     setDocked: docked.set,
-    getInitialPosition: initialBounds.get,
-    setInitialPosition: initialBounds.set,
+    getInitialPos: initialBounds.get,
+    setInitialPos: initialBounds.set,
+    clearInitialPos: initialBounds.clear,
     isVisible: visible.get,
     setVisible: visible.set,
     getModes: modes.get,

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingTypes.ts
@@ -45,8 +45,9 @@ export interface DockingConfig extends Behaviour.BehaviourConfigDetail {
 export interface DockingState extends BehaviourState {
   isDocked: () => boolean;
   setDocked: (docked: boolean) => void;
-  getInitialPosition: () => Optional<InitialDockingPosition>;
-  setInitialPosition: (bounds: Optional<InitialDockingPosition>) => void;
+  getInitialPos: () => Optional<InitialDockingPosition>;
+  setInitialPos: (bounds: InitialDockingPosition) => void;
+  clearInitialPos: () => void;
   isVisible: () => boolean;
   setVisible: (visible: boolean) => void;
   getModes: () => DockingMode[];

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/keyboard/KeyingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/keyboard/KeyingState.ts
@@ -1,4 +1,4 @@
-import { Cell, Optional } from '@ephox/katamari';
+import { Singleton } from '@ephox/katamari';
 
 import { FlatgridState, GeneralKeyingConfig } from '../../keying/KeyingModeTypes';
 import { nuState, Stateless } from '../common/BehaviourState';
@@ -9,12 +9,10 @@ interface RowsCols {
 }
 
 const flatgrid = (): FlatgridState => {
-  const dimensions = Cell(Optional.none<RowsCols>());
+  const dimensions = Singleton.value<RowsCols>();
 
   const setGridSize = (numRows: number, numColumns: number) => {
-    dimensions.set(
-      Optional.some({ numRows, numColumns })
-    );
+    dimensions.set({ numRows, numColumns });
   };
 
   const getNumRows = () => dimensions.get().map((d) => d.numRows);

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/reflecting/ReflectingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/reflecting/ReflectingState.ts
@@ -1,20 +1,18 @@
-import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Cell, Optional } from '@ephox/katamari';
 
 import { ReflectingState } from './ReflectingTypes';
 
 const init = <S>(): ReflectingState<S> => {
-  const cell: Cell<Optional<S>> = Cell(Optional.none<S>());
+  const cell = Cell(Optional.none<S>());
 
-  const set = (optS: Optional<S>) => cell.set(optS);
   const clear = () => cell.set(Optional.none<S>());
-  const get = () => cell.get();
 
-  const readState = (): any => cell.get().fold<any>(Fun.constant('none'), Fun.identity);
+  const readState = (): any => cell.get().getOr('none');
 
   return {
     readState,
-    get,
-    set,
+    get: cell.get,
+    set: cell.set,
     clear
   };
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxState.ts
@@ -1,32 +1,20 @@
-import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Fun, Singleton } from '@ephox/katamari';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { nuState } from '../common/BehaviourState';
 import { SandboxingState } from './SandboxingTypes';
 
 const init = (): SandboxingState => {
-  const contents = Cell(Optional.none<AlloyComponent>());
+  const contents = Singleton.value<AlloyComponent>();
 
   const readState = Fun.constant('not-implemented');
 
-  const isOpen = () => contents.get().isSome();
-
-  const set = (comp: AlloyComponent) => {
-    contents.set(Optional.some(comp));
-  };
-
-  const get = () => contents.get();
-
-  const clear = () => {
-    contents.set(Optional.none());
-  };
-
   return nuState({
     readState,
-    isOpen,
-    clear,
-    set,
-    get
+    isOpen: contents.isSet,
+    clear: contents.clear,
+    set: contents.set,
+    get: contents.get
   });
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingState.ts
@@ -1,52 +1,29 @@
-import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Fun, Singleton } from '@ephox/katamari';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { nuState } from '../common/BehaviourState';
 import { TooltippingState } from './TooltippingTypes';
 
 const init = (): TooltippingState => {
-  const timer = Cell(Optional.none<number>());
-  const popup = Cell(Optional.none<AlloyComponent>());
-
-  const getTooltip = () => popup.get();
-
-  const setTooltip = (comp: AlloyComponent) => {
-    popup.set(Optional.some(comp));
-  };
-
-  const clearTooltip = () => {
-    popup.set(Optional.none());
-  };
+  const timer = Singleton.value<number>();
+  const popup = Singleton.value<AlloyComponent>();
 
   const clearTimer = () => {
-    timer.get().each((t) => {
-      clearTimeout(t);
-    });
+    timer.on(clearTimeout);
   };
 
-  const resetTimer = (f: () => any, delay: number) => {
+  const resetTimer = (f: () => void, delay: number) => {
     clearTimer();
-    timer.set(
-      Optional.some(
-        setTimeout(
-          () => {
-            f();
-          },
-          delay
-        )
-      )
-    );
+    timer.set(setTimeout(f, delay));
   };
-
-  const isShowing = () => popup.get().isSome();
 
   const readState = Fun.constant('not-implemented');
 
   return nuState({
-    getTooltip,
-    isShowing,
-    setTooltip,
-    clearTooltip,
+    getTooltip: popup.get,
+    isShowing: popup.isSet,
+    setTooltip: popup.set,
+    clearTooltip: popup.clear,
     clearTimer,
     resetTimer,
     readState

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingTypes.ts
@@ -41,6 +41,6 @@ export interface TooltippingState extends BehaviourState {
   setTooltip: (popup: AlloyComponent) => void;
   clearTooltip: () => void;
   clearTimer: () => void;
-  resetTimer: (f: () => any, delay: number) => void;
+  resetTimer: (f: () => void, delay: number) => void;
   isShowing: () => boolean;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/ImageClone.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/ImageClone.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell, Optional } from '@ephox/katamari';
+import { Arr, Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute, Css, DomEvent, Insert, Remove, Replication, SugarElement } from '@ephox/sugar';
 
@@ -66,7 +66,7 @@ const blockDefaultGhost = (target: SugarElement): void => {
 // Edge doesn't have setDragImage support and just hiding the target element will position the drop icon incorrectly so we need custom ghost
 // TODO: Get rid of this once Edge switches to Chromium we feature detect setDragImage support so once they have it should use that instead
 const setDragImageFromCloneEdgeFallback = (image: DragnDropImageClone, parent: SugarElement, target: SugarElement): void => {
-  const ghostState = Cell(Optional.none<SugarElement<any>>());
+  const ghostState = Singleton.value<SugarElement<any>>();
 
   const drag = DomEvent.bind(target, 'drag', (evt) => {
     // The calculated position needs to at least be cord + 1 since it would otherwise interfere with dropping
@@ -76,7 +76,7 @@ const setDragImageFromCloneEdgeFallback = (image: DragnDropImageClone, parent: S
     const ghost = ghostState.get().getOrThunk(() => {
       const newGhost = createGhostClone(image);
 
-      ghostState.set(Optional.some(newGhost));
+      ghostState.set(newGhost);
 
       Css.setAll(newGhost, {
         position: 'fixed',
@@ -98,7 +98,7 @@ const setDragImageFromCloneEdgeFallback = (image: DragnDropImageClone, parent: S
   });
 
   const dragEnd = DomEvent.bind(target, 'dragend', (_) => {
-    ghostState.get().each(Remove.remove);
+    ghostState.on(Remove.remove);
     drag.unbind();
     dragEnd.unbind();
   });

--- a/modules/alloy/src/main/ts/ephox/alloy/events/GuiEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/GuiEvents.ts
@@ -1,5 +1,5 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Arr, Cell, Optional } from '@ephox/katamari';
+import { Arr, Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { DomEvent, EventArgs, EventUnbinder, SelectorExists, SugarElement, SugarNode } from '@ephox/sugar';
 
@@ -95,7 +95,7 @@ const setup = (container: SugarElement, rawSettings: { }): { unbind: () => void 
       }
     })
   );
-  const pasteTimeout = Cell(Optional.none<number>());
+  const pasteTimeout = Singleton.value<number>();
   const onPaste = DomEvent.bind(container, 'paste', (event) => {
     tapEvent.fireIfReady(event, 'paste').each((tapStopped) => {
       if (tapStopped) {
@@ -107,9 +107,9 @@ const setup = (container: SugarElement, rawSettings: { }): { unbind: () => void 
     if (stopped) {
       event.kill();
     }
-    pasteTimeout.set(Optional.some(setTimeout(() => {
+    pasteTimeout.set(setTimeout(() => {
       settings.triggerEvent(SystemEvents.postPaste(), event);
-    }, 0)));
+    }, 0));
   });
 
   const onKeydown = DomEvent.bind(container, 'keydown', (event) => {
@@ -129,7 +129,7 @@ const setup = (container: SugarElement, rawSettings: { }): { unbind: () => void 
     }
   });
 
-  const focusoutTimeout = Cell(Optional.none<number>());
+  const focusoutTimeout = Singleton.value<number>();
   const onFocusOut = bindBlur(container, (event) => {
     const stopped = settings.triggerEvent('focusout', event);
     if (stopped) {
@@ -139,9 +139,9 @@ const setup = (container: SugarElement, rawSettings: { }): { unbind: () => void 
     // INVESTIGATE: Come up with a better way of doing this. Related target can be used, but not on FF.
     // It allows the active element to change before firing the blur that we will listen to
     // for things like closing popups
-    focusoutTimeout.set(Optional.some(setTimeout(() => {
+    focusoutTimeout.set(setTimeout(() => {
       settings.triggerEvent(SystemEvents.postBlur(), event);
-    }, 0)));
+    }, 0));
   });
 
   const unbind = (): void => {
@@ -152,8 +152,8 @@ const setup = (container: SugarElement, rawSettings: { }): { unbind: () => void 
     onFocusIn.unbind();
     onFocusOut.unbind();
     onPaste.unbind();
-    pasteTimeout.get().each(clearTimeout);
-    focusoutTimeout.get().each(clearTimeout);
+    pasteTimeout.on(clearTimeout);
+    focusoutTimeout.on(clearTimeout);
   };
 
   return {

--- a/modules/alloy/src/main/ts/ephox/alloy/events/TapEvent.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/TapEvent.ts
@@ -1,5 +1,5 @@
 import { Objects } from '@ephox/boulder';
-import { Cell, Obj, Optional } from '@ephox/katamari';
+import { Cell, Obj, Optional, Singleton } from '@ephox/katamari';
 import { Compare, EventArgs, SugarElement } from '@ephox/sugar';
 
 import { DelayedFunction } from '../alien/DelayedFunction';
@@ -43,8 +43,7 @@ const monitor = (settings: GuiEventSettings): Monitor => {
    * without a *significant* touchmove in between.
    */
 
-  // Need a return value, so can't use Singleton.value;
-  const startData: Cell<Optional<TouchHistoryData>> = Cell(Optional.none());
+  const startData = Singleton.value<TouchHistoryData>();
   const longpressFired = Cell<boolean>(false);
 
   const longpress = DelayedFunction((event: EventArgs) => {
@@ -64,7 +63,7 @@ const monitor = (settings: GuiEventSettings): Monitor => {
 
       longpress.schedule(event);
       longpressFired.set(false);
-      startData.set(Optional.some(data));
+      startData.set(data);
     });
     return Optional.none();
   };
@@ -72,9 +71,9 @@ const monitor = (settings: GuiEventSettings): Monitor => {
   const handleTouchmove = (event: EventArgs<TouchEvent>): Optional<boolean> => {
     longpress.cancel();
     getTouch(event).each((touch) => {
-      startData.get().each((data) => {
+      startData.on((data) => {
         if (isFarEnough(touch, data)) {
-          startData.set(Optional.none());
+          startData.clear();
         }
       });
     });

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell, Obj, Optional, Optionals } from '@ephox/katamari';
+import { Arr, Cell, Obj, Optional, Optionals, Singleton } from '@ephox/katamari';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { MenuPreparation } from '../../ui/single/TieredMenuSpec';
@@ -31,7 +31,7 @@ const init = (): LayeredState => {
   const expansions: Cell<Record<string, string>> = Cell({ });
   const menus: Cell<Record<string, MenuPreparation>> = Cell({ });
   const paths: Cell<Record<string, string[]>> = Cell({ });
-  const primary: Cell<Optional<string>> = Cell(Optional.none());
+  const primary = Singleton.value<string>();
 
   // Probably think of a better way to store this information.
   const directory: Cell<MenuDirectory> = Cell({ });
@@ -40,7 +40,7 @@ const init = (): LayeredState => {
     expansions.set({});
     menus.set({});
     paths.set({});
-    primary.set(Optional.none());
+    primary.clear();
   };
 
   const isClear = (): boolean => primary.get().isNone();
@@ -56,7 +56,7 @@ const init = (): LayeredState => {
   };
 
   const setContents = (sPrimary: string, sMenus: Record<string, MenuPreparation>, sExpansions: Record<string, string>, dir: MenuDirectory): void => {
-    primary.set(Optional.some(sPrimary));
+    primary.set(sPrimary);
     expansions.set(sExpansions);
     menus.set(sMenus);
     directory.set(dir);

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell, Fun, Obj, Optional, Optionals } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Optionals, Singleton } from '@ephox/katamari';
 import { Attribute, Class, Classes, SelectorFilter, SelectorFind, SugarBody } from '@ephox/sugar';
 
 import * as EditableFields from '../../alien/EditableFields';
@@ -37,7 +37,7 @@ export interface MenuNotBuilt {
 }
 
 const make: SingleSketchFactory<TieredMenuDetail, TieredMenuSpec> = (detail, _rawUiSpec) => {
-  const submenuParentItems: Cell<Optional<Record<string, AlloyComponent>>> = Cell(Optional.none());
+  const submenuParentItems = Singleton.value<Record<string, AlloyComponent>>();
 
   const buildMenus = (container: AlloyComponent, primaryName: string, menus: Record<string, PartialMenuSpec>): Record<string, MenuPreparation> => Obj.map(menus, (spec, name) => {
 
@@ -120,7 +120,7 @@ const make: SingleSketchFactory<TieredMenuDetail, TieredMenuSpec> = (detail, _ra
         r[key] = itemComp;
       });
     });
-    submenuParentItems.set(Optional.some(r));
+    submenuParentItems.set(r);
     return r;
   });
 

--- a/modules/alloy/src/test/ts/browser/behaviour/InvalidatingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/InvalidatingTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions, Chain, GeneralSteps, Guard, Logger, Step, UiControls, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Cell, Future, Optional, Result } from '@ephox/katamari';
+import { Future, Result, Singleton } from '@ephox/katamari';
 import { SugarElement, Value } from '@ephox/sugar';
 
 import * as Behaviour from 'ephox/alloy/api/behaviour/Behaviour';
@@ -12,7 +12,7 @@ import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 
 UnitTest.asynctest('InvalidatingTest', (success, failure) => {
 
-  const root = Cell(Optional.none<SugarElement<any>>());
+  const root = Singleton.value<SugarElement<any>>();
 
   GuiSetup.setup((_store, _doc, _body) => GuiFactory.build({
     dom: {
@@ -244,7 +244,7 @@ UnitTest.asynctest('InvalidatingTest', (success, failure) => {
 
       sCheckValidOf('Other should initially be valid', other),
       Step.sync(() => {
-        root.set(Optional.some(other.element));
+        root.set(other.element);
       }),
 
       Chain.asStep({ }, [

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell, Fun, Optional, Optionals } from '@ephox/katamari';
+import { Arr, Fun, Optional, Optionals, Singleton } from '@ephox/katamari';
 import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { getAttrValue } from '../util/CellUtils';
@@ -66,7 +66,7 @@ const elementToData = (element: SugarElement): CellSpan => {
 
 // note that `toData` seems to be only for testing
 const modification = (generators: Generators, toData = elementToData): GeneratorsModification => {
-  const position = Cell(Optional.none<SugarElement>());
+  const position = Singleton.value<SugarElement>();
 
   const nu = (data: CellSpan) => {
     switch (SugarNode.name(data.element)) {
@@ -84,8 +84,8 @@ const modification = (generators: Generators, toData = elementToData): Generator
 
   const add = (element: SugarElement) => {
     const replacement = nuFrom(element);
-    if (position.get().isNone()) {
-      position.set(Optional.some(replacement));
+    if (!position.isSet()) {
+      position.set(replacement);
     }
     recent = Optional.some({ item: element, replacement });
     return replacement;
@@ -108,7 +108,7 @@ const modification = (generators: Generators, toData = elementToData): Generator
 
 const transform = <K extends keyof HTMLElementTagNameMap> (scope: string | null, tag: K) => {
   return (generators: Generators): GeneratorsTransform => {
-    const position = Cell(Optional.none<SugarElement>());
+    const position = Singleton.value<SugarElement>();
     const list: Item[] = [];
 
     const find = (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) => {
@@ -126,8 +126,8 @@ const transform = <K extends keyof HTMLElementTagNameMap> (scope: string | null,
         item: element,
         sub: cell
       });
-      if (position.get().isNone()) {
-        position.set(Optional.some(cell));
+      if (!position.isSet()) {
+        position.set(cell);
       }
       return cell;
     };
@@ -159,11 +159,11 @@ const getScopeAttribute = (cell: SugarElement) =>
   );
 
 const merging = (generators: Generators): GeneratorsMerging => {
-  const position = Cell(Optional.none<SugarElement>());
+  const position = Singleton.value<SugarElement>();
 
   const unmerge = (cell: SugarElement) => {
-    if (position.get().isNone()) {
-      position.set(Optional.some(cell));
+    if (!position.isSet()) {
+      position.set(cell);
     }
 
     const scope = getScopeAttribute(cell);

--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
@@ -5,21 +5,21 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Cell, Obj, Optional, Optionals, Throttler } from '@ephox/katamari';
+import { Arr, Cell, Obj, Optional, Optionals, Singleton, Throttler } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
 import { AnnotationsRegistry } from './AnnotationsRegistry';
 import { identify } from './Identification';
 
 export interface AnnotationChanges {
-  addListener: (name: string, f: AnnotationListener) => void;
+  readonly addListener: (name: string, f: AnnotationListener) => void;
 }
 
 export type AnnotationListener = (state: boolean, name: string, data?: { uid: string; nodes: any[] }) => void;
 
 export interface AnnotationListenerData {
-  listeners: AnnotationListener[];
-  previous: Cell<Optional<string>>;
+  readonly listeners: AnnotationListener[];
+  readonly previous: Singleton.Value<string>;
 }
 
 export type AnnotationListenerMap = Record<string, AnnotationListenerData>;
@@ -29,7 +29,7 @@ const setup = (editor: Editor, _registry: AnnotationsRegistry): AnnotationChange
 
   const initData = (): AnnotationListenerData => ({
     listeners: [ ],
-    previous: Cell(Optional.none())
+    previous: Singleton.value()
   });
 
   const withCallbacks = (name: string, f: (listeners: AnnotationListenerData) => void) => {
@@ -74,14 +74,14 @@ const setup = (editor: Editor, _registry: AnnotationsRegistry): AnnotationChange
             if (prev.isSome()) {
               // Changed from something to nothing.
               fireNoAnnotation(name);
-              data.previous.set(Optional.none());
+              data.previous.clear();
             }
           },
           ({ uid, name, elements }) => {
             // Changed from a different annotation (or nothing)
             if (!Optionals.is(prev, uid)) {
               fireCallbacks(name, uid, elements);
-              data.previous.set(Optional.some(uid));
+              data.previous.set(uid);
             }
           }
         );

--- a/modules/tinymce/src/core/main/ts/annotate/Wrapping.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/Wrapping.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Cell, Id, Optional, Unicode } from '@ephox/katamari';
+import { Arr, Id, Singleton, Unicode } from '@ephox/katamari';
 import { Attribute, Class, Classes, Html, Insert, Replication, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
@@ -54,12 +54,12 @@ const annotate = (editor: Editor, rng: Range, annotationName: string, decorate: 
   const master = makeAnnotation(editor.getDoc(), data, annotationName, decorate);
 
   // Set the current wrapping element
-  const wrapper = Cell(Optional.none<SugarElement<any>>());
+  const wrapper = Singleton.value<SugarElement<any>>();
 
   // Clear the current wrapping element, so that subsequent calls to
   // getOrOpenWrapper spawns a new one.
   const finishWrapper = () => {
-    wrapper.set(Optional.none());
+    wrapper.clear();
   };
 
   // Get the existing wrapper, or spawn a new one.
@@ -67,7 +67,7 @@ const annotate = (editor: Editor, rng: Range, annotationName: string, decorate: 
     wrapper.get().getOrThunk(() => {
       const nu = Replication.shallow(master);
       newWrappers.push(nu);
-      wrapper.set(Optional.some(nu));
+      wrapper.set(nu);
       return nu;
     });
 

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Singleton } from '@ephox/katamari';
 
 import { Bookmark } from '../bookmark/BookmarkTypes';
 import * as Rtc from '../Rtc';
@@ -19,7 +19,7 @@ import Editor from './Editor';
  * @class tinymce.UndoManager
  */
 const UndoManager = (editor: Editor): UndoManager => {
-  const beforeBookmark: Cell<Optional<Bookmark>> = Cell(Optional.none());
+  const beforeBookmark = Singleton.value<Bookmark>();
   const locks: Locks = Cell(0);
   const index: Index = Cell(0);
 

--- a/modules/tinymce/src/core/main/ts/events/TouchEvents.ts
+++ b/modules/tinymce/src/core/main/ts/events/TouchEvents.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell, Optional, Throttler } from '@ephox/katamari';
+import { Cell, Optional, Singleton, Throttler } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
 
@@ -34,7 +34,7 @@ const isFarEnough = (touch: Touch, data: TouchHistoryData): boolean => {
 };
 
 const setup = (editor: Editor) => {
-  const startData = Cell<Optional<TouchHistoryData>>(Optional.none());
+  const startData = Singleton.value<TouchHistoryData>();
   const longpressFired = Cell<boolean>(false);
 
   const debounceLongpress = Throttler.last((e) => {
@@ -54,16 +54,16 @@ const setup = (editor: Editor) => {
 
       debounceLongpress.throttle(e);
       longpressFired.set(false);
-      startData.set(Optional.some(data));
+      startData.set(data);
     });
   }, true);
 
   editor.on('touchmove', (e) => {
     debounceLongpress.cancel();
     getTouch(e).each((touch) => {
-      startData.get().each((data) => {
+      startData.on((data) => {
         if (isFarEnough(touch, data)) {
-          startData.set(Optional.none());
+          startData.clear();
           longpressFired.set(false);
           editor.fire('longpresscancel');
         }

--- a/modules/tinymce/src/core/main/ts/undo/Levels.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Levels.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Cell, Optional } from '@ephox/katamari';
+import { Arr, Thunk } from '@ephox/katamari';
 import { Html, Remove, SelectorFilter, SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
@@ -13,15 +13,9 @@ import * as TrimHtml from '../dom/TrimHtml';
 import * as Fragments from './Fragments';
 import { UndoLevel, UndoLevelType } from './UndoManagerTypes';
 
-const undoLevelDocument = Cell<Optional<Document>>(Optional.none());
-
 // We need to create a temporary document instead of using the global document since
 // innerHTML on a detached element will still make http requests to the images
-const lazyTempDocument = () => undoLevelDocument.get().getOrThunk(() => {
-  const doc = document.implementation.createHTMLDocument('undo');
-  undoLevelDocument.set(Optional.some(doc));
-  return doc;
-});
+const lazyTempDocument = Thunk.cached(() => document.implementation.createHTMLDocument('undo'));
 
 const hasIframes = (html: string) => {
   return html.indexOf('</iframe>') !== -1;

--- a/modules/tinymce/src/core/main/ts/undo/Operations.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Operations.ts
@@ -5,8 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional } from '@ephox/katamari';
-
 import Editor from '../api/Editor';
 import * as Settings from '../api/Settings';
 import Tools from '../api/util/Tools';
@@ -18,7 +16,7 @@ import { Index, Locks, UndoBookmark, UndoLevel, UndoManager } from './UndoManage
 
 export const beforeChange = (editor: Editor, locks: Locks, beforeBookmark: UndoBookmark) => {
   if (isUnlocked(locks)) {
-    beforeBookmark.set(Optional.some(GetBookmark.getUndoBookmark(editor.selection)));
+    beforeBookmark.set(GetBookmark.getUndoBookmark(editor.selection));
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
+++ b/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell, Optional } from '@ephox/katamari';
+import { Cell, Singleton } from '@ephox/katamari';
 
 import { EditorEvent } from '../api/util/EventDispatcher';
 import { Bookmark } from '../bookmark/BookmarkTypes';
@@ -43,4 +43,4 @@ export type Index = Cell<number>;
 
 export type Locks = Cell<number>;
 
-export type UndoBookmark = Cell<Optional<Bookmark>>;
+export type UndoBookmark = Singleton.Value<Bookmark>;

--- a/modules/tinymce/src/core/test/ts/browser/init/RegisterFormatsBeforeSetContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/RegisterFormatsBeforeSetContentTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { Arr, Cell, Obj, Optional, Strings } from '@ephox/katamari';
+import { Arr, Obj, Singleton, Strings } from '@ephox/katamari';
 import { TinyHooks } from '@ephox/mcagar';
 import { assert } from 'chai';
 
@@ -7,7 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.RegisterFormatsBeforeSetContentTest', () => {
-  const customFormatNames = Cell<Optional<string[]>>(Optional.none());
+  const customFormatNames = Singleton.value<string[]>();
   TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     style_formats: [
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.init.RegisterFormatsBeforeSetContentTest', () => 
     setup: (editor: Editor) => {
       editor.on('BeforeSetContent', (_) => {
         const names = Arr.filter(Obj.keys(editor.formatter.get()), (key) => Strings.startsWith(key, 'custom-'));
-        customFormatNames.set(Optional.some(names));
+        customFormatNames.set(names);
       });
     }
   }, [ Theme ]);

--- a/modules/tinymce/src/plugins/emoticons/main/ts/core/EmojiDatabase.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/core/EmojiDatabase.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell, Merger, Obj, Optional, Strings } from '@ephox/katamari';
+import { Merger, Obj, Optional, Singleton, Strings } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Resource from 'tinymce/core/api/Resource';
@@ -58,8 +58,8 @@ const getUserDefinedEmoticons = (editor: Editor) => {
 
 // TODO: Consider how to share this loading across different editors
 const initDatabase = (editor: Editor, databaseUrl: string, databaseId: string): EmojiDatabase => {
-  const categories = Cell<Optional<Record<string, EmojiEntry[]>>>(Optional.none());
-  const all = Cell<Optional<EmojiEntry[]>>(Optional.none());
+  const categories = Singleton.value<Record<string, EmojiEntry[]>>();
+  const all = Singleton.value<EmojiEntry[]>();
 
   const emojiImagesUrl = Settings.getEmotionsImageUrl(editor);
 
@@ -89,8 +89,8 @@ const initDatabase = (editor: Editor, databaseUrl: string, databaseId: string): 
       everything.push(entry);
     });
 
-    categories.set(Optional.some(cats));
-    all.set(Optional.some(everything));
+    categories.set(cats);
+    all.set(everything);
   };
 
   editor.on('init', () => {
@@ -100,8 +100,8 @@ const initDatabase = (editor: Editor, databaseUrl: string, databaseId: string): 
     }, (err) => {
       // eslint-disable-next-line no-console
       console.log(`Failed to load emoticons: ${err}`);
-      categories.set(Optional.some({}));
-      all.set(Optional.some([]));
+      categories.set({});
+      all.set([]);
     });
   });
 
@@ -142,7 +142,7 @@ const initDatabase = (editor: Editor, databaseUrl: string, databaseId: string): 
     }
   };
 
-  const hasLoaded = (): boolean => categories.get().isSome() && all.get().isSome();
+  const hasLoaded = (): boolean => categories.isSet() && all.isSet();
 
   return {
     listCategories,

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCustomFetchTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCustomFetchTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { BlobConversions } from '@ephox/imagetools';
-import { Cell, Optional } from '@ephox/katamari';
+import { Singleton } from '@ephox/katamari';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { assert } from 'chai';
 
@@ -14,7 +14,7 @@ import * as ImageUtils from '../module/test/ImageUtils';
 describe('browser.tinymce.plugins.imagetools.ImageToolsCustomFetchTest', () => {
   const uploadHandlerState = ImageUtils.createStateContainer();
   const srcUrl = '/project/tinymce/src/plugins/imagetools/demo/img/dogleft.jpg';
-  const fetchState = Cell(Optional.none<string>());
+  const fetchState = Singleton.value<string>();
 
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'imagetools',
@@ -27,7 +27,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsCustomFetchTest', () => {
   it('TBA: flip image with custom fetch image', async () => {
     const editor = hook.editor();
     editor.settings.imagetools_fetch_image = (img: HTMLImageElement) => {
-      fetchState.set(Optional.some(img.src));
+      fetchState.set(img.src);
       return BlobConversions.imageToBlob(img);
     };
     await ImageUtils.pLoadImage(editor, srcUrl);

--- a/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell, Optional } from '@ephox/katamari';
+import { Optional, Singleton } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 export interface Clipboard {
@@ -19,25 +19,21 @@ export interface Clipboard {
 }
 
 export const Clipboard = (): Clipboard => {
-  const rows = Cell(Optional.none<SugarElement<HTMLTableRowElement>[]>());
-  const cols = Cell(Optional.none<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>());
-
-  const clearClipboard = (clipboard: Cell<Optional<SugarElement<any>[]>>) => {
-    clipboard.set(Optional.none());
-  };
+  const rows = Singleton.value<SugarElement<HTMLTableRowElement>[]>();
+  const cols = Singleton.value<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>();
 
   return {
     getRows: rows.get,
     setRows: (r: Optional<SugarElement<HTMLTableRowElement>[]>) => {
-      rows.set(r);
-      clearClipboard(cols);
+      r.fold(rows.clear, rows.set);
+      cols.clear();
     },
-    clearRows: () => clearClipboard(rows),
+    clearRows: rows.clear,
     getColumns: cols.get,
     setColumns: (c: Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>) => {
-      cols.set(c);
-      clearClipboard(rows);
+      c.fold(cols.clear, cols.set);
+      rows.clear();
     },
-    clearColumns: () => clearClipboard(cols)
+    clearColumns: cols.clear
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
@@ -7,7 +7,7 @@
 
 import { AddEventsBehaviour, AlloyEvents, Behaviour, GuiFactory, Highlighting, InlineView, ItemTypes, Menu, SystemEvents } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
-import { Arr, Cell, Optional, Throttler, Thunk } from '@ephox/katamari';
+import { Arr, Cell, Optional, Singleton, Throttler, Thunk } from '@ephox/katamari';
 import { Remove, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -29,7 +29,7 @@ interface ActiveAutocompleter {
 }
 
 const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared) => {
-  const activeAutocompleter = Cell<Optional<ActiveAutocompleter>>(Optional.none());
+  const activeAutocompleter = Singleton.value<ActiveAutocompleter>();
   const processingAction = Cell<boolean>(false);
 
   const autocompleter = GuiFactory.build(
@@ -66,7 +66,7 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared) => 
 
       // Hide the menu and reset
       hideIfNecessary();
-      activeAutocompleter.set(Optional.none());
+      activeAutocompleter.clear();
       processingAction.set(false);
     }
   };
@@ -122,11 +122,11 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared) => 
       const wrapper = AutocompleteTag.create(editor, context.range);
 
       // store the element/context
-      activeAutocompleter.set(Optional.some({
+      activeAutocompleter.set({
         triggerChar: context.triggerChar,
         element: wrapper,
         matchLength: context.text.length
-      }));
+      });
       processingAction.set(false);
     }
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/DialogTabHeight.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/DialogTabHeight.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, AlloyEvents, Replacing, SystemEvents, TabbarTypes, TabSection } from '@ephox/alloy';
-import { Arr, Cell, Optional } from '@ephox/katamari';
+import { Arr, Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Css, Focus, Height, SelectorFind, SugarElement, SugarShadowDom, Traverse, Width } from '@ephox/sugar';
 
@@ -74,7 +74,7 @@ const setTabviewHeight = (tabview: SugarElement<Element>, height: number) => {
   }
 };
 
-const updateTabviewHeight = (dialogBody: SugarElement, tabview: SugarElement, maxTabHeight: Cell<Optional<number>>) => {
+const updateTabviewHeight = (dialogBody: SugarElement, tabview: SugarElement, maxTabHeight: Singleton.Value<number>) => {
   SelectorFind.ancestor(dialogBody, '[role="dialog"]').each((dialog) => {
     SelectorFind.descendant(dialog, '[role="tablist"]').each((tablist) => {
       maxTabHeight.get().map((height) => {
@@ -93,7 +93,7 @@ const getTabview = (dialog: SugarElement<Element>) => SelectorFind.descendant(di
 
 const setMode = (allTabs: Array<Partial<TabbarTypes.TabButtonWithViewSpec>>) => {
   const smartTabHeight = (() => {
-    const maxTabHeight = Cell<Optional<number>>(Optional.none());
+    const maxTabHeight = Singleton.value<number>();
 
     const extraEvents = [
       AlloyEvents.runOnAttached((comp) => {
@@ -107,7 +107,7 @@ const setMode = (allTabs: Array<Partial<TabbarTypes.TabButtonWithViewSpec>>) => 
 
             // Calculate the maximum tab height and store it
             const maxTabHeightOpt = getMaxHeight(heights);
-            maxTabHeight.set(maxTabHeightOpt);
+            maxTabHeightOpt.fold(maxTabHeight.clear, maxTabHeight.set);
           });
 
           // Set an initial height, based on the current size
@@ -142,7 +142,7 @@ const setMode = (allTabs: Array<Partial<TabbarTypes.TabButtonWithViewSpec>>) => 
           const hasGrown = oldHeight.forall((h) => newHeight > h);
 
           if (hasGrown) {
-            maxTabHeight.set(Optional.from(newHeight));
+            maxTabHeight.set(newHeight);
             updateTabviewHeight(dialog, tabview, maxTabHeight);
           } else {
             oldHeight.each((h) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -7,7 +7,7 @@
 
 import { AddEventsBehaviour, AlloyEvents, Behaviour, Memento, Representing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Cell, Obj, Optional } from '@ephox/katamari';
+import { Obj, Singleton } from '@ephox/katamari';
 
 import Resource from 'tinymce/core/api/Resource';
 
@@ -20,7 +20,7 @@ const isOldCustomEditor = (spec: CustomEditorSpec): spec is Dialog.CustomEditorO
   Obj.has(spec as Dialog.CustomEditorOld, 'init');
 
 export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
-  const editorApi = Cell(Optional.none<Dialog.CustomEditorInit>());
+  const editorApi = Singleton.value<Dialog.CustomEditorInit>();
 
   const memReplaced = Memento.record({
     dom: {
@@ -28,7 +28,7 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
     }
   });
 
-  const initialValue = Cell(Optional.none<string>());
+  const initialValue = Singleton.value<string>();
 
   return {
     dom: {
@@ -45,12 +45,12 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
                 (init: CustomEditorInitFn) => init(ta.element.dom, spec.settings)
               )
             ).then((ea) => {
-              initialValue.get().each((cvalue) => {
+              initialValue.on((cvalue) => {
                 ea.setValue(cvalue);
               });
 
-              initialValue.set(Optional.none());
-              editorApi.set(Optional.some(ea));
+              initialValue.clear();
+              editorApi.set(ea);
             });
           });
         })
@@ -65,7 +65,7 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
           setValue: (component, value) => {
             editorApi.get().fold(
               () => {
-                initialValue.set(Optional.some(value));
+                initialValue.set(value);
               },
               (ed) => ed.setValue(value)
             );

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/ImagePanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/ImagePanel.ts
@@ -6,7 +6,7 @@
  */
 
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Container, GuiFactory, Memento, Replacing } from '@ephox/alloy';
-import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional, Singleton } from '@ephox/katamari';
 import { Attribute, Css, Height, SugarElement, Width } from '@ephox/sugar';
 
 import Rect, { GeomRect } from 'tinymce/core/api/geom/Rect';
@@ -41,7 +41,7 @@ const renderImagePanel = (initialUrl: string) => {
   );
 
   const zoomState = Cell(1);
-  const cropRect = Cell(Optional.none<CropRect>());
+  const cropRect = Singleton.value<CropRect>();
   const rectState = Cell({
     x: 0,
     y: 0,
@@ -79,7 +79,7 @@ const renderImagePanel = (initialUrl: string) => {
         Css.setAll(bg.element, css);
       });
 
-      cropRect.get().each((cRect) => {
+      cropRect.on((cRect) => {
         const rect = rectState.get();
         cRect.setRect({
           x: rect.x * zoom + left,
@@ -166,13 +166,13 @@ const renderImagePanel = (initialUrl: string) => {
   };
 
   const showCrop = (): void => {
-    cropRect.get().each((cRect) => {
+    cropRect.on((cRect) => {
       cRect.toggleVisibility(true);
     });
   };
 
   const hideCrop = (): void => {
-    cropRect.get().each((cRect) => {
+    cropRect.on((cRect) => {
       cRect.toggleVisibility(false);
     });
   };
@@ -222,7 +222,7 @@ const renderImagePanel = (initialUrl: string) => {
                   };
                   rectState.set(newRect);
                 });
-                cropRect.set(Optional.some(cRect));
+                cropRect.set(cRect);
               });
             })
           ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/state/ImageToolsState.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/state/ImageToolsState.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Cell, Fun, Singleton } from '@ephox/katamari';
 
 import Tools from 'tinymce/core/api/util/Tools';
 
@@ -23,7 +23,7 @@ interface UndoRedoState {
 
 const makeState = (initialState: BlobState) => {
   const blobState = Cell(initialState);
-  const tempState = Cell(Optional.none<BlobState>());
+  const tempState = Singleton.value<BlobState>();
   const undoStack = UndoStack();
   undoStack.add(initialState);
 
@@ -39,7 +39,7 @@ const makeState = (initialState: BlobState) => {
     const newTempState = createState(blob);
 
     destroyTempState();
-    tempState.set(Optional.some(newTempState));
+    tempState.set(newTempState);
     return newTempState.url;
   };
 
@@ -57,8 +57,8 @@ const makeState = (initialState: BlobState) => {
   };
 
   const destroyTempState = (): void => {
-    tempState.get().each(destroyState);
-    tempState.set(Optional.none());
+    tempState.on(destroyState);
+    tempState.clear();
   };
 
   const addBlobState = (blob: Blob): string => {
@@ -71,7 +71,7 @@ const makeState = (initialState: BlobState) => {
 
   const addTempState = (blob: Blob): string => {
     const newState = createState(blob);
-    tempState.set(Optional.some(newState));
+    tempState.set(newState);
     return newState.url;
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, Boxes, Channels, Docking, Focusing, Receiving } from '@ephox/alloy';
-import { Arr, Cell, Optional, Result } from '@ephox/katamari';
+import { Arr, Optional, Result, Singleton } from '@ephox/katamari';
 import { Class, Classes, Compare, Css, Focus, Height, Scroll, SugarElement, SugarLocation, Traverse, Visibility, Width } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -184,7 +184,7 @@ const getIframeBehaviours = () => [
 ];
 
 const getBehaviours = (editor: Editor, sharedBackstage: UiFactoryBackstageShared) => {
-  const focusedElm = Cell<Optional<SugarElement>>(Optional.none());
+  const focusedElm = Singleton.value<SugarElement>();
   const lazySink = sharedBackstage.getSink;
 
   const runOnSinkElement = (f: (sink: SugarElement) => void) => {
@@ -223,11 +223,11 @@ const getBehaviours = (editor: Editor, sharedBackstage: UiFactoryBackstageShared
           // Restore focus and reset the stored focused element
           focusedElm.get().each((elem) => {
             restoreFocus(comp.element, elem);
-            focusedElm.set(Optional.none());
+            focusedElm.clear();
           });
         },
         onHide: (comp) => {
-          focusedElm.set(findFocusedElem(comp.element, lazySink));
+          findFocusedElem(comp.element, lazySink).fold(focusedElm.clear, focusedElm.set);
           runOnSinkElement((elem) => updateSinkVisibility(elem, false));
         },
         onHidden: () => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/selector/TableSelectorHandles.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/selector/TableSelectorHandles.ts
@@ -8,7 +8,7 @@
 import {
   AlloyComponent, Attachment, Behaviour, Boxes, Button, DragCoord, Dragging, DraggingTypes, GuiFactory, Memento, Unselecting
 } from '@ephox/alloy';
-import { Arr, Cell, Optional } from '@ephox/katamari';
+import { Arr, Cell, Optional, Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Compare, Css, SugarElement, SugarPosition, Traverse } from '@ephox/sugar';
 
@@ -59,7 +59,7 @@ const calcSnap = (selectorOpt: Optional<AlloyComponent>, td: SugarElement<HTMLTa
   });
 });
 
-const getSnapsConfig = (getSnapPoints: () => DraggingTypes.SnapConfig<SnapExtra>[], cell: Cell<Optional<SugarElement<HTMLTableDataCellElement>>>, onChange: (td: SugarElement<HTMLTableDataCellElement>) => void): DraggingTypes.SnapsConfigSpec<SnapExtra> => {
+const getSnapsConfig = (getSnapPoints: () => DraggingTypes.SnapConfig<SnapExtra>[], cell: Singleton.Value<SugarElement<HTMLTableDataCellElement>>, onChange: (td: SugarElement<HTMLTableDataCellElement>) => void): DraggingTypes.SnapsConfigSpec<SnapExtra> => {
   // Can't use Optional.is() here since we need to do a dom compare, not an equality compare
   const isSameCell = (cellOpt: Optional<SugarElement<HTMLTableDataCellElement>>, td: SugarElement<HTMLTableDataCellElement>) => cellOpt.exists((currentTd) => Compare.eq(currentTd, td));
 
@@ -70,7 +70,7 @@ const getSnapsConfig = (getSnapPoints: () => DraggingTypes.SnapConfig<SnapExtra>
     onSensor: (component, extra) => {
       const td = extra.td;
       if (!isSameCell(cell.get(), td)) {
-        cell.set(Optional.some(td));
+        cell.set(td);
         onChange(td);
       }
     },
@@ -105,8 +105,8 @@ const setup = (editor: Editor, sink: AlloyComponent) => {
   const tlTds = Cell<SugarElement<HTMLTableDataCellElement>[]>([]);
   const brTds = Cell<SugarElement<HTMLTableDataCellElement>[]>([]);
   const isVisible = Cell<Boolean>(false);
-  const startCell = Cell<Optional<SugarElement<HTMLTableDataCellElement>>>(Optional.none());
-  const finishCell = Cell<Optional<SugarElement<HTMLTableDataCellElement>>>(Optional.none());
+  const startCell = Singleton.value<SugarElement<HTMLTableDataCellElement>>();
+  const finishCell = Singleton.value<SugarElement<HTMLTableDataCellElement>>();
 
   const getTopLeftSnap = (td: SugarElement<HTMLTableDataCellElement>) => {
     const box = Boxes.absolute(td);
@@ -185,8 +185,8 @@ const setup = (editor: Editor, sink: AlloyComponent) => {
         Attachment.attach(sink, bottomRight);
         isVisible.set(true);
       }
-      startCell.set(Optional.some(e.start));
-      finishCell.set(Optional.some(e.finish));
+      startCell.set(e.start);
+      finishCell.set(e.finish);
 
       e.otherCells.each((otherCells) => {
         tlTds.set(otherCells.upOrLeftCells);
@@ -208,8 +208,8 @@ const setup = (editor: Editor, sink: AlloyComponent) => {
         Attachment.detach(bottomRight);
         isVisible.set(false);
       }
-      startCell.set(Optional.none());
-      finishCell.set(Optional.none());
+      startCell.clear();
+      finishCell.clear();
     });
   }
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
@@ -6,7 +6,7 @@
  */
 
 import { AlloyComponent, AlloySpec, Behaviour, Blocking, Composing, DomFactory, Replacing } from '@ephox/alloy';
-import { Arr, Cell, Optional, Type } from '@ephox/katamari';
+import { Arr, Cell, Optional, Singleton, Type } from '@ephox/katamari';
 import { Attribute, Class, Css, Focus, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { EventUtilsEvent } from 'tinymce/core/api/dom/EventUtils';
@@ -125,7 +125,7 @@ const isPasteBinTarget = (event: EditorEvent<ExecCommandEvent> | EventUtilsEvent
 
 const setup = (editor: Editor, lazyThrobber: () => AlloyComponent, sharedBackstage: UiFactoryBackstageShared) => {
   const throbberState = Cell<boolean>(false);
-  const timer = Cell<Optional<number>>(Optional.none());
+  const timer = Singleton.value<number>();
 
   const stealFocus = (e: EditorEvent<ExecCommandEvent> | EventUtilsEvent<FocusEvent>) => {
     if (throbberState.get() && !isPasteBinTarget(e)) {
@@ -159,13 +159,13 @@ const setup = (editor: Editor, lazyThrobber: () => AlloyComponent, sharedBacksta
   };
 
   editor.on('ProgressState', (e) => {
-    timer.get().each(Delay.clearTimeout);
+    timer.on(Delay.clearTimeout);
     if (Type.isNumber(e.time)) {
       const timerId = Delay.setEditorTimeout(editor, () => toggle(e.state), e.time);
-      timer.set(Optional.some(timerId));
+      timer.set(timerId);
     } else {
       toggle(e.state);
-      timer.set(Optional.none());
+      timer.clear();
     }
   });
 };


### PR DESCRIPTION
Related Ticket: TINY-7678

Description of Changes:
* Replace `Cell<Optional<T>>` uses with `Singleton<T>`
* Clean up `Singleton` to remove some duplication

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
