### PR TITLE
TINY-7393: Clean up formatter types and logic

### DIFF
--- a/modules/tinymce/src/core/main/ts/annotate/Wrapping.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/Wrapping.ts
@@ -28,7 +28,7 @@ export type Decorator = (
 };
 
 const applyWordGrab = (editor: Editor, rng: Range): void => {
-  const r = ExpandRange.expandRng(editor, rng, [{ inline: true }]);
+  const r = ExpandRange.expandRng(editor, rng, [{ inline: 'span' }]);
   rng.setStart(r.startContainer, r.startOffset);
   rng.setEnd(r.endContainer, r.endOffset);
   editor.selection.setRng(rng);

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -11,6 +11,7 @@ import { PredicateExists, SugarElement } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import * as Settings from '../api/Settings';
+import Tools from '../api/util/Tools';
 import * as Bookmarks from '../bookmark/Bookmarks';
 import * as Empty from '../dom/Empty';
 import * as NodeType from '../dom/NodeType';
@@ -28,6 +29,8 @@ import * as FormatUtils from './FormatUtils';
 import * as Hooks from './Hooks';
 import * as MatchFormat from './MatchFormat';
 import * as MergeFormats from './MergeFormats';
+
+const each = Tools.each;
 
 const isElementNode = (node: Node): node is Element => {
   return NodeType.isElement(node) && !Bookmarks.isBookmarkNode(node) && !isCaretNode(node) && !NodeType.isBogus(node);
@@ -69,7 +72,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
       fmt.onformat(elm, fmt as any, vars, node);
     }
 
-    Obj.each(fmt.styles, (value, name) => {
+    each(fmt.styles, (value, name) => {
       dom.setStyle(elm, name, FormatUtils.replaceVars(value, vars));
     });
 
@@ -83,11 +86,11 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
       }
     }
 
-    Obj.each(fmt.attributes, (value, name) => {
+    each(fmt.attributes, (value, name) => {
       dom.setAttrib(elm, name, FormatUtils.replaceVars(value, vars));
     });
 
-    Arr.each(fmt.classes, (value) => {
+    each(fmt.classes, (value) => {
       value = FormatUtils.replaceVars(value, vars);
 
       if (!dom.hasClass(elm, value)) {
@@ -104,7 +107,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
     }
 
     // Look for matching formats
-    Arr.each(formatList, (format) => {
+    each(formatList, (format) => {
       // Check collapsed state if it exists
       if (Type.isNonNullable(format.collapsed) && format.collapsed !== isCollapsed) {
         return;

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Obj } from '@ephox/katamari';
+import { Arr, Obj, Type } from '@ephox/katamari';
 import { PredicateExists, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
@@ -13,7 +13,6 @@ import Editor from '../api/Editor';
 import * as Settings from '../api/Settings';
 import Tools from '../api/util/Tools';
 import * as Bookmarks from '../bookmark/Bookmarks';
-import { IdBookmark, IndexBookmark } from '../bookmark/BookmarkTypes';
 import * as Empty from '../dom/Empty';
 import * as NodeType from '../dom/NodeType';
 import * as RangeNormalizer from '../selection/RangeNormalizer';
@@ -21,10 +20,11 @@ import { RangeLikeObject } from '../selection/RangeTypes';
 import * as RangeWalk from '../selection/RangeWalk';
 import * as SelectionUtils from '../selection/SelectionUtils';
 import * as TableCellSelection from '../selection/TableCellSelection';
+import * as Zwsp from '../text/Zwsp';
 import * as CaretFormat from './CaretFormat';
 import * as ExpandRange from './ExpandRange';
 import { isCaretNode } from './FormatContainer';
-import { ApplyFormat, BlockFormat, FormatVars, InlineFormat, SelectorFormat } from './FormatTypes';
+import { ApplyFormat, BlockFormat, FormatVars, InlineFormat } from './FormatTypes';
 import * as FormatUtils from './FormatUtils';
 import * as Hooks from './Hooks';
 import * as MatchFormat from './MatchFormat';
@@ -32,13 +32,8 @@ import * as MergeFormats from './MergeFormats';
 
 const each = Tools.each;
 
-type ApplyFormatProp = keyof InlineFormat | keyof BlockFormat | keyof SelectorFormat;
-
-const hasFormatProperty = (format: ApplyFormat, prop: ApplyFormatProp): boolean =>
-  Obj.hasNonNullableKey(format as any, prop);
-
-const isElementNode = (node: Node) => {
-  return node && node.nodeType === 1 && !Bookmarks.isBookmarkNode(node) && !isCaretNode(node) && !NodeType.isBogus(node);
+const isElementNode = (node: Node): node is Element => {
+  return NodeType.isElement(node) && !Bookmarks.isBookmarkNode(node) && !isCaretNode(node) && !NodeType.isBogus(node);
 };
 
 const canFormatBR = (editor: Editor, format: ApplyFormat, node: HTMLBRElement, parentName: string) => {
@@ -72,44 +67,39 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
   const dom = ed.dom;
   const selection = ed.selection;
 
-  // TODO: Add actual type for fmt below
-  const setElementFormat = (elm: Node, fmt?: ApplyFormat) => {
-    fmt = fmt || format;
-
-    if (elm) {
-      if (fmt.onformat) {
-        fmt.onformat(elm, fmt as any, vars, node);
-      }
-
-      each(fmt.styles, (value, name) => {
-        dom.setStyle(elm, name, FormatUtils.replaceVars(value, vars));
-      });
-
-      // Needed for the WebKit span spam bug
-      // TODO: Remove this once WebKit/Blink fixes this
-      if (fmt.styles) {
-        const styleVal = dom.getAttrib(elm, 'style');
-
-        if (styleVal) {
-          dom.setAttrib(elm, 'data-mce-style', styleVal);
-        }
-      }
-
-      each(fmt.attributes, (value, name) => {
-        dom.setAttrib(elm, name, FormatUtils.replaceVars(value, vars));
-      });
-
-      each(fmt.classes, (value) => {
-        value = FormatUtils.replaceVars(value, vars);
-
-        if (!dom.hasClass(elm, value)) {
-          dom.addClass(elm, value);
-        }
-      });
+  const setElementFormat = (elm: Node, fmt: ApplyFormat = format) => {
+    if (Type.isFunction(fmt.onformat)) {
+      fmt.onformat(elm, fmt as any, vars, node);
     }
+
+    each(fmt.styles, (value, name) => {
+      dom.setStyle(elm, name, FormatUtils.replaceVars(value, vars));
+    });
+
+    // Needed for the WebKit span spam bug
+    // TODO: Remove this once WebKit/Blink fixes this
+    if (fmt.styles) {
+      const styleVal = dom.getAttrib(elm, 'style');
+
+      if (styleVal) {
+        dom.setAttrib(elm, 'data-mce-style', styleVal);
+      }
+    }
+
+    each(fmt.attributes, (value, name) => {
+      dom.setAttrib(elm, name, FormatUtils.replaceVars(value, vars));
+    });
+
+    each(fmt.classes, (value) => {
+      value = FormatUtils.replaceVars(value, vars);
+
+      if (!dom.hasClass(elm, value)) {
+        dom.addClass(elm, value);
+      }
+    });
   };
 
-  const applyNodeStyle = (formatList, node: Node) => {
+  const applyNodeStyle = (formatList: ApplyFormat[], node: Node) => {
     let found = false;
 
     if (!FormatUtils.isSelectorFormat(format)) {
@@ -117,13 +107,13 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
     }
 
     // Look for matching formats
-    each(formatList, (format: any) => {
+    each(formatList, (format) => {
       // Check collapsed state if it exists
-      if ('collapsed' in format && format.collapsed !== isCollapsed) {
+      if (Type.isNonNullable(format.collapsed) && format.collapsed !== isCollapsed) {
         return;
       }
 
-      if (dom.is(node, format.selector) && !isCaretNode(node)) {
+      if (FormatUtils.isSelectorFormat(format) && dom.is(node, format.selector) && !isCaretNode(node)) {
         setElementFormat(node, format);
         found = true;
         return false;
@@ -133,14 +123,23 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
     return found;
   };
 
-  const applyRngStyle = (dom: DOMUtils, rng: RangeLikeObject, bookmark: IdBookmark | IndexBookmark, nodeSpecific?: boolean) => {
+  const createWrapElement = (wrapName: string | undefined): HTMLElement | null => {
+    if (Type.isString(wrapName)) {
+      const wrapElm = dom.create(wrapName);
+      setElementFormat(wrapElm);
+      return wrapElm;
+    } else {
+      return null;
+    }
+  };
+
+  const applyRngStyle = (dom: DOMUtils, rng: RangeLikeObject, nodeSpecific: boolean) => {
     const newWrappers: Element[] = [];
     let contentEditable = true;
 
     // Setup wrapper element
     const wrapName = (format as InlineFormat).inline || (format as BlockFormat).block;
-    const wrapElm = dom.create(wrapName);
-    setElementFormat(wrapElm);
+    const wrapElm = createWrapElement(wrapName);
 
     RangeWalk.walk(dom, rng, (nodes) => {
       let currentWrapElm: Element | null;
@@ -171,7 +170,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
         }
 
         // If node is wrapper type
-        if (format.wrapper && MatchFormat.matchNode(ed, node, name, vars)) {
+        if (FormatUtils.isBlockFormat(format) && format.wrapper && MatchFormat.matchNode(ed, node, name, vars)) {
           currentWrapElm = null;
           return;
         }
@@ -197,7 +196,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           }
 
           // Continue processing if a selector match wasn't found and a inline element is defined
-          if (!hasFormatProperty(format, 'inline') || found) {
+          if (!FormatUtils.isInlineFormat(format) || found) {
             currentWrapElm = null;
             return;
           }
@@ -206,11 +205,10 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
         // Is it valid to wrap this item
         // TODO: Break this if up, too complex
         if (contentEditable && !hasContentEditableState && FormatUtils.isValid(ed, wrapName, nodeName) && FormatUtils.isValid(ed, parentName, wrapName) &&
-          !(!nodeSpecific && node.nodeType === 3 &&
-            node.nodeValue.length === 1 &&
-            node.nodeValue.charCodeAt(0) === 65279) &&
+          !(!nodeSpecific && NodeType.isText(node) && Zwsp.isZwsp(node.data)) &&
           !isCaretNode(node) &&
-          (!hasFormatProperty(format, 'inline') || !dom.isBlock(node))) {
+          (!FormatUtils.isInlineFormat(format) || !dom.isBlock(node))
+        ) {
           // Start wrapping
           if (!currentWrapElm) {
             // Wrap the node
@@ -233,17 +231,15 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           // End the last wrapper
           currentWrapElm = null;
         }
-
       };
 
-      // Process siblings from range
-      each(nodes, process);
+      Arr.each(nodes, process);
     });
 
     // Apply formats to links as well to get the color of the underline to change as well
     if (format.links === true) {
       each(newWrappers, (node) => {
-        const process = (node: Element) => {
+        const process = (node: Node) => {
           if (node.nodeName === 'A') {
             setElementFormat(node, format);
           }
@@ -269,33 +265,18 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
         return count;
       };
 
-      const getChildElementNode = (root: Node): Node | false => {
-        let child: Node | false = false;
-        each(root.childNodes, (node) => {
-          if (isElementNode(node)) {
-            child = node;
-            return false; // break loop
-          }
-        });
-        return child;
-      };
-
-      const mergeStyles = (node: Element) => {
-        let clone;
-
-        const child = getChildElementNode(node);
-
-        // If child was found and of the same type as the current node
-        if (child && !Bookmarks.isBookmarkNode(child) && MatchFormat.matchName(dom, child, format)) {
-          clone = dom.clone(child, false);
+      const mergeStyles = (node: Element): Element => {
+        // Check if a child was found and of the same type as the current node
+        const childElement = Arr.find(node.childNodes, isElementNode)
+          .filter((child) => MatchFormat.matchName(dom, child, format));
+        return childElement.map((child) => {
+          const clone = dom.clone(child, false) as Element;
           setElementFormat(clone);
 
-          // "matchName" will made sure we're dealing with an element, so cast as one
           dom.replace(clone, node, true);
           dom.remove(child, true);
-        }
-
-        return clone || node;
+          return clone;
+        }).getOr(node);
       };
 
       const childCount = getChildCount(node);
@@ -308,7 +289,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
         return;
       }
 
-      if (FormatUtils.isInlineFormat(format) || format.wrapper) {
+      if (FormatUtils.isInlineFormat(format) || FormatUtils.isBlockFormat(format) && format.wrapper) {
         // Merges the current node with it's children of similar type to reduce the number of elements
         if (!format.exact && childCount === 1) {
           node = mergeStyles(node);
@@ -344,10 +325,10 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           const rng = dom.createRng();
           rng.setStartBefore(node);
           rng.setEndAfter(node);
-          applyRngStyle(dom, ExpandRange.expandRng(ed, rng, formatList), null, true);
+          applyRngStyle(dom, ExpandRange.expandRng(ed, rng, formatList), true);
         }
       } else {
-        applyRngStyle(dom, node, null, true);
+        applyRngStyle(dom, node, true);
       }
     } else {
       if (!isCollapsed || !FormatUtils.isInlineFormat(format) || TableCellSelection.getCellsFromEditor(ed).length) {
@@ -357,17 +338,17 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
         // If the formats have a default block and we can't find a parent block then
         // start wrapping it with a DIV this is for forced_root_blocks: false
         // It's kind of a hack but people should be using the default block type P since all desktop editors work that way
-        const firstFormat = (formatList[0] as ApplyFormat & { defaultBlock?: string }); // TODO: Should this just check if it's a SelectorFormat
+        const firstFormat = formatList[0];
         if (!ed.settings.forced_root_block && firstFormat.defaultBlock && !dom.getParent(curSelNode, dom.isBlock)) {
           applyFormat(ed, firstFormat.defaultBlock);
         }
 
         // Apply formatting to selection
         selection.setRng(RangeNormalizer.normalize(selection.getRng()));
-        SelectionUtils.preserve(selection, true, (bookmark) => {
+        SelectionUtils.preserve(selection, true, () => {
           SelectionUtils.runOnRanges(ed, (selectionRng, fake) => {
             const expandedRng = fake ? selectionRng : ExpandRange.expandRng(ed, selectionRng, formatList);
-            applyRngStyle(dom, expandedRng, bookmark);
+            applyRngStyle(dom, expandedRng, false);
           });
         });
 

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -11,7 +11,6 @@ import { PredicateExists, SugarElement } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import * as Settings from '../api/Settings';
-import Tools from '../api/util/Tools';
 import * as Bookmarks from '../bookmark/Bookmarks';
 import * as Empty from '../dom/Empty';
 import * as NodeType from '../dom/NodeType';
@@ -29,8 +28,6 @@ import * as FormatUtils from './FormatUtils';
 import * as Hooks from './Hooks';
 import * as MatchFormat from './MatchFormat';
 import * as MergeFormats from './MergeFormats';
-
-const each = Tools.each;
 
 const isElementNode = (node: Node): node is Element => {
   return NodeType.isElement(node) && !Bookmarks.isBookmarkNode(node) && !isCaretNode(node) && !NodeType.isBogus(node);
@@ -72,7 +69,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
       fmt.onformat(elm, fmt as any, vars, node);
     }
 
-    each(fmt.styles, (value, name) => {
+    Obj.each(fmt.styles, (value, name) => {
       dom.setStyle(elm, name, FormatUtils.replaceVars(value, vars));
     });
 
@@ -86,11 +83,11 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
       }
     }
 
-    each(fmt.attributes, (value, name) => {
+    Obj.each(fmt.attributes, (value, name) => {
       dom.setAttrib(elm, name, FormatUtils.replaceVars(value, vars));
     });
 
-    each(fmt.classes, (value) => {
+    Arr.each(fmt.classes, (value) => {
       value = FormatUtils.replaceVars(value, vars);
 
       if (!dom.hasClass(elm, value)) {
@@ -107,7 +104,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
     }
 
     // Look for matching formats
-    each(formatList, (format) => {
+    Arr.each(formatList, (format) => {
       // Check collapsed state if it exists
       if (Type.isNonNullable(format.collapsed) && format.collapsed !== isCollapsed) {
         return;
@@ -222,7 +219,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           // Start a new wrapper for possible children
           currentWrapElm = null;
 
-          each(Tools.grep(node.childNodes), process);
+          Arr.each(Arr.from(node.childNodes), process);
 
           if (hasContentEditableState) {
             contentEditable = lastContentEditable; // Restore last contentEditable state from stack
@@ -238,13 +235,13 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
 
     // Apply formats to links as well to get the color of the underline to change as well
     if (format.links === true) {
-      each(newWrappers, (node) => {
+      Arr.each(newWrappers, (node) => {
         const process = (node: Node) => {
           if (node.nodeName === 'A') {
             setElementFormat(node, format);
           }
 
-          each(Tools.grep(node.childNodes), process);
+          Arr.each(Arr.from(node.childNodes), process);
         };
 
         process(node);
@@ -252,11 +249,11 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
     }
 
     // Cleanup
-    each(newWrappers, (node) => {
+    Arr.each(newWrappers, (node) => {
       const getChildCount = (node: Node) => {
         let count = 0;
 
-        each(node.childNodes, (node) => {
+        Arr.each(node.childNodes, (node) => {
           if (!FormatUtils.isEmptyTextNode(node) && !Bookmarks.isBookmarkNode(node)) {
             count++;
           }

--- a/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional, Type } from '@ephox/katamari';
+import { Optional, Strings, Type } from '@ephox/katamari';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import TextSeeker from '../api/dom/TextSeeker';
@@ -15,6 +15,7 @@ import * as NodeType from '../dom/NodeType';
 import * as RangeNodes from '../selection/RangeNodes';
 import { RangeLikeObject } from '../selection/RangeTypes';
 import { isContent, isNbsp, isWhiteSpace } from '../text/CharType';
+import { Format } from './FormatTypes';
 import * as FormatUtils from './FormatUtils';
 
 type Sibling = 'previousSibling' | 'nextSibling';
@@ -95,22 +96,22 @@ const findWordEndPoint = (
   );
 };
 
-const findSelectorEndPoint = (dom: DOMUtils, format, rng: Range, container: Node, siblingName: Sibling) => {
-  if (NodeType.isText(container) && container.nodeValue.length === 0 && container[siblingName]) {
+const findSelectorEndPoint = (dom: DOMUtils, formatList: Format[], rng: Range, container: Node, siblingName: Sibling) => {
+  if (NodeType.isText(container) && Strings.isEmpty(container.data) && container[siblingName]) {
     container = container[siblingName];
   }
 
   const parents = getParents(dom, container);
   for (let i = 0; i < parents.length; i++) {
-    for (let y = 0; y < format.length; y++) {
-      const curFormat = format[y];
+    for (let y = 0; y < formatList.length; y++) {
+      const curFormat = formatList[y];
 
       // If collapsed state is set then skip formats that doesn't match that
-      if ('collapsed' in curFormat && curFormat.collapsed !== rng.collapsed) {
+      if (Type.isNonNullable(curFormat.collapsed) && curFormat.collapsed !== rng.collapsed) {
         continue;
       }
 
-      if (dom.is(parents[i], curFormat.selector)) {
+      if (FormatUtils.isSelectorFormat(curFormat) && dom.is(parents[i], curFormat.selector)) {
         return parents[i];
       }
     }
@@ -119,14 +120,15 @@ const findSelectorEndPoint = (dom: DOMUtils, format, rng: Range, container: Node
   return container;
 };
 
-const findBlockEndPoint = (editor: Editor, format, container: Node, siblingName: Sibling) => {
-  let node: Node;
+const findBlockEndPoint = (editor: Editor, formatList: Format[], container: Node, siblingName: Sibling) => {
+  let node = container;
   const dom = editor.dom;
   const root = dom.getRoot();
+  const format = formatList[0];
 
   // Expand to block of similar type
-  if (!format[0].wrapper) {
-    node = dom.getParent(container, format[0].block, root);
+  if (FormatUtils.isBlockFormat(format) && !format.wrapper) {
+    node = dom.getParent(container, format.block, root);
   }
 
   // Expand to first wrappable block element or any block element
@@ -141,7 +143,7 @@ const findBlockEndPoint = (editor: Editor, format, container: Node, siblingName:
   }
 
   // Exclude inner lists from wrapping
-  if (node && format[0].wrapper) {
+  if (node && FormatUtils.isBlockFormat(format) && format.wrapper) {
     node = getParents(dom, node, 'ul,ol').reverse()[0] || node;
   }
 
@@ -180,13 +182,12 @@ const isAtBlockBoundary = (dom: DOMUtils, root: Node, container: Node, siblingNa
 // If a sibling is found then the container is returned
 const findParentContainer = (
   dom: DOMUtils,
-  format,
+  formatList: Format[],
   container: Node,
   offset: number,
   start: boolean
 ) => {
   let parent = container;
-  let sibling: Node;
 
   const siblingName = start ? 'previousSibling' : 'nextSibling';
   const root = dom.getRoot();
@@ -201,12 +202,12 @@ const findParentContainer = (
   /* eslint no-constant-condition:0 */
   while (true) {
     // Stop expanding on block elements
-    if (!format[0].block_expand && dom.isBlock(parent)) {
+    if (!formatList[0].block_expand && dom.isBlock(parent)) {
       return parent;
     }
 
     // Walk left/right
-    for (sibling = parent[siblingName]; sibling; sibling = sibling[siblingName]) {
+    for (let sibling = parent[siblingName]; sibling; sibling = sibling[siblingName]) {
       // Allow spaces if not at the edge of a block element, as the spaces won't have been collapsed
       const allowSpaces = NodeType.isText(sibling) && !isAtBlockBoundary(dom, root, sibling, siblingName);
       if (!isBookmarkNode(sibling) && !isBogusBr(sibling) && !isWhiteSpaceNode(sibling, allowSpaces)) {
@@ -228,12 +229,10 @@ const findParentContainer = (
 
 const isSelfOrParentBookmark = (container: Node) => isBookmarkNode(container.parentNode) || isBookmarkNode(container);
 
-const expandRng = (editor: Editor, rng: Range, format, includeTrailingSpace: boolean = false): RangeLikeObject => {
-  let startContainer = rng.startContainer,
-    startOffset = rng.startOffset,
-    endContainer = rng.endContainer,
-    endOffset = rng.endOffset;
+const expandRng = (editor: Editor, rng: Range, formatList: Format[], includeTrailingSpace: boolean = false): RangeLikeObject => {
+  let { startContainer, startOffset, endContainer, endOffset } = rng;
   const dom = editor.dom;
+  const format = formatList[0];
 
   // If index based start position then resolve it
   if (NodeType.isElement(startContainer) && startContainer.hasChildNodes()) {
@@ -309,37 +308,37 @@ const expandRng = (editor: Editor, rng: Range, format, includeTrailingSpace: boo
   // Example * becomes !: !<p><b><i>*text</i><i>text*</i></b></p>!
   // This will reduce the number of wrapper elements that needs to be created
   // Move start point up the tree
-  if (format[0].inline || format[0].block_expand) {
-    if (!format[0].inline || (!NodeType.isText(startContainer) || startOffset === 0)) {
-      startContainer = findParentContainer(dom, format, startContainer, startOffset, true);
+  if (FormatUtils.isInlineFormat(format) || format.block_expand) {
+    if (!FormatUtils.isInlineFormat(format) || (!NodeType.isText(startContainer) || startOffset === 0)) {
+      startContainer = findParentContainer(dom, formatList, startContainer, startOffset, true);
     }
 
-    if (!format[0].inline || (!NodeType.isText(endContainer) || endOffset === endContainer.nodeValue.length)) {
-      endContainer = findParentContainer(dom, format, endContainer, endOffset, false);
+    if (!FormatUtils.isInlineFormat(format) || (!NodeType.isText(endContainer) || endOffset === endContainer.nodeValue.length)) {
+      endContainer = findParentContainer(dom, formatList, endContainer, endOffset, false);
     }
   }
 
   // Expand start/end container to matching selector
-  if (format[0].selector && format[0].expand !== false && !format[0].inline) {
+  if (FormatUtils.isSelectorFormat(format) && format.expand !== false && !FormatUtils.isInlineFormat(format)) {
     // Find new startContainer/endContainer if there is better one
-    startContainer = findSelectorEndPoint(dom, format, rng, startContainer, 'previousSibling');
-    endContainer = findSelectorEndPoint(dom, format, rng, endContainer, 'nextSibling');
+    startContainer = findSelectorEndPoint(dom, formatList, rng, startContainer, 'previousSibling');
+    endContainer = findSelectorEndPoint(dom, formatList, rng, endContainer, 'nextSibling');
   }
 
   // Expand start/end container to matching block element or text node
-  if (format[0].block || format[0].selector) {
+  if (FormatUtils.isBlockFormat(format) || FormatUtils.isSelectorFormat(format)) {
     // Find new startContainer/endContainer if there is better one
-    startContainer = findBlockEndPoint(editor, format, startContainer, 'previousSibling');
-    endContainer = findBlockEndPoint(editor, format, endContainer, 'nextSibling');
+    startContainer = findBlockEndPoint(editor, formatList, startContainer, 'previousSibling');
+    endContainer = findBlockEndPoint(editor, formatList, endContainer, 'nextSibling');
 
     // Non block element then try to expand up the leaf
-    if (format[0].block) {
+    if (FormatUtils.isBlockFormat(format)) {
       if (!dom.isBlock(startContainer)) {
-        startContainer = findParentContainer(dom, format, startContainer, startOffset, true);
+        startContainer = findParentContainer(dom, formatList, startContainer, startOffset, true);
       }
 
       if (!dom.isBlock(endContainer)) {
-        endContainer = findParentContainer(dom, format, endContainer, endOffset, false);
+        endContainer = findParentContainer(dom, formatList, endContainer, endOffset, false);
       }
     }
   }

--- a/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
@@ -5,17 +5,17 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Obj, Type } from '@ephox/katamari';
+import { Arr, Obj, Type } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
 import * as Settings from '../api/Settings';
-import Tools from '../api/util/Tools';
 import * as DefaultFormats from './DefaultFormats';
 import { Format, Formats } from './FormatTypes';
+import { isInlineFormat, isSelectorFormat } from './FormatUtils';
 
 export interface FormatRegistry {
   get: {
-    (name: string): Format[];
+    (name: string): Format[] | undefined;
     (): Record<string, Format[]>;
   };
   has: (name: string) => boolean;
@@ -26,15 +26,15 @@ export interface FormatRegistry {
 export const FormatRegistry = (editor: Editor): FormatRegistry => {
   const formats: Record<string, Format[]> = {};
 
-  const get = (name?: string): Format[] | Record<string, Format[]> =>
-    name ? formats[name] : formats;
+  const get = (name?: string): Format[] | Record<string, Format[]> | undefined =>
+    Type.isNonNullable(name) ? formats[name] : formats;
 
   const has = (name: string): boolean => Obj.has(formats, name);
 
   const register = (name: string | Formats, format?: Format | Format[]) => {
     if (name) {
-      if (typeof name !== 'string') {
-        Tools.each(name, (format, name) => {
+      if (!Type.isString(name)) {
+        Obj.each(name, (format, name) => {
           register(name, format);
         });
       } else {
@@ -43,31 +43,31 @@ export const FormatRegistry = (editor: Editor): FormatRegistry => {
           format = [ format ];
         }
 
-        Tools.each(format, (format: any) => {
+        Arr.each(format, (format) => {
           // Set deep to false by default on selector formats this to avoid removing
           // alignment on images inside paragraphs when alignment is changed on paragraphs
-          if (typeof format.deep === 'undefined') {
-            format.deep = !format.selector;
+          if (Type.isUndefined(format.deep)) {
+            format.deep = !isSelectorFormat(format);
           }
 
           // Default to true
-          if (typeof format.split === 'undefined') {
-            format.split = !format.selector || format.inline;
+          if (Type.isUndefined(format.split)) {
+            format.split = !isSelectorFormat(format) || isInlineFormat(format);
           }
 
           // Default to true
-          if (typeof format.remove === 'undefined' && format.selector && !format.inline) {
+          if (Type.isUndefined(format.remove) && isSelectorFormat(format) && !isInlineFormat(format)) {
             format.remove = 'none';
           }
 
           // Mark format as a mixed format inline + block level
-          if (format.selector && format.inline) {
+          if (isSelectorFormat(format) && isInlineFormat(format)) {
             format.mixed = true;
             format.block_expand = true;
           }
 
           // Split classes if needed
-          if (typeof format.classes === 'string') {
+          if (Type.isString(format.classes)) {
             format.classes = format.classes.split(/\s+/);
           }
         });

--- a/modules/tinymce/src/core/main/ts/fmt/FormatTypes.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatTypes.ts
@@ -26,7 +26,6 @@ export interface BaseFormat<T> {
   mixed?: boolean;
   block_expand?: boolean;
   onmatch?: (node: Node, fmt: T, itemName: string) => boolean;
-  onformat?: (elm: Node, fmt: T, vars?: FormatVars, node?: Node | RangeLikeObject) => void;
 
   // These are only used when removing formats
   remove?: 'none' | 'empty' | 'all';
@@ -55,10 +54,11 @@ interface Selector {
 export interface CommonFormat<T> extends BaseFormat<T> {
   attributes?: Record<string, FormatAttrOrStyleValue>;
   styles?: Record<string, FormatAttrOrStyleValue>;
+  toggle?: boolean;
+  preview?: string | false;
 
   // These are only used when applying formats
-  preview?: string | false;
-  toggle?: boolean;
+  onformat?: (elm: Node, fmt: T, vars?: FormatVars, node?: Node | RangeLikeObject) => void;
   clear_child_styles?: boolean;
   merge_siblings?: boolean;
   merge_with_parents?: boolean;

--- a/modules/tinymce/src/core/main/ts/fmt/FormatTypes.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatTypes.ts
@@ -28,17 +28,9 @@ export interface BaseFormat<T> {
   onmatch?: (node: Node, fmt: T, itemName: string) => boolean;
   onformat?: (elm: Node, fmt: T, vars?: FormatVars, node?: Node | RangeLikeObject) => void;
 
-  // Apply format only properties
-  preview?: string | false;
-  toggle?: boolean;
-  clear_child_styles?: boolean;
-  merge_siblings?: boolean;
-  merge_with_parents?: boolean;
-  defaultBlock?: string;
-
-  // Remove format only properties
-  remove_similar?: boolean;
+  // These are only used when removing formats
   remove?: 'none' | 'empty' | 'all';
+  remove_similar?: boolean;
   split?: boolean;
   deep?: boolean;
   preserve_attributes?: string[];
@@ -59,9 +51,18 @@ interface Selector {
   inherit?: boolean;
 }
 
+// A common format is one that can be both applied and removed
 export interface CommonFormat<T> extends BaseFormat<T> {
   attributes?: Record<string, FormatAttrOrStyleValue>;
   styles?: Record<string, FormatAttrOrStyleValue>;
+
+  // These are only used when applying formats
+  preview?: string | false;
+  toggle?: boolean;
+  clear_child_styles?: boolean;
+  merge_siblings?: boolean;
+  merge_with_parents?: boolean;
+  defaultBlock?: string;
 }
 
 export interface BlockFormat extends Block, CommonFormat<BlockFormat> {}
@@ -71,19 +72,19 @@ export interface InlineFormat extends Inline, CommonFormat<InlineFormat> {}
 export interface SelectorFormat extends Selector, CommonFormat<SelectorFormat> {}
 
 // Mixed format is a combination of SelectorFormat and InlineFormat
-export interface MixedFormat extends CommonFormat<MixedFormat>, Inline, Selector {
+export interface MixedFormat extends Inline, Selector, CommonFormat<MixedFormat> {
   block_expand: true;
   mixed: true;
 }
 
 // A remove format is one that can only be removed and never applied
-export interface BaseRemoveFormat<T> extends BaseFormat<T> {
+export interface CommonRemoveFormat<T> extends BaseFormat<T> {
   attributes?: string[] | Record<string, FormatAttrOrStyleValue>;
   styles?: string[] | Record<string, FormatAttrOrStyleValue>;
 }
 
-export interface RemoveBlockFormat extends Block, BaseRemoveFormat<RemoveBlockFormat> {}
+export interface RemoveBlockFormat extends Block, CommonRemoveFormat<RemoveBlockFormat> {}
 
-export interface RemoveInlineFormat extends Inline, BaseRemoveFormat<RemoveInlineFormat> {}
+export interface RemoveInlineFormat extends Inline, CommonRemoveFormat<RemoveInlineFormat> {}
 
-export interface RemoveSelectorFormat extends Selector, BaseRemoveFormat<RemoveSelectorFormat> {}
+export interface RemoveSelectorFormat extends Selector, CommonRemoveFormat<RemoveSelectorFormat> {}

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -202,7 +202,7 @@ const canApply = (editor: Editor, name: string) => {
       const format = formatList[x];
 
       // Format is not selector based then always return TRUE
-      // Is it has a defaultBlock then it's likely it can be applied for example align on a non block element line
+      // If it has a defaultBlock then it's likely it can be applied, for example align on a non block element line
       if (!FormatUtils.isSelectorFormat(format) || Type.isNonNullable(format.defaultBlock)) {
         return true;
       }

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj, Optional, Type } from '@ephox/katamari';
+import { Arr, Obj, Optional, Strings, Type } from '@ephox/katamari';
 import { Compare, SugarElement, TransformFind } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
@@ -71,7 +71,7 @@ const matchItems = (dom: DOMUtils, node: Node, format: Format, itemName: string,
   const items = format[itemName];
 
   // Custom match
-  if (format.onmatch) {
+  if (Type.isFunction(format.onmatch)) {
     // onmatch is generic in a way that we can't really express without casting
     return format.onmatch(node, format as any, itemName);
   }
@@ -79,17 +79,18 @@ const matchItems = (dom: DOMUtils, node: Node, format: Format, itemName: string,
   // Check all items
   if (items) {
     // Non indexed object
-    if (typeof items.length === 'undefined') {
+    if (Type.isUndefined(items.length)) {
       for (const key in items) {
         if (Obj.has(items, key)) {
           const value = itemName === 'attributes' ? dom.getAttrib(node, key) : FormatUtils.getStyle(dom, node, key);
           const expectedValue = FormatUtils.replaceVars(items[key], vars);
+          const isEmptyValue = Type.isNullable(value) || Strings.isEmpty(value);
 
-          if ((Type.isNullable(value) || value === '') && Type.isNullable(expectedValue)) {
+          if (isEmptyValue && Type.isNullable(expectedValue)) {
             continue;
           }
 
-          if (similar && !value && !format.exact) {
+          if (similar && isEmptyValue && !format.exact) {
             return false;
           }
 
@@ -191,24 +192,23 @@ const closest = (editor: Editor, names: string[]): string | null => {
 
 const canApply = (editor: Editor, name: string) => {
   const formatList = editor.formatter.get(name);
-  let startNode, parents, i, x, selector;
   const dom = editor.dom;
 
   if (formatList) {
-    startNode = editor.selection.getStart();
-    parents = FormatUtils.getParents(dom, startNode);
+    const startNode = editor.selection.getStart();
+    const parents = FormatUtils.getParents(dom, startNode);
 
-    for (x = formatList.length - 1; x >= 0; x--) {
-      selector = (formatList[x] as SelectorFormat).selector;
+    for (let x = formatList.length - 1; x >= 0; x--) {
+      const format = formatList[x];
 
       // Format is not selector based then always return TRUE
       // Is it has a defaultBlock then it's likely it can be applied for example align on a non block element line
-      if (!selector || (formatList[x] as SelectorFormat).defaultBlock) {
+      if (!FormatUtils.isSelectorFormat(format) || Type.isNonNullable(format.defaultBlock)) {
         return true;
       }
 
-      for (i = parents.length - 1; i >= 0; i--) {
-        if (dom.is(parents[i], selector)) {
+      for (let i = parents.length - 1; i >= 0; i--) {
+        if (dom.is(parents[i], format.selector)) {
           return true;
         }
       }

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -22,7 +22,7 @@ import * as SplitRange from '../selection/SplitRange';
 import * as TableCellSelection from '../selection/TableCellSelection';
 import * as CaretFormat from './CaretFormat';
 import * as ExpandRange from './ExpandRange';
-import { FormatAttrOrStyleValue, FormatVars, RemoveFormat, RemoveFormatPartial } from './FormatTypes';
+import { Format, FormatAttrOrStyleValue, FormatVars } from './FormatTypes';
 import * as FormatUtils from './FormatUtils';
 import * as MatchFormat from './MatchFormat';
 import { mergeSiblings } from './MergeUtils';
@@ -60,10 +60,8 @@ const isTableCellOrRow = (node: Node) => /^(TR|TH|TD)$/.test(node.nodeName);
 const isChildOfInlineParent = (dom: DOMUtils, node: Node, parent: Node): boolean => dom.isChildOf(node, parent) && node !== parent && !dom.isBlock(parent);
 
 const getContainer = (ed: Editor, rng: RangeLikeObject, start?: boolean) => {
-  let container: Node, offset: number;
-
-  container = rng[start ? 'startContainer' : 'endContainer'];
-  offset = rng[start ? 'startOffset' : 'endOffset'];
+  let container = rng[start ? 'startContainer' : 'endContainer'];
+  let offset = rng[start ? 'startOffset' : 'endOffset'];
 
   if (NodeType.isElement(container)) {
     const lastIdx = container.childNodes.length - 1;
@@ -136,28 +134,28 @@ const wrapWithSiblings = (dom: DOMUtils, node: Node, next: boolean, name: string
  * @param {Object} format Format object o match with.
  * @return {boolean} true/false if the format matches.
  */
-const matchName = (dom: DOMUtils, node: Node, format: RemoveFormatPartial) => {
+const matchName = (dom: DOMUtils, node: Node, format: Format) => {
   // Check for inline match
-  if (isEq(node, format.inline)) {
+  if (FormatUtils.isInlineFormat(format) && isEq(node, format.inline)) {
     return true;
   }
 
   // Check for block match
-  if (isEq(node, format.block)) {
+  if (FormatUtils.isBlockFormat(format) && isEq(node, format.block)) {
     return true;
   }
 
   // Check for selector match
-  if (format.selector) {
+  if (FormatUtils.isSelectorFormat(format)) {
     return NodeType.isElement(node) && dom.is(node, format.selector);
   }
 };
 
-const isColorFormatAndAnchor = (node: Node, format: RemoveFormatPartial) => format.links && node.nodeName === 'A';
+const isColorFormatAndAnchor = (node: Node, format: Format) => format.links && node.nodeName === 'A';
 
-const find = (dom: DOMUtils, node: Node, next: boolean, inc?: boolean) => {
-  node = FormatUtils.getNonWhiteSpaceSibling(node, next, inc);
-  return !node || (node.nodeName === 'BR' || dom.isBlock(node));
+const find = (dom: DOMUtils, node: Node, next: boolean, inc?: boolean): boolean => {
+  const sibling = FormatUtils.getNonWhiteSpaceSibling(node, next, inc);
+  return Type.isNullable(sibling) || sibling.nodeName === 'BR' || dom.isBlock(sibling);
 };
 
 /**
@@ -178,12 +176,12 @@ const find = (dom: DOMUtils, node: Node, next: boolean, inc?: boolean) => {
  * @param {Object} format Format rule.
  * @return {Node} Input node.
  */
-const removeNode = (ed: Editor, node: Node, format: RemoveFormatPartial) => {
+const removeNode = (ed: Editor, node: Node, format: Format) => {
   const parentNode = node.parentNode;
-  let rootBlockElm;
+  let rootBlockElm: Node | null;
   const dom = ed.dom, forcedRootBlock = Settings.getForcedRootBlock(ed);
 
-  if (format.block) {
+  if (FormatUtils.isBlockFormat(format)) {
     if (!forcedRootBlock) {
       // Append BR elements if needed before we remove the block
       if (dom.isBlock(node) && !dom.isBlock(parentNode)) {
@@ -208,7 +206,7 @@ const removeNode = (ed: Editor, node: Node, format: RemoveFormatPartial) => {
                 rootBlockElm.appendChild(node);
               }
             } else {
-              rootBlockElm = 0;
+              rootBlockElm = null;
             }
           });
         }
@@ -216,15 +214,15 @@ const removeNode = (ed: Editor, node: Node, format: RemoveFormatPartial) => {
     }
   }
 
-  // Never remove nodes that isn't the specified inline element if a selector is specified too
-  if (format.selector && format.inline && !isEq(format.inline, node)) {
+  // Never remove nodes that aren't the specified inline element if a selector is specified too
+  if (FormatUtils.isMixedFormat(format) && !isEq(format.inline, node)) {
     return;
   }
 
   dom.remove(node, true);
 };
 
-const removeFormatInternal = (ed: Editor, format: RemoveFormatPartial, vars?: FormatVars, node?: Node, compareNode?: Node): RemoveFormatAdt => {
+const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, node?: Node, compareNode?: Node): RemoveFormatAdt => {
   let stylesModified: boolean;
   const dom = ed.dom;
 
@@ -237,7 +235,7 @@ const removeFormatInternal = (ed: Editor, format: RemoveFormatPartial, vars?: Fo
   const elm = node as Element;
 
   // Applies to styling elements like strong, em, i, u, etc. so that if they have styling attributes, the attributes can be kept but the styling element is removed
-  if (format.inline && format.remove === 'all' && Type.isArray(format.preserve_attributes)) {
+  if (FormatUtils.isInlineFormat(format) && format.remove === 'all' && Type.isArray(format.preserve_attributes)) {
     // Remove all attributes except for the attributes specified in preserve_attributes
     const attrsToPreserve = Arr.filter(dom.getAttribs(elm), (attr) => Arr.contains(format.preserve_attributes, attr.name.toLowerCase()));
     dom.removeAllAttribs(elm);
@@ -367,7 +365,7 @@ const removeFormatInternal = (ed: Editor, format: RemoveFormatPartial, vars?: Fo
  * @param {Node} compareNode Optional compare node, if specified the styles will be compared to that node.
  * @return {Boolean} True/false if the node was removed or not.
  */
-const removeFormat = (ed: Editor, format: RemoveFormatPartial, vars?: FormatVars, node?: Node, compareNode?: Node): boolean =>
+const removeFormat = (ed: Editor, format: Format, vars?: FormatVars, node?: Node, compareNode?: Node): boolean =>
   removeFormatInternal(ed, format, vars, node, compareNode).fold(
     Fun.never,
     (newName) => {
@@ -387,7 +385,7 @@ const findFormatRoot = (editor: Editor, container: Node, name: string, vars: For
     if (!formatRoot && parent.id !== '_start' && parent.id !== '_end') {
       // Is the node matching the format we are looking for
       const format = MatchFormat.matchNode(editor, parent, name, vars, similar);
-      if (format && (format as RemoveFormat).split !== false) {
+      if (format && format.split !== false) {
         formatRoot = parent;
       }
     }
@@ -396,7 +394,7 @@ const findFormatRoot = (editor: Editor, container: Node, name: string, vars: For
   return formatRoot;
 };
 
-const removeFormatFromClone = (editor: Editor, format: RemoveFormatPartial, vars: FormatVars, clone: Node) =>
+const removeFormatFromClone = (editor: Editor, format: Format, vars: FormatVars, clone: Node) =>
   removeFormatInternal(editor, format, vars, clone, clone).fold(
     Fun.constant(clone),
     (newName) => {
@@ -409,7 +407,7 @@ const removeFormatFromClone = (editor: Editor, format: RemoveFormatPartial, vars
     Fun.constant(null)
   );
 
-const wrapAndSplit = (editor: Editor, formatList: RemoveFormatPartial[], formatRoot: Node, container: Node, target: Node, split: boolean, format: RemoveFormatPartial, vars: FormatVars) => {
+const wrapAndSplit = (editor: Editor, formatList: Format[], formatRoot: Node, container: Node, target: Node, split: boolean, format: Format, vars: FormatVars) => {
   let clone: Node | null, lastClone: Node, firstClone: Node;
   const dom = editor.dom;
 
@@ -453,7 +451,7 @@ const wrapAndSplit = (editor: Editor, formatList: RemoveFormatPartial[], formatR
 
       // After splitting the nodes may match with other siblings so we need to attempt to merge them
       // Note: We can't use MergeFormats, as that'd create a circular dependency
-      if (format.inline) {
+      if (FormatUtils.isInlineFormat(format)) {
         mergeSiblings(dom, format, vars, lastClone);
       }
     }
@@ -463,7 +461,7 @@ const wrapAndSplit = (editor: Editor, formatList: RemoveFormatPartial[], formatR
 };
 
 const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean) => {
-  const formatList = ed.formatter.get(name) as RemoveFormatPartial[];
+  const formatList = ed.formatter.get(name);
   const format = formatList[0];
   let contentEditable = true;
   const dom = ed.dom;
@@ -662,7 +660,7 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
     return;
   }
 
-  if (!selection.isCollapsed() || !format.inline || TableCellSelection.getCellsFromEditor(ed).length) {
+  if (!selection.isCollapsed() || !FormatUtils.isInlineFormat(format) || TableCellSelection.getCellsFromEditor(ed).length) {
     // Remove formatting on the selection
     SelectionUtils.preserve(selection, true, () => {
       SelectionUtils.runOnRanges(ed, removeRngStyle);
@@ -670,7 +668,7 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
 
     // Check if start element still has formatting then we are at: "<b>text|</b>text"
     // and need to move the start into the next text node
-    if (format.inline && MatchFormat.match(ed, name, vars, selection.getStart())) {
+    if (FormatUtils.isInlineFormat(format) && MatchFormat.match(ed, name, vars, selection.getStart())) {
       FormatUtils.moveStart(dom, selection, selection.getRng());
     }
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -12,13 +12,13 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme ], true);
 
-  const removeFormat = [{
+  const removeFormat: Format[] = [{
     selector: 'strong, em',
     remove: 'all',
     split: true,
     expand: false
   }];
-  const boldFormat = [{
+  const boldFormat: Format[] = [{
     inline: 'strong',
     remove: 'all',
     preserve_attributes: [ 'style', 'class' ]


### PR DESCRIPTION
Related Ticket: TINY-7393

Description of Changes:
This is just an initial step towards fixing the root cause of this, as I kept struggling with the types and getting things incorrect. So this fixes the internal formatter types that I've known were incorrect for quite a while and also does a little clean up here and there to try and make things a little more manageable.

Note: This definitely doesn't fix all the various issues with formatter, it's just a partial step towards making it easier to maintain.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
