### PR TITLE
TINY-6298: Fix table cell selection issue with nested tables

### DIFF
--- a/modules/darwin/CHANGELOG.md
+++ b/modules/darwin/CHANGELOG.md
@@ -8,3 +8,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
+- Changed the `MouseSelection` and `KeySelection` fake selection logic to only apply if more than one cell of the same table is selected.

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
@@ -27,7 +27,7 @@ const detect = (container: SugarElement, isRoot: (element: SugarElement) => bool
   if (!Compare.eq(start, finish)) {
     return CellSelection.identify(start, finish, isRoot).bind((cellSel) => {
       const boxes = cellSel.boxes.getOr([]);
-      if (boxes.length > 0) {
+      if (boxes.length > 1) {
         selectRange(container, boxes, cellSel.start, cellSel.finish);
         return Optional.some(Response.create(
           Optional.some(Util.makeSitus(start, 0, start, Awareness.getEnd(start))),

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Flash of unstyled content while loading the editor because the content css was loaded after the editor content was rendered #TINY-7249
 - Only table content would be deleted when partially selecting a table and content outside the table #TINY-6044
 - Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
+- The table cell selection handling was incorrect in some cases when dealing with nested tables #TINY-6298
 - Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
 - Partially transparent RGBA values provided in the `color_map` setting were given the wrong hex value #TINY-7163
 - HTML comments with mismatched quotes were parsed incorrectly under certain circumstances #TINY-7589

--- a/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
@@ -1,15 +1,16 @@
-import { Assertions, Mouse } from '@ephox/agar';
+import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
-import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-describe('browser.tinymce.plugins.table.GridSelectionTest', () => {
+import { assertSelectedCells, selectWithMouse } from '../module/test/TableTestUtils';
+
+describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     indent: false,
@@ -25,13 +26,6 @@ describe('browser.tinymce.plugins.table.GridSelectionTest', () => {
   const simpleColgroupTable =
   '<table><colgroup><col /><col /></colgroup><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>';
 
-  // The critical part is the target element as this is what Darwin (MouseSelection.ts) uses to determine the fake selection
-  const selectWithMouse = (startTd: SugarElement<Element>, endTd: SugarElement<Element>) => {
-    Mouse.mouseDown(startTd, { button: 0 });
-    Mouse.mouseOver(endTd, { button: 0 });
-    Mouse.mouseUp(endTd, { button: 0 });
-  };
-
   const getCells = (table: SugarElement<HTMLTableElement>, selector: string = 'td,th'): SugarElement<HTMLTableCellElement>[] =>
     SelectorFilter.descendants(table, selector);
 
@@ -44,9 +38,7 @@ describe('browser.tinymce.plugins.table.GridSelectionTest', () => {
     const endTd = Arr.find(cells, (elm) => Html.get(elm) === selectCells[1]).getOrDie('Could not find end TD');
 
     selectWithMouse(startTd, endTd);
-    const selectedCells = getCells(table, 'td[data-mce-selected],th[data-mce-selected]');
-    const selection = Arr.map(selectedCells, Html.get);
-    assert.deepEqual(selection, cellContents);
+    assertSelectedCells(editor, cellContents, Html.get);
   };
 
   const assertSelectionContent = (editor: Editor, expectedHtml: string) => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
@@ -1,10 +1,11 @@
-import { Assertions } from '@ephox/agar';
+import { Assertions, Mouse } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { Arr } from '@ephox/katamari';
+import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Tools from 'tinymce/core/api/util/Tools';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
@@ -18,37 +19,33 @@ describe('browser.tinymce.plugins.table.GridSelectionTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin, Theme ]);
 
-  const assertTableSelection = (editor: Editor, tableHtml: string, selectCells: string[], cellContents: string[]) => {
-    const selectRangeXY = (table: HTMLTableElement, startTd: HTMLTableCellElement, endTd: HTMLTableCellElement) => {
-      editor.fire('mousedown', { target: startTd, button: 0 } as unknown as MouseEvent);
-      editor.fire('mouseover', { target: endTd, button: 0 } as unknown as MouseEvent);
-      editor.fire('mouseup', { target: endTd, button: 0 } as unknown as MouseEvent);
-    };
+  const simpleTable =
+  '<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>';
 
-    const getCells = (table: HTMLTableElement) => editor.$(table).find('td').toArray();
+  const simpleColgroupTable =
+  '<table><colgroup><col /><col /></colgroup><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>';
 
-    const getSelectedCells = (table: HTMLTableElement) =>
-      editor.$(table).find<HTMLTableCellElement>('td[data-mce-selected]').toArray();
+  // The critical part is the target element as this is what Darwin (MouseSelection.ts) uses to determine the fake selection
+  const selectWithMouse = (startTd: SugarElement<Element>, endTd: SugarElement<Element>) => {
+    Mouse.mouseDown(startTd, { button: 0 });
+    Mouse.mouseOver(endTd, { button: 0 });
+    Mouse.mouseUp(endTd, { button: 0 });
+  };
 
+  const getCells = (table: SugarElement<HTMLTableElement>, selector: string = 'td,th'): SugarElement<HTMLTableCellElement>[] =>
+    SelectorFilter.descendants(table, selector);
+
+  const assertTableSelection = (editor: Editor, tableHtml: string, selectCells: [ string, string ], cellContents: string[]) => {
     editor.setContent(tableHtml);
 
-    const table = editor.$<HTMLTableElement>('table')[0];
+    const table = SelectorFind.descendant<HTMLTableElement>(TinyDom.body(editor), 'table').getOrDie('Could not find table');
     const cells = getCells(table);
+    const startTd = Arr.find(cells, (elm) => Html.get(elm) === selectCells[0]).getOrDie('Could not find start TD');
+    const endTd = Arr.find(cells, (elm) => Html.get(elm) === selectCells[1]).getOrDie('Could not find end TD');
 
-    const startTd = Tools.grep(cells, (elm) => {
-      return elm.innerHTML === selectCells[0];
-    })[0];
-
-    const endTd = Tools.grep(cells, (elm) => {
-      return elm.innerHTML === selectCells[1];
-    })[0];
-
-    selectRangeXY(table, startTd, endTd);
-
-    const selection = Tools.map(getSelectedCells(table), (elm) => {
-      return elm.innerHTML;
-    });
-
+    selectWithMouse(startTd, endTd);
+    const selectedCells = getCells(table, 'td[data-mce-selected],th[data-mce-selected]');
+    const selection = Arr.map(selectedCells, Html.get);
     assert.deepEqual(selection, cellContents);
   };
 
@@ -58,21 +55,42 @@ describe('browser.tinymce.plugins.table.GridSelectionTest', () => {
 
   it('TBA: select row', () => assertTableSelection(
     hook.editor(),
-    '<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>',
+    simpleTable,
+    [ '1', '2' ],
+    [ '1', '2' ]
+  ));
+
+  it('TBA: select row - colgroup', () => assertTableSelection(
+    hook.editor(),
+    simpleColgroupTable,
     [ '1', '2' ],
     [ '1', '2' ]
   ));
 
   it('TBA: select column', () => assertTableSelection(
     hook.editor(),
-    '<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>',
+    simpleTable,
+    [ '1', '3' ],
+    [ '1', '3' ]
+  ));
+
+  it('TBA: select column - colgroup', () => assertTableSelection(
+    hook.editor(),
+    simpleColgroupTable,
     [ '1', '3' ],
     [ '1', '3' ]
   ));
 
   it('TBA: select whole table', () => assertTableSelection(
     hook.editor(),
-    '<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>',
+    simpleTable,
+    [ '1', '4' ],
+    [ '1', '2', '3', '4' ]
+  ));
+
+  it('TBA: select whole table - colgroup', () => assertTableSelection(
+    hook.editor(),
+    simpleColgroupTable,
     [ '1', '4' ],
     [ '1', '2', '3', '4' ]
   ));

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NestedFakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NestedFakeSelectionTest.ts
@@ -1,0 +1,436 @@
+import { Cursors, Keys, Mouse } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { Attribute, SelectorFilter, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/table/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+interface Scenario {
+  readonly content: string;
+  readonly selection: Cursors.CursorPath;
+  readonly expectedSelectedCells: string[];
+  readonly keyDirection: number;
+}
+
+describe('browser.tinymce.plugins.table.NestedFakeSelectionTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'table',
+    indent: false,
+    valid_styles: {
+      '*': 'width,height,vertical-align,text-align,float,border-color,background-color,border,padding,border-spacing,border-collapse'
+    },
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin, Theme ]);
+
+  // The critical part is the target element as this is what Darwin (MouseSelection.ts) uses to determine the fake selection
+  const selectWithMouse = (start: SugarElement<Element>, end: SugarElement<Element>) => {
+    Mouse.mouseDown(start, { button: 0 });
+    Mouse.mouseOver(end, { button: 0 });
+    Mouse.mouseUp(end, { button: 0 });
+  };
+
+  // Set up to mock what the listeners are looking for in InputHandlers.ts - keyup()
+  const selectWithKeyboard = (editor: Editor, cursorRange: Cursors.CursorPath, direction: number) => {
+    const { startPath, soffset, finishPath, foffset } = cursorRange;
+    TinySelections.setSelection(editor, startPath, soffset, finishPath, foffset);
+    TinyContentActions.keydown(editor, direction, { shiftKey: true });
+    TinyContentActions.keyup(editor, direction, { shiftKey: true });
+  };
+
+  const getSelectedCells = (editor: Editor) =>
+    SelectorFilter.descendants(TinyDom.body(editor), 'td[data-mce-selected],th[data-mce-selected]');
+
+  const assertSelectedCells = (editor: Editor, expectedSelectedCells: string[]) => {
+    const selectedCells = Arr.map(getSelectedCells(editor), (cell) => Attribute.get(cell, 'data-cell'));
+    assert.deepEqual(selectedCells, expectedSelectedCells);
+  };
+
+  const assertMouseTableSelection = (editor: Editor, content: string, selection: Cursors.CursorPath, expectedSelectedCells: string[]) => {
+    editor.setContent(content);
+    const cursorRange = Cursors.calculate(TinyDom.body(editor), selection);
+    selectWithMouse(cursorRange.start, cursorRange.finish);
+    assertSelectedCells(editor, expectedSelectedCells);
+  };
+
+  const assertKeyboardTableSelection = (editor: Editor, content: string, selection: Cursors.CursorPath, direction: number, expectedSelectedCells: string[]) => {
+    editor.setContent(content);
+    selectWithKeyboard(editor, selection, direction);
+    assertSelectedCells(editor, expectedSelectedCells);
+  };
+
+  const assertTableSelection = (editor: Editor, scenario: Scenario) => {
+    assertMouseTableSelection(editor, scenario.content, scenario.selection, scenario.expectedSelectedCells);
+    assertKeyboardTableSelection(editor, scenario.content, scenario.selection, scenario.keyDirection, scenario.expectedSelectedCells);
+  };
+
+  it('TINY-6298: Partially selecting cell content in the nested table', () => {
+    const editor = hook.editor();
+    const content = (
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="1a">' +
+      '<p>abc</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="2a">nested1</td>' +
+      '<td data-cell="2b">nested2</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>' +
+      '<p>def</p>' +
+      '</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+
+    const firstTableCell = [ 0, 0, 0, 0 ];
+    assertTableSelection(
+      editor,
+      {
+        content,
+        selection: {
+          startPath: [ ...firstTableCell, 1, 0, 0, 0, 0 ],
+          soffset: 0,
+          finishPath: [ ...firstTableCell, 1, 0, 0, 0, 0 ],
+          foffset: 3,
+        },
+        expectedSelectedCells: [],
+        keyDirection: Keys.right()
+      }
+    );
+  });
+
+  it('TINY-6298: Partially selecting cell content in outer table', () => {
+    const editor = hook.editor();
+    const content = (
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="1a">' +
+      '<p>abc</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="2a">nested1</td>' +
+      '<td data-cell="2b">nested2</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>' +
+      '<p>def</p>' +
+      '</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+
+    const firstTableCell = [ 0, 0, 0, 0 ];
+    assertTableSelection(
+      editor,
+      {
+        content,
+        selection: {
+          startPath: [ ...firstTableCell, 0, 0 ],
+          soffset: 1,
+          finishPath: [ ...firstTableCell, 0, 0 ],
+          foffset: 3,
+        },
+        expectedSelectedCells: [],
+        keyDirection: Keys.right()
+      }
+    );
+  });
+
+  it('TINY-6298: Partially selecting cell content in outer table that includes nested table in selection', () => {
+    const editor = hook.editor();
+    const content = (
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="1a">' +
+      '<p>abc</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="2a">nested1</td>' +
+      '<td data-cell="2b">nested2</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>' +
+      '<p>def</p>' +
+      '</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+
+    const firstTableCell = [ 0, 0, 0, 0 ];
+    assertTableSelection(
+      editor,
+      {
+        content,
+        selection: {
+          startPath: [ ...firstTableCell, 0, 0 ],
+          soffset: 1,
+          finishPath: [ ...firstTableCell, 2, 0 ],
+          foffset: 2,
+        },
+        expectedSelectedCells: [],
+        keyDirection: Keys.right()
+      }
+    );
+  });
+
+  it('TINY-6298: Selecting cells in the nested table', () => {
+    const editor = hook.editor();
+    const content = (
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="1a">' +
+      '<p>abc</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="2a">nested1</td>' +
+      '<td data-cell="2b">nested2</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>' +
+      '<p>def</p>' +
+      '</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+
+    const firstTableCell = [ 0, 0, 0, 0 ];
+    assertTableSelection(
+      editor,
+      {
+        content,
+        selection: {
+          startPath: [ ...firstTableCell, 1, 0, 0, 0, 0 ],
+          soffset: 0,
+          finishPath: [ ...firstTableCell, 1, 0, 0, 1, 0 ],
+          foffset: 3,
+        },
+        expectedSelectedCells: [ '2a', '2b' ],
+        keyDirection: Keys.right()
+      }
+    );
+  });
+
+  it('TINY-6298: Selecting cells in the outer table', () => {
+    const editor = hook.editor();
+    const content = (
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="1a">' +
+      '<p>abc</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="2a">nested1</td>' +
+      '<td data-cell="2b">nested2</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>' +
+      '<p>def</p>' +
+      '</td>' +
+      '</tr>' +
+      '<tr>' +
+      '<td data-cell="1b">1b</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+
+    assertTableSelection(
+      editor,
+      {
+        content,
+        selection: {
+          startPath: [ 0, 0, 0, 0, 0, 0 ],
+          soffset: 1,
+          finishPath: [ 0, 0, 1, 0, 0 ],
+          foffset: 1,
+        },
+        expectedSelectedCells: [ '1a', '1b' ],
+        keyDirection: Keys.right()
+      }
+    );
+  });
+
+  it('TINY-6298: Selecting from outer table cell to the nested table cell in the same outer table cell', () => {
+    const editor = hook.editor();
+    const content = (
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="1a">' +
+      '<p>abc</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="2a">nested1</td>' +
+      '<td data-cell="2b">nested2</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>' +
+      '<p>def</p>' +
+      '</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+
+    const firstTableCell = [ 0, 0, 0, 0 ];
+    assertTableSelection(
+      editor,
+      {
+        content,
+        selection: {
+          startPath: [ ...firstTableCell, 0, 0 ],
+          soffset: 1,
+          finishPath: [ ...firstTableCell, 1, 0, 0, 1, 0 ],
+          foffset: 3,
+        },
+        expectedSelectedCells: [],
+        keyDirection: Keys.right()
+      }
+    );
+  });
+
+  it('TINY-6298: Selecting from nested table cell to the parent outer table cell', () => {
+    const editor = hook.editor();
+    const content = (
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="1a">' +
+      '<p>abc</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="2a">nested1</td>' +
+      '<td data-cell="2b">nested2</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>' +
+      '<p>def</p>' +
+      '</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+
+    const firstTableCell = [ 0, 0, 0, 0 ];
+    assertTableSelection(
+      editor,
+      {
+        content,
+        selection: {
+          startPath: [ ...firstTableCell, 1, 0, 0, 0, 0 ],
+          soffset: 1,
+          finishPath: [ ...firstTableCell, 2, 0 ],
+          foffset: 1,
+        },
+        expectedSelectedCells: [],
+        keyDirection: Keys.right()
+      }
+    );
+  });
+
+  it('TINY-6298: Selecting from outer table cell to a nested table cell not in the same outer table cell', () => {
+    const editor = hook.editor();
+    const content = (
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="1a">1a</td>' +
+      '</tr>' +
+      '<tr>' +
+      '<td data-cell="1b">' +
+      '<p>abc</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="2a">nested1</td>' +
+      '<td data-cell="2b">nested2</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>' +
+      '<p>def</p>' +
+      '</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+
+    assertTableSelection(
+      editor,
+      {
+        content,
+        selection: {
+          startPath: [ 0, 0, 0, 0, 0 ],
+          soffset: 1,
+          finishPath: [ 0, 0, 1, 0, 1, 0, 0, 0, 0 ],
+          foffset: 3,
+        },
+        expectedSelectedCells: [ '1a', '1b' ],
+        keyDirection: Keys.right()
+      }
+    );
+  });
+
+  it('TINY-6298: Selecting from outside paragraph to the nested table cell', () => {
+    const editor = hook.editor();
+    const content = (
+      '<p>outside paragraph</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="1a">' +
+      '<p>abc</p>' +
+      '<table>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-cell="2a">nested1</td>' +
+      '<td data-cell="2b">nested2</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>' +
+      '<p>def</p>' +
+      '</td>' +
+      '</tr>' +
+      '<tr>' +
+      '<td data-cell="1b">1b</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+
+    assertTableSelection(
+      editor,
+      {
+        content,
+        selection: {
+          startPath: [ 0, 0 ],
+          soffset: 1,
+          finishPath: [ 1, 0, 0, 0, 1, 0, 0, 0, 0 ],
+          foffset: 2,
+        },
+        expectedSelectedCells: [],
+        keyDirection: Keys.right()
+      }
+    );
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-6298

Description of Changes:
* Update Darwin `MouseSelection` and `KeySelection` logic to only make a fake selection when more than one cell of the same table has been selected

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
