### PR TITLE
TINY-7737: Table buttons enable only when whole selection is within the same table

### DIFF
--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -24,12 +24,12 @@ import * as TabContext from './queries/TabContext';
 import CellSelection from './selection/CellSelection';
 import { ephemera } from './selection/Ephemera';
 import { getSelectionTargets } from './selection/SelectionTargets';
-import { getSelectionStartCellOrCaption } from './selection/TableSelection';
+import { getSelectionCellOrCaption } from './selection/TableSelection';
 import * as Buttons from './ui/Buttons';
 import * as MenuItems from './ui/MenuItems';
 
 const Plugin = (editor: Editor) => {
-  const selections = Selections(() => Util.getBody(editor), () => getSelectionStartCellOrCaption(Util.getSelectionStart(editor)), ephemera.selectedSelector);
+  const selections = Selections(() => Util.getBody(editor), () => getSelectionCellOrCaption(Util.getSelectionStart(editor)), ephemera.selectedSelector);
   const selectionTargets = getSelectionTargets(editor, selections);
   const resizeHandler = getResizeHandler(editor);
   const cellSelection = CellSelection(editor, resizeHandler.lazyResize, selectionTargets);

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -29,9 +29,9 @@ import { isPercentagesForced, isPixelsForced, isResponsiveForced } from './Setti
 
 type ExecuteAction<T> = (table: SugarElement<HTMLTableElement>, startCell: SugarElement<HTMLTableCellElement>) => T;
 
-const getSelectionStartCellOrCaption = (editor: Editor) => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor), Util.getIsRoot(editor));
+const getSelectionStartCellOrCaption = (editor: Editor) => TableSelection.getSelectionCellOrCaption(Util.getSelectionStart(editor), Util.getIsRoot(editor));
 
-const getSelectionStartCell = (editor: Editor) => TableSelection.getSelectionStartCell(Util.getSelectionStart(editor), Util.getIsRoot(editor));
+const getSelectionStartCell = (editor: Editor) => TableSelection.getSelectionCell(Util.getSelectionStart(editor), Util.getIsRoot(editor));
 
 const registerCommands = (editor: Editor, actions: TableActions, cellSelection: CellSelectionApi, selections: Selections, clipboard: Clipboard) => {
   const isRoot = Util.getIsRoot(editor);

--- a/modules/tinymce/src/plugins/table/main/ts/api/QueryCommands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/QueryCommands.ts
@@ -24,7 +24,7 @@ const registerQueryCommands = (editor: Editor, actions: TableActions, selections
   Obj.each({
     mceTableRowType: () => actions.getTableRowType(editor),
     mceTableCellType: () => actions.getTableCellType(editor),
-    mceTableColType: () => TableSelection.getSelectionStartCell(Util.getSelectionStart(editor)).bind((cell) =>
+    mceTableColType: () => TableSelection.getSelectionCell(Util.getSelectionStart(editor)).bind((cell) =>
       getTableFromCell(cell).map((table): string => {
         const targets = TableTargets.forMenu(selections, table, cell);
         return actions.getTableColType(table, targets);

--- a/modules/tinymce/src/plugins/table/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Util.ts
@@ -44,6 +44,8 @@ const isPixel = (value: string): boolean => /^(\d+(\.\d+)?)px$/.test(value);
 
 const getSelectionStart = (editor: Editor) => SugarElement.fromDom(editor.selection.getStart());
 
+const getSelectionEnd = (editor: Editor) => SugarElement.fromDom(editor.selection.getEnd());
+
 const getThunkedSelectionStart = (editor: Editor) => () => SugarElement.fromDom(editor.selection.getStart());
 
 export {
@@ -59,5 +61,6 @@ export {
   isPercentage,
   isPixel,
   getSelectionStart,
+  getSelectionEnd,
   getThunkedSelectionStart
 };

--- a/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
@@ -6,7 +6,7 @@
  */
 
 import { Selections } from '@ephox/darwin';
-import { Arr, Cell, Fun, Optional, Thunk } from '@ephox/katamari';
+import { Arr, Cell, Fun, Optional, Optionals, Thunk } from '@ephox/katamari';
 import { RunOperation, Structs, TableLookup, Warehouse } from '@ephox/snooker';
 import { Compare, SelectorExists, SugarElement, SugarNode } from '@ephox/sugar';
 
@@ -67,8 +67,8 @@ export const getSelectionTargets = (editor: Editor, selections: Selections): Sel
 
   const findTargets = (): Optional<RunOperation.CombinedTargets> =>
     getStart().bind((startCellOrCaption) =>
-      getEnd().bind(TableLookup.table).bind((endTable) =>
-        TableLookup.table(startCellOrCaption).bind((startTable) => {
+      Optionals.flatten(
+        Optionals.lift2(TableLookup.table(startCellOrCaption), getEnd().bind(TableLookup.table), (startTable, endTable) => {
           if (Compare.eq(startTable, endTable)) {
             if (isCaption(startCellOrCaption)) {
               return Optional.some(TableTargets.noMenu(startCellOrCaption));

--- a/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
@@ -62,8 +62,8 @@ export const getSelectionTargets = (editor: Editor, selections: Selections): Sel
 
   const isCaption = SugarNode.isTag('caption');
   const isDisabledForSelection = (key: keyof ExtractedSelectionDetails) => selectionDetails.forall((details) => !details[key]);
-  const getStart = () => TableSelection.getSelectionStartCellOrCaption(Util.getSelectionStart(editor), Util.getIsRoot(editor));
-  const getEnd = () => TableSelection.getSelectionEndCellOrCaption(Util.getSelectionEnd(editor), Util.getIsRoot(editor));
+  const getStart = () => TableSelection.getSelectionCellOrCaption(Util.getSelectionStart(editor), Util.getIsRoot(editor));
+  const getEnd = () => TableSelection.getSelectionCellOrCaption(Util.getSelectionEnd(editor), Util.getIsRoot(editor));
 
   const findTargets = (): Optional<RunOperation.CombinedTargets> =>
     getStart().bind((startCellOrCaption) =>

--- a/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
@@ -32,7 +32,7 @@ const getSelectionStartCell = getSelectionFromSelector<HTMLTableCellElement>('th
 
 const getSelectionStartCellOrCaption = getSelectionFromSelector<HTMLTableCellElement | HTMLTableCaptionElement>('th,td,caption', false);
 
-const getSelectionEndCellOrCaption = getSelectionFromSelector<HTMLTableCellElement | HTMLTableCaptionElement>('th,td,caption', false);
+const getSelectionEndCellOrCaption = getSelectionFromSelector<HTMLTableCellElement | HTMLTableCaptionElement>('th,td,caption', true);
 
 const getCellsFromSelection = (start: SugarElement<Node>, selections: Selections, isRoot?: (el: SugarElement<Node>) => boolean): SugarElement<HTMLTableCellElement>[] =>
   getSelectionStartCell(start, isRoot)

--- a/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
@@ -6,7 +6,7 @@
  */
 
 import { CellOpSelection, Selections, TableSelection } from '@ephox/darwin';
-import { Arr, Optionals } from '@ephox/katamari';
+import { Arr, Fun, Optionals } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
 import { Attribute, Compare, SelectorFind, SugarElement, SugarElements, SugarNode } from '@ephox/sugar';
 
@@ -16,7 +16,7 @@ const getSelectionCellFallback = (element: SugarElement<Node>, takeLast: boolean
   TableLookup.table(element).bind((table) =>
     TableSelection.retrieve(table, ephemera.firstSelectedSelector)
   ).fold(
-    () => element,
+    Fun.constant(element),
     (cells) => takeLast ? cells[cells.length - 1] : cells[0]);
 
 const getSelectionFromSelector = <T extends Element>(selector: string, takeLast: boolean) =>

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
@@ -1,5 +1,5 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { before, context, describe, it } from '@ephox/bedrock-client';
+import { before, describe, it } from '@ephox/bedrock-client';
 import { McEditor, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
 
@@ -15,7 +15,6 @@ describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
 
   const tableHtml = '<table><tbody><tr><td>x</td></tr></tbody></table>';
   const tableWithCaptionHtml = '<table><caption>Caption</caption><tbody><tr><td>x</td></tr></tbody></table>';
-  const tableWithAdditionalHtml = '<p>A</p><table><tbody><tr><td>B</td></tr></tbody></table><p>C</p>';
 
   const pCreateEditor = (toolbar: string) => McEditor.pFromSettings<Editor>({
     plugins: 'table',
@@ -51,56 +50,5 @@ describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
     // The paste row button should now be enabled
     await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[title="Paste row before"]:not(.tox-tbtn--disabled)');
     McEditor.remove(editor);
-  });
-
-  context('Ensure table buttons are enabled when appropriate', () => {
-    it('TINY-7737: When the whole selection is in the table', async () => {
-      const editor = await pCreateEditor('tablecaption');
-      editor.focus();
-      editor.setContent(tableWithAdditionalHtml);
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
-      TinySelections.setSelection(editor, [ 1, 0, 0, 0 ], 0, [ 1, 0, 0, 0 ], 1);
-      // Wait for a while to allow the toolbar a chance to render
-      await Waiter.pWait(100);
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Table caption"]');
-      UiFinder.notExists(SugarBody.body(), '.tox-tbtn--disabled[title="Table caption"]');
-      McEditor.remove(editor);
-    });
-
-    it('TINY-7737: When the selection starts outside the table, but ends in the table', async () => {
-      const editor = await pCreateEditor('tablecaption');
-      editor.focus();
-      editor.setContent(tableWithAdditionalHtml);
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
-      TinySelections.setSelection(editor, [ 1, 0, 0, 0 ], 0, [ 2 ], 1);
-      // Wait for a while to allow the toolbar a chance to render
-      await Waiter.pWait(100);
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
-      McEditor.remove(editor);
-    });
-
-    it('TINY-7737: When the selection starts inside the table, but ends outside the table', async () => {
-      const editor = await pCreateEditor('tablecaption');
-      editor.focus();
-      editor.setContent(tableWithAdditionalHtml);
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
-      TinySelections.setSelection(editor, [ 0 ], 0, [ 1, 0, 0, 0 ], 1);
-      // Wait for a while to allow the toolbar a chance to render
-      await Waiter.pWait(100);
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
-      McEditor.remove(editor);
-    });
-
-    it('TINY-7737: When the selection starts and ends outside of the table', async () => {
-      const editor = await pCreateEditor('tablecaption');
-      editor.focus();
-      editor.setContent(tableWithAdditionalHtml);
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
-      TinySelections.setSelection(editor, [ 0 ], 0, [ 2 ], 1);
-      // Wait for a while to allow the toolbar a chance to render
-      await Waiter.pWait(100);
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
-      McEditor.remove(editor);
-    });
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
@@ -18,7 +18,6 @@ describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
 
   const pCreateEditor = (toolbar: string) => McEditor.pFromSettings<Editor>({
     plugins: 'table',
-    toolbar: 'tablecaption',
     table_toolbar: toolbar,
     base_url: '/project/tinymce/js/tinymce'
   });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
@@ -1,5 +1,5 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { before, context, describe, it } from '@ephox/bedrock-client';
 import { McEditor, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
 
@@ -15,9 +15,11 @@ describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
 
   const tableHtml = '<table><tbody><tr><td>x</td></tr></tbody></table>';
   const tableWithCaptionHtml = '<table><caption>Caption</caption><tbody><tr><td>x</td></tr></tbody></table>';
+  const tableWithAdditionalHtml = '<p>A</p><table><tbody><tr><td>B</td></tr></tbody></table><p>C</p>';
 
   const pCreateEditor = (toolbar: string) => McEditor.pFromSettings<Editor>({
     plugins: 'table',
+    toolbar: 'tablecaption',
     table_toolbar: toolbar,
     base_url: '/project/tinymce/js/tinymce'
   });
@@ -49,5 +51,56 @@ describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
     // The paste row button should now be enabled
     await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[title="Paste row before"]:not(.tox-tbtn--disabled)');
     McEditor.remove(editor);
+  });
+
+  context('Ensure table buttons are enabled when appropriate', () => {
+    it('TINY-7737: When the whole selection is in the table', async () => {
+      const editor = await pCreateEditor('tablecaption');
+      editor.focus();
+      editor.setContent(tableWithAdditionalHtml);
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+      TinySelections.setSelection(editor, [ 1, 0, 0, 0 ], 0, [ 1, 0, 0, 0 ], 1);
+      // Wait for a while to allow the toolbar a chance to render
+      await Waiter.pWait(100);
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Table caption"]');
+      UiFinder.notExists(SugarBody.body(), '.tox-tbtn--disabled[title="Table caption"]');
+      McEditor.remove(editor);
+    });
+
+    it('TINY-7737: When the selection starts outside the table, but ends in the table', async () => {
+      const editor = await pCreateEditor('tablecaption');
+      editor.focus();
+      editor.setContent(tableWithAdditionalHtml);
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+      TinySelections.setSelection(editor, [ 1, 0, 0, 0 ], 0, [ 2 ], 1);
+      // Wait for a while to allow the toolbar a chance to render
+      await Waiter.pWait(100);
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+      McEditor.remove(editor);
+    });
+
+    it('TINY-7737: When the selection starts inside the table, but ends outside the table', async () => {
+      const editor = await pCreateEditor('tablecaption');
+      editor.focus();
+      editor.setContent(tableWithAdditionalHtml);
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+      TinySelections.setSelection(editor, [ 0 ], 0, [ 1, 0, 0, 0 ], 1);
+      // Wait for a while to allow the toolbar a chance to render
+      await Waiter.pWait(100);
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+      McEditor.remove(editor);
+    });
+
+    it('TINY-7737: When the selection starts and ends outside of the table', async () => {
+      const editor = await pCreateEditor('tablecaption');
+      editor.focus();
+      editor.setContent(tableWithAdditionalHtml);
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+      TinySelections.setSelection(editor, [ 0 ], 0, [ 2 ], 1);
+      // Wait for a while to allow the toolbar a chance to render
+      await Waiter.pWait(100);
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+      McEditor.remove(editor);
+    });
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
@@ -1,7 +1,5 @@
-import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
-import { SugarBody } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
@@ -16,35 +14,34 @@ describe('browser.tinymce.plugins.table.ToolbarButtonDisplayTest', () => {
 
   const editorContent = '<p>A</p><table><tbody><tr><td>B</td></tr></tbody></table><p>C</p>';
 
-  const displayTest = async (startPath: number[], startOffset: number, endPath: number[], endOffset: number, shouldBeEnabled: boolean) => {
+  const pDisplayTest = async (startPath: number[], startOffset: number, endPath: number[], endOffset: number, shouldBeEnabled: boolean) => {
     const editor = hook.editor();
     editor.setContent(editorContent);
     await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
     TinySelections.setSelection(editor, startPath, startOffset, endPath, endOffset);
 
     if (shouldBeEnabled) {
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Table caption"]');
-      UiFinder.notExists(SugarBody.body(), '.tox-tbtn--disabled[title="Table caption"]');
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Table caption"]:not(.tox-tbtn-disabled)');
     } else {
       await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
     }
   };
 
-  context('Ensure table buttons are enabled when appropriate', () => {
-    it('TINY-7737: When the whole selection is in the table', async () => {
-      await displayTest([ 1, 0, 0, 0 ], 0, [ 1, 0, 0, 0 ], 1, true);
-    });
+  context('Ensure table caption buttons are enabled when appropriate', () => {
+    it('TINY-7737: When the whole selection is in the table', async () =>
+      pDisplayTest([ 1, 0, 0, 0 ], 0, [ 1, 0, 0, 0 ], 1, true)
+    );
 
-    it('TINY-7737: When the selection starts outside the table, but ends in the table', async () => {
-      await displayTest([ 1, 0, 0, 0 ], 0, [ 2 ], 1, false);
-    });
+    it('TINY-7737: When the selection starts outside the table, but ends in the table', async () =>
+      pDisplayTest([ 1, 0, 0, 0 ], 0, [ 2 ], 1, false)
+    );
 
-    it('TINY-7737: When the selection starts inside the table, but ends outside the table', async () => {
-      await displayTest([ 0 ], 0, [ 1, 0, 0, 0 ], 1, false);
-    });
+    it('TINY-7737: When the selection starts inside the table, but ends outside the table', async () =>
+      pDisplayTest([ 0 ], 0, [ 1, 0, 0, 0 ], 1, false)
+    );
 
-    it('TINY-7737: When the selection starts and ends outside of the table', async () => {
-      await displayTest([ 0 ], 0, [ 2 ], 1, false);
-    });
+    it('TINY-7737: When the selection starts and ends outside of the table', async () =>
+      pDisplayTest([ 0 ], 0, [ 2 ], 1, false)
+    );
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
@@ -12,11 +12,9 @@ describe('browser.tinymce.plugins.table.ToolbarButtonDisplayTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin, Theme ], true);
 
-  const editorContent = '<p>A</p><table><tbody><tr><td>B</td></tr></tbody></table><p>C</p>';
-
   const pDisplayTest = async (startPath: number[], startOffset: number, endPath: number[], endOffset: number, shouldBeEnabled: boolean) => {
     const editor = hook.editor();
-    editor.setContent(editorContent);
+    editor.setContent('<p>A</p><table><tbody><tr><td>B</td></tr></tbody></table><p>C</p>');
     await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
     TinySelections.setSelection(editor, startPath, startOffset, endPath, endOffset);
 
@@ -28,19 +26,19 @@ describe('browser.tinymce.plugins.table.ToolbarButtonDisplayTest', () => {
   };
 
   context('Ensure table caption buttons are enabled when appropriate', () => {
-    it('TINY-7737: When the whole selection is in the table', async () =>
+    it('TINY-7737: When the whole selection is in the table', () =>
       pDisplayTest([ 1, 0, 0, 0 ], 0, [ 1, 0, 0, 0 ], 1, true)
     );
 
-    it('TINY-7737: When the selection starts outside the table, but ends in the table', async () =>
+    it('TINY-7737: When the selection starts outside the table, but ends in the table', () =>
       pDisplayTest([ 1, 0, 0, 0 ], 0, [ 2 ], 1, false)
     );
 
-    it('TINY-7737: When the selection starts inside the table, but ends outside the table', async () =>
+    it('TINY-7737: When the selection starts inside the table, but ends outside the table', () =>
       pDisplayTest([ 0 ], 0, [ 1, 0, 0, 0 ], 1, false)
     );
 
-    it('TINY-7737: When the selection starts and ends outside of the table', async () =>
+    it('TINY-7737: When the selection starts and ends outside of the table', () =>
       pDisplayTest([ 0 ], 0, [ 2 ], 1, false)
     );
   });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
@@ -1,0 +1,50 @@
+import { UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/table/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+describe('browser.tinymce.plugins.table.ToolbarButtonDisplayTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'table',
+    toolbar: 'tablecaption',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin, Theme ], true);
+
+  const editorContent = '<p>A</p><table><tbody><tr><td>B</td></tr></tbody></table><p>C</p>';
+
+  const displayTest = async (startPath: number[], startOffset: number, endPath: number[], endOffset: number, shouldBeEnabled: boolean) => {
+    const editor = hook.editor();
+    editor.setContent(editorContent);
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+    TinySelections.setSelection(editor, startPath, startOffset, endPath, endOffset);
+
+    if (shouldBeEnabled) {
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Table caption"]');
+      UiFinder.notExists(SugarBody.body(), '.tox-tbtn--disabled[title="Table caption"]');
+    } else {
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+    }
+  };
+
+  context('Ensure table buttons are enabled when appropriate', () => {
+    it('TINY-7737: When the whole selection is in the table', async () => {
+      await displayTest([ 1, 0, 0, 0 ], 0, [ 1, 0, 0, 0 ], 1, true);
+    });
+
+    it('TINY-7737: When the selection starts outside the table, but ends in the table', async () => {
+      await displayTest([ 1, 0, 0, 0 ], 0, [ 2 ], 1, false);
+    });
+
+    it('TINY-7737: When the selection starts inside the table, but ends outside the table', async () => {
+      await displayTest([ 0 ], 0, [ 1, 0, 0, 0 ], 1, false);
+    });
+
+    it('TINY-7737: When the selection starts and ends outside of the table', async () => {
+      await displayTest([ 0 ], 0, [ 2 ], 1, false);
+    });
+  });
+});


### PR DESCRIPTION
Description of Changes:
Now check that the start and end are both within the same table.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
