### PR TITLE
TINY-1264: Make iframe title configurable

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new plugin commands: `mceEmoticons` (emoticons), `mceWordCount` (wordcount), and `mceTemplate` (template) #TINY-7619
 - Added a new `tablerowheader` toolbar button and menu item to toggle the header state of row cells #TINY-7478
 - Added a new `tablecolheader` toolbar button and menu item to toggle the header state of column cells #TINY-7482
-- Added a new `content_aria_label` setting to set the iframe title attribute #TINY-1264
+- Added a new `iframe_aria_text` setting to set the iframe title attribute #TINY-1264
 
 ### Improved
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new plugin commands: `mceEmoticons` (emoticons), `mceWordCount` (wordcount), and `mceTemplate` (template) #TINY-7619
 - Added a new `tablerowheader` toolbar button and menu item to toggle the header state of row cells #TINY-7478
 - Added a new `tablecolheader` toolbar button and menu item to toggle the header state of column cells #TINY-7482
+- Added a new `content_aria_label` setting to set the iframe title attribute #TINY-1264
 
 ### Improved
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504

--- a/modules/tinymce/src/core/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/core/main/ts/api/Settings.ts
@@ -206,6 +206,8 @@ const getVisualAidsTableClass = (editor: Editor) => editor.getParam('visual_tabl
 
 const getVisualAidsAnchorClass = (editor: Editor) => editor.getParam('visual_anchor_class', 'mce-item-anchor', 'string');
 
+const getIframeTitle = (editor: Editor) => editor.getParam('iframe_aria_text', 'Rich Text Area. Press ALT-0 for help.', 'string');
+
 export {
   getIframeAttrs,
   getDocType,
@@ -271,5 +273,6 @@ export {
   isVisualAidsEnabled,
   getVisualAidsTableClass,
   getFontCss,
-  getVisualAidsAnchorClass
+  getVisualAidsAnchorClass,
+  getIframeTitle
 };

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -69,6 +69,7 @@ interface BaseEditorSettings {
   cache_suffix?: string;
   color_cols?: number;
   color_map?: string[];
+  content_aria_label?: string;
   content_css?: boolean | string | string[];
   content_css_cors?: boolean;
   content_security_policy?: string;

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -69,7 +69,6 @@ interface BaseEditorSettings {
   cache_suffix?: string;
   color_cols?: number;
   color_map?: string[];
-  iframe_aria_text?: string;
   content_css?: boolean | string | string[];
   content_css_cors?: boolean;
   content_security_policy?: string;
@@ -116,6 +115,7 @@ interface BaseEditorSettings {
   icons?: string;
   icons_url?: string;
   id?: string;
+  iframe_aria_text?: string;
   images_dataimg_filter?: (imgElm: HTMLImageElement) => boolean;
   images_file_types?: string;
   images_replace_blob_uris?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -69,7 +69,7 @@ interface BaseEditorSettings {
   cache_suffix?: string;
   color_cols?: number;
   color_map?: string[];
-  content_aria_label?: string;
+  iframe_aria_text?: string;
   content_css?: boolean | string | string[];
   content_css_cors?: boolean;
   content_security_policy?: string;

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -83,9 +83,7 @@ const getIframeHtml = (editor: Editor) => {
 };
 
 const createIframe = (editor: Editor, o) => {
-  const iframeTitle = editor.getParam('content_aria_label', 'Rich Text Area. Press ALT-0 for help.');
-  const iframeTranslatedTitle = editor.editorManager.translate(iframeTitle);
-
+  const iframeTranslatedTitle = editor.translate(Settings.getIframeTitle(editor));
   const ifr = createIframeElement(editor.id, iframeTranslatedTitle, o.height, Settings.getIframeAttrs(editor)).dom;
 
   ifr.onload = () => {

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -83,11 +83,10 @@ const getIframeHtml = (editor: Editor) => {
 };
 
 const createIframe = (editor: Editor, o) => {
-  const title = editor.editorManager.translate(
-    'Rich Text Area. Press ALT-0 for help.'
-  );
+  const iframeTitle = editor.getParam('content_aria_label', 'Rich Text Area. Press ALT-0 for help.');
+  const iframeTranslatedTitle = editor.editorManager.translate(iframeTitle);
 
-  const ifr = createIframeElement(editor.id, title, o.height, Settings.getIframeAttrs(editor)).dom;
+  const ifr = createIframeElement(editor.id, iframeTranslatedTitle, o.height, Settings.getIframeAttrs(editor)).dom;
 
   ifr.onload = () => {
     ifr.onload = null;

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
-describe('browser.tinymce.core.init.InitIframeContentAriaLabelTest', () => {
+describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
   const defaultIframeTitle = 'Rich Text Area. Press ALT-0 for help.';
   const customIframeTitle = 'Cupidatat magna aliquip.';
 

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeContentAriaLabelTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeContentAriaLabelTest.ts
@@ -1,0 +1,33 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/mcagar';
+import { Attribute, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
+
+describe('browser.tinymce.core.init.InitIframeContentAriaLabelTest', () => {
+  const defaultIframeTitle = 'Rich Text Area. Press ALT-0 for help.';
+  const customIframeTitle = 'Cupidatat magna aliquip.';
+  const hookWithDefaultIframeTitle = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+  }, [ Theme ]);
+  const hookWithContentAriaLabel = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    content_aria_label: customIframeTitle
+  }, [ Theme ]);
+
+  it('TINY-1264: Should use default iframe title when content_aria_label is not set', () => {
+    const editor = hookWithDefaultIframeTitle.editor();
+    const iframe = SugarElement.fromDom(editor.iframeElement);
+
+    assert.equal(Attribute.get(iframe, 'title'), defaultIframeTitle);
+  });
+
+  it('TINY-1264: Should use content_aria_label as iframe title', () => {
+    const editor = hookWithContentAriaLabel.editor();
+    const iframe = SugarElement.fromDom(editor.iframeElement);
+
+    assert.equal(Attribute.get(iframe, 'title'), customIframeTitle);
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeContentAriaLabelTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeContentAriaLabelTest.ts
@@ -1,33 +1,30 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { McEditor } from '@ephox/mcagar';
 import { Attribute, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.InitIframeContentAriaLabelTest', () => {
   const defaultIframeTitle = 'Rich Text Area. Press ALT-0 for help.';
   const customIframeTitle = 'Cupidatat magna aliquip.';
-  const hookWithDefaultIframeTitle = TinyHooks.bddSetupLight<Editor>({
-    base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme ]);
-  const hookWithContentAriaLabel = TinyHooks.bddSetupLight<Editor>({
-    base_url: '/project/tinymce/js/tinymce',
-    content_aria_label: customIframeTitle
-  }, [ Theme ]);
 
-  it('TINY-1264: Should use the default iframe title when content_aria_label is not set', () => {
-    const editor = hookWithDefaultIframeTitle.editor();
+  it('TINY-1264: Should use the default iframe title when iframe_aria_text is not set', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({
+      base_url: '/project/tinymce/js/tinymce'
+    });
     const iframe = SugarElement.fromDom(editor.iframeElement);
-
     assert.equal(Attribute.get(iframe, 'title'), defaultIframeTitle);
+    McEditor.remove(editor);
   });
 
-  it('TINY-1264: Should use content_aria_label as iframe title', () => {
-    const editor = hookWithContentAriaLabel.editor();
+  it('TINY-1264: Should use iframe_aria_text as the iframe title', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      iframe_aria_text: customIframeTitle
+    });
     const iframe = SugarElement.fromDom(editor.iframeElement);
-
     assert.equal(Attribute.get(iframe, 'title'), customIframeTitle);
+    McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeContentAriaLabelTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeContentAriaLabelTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.core.init.InitIframeContentAriaLabelTest', () => {
     content_aria_label: customIframeTitle
   }, [ Theme ]);
 
-  it('TINY-1264: Should use default iframe title when content_aria_label is not set', () => {
+  it('TINY-1264: Should use the default iframe title when content_aria_label is not set', () => {
     const editor = hookWithDefaultIframeTitle.editor();
     const iframe = SugarElement.fromDom(editor.iframeElement);
 


### PR DESCRIPTION
Related Ticket: TINY-1264

Description of Changes:
* Create new setting `iframe_aria_text` to set the iframe title attribute

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
`modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts`
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
[Labeling editor field for accessibility doesn't work #177](https://github.com/tinymce/tinymce-react/issues/177)