### PR TITLE
TINY-7260: Add removal notices to plugins scheduled to be removed in 6.0

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The editor selection could be placed in an incorrect location when undoing or redoing changes in a document containing `contenteditable="false"` elements #TINY-7663
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 
+### Deprecated
+
+- Added removal notices for the `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins #TINY-7260
+
 ## 5.8.2 - 2021-06-23
 
 ### Fixed

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 
 ### Deprecated
-- The `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins have been deprecated and will be removed in the next major release #TINY-7260
+- The `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins have been deprecated and marked for removal in the next major release #TINY-7260
 
 ## 5.8.2 - 2021-06-23
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -62,8 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 
 ### Deprecated
-
-- Added removal notices for the `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins #TINY-7260
+- The `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins have been deprecated and will be removed in the next major release #TINY-7260
 
 ## 5.8.2 - 2021-06-23
 

--- a/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
@@ -10,8 +10,8 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Convert from './core/Convert';
 
 export default () => {
-  console.warn('Notice: The bbcode plugin has been marked for removal from TinyMCE 6.0');
   PluginManager.add('bbcode', (editor) => {
+    console.warn('The bbcode plugin has been deprecated and marked for removal in TinyMCE 6.0');
     editor.on('BeforeSetContent', (e) => {
       e.content = Convert.bbcode2html(e.content);
     });

--- a/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
@@ -10,6 +10,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Convert from './core/Convert';
 
 export default () => {
+  console.warn('Notice: The bbcode plugin has been marked for removal from TinyMCE 6.0');
   PluginManager.add('bbcode', (editor) => {
     editor.on('BeforeSetContent', (e) => {
       e.content = Convert.bbcode2html(e.content);

--- a/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
@@ -11,6 +11,7 @@ import * as Convert from './core/Convert';
 
 export default () => {
   PluginManager.add('bbcode', (editor) => {
+    // eslint-disable-next-line no-console
     console.warn('The bbcode plugin has been deprecated and marked for removal in TinyMCE 6.0');
     editor.on('BeforeSetContent', (e) => {
       e.content = Convert.bbcode2html(e.content);

--- a/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
@@ -15,6 +15,7 @@ import * as Buttons from './ui/Buttons';
 
 export default () => {
   PluginManager.add('fullpage', (editor) => {
+    // eslint-disable-next-line no-console
     console.warn('The fullpage plugin has been deprecated and marked for removal in TinyMCE 6.0');
     const headState = Cell(''), footState = Cell('');
 

--- a/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
@@ -14,6 +14,7 @@ import * as FilterContent from './core/FilterContent';
 import * as Buttons from './ui/Buttons';
 
 export default () => {
+  console.warn('Notice: The fullpage plugin has been marked for removal from TinyMCE 6.0');
   PluginManager.add('fullpage', (editor) => {
     const headState = Cell(''), footState = Cell('');
 

--- a/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
@@ -14,8 +14,8 @@ import * as FilterContent from './core/FilterContent';
 import * as Buttons from './ui/Buttons';
 
 export default () => {
-  console.warn('Notice: The fullpage plugin has been marked for removal from TinyMCE 6.0');
   PluginManager.add('fullpage', (editor) => {
+    console.warn('The fullpage plugin has been deprecated and marked for removal in TinyMCE 6.0');
     const headState = Cell(''), footState = Cell('');
 
     Commands.register(editor, headState);

--- a/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
@@ -18,6 +18,7 @@ import * as Formats from './core/Formats';
 
 export default () => {
   PluginManager.add('legacyoutput', (editor) => {
+    // eslint-disable-next-line no-console
     console.warn('The legacyoutput plugin has been deprecated and marked for removal in TinyMCE 6.0');
     Formats.setup(editor);
   });

--- a/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
@@ -17,8 +17,8 @@ import * as Formats from './core/Formats';
  */
 
 export default () => {
-  console.warn('Notice: The legacyoutput plugin has been marked for removal from TinyMCE 6.0');
   PluginManager.add('legacyoutput', (editor) => {
+    console.warn('The legacyoutput plugin has been deprecated and marked for removal in TinyMCE 6.0');
     Formats.setup(editor);
   });
 };

--- a/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
@@ -17,6 +17,7 @@ import * as Formats from './core/Formats';
  */
 
 export default () => {
+  console.warn('Notice: The legacyoutput plugin has been marked for removal from TinyMCE 6.0');
   PluginManager.add('legacyoutput', (editor) => {
     Formats.setup(editor);
   });

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
@@ -18,8 +18,8 @@ import * as Buttons from './ui/Buttons';
 import * as SuggestionsMenu from './ui/SuggestionsMenu';
 
 export default () => {
-  console.warn('Notice: The spellchecker plugin has been marked for removal from TinyMCE 6.0');
   PluginManager.add('spellchecker', (editor, pluginUrl) => {
+    console.warn('The spellchecker plugin has been deprecated and marked for removal in TinyMCE 6.0');
     if (DetectProPlugin.hasProPlugin(editor) === false) {
       const startedState = Cell(false);
       const currentLanguageState = Cell<string>(Settings.getLanguage(editor));

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
@@ -20,6 +20,7 @@ import * as SuggestionsMenu from './ui/SuggestionsMenu';
 export default () => {
   PluginManager.add('spellchecker', (editor, pluginUrl) => {
     if (DetectProPlugin.hasProPlugin(editor) === false) {
+      // eslint-disable-next-line no-console
       console.warn('The spellchecker plugin has been deprecated and marked for removal in TinyMCE 6.0');
       const startedState = Cell(false);
       const currentLanguageState = Cell<string>(Settings.getLanguage(editor));

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
@@ -18,6 +18,7 @@ import * as Buttons from './ui/Buttons';
 import * as SuggestionsMenu from './ui/SuggestionsMenu';
 
 export default () => {
+  console.warn('Notice: The spellchecker plugin has been marked for removal from TinyMCE 6.0');
   PluginManager.add('spellchecker', (editor, pluginUrl) => {
     if (DetectProPlugin.hasProPlugin(editor) === false) {
       const startedState = Cell(false);

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
@@ -19,8 +19,8 @@ import * as SuggestionsMenu from './ui/SuggestionsMenu';
 
 export default () => {
   PluginManager.add('spellchecker', (editor, pluginUrl) => {
-    console.warn('The spellchecker plugin has been deprecated and marked for removal in TinyMCE 6.0');
     if (DetectProPlugin.hasProPlugin(editor) === false) {
+      console.warn('The spellchecker plugin has been deprecated and marked for removal in TinyMCE 6.0');
       const startedState = Cell(false);
       const currentLanguageState = Cell<string>(Settings.getLanguage(editor));
       const textMatcherState = Cell(null);


### PR DESCRIPTION
Related Ticket: TINY-7260

Description of Changes:
- Add removal notices to plugins scheduled to be removed in 6.0

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
