### PR TITLE
TINY-7729: Use Utils.link() to both create and edit links from the quicklink bar

### DIFF
--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -209,7 +209,7 @@ const unlinkDomMutation = (editor: Editor) => {
   });
 };
 
-/**
+/*
  * RTC uses unwrapped options.
  *
  * To best simulate this, we unwrap to null and filter out empty values.

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -209,6 +209,11 @@ const unlinkDomMutation = (editor: Editor) => {
   });
 };
 
+/**
+ * RTC uses unwrapped options.
+ *
+ * To best simulate this, we unwrap to null and filter out empty values.
+ */
 const unwrapOptions = (data: LinkDialogOutput) => {
   const { class: cls, href, rel, target, text, title } = data;
 

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -79,7 +79,7 @@ const setupContextToolbars = (editor: Editor) => {
     return Fun.noop;
   };
 
-  /**
+  /*
    * if we're editing a link, don't change the text.
    * if anything other than text is selected, don't change the text.
    */

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -105,28 +105,25 @@ const setupContextToolbars = (editor: Editor) => {
           return Actions.toggleActiveState(editor)(buttonApi);
         },
         onAction: (formApi) => {
-          const anchor = Utils.getAnchorElement(editor);
           const value = formApi.getValue();
-          if (!anchor) {
-            const attachState = { href: value, attach: Fun.noop };
-            const onlyText = Utils.isOnlyTextSelected(editor);
-            const text: Optional<string> = onlyText ? Optional.some(Utils.getAnchorText(editor.selection, anchor)).filter((t) => t.length > 0).or(Optional.from(value)) : Optional.none();
-            Utils.link(editor, attachState, {
-              href: value,
-              text,
-              title: Optional.none(),
-              rel: Optional.none(),
-              target: Optional.none(),
-              class: Optional.none()
-            });
-            formApi.hide();
-          } else {
-            editor.undoManager.transact(() => {
-              editor.dom.setAttrib(anchor, 'href', value);
-              collapseSelectionToEnd(editor);
-              formApi.hide();
-            });
-          }
+
+          // if we're editing a link, don't change the text.
+          // if anything other than text is selected, don't change the text.
+          const anchor = Utils.getAnchorElement(editor);
+          const onlyText = Utils.isOnlyTextSelected(editor);
+          const text: Optional<string> = !anchor && onlyText ? Optional.some(Utils.getAnchorText(editor.selection, anchor)).filter((t) => t.length > 0).or(Optional.from(value)) : Optional.none();
+
+          const attachState = { href: value, attach: Fun.noop };
+          Utils.link(editor, attachState, {
+            href: value,
+            text,
+            title: Optional.none(),
+            rel: Optional.none(),
+            target: Optional.none(),
+            class: Optional.none()
+          });
+          collapseSelectionToEnd(editor);
+          formApi.hide();
         }
       },
       {

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -79,6 +79,21 @@ const setupContextToolbars = (editor: Editor) => {
     return Fun.noop;
   };
 
+  /**
+   * if we're editing a link, don't change the text.
+   * if anything other than text is selected, don't change the text.
+   */
+  const getLinkText = (value: string) => {
+    const anchor = Utils.getAnchorElement(editor);
+    const onlyText = Utils.isOnlyTextSelected(editor);
+    if (!anchor && onlyText) {
+      const text = Utils.getAnchorText(editor.selection, anchor);
+      return Optional.some(text.length > 0 ? text : value);
+    } else {
+      return Optional.none();
+    }
+  };
+
   editor.ui.registry.addContextForm('quicklink', {
     launch: {
       type: 'contextformtogglebutton',
@@ -106,13 +121,7 @@ const setupContextToolbars = (editor: Editor) => {
         },
         onAction: (formApi) => {
           const value = formApi.getValue();
-
-          // if we're editing a link, don't change the text.
-          // if anything other than text is selected, don't change the text.
-          const anchor = Utils.getAnchorElement(editor);
-          const onlyText = Utils.isOnlyTextSelected(editor);
-          const text: Optional<string> = !anchor && onlyText ? Optional.some(Utils.getAnchorText(editor.selection, anchor)).filter((t) => t.length > 0).or(Optional.from(value)) : Optional.none();
-
+          const text = getLinkText(value);
           const attachState = { href: value, attach: Fun.noop };
           Utils.link(editor, attachState, {
             href: value,


### PR DESCRIPTION
Use `Utils.link()` to both create and edit links from the quicklink bar.

Related Ticket: TINY-7729

Description of Changes:
* No user-visible changes, so no changelog, just redirecting quicklink code into existing code for create/edit link that knows about RTC.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
