### PR TITLE
TINY-7663: Fix selection location when undoing or redoing in a document with CEF elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Links in notification text did not show the correct mouse pointer #TINY-7661
 - The formatter match APIs were incorrectly returning false for formats that specified an attribute or style should be removed from an element #TINY-6149
 - The type signature on `editor.formatter.matchNode` had the wrong return type (was `boolean` but should have been `Formatter | undefined`) #TINY-6149
+- The editor selection could be placed in an incorrect location when undoing or redoing changes in a document containing `contenteditable="false"` elements #TINY-7663
 
 ## 5.8.2 - 2021-06-23
 

--- a/modules/tinymce/src/core/main/ts/bookmark/BookmarkTypes.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/BookmarkTypes.ts
@@ -31,6 +31,7 @@ export interface IndexBookmark {
 export interface PathBookmark {
   start: number[];
   end?: number[];
+  isFakeCaret?: boolean;
 }
 
 export type Bookmark = StringPathBookmark | RangeBookmark | IdBookmark | IndexBookmark | PathBookmark;

--- a/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
@@ -70,6 +70,10 @@ const getLocation = (trim: TrimFn, selection: EditorSelection, normalized: boole
     bookmark.end = getPoint(dom, trim, normalized, rng, false);
   }
 
+  if (CaretContainer.isRangeInCaretContainerBlock(rng)) {
+    bookmark.isFakeCaret = true;
+  }
+
   return bookmark;
 };
 

--- a/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
+++ b/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
@@ -24,6 +24,7 @@ export interface SetContentArgs {
   set?: boolean;
   content?: string;
   no_events?: boolean;
+  no_selection?: boolean;
 }
 
 export interface InsertContentDetails {

--- a/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
@@ -35,9 +35,11 @@ const moveSelection = (editor: Editor): void => {
   }
 };
 
-const setEditorHtml = (editor: Editor, html: string): void => {
+const setEditorHtml = (editor: Editor, html: string, noSelection: boolean = false): void => {
   editor.dom.setHTML(editor.getBody(), html);
-  moveSelection(editor);
+  if (!noSelection) {
+    moveSelection(editor);
+  }
 };
 
 const setContentString = (editor: Editor, body: HTMLElement, content: string, args: SetContentArgs): string => {
@@ -65,7 +67,7 @@ const setContentString = (editor: Editor, body: HTMLElement, content: string, ar
       content = '<br data-mce-bogus="1">';
     }
 
-    setEditorHtml(editor, content);
+    setEditorHtml(editor, content, args.no_selection);
 
     editor.fire('SetContent', args);
   } else {
@@ -78,7 +80,7 @@ const setContentString = (editor: Editor, body: HTMLElement, content: string, ar
     }
 
     args.content = isWsPreserveElement(SugarElement.fromDom(body)) ? content : Tools.trim(content);
-    setEditorHtml(editor, args.content);
+    setEditorHtml(editor, args.content, args.no_selection);
 
     if (!args.no_events) {
       editor.fire('SetContent', args);

--- a/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
@@ -35,9 +35,9 @@ const moveSelection = (editor: Editor): void => {
   }
 };
 
-const setEditorHtml = (editor: Editor, html: string, noSelection: boolean = false): void => {
+const setEditorHtml = (editor: Editor, html: string, noSelection: boolean | undefined): void => {
   editor.dom.setHTML(editor.getBody(), html);
-  if (!noSelection) {
+  if (noSelection !== true) {
     moveSelection(editor);
   }
 };
@@ -96,7 +96,7 @@ const setContentTree = (editor: Editor, body: HTMLElement, content: AstNode, arg
   const html = HtmlSerializer({ validate: editor.validate }, editor.schema).serialize(content);
 
   args.content = isWsPreserveElement(SugarElement.fromDom(body)) ? html : Tools.trim(html);
-  setEditorHtml(editor, args.content);
+  setEditorHtml(editor, args.content, args.no_selection);
 
   if (!args.no_events) {
     editor.fire('SetContent', args);

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -578,9 +578,9 @@ describe('browser.tinymce.core.UndoManager', () => {
       TinyAssertions.assertContentPresence(editor, { 'p[data-mce-caret=before]': 1 });
       // selection path must include fake caret which is before the CEF div
       TinySelections.setCursor(editor, [ 3, 0 ], 14);
-      // moving the selection removed the CEF div
+      // moving the selection removed the fake caret
       TinyAssertions.assertContentPresence(editor, { 'p[data-mce-caret=before]': 0 });
-      // the act of moving the cursor removed the CEF div so now the selection path is off by one (expected)
+      // the act of moving the cursor removed the fake caret so now the selection path is off by one (expected)
       TinyAssertions.assertCursor(editor, [ 2, 0 ], 14);
 
       TinyContentActions.keystroke(editor, Keys.enter());

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -1,6 +1,7 @@
+import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -190,7 +191,7 @@ describe('browser.tinymce.core.UndoManager', () => {
     editor.dom.fire(editor.getBody(), 'keyup', evt);
 
     assert.isFalse(added);
-    assert.deepEqual(commands, [ 'mceFocus', 'mceFocus', 'Undo' ]);
+    assert.deepEqual(commands, [ 'mceFocus', 'Undo' ]);
   });
 
   it('Transact', () => {
@@ -563,5 +564,18 @@ describe('browser.tinymce.core.UndoManager', () => {
     editor.undoManager.clear();
     editor.execCommand('mceFocus');
     assert.isFalse(editor.undoManager.hasUndo());
+  });
+
+  it('TINY-7663: Undo when first element is contenteditable="false" should restore correct cursor location', () => {
+    const editor = hook.editor();
+    editor.undoManager.clear();
+    editor.setDirty(false);
+    editor.setContent('<div contenteditable="false"><p>CEF</p></div><p>something</p><p>something else</p>', { format: 'raw' });
+    TinySelections.setCursor(editor, [ 2, 0 ], 14);
+
+    TinyContentActions.keystroke(editor, Keys.enter());
+    editor.undoManager.undo();
+    TinyAssertions.assertContent(editor, '<div contenteditable="false"><p>CEF</p></div><p>something</p><p>something else</p>');
+    TinyAssertions.assertCursor(editor, [ 2, 0 ], 14);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -569,9 +569,7 @@ describe('browser.tinymce.core.UndoManager', () => {
   context('Undo when first element is contenteditable="false"', () => {
     beforeEach(() => {
       const editor = hook.editor();
-      editor.undoManager.clear();
-      editor.setDirty(false);
-      editor.setContent('<div contenteditable="false"><p>CEF</p></div><p>something</p><p>something else</p>', { format: 'raw' });
+      editor.resetContent('<div contenteditable="false"><p>CEF</p></div><p>something</p><p>something else</p>');
       editor.focus();
     });
 


### PR DESCRIPTION
**Related Ticket:**

TINY-7663

**Description of Changes:**

When setting a bookmark, we now check to see if the selection is within a fake caret. If it _isn't_, we need to ensure that when we call `setContent` when restoring the content that a fake caret is not created (this will happen if the first element in the content is `contenteditable="false"`) by `moveSelection` in `SetContentImpl.ts`. 

If a fake caret is created - as it was previously - as this will mean when the selection is restored in `Levels.ts` that the path will be off by one.

**Pre-checks:**
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

**Review:**
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
