### PR TITLE
TINY-7393: Fixed formats not applied correctly to nested list items

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Partially transparent RGBA values provided in the `color_map` setting were given the wrong hex value #TINY-7163
 - HTML comments with mismatched quotes were parsed incorrectly under certain circumstances #TINY-7589
 - Links in notification text did not show the correct mouse pointer #TINY-7661
-- Applying selector formats would sometimes not apply the format correctly on lists #TINY-7393
+- Applying selector formats would sometimes not apply the format correctly to elements in a list #TINY-7393
 - The formatter match APIs were incorrectly returning false for formats that specified an attribute or style should be removed from an element #TINY-6149
 - The type signature on `editor.formatter.matchNode` had the wrong return type (was `boolean` but should have been `Formatter | undefined`) #TINY-6149
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Partially transparent RGBA values provided in the `color_map` setting were given the wrong hex value #TINY-7163
 - HTML comments with mismatched quotes were parsed incorrectly under certain circumstances #TINY-7589
 - Links in notification text did not show the correct mouse pointer #TINY-7661
+- Applying selector formats would sometimes not apply the format correctly on lists #TINY-7393
 - The formatter match APIs were incorrectly returning false for formats that specified an attribute or style should be removed from an element #TINY-6149
 - The type signature on `editor.formatter.matchNode` had the wrong return type (was `boolean` but should have been `Formatter | undefined`) #TINY-6149
 

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -45,7 +45,7 @@ interface RtcRuntimeApi {
     match: (format: string, vars: Record<string, string>) => boolean;
     matchAll: () => string[];
     matchNode: () => Format | undefined;
-    closest: (formats: string) => string;
+    closest: (formats: string[]) => string;
     apply: (format: string, vars: Record<string, string>) => void;
     remove: (format: string, vars: Record<string, string>) => void;
     toggle: (format: string, vars: Record<string, string>) => void;
@@ -372,7 +372,7 @@ export const canApplyFormat = (
 
 export const closestFormat = (
   editor: Editor,
-  names: string): string => getRtcInstanceWithError(editor).formatter.closest(names);
+  names: string[]): string => getRtcInstanceWithError(editor).formatter.closest(names);
 
 export const applyFormat = (
   editor: Editor,

--- a/modules/tinymce/src/core/main/ts/api/Formatter.ts
+++ b/modules/tinymce/src/core/main/ts/api/Formatter.ts
@@ -37,7 +37,7 @@ interface Formatter extends FormatRegistry {
   remove: (name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean) => void;
   toggle: (name: string, vars?: FormatVars, node?: Node) => void;
   match: (name: string, vars?: FormatVars, node?: Node) => boolean;
-  closest: (names) => string | null;
+  closest: (names: string[]) => string | null;
   matchAll: (names: string[], vars?: FormatVars) => string[];
   matchNode: (node: Node, name: string, vars?: FormatVars, similar?: boolean) => Format | undefined;
   canApply: (name: string) => boolean;
@@ -167,7 +167,7 @@ const Formatter = (editor: Editor): Formatter => {
      * @param {Boolean} similar Match format that has similar properties.
      * @return {Object} Returns the format object it matches or undefined if it doesn't match.
      */
-    matchNode: (node, names, vars?, similar?) => Rtc.matchNodeFormat(editor, node, names, vars, similar),
+    matchNode: (node, name, vars?, similar?) => Rtc.matchNodeFormat(editor, node, name, vars, similar),
 
     /**
      * Returns true/false if the specified format can be applied to the current selection or not. It

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1205,15 +1205,21 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
   };
 
   const isChildOf = (node: Node, parent: Node) => {
-    while (node) {
-      if (parent === node) {
-        return true;
+    // IE only supports the native `contains` functions on HTMLElements, but not Nodes or Elements
+    // so we have to use the slow walking path for IE unfortunately.
+    if (!isIE) {
+      return node === parent || parent.contains(node);
+    } else {
+      while (node) {
+        if (parent === node) {
+          return true;
+        }
+
+        node = node.parentNode;
       }
 
-      node = node.parentNode;
+      return false;
     }
-
-    return false;
   };
 
   const dumpRng = (r: Range) => (

--- a/modules/tinymce/src/core/main/ts/caret/CaretPosition.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretPosition.ts
@@ -36,7 +36,7 @@ const isNotPre = Fun.not(NodeType.matchStyleValues('white-space', 'pre pre-line 
 const isText = NodeType.isText;
 const isBr = NodeType.isBr;
 const nodeIndex = DOMUtils.nodeIndex;
-const resolveIndex = RangeNodes.getNode;
+const resolveIndex = RangeNodes.getNodeUnsafe;
 const createRange = (doc: Document): Range => 'createRange' in doc ? doc.createRange() : DOMUtils.DOM.createRng();
 const isWhiteSpace = (chr: string): boolean => chr && /[\r\n\t ]/.test(chr);
 const isRange = (rng: any): rng is Range => !!rng.setStart && !!rng.setEnd;
@@ -230,7 +230,7 @@ export interface CaretPosition {
   isAtStart: () => boolean;
   isAtEnd: () => boolean;
   isEqual: (caretPosition: CaretPosition) => boolean;
-  getNode: (before?: boolean) => Node;
+  getNode: (before?: boolean) => Node | undefined;
 }
 
 /**
@@ -278,7 +278,8 @@ export const CaretPosition = (container: Node, offset: number, clientRects?: Cli
 
   const isEqual = (caretPosition: CaretPosition) => caretPosition && container === caretPosition.container() && offset === caretPosition.offset();
 
-  const getNode = (before?: boolean): Node => resolveIndex(container, before ? offset - 1 : offset);
+  const getNode = (before?: boolean): Node | undefined =>
+    resolveIndex(container, before ? offset - 1 : offset);
 
   return {
     /**

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -7,22 +7,24 @@
 
 import { Arr } from '@ephox/katamari';
 
-const isNodeType = (type: number) => {
-  return (node: Node | null) => {
+type NullableNode = Node | null | undefined;
+
+const isNodeType = <T extends Node>(type: number) => {
+  return (node: NullableNode): node is T => {
     return !!node && node.nodeType === type;
   };
 };
 
 // Firefox can allow you to get a selection on a restricted node, such as file/number inputs. These nodes
 // won't implement the Object prototype, so Object.getPrototypeOf() will return null or something similar.
-const isRestrictedNode = (node: Node): boolean => !!node && !Object.getPrototypeOf(node);
+const isRestrictedNode = (node: NullableNode): boolean => !!node && !Object.getPrototypeOf(node);
 
-const isElement = isNodeType(1) as (node: Node | null) => node is HTMLElement;
+const isElement = isNodeType<HTMLElement>(1);
 
-const matchNodeNames = <T extends Node>(names: string[]): (node: Node | null) => node is T => {
+const matchNodeNames = <T extends Node>(names: string[]): (node: NullableNode) => node is T => {
   const lowercasedNames = names.map((s) => s.toLowerCase());
 
-  return (node: Node | null): node is T => {
+  return (node: NullableNode): node is T => {
     if (node && node.nodeName) {
       const nodeName = node.nodeName.toLowerCase();
       return Arr.contains(lowercasedNames, nodeName);
@@ -32,10 +34,10 @@ const matchNodeNames = <T extends Node>(names: string[]): (node: Node | null) =>
   };
 };
 
-const matchStyleValues = (name: string, values: string): (node: Node) => boolean => {
+const matchStyleValues = (name: string, values: string): (node: NullableNode) => boolean => {
   const items = values.toLowerCase().split(' ');
 
-  return (node: Node) => {
+  return (node: NullableNode) => {
     if (isElement(node)) {
       for (let i = 0; i < items.length; i++) {
         const computed = node.ownerDocument.defaultView.getComputedStyle(node, null);
@@ -51,29 +53,29 @@ const matchStyleValues = (name: string, values: string): (node: Node) => boolean
 };
 
 const hasPropValue = (propName: keyof HTMLElement, propValue: any) => {
-  return (node: Node): boolean => {
+  return (node: NullableNode): boolean => {
     return isElement(node) && node[propName] === propValue;
   };
 };
 
 const hasAttribute = (attrName: string) => {
-  return (node: Node): boolean => {
+  return (node: NullableNode): boolean => {
     return isElement(node) && node.hasAttribute(attrName);
   };
 };
 
 const hasAttributeValue = (attrName: string, attrValue: string) => {
-  return (node: Node): boolean => {
+  return (node: NullableNode): boolean => {
     return isElement(node) && node.getAttribute(attrName) === attrValue;
   };
 };
 
-const isBogus = (node: Node): node is Element => isElement(node) && node.hasAttribute('data-mce-bogus');
-const isBogusAll = (node: Node): node is Element => isElement(node) && node.getAttribute('data-mce-bogus') === 'all';
-const isTable = (node: Node): node is Element => isElement(node) && node.tagName === 'TABLE';
+const isBogus = (node: NullableNode): node is Element => isElement(node) && node.hasAttribute('data-mce-bogus');
+const isBogusAll = (node: NullableNode): node is Element => isElement(node) && node.getAttribute('data-mce-bogus') === 'all';
+const isTable = (node: NullableNode): node is Element => isElement(node) && node.tagName === 'TABLE';
 
 const hasContentEditableState = (value: string) => {
-  return (node: Node) => {
+  return (node: NullableNode): node is HTMLElement => {
     if (isElement(node)) {
       if (node.contentEditable === value) {
         return true;
@@ -90,14 +92,14 @@ const hasContentEditableState = (value: string) => {
 
 const isTextareaOrInput = matchNodeNames<HTMLTextAreaElement | HTMLInputElement>([ 'textarea', 'input' ]);
 
-const isText = isNodeType(3) as (node: Node | null) => node is Text;
-const isComment = isNodeType(8) as (node: Node | null) => node is Comment;
-const isDocument = isNodeType(9) as (node: Node | null) => node is Document;
-const isDocumentFragment = isNodeType(11) as (node: Node | null) => node is DocumentFragment;
+const isText = isNodeType<Text>(3);
+const isComment = isNodeType<Comment>(8);
+const isDocument = isNodeType<Document>(9);
+const isDocumentFragment = isNodeType<DocumentFragment>(11);
 const isBr = matchNodeNames<HTMLBRElement>([ 'br' ]);
 const isImg = matchNodeNames<HTMLImageElement>([ 'img' ]);
-const isContentEditableTrue = hasContentEditableState('true') as (node: Node | null) => node is HTMLElement;
-const isContentEditableFalse = hasContentEditableState('false') as (node: Node | null) => node is HTMLElement;
+const isContentEditableTrue = hasContentEditableState('true');
+const isContentEditableFalse = hasContentEditableState('false');
 
 const isTableCell = matchNodeNames<HTMLTableCellElement>([ 'td', 'th' ]);
 const isMedia = matchNodeNames<HTMLElement>([ 'video', 'audio', 'object', 'embed' ]);

--- a/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
@@ -319,7 +319,7 @@ const expandRng = (editor: Editor, rng: Range, formatList: Format[], includeTrai
   }
 
   // Expand start/end container to matching selector
-  if (FormatUtils.isSelectorFormat(format) && format.expand !== false && !FormatUtils.isInlineFormat(format)) {
+  if (FormatUtils.shouldExpandToSelector(format)) {
     // Find new startContainer/endContainer if there is better one
     startContainer = findSelectorEndPoint(dom, formatList, rng, startContainer, 'previousSibling');
     endContainer = findSelectorEndPoint(dom, formatList, rng, endContainer, 'nextSibling');

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -23,17 +23,18 @@ const isInlineBlock = (node: Node): boolean => {
 
 const moveStart = (dom: DOMUtils, selection: EditorSelection, rng: Range) => {
   const offset = rng.startOffset;
-  let container = rng.startContainer, walker, node, nodes;
+  let container = rng.startContainer;
 
-  if (rng.startContainer === rng.endContainer) {
-    if (isInlineBlock(rng.startContainer.childNodes[rng.startOffset])) {
+  if (container === rng.endContainer) {
+    if (isInlineBlock(container.childNodes[offset])) {
       return;
     }
   }
 
   // Move startContainer/startOffset in to a suitable node
-  if (container.nodeType === 1) {
-    nodes = container.childNodes;
+  if (NodeType.isElement(container)) {
+    const nodes = container.childNodes;
+    let walker: DomTreeWalker;
     if (offset < nodes.length) {
       container = nodes[offset];
       walker = new DomTreeWalker(container, dom.getParent(container, dom.isBlock));
@@ -43,8 +44,8 @@ const moveStart = (dom: DOMUtils, selection: EditorSelection, rng: Range) => {
       walker.next(true);
     }
 
-    for (node = walker.current(); node; node = walker.next()) {
-      if (node.nodeType === 3 && !isWhiteSpaceNode(node)) {
+    for (let node = walker.current(); node; node = walker.next()) {
+      if (NodeType.isText(node) && !isWhiteSpaceNode(node)) {
         rng.setStart(node, 0);
         selection.setRng(rng);
 
@@ -68,7 +69,7 @@ const getNonWhiteSpaceSibling = (node: Node, next?: boolean, inc?: boolean) => {
     const nextName = next ? 'nextSibling' : 'previousSibling';
 
     for (node = inc ? node : node[nextName]; node; node = node[nextName]) {
-      if (node.nodeType === 1 || !isWhiteSpaceNode(node)) {
+      if (NodeType.isElement(node) || !isWhiteSpaceNode(node)) {
         return node;
       }
     }

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -218,7 +218,8 @@ const isInlineFormat = (format: Format): format is InlineFormat =>
 const isMixedFormat = (format: Format): format is MixedFormat =>
   isSelectorFormat(format) && isInlineFormat(format) && Optionals.is(Obj.get(format as any, 'mixed'), true);
 
-const hasBlockChildren = (dom: DOMUtils, elm: Node) => Arr.exists(elm.childNodes, dom.isBlock);
+const shouldExpandToSelector = (format: Format) =>
+  isSelectorFormat(format) && format.expand !== false && !isInlineFormat(format);
 
 export {
   isNode,
@@ -241,5 +242,5 @@ export {
   isInlineFormat,
   isBlockFormat,
   isMixedFormat,
-  hasBlockChildren
+  shouldExpandToSelector
 };

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -10,18 +10,18 @@ import { Compare, SugarElement, TransformFind } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
-import { Format, FormatVars, SelectorFormat } from './FormatTypes';
+import { Format, FormatVars } from './FormatTypes';
 import * as FormatUtils from './FormatUtils';
 
 const isEq = FormatUtils.isEq;
 
 const matchesUnInheritedFormatSelector = (ed: Editor, node: Node, name: string) => {
-  // TODO: Is this safe? it doesn't look like it is this could be a block or inline format
-  const formatList = ed.formatter.get(name) as SelectorFormat[];
+  const formatList = ed.formatter.get(name);
 
   if (formatList) {
     for (let i = 0; i < formatList.length; i++) {
-      if (formatList[i].inherit === false && ed.dom.is(node, formatList[i].selector)) {
+      const format = formatList[i];
+      if (FormatUtils.isSelectorFormat(format) && format.inherit === false && ed.dom.is(node, format.selector)) {
         return true;
       }
     }

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -520,7 +520,7 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
     }
 
     // Note: Assists with cleaning up any stray text decorations that may been applied when text decorations
-    // and text colors were merged together from a applied format
+    // and text colors were merged together from an applied format
     // Remove child span if it only contains text-decoration and a parent node also has the same text decoration.
     const textDecorations = [ 'underline', 'line-through', 'overline' ];
     Arr.each(textDecorations, (decoration) => {

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -474,17 +474,16 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
 
   // Make sure to only check for bookmarks created here (eg _start or _end)
   // as there maybe nested bookmarks
-  const isRemoveBookmarkNode = (node: Node) => Bookmarks.isBookmarkNode(node) && NodeType.isElement(node) && (node.id === '_start' || node.id === '_end');
+  const isRemoveBookmarkNode = (node: Node) =>
+    Bookmarks.isBookmarkNode(node) && NodeType.isElement(node) && (node.id === '_start' || node.id === '_end');
+
+  const removeNodeFormat = (node: Node) =>
+    Arr.exists(formatList, (fmt) => removeFormat(ed, fmt, vars, node, node));
 
   // Merges the styles for each node
   const process = (node: Node) => {
-    let lastContentEditable: boolean, hasContentEditableState: boolean;
-
-    // TINY-6567 Include the last node in the selection
-    const parentNode = node.parentNode;
-    if (NodeType.isText(node) && FormatUtils.hasBlockChildren(dom, parentNode)) {
-      removeFormat(ed, format, vars, parentNode, parentNode);
-    }
+    let lastContentEditable = true;
+    let hasContentEditableState = false;
 
     // Node has a contentEditable value
     if (NodeType.isElement(node) && dom.getContentEditable(node)) {
@@ -498,10 +497,12 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
 
     // Process current node
     if (contentEditable && !hasContentEditableState) {
-      for (let i = 0; i < formatList.length; i++) {
-        if (removeFormat(ed, formatList[i], vars, node, node)) {
-          break;
-        }
+      const removed = removeNodeFormat(node);
+
+      // TINY-6567/TINY-7393: Include the parent if using an expanded selector format and no match was found for the current node
+      const parentNode = node.parentNode;
+      if (!removed && Type.isNonNullable(parentNode) && FormatUtils.shouldExpandToSelector(format)) {
+        removeNodeFormat(parentNode);
       }
     }
 
@@ -517,6 +518,24 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
         }
       }
     }
+
+    // Note: Assists with cleaning up any stray text decorations that may been applied when text decorations
+    // and text colors were merged together from a applied format
+    // Remove child span if it only contains text-decoration and a parent node also has the same text decoration.
+    const textDecorations = [ 'underline', 'line-through', 'overline' ];
+    Arr.each(textDecorations, (decoration) => {
+      if (NodeType.isElement(node) && ed.dom.getStyle(node, 'text-decoration') === decoration &&
+        node.parentNode && FormatUtils.getTextDecoration(dom, node.parentNode) === decoration) {
+        removeFormat(ed, {
+          deep: false,
+          exact: true,
+          inline: 'span',
+          styles: {
+            textDecoration: decoration
+          }
+        }, null, node);
+      }
+    });
   };
 
   const unwrap = (start?: boolean) => {
@@ -609,27 +628,7 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
 
     // Remove items between start/end
     RangeWalk.walk(dom, expandedRng, (nodes) => {
-      Arr.each(nodes, (node) => {
-        process(node);
-
-        // Note: Assists with cleaning up any stray text decorations that may been applied when text decorations
-        // and text colors were merged together from a applied format
-        // Remove child span if it only contains text-decoration and a parent node also has the same text decoration.
-        const textDecorations = [ 'underline', 'line-through', 'overline' ];
-        Arr.each(textDecorations, (decoration) => {
-          if (NodeType.isElement(node) && ed.dom.getStyle(node, 'text-decoration') === decoration &&
-            node.parentNode && FormatUtils.getTextDecoration(dom, node.parentNode) === decoration) {
-            removeFormat(ed, {
-              deep: false,
-              exact: true,
-              inline: 'span',
-              styles: {
-                textDecoration: decoration
-              }
-            }, null, node);
-          }
-        });
-      });
+      Arr.each(nodes, process);
     });
   };
 

--- a/modules/tinymce/src/core/main/ts/selection/RangeNodes.ts
+++ b/modules/tinymce/src/core/main/ts/selection/RangeNodes.ts
@@ -5,6 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Num } from '@ephox/katamari';
+
+import * as NodeType from '../dom/NodeType';
+
 const getSelectedNode = (range: Range): Node => {
   const startContainer = range.startContainer,
     startOffset = range.startOffset;
@@ -17,18 +21,27 @@ const getSelectedNode = (range: Range): Node => {
 };
 
 const getNode = (container: Node, offset: number): Node => {
-  if (container.nodeType === 1 && container.hasChildNodes()) {
-    if (offset >= container.childNodes.length) {
-      offset = container.childNodes.length - 1;
-    }
-
-    container = container.childNodes[offset];
+  if (NodeType.isElement(container) && container.hasChildNodes()) {
+    const childNodes = container.childNodes;
+    const safeOffset = Num.clamp(offset, 0, childNodes.length - 1);
+    return childNodes[safeOffset];
+  } else {
+    return container;
   }
+};
 
-  return container;
+/** @deprecated Use getNode instead */
+const getNodeUnsafe = (container: Node, offset: number): Node | undefined => {
+  // If a negative offset is used on an element then `undefined` should be returned
+  if (offset < 0 && NodeType.isElement(container) && container.hasChildNodes()) {
+    return undefined;
+  } else {
+    return getNode(container, offset);
+  }
 };
 
 export {
   getSelectedNode,
-  getNode
+  getNode,
+  getNodeUnsafe
 };

--- a/modules/tinymce/src/core/main/ts/selection/RangeWalk.ts
+++ b/modules/tinymce/src/core/main/ts/selection/RangeWalk.ts
@@ -6,27 +6,15 @@
  */
 
 import DOMUtils from '../api/dom/DOMUtils';
+import * as NodeType from '../dom/NodeType';
+import * as RangeNodes from './RangeNodes';
 import { RangeLikeObject } from './RangeTypes';
 
-const clampToExistingChildren = (container: Node, index: number) => {
-  const childNodes = container.childNodes;
-
-  if (index >= childNodes.length) {
-    index = childNodes.length - 1;
-  } else if (index < 0) {
-    index = 0;
-  }
-
-  return childNodes[index] || container;
-};
-
-const getEndChild = (container: Node, index: number) => clampToExistingChildren(container, index - 1);
-
 const walk = (dom: DOMUtils, rng: RangeLikeObject, callback: (nodes: Node[]) => void) => {
-  let startContainer = rng.startContainer;
   const startOffset = rng.startOffset;
-  let endContainer = rng.endContainer;
+  const startContainer = RangeNodes.getNode(rng.startContainer, startOffset);
   const endOffset = rng.endOffset;
+  const endContainer = RangeNodes.getNode(rng.endContainer, endOffset - 1);
 
   /**
    * Excludes start/end text node if they are out side the range
@@ -36,24 +24,22 @@ const walk = (dom: DOMUtils, rng: RangeLikeObject, callback: (nodes: Node[]) => 
    * @return {Array} Array with nodes excluding the start/end container if needed.
    */
   const exclude = (nodes: Node[]) => {
-    let node;
-
     // First node is excluded
-    node = nodes[0];
-    if (node.nodeType === 3 && node === startContainer && startOffset >= node.nodeValue.length) {
+    const firstNode = nodes[0];
+    if (NodeType.isText(firstNode) && firstNode === startContainer && startOffset >= firstNode.data.length) {
       nodes.splice(0, 1);
     }
 
     // Last node is excluded
-    node = nodes[nodes.length - 1];
-    if (endOffset === 0 && nodes.length > 0 && node === endContainer && node.nodeType === 3) {
+    const lastNode = nodes[nodes.length - 1];
+    if (endOffset === 0 && nodes.length > 0 && lastNode === endContainer && NodeType.isText(lastNode)) {
       nodes.splice(nodes.length - 1, 1);
     }
 
     return nodes;
   };
 
-  const collectSiblings = (node: Node, name: string, endNode?: Node) => {
+  const collectSiblings = (node: Node | undefined, name: string, endNode?: Node) => {
     const siblings = [];
 
     for (; node && node !== endNode; node = node[name]) {
@@ -63,15 +49,8 @@ const walk = (dom: DOMUtils, rng: RangeLikeObject, callback: (nodes: Node[]) => 
     return siblings;
   };
 
-  const findEndPoint = (node: Node, root: Node) => {
-    do {
-      if (node.parentNode === root) {
-        return node;
-      }
-
-      node = node.parentNode;
-    } while (node);
-  };
+  const findEndPoint = (node: Node, root: Node) =>
+    dom.getParent(node, (node) => node.parentNode === root, root);
 
   const walkBoundary = (startNode: Node, endNode: Node, next?: boolean) => {
     const siblingName = next ? 'nextSibling' : 'previousSibling';
@@ -90,16 +69,6 @@ const walk = (dom: DOMUtils, rng: RangeLikeObject, callback: (nodes: Node[]) => 
     }
   };
 
-  // If index based start position then resolve it
-  if (startContainer.nodeType === 1 && startContainer.hasChildNodes()) {
-    startContainer = clampToExistingChildren(startContainer, startOffset);
-  }
-
-  // If index based end position then resolve it
-  if (endContainer.nodeType === 1 && endContainer.hasChildNodes()) {
-    endContainer = getEndChild(endContainer, endOffset);
-  }
-
   // Same container
   if (startContainer === endContainer) {
     return callback(exclude([ startContainer ]));
@@ -109,25 +78,13 @@ const walk = (dom: DOMUtils, rng: RangeLikeObject, callback: (nodes: Node[]) => 
   const ancestor = dom.findCommonAncestor(startContainer, endContainer);
 
   // Process left side
-  for (let node = startContainer; node; node = node.parentNode) {
-    if (node === endContainer) {
-      return walkBoundary(startContainer, ancestor, true);
-    }
-
-    if (node === ancestor) {
-      break;
-    }
+  if (dom.isChildOf(startContainer, endContainer)) {
+    return walkBoundary(startContainer, ancestor, true);
   }
 
   // Process right side
-  for (let node = endContainer; node; node = node.parentNode) {
-    if (node === startContainer) {
-      return walkBoundary(endContainer, ancestor);
-    }
-
-    if (node === ancestor) {
-      break;
-    }
+  if (dom.isChildOf(endContainer, startContainer)) {
+    return walkBoundary(endContainer, ancestor);
   }
 
   // Find start/end point

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -2323,7 +2323,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
         '</li>' +
       '</ul>'
     );
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 1, 2, 1 ], 0);
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 1, 2, 1 ], 1);
     editor.formatter.apply('aligncenter');
     assert.equal(getContent(editor),
       '<ul>' +
@@ -2351,7 +2351,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
         '</li>' +
       '</ol>'
     );
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 1, 2, 0 ], 0);
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 1, 2, 0 ], 1);
     editor.formatter.apply('aligncenter');
     assert.equal(getContent(editor),
       '<ol>' +
@@ -2363,6 +2363,34 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
           '</ol>' +
         '</li>' +
       '</ol>'
+    );
+  });
+
+  it('TINY-7393: Apply aligncenter to lists with other formatting', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ul>' +
+        '<li>a</li>' +
+        '<li><strong>b</strong><br />' +
+          '<ul>' +
+            '<li>c</li>' +
+            '<li>d</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>'
+    );
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 1, 2, 1 ], 1);
+    editor.formatter.apply('aligncenter');
+    assert.equal(getContent(editor),
+      '<ul>' +
+        '<li style="text-align: center;">a</li>' +
+        '<li style="text-align: center;"><strong>b</strong><br />' +
+          '<ul>' +
+            '<li style="text-align: center;">c</li>' +
+            '<li style="text-align: center;">d</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>'
     );
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -776,58 +776,79 @@ describe('browser.tinymce.core.dom.DOMUtils', () => {
     assert.equal(count, 0);
   });
 
-  it('get - by id in head', () => {
-    const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
+  context('get', () => {
+    it('by id in head', () => {
+      const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
 
-    const meta: HTMLMetaElement = document.createElement('meta');
-    meta.setAttribute('id', 'myid');
-    document.head.appendChild(meta);
+      const meta: HTMLMetaElement = document.createElement('meta');
+      meta.setAttribute('id', 'myid');
+      document.head.appendChild(meta);
 
-    assert.strictEqual(DOM.get('myid'), meta, 'get meta');
-    document.head.removeChild(meta);
+      assert.strictEqual(DOM.get('myid'), meta, 'get meta');
+      document.head.removeChild(meta);
+    });
+
+    it('does not find element by name in head', () => {
+      const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
+
+      const meta: HTMLMetaElement = document.createElement('meta');
+      meta.setAttribute('name', 'myname');
+      document.head.appendChild(meta);
+
+      assert.isNull(DOM.get('myname'), 'get meta');
+      document.head.removeChild(meta);
+    });
+
+    it('does not find element by name in body', () => {
+      const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
+
+      const meta: HTMLMetaElement = document.createElement('meta');
+      meta.setAttribute('name', 'myname');
+      document.body.appendChild(meta);
+
+      assert.isNull(DOM.get('myname'), 'get meta');
+      document.body.removeChild(meta);
+    });
+
+    it('finds element by id in body, not element by name in head', () => {
+      const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
+
+      const meta = document.createElement('meta');
+      meta.setAttribute('name', 'myname');
+      document.head.appendChild(meta);
+
+      const div = document.createElement('div');
+      div.setAttribute('id', 'myname');
+      document.body.appendChild(div);
+
+      assert.strictEqual(DOM.get('myname'), div, 'get div');
+      document.head.removeChild(meta);
+      document.body.removeChild(div);
+    });
+
+    it('returns element', () => {
+      const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
+      const e = document.createElement('div');
+      assert.strictEqual(DOM.get(e), e, 'get');
+    });
   });
 
-  it('get - does not find element by name in head', () => {
-    const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
+  context('isChildOf', () => {
+    it('same node', () => {
+      const p = document.createElement('div');
+      assert.isTrue(DOM.isChildOf(p, p), 'Same node');
+    });
 
-    const meta: HTMLMetaElement = document.createElement('meta');
-    meta.setAttribute('name', 'myname');
-    document.head.appendChild(meta);
-
-    assert.isNull(DOM.get('myname'), 'get meta');
-    document.head.removeChild(meta);
-  });
-
-  it('get - does not find element by name in body', () => {
-    const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
-
-    const meta: HTMLMetaElement = document.createElement('meta');
-    meta.setAttribute('name', 'myname');
-    document.body.appendChild(meta);
-
-    assert.isNull(DOM.get('myname'), 'get meta');
-    document.body.removeChild(meta);
-  });
-
-  it('get - finds element by id in body, not element by name in head', () => {
-    const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
-
-    const meta = document.createElement('meta');
-    meta.setAttribute('name', 'myname');
-    document.head.appendChild(meta);
-
-    const div = document.createElement('div');
-    div.setAttribute('id', 'myname');
-    document.body.appendChild(div);
-
-    assert.strictEqual(DOM.get('myname'), div, 'get div');
-    document.head.removeChild(meta);
-    document.body.removeChild(div);
-  });
-
-  it('get - returns element', () => {
-    const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
-    const e = document.createElement('div');
-    assert.strictEqual(DOM.get(e), e, 'get');
+    it('child nodes', () => {
+      const p = document.createElement('div');
+      const m = document.createElement('p');
+      const s = document.createTextNode('Content');
+      m.appendChild(s);
+      assert.isFalse(DOM.isChildOf(s, p), 'Detached text node');
+      assert.isFalse(DOM.isChildOf(m, p), 'Detached para node');
+      p.appendChild(m);
+      assert.isTrue(DOM.isChildOf(s, p), 'Attached text node');
+      assert.isTrue(DOM.isChildOf(m, p), 'Attached para node');
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -140,7 +140,9 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
       TinyAssertions.assertContent(editor, '<p><em>ab&nbsp; &nbsp;<strong>cd</strong></em></p>');
       TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 2, [ 0, 0, 0 ], 2);
     });
+  });
 
+  context('Remove single format with range selection', () => {
     it('TINY-6567: Remove format including the final item in the list', () => {
       const editor = hook.editor();
       editor.setContent(
@@ -179,7 +181,7 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
           '<li style="text-align: center;">2' +
             '<ul>' +
               '<li style="text-align: center;">a</li>' +
-              '<li style="text-align: center;">b' +
+              '<li style="text-align: center;"><strong>b</strong>' +
                 '<ul>' +
                   '<li style="text-align: center;">1</li>' +
                   '<li style="text-align: center;">2</li>' +
@@ -198,7 +200,7 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
           '<li>2' +
             '<ul>' +
               '<li>a</li>' +
-              '<li>b' +
+              '<li><strong>b</strong>' +
                 '<ul>' +
                   '<li>1</li>' +
                   '<li>2</li>' +

--- a/modules/tinymce/src/core/test/ts/browser/selection/RangeWalkTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/RangeWalkTest.ts
@@ -1,0 +1,113 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import * as RangeWalk from 'tinymce/core/selection/RangeWalk';
+import Theme from 'tinymce/themes/silver/Theme';
+
+describe('browser.tinymce.core.selection.RangeWalkTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Theme ]);
+
+  const complexList = '<ul>' +
+    '<li>Test 1</li>' +
+    '<li>Test 2' +
+      '<ul>' +
+        '<li>Test 2.1</li>' +
+        '<li><strong>Test 2.2</strong>' +
+          '<ul>' +
+            '<li>Test 2.2.1</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>' +
+    '</li>' +
+    '<li>Test 3</li>' +
+  '</ul>';
+
+  const testWalking = (editor: Editor, expected: string[][]) => {
+    const nodeNames: string[][] = [];
+
+    const rng = editor.selection.getRng();
+    RangeWalk.walk(editor.dom, rng, (nodes) => {
+      nodeNames.push(Arr.map(nodes, (node) => node.nodeName.toLowerCase()));
+    });
+
+    assert.deepEqual(nodeNames, expected);
+  };
+
+  it('TBD: should only include itself if the full node is selected', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<div>' +
+      '<p>Paragraph 1</p>' +
+      '<p>Paragraph 2, with <strong>bold</strong> content</p>' +
+      '</div>'
+    );
+    TinySelections.setSelection(editor, [], 0, [], 1);
+
+    testWalking(editor, [
+      [ 'div' ]
+    ]);
+  });
+
+  it('TBD: should only traverse the boundaries once if the end node is inside the start node', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><strong>Some <em>text <span style="color: red">with</span> formatting</em></strong></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0, 0, 1, 1, 0 ], 2);
+
+    testWalking(editor, [
+      [ '#text' ],
+      [ '#text' ],
+      [ '#text' ]
+    ]);
+  });
+
+  it('TBD: should only traverse the boundaries once if the start node is inside the end node', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><strong>Some <em>text <span style="color: red">with</span> formatting</em></strong></p>');
+    TinySelections.setSelection(editor, [ 0, 0, 1, 1, 0 ], 2, [ 0 ], 1);
+
+    testWalking(editor, [
+      [ '#text' ],
+      [ '#text' ]
+    ]);
+  });
+
+  it('TBD: should only walk over siblings and not traverse down', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<div>' +
+      '<p>Paragraph 1</p>' +
+      '<ul>' +
+        '<li>List item</li>' +
+      '</ul>' +
+      '<p>Paragraph 2, with <strong>bold</strong> content</p>' +
+      '</div>'
+    );
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
+
+    testWalking(editor, [
+      [ 'p', 'ul', 'p' ]
+    ]);
+  });
+
+  it('TINY-7393: should exclude edge nodes when walking boundaries', () => {
+    const editor = hook.editor();
+    editor.setContent(complexList);
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 1, 1, 1, 1, 0, 0 ], 4);
+
+    testWalking(editor, [
+      // Left boundary
+      [ '#text' ],
+      // Right boundary
+      [ '#text' ],
+      [ 'strong' ],
+      [ 'li' ],
+      [ '#text' ]
+    ]);
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/selection/RangeWalkTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/RangeWalkTest.ts
@@ -39,7 +39,7 @@ describe('browser.tinymce.core.selection.RangeWalkTest', () => {
     assert.deepEqual(nodeNames, expected);
   };
 
-  it('TBD: should only include itself if the full node is selected', () => {
+  it('should only include itself if the full node is selected', () => {
     const editor = hook.editor();
     editor.setContent(
       '<div>' +
@@ -54,7 +54,7 @@ describe('browser.tinymce.core.selection.RangeWalkTest', () => {
     ]);
   });
 
-  it('TBD: should only traverse the boundaries once if the end node is inside the start node', () => {
+  it('should only traverse the boundaries once if the end node is inside the start node', () => {
     const editor = hook.editor();
     editor.setContent('<p><strong>Some <em>text <span style="color: red">with</span> formatting</em></strong></p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0, 0, 1, 1, 0 ], 2);
@@ -66,7 +66,7 @@ describe('browser.tinymce.core.selection.RangeWalkTest', () => {
     ]);
   });
 
-  it('TBD: should only traverse the boundaries once if the start node is inside the end node', () => {
+  it('should only traverse the boundaries once if the start node is inside the end node', () => {
     const editor = hook.editor();
     editor.setContent('<p><strong>Some <em>text <span style="color: red">with</span> formatting</em></strong></p>');
     TinySelections.setSelection(editor, [ 0, 0, 1, 1, 0 ], 2, [ 0 ], 1);
@@ -77,7 +77,7 @@ describe('browser.tinymce.core.selection.RangeWalkTest', () => {
     ]);
   });
 
-  it('TBD: should only walk over siblings and not traverse down', () => {
+  it('should only walk over siblings and not traverse down', () => {
     const editor = hook.editor();
     editor.setContent(
       '<div>' +
@@ -95,7 +95,7 @@ describe('browser.tinymce.core.selection.RangeWalkTest', () => {
     ]);
   });
 
-  it('TINY-7393: should exclude edge nodes when walking boundaries', () => {
+  it('should exclude edge nodes when walking boundaries', () => {
     const editor = hook.editor();
     editor.setContent(complexList);
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 1, 1, 1, 1, 0, 0 ], 4);


### PR DESCRIPTION
**Related Ticket:** TINY-7393

**Description of Changes:**
* Fixes an issue where selector formats (eg center alignment) wouldn't work due to how the ranges are walked (only nodes that are fully selected are returned). This expands on the original fix done in: https://github.com/tinymce/tinymce/pull/6666
* As part of this, I tried a number of solutions, one of which was making range walker return all the leaf nodes (which did work but ran into other edge case issues). As part of that I did a fair amount of clean up and wrote some additional tests, as `RangeWalk` has no tests currently, so this includes all of those clean ups/improvements as well (as discussed at standup).

Note: There's 2 commits to help with reviewing the different parts above.

**Additional information:**
So for those not familiar with formats, TinyMCE has 3 types of formats: block, inline and selector. Both block and inline formats will wrap/replace the relevant nodes within the selection. Selector formats are different, as they match existing nodes and mutate them instead.

Now, the most useful background information to know here is that when applying the format, it'll take the current selection and expand it to match the format being applied for block and selector formats (both are expanded differently). So in the selector case, it'll expand the start and end container until it find a nodes that matches the selector provided in the format. So for lists, it'll expand out to the closest `li` elements. So the problem here, is since the selection expands to the closest node that matches, the entire list item isn't in the selection so only the nodes that are fully in the selection are processed when walking.

So this solution expands on the previous one, which takes each node processed and firstly tries to apply the format directly to the node. If the format matches, then nothing more is done. However, if it's not matched then we walk up to the parent and also try to apply the selection there (which in this case will be the `li` elements). We need to make sure we don't do this however, if the selector format is configured to not expand.

**Pre-checks:**
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

**Review:**
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
