### PR TITLE
TINY-7720: Disable the UglifyJS `merge_vars` functionality due to issues with IE 11

### DIFF
--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -185,6 +185,10 @@ module.exports = function (grunt) {
             comments: 'all',
             ascii_only: true
           },
+          compress: {
+            // TINY-7720: Disable merge_vars as it has a bug that causes errors on IE 11
+            merge_vars: false
+          },
           ie8: true
         },
         core: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11625,9 +11625,9 @@ uglify-js@^2.8.22:
     uglify-to-browserify "~1.0.0"
 
 uglify-js@^3.1.4, uglify-js@^3.13.3:
-  version "3.13.8"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.8.tgz#7c2f9f2553f611f3ff592bdc19c6fb208dc60afb"
-  integrity sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==
+  version "3.13.10"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.10.tgz#a6bd0d28d38f592c3adb6b180ea6e07e1e540a8d"
+  integrity sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Related Ticket: TINY-7720

Description of Changes:
* Upgrade to the latest UglifyJS version
* Disable the `merge_vars` setting as it causes a behaviour change on IE 11 that results in things always being `undefined`

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
