### PR TITLE
TINY-7065: Add optional eventName to UiControls.setValue

### DIFF
--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 5.4.0 - 2021-07-19
+
+### Improved
+- `UiControls.setValue` now takes an optional `eventName` to fire after changing the value.
+
 ## 5.3.0 - 2021-05-06
 
 ### Added

--- a/modules/agar/src/main/ts/ephox/agar/api/UiControls.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/UiControls.ts
@@ -1,3 +1,4 @@
+import { Type } from '@ephox/katamari';
 import { SugarElement, Value } from '@ephox/sugar';
 
 import { Chain } from './Chain';
@@ -6,13 +7,30 @@ import * as UiFinder from './UiFinder';
 
 type TogglableElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | HTMLOptionElement | HTMLButtonElement;
 
-const setValue = (element: SugarElement<TogglableElement>, newValue: string): void => {
-  Value.set(element, newValue);
+const fireEvent = (elem: SugarElement, event: string) => {
+  let evt: Event;
+  if (Type.isFunction(Event)) {
+    evt = new Event(event, {
+      bubbles: true,
+      cancelable: true
+    });
+  } else { // support IE
+    evt = document.createEvent('Event');
+    evt.initEvent(event, true, true);
+  }
+  elem.dom.dispatchEvent(evt);
 };
 
-const setValueOn = (container: SugarElement<Node>, selector: string, newValue: string): void => {
+const setValue = (element: SugarElement<TogglableElement>, newValue: string, eventName?: string): void => {
+  Value.set(element, newValue);
+  if (Type.isNonNullable(eventName)) {
+    fireEvent(element, eventName);
+  }
+};
+
+const setValueOn = (container: SugarElement<Node>, selector: string, newValue: string, eventName?: string): void => {
   const element = UiFinder.findIn(container, selector).getOrDie();
-  setValue(element, newValue);
+  setValue(element, newValue, eventName);
 };
 
 const getValue = (element: SugarElement<TogglableElement>): string => Value.get(element);


### PR DESCRIPTION
Related Ticket: TINY-7065

Description of Changes:
* Add optional eventName to UiControls.setValue

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] ~Milestone set~
* [x] Review comments resolved

Upon merge:
* [x] Release minor for agar

GitHub issues (if applicable):
