### PR TITLE
TINY-7570: Allow overrides to language extraction in robin's Zones APIs

### DIFF
--- a/modules/boss/CHANGELOG.md
+++ b/modules/boss/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## 4.2.0 - 2021-07-09
+## 4.2.0 - 2021-07-12
 
 ### Added
 - Added `property().getLanguage` function to Universe #TINY-7570

--- a/modules/boss/CHANGELOG.md
+++ b/modules/boss/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 4.2.0 - 2021-07-09
+
+### Added
+- Added `property().getLanguage` method to Universe

--- a/modules/boss/CHANGELOG.md
+++ b/modules/boss/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 4.2.0 - 2021-07-09
 
 ### Added
-- Added `property().getLanguage` method to Universe
+- Added `property().getLanguage` function to Universe #TINY-7570

--- a/modules/boss/src/main/ts/ephox/boss/api/DomUniverse.ts
+++ b/modules/boss/src/main/ts/ephox/boss/api/DomUniverse.ts
@@ -48,13 +48,8 @@ export default (): Universe<SugarElement, Document> => {
     ], tag);
   };
 
-  const getLanguage = (element: SugarElement<Node>): Optional<string> => {
-    if (SugarNode.isElement(element)) {
-      return Attribute.getOpt(element, 'lang');
-    } else {
-      return Optional.none();
-    }
-  };
+  const getLanguage = (element: SugarElement<Node>): Optional<string> =>
+    SugarNode.isElement(element) ? Attribute.getOpt(element, 'lang') : Optional.none();
 
   return {
     up: Fun.constant({

--- a/modules/boss/src/main/ts/ephox/boss/api/DomUniverse.ts
+++ b/modules/boss/src/main/ts/ephox/boss/api/DomUniverse.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import {
   Attribute, Compare, Css, Insert, InsertAll, PredicateFilter, PredicateFind, Remove, SelectorFilter, SelectorFind, SugarElement, SugarNode,
   SugarText, Traverse
@@ -46,6 +46,14 @@ export default (): Universe<SugarElement, Document> => {
     return Arr.contains([
       'script', 'noscript', 'iframe', 'noframes', 'noembed', 'title', 'style', 'textarea', 'xmp'
     ], tag);
+  };
+
+  const getLanguage = (element: SugarElement<Node>): Optional<string> => {
+    if (SugarNode.isElement(element)) {
+      return Attribute.getOpt(element, 'lang');
+    } else {
+      return Optional.none();
+    }
   };
 
   return {
@@ -103,6 +111,7 @@ export default (): Universe<SugarElement, Document> => {
       isComment: SugarNode.isComment,
       isElement: SugarNode.isElement,
       isSpecial,
+      getLanguage,
       getText: SugarText.get,
       setText: SugarText.set,
       isBoundary,

--- a/modules/boss/src/main/ts/ephox/boss/api/TestUniverse.ts
+++ b/modules/boss/src/main/ts/ephox/boss/api/TestUniverse.ts
@@ -106,6 +106,7 @@ export const TestUniverse = (raw: Gene): TestUniverse => {
       isComment: Properties.isComment,
       isElement: Properties.isElement,
       isSpecial: Properties.isSpecial,
+      getLanguage: Properties.getLanguage,
       setText: Properties.setText,
       getText: Properties.getText,
       isEmptyTag: Properties.isEmptyTag,

--- a/modules/boss/src/main/ts/ephox/boss/api/Universe.ts
+++ b/modules/boss/src/main/ts/ephox/boss/api/Universe.ts
@@ -55,6 +55,7 @@ export interface Universe<E, D> {
     isComment: (element: E) => boolean;
     isElement: (element: E) => boolean;
     isSpecial: (element: E) => boolean;
+    getLanguage: (element: E) => Optional<string>;
     getText: (element: E) => string;
     setText: (element: E, value: string) => void;
     isBoundary: (element: E) => boolean;

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Properties.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Properties.ts
@@ -1,4 +1,4 @@
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Obj, Optional } from '@ephox/katamari';
 import { Gene } from '../api/Gene';
 import TagBoundaries from '../common/TagBoundaries';
 
@@ -41,6 +41,10 @@ const isSpecial = (item: Gene): boolean => {
   return item.name === GeneTypes.Special;
 };
 
+const getLanguage = (item: Gene): Optional<string> => {
+  return Obj.get(item.attrs, 'lang');
+};
+
 const getText = (item: Gene): string => {
   return Optional.from(item.text).getOrDie('Text not available on this node');
 };
@@ -70,6 +74,7 @@ export {
   isComment,
   isElement,
   isSpecial,
+  getLanguage,
   getText,
   setText,
   isEmptyTag,

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Properties.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Properties.ts
@@ -41,9 +41,8 @@ const isSpecial = (item: Gene): boolean => {
   return item.name === GeneTypes.Special;
 };
 
-const getLanguage = (item: Gene): Optional<string> => {
-  return Obj.get(item.attrs, 'lang');
-};
+const getLanguage = (item: Gene): Optional<string> =>
+  Obj.get(item.attrs, 'lang');
 
 const getText = (item: Gene): string => {
   return Optional.from(item.text).getOrDie('Text not available on this node');

--- a/modules/robin/CHANGELOG.md
+++ b/modules/robin/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 8.1.0 - 2021-07-09
 
 ### Changed
-- TextZones APIs now use `universe.property().getLanguage` method instead of looking at `lang` attribute directly
+- `TextZones` APIs now use `universe.property().getLanguage` function instead of looking at `lang` attribute directly #TINY-7570

--- a/modules/robin/CHANGELOG.md
+++ b/modules/robin/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 8.1.0 - 2021-07-09
+
+### Changed
+- TextZones APIs now use `universe.property().getLanguage` method instead of looking at `lang` attribute directly

--- a/modules/robin/CHANGELOG.md
+++ b/modules/robin/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## 8.1.0 - 2021-07-09
+## 8.1.0 - 2021-07-12
 
 ### Changed
 - `TextZones` APIs now use `universe.property().getLanguage` function instead of looking at `lang` attribute directly #TINY-7570

--- a/modules/robin/src/main/ts/ephox/robin/zone/LanguageZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/LanguageZones.ts
@@ -122,10 +122,10 @@ const nu = <E>(defaultLang: string): LanguageZones<E> => {
 //    (regardless of 'classic'/iframe or 'inline'/div mode).
 // Note: there may be descendant elements with a different language
 const calculate = <E, D>(universe: Universe<E, D>, item: E): Optional<string> => {
-  const getLanguage = universe.property().getLanguage;
-  return getLanguage(item).orThunk(() => {
+  const props = universe.property();
+  return props.getLanguage(item).orThunk(() => {
     const ancestors = universe.up().all(item, Fun.never);
-    return Arr.findMap(ancestors, getLanguage);
+    return Arr.findMap(ancestors, props.getLanguage);
   });
 };
 

--- a/modules/robin/src/main/ts/ephox/robin/zone/LanguageZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/LanguageZones.ts
@@ -1,5 +1,5 @@
 import { Universe } from '@ephox/boss';
-import { Fun, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import { WordDecisionItem } from '../words/WordDecision';
 
 export interface ZoneDetails<E> {
@@ -122,9 +122,10 @@ const nu = <E>(defaultLang: string): LanguageZones<E> => {
 //    (regardless of 'classic'/iframe or 'inline'/div mode).
 // Note: there may be descendant elements with a different language
 const calculate = <E, D>(universe: Universe<E, D>, item: E): Optional<string> => {
-  return universe.up().closest(item, '[lang]', Fun.never).bind((el) => {
-    const lang = universe.attrs().get(el, 'lang');
-    return lang === undefined ? Optional.none<string>() : Optional.some(lang);
+  const getLanguage = universe.property().getLanguage;
+  return getLanguage(item).orThunk(() => {
+    const ancestors = universe.up().all(item, Fun.never);
+    return Arr.findMap(ancestors, getLanguage);
   });
 };
 

--- a/modules/robin/src/main/ts/ephox/robin/zone/ZoneWalker.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/ZoneWalker.ts
@@ -43,9 +43,7 @@ const visit = <E, D>(
   traverse: Traverse<E>
 ): void => {
   // Find if the current item has a lang property on it.
-  const currentLang = universe.property().isElement(traverse.item) ?
-    Optional.from(universe.attrs().get(traverse.item, 'lang')) :
-    Optional.none<string>();
+  const currentLang = universe.property().getLanguage(traverse.item);
 
   if (universe.property().isText(traverse.item)) {
     stack.addDetail(transform(universe, traverse.item));

--- a/modules/robin/src/test/ts/atomic/zone/LanguageGetTest.ts
+++ b/modules/robin/src/test/ts/atomic/zone/LanguageGetTest.ts
@@ -1,6 +1,6 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { LanguageZones } from 'ephox/robin/zone/LanguageZones';
 
 UnitTest.test('LanguageGetTest', () => {
@@ -79,4 +79,26 @@ UnitTest.test('LanguageGetTest', () => {
   check(doc, 'p3s1', Optional.some('DE'));
   check(doc, 'p3s2', Optional.some('DE'));
   check(doc, 'p3s3', Optional.some('FR'));
+
+  // Make sure it's using getLanguage, and that getLanguage can be overridden
+  const fakeUniverse: TestUniverse = {
+    ...doc,
+    property: Fun.constant({
+      ...doc.property(),
+      getLanguage: (e) => doc.property().getLanguage(e).map((lang) => 'custom:' + lang)
+    })
+  };
+
+  check(fakeUniverse, 'p1', Optional.none());
+  check(fakeUniverse, 'p1s1', Optional.none());
+  check(fakeUniverse, 'p1s2', Optional.none());
+  check(fakeUniverse, 'p1s3', Optional.some('custom:FR'));
+  check(fakeUniverse, 'p2', Optional.some('custom:DE'));
+  check(fakeUniverse, 'p2s1', Optional.some('custom:DE'));
+  check(fakeUniverse, 'p2s2', Optional.some('custom:DE'));
+  check(fakeUniverse, 'p2s3', Optional.some('custom:DE'));
+  check(fakeUniverse, 'p3', Optional.some('custom:DE'));
+  check(fakeUniverse, 'p3s1', Optional.some('custom:DE'));
+  check(fakeUniverse, 'p3s2', Optional.some('custom:DE'));
+  check(fakeUniverse, 'p3s3', Optional.some('custom:FR'));
 });

--- a/modules/robin/src/test/ts/browser/LanguageOverrideTest.ts
+++ b/modules/robin/src/test/ts/browser/LanguageOverrideTest.ts
@@ -1,0 +1,72 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { DomUniverse, Universe } from '@ephox/boss';
+import { Arr, Fun } from '@ephox/katamari';
+import { SugarElement, Traverse } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import { TextZones, ZoneViewports } from 'ephox/robin/api/Main';
+
+// Strip out the bits of an actual Zone that aren't compatible with assert.deepEqual
+interface AssertableZone {
+  readonly words: string[];
+  readonly lang: string;
+}
+
+describe('browser.robin.LanguageOverrideTest', () => {
+  const top = SugarElement.fromHtml('<div>' +
+    '<p lang="en">Hello <span>world</span></p>' +
+    '<p>This is <span lang="pt">multi-lingual content</span></p>' +
+    '</div>'
+  );
+
+  const walk = (universe: Universe<SugarElement, Document>): Array<AssertableZone> => {
+    const start = Traverse.firstChild(top).getOrDie();
+    const end = Traverse.lastChild(top).getOrDie();
+    const walkResult = TextZones.range(universe, start, 0, end, 2, 'default', ZoneViewports.anything());
+    return Arr.map(walkResult.zones, (zone) => ({
+      words: Arr.map(zone.words, (w) => w.word),
+      lang: zone.lang
+    }));
+  };
+
+  const normal = DomUniverse();
+  const override: Universe<SugarElement, Document> = {
+    ...normal,
+    property: Fun.constant({
+      ...normal.property(),
+      getLanguage: (ele: SugarElement) => normal.property().getLanguage(ele).map((lang) => 'custom:' + lang)
+    })
+  };
+
+  it('TINY-7570: Correctly marks languages', () => {
+    const zones = walk(normal);
+    assert.deepEqual(zones, [
+      {
+        lang: 'en',
+        words: [ 'Hello', 'world' ]
+      }, {
+        lang: 'default',
+        words: [ 'This', 'is' ]
+      }, {
+        lang: 'pt',
+        words: [ 'multi-lingual', 'content' ]
+      }
+    ]);
+  });
+
+  it('TINY-7570: Correctly marks overridden languages', () => {
+    const zones = walk(override);
+    assert.deepEqual(zones, [
+      {
+        lang: 'custom:en',
+        words: [ 'Hello', 'world' ]
+      }, {
+        lang: 'default',
+        words: [ 'This', 'is' ]
+      }, {
+        lang: 'custom:pt',
+        words: [ 'multi-lingual', 'content' ]
+      }
+    ]);
+  });
+});

--- a/modules/robin/src/test/ts/browser/LanguageOverrideTest.ts
+++ b/modules/robin/src/test/ts/browser/LanguageOverrideTest.ts
@@ -19,7 +19,7 @@ describe('browser.robin.LanguageOverrideTest', () => {
     '</div>'
   );
 
-  const walk = (universe: Universe<SugarElement, Document>): Array<AssertableZone> => {
+  const walk = (universe: Universe<SugarElement, Document>): AssertableZone[] => {
     const start = Traverse.firstChild(top).getOrDie();
     const end = Traverse.lastChild(top).getOrDie();
     const walkResult = TextZones.range(universe, start, 0, end, 2, 'default', ZoneViewports.anything());

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,2 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
-
-boss@4.2.0
-robin@8.1.0

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,5 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+
+boss@4.2.0
+robin@8.1.0


### PR DESCRIPTION
Related Ticket: TINY-7570

Description of Changes:
* Add a new `getLanguage` function to boss' Universe
* Use that function everywhere we were previously looking at `.attr('lang')`

I'm targeting master here, so that we can get the changes released before 5.9 so that we can start using them elsewhere.
* This is a minor version bump of boss and robin, but that's okay because they've both received major version bumps on the develop branch

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~ Technically it is a "new feature" but it's also targeting master so I kept this name.

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): N/A
