### PR TITLE
TINY-7666: Changed context toolbars to not overlap the statusbar

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents #TINY-7249
 - Changed `emoticons`, `wordcount`, `code`, `codesample`, and `template` plugins to open dialogs using commands #TINY-7619
 - The context toolbar will no longer show an arrow when it overlaps the content, such as in table cells #TINY-7665
+- The context toolbar will no longer overlap the statusbar for toolbars using `node` or `selection` positions #TINY-7666
 
 ### Fixed
 - The `dir` attribute was being incorrectly applied to list items #TINY-4589

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -53,6 +53,7 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
   const lastPosition = Singleton.value<Bounds>();
   const lastTrigger = Singleton.value<TriggerCause>();
   const lastBounds = Singleton.value<Bounds>();
+  const lastContextPosition = Singleton.value<InlineContent.ContextPosition>();
 
   const contextbar = GuiFactory.build(
     renderContextToolbar({
@@ -65,7 +66,8 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
   );
 
   const getBounds = () => {
-    const bounds = ContextToolbarBounds.getContextToolbarBounds(editor, sharedBackstage);
+    const position = lastContextPosition.get().getOr('node');
+    const bounds = ContextToolbarBounds.getContextToolbarBounds(editor, sharedBackstage, position);
     lastBounds.set(bounds);
     return bounds;
   };
@@ -92,6 +94,7 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
     lastPosition.clear();
     lastTrigger.clear();
     lastBounds.clear();
+    lastContextPosition.clear();
     InlineView.hide(contextbar);
   };
 
@@ -192,7 +195,9 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
     // TINY-4495 ASSUMPTION: Can only do toolbarApi[0].position because ContextToolbarLookup.filterToolbarsByPosition
     // ensures all toolbars returned by ContextToolbarLookup have the same position.
     // And everything else that gets toolbars from elsewhere only returns maximum 1 toolbar
-    const anchor = getAnchor(toolbarApi[0].position, sElem);
+    const position = toolbarApi[0].position;
+    const anchor = getAnchor(position, sElem);
+    lastContextPosition.set(position);
     lastTrigger.set(TriggerCause.NewAnchor);
 
     const contextBarEle = contextbar.element;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
@@ -6,6 +6,7 @@
  */
 
 import { Bounds, Boxes } from '@ephox/alloy';
+import { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
 import { Scroll, SelectorFind, SugarBody, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
 
@@ -59,7 +60,13 @@ const getHorizontalBounds = (contentAreaBox: Bounds, viewportBounds: Bounds): { 
   return { x, width };
 };
 
-const getVerticalBounds = (editor: Editor, contentAreaBox: Bounds, viewportBounds: Bounds, isToolbarLocationTop: boolean): { y: number; bottom: number } => {
+const getVerticalBounds = (
+  editor: Editor,
+  contentAreaBox: Bounds,
+  viewportBounds: Bounds,
+  isToolbarLocationTop: boolean,
+  toolbarType: InlineContent.ContextPosition
+): { y: number; bottom: number } => {
   const container = SugarElement.fromDom(editor.getContainer());
   const header = SelectorFind.descendant<HTMLElement>(container, '.tox-editor-header').getOr(container);
   const headerBox = Boxes.box(header);
@@ -82,7 +89,8 @@ const getVerticalBounds = (editor: Editor, contentAreaBox: Bounds, viewportBound
     };
   }
 
-  const containerBounds = Boxes.box(container);
+  // Allow line based context toolbar to overlap the statusbar
+  const containerBounds = toolbarType === 'line' ? Boxes.box(container) : contentAreaBox;
 
   // Scenario toolbar bottom & Iframe: Bottom of the header -> Bottom of the editor container
   if (isToolbarAbove) {
@@ -99,7 +107,7 @@ const getVerticalBounds = (editor: Editor, contentAreaBox: Bounds, viewportBound
   };
 };
 
-const getContextToolbarBounds = (editor: Editor, sharedBackstage: UiFactoryBackstageShared): Bounds => {
+const getContextToolbarBounds = (editor: Editor, sharedBackstage: UiFactoryBackstageShared, toolbarType: InlineContent.ContextPosition): Bounds => {
   const viewportBounds = WindowVisualViewport.getBounds(window);
   const contentAreaBox = Boxes.box(SugarElement.fromDom(editor.getContentAreaContainer()));
   const toolbarOrMenubarEnabled = Settings.isMenubarEnabled(editor) || Settings.isToolbarEnabled(editor) || Settings.isMultipleToolbars(editor);
@@ -111,7 +119,7 @@ const getContextToolbarBounds = (editor: Editor, sharedBackstage: UiFactoryBacks
     return Boxes.bounds(x, viewportBounds.y, width, viewportBounds.height);
   } else {
     const isToolbarTop = sharedBackstage.header.isPositionedAtTop();
-    const { y, bottom } = getVerticalBounds(editor, contentAreaBox, viewportBounds, isToolbarTop);
+    const { y, bottom } = getVerticalBounds(editor, contentAreaBox, viewportBounds, isToolbarTop, toolbarType);
     return Boxes.bounds(x, y, width, bottom - y);
   }
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/MobileContextMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/MobileContextMenu.ts
@@ -115,7 +115,7 @@ const show = (editor: Editor, e: EditorEvent<TouchEvent>, items: MenuItems, back
       },
       data: menuData,
       type: 'horizontal'
-    }, () => Optional.some(getContextToolbarBounds(editor, backstage.shared)));
+    }, () => Optional.some(getContextToolbarBounds(editor, backstage.shared, useNodeAnchor ? 'node' : 'selection')));
 
     // Ensure the context toolbar is hidden
     editor.fire(hideContextToolbarEvent);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -1,5 +1,6 @@
 import { Bounds, Boxes } from '@ephox/alloy';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
+import { InlineContent } from '@ephox/bridge';
 import { McEditor, TinyDom } from '@ephox/mcagar';
 import { Css, Scroll, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
@@ -21,6 +22,7 @@ interface TestBounds {
 interface Scenario {
   readonly label: string;
   readonly settings: Record<string, any>;
+  readonly position: InlineContent.ContextPosition;
   readonly scroll?: {
     readonly relativeTop: boolean;
     readonly delta: number;
@@ -81,7 +83,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
     };
 
     const asserted = scenario.assertBounds(getBounds(editor));
-    const actual = getContextToolbarBounds(editor, backstage.shared);
+    const actual = getContextToolbarBounds(editor, backstage.shared, scenario.position);
 
     assertBounds('x');
     assertBounds('y');
@@ -108,6 +110,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
     testScenario({
       label: 'Inline(full view): bottom of the header -> Bottom of the viewport',
       settings: { inline: true },
+      position: 'selection',
       scroll: { relativeTop: true, delta: -10 },
       assertBounds: (bounds) => ({
         x: bounds.content.x,
@@ -120,6 +123,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
     testScenario({
       label: 'Distraction Free(full view): Top of the viewport -> Bottom of the viewport',
       settings: { menubar: false, inline: true, toolbar: false },
+      position: 'selection',
       scroll: { relativeTop: true, delta: -10 },
       assertBounds: (bounds) => ({
         x: bounds.content.x,
@@ -130,8 +134,35 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
     });
 
     testScenario({
-      label: 'Iframe(full view): Bottom of the header -> Bottom of the editor container',
+      label: 'Iframe(full view) selection toolbar: Bottom of the header -> Bottom of the content area',
       settings: { },
+      position: 'selection',
+      scroll: { relativeTop: true, delta: -10 },
+      assertBounds: (bounds) => ({
+        x: bounds.content.x,
+        y: bounds.header.bottom,
+        right: bounds.content.right,
+        bottom: bounds.content.bottom
+      })
+    });
+
+    testScenario({
+      label: 'Iframe(full view) node toolbar: Bottom of the header -> Bottom of the content area',
+      settings: { },
+      position: 'node',
+      scroll: { relativeTop: true, delta: -10 },
+      assertBounds: (bounds) => ({
+        x: bounds.content.x,
+        y: bounds.header.bottom,
+        right: bounds.content.right,
+        bottom: bounds.content.bottom
+      })
+    });
+
+    testScenario({
+      label: 'Iframe(full view) line toolbar: Bottom of the header -> Bottom of the editor container',
+      settings: { },
+      position: 'line',
       scroll: { relativeTop: true, delta: -10 },
       assertBounds: (bounds) => ({
         x: bounds.content.x,
@@ -142,20 +173,22 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
     });
 
     testScenario({
-      label: 'Iframe(editor partly in view): Top of viewport -> Bottom of the editor container',
+      label: 'Iframe(editor partly in view): Top of viewport -> Bottom of the content area',
       settings: { height: 400 },
+      position: 'selection',
       scroll: { relativeTop: true, delta: 200 },
       assertBounds: (bounds) => ({
         x: bounds.content.x,
         y: bounds.viewport.y,
         right: bounds.content.right,
-        bottom: bounds.container.bottom
+        bottom: bounds.content.bottom
       })
     });
 
     testScenario({
-      label: 'Iframe(editor partly in view): Bottom of viewport -> Top of content area',
+      label: 'Iframe(editor partly in view): Bottom of viewport -> Top of the content area',
       settings: { height: 400 },
+      position: 'selection',
       scroll: { relativeTop: false, delta: -200 },
       assertBounds: (bounds: TestBounds) => ({
         x: bounds.content.x,
@@ -168,12 +201,13 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
 
   context('Context toolbar bounds with toolbar bottom', () => {
     testScenario({
-      label: 'Iframe(full view): Bottom of the header -> Bottom of the editor container',
+      label: 'Iframe(full view): Top of the content area -> Top of the header',
       settings: { toolbar_location: 'bottom' },
+      position: 'node',
       scroll: { relativeTop: true, delta: -10 },
       assertBounds: (bounds: TestBounds) => ({
         x: bounds.content.x,
-        y: bounds.container.y,
+        y: bounds.content.y,
         right: bounds.content.right,
         bottom: bounds.header.y
       })
@@ -182,6 +216,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
     testScenario({
       label: 'Inline(full view): Top of the viewport -> Top of the header',
       settings: { inline: true, toolbar_location: 'bottom' },
+      position: 'selection',
       scroll: { relativeTop: true, delta: -10 },
       assertBounds: (bounds: TestBounds) => ({
         x: bounds.content.x,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -172,10 +172,11 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     TinySelections.setCursor(editor, [ 0 ], 1);
     TinyContentActions.keystroke(editor, Keys.enter());
     TinyContentActions.keystroke(editor, Keys.enter());
+    TinyContentActions.keystroke(editor, Keys.enter());
     editor.nodeChanged();
     TinySelections.select(editor, 'img', []);
     await UiFinder.pWaitForVisible('Waiting for toolbar to appear below content', SugarBody.body(), bottomSelector);
-    await pAssertPosition('top', -56);
+    await pAssertPosition('top', -76);
   });
 
   it(`TINY-4586: Line context toolbar remains inside iframe container and doesn't overlap the header`, async () => {
@@ -257,7 +258,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
 
     scrollTo(editor, 0, 400);
     await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the bottom inside content', SugarBody.body(), bottomInsetSelector);
-    await pAssertPosition('bottom', 6);
+    await pAssertPosition('bottom', 24);
 
     scrollTo(editor, 0, 0);
     await UiFinder.pWaitForVisible('Waiting for toolbar to appear at the bottom inside content', SugarBody.body(), topSelector);


### PR DESCRIPTION
Related Ticket: TINY-7666

Description of Changes:
Changed the context toolbar bounds so that it can no longer overlap the statusbar for node/selection context toolbars (north/south). Line based (east/west) context toolbar will still overlap as discussed. The relevant positions should have moved by 18px (the height of the statusbar).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
