### PR TITLE
TINY-7665: Update the context toolbar to hide the bubble arrow when using an inset layout

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a new `preserve` option to `LayoutInset` which will preserve the previous placement inside the component.
 - Added a new `flip` option to `LayoutInset` which will swap the previous placement to the opposite direction inside the component.
 - Added the `alwaysFit` layout property which allows for the layout to specify if it should always claim to fit, no matter what.
+- `Bubble` can include an optional `inset` class to be added when using an inset layout.
 
 ### Improved
 - Improved the performance of constructing event handlers and components.

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added new `focus` property to the `Blocking` behaviour config.
-- Added a new `preserve` option to `LayoutInside` which will preserve the previous placement inside the component.
-- Added a new `flip` option to `LayoutInside` which will swap the previous placement to the opposite direction inside the component.
+- Added a new `preserve` option to `LayoutInset` which will preserve the previous placement inside the component.
+- Added a new `flip` option to `LayoutInset` which will swap the previous placement to the opposite direction inside the component.
 - Added the `alwaysFit` layout property which allows for the layout to specify if it should always claim to fit, no matter what.
 
 ### Improved
@@ -18,12 +18,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Changed disconnected components to log a warning instead of throwing an error when triggering or broadcasting events.
-- Changed `LayoutInside` rendering behaviour, as it was inconsistent with other layouts. It will now mirror the `Layout` logic for each direction.
+- Renamed `LayoutInside` to `LayoutInset` to better reflect what it does.
+- Changed `LayoutInset` rendering behaviour, as it was inconsistent with other layouts. It will now mirror the `Layout` logic for each direction.
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
 
 ### Fixed
-- Fixed a number of positioning bugs when using an "inside" layout, especially any that renders at the bottom.
-- `LayoutInside` bubble classes were applied incorrectly, causing the bubble arrows to show on the opposite side.
+- Fixed a number of positioning bugs when using an "inset" layout, especially any that renders at the bottom.
+- `LayoutInset` bubble classes were applied incorrectly, causing the bubble arrows to show on the opposite side.
 
 ## 8.2.0 - 2021-05-06
 

--- a/modules/alloy/src/demo/html/layout-inset-demo.html
+++ b/modules/alloy/src/demo/html/layout-inset-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <title>LayoutInside Demo</title>
+    <title>LayoutInset Demo</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link href="../css/alloy-demo.css" rel="Stylesheet">
 
@@ -13,10 +13,10 @@
   </head>
 
   <body>
-    <h2>LayoutInside Demo</h2>
+    <h2>LayoutInset Demo</h2>
 
     <div id="ephox-ui"></div>
     <script type="text/javascript" src="../../../demo.js"></script>
-    <script>demos.LayoutInsideDemo();</script>
+    <script>demos.LayoutInsetDemo();</script>
   </body>
 </html>

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/Demos.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/Demos.ts
@@ -19,7 +19,7 @@ import HtmlConverter from './HtmlConverter';
 import * as HtmlDisplay from './HtmlDisplay';
 import InlinesDemo from './InlinesDemo';
 import InspectorDemo from './InspectorDemo';
-import LayoutInsideDemo from './LayoutInsideDemo';
+import LayoutInsetDemo from './LayoutInsetDemo';
 import LongpressDemo from './LongpressDemo';
 import PinchingDemo from './PinchingDemo';
 import PositionDemo from './PositionDemo';
@@ -55,7 +55,7 @@ window.demos = {
   HtmlDisplay,
   InlinesDemo,
   InspectorDemo,
-  LayoutInsideDemo,
+  LayoutInsetDemo,
   LongpressDemo,
   PinchingDemo,
   PositionDemo,

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/LayoutInsetDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/LayoutInsetDemo.ts
@@ -9,7 +9,7 @@ import { Button } from 'ephox/alloy/api/ui/Button';
 import { Container } from 'ephox/alloy/api/ui/Container';
 import * as DemoSink from 'ephox/alloy/demo/DemoSink';
 import * as HtmlDisplay from 'ephox/alloy/demo/HtmlDisplay';
-import * as LayoutInside from 'ephox/alloy/positioning/layout/LayoutInside';
+import * as LayoutInset from 'ephox/alloy/positioning/layout/LayoutInset';
 import { Layouts } from 'ephox/alloy/positioning/mode/Anchoring';
 
 export default (): void => {
@@ -82,37 +82,37 @@ export default (): void => {
 
   // North
   makeExample('n', 'top', 'top', {
-    onLtr: () => [ LayoutInside.north ],
-    onRtl: () => [ LayoutInside.north ]
+    onLtr: () => [ LayoutInset.north ],
+    onRtl: () => [ LayoutInset.north ]
   });
 
   // South
   makeExample('s', 'bottom', 'bottom', {
-    onLtr: () => [ LayoutInside.south ],
-    onRtl: () => [ LayoutInside.south ]
+    onLtr: () => [ LayoutInset.south ],
+    onRtl: () => [ LayoutInset.south ]
   });
 
   // East/west
   makeExample('e', 'right', 'left', {
-    onLtr: () => [ LayoutInside.east ],
-    onRtl: () => [ LayoutInside.west ]
+    onLtr: () => [ LayoutInset.east ],
+    onRtl: () => [ LayoutInset.west ]
   });
 
   // West/east
   makeExample('w', 'left', 'right', {
-    onLtr: () => [ LayoutInside.west ],
-    onRtl: () => [ LayoutInside.east ]
+    onLtr: () => [ LayoutInset.west ],
+    onRtl: () => [ LayoutInset.east ]
   });
 
   // Northeast/northwest
   makeExample('ne-nw', 'top right', 'top left', {
-    onLtr: () => [ LayoutInside.northwest ],
-    onRtl: () => [ LayoutInside.northeast ]
+    onLtr: () => [ LayoutInset.northwest ],
+    onRtl: () => [ LayoutInset.northeast ]
   });
 
   // Southeast/southwestt
   makeExample('se-sw', 'bottom right', 'bottom left', {
-    onLtr: () => [ LayoutInside.southwest ],
-    onRtl: () => [ LayoutInside.southeast ]
+    onLtr: () => [ LayoutInset.southwest ],
+    onRtl: () => [ LayoutInset.southeast ]
   });
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
@@ -16,7 +16,7 @@ import * as AlloyParts from '../parts/AlloyParts';
 import * as PartType from '../parts/PartType';
 import * as Bubble from '../positioning/layout/Bubble';
 import * as Layout from '../positioning/layout/Layout';
-import * as LayoutInside from '../positioning/layout/LayoutInside';
+import * as LayoutInset from '../positioning/layout/LayoutInset';
 import * as LayoutTypes from '../positioning/layout/LayoutTypes';
 import * as MaxHeight from '../positioning/layout/MaxHeight';
 import * as MaxWidth from '../positioning/layout/MaxWidth';
@@ -246,7 +246,7 @@ export {
 
   // layout
   Layout,
-  LayoutInside,
+  LayoutInset,
   LayoutTypes,
   Bubble,
   MaxHeight,

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Bubble.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Bubble.ts
@@ -16,14 +16,14 @@ export interface Bubble {
   north: () => BubbleInstance;
   east: () => BubbleInstance;
   west: () => BubbleInstance;
-  innerSoutheast: () => BubbleInstance;
-  innerSouthwest: () => BubbleInstance;
-  innerNorthwest: () => BubbleInstance;
-  innerNortheast: () => BubbleInstance;
-  innerSouth: () => BubbleInstance;
-  innerNorth: () => BubbleInstance;
-  innerEast: () => BubbleInstance;
-  innerWest: () => BubbleInstance;
+  insetSoutheast: () => BubbleInstance;
+  insetSouthwest: () => BubbleInstance;
+  insetNorthwest: () => BubbleInstance;
+  insetNortheast: () => BubbleInstance;
+  insetSouth: () => BubbleInstance;
+  insetNorth: () => BubbleInstance;
+  insetEast: () => BubbleInstance;
+  insetWest: () => BubbleInstance;
 }
 
 export interface BubbleAlignments {
@@ -80,14 +80,14 @@ const nu = (width: number, yoffset: number, classes: BubbleAlignments): Bubble =
     north: () => make(-width / 2, -yoffset, [ 'bottom', 'alignCentre' ]),
     east: () => make(width, -yoffset / 2, [ 'valignCentre', 'left' ]),
     west: () => make(-width, -yoffset / 2, [ 'valignCentre', 'right' ]),
-    innerNortheast: () => make(width, yoffset, [ 'top', 'alignLeft' ]),
-    innerNorthwest: () => make(-width, yoffset, [ 'top', 'alignRight' ]),
-    innerNorth: () => make(-width / 2, yoffset, [ 'top', 'alignCentre' ]),
-    innerSoutheast: () => make(width, -yoffset, [ 'bottom', 'alignLeft' ]),
-    innerSouthwest: () => make(-width, -yoffset, [ 'bottom', 'alignRight' ]),
-    innerSouth: () => make(-width / 2, -yoffset, [ 'bottom', 'alignCentre' ]),
-    innerEast: () => make(-width, -yoffset / 2, [ 'valignCentre', 'right' ]),
-    innerWest: () => make(width, -yoffset / 2, [ 'valignCentre', 'left' ])
+    insetNortheast: () => make(width, yoffset, [ 'top', 'alignLeft' ]),
+    insetNorthwest: () => make(-width, yoffset, [ 'top', 'alignRight' ]),
+    insetNorth: () => make(-width / 2, yoffset, [ 'top', 'alignCentre' ]),
+    insetSoutheast: () => make(width, -yoffset, [ 'bottom', 'alignLeft' ]),
+    insetSouthwest: () => make(-width, -yoffset, [ 'bottom', 'alignRight' ]),
+    insetSouth: () => make(-width / 2, -yoffset, [ 'bottom', 'alignCentre' ]),
+    insetEast: () => make(-width, -yoffset / 2, [ 'valignCentre', 'right' ]),
+    insetWest: () => make(width, -yoffset / 2, [ 'valignCentre', 'left' ])
   };
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Bubble.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Bubble.ts
@@ -44,6 +44,9 @@ export interface BubbleAlignments {
   left?: string[];
   // Used for west
   right?: string[];
+
+  // Used for insets
+  inset?: string[];
 }
 
 const allAlignments: Array<keyof BubbleAlignments> = [
@@ -56,10 +59,15 @@ const allAlignments: Array<keyof BubbleAlignments> = [
   'top',
   'bottom',
   'left',
-  'right'
+  'right',
+
+  'inset'
 ];
 
-const nu = (width: number, yoffset: number, classes: BubbleAlignments): Bubble => {
+const nu = (xOffset: number, yOffset: number, classes: BubbleAlignments, insetModifier: number = 1): Bubble => {
+  const insetXOffset = xOffset * insetModifier;
+  const insetYOffset = yOffset * insetModifier;
+
   const getClasses = (prop: keyof BubbleAlignments): string[] => Obj.get(classes, prop).getOr([ ]);
 
   const make = (xDelta: number, yDelta: number, alignmentsOn: Array<(keyof BubbleAlignments)>) => {
@@ -72,22 +80,22 @@ const nu = (width: number, yoffset: number, classes: BubbleAlignments): Bubble =
   };
 
   return {
-    southeast: () => make(-width, yoffset, [ 'top', 'alignLeft' ]),
-    southwest: () => make(width, yoffset, [ 'top', 'alignRight' ]),
-    south: () => make(-width / 2, yoffset, [ 'top', 'alignCentre' ]),
-    northeast: () => make(-width, -yoffset, [ 'bottom', 'alignLeft' ]),
-    northwest: () => make(width, -yoffset, [ 'bottom', 'alignRight' ]),
-    north: () => make(-width / 2, -yoffset, [ 'bottom', 'alignCentre' ]),
-    east: () => make(width, -yoffset / 2, [ 'valignCentre', 'left' ]),
-    west: () => make(-width, -yoffset / 2, [ 'valignCentre', 'right' ]),
-    insetNortheast: () => make(width, yoffset, [ 'top', 'alignLeft' ]),
-    insetNorthwest: () => make(-width, yoffset, [ 'top', 'alignRight' ]),
-    insetNorth: () => make(-width / 2, yoffset, [ 'top', 'alignCentre' ]),
-    insetSoutheast: () => make(width, -yoffset, [ 'bottom', 'alignLeft' ]),
-    insetSouthwest: () => make(-width, -yoffset, [ 'bottom', 'alignRight' ]),
-    insetSouth: () => make(-width / 2, -yoffset, [ 'bottom', 'alignCentre' ]),
-    insetEast: () => make(-width, -yoffset / 2, [ 'valignCentre', 'right' ]),
-    insetWest: () => make(width, -yoffset / 2, [ 'valignCentre', 'left' ])
+    southeast: () => make(-xOffset, yOffset, [ 'top', 'alignLeft' ]),
+    southwest: () => make(xOffset, yOffset, [ 'top', 'alignRight' ]),
+    south: () => make(-xOffset / 2, yOffset, [ 'top', 'alignCentre' ]),
+    northeast: () => make(-xOffset, -yOffset, [ 'bottom', 'alignLeft' ]),
+    northwest: () => make(xOffset, -yOffset, [ 'bottom', 'alignRight' ]),
+    north: () => make(-xOffset / 2, -yOffset, [ 'bottom', 'alignCentre' ]),
+    east: () => make(xOffset, -yOffset / 2, [ 'valignCentre', 'left' ]),
+    west: () => make(-xOffset, -yOffset / 2, [ 'valignCentre', 'right' ]),
+    insetNortheast: () => make(insetXOffset, insetYOffset, [ 'top', 'alignLeft', 'inset' ]),
+    insetNorthwest: () => make(-insetXOffset, insetYOffset, [ 'top', 'alignRight', 'inset' ]),
+    insetNorth: () => make(-insetXOffset / 2, insetYOffset, [ 'top', 'alignCentre', 'inset' ]),
+    insetSoutheast: () => make(insetXOffset, -insetYOffset, [ 'bottom', 'alignLeft', 'inset' ]),
+    insetSouthwest: () => make(-insetXOffset, -insetYOffset, [ 'bottom', 'alignRight', 'inset' ]),
+    insetSouth: () => make(-insetXOffset / 2, -insetYOffset, [ 'bottom', 'alignCentre', 'inset' ]),
+    insetEast: () => make(-insetXOffset, -insetYOffset / 2, [ 'valignCentre', 'right', 'inset' ]),
+    insetWest: () => make(insetXOffset, -insetYOffset / 2, [ 'valignCentre', 'left', 'inset' ])
   };
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInset.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInset.ts
@@ -12,7 +12,7 @@ import { Placement, getPlacement } from './Placement';
   the `Layout` logic.
 
   As an example `Layout.north` will appear horizontally centered above the anchor, whereas
-  `LayoutInside.north` will appear horizontally centered overlapping the top of the anchor.
+  `LayoutInset.north` will appear horizontally centered overlapping the top of the anchor.
  */
 
 const labelPrefix = 'layout-inner';
@@ -39,7 +39,7 @@ const centreY = (anchor: AnchorBox, element: AnchorElement): number => anchor.y 
 const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   eastEdgeX(anchor, element),
   southY(anchor, element),
-  bubbles.innerSouthwest(),
+  bubbles.insetSouthwest(),
   Direction.northwest(),
   Placement.Southwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.BottomEdge }),
@@ -50,7 +50,7 @@ const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
 const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   westEdgeX(anchor),
   southY(anchor, element),
-  bubbles.innerSoutheast(),
+  bubbles.insetSoutheast(),
   Direction.northeast(),
   Placement.Southeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.BottomEdge }),
@@ -61,7 +61,7 @@ const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
 const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   eastEdgeX(anchor, element),
   northY(anchor),
-  bubbles.innerNorthwest(),
+  bubbles.insetNorthwest(),
   Direction.southwest(),
   Placement.Northwest,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.TopEdge }),
@@ -72,7 +72,7 @@ const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
 const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   westEdgeX(anchor),
   northY(anchor),
-  bubbles.innerNortheast(),
+  bubbles.insetNortheast(),
   Direction.southeast(),
   Placement.Northeast,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.TopEdge }),
@@ -83,7 +83,7 @@ const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
 const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   middleX(anchor, element),
   northY(anchor),
-  bubbles.innerNorth(),
+  bubbles.insetNorth(),
   Direction.south(),
   Placement.North,
   boundsRestriction(anchor, { top: AnchorBoxBounds.TopEdge }),
@@ -94,7 +94,7 @@ const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
 const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   middleX(anchor, element),
   southY(anchor, element),
-  bubbles.innerSouth(),
+  bubbles.insetSouth(),
   Direction.north(),
   Placement.South,
   boundsRestriction(anchor, { bottom: AnchorBoxBounds.BottomEdge }),
@@ -105,7 +105,7 @@ const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
 const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   eastEdgeX(anchor, element),
   centreY(anchor, element),
-  bubbles.innerEast(),
+  bubbles.insetEast(),
   Direction.west(),
   Placement.East,
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge }),
@@ -116,7 +116,7 @@ const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
 const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   westEdgeX(anchor),
   centreY(anchor, element),
-  bubbles.innerWest(),
+  bubbles.insetWest(),
   Direction.east(),
   Placement.West,
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge }),

--- a/modules/alloy/src/test/ts/browser/position/layout/LayoutInsetTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/layout/LayoutInsetTest.ts
@@ -6,11 +6,11 @@ import * as fc from 'fast-check';
 
 import * as Boxes from 'ephox/alloy/alien/Boxes';
 import * as Bubble from 'ephox/alloy/positioning/layout/Bubble';
-import * as LayoutInside from 'ephox/alloy/positioning/layout/LayoutInside';
+import * as LayoutInset from 'ephox/alloy/positioning/layout/LayoutInset';
 import { Placement, setPlacement } from 'ephox/alloy/positioning/layout/Placement';
 import { boxArb } from 'ephox/alloy/test/BoundsUtils';
 
-describe('LayoutInsideTest', () => {
+describe('LayoutInsetTest', () => {
   const placements = [
     Placement.North, Placement.South, Placement.Northeast, Placement.Southeast,
     Placement.Northwest, Placement.Southwest, Placement.East, Placement.West
@@ -21,14 +21,14 @@ describe('LayoutInsideTest', () => {
       const element = SugarElement.fromTag('div');
       fc.assert(fc.property(boxArb(), fc.constantFrom(...placements), (box, placement) => {
         setPlacement(element, placement);
-        const newLayout = LayoutInside.preserve(box, { width: 10, height: 10 }, Bubble.fallback(), element);
+        const newLayout = LayoutInset.preserve(box, { width: 10, height: 10 }, Bubble.fallback(), element);
         assert.equal(newLayout.placement, placement);
       }));
     });
 
     it('TINY-7545: falls back to north if no previous placement is found', () => {
       const element = SugarElement.fromTag('div');
-      const newLayout = LayoutInside.preserve(Boxes.bounds(0, 0, 50, 50), { width: 10, height: 10 }, Bubble.fallback(), element);
+      const newLayout = LayoutInset.preserve(Boxes.bounds(0, 0, 50, 50), { width: 10, height: 10 }, Bubble.fallback(), element);
       assert.equal(newLayout.placement, Placement.North);
     });
   });
@@ -54,7 +54,7 @@ describe('LayoutInsideTest', () => {
       const element = SugarElement.fromTag('div');
       fc.assert(fc.property(boxArb(), fc.constantFrom(...placements), (box, placement) => {
         setPlacement(element, placement);
-        const newLayout = LayoutInside.flip(box, { width: 10, height: 10 }, Bubble.fallback(), element);
+        const newLayout = LayoutInset.flip(box, { width: 10, height: 10 }, Bubble.fallback(), element);
         const expectedLayout = getExpectedFlippedPlacement(placement);
         assert.equal(newLayout.placement, expectedLayout);
       }));
@@ -62,7 +62,7 @@ describe('LayoutInsideTest', () => {
 
     it('TINY-7192: falls back to north if no previous placement is found', () => {
       const element = SugarElement.fromTag('div');
-      const newLayout = LayoutInside.flip(Boxes.bounds(0, 0, 50, 50), { width: 10, height: 10 }, Bubble.fallback(), element);
+      const newLayout = LayoutInset.flip(Boxes.bounds(0, 0, 50, 50), { width: 10, height: 10 }, Bubble.fallback(), element);
       assert.equal(newLayout.placement, Placement.North);
     });
   });

--- a/modules/alloy/src/test/ts/browser/position/view/BounderOverlappingTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/view/BounderOverlappingTest.ts
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 
 import { Bounds, bounds } from 'ephox/alloy/alien/Boxes';
 import { Bubble, BubbleInstance } from 'ephox/alloy/positioning/layout/Bubble';
-import * as LayoutInside from 'ephox/alloy/positioning/layout/LayoutInside';
+import * as LayoutInset from 'ephox/alloy/positioning/layout/LayoutInset';
 import { AnchorBox, AnchorElement, AnchorLayout } from 'ephox/alloy/positioning/layout/LayoutTypes';
 import * as Bounder from 'ephox/alloy/positioning/view/Bounder';
 
@@ -89,19 +89,19 @@ describe('BounderOverlappingTest', () => {
       north: notImplemented,
       east: notImplemented,
       west: notImplemented,
-      innerSouthwest: southwest,
-      innerSoutheast: southeast,
-      innerSouth: south,
-      innerNorthwest: northwest,
-      innerNortheast: northeast,
-      innerNorth: north,
-      innerWest: west,
-      innerEast: east
+      insetSouthwest: southwest,
+      insetSoutheast: southeast,
+      insetSouth: south,
+      insetNorthwest: northwest,
+      insetNortheast: northeast,
+      insetNorth: north,
+      insetWest: west,
+      insetEast: east
     };
   };
 
-  const four = [ LayoutInside.southeast, LayoutInside.southwest, LayoutInside.northeast, LayoutInside.northwest ];
-  const two = [ LayoutInside.east, LayoutInside.west ];
+  const four = [ LayoutInset.southeast, LayoutInset.southwest, LayoutInset.northeast, LayoutInset.northwest ];
+  const two = [ LayoutInset.east, LayoutInset.west ];
 
   const panelBox = bounds(0, 0, 15, 10);
   const bigPanel = bounds(0, 0, 100, 100);

--- a/modules/alloy/src/test/ts/browser/position/view/BounderToolbuttonTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/view/BounderToolbuttonTest.ts
@@ -90,14 +90,14 @@ describe('BounderToolbuttonTest', () => {
       north,
       east,
       west,
-      innerSouthwest: notImplemented,
-      innerSoutheast: notImplemented,
-      innerSouth: notImplemented,
-      innerNorthwest: notImplemented,
-      innerNortheast: notImplemented,
-      innerNorth: notImplemented,
-      innerWest: notImplemented,
-      innerEast: notImplemented
+      insetSouthwest: notImplemented,
+      insetSoutheast: notImplemented,
+      insetSouth: notImplemented,
+      insetNorthwest: notImplemented,
+      insetNortheast: notImplemented,
+      insetNorth: notImplemented,
+      insetWest: notImplemented,
+      insetEast: notImplemented
     };
   };
 

--- a/modules/oxide/src/less/theme/components/pop/pop.less
+++ b/modules/oxide/src/less/theme/components/pop/pop.less
@@ -64,6 +64,12 @@
     width: 0;
   }
 
+  // Hide the arrows on inset layouts
+  .tox-pop.tox-pop--inset::before,
+  .tox-pop.tox-pop--inset::after {
+    opacity: 0;
+  }
+
   // Default (bottom) pointing arrow
   .tox-pop.tox-pop--bottom::before,
   .tox-pop.tox-pop--bottom::after {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents #TINY-7249
 - Changed `emoticons`, `wordcount`, `code`, `codesample`, and `template` plugins to open dialogs using commands #TINY-7619
+- The context toolbar will no longer show an arrow when it overlaps the content, such as in table cells #TINY-7665
 
 ### Fixed
 - The `dir` attribute was being incorrectly applied to list items #TINY-4589

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Gui, GuiFactory, InlineView, Layout, LayoutInside, NodeAnchorSpec } from '@ephox/alloy';
+import { Gui, GuiFactory, InlineView, Layout, LayoutInset, NodeAnchorSpec } from '@ephox/alloy';
 import { Arr, Optional } from '@ephox/katamari';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 
@@ -22,9 +22,9 @@ export default (editor: Editor, extras, uiMothership: Gui.GuiSystem): Notificati
   const getLayoutDirection = (rel: 'tc-tc' | 'bc-bc' | 'bc-tc' | 'tc-bc') => {
     switch (rel) {
       case 'bc-bc':
-        return LayoutInside.south;
+        return LayoutInset.south;
       case 'tc-tc':
-        return LayoutInside.north;
+        return LayoutInset.north;
       case 'tc-bc':
         return Layout.north;
       case 'bc-tc':

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, Bubble, HotspotAnchorSpec, Layout, LayoutInside, MaxHeight, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
+import { AlloyComponent, Bubble, HotspotAnchorSpec, Layout, LayoutInset, MaxHeight, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SimSelection, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
@@ -36,8 +36,8 @@ const getInlineDialogAnchor = (contentAreaElement: () => SugarElement, lazyAncho
     node: Optional.from(contentAreaElement()),
     bubble: Bubble.nu(bubbleSize, bubbleSize, bubbleAlignments),
     layouts: {
-      onRtl: () => [ LayoutInside.northeast ],
-      onLtr: () => [ LayoutInside.northwest ]
+      onRtl: () => [ LayoutInset.northeast ],
+      onLtr: () => [ LayoutInset.northwest ]
     },
     overrides
   });
@@ -62,8 +62,8 @@ const getBannerAnchor = (contentAreaElement: () => SugarElement, lazyAnchorbar: 
     root: SugarShadowDom.getContentContainer(contentAreaElement()),
     node: Optional.from(contentAreaElement()),
     layouts: {
-      onRtl: () => [ LayoutInside.north ],
-      onLtr: () => [ LayoutInside.north ]
+      onRtl: () => [ LayoutInset.north ],
+      onLtr: () => [ LayoutInset.north ]
     }
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
@@ -32,7 +32,8 @@ const bubbleAlignments = {
   right: [ 'tox-pop--right' ],
   left: [ 'tox-pop--left' ],
   bottom: [ 'tox-pop--bottom' ],
-  top: [ 'tox-pop--top' ]
+  top: [ 'tox-pop--top' ],
+  inset: [ 'tox-pop--inset' ]
 };
 
 const anchorOverrides = {
@@ -110,7 +111,8 @@ const getAnchorLayout = (editor: Editor, position: InlineContent.ContextPosition
     };
   } else {
     return {
-      bubble: Bubble.nu(0, bubbleSize, bubbleAlignments),
+      // Ensure that insets use half the bubble size since we're hiding the bubble arrow
+      bubble: Bubble.nu(0, bubbleSize, bubbleAlignments, 0.5),
       layouts: getAnchorSpec(editor, isTouch, data),
       overrides: anchorOverrides
     };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AnchorSpec, Bounds, Bubble, Layout, LayoutInside, MaxHeight, MaxWidth } from '@ephox/alloy';
+import { AnchorSpec, Bounds, Bubble, Layout, LayoutInset, MaxHeight, MaxWidth } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
 import { Compare, Height, SugarElement, Traverse } from '@ephox/sugar';
@@ -14,7 +14,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import { getSelectionBounds, isVerticalOverlap } from './ContextToolbarBounds';
 
-type Layout = typeof LayoutInside.north;
+type Layout = typeof LayoutInset.north;
 
 export interface PositionData {
   readonly lastPos: () => Optional<Bounds>;
@@ -59,17 +59,17 @@ const determineInsideLayout = (editor: Editor, contextbar: SugarElement<HTMLElem
   if (isEntireElementSelected(editor, elem)) {
     // The entire anchor element is selected so it'll always overlap with the selection, in which case just
     // preserve or show at the top for a new anchor element.
-    return isSameAnchorElement ? LayoutInside.preserve : LayoutInside.north;
+    return isSameAnchorElement ? LayoutInset.preserve : LayoutInset.north;
   } else if (isSameAnchorElement) {
     // If overlapping and this wasn't triggered by a reposition then flip the placement
     const isOverlapping = data.lastPos().exists((box) => isVerticalOverlap(selectionBounds, box));
-    return isOverlapping && !data.isReposition() ? LayoutInside.flip : LayoutInside.preserve;
+    return isOverlapping && !data.isReposition() ? LayoutInset.flip : LayoutInset.preserve;
   } else {
     // Attempt to find the best layout to use that won't cause an overlap for the new anchor element
     return data.bounds().map((bounds) => {
       const contextbarHeight = Height.get(contextbar) + bubbleSize;
-      return bounds.y + contextbarHeight <= selectionBounds.y ? LayoutInside.north : LayoutInside.south;
-    }).getOr(LayoutInside.north);
+      return bounds.y + contextbarHeight <= selectionBounds.y ? LayoutInset.north : LayoutInset.south;
+    }).getOr(LayoutInset.north);
   }
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/MobileContextMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/MobileContextMenu.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, Bubble, InlineView, Layout, LayoutInside, MaxHeight, MaxWidth } from '@ephox/alloy';
+import { AlloyComponent, Bubble, InlineView, Layout, LayoutInset, MaxHeight, MaxWidth } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SimSelection, WindowSelection } from '@ephox/sugar';
@@ -27,9 +27,9 @@ type MenuItems = string | Array<string | SingleMenuItemSpec>;
 
 const layouts = {
   onLtr: () => [ Layout.south, Layout.southeast, Layout.southwest, Layout.northeast, Layout.northwest, Layout.north,
-    LayoutInside.north, LayoutInside.south, LayoutInside.northeast, LayoutInside.southeast, LayoutInside.northwest, LayoutInside.southwest ],
+    LayoutInset.north, LayoutInset.south, LayoutInset.northeast, LayoutInset.southeast, LayoutInset.northwest, LayoutInset.southwest ],
   onRtl: () => [ Layout.south, Layout.southwest, Layout.southeast, Layout.northwest, Layout.northeast, Layout.north,
-    LayoutInside.north, LayoutInside.south, LayoutInside.northwest, LayoutInside.southwest, LayoutInside.northeast, LayoutInside.southeast ]
+    LayoutInset.north, LayoutInset.south, LayoutInset.northwest, LayoutInset.southwest, LayoutInset.northeast, LayoutInset.southeast ]
 };
 
 const bubbleSize = 12;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
@@ -20,6 +20,9 @@ interface Scenario {
 }
 
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarDistractionFreePositionTest', () => {
+  const topSelector = '.tox-pop.tox-pop--bottom:not(.tox-pop--inset)';
+  const bottomSelector = '.tox-pop.tox-pop--top:not(.tox-pop--inset)';
+
   const hook = TinyHooks.bddSetup<Editor>({
     toolbar: false,
     menubar: false,
@@ -62,12 +65,12 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarDist
       editor.setContent(`<p style="height: 25px;${scenario.contentStyles || ''}">${scenario.content}</p>`);
       scrollTo(editor, 0, -250);
       TinySelections.setCursor(editor, scenario.cursor.elementPath, scenario.cursor.offset);
-      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), '.tox-pop.tox-pop--bottom' + scenario.classes);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), topSelector + scenario.classes);
       assertPosition('bottom', 1537);
 
       // Position the link at the top of the viewport
       scrollTo(editor, 0, 0);
-      await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), '.tox-pop.tox-pop--top' + scenario.classes);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), bottomSelector + scenario.classes);
       assertPosition('top', -1496);
 
       // Position the element off the bottom of the screen and check the toolbar is hidden
@@ -76,7 +79,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarDist
 
       // Position the element just back into view
       scrollTo(editor, 0, -60);
-      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), '.tox-pop.tox-pop--bottom' + scenario.classes);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), topSelector + scenario.classes);
       assertPosition('bottom', 1537);
 
       // Position the element off the top of the screen and check the toolbar is hidden

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -23,12 +23,21 @@ interface Scenario {
 }
 
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFramePosition test', () => {
+  const topSelector = '.tox-pop.tox-pop--bottom:not(.tox-pop--inset)';
+  const bottomSelector = '.tox-pop.tox-pop--top:not(.tox-pop--inset)';
+  const rightSelector = '.tox-pop.tox-pop--left:not(.tox-pop--inset)';
+  const topInsetSelector = '.tox-pop.tox-pop--top.tox-pop--inset';
+  const bottomInsetSelector = '.tox-pop.tox-pop--bottom.tox-pop--inset';
+
+  const fullscreenSelector = '.tox.tox-fullscreen';
+  const fullscreenButtonSelector = 'button[aria-label="Fullscreen"]';
+
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'fullscreen',
     toolbar: 'fullscreen',
     height: 400,
     base_url: '/project/tinymce/js/tinymce',
-    content_style: 'body, p { margin: 0; }',
+    content_style: 'body, p { margin: 0; } tr { height: 36px; }',
     setup: (ed: Editor) => {
       ed.ui.registry.addButton('alpha', {
         text: 'Alpha',
@@ -95,12 +104,12 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
       editor.focus();
       scrollTo(editor, 0, 200);
       TinySelections.setCursor(editor, scenario.cursor.elementPath, scenario.cursor.offset);
-      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), '.tox-pop.tox-pop--bottom' + scenario.classes);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), topSelector + scenario.classes);
       await pAssertPosition('bottom', 232);
 
       // Position the link at the top of the viewport, just below the toolbar
       scrollTo(editor, 0, 300);
-      await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), '.tox-pop.tox-pop--top' + scenario.classes);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), bottomSelector + scenario.classes);
       await pAssertPosition('top', -289);
 
       // Position the behind the menu/toolbar and check the context toolbar is hidden
@@ -109,7 +118,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
 
       // Position the element back into view
       scrollTo(editor, 0, 200);
-      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), '.tox-pop.tox-pop--bottom' + scenario.classes);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), topSelector + scenario.classes);
       await pAssertPosition('bottom', 232);
 
       // Position the element off the top of the screen and check the context toolbar is hidden
@@ -117,9 +126,6 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
       await pWaitForToolbarHidden();
     });
   };
-
-  const fullscreenSelector = '.tox.tox-fullscreen';
-  const fullscreenButtonSelector = 'button[aria-label="Fullscreen"]';
 
   context('Context toolbar selection position while scrolling', () => {
     // north/south
@@ -161,14 +167,14 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     const editor = hook.editor();
     editor.setContent(`<p><img src="${getGreenImageDataUrl()}" style="height: 380px; width: 100px"></p>`);
     TinySelections.select(editor, 'img', []);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear to top inside content', SugarBody.body(), '.tox-pop.tox-pop--top');
-    await pAssertPosition('top', -309);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear to top inside content', SugarBody.body(), topInsetSelector);
+    await pAssertPosition('top', -315);
     TinySelections.setCursor(editor, [ 0 ], 1);
     TinyContentActions.keystroke(editor, Keys.enter());
     TinyContentActions.keystroke(editor, Keys.enter());
     editor.nodeChanged();
     TinySelections.select(editor, 'img', []);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), '.tox-pop.tox-pop--top');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), bottomSelector);
     await pAssertPosition('top', -56);
   });
 
@@ -183,7 +189,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     TinySelections.setCursor(editor, [ 1, 0 ], 0);
 
     // Middle
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear', SugarBody.body(), '.tox-pop.tox-pop--left');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear', SugarBody.body(), rightSelector);
     await pAssertPosition('top', -155);
 
     // Scroll so div is below the status bar
@@ -192,7 +198,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
 
     // Bottom
     scrollTo(editor, 0, 100);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear', SugarBody.body(), '.tox-pop.tox-pop--left');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear', SugarBody.body(), rightSelector);
     await pAssertPosition('top', -40);
 
     // Scroll so div is behind header
@@ -201,7 +207,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
 
     // Top
     scrollTo(editor, 0, 420);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear', SugarBody.body(), '.tox-pop.tox-pop--left');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear', SugarBody.body(), rightSelector);
     await pAssertPosition('top', -321);
   });
 
@@ -211,9 +217,9 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     TinyUiActions.pWaitForUi(editor, fullscreenSelector);
     editor.setContent(`<p><img src="${getGreenImageDataUrl()}" style="height: 380px; width: 100px"></p>`);
     TinySelections.select(editor, 'img', []);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear to top inside content', SugarBody.body(), '.tox-pop.tox-pop--top');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear to below the content', SugarBody.body(), bottomSelector);
     await pAssertFullscreenPosition('top', 470);
-    await UiFinder.pWaitForVisible('Check toolbar is still visible', SugarBody.body(), '.tox-pop.tox-pop--top');
+    await UiFinder.pWaitForVisible('Check toolbar is still visible', SugarBody.body(), bottomSelector);
     TinyUiActions.clickOnToolbar(editor, fullscreenButtonSelector);
     await Waiter.pTryUntil('Wait for fullscreen to turn off', () => UiFinder.notExists(SugarBody.body(), fullscreenSelector));
   });
@@ -223,7 +229,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     Css.set(TinyDom.container(editor), 'margin-bottom', '5000px');
     editor.setContent('<p><a href="http://tiny.cloud">link</a></p>');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), '.tox-pop.tox-pop--top');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), bottomSelector);
     await Waiter.pWait(250); // TODO: Find out why Safari fails without this wait
     window.scrollTo(0, 2000);
     await UiFinder.pWaitForHidden('Waiting for toolbar to be hidden', SugarBody.body(), '.tox-pop');
@@ -238,23 +244,23 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
       '<p style="padding-top: 200px"></p>'
     );
     TinySelections.select(editor, 'img', []);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top outside content', SugarBody.body(), '.tox-pop.tox-pop--bottom');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top outside content', SugarBody.body(), topSelector);
     await pAssertPosition('bottom', 111);
 
     scrollTo(editor, 0, 400);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), '.tox-pop.tox-pop--top');
-    await pAssertPosition('top', -309);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), topInsetSelector);
+    await pAssertPosition('top', -315);
 
-    // Note: Can't wait for the anchor classes here as they will remain the same
     scrollTo(editor, 0, 700);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the bottom outside content', SugarBody.body(), bottomSelector);
     await pAssertPosition('top', -234);
 
     scrollTo(editor, 0, 400);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the bottom inside content', SugarBody.body(), '.tox-pop.tox-pop--bottom');
-    await pAssertPosition('bottom', 12);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the bottom inside content', SugarBody.body(), bottomInsetSelector);
+    await pAssertPosition('bottom', 6);
 
-    // Note: Can't wait for the anchor classes here as they will remain the same
     scrollTo(editor, 0, 0);
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the bottom inside content', SugarBody.body(), topSelector);
     await pAssertPosition('bottom', 111);
   });
 
@@ -269,12 +275,12 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
 
     // Select the div and make sure the toolbar shows to the right
     TinySelections.setCursor(editor, [ 1, 0 ], 0);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear', SugarBody.body(), '.tox-pop.tox-pop--left');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear', SugarBody.body(), rightSelector);
 
     // Scroll to and select the image, then make sure the toolbar appears at the top
     scrollTo(editor, 0, 400);
     TinySelections.select(editor, 'img', []);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), '.tox-pop.tox-pop--top');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), topInsetSelector);
   });
 
   it('TINY-7192: Toolbar should flip to the opposite position when the selection overlaps', async () => {
@@ -290,23 +296,23 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
 
     // Select the 1st row in the table, then make sure the toolbar appears at the bottom due to the overlap
     TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the bottom inside content', SugarBody.body(), '.tox-pop.tox-pop--bottom');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the bottom inside content', SugarBody.body(), bottomInsetSelector);
 
     // select the 4th row (middle of the viewport) and ensure it doesn't move
     TinySelections.setCursor(editor, [ 0, 0, 3, 0, 0 ], 0);
-    await pAssertHasNotFlipped('.tox-pop.tox-pop--bottom');
+    await pAssertHasNotFlipped(bottomInsetSelector);
 
     // select the 8th row (bottom of the viewport) and ensure it goes back to the top due to the overlap
     TinySelections.setCursor(editor, [ 0, 0, 7, 0, 0 ], 0);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), '.tox-pop.tox-pop--top');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), topInsetSelector);
 
     // select the 4th row (middle of the viewport) and again ensure it doesn't move
     TinySelections.setCursor(editor, [ 0, 0, 3, 0, 0 ], 0);
-    await pAssertHasNotFlipped('.tox-pop.tox-pop--top');
+    await pAssertHasNotFlipped(topInsetSelector);
 
     // Select the 1st row again to make sure it flips back to the bottom
     TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear back at the bottom inside content', SugarBody.body(), '.tox-pop.tox-pop--bottom');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear back at the bottom inside content', SugarBody.body(), bottomInsetSelector);
   });
 
   it('TINY-7192: It should not flip when the selection overlaps and the user is scrolling', async () => {
@@ -323,12 +329,12 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     // Select the 1st row in the table, then make sure the toolbar appears above the table
     scrollTo(editor, 0, 0);
     TinySelections.setCursor(editor, [ 1, 0, 0, 0, 0 ], 0);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top', SugarBody.body(), '.tox-pop.tox-pop--bottom');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top', SugarBody.body(), topSelector);
     await Waiter.pWait(20); // Need to wait for all NodeChange events to finish firing
 
     // Scroll the 1st row to the top and make sure the toolbar doesn't flip to the bottom
     scrollTo(editor, 0, 220);
-    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), '.tox-pop.tox-pop--top');
+    await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the top inside content', SugarBody.body(), topInsetSelector);
 
     // Select the 4th row
     TinySelections.setCursor(editor, [ 1, 0, 3, 0, 0 ], 0);
@@ -336,6 +342,6 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
 
     // Scroll the 4th row so it is now at the top and make sure the toolbar hasn't moved
     scrollTo(editor, 0, 220 + 3 * 22);
-    await pAssertHasNotFlipped('.tox-pop.tox-pop--top');
+    await pAssertHasNotFlipped(topInsetSelector);
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
@@ -20,6 +20,9 @@ interface Scenario {
 }
 
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarInlinePositionTest', () => {
+  const topSelector = '.tox-pop.tox-pop--bottom:not(.tox-pop--inset)';
+  const bottomSelector = '.tox-pop.tox-pop--top:not(.tox-pop--inset)';
+
   const hook = TinyHooks.bddSetup<Editor>({
     inline: true,
     base_url: '/project/tinymce/js/tinymce',
@@ -69,12 +72,12 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarInli
       editor.setContent(`<p style="height: ${offset}px"></p><p style="height: 25px;${scenario.contentStyles || ''}">${scenario.content}</p><p style="height: 100px"></p>`);
       scrollTo(editor, 0, -250, offset);
       TinySelections.setCursor(editor, scenario.cursor.elementPath, scenario.cursor.offset);
-      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), '.tox-pop.tox-pop--bottom' + scenario.classes);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), topSelector + scenario.classes);
       await pAssertPosition('absolute', 'bottom', 1637);
 
       // Position the link at the top of the viewport, just below the toolbar
       scrollTo(editor, 0, -80, offset);
-      await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), '.tox-pop.tox-pop--top' + scenario.classes);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), bottomSelector + scenario.classes);
       await pAssertPosition('fixed', 'top', 109);
 
       // Position the element offscreen and check the toolbar is hidden
@@ -83,7 +86,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarInli
 
       // Position the element back into view
       scrollTo(editor, 0, -250, offset);
-      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), '.tox-pop.tox-pop--bottom' + scenario.classes);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear above content', SugarBody.body(), topSelector + scenario.classes);
       await pAssertPosition('absolute', 'bottom', 1637);
 
       // Position the element behind the docked toolbar and check the toolbar is hidden


### PR DESCRIPTION
Related Ticket: TINY-7665

Description of Changes:
* Renamed `LayoutInside` to `LayoutInset` since that's the relevant CSS term and what we've been calling it more lately.
* Make `Bubble` include a new inset class when generating a bubble to be used for an inset layout.
* Changed context toolbars to use the new `tox-pop--inset` class when using an inset layout. This class will hide the bubble arrow. Additionally to match the gif provided I've halved the bubble for insets.
  * Note: I've intentionally used `opacity` here instead of `display: none` as there was some talk about making it transition as it disappears.
* Updated the tests to properly check if the toolbar is positioned so that it's overlapping (this couldn't be done previously since we didn't have a selector that was different). Also took `6px` away for the positioning assertions of the toolbars due to the reduced bubble.

![image](https://user-images.githubusercontent.com/1575550/125605267-31cdb221-b942-4d5f-9eb5-6b32cc8a00ad.png)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
