### PR TITLE
TINY-7691: Table cell class changing now as a group, not individually

### DIFF
--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -40,8 +40,8 @@ const Plugin = (editor: Editor) => {
   QueryCommands.registerQueryCommands(editor, actions, selections);
   Clipboard.registerEvents(editor, selections, actions, cellSelection);
 
-  MenuItems.addMenuItems(editor, selectionTargets, clipboard);
-  Buttons.addButtons(editor, selectionTargets, clipboard);
+  MenuItems.addMenuItems(editor, selections, selectionTargets, clipboard);
+  Buttons.addButtons(editor, selections, selectionTargets, clipboard);
   Buttons.addToolbars(editor);
 
   editor.on('PreInit', () => {

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -84,11 +84,14 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
   };
 
   const toggleTableCellClass = (_ui: boolean, clazz: string) => {
-    performActionOnSelection((table, startCell) => {
-      const cells = TableSelection.getCellsFromSelection(startCell, selections, isRoot);
-      Arr.each(cells, (value) => {
-        editor.formatter.toggle('tablecellclass', { value: clazz }, value.dom);
-      });
+    performActionOnSelection((table) => {
+      const selectedCells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, Util.getIsRoot(editor));
+      const allHaveClass = Arr.forall(selectedCells, (cell) => editor.formatter.match('tablecellclass', { value: clazz }, cell.dom));
+      const formatterAction = allHaveClass ? editor.formatter.remove : editor.formatter.apply;
+
+      Arr.each(selectedCells, (value) =>
+        formatterAction('tablecellclass', { value: clazz }, value.dom)
+      );
       Events.fireTableModified(editor, table.dom, Events.styleModified);
     });
   };

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -89,8 +89,8 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
       const allHaveClass = Arr.forall(selectedCells, (cell) => editor.formatter.match('tablecellclass', { value: clazz }, cell.dom));
       const formatterAction = allHaveClass ? editor.formatter.remove : editor.formatter.apply;
 
-      Arr.each(selectedCells, (value) =>
-        formatterAction('tablecellclass', { value: clazz }, value.dom)
+      Arr.each(selectedCells, (cell) =>
+        formatterAction('tablecellclass', { value: clazz }, cell.dom)
       );
       Events.fireTableModified(editor, table.dom, Events.styleModified);
     });

--- a/modules/tinymce/src/plugins/table/main/ts/core/TableFormats.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/TableFormats.ts
@@ -11,39 +11,46 @@ const cellFormats = {
   tablecellbackgroundcolor: {
     selector: 'td,th',
     styles: { backgroundColor: '%value' },
-    remove_similar: true
+    remove_similar: true,
+    inherit: false
   },
   tablecellverticalalign: {
     selector: 'td,th',
     styles: {
       'vertical-align': '%value'
     },
-    remove_similar: true
+    remove_similar: true,
+    inherit: false
   },
   tablecellbordercolor: {
     selector: 'td,th',
     styles: { borderColor: '%value' },
-    remove_similar: true
+    remove_similar: true,
+    inherit: false
   },
   tablecellclass: {
     selector: 'td,th',
     classes: [ '%value' ],
-    remove_similar: true
+    remove_similar: true,
+    inherit: false
   },
   tableclass: {
     selector: 'table',
     classes: [ '%value' ],
-    remove_similar: true
+    remove_similar: true,
+    inherit: false
   },
   tablecellborderstyle: {
     selector: 'td,th',
     styles: { borderStyle: '%value' },
-    remove_similar: true
+    remove_similar: true,
+    inherit: false
   },
   tablecellborderwidth: {
     selector: 'td,th',
     styles: { borderWidth: '%value' },
-    remove_similar: true
+    remove_similar: true,
+    inherit: false
   }
 };
 

--- a/modules/tinymce/src/plugins/table/main/ts/core/TableFormats.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/TableFormats.ts
@@ -6,51 +6,47 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+const genericBase = {
+  remove_similar: true,
+  inherit: false
+};
+
+const cellBase = {
+  selector: 'td,th',
+  ...genericBase
+};
 
 const cellFormats = {
   tablecellbackgroundcolor: {
-    selector: 'td,th',
     styles: { backgroundColor: '%value' },
-    remove_similar: true,
-    inherit: false
+    ...cellBase
   },
   tablecellverticalalign: {
-    selector: 'td,th',
     styles: {
       'vertical-align': '%value'
     },
-    remove_similar: true,
-    inherit: false
+    ...cellBase
   },
   tablecellbordercolor: {
-    selector: 'td,th',
     styles: { borderColor: '%value' },
-    remove_similar: true,
-    inherit: false
+    ...cellBase
   },
   tablecellclass: {
-    selector: 'td,th',
     classes: [ '%value' ],
-    remove_similar: true,
-    inherit: false
+    ...cellBase
   },
   tableclass: {
     selector: 'table',
     classes: [ '%value' ],
-    remove_similar: true,
-    inherit: false
+    ...genericBase
   },
   tablecellborderstyle: {
-    selector: 'td,th',
     styles: { borderStyle: '%value' },
-    remove_similar: true,
-    inherit: false
+    ...cellBase
   },
   tablecellborderwidth: {
-    selector: 'td,th',
     styles: { borderWidth: '%value' },
-    remove_similar: true,
-    inherit: false
+    ...cellBase
   }
 };
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
@@ -5,6 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Selections } from '@ephox/darwin';
+
 import Editor from 'tinymce/core/api/Editor';
 
 import { getCellClassList, getTableBorderStyles, getTableBorderWidths, getTableCellBackgroundColors, getTableCellBorderColors, getTableClassList, getToolbar } from '../api/Settings';
@@ -13,7 +15,7 @@ import { SelectionTargets, LockedDisable } from '../selection/SelectionTargets';
 import { verticalAlignValues } from './CellAlignValues';
 import { applyTableCellStyle, changeColumnHeader, changeRowHeader, filterNoneItem, generateColorSelector, generateItemsCallback } from './UiUtils';
 
-const addButtons = (editor: Editor, selectionTargets: SelectionTargets, clipboard: Clipboard) => {
+const addButtons = (editor: Editor, selections: Selections, selectionTargets: SelectionTargets, clipboard: Clipboard) => {
   editor.ui.registry.addMenuButton('table', {
     tooltip: 'Table',
     icon: 'table',
@@ -175,6 +177,7 @@ const addButtons = (editor: Editor, selectionTargets: SelectionTargets, clipboar
       tooltip: 'Table styles',
       fetch: generateItemsCallback(
         editor,
+        selections,
         tableClassList,
         'tableclass',
         (item) => item.title,
@@ -191,6 +194,7 @@ const addButtons = (editor: Editor, selectionTargets: SelectionTargets, clipboar
       tooltip: 'Cell styles',
       fetch: generateItemsCallback(
         editor,
+        selections,
         tableCellClassList,
         'tablecellclass',
         (item) => item.title,
@@ -205,6 +209,7 @@ const addButtons = (editor: Editor, selectionTargets: SelectionTargets, clipboar
     tooltip: 'Vertical align',
     fetch: generateItemsCallback(
       editor,
+      selections,
       verticalAlignValues,
       'tablecellverticalalign',
       (item) => item.text,
@@ -219,6 +224,7 @@ const addButtons = (editor: Editor, selectionTargets: SelectionTargets, clipboar
     tooltip: 'Border width',
     fetch: generateItemsCallback(
       editor,
+      selections,
       tableCellBorderWidthsList,
       'tablecellborderwidth',
       (item) => item.title,
@@ -233,6 +239,7 @@ const addButtons = (editor: Editor, selectionTargets: SelectionTargets, clipboar
     tooltip: 'Border style',
     fetch: generateItemsCallback(
       editor,
+      selections,
       tableCellBorderStylesList,
       'tablecellborderstyle',
       (item) => item.text,

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -5,6 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Selections } from '@ephox/darwin';
 import { Fun } from '@ephox/katamari';
 import { SugarNode } from '@ephox/sugar';
 
@@ -17,7 +18,7 @@ import { SelectionTargets, LockedDisable } from '../selection/SelectionTargets';
 import { verticalAlignValues } from './CellAlignValues';
 import { applyTableCellStyle, changeColumnHeader, changeRowHeader, filterNoneItem, generateColorSelector, generateItems } from './UiUtils';
 
-const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipboard: Clipboard) => {
+const addMenuItems = (editor: Editor, selections: Selections, selectionTargets: SelectionTargets, clipboard: Clipboard) => {
   const cmd = (command: string) => () => editor.execCommand(command);
 
   const insertTableAction = (data: { numRows: number; numColumns: number }) => {
@@ -223,6 +224,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipbo
       text: 'Table styles',
       getSubmenuItems: () => generateItems(
         editor,
+        selections,
         tableClassList,
         'tableclass',
         (item) => item.title,
@@ -239,6 +241,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipbo
       text: 'Cell styles',
       getSubmenuItems: () => generateItems(
         editor,
+        selections,
         tableCellClassList,
         'tablecellclass',
         (item) => item.title,
@@ -253,6 +256,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipbo
     text: 'Vertical align',
     getSubmenuItems: () => generateItems(
       editor,
+      selections,
       verticalAlignValues,
       'tablecellverticalalign',
       (item) => item.text,
@@ -267,6 +271,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipbo
     text: 'Border width',
     getSubmenuItems: () => generateItems(
       editor,
+      selections,
       tableCellBorderWidthsList,
       'tablecellborderwidth',
       (item) => item.title,
@@ -281,6 +286,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets, clipbo
     text: 'Border style',
     getSubmenuItems: () => generateItems(
       editor,
+      selections,
       tableCellBorderStylesList,
       'tablecellborderstyle',
       (item) => item.text,

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -7,6 +7,7 @@
 
 import { Selections } from '@ephox/darwin';
 import { Arr, Singleton, Strings } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
@@ -29,9 +30,15 @@ const onSetupToggle = (editor: Editor, selections: Selections, formatName: strin
         api.setActive(isNone ? !matched : matched);
 
       const selectedCells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, Util.getIsRoot(editor));
-      const forAll = () => Arr.forall(selectedCells, (cell) => editor.formatter.match(formatName, { value: formatValue }, cell.dom));
-      const forAny = () => Arr.exists(selectedCells, (cell) => editor.formatter.match(formatName, { value: formatValue }, cell.dom, isNone));
-      setActive(isNone ? forAny() : forAll());
+
+      const checkNode = (cell: SugarElement<Element>) =>
+        editor.formatter.match(formatName, { value: formatValue }, cell.dom, isNone);
+
+      if (isNone) {
+        setActive(Arr.exists(selectedCells, checkNode));
+      } else {
+        setActive(Arr.forall(selectedCells, checkNode));
+      }
       // TODO: TINY-7713: formatChanged doesn't currently handle formats with dynamic values so this will currently cause all items to show as active
       // const binding = editor.formatter.formatChanged(formatName, setActive, isNone);
       // boundCallback.set(binding);

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -25,14 +25,14 @@ const onSetupToggle = (editor: Editor, selections: Selections, formatName: strin
     const isNone = Strings.isEmpty(formatValue);
 
     const init = () => {
-      // If value is empty (A None-entry in the list), check if the format is not set at all. Otherwise, check if the format is set to the correct value.
-      const setActive = (matched: boolean) =>
-        api.setActive(isNone ? !matched : matched);
-
       const selectedCells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, Util.getIsRoot(editor));
 
       const checkNode = (cell: SugarElement<Element>) =>
         editor.formatter.match(formatName, { value: formatValue }, cell.dom, isNone);
+
+      // If value is empty (A None-entry in the list), check if the format is not set at all. Otherwise, check if the format is set to the correct value.
+      const setActive = (matched: boolean) =>
+        api.setActive(isNone ? !matched : matched);
 
       if (isNone) {
         setActive(Arr.exists(selectedCells, checkNode));

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -31,13 +31,10 @@ const onSetupToggle = (editor: Editor, selections: Selections, formatName: strin
         editor.formatter.match(formatName, { value: formatValue }, cell.dom, isNone);
 
       // If value is empty (A None-entry in the list), check if the format is not set at all. Otherwise, check if the format is set to the correct value.
-      const setActive = (matched: boolean) =>
-        api.setActive(isNone ? !matched : matched);
-
       if (isNone) {
-        setActive(Arr.exists(selectedCells, checkNode));
+        api.setActive(!Arr.exists(selectedCells, checkNode));
       } else {
-        setActive(Arr.forall(selectedCells, checkNode));
+        api.setActive(Arr.forall(selectedCells, checkNode));
       }
       // TODO: TINY-7713: formatChanged doesn't currently handle formats with dynamic values so this will currently cause all items to show as active
       // const binding = editor.formatter.formatChanged(formatName, setActive, isNone);

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -5,16 +5,20 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Selections } from '@ephox/darwin';
 import { Arr, Singleton, Strings } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
+import * as Util from '../core/Util';
+import * as TableSelection from '../selection/TableSelection';
+
 interface Item {
   readonly value: string;
 }
 
-const onSetupToggle = (editor: Editor, formatName: string, formatValue: string) => {
+const onSetupToggle = (editor: Editor, selections: Selections, formatName: string, formatValue: string) => {
   return (api: Toolbar.ToolbarMenuButtonInstanceApi) => {
     const boundCallback = Singleton.unbindable();
     const isNone = Strings.isEmpty(formatValue);
@@ -24,7 +28,10 @@ const onSetupToggle = (editor: Editor, formatName: string, formatValue: string) 
       const setActive = (matched: boolean) =>
         api.setActive(isNone ? !matched : matched);
 
-      setActive(editor.formatter.match(formatName, { value: formatValue }, undefined, isNone));
+      const selectedCells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, Util.getIsRoot(editor));
+      const forAll = () => Arr.forall(selectedCells, (cell) => editor.formatter.match(formatName, { value: formatValue }, cell.dom));
+      const forAny = () => Arr.exists(selectedCells, (cell) => editor.formatter.match(formatName, { value: formatValue }, cell.dom, isNone));
+      setActive(isNone ? forAny() : forAll());
       // TODO: TINY-7713: formatChanged doesn't currently handle formats with dynamic values so this will currently cause all items to show as active
       // const binding = editor.formatter.formatChanged(formatName, setActive, isNone);
       // boundCallback.set(binding);
@@ -44,19 +51,19 @@ const applyTableCellStyle = <T extends Item>(editor: Editor, style: string) =>
 const filterNoneItem = <T extends Item>(list: T[]) =>
   Arr.filter(list, (item) => Strings.isNotEmpty(item.value));
 
-const generateItem = <T extends Item>(editor: Editor, item: T, format: string, extractText: (item: T) => string, onAction: (item: T) => void): Menu.ToggleMenuItemSpec => ({
+const generateItem = <T extends Item>(editor: Editor, selections: Selections, item: T, format: string, extractText: (item: T) => string, onAction: (item: T) => void): Menu.ToggleMenuItemSpec => ({
   text: extractText(item),
   type: 'togglemenuitem',
   onAction: () => onAction(item),
-  onSetup: onSetupToggle(editor, format, item.value)
+  onSetup: onSetupToggle(editor, selections, format, item.value)
 });
 
-const generateItems = <T extends Item>(editor: Editor, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void): Menu.ToggleMenuItemSpec[] =>
-  Arr.map(items, (item) => generateItem(editor, item, format, extractText, onAction));
+const generateItems = <T extends Item>(editor: Editor, selections: Selections, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void): Menu.ToggleMenuItemSpec[] =>
+  Arr.map(items, (item) => generateItem(editor, selections, item, format, extractText, onAction));
 
-const generateItemsCallback = <T extends Item>(editor: Editor, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void) =>
+const generateItemsCallback = <T extends Item>(editor: Editor, selections: Selections, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void) =>
   (callback: (items: Menu.ToggleMenuItemSpec[]) => void) =>
-    callback(generateItems(editor, items, format, extractText, onAction));
+    callback(generateItems(editor, selections, items, format, extractText, onAction));
 
 const fixColorValue = (value: string, setColor: (colorValue: string) => void) => {
   if (value === 'remove') {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
@@ -31,6 +31,11 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
     TinySelections.setSelection(editor, [ 0, 0, 0 ], startCellOffset, [ 0, 0, 0 ], endCellOffset);
   };
 
+  const setContentAndCursor = (editor: Editor, content: string) => {
+    editor.setContent(content);
+    TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+  };
+
   const execCmdAndAssertEvent = (editor: Editor, cmdName: string, data: string) => {
     assert.lengthOf(events, 0, 'Before executing the command');
     editor.execCommand(cmdName, false, data);
@@ -130,7 +135,7 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
 
         it('TINY-7691: Can be toggled on', () => {
           const editor = hook.editor();
-          editor.setContent(contentWithoutClassDoubleSelection);
+          setContentAndCursor(editor, contentWithoutClassDoubleSelection);
 
           execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
           TinyAssertions.assertContent(editor, contentWithDoubleClass);
@@ -138,7 +143,7 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
 
         it('TINY-7691: Can be toggled on while mixed', () => {
           const editor = hook.editor();
-          editor.setContent(contentWithMixedClassDoubleSelection);
+          setContentAndCursor(editor, contentWithMixedClassDoubleSelection);
 
           execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
           TinyAssertions.assertContent(editor, contentWithDoubleClass);
@@ -146,7 +151,7 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
 
         it('TINY-7163: Can be toggled off', () => {
           const editor = hook.editor();
-          editor.setContent(contentWithClassDoubleSelection);
+          setContentAndCursor(editor, contentWithClassDoubleSelection);
 
           execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
           TinyAssertions.assertContent(editor, contentWithoutClass);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
@@ -26,6 +26,11 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
     events.push(event);
   };
 
+  const setContentAndSelection = (editor: Editor, content: string, selectionStart: number, selectionEnd: number) => {
+    editor.setContent(content);
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], selectionStart, [ 0, 0, 0 ], selectionEnd);
+  };
+
   const execCmdAndAssertEvent = (editor: Editor, cmdName: string, data: string) => {
     assert.lengthOf(events, 0, 'Before executing the command');
     editor.execCommand(cmdName, false, data);
@@ -60,22 +65,92 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
         '</table>'
       );
 
-      it('TINY-7163: Can be toggled on', () => {
-        const editor = hook.editor();
-        editor.setContent(contentWithoutClass);
-        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+      context('With a selection of one', () => {
+        it('TINY-7163: Can be toggled on', () => {
+          const editor = hook.editor();
+          setContentAndSelection(editor, contentWithoutClass, 0, 1);
 
-        execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
-        TinyAssertions.assertContent(editor, contentWithClass);
+          execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
+          TinyAssertions.assertContent(editor, contentWithClass);
+        });
+
+        it('TINY-7163: Can be toggled off', () => {
+          const editor = hook.editor();
+          setContentAndSelection(editor, contentWithClass, 0, 1);
+
+          execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
+          TinyAssertions.assertContent(editor, contentWithoutClass);
+        });
       });
 
-      it('TINY-7163: Can be toggled off', () => {
-        const editor = hook.editor();
-        editor.setContent(contentWithClass);
-        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+      context('With a selection of several cells', () => {
+        const contentWithDoubleClass = (
+          '<table>' +
+            '<tbody>' +
+              '<tr>' +
+                '<td class="a">1</td>' +
+                '<td class="a">2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+        );
 
-        execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
-        TinyAssertions.assertContent(editor, contentWithoutClass);
+        const contentWithoutClassDoubleSelection = (
+          '<table>' +
+            '<tbody>' +
+              '<tr>' +
+                '<td data-mce-first-selected="1" data-mce-selected="1">1</td>' +
+                '<td data-mce-last-selected="1" data-mce-selected="1">2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+        );
+
+        const contentWithMixedClassDoubleSelection = (
+          '<table>' +
+            '<tbody>' +
+              '<tr>' +
+                '<td data-mce-first-selected="1" data-mce-selected="1" class="a">1</td>' +
+                '<td data-mce-last-selected="1" data-mce-selected="1">2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+        );
+
+        const contentWithClassDoubleSelection = (
+          '<table>' +
+            '<tbody>' +
+              '<tr>' +
+                '<td data-mce-first-selected="1" data-mce-selected="1" class="a">1</td>' +
+                '<td data-mce-last-selected="1" data-mce-selected="1" class="a">2</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+        );
+
+        it('TINY-7691: Can be toggled on', () => {
+          const editor = hook.editor();
+          editor.setContent(contentWithoutClassDoubleSelection);
+
+          execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
+          TinyAssertions.assertContent(editor, contentWithDoubleClass);
+        });
+
+        it('TINY-7691: Can be toggled on while mixed', () => {
+          const editor = hook.editor();
+          editor.setContent(contentWithMixedClassDoubleSelection);
+
+          execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
+          TinyAssertions.assertContent(editor, contentWithDoubleClass);
+        });
+
+        it('TINY-7163: Can be toggled off', () => {
+          const editor = hook.editor();
+          editor.setContent(contentWithClassDoubleSelection);
+
+          execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
+          TinyAssertions.assertContent(editor, contentWithoutClass);
+        });
       });
     });
 
@@ -104,8 +179,7 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
 
       it('TINY-7163: Can be toggled on', () => {
         const editor = hook.editor();
-        editor.setContent(contentWithoutClass);
-        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+        setContentAndSelection(editor, contentWithoutClass, 0, 1);
 
         execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
         TinyAssertions.assertContent(editor, contentWithClass);
@@ -113,8 +187,7 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
 
       it('TINY-7163: Can be toggled off', () => {
         const editor = hook.editor();
-        editor.setContent(contentWithClass);
-        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+        setContentAndSelection(editor, contentWithClass, 0, 1);
 
         execCmdAndAssertEvent(editor, 'mceTableCellToggleClass', 'a');
         TinyAssertions.assertContent(editor, contentWithoutClass);
@@ -148,8 +221,7 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
 
       it('TINY-7163: Can be toggled on', () => {
         const editor = hook.editor();
-        editor.setContent(contentWithoutClass);
-        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+        setContentAndSelection(editor, contentWithoutClass, 0, 1);
 
         execCmdAndAssertEvent(editor, 'mceTableToggleClass', 'a');
         TinyAssertions.assertContent(editor, contentWithClass);
@@ -157,8 +229,7 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
 
       it('TINY-7163: Can be toggled off', () => {
         const editor = hook.editor();
-        editor.setContent(contentWithClass);
-        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+        setContentAndSelection(editor, contentWithClass, 0, 1);
 
         execCmdAndAssertEvent(editor, 'mceTableToggleClass', 'a');
         TinyAssertions.assertContent(editor, contentWithoutClass);
@@ -189,31 +260,29 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
       );
 
       context('Can be toggled on', () => {
-        const testWithSelection = (startPath: number[], startOffset: number, endPath: number[], endOffset: number) => {
+        const testWithSelection = (startOffset: number, endOffset: number) => {
           const editor = hook.editor();
-          editor.setContent(contentWithoutClass);
-          TinySelections.setSelection(editor, startPath, startOffset, endPath, endOffset);
+          setContentAndSelection(editor, contentWithoutClass, startOffset, endOffset);
           execCmdAndAssertEvent(editor, 'mceTableToggleClass', 'a');
           TinyAssertions.assertContent(editor, contentWithClass);
         };
 
         it('TINY-7163: When the first cell is selected', () => {
-          testWithSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+          testWithSelection(0, 1);
         });
 
         it('TINY-7163: When the second cell is selected', () => {
-          testWithSelection([ 0, 0, 0 ], 1, [ 0, 0, 0 ], 2);
+          testWithSelection(1, 2);
         });
 
         it('TINY-7163: When both cells are selected', () => {
-          testWithSelection([ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
+          testWithSelection(0, 2);
         });
       });
 
       it('TINY-7163: Can be toggled off', () => {
         const editor = hook.editor();
-        editor.setContent(contentWithClass);
-        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+        setContentAndSelection(editor, contentWithClass, 0, 1);
         execCmdAndAssertEvent(editor, 'mceTableToggleClass', 'a');
         TinyAssertions.assertContent(editor, contentWithoutClass);
       });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
@@ -26,9 +26,9 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
     events.push(event);
   };
 
-  const setContentAndSelection = (editor: Editor, content: string, selectionStart: number, selectionEnd: number) => {
+  const setContentAndSelection = (editor: Editor, content: string, startCellOffset: number, endCellOffset: number) => {
     editor.setContent(content);
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], selectionStart, [ 0, 0, 0 ], selectionEnd);
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], startCellOffset, [ 0, 0, 0 ], endCellOffset);
   };
 
   const execCmdAndAssertEvent = (editor: Editor, cmdName: string, data: string) => {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Classes are now toggled as a group. Buttons also now consider the whole selection, not just the first.
No changelog since it's a bug-fix for unreleased feature.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
