### PR TITLE
TINY-7690: None-entries are now selected if none other is.

### DIFF
--- a/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
@@ -3,7 +3,8 @@ declare let tinymce: any;
 tinymce.init({
   selector: 'div.tinymce',
   plugins: 'table',
-  toolbar: 'table tableprops tablecellprops tablerowprops | tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol | tablecutrow tablecopyrow tablepasterowbefore tablepasterowafter',
+  toolbar: 'table tableprops tablecellprops tablerowprops | tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol | tablecutrow tablecopyrow tablepasterowbefore tablepasterowafter |' +
+  ' tableclass tablecellclass | tablecellvalign | tablecellborderwidth tablecellborderstyle | tablecaption | tablecellbackgroundcolor tablecellbordercolor | tablerowheader tablecolheader',
   media_dimensions: false,
   table_class_list: [
     { title: 'None', value: '' },

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -31,13 +31,11 @@ const onSetupToggle = (editor: Editor, formatName: string, active: () => boolean
   };
 };
 
-const onSetupToggleSingle = (editor: Editor, formatName: string, formatValue: string) => {
-  return onSetupToggle(editor, formatName, () => editor.formatter.match(formatName, { value: formatValue }));
-};
+const onSetupToggleSingle = (editor: Editor, formatName: string, formatValue: string) =>
+  onSetupToggle(editor, formatName, () => editor.formatter.match(formatName, { value: formatValue }));
 
-const onSetupToggleInverse = (editor: Editor, formatName: string, formatValues: string[]) => {
-  return onSetupToggle(editor, formatName, () => !Arr.exists(formatValues, (value) => editor.formatter.match(formatName, { value })));
-};
+const onSetupToggleInverse = (editor: Editor, formatName: string, formatValues: string[]) =>
+  onSetupToggle(editor, formatName, () => !Arr.exists(formatValues, (value) => editor.formatter.match(formatName, { value })));
 
 const applyTableCellStyle = <T extends Item>(editor: Editor, style: string) =>
   (item: T) =>
@@ -58,7 +56,7 @@ const generateItem = <T extends Item>(editor: Editor, item: T, otherValues: Opti
 
 const generateItems = <T extends Item>(editor: Editor, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void): Menu.ToggleMenuItemSpec[] =>
   Arr.map(items, (item) => {
-    if (item.value === '') {
+    if (Strings.isEmpty(item.value)) {
       const otherValues = Optional.some(Arr.map(filterNoneItem(items), (itemValue) => itemValue.value));
       return generateItem(editor, item, otherValues, format, extractText, onAction);
     } else {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -25,9 +25,9 @@ const onSetupToggle = (editor: Editor, formatName: string, formatValue: string) 
         api.setActive(isNone ? !matched : matched);
 
       setActive(editor.formatter.match(formatName, { value: formatValue }, undefined, isNone));
-      // formatChanged currently incorrectly highlights items. TODO TINY-7713
-      const binding = editor.formatter.formatChanged(formatName, setActive, isNone);
-      boundCallback.set(binding);
+      // TODO: TINY-7713: formatChanged doesn't currently handle formats with dynamic values so this will currently cause all items to show as active
+      // const binding = editor.formatter.formatChanged(formatName, setActive, isNone);
+      // boundCallback.set(binding);
     };
 
     // The editor may or may not have been setup yet, so check for that

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -20,6 +20,7 @@ const onSetupToggle = (editor: Editor, formatName: string, formatValue: string) 
     const isNone = Strings.isEmpty(formatValue);
 
     const init = () => {
+      // If value is empty (A None-entry in the list), check it only if the format is not set at all. Otherwise, check it if the format is set to the correct value.
       const setActive = (matched) =>
         api.setActive(isNone ? !matched : matched);
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -20,11 +20,12 @@ const onSetupToggle = (editor: Editor, formatName: string, formatValue: string) 
     const isNone = Strings.isEmpty(formatValue);
 
     const init = () => {
-      // If value is empty (A None-entry in the list), check it only if the format is not set at all. Otherwise, check it if the format is set to the correct value.
-      const setActive = (matched) =>
+      // If value is empty (A None-entry in the list), check if the format is not set at all. Otherwise, check if the format is set to the correct value.
+      const setActive = (matched: boolean) =>
         api.setActive(isNone ? !matched : matched);
 
       setActive(editor.formatter.match(formatName, { value: formatValue }, undefined, isNone));
+      // formatChanged currently incorrectly highlights items. TODO TINY-7713
       const binding = editor.formatter.formatChanged(formatName, setActive, isNone);
       boundCallback.set(binding);
     };
@@ -51,8 +52,7 @@ const generateItem = <T extends Item>(editor: Editor, item: T, format: string, e
 });
 
 const generateItems = <T extends Item>(editor: Editor, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void): Menu.ToggleMenuItemSpec[] =>
-  Arr.map(items, (item) =>
-    generateItem(editor, item, format, extractText, onAction));
+  Arr.map(items, (item) => generateItem(editor, item, format, extractText, onAction));
 
 const generateItemsCallback = <T extends Item>(editor: Editor, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void) =>
   (callback: (items: Menu.ToggleMenuItemSpec[]) => void) =>

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
@@ -151,14 +151,14 @@ const pAssertStyleCanBeToggledWithoutCheckmarks = async (editor: Editor, options
 const pAssertStyleCanBeToggled = async (editor: Editor, options: AssertStyleOptionsWithCheckmarks, useMenuOrToolbar: 'toolbar' | 'menuitem') => {
   const sugarContainer = SugarBody.body();
   setEditorContentTableAndSelection(editor, options.rows, options.columns);
-  await pAssertNoCheckmarksInMenu(editor, options.menuTitle, options.checkMarkEntries, sugarContainer, useMenuOrToolbar);
+  await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuRemoveTitle, options.checkMarkEntries - 1, sugarContainer, useMenuOrToolbar);
 
   await pClickOnSubMenu(editor, options.menuTitle, options.subMenuTitle, useMenuOrToolbar);
   await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuTitle, options.checkMarkEntries - 1, sugarContainer, useMenuOrToolbar);
   assertStructureHasCustomStyle(editor, options.rows, options.columns, options.customStyle);
 
   await pClickOnSubMenu(editor, options.menuTitle, options.subMenuRemoveTitle, useMenuOrToolbar);
-  await pAssertNoCheckmarksInMenu(editor, options.menuTitle, options.checkMarkEntries, sugarContainer, useMenuOrToolbar);
+  await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuRemoveTitle, options.checkMarkEntries - 1, sugarContainer, useMenuOrToolbar);
   assertStructureIsRestoredToDefault(editor, options.rows, options.columns);
 };
 

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
@@ -107,11 +107,11 @@ const pAssertMenuPresence = async (editor: Editor, label: string, menuTitle: str
   closeMenu(editor);
 };
 
-const pAssertCheckmarkOn = async (editor: Editor, menuTitle: string, itemTitle: string, unchecked: number, sugarContainer: SugarElement<HTMLElement>, useMenuOrToolbar: 'toolbar' | 'menuitem') => {
+const pAssertCheckmarkOn = async (editor: Editor, menuTitle: string, itemTitle: string, totalNumberOfEntries: number, sugarContainer: SugarElement<HTMLElement>, useMenuOrToolbar: 'toolbar' | 'menuitem') => {
   const expected = {
     '.tox-menu': useMenuOrToolbar === 'toolbar' ? 1 : 2,
     [`.tox-collection__item[aria-checked="true"][title="${itemTitle}"]`]: 1,
-    '.tox-collection__item[aria-checked="false"]': unchecked,
+    '.tox-collection__item[aria-checked="false"]': (totalNumberOfEntries - 1),
     '.tox-collection__item[aria-checked="true"]': 1,
   };
   await pAssertMenuPresence(editor, 'There should be a checkmark', menuTitle, expected, sugarContainer, useMenuOrToolbar);
@@ -151,14 +151,14 @@ const pAssertStyleCanBeToggledWithoutCheckmarks = async (editor: Editor, options
 const pAssertStyleCanBeToggled = async (editor: Editor, options: AssertStyleOptionsWithCheckmarks, useMenuOrToolbar: 'toolbar' | 'menuitem') => {
   const sugarContainer = SugarBody.body();
   setEditorContentTableAndSelection(editor, options.rows, options.columns);
-  await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuRemoveTitle, options.checkMarkEntries - 1, sugarContainer, useMenuOrToolbar);
+  await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuRemoveTitle, options.checkMarkEntries, sugarContainer, useMenuOrToolbar);
 
   await pClickOnSubMenu(editor, options.menuTitle, options.subMenuTitle, useMenuOrToolbar);
-  await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuTitle, options.checkMarkEntries - 1, sugarContainer, useMenuOrToolbar);
+  await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuTitle, options.checkMarkEntries, sugarContainer, useMenuOrToolbar);
   assertStructureHasCustomStyle(editor, options.rows, options.columns, options.customStyle);
 
   await pClickOnSubMenu(editor, options.menuTitle, options.subMenuRemoveTitle, useMenuOrToolbar);
-  await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuRemoveTitle, options.checkMarkEntries - 1, sugarContainer, useMenuOrToolbar);
+  await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuRemoveTitle, options.checkMarkEntries, sugarContainer, useMenuOrToolbar);
   assertStructureIsRestoredToDefault(editor, options.rows, options.columns);
 };
 


### PR DESCRIPTION
Related Ticket:

Description of Changes:
For table lists with a None-entry, it now selects that entry if no other entry could be selected.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
