### PR TITLE
TINY-6533: Turn off parts of image upload that RTC handles itself

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -155,7 +155,11 @@ const EditorUpload = (editor: Editor): EditorUpload => {
 
           if (uploadInfo.status && Settings.shouldReplaceBlobUris(editor)) {
             blobCache.removeByUri(image.src);
-            replaceImageUriInView(image, uploadInfo.url);
+            if (Rtc.isRtc(editor)) {
+              // RTC handles replacing the image URL through callback events
+            } else {
+              replaceImageUriInView(image, uploadInfo.url);
+            }
           } else if (uploadInfo.error) {
             if (uploadInfo.error.options.remove) {
               replaceUrlInUndoStack(image.getAttribute('src'), Env.transparentSrc);
@@ -179,7 +183,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
 
         if (imagesToRemove.length > 0) {
           if (Rtc.isRtc(editor)) {
-            // To be replaced by RTC API to mirror DOM changes when such is implemented.
+            // TODO TINY-7735 replace with RTC API to remove images
             console.error('Removing images on failed uploads is currently unsupported for RTC'); // eslint-disable-line no-console
           } else {
             editor.undoManager.transact(() => {
@@ -239,11 +243,14 @@ const EditorUpload = (editor: Editor): EditorUpload => {
         return true;
       });
 
-      Arr.each(result, (resultItem) => {
-        replaceUrlInUndoStack(resultItem.image.src, resultItem.blobInfo.blobUri());
-        resultItem.image.src = resultItem.blobInfo.blobUri();
-        resultItem.image.removeAttribute('data-mce-src');
-      });
+      if (!Rtc.isRtc(editor)) {
+        // RTC is set up so that image sources are only ever blob
+        Arr.each(result, (resultItem) => {
+          replaceUrlInUndoStack(resultItem.image.src, resultItem.blobInfo.blobUri());
+          resultItem.image.src = resultItem.blobInfo.blobUri();
+          resultItem.image.removeAttribute('data-mce-src');
+        });
+      }
 
       return result;
     }));

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -243,8 +243,9 @@ const EditorUpload = (editor: Editor): EditorUpload => {
         return true;
       });
 
-      if (!Rtc.isRtc(editor)) {
+      if (Rtc.isRtc(editor)) {
         // RTC is set up so that image sources are only ever blob
+      } else {
         Arr.each(result, (resultItem) => {
           replaceUrlInUndoStack(resultItem.image.src, resultItem.blobInfo.blobUri());
           resultItem.image.src = resultItem.blobInfo.blobUri();


### PR DESCRIPTION
Related Ticket: TINY-6533

Description of Changes:
* No user-visible changes, so no changelog, just turning off code that mutates the DOM when RTC is active.
* RTC already handles image upload updates; we just had special code in our mutation blocker to allow these modifications to the view. They had no effect on the model.
* Turning off the unnecessary modifications allows us to remove those checks from our mutation blocker and prevent a class of mutations that could be performed without an error.

From what I can tell the image scanner should _never_ need to convert base64 to blob anymore - Spocke updated the parser to do it - but I'm not prepared to verify that right now.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
