### PR TITLE
TINY-7707: Fixed the new language toolbar not showing as active when inside a language span

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/ChoiceControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/ChoiceControls.ts
@@ -109,7 +109,7 @@ const lineHeightSpec: ControlSpec<string> = {
   display: Fun.identity,
 
   getCurrent: (editor) => Optional.from(editor.queryCommandValue('LineHeight')),
-  setCurrent: (editor, value) => editor.execCommand('LineHeight', false, value),
+  setCurrent: (editor, value) => editor.execCommand('LineHeight', false, value)
 };
 
 const languageSpec = (editor: Editor): Optional<ControlSpec<ContentLanguage>> => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/ChoiceControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/ChoiceControls.ts
@@ -10,7 +10,7 @@ import { Attribute, Dimension, SugarElement, SugarNode, TransformFind } from '@e
 
 import Editor from 'tinymce/core/api/Editor';
 import { ContentLanguage } from 'tinymce/core/api/SettingsTypes';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import * as Settings from '../../api/Settings';
 
@@ -26,6 +26,9 @@ interface ControlSpec<T> {
 
   readonly getCurrent: (editor: Editor) => Optional<T>;
   readonly setCurrent: (editor: Editor, value: T) => void;
+
+  readonly onToolbarSetup?: (api: Toolbar.ToolbarMenuButtonInstanceApi) => () => void;
+  readonly onMenuSetup?: (api: Menu.NestedMenuItemInstanceApi) => () => void;
 }
 
 const registerController = <T>(editor: Editor, spec: ControlSpec<T>) => {
@@ -84,13 +87,15 @@ const registerController = <T>(editor: Editor, spec: ControlSpec<T>) => {
   editor.ui.registry.addMenuButton(spec.name, {
     tooltip: spec.text,
     icon: spec.icon,
-    fetch: (callback) => callback(getMenuItems())
+    fetch: (callback) => callback(getMenuItems()),
+    onSetup: spec.onToolbarSetup
   });
 
   editor.ui.registry.addNestedMenuItem(spec.name, {
     type: 'nestedmenuitem',
     text: spec.text,
-    getSubmenuItems: getMenuItems
+    getSubmenuItems: getMenuItems,
+    onSetup: spec.onMenuSetup
   });
 };
 
@@ -104,7 +109,7 @@ const lineHeightSpec: ControlSpec<string> = {
   display: Fun.identity,
 
   getCurrent: (editor) => Optional.from(editor.queryCommandValue('LineHeight')),
-  setCurrent: (editor, value) => editor.execCommand('LineHeight', false, value)
+  setCurrent: (editor, value) => editor.execCommand('LineHeight', false, value),
 };
 
 const languageSpec = (editor: Editor): Optional<ControlSpec<ContentLanguage>> => {
@@ -132,7 +137,14 @@ const languageSpec = (editor: Editor): Optional<ControlSpec<ContentLanguage>> =>
           })
       );
     },
-    setCurrent: (editor, lang) => editor.execCommand('Lang', false, lang)
+    setCurrent: (editor, lang) => editor.execCommand('Lang', false, lang),
+
+    onToolbarSetup: (api) => {
+      const unbinder = Singleton.unbindable();
+      api.setActive(editor.formatter.match('lang', {}, undefined, true));
+      unbinder.set(editor.formatter.formatChanged('lang', api.setActive, true));
+      return unbinder.clear;
+    }
   }));
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -237,6 +237,20 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
           await Waiter.pTryUntil('Language has changed back', () => TinyAssertions.assertContent(editor, '<p>Some content</p>'));
         });
       });
+
+      it('TINY-7707: The toolbar button should be active when the selection is within lang span', async () => {
+        const editor = hook.editor();
+        editor.setContent('<p><span lang="de">Some German content</span></p><p>Some content</p>');
+
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
+        await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled');
+
+        TinySelections.setCursor(editor, [ 1, 0 ], 4);
+        await TinyUiActions.pWaitForUi(editor, '.tox-tbtn:not(.tox-tbtn--enabled)');
+
+        editor.formatter.apply('lang', { value: 'zh' });
+        await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled');
+      });
     });
 
     context('Advanced settings', () => {


### PR DESCRIPTION
Related Ticket: TINY-7707

Description of Changes:
* Added new callbacks to `ChoiceControls` to define a custom setup function for the toolbar button/menu (they need to be different as they have different APIs and it's not something we can standardise).
* Updated the `language` toolbar button to mark itself as active when a `lang` format is active (i.e the selection is inside a lang span). This is done by using the format changed listener.

Pre-checks:
* [x] ~Changelog entry added~ Already has a changelog entry since this is a new feature
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
