### PR TITLE
TINY-7730: Fix problem where 'editor.off()' could cause 'editor.remove()' to fail

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus and context menus were not closed when clicking into a different editor #TINY-7399
 - Using the Tab key to navigate into the editor on IE 11 would incorrectly focus the toolbar #TINY-3707
 - The editor selection could be placed in an incorrect location when undoing or redoing changes in a document containing `contenteditable="false"` elements #TINY-7663
-- Unbinding a native event handler inside the 'remove' event caused an exception that blocked editor removal #TINY-7730
+- Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 
 ## 5.8.2 - 2021-06-23
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus and context menus were not closed when clicking into a different editor #TINY-7399
 - Using the Tab key to navigate into the editor on IE 11 would incorrectly focus the toolbar #TINY-3707
 - The editor selection could be placed in an incorrect location when undoing or redoing changes in a document containing `contenteditable="false"` elements #TINY-7663
+- Unbinding a native event handler inside the 'remove' event caused an exception that blocked editor removal #TINY-7730
 
 ## 5.8.2 - 2021-06-23
 

--- a/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
@@ -174,6 +174,11 @@ const EditorObservable: EditorObservable = {
       return;
     }
 
+    // If the editor has been removed, `unbindAllNativeEvents` has already deleted all native event delegates
+    if (self.removed) {
+      return;
+    }
+
     if (state) {
       if (self.initialized) {
         bindEventDelegate(self, name);

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -89,8 +89,8 @@ describe('browser.tinymce.core.EditorRemoveTest', () => {
     testRemoveStyles(editor, 'block');
   });
 
-  it('remove editor that unbinds mousedown in the remove handler', async () => {
-    const editor = await McEditor.pFromHtml('<textarea></textarea>', {
+  it('TINY-7730: remove editor that unbinds mousedown in the remove handler', async () => {
+    const editor = await McEditor.pFromSettings({
       ...settings,
       setup: (editor: Editor) => {
         editor.on('remove', () => {

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -88,4 +88,18 @@ describe('browser.tinymce.core.EditorRemoveTest', () => {
     const editor = await McEditor.pFromHtml<Editor>('<textarea id="tinymce" style="display: block;"></textarea>', settings);
     testRemoveStyles(editor, 'block');
   });
+
+  it('remove editor that unbinds mousedown in the remove handler', async () => {
+    const editor = await McEditor.pFromHtml('<textarea></textarea>', {
+      ...settings,
+      setup: (editor: Editor) => {
+        editor.on('remove', () => {
+          // the native events have all been unbound
+          // so unbinding 'mousedown' now must do nothing or it will throw an exception
+          editor.off('mousedown');
+        });
+      }
+    });
+    editor.remove();
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7730

Description of Changes:
* Block `toggleNativeEvent` from doing anything if the editor has been removed

This condition has lurked for a _very_ long time, but we never hit it before RTC because most of the editor doesn't clean up event listeners (there's usually no need to). RTC disables most native event listeners but one was added a week ago (#7015).

The newly added listener is the only `mousedown` listener in RTC mode and it unbinds itself in the `remove` event.

The problem flow is:
* `editor.off()` triggers `toggleNativeEvent` for native event names
* However if this is done inside the `remove` event the delegates have already been unbound and `self.delegates` is undefined
* The result is an exception that blocks editor removal

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
