### PR TITLE
TINY-7374: Fixed SandHTMLElement not working across different windows

### DIFF
--- a/modules/sand/src/main/ts/ephox/sand/api/SandHTMLElement.ts
+++ b/modules/sand/src/main/ts/ephox/sand/api/SandHTMLElement.ts
@@ -1,5 +1,7 @@
-import { Resolve } from '@ephox/katamari';
+import { Resolve, Type } from '@ephox/katamari';
 import * as Global from '../util/Global';
+
+const getPrototypeOf = Object.getPrototypeOf;
 
 /*
  * IE9 and above
@@ -16,7 +18,9 @@ const isPrototypeOf = (x: any): x is HTMLElement => {
   // undefined scope later triggers using the global window.
   const scope: Window | undefined = Resolve.resolve('ownerDocument.defaultView', x);
 
-  return sandHTMLElement(scope).prototype.isPrototypeOf(x);
+  // TINY-7374: We can't rely on looking at the owner window HTMLElement as the element may have
+  // been constructed in a different window and then appended to the current window document.
+  return Type.isObject(x) && (sandHTMLElement(scope).prototype.isPrototypeOf(x) || /^\[object HTML\w*Element\]$/.test(getPrototypeOf(x).toString()));
 };
 
 export {

--- a/modules/sand/src/test/ts/browser/HtmlElementTest.ts
+++ b/modules/sand/src/test/ts/browser/HtmlElementTest.ts
@@ -1,11 +1,53 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
-import { SandHTMLElement } from 'ephox/sand/api/Main';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
 
-UnitTest.test('HtmlElementTest', () => {
-  const span = document.createElement('div');
-  assert.eq(false, SandHTMLElement.isPrototypeOf(null));
-  assert.eq(false, SandHTMLElement.isPrototypeOf(undefined));
-  assert.eq(false, SandHTMLElement.isPrototypeOf('a string'));
-  assert.eq(false, SandHTMLElement.isPrototypeOf({}));
-  assert.eq(true, SandHTMLElement.isPrototypeOf(span));
+import * as SandHTMLElement from 'ephox/sand/api/SandHTMLElement';
+
+describe('HtmlElementTest', () => {
+  context('isPrototypeOf', () => {
+    it('non elements should be false', () => {
+      assert.isFalse(SandHTMLElement.isPrototypeOf(null));
+      assert.isFalse(SandHTMLElement.isPrototypeOf(undefined));
+      assert.isFalse(SandHTMLElement.isPrototypeOf('a string'));
+      assert.isFalse(SandHTMLElement.isPrototypeOf({}));
+    });
+
+    it('nodes should be false', () => {
+      const text = document.createTextNode('text');
+      const comment = document.createComment('comment');
+      const frag = document.createDocumentFragment();
+      assert.isFalse(SandHTMLElement.isPrototypeOf(text));
+      assert.isFalse(SandHTMLElement.isPrototypeOf(comment));
+      assert.isFalse(SandHTMLElement.isPrototypeOf(frag));
+    });
+
+    it('SVG elements should be false', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      assert.isFalse(SandHTMLElement.isPrototypeOf(svg));
+    });
+
+    it('same window elements should be true', () => {
+      const div = document.createElement('div');
+      assert.isTrue(SandHTMLElement.isPrototypeOf(div));
+    });
+
+    it('TINY-7374: different window elements should be true', () => {
+      const span = document.createElement('span');      // HTMLSpanElement
+      const strong = document.createElement('strong');  // HTMLElement
+      const iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+
+      const iframeDoc = iframe.contentDocument;
+      iframeDoc.open();
+      iframeDoc.write('<html><body></body></html>');
+      iframeDoc.close();
+
+      iframeDoc.body.appendChild(span);
+      iframeDoc.body.appendChild(strong);
+      assert.isTrue(SandHTMLElement.isPrototypeOf(span));
+      assert.isTrue(SandHTMLElement.isPrototypeOf(strong));
+
+      document.body.removeChild(iframe);
+    });
+  });
 });

--- a/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
+++ b/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
@@ -1,5 +1,6 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 import { Css, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 import { TableSize } from 'ephox/snooker/api/TableSize';
 import { Warehouse } from 'ephox/snooker/api/Warehouse';
@@ -16,6 +17,8 @@ const pixelTableMissingWidthsHtml = `<table style="width: 400px; border-collapse
 </table>`;
 const tableWithSpansHtml = '<table style="width: 400px; border-collapse: collapse"><tbody><tr><td style="width: 400px;" colspan="2">A</td></tr></tbody></table>';
 const noneTableWithColsHtml = '<table><colgroup><col><col></colgroup><tbody><tr><td>A</td><td>A</td></tr></tbody></table>';
+const browser = PlatformDetection.detect().browser;
+const isChrome92 = browser.isChrome() && browser.version.major >= 92;
 
 UnitTest.test('ColumnSizes.getPixelWidths', () => {
   const sTest = (label: string, html: string, getExpectedWidths: (cellWidth: number) => number[]) => {
@@ -39,7 +42,12 @@ UnitTest.test('ColumnSizes.getPixelWidths', () => {
   sTest('Pixel Table - Column widths with missing widths on some cells should be the raw size of the cell', pixelTableMissingWidthsHtml, () => [ 200, 200 ]);
   sTest('Pixel Table - Column width should be the size of the table when using colspans', tableWithSpansHtml, () => [ 0, 400 ]);
   sTest('None Table - Column widths should be the computed size of the cell', noneTableHtml, (width) => [ width, width ]);
-  sTest('None Table - Column widths for cols should be the computed size of the cell', noneTableWithColsHtml, (width) => [ width + 2, width + 2 ]); // Add 2 to account for the borders
+  if (isChrome92) {
+    // TODO: Remove this once the cell width bug introduced in Chrome 92 is fixed (see TINY-7758 for more details)
+    sTest('None Table - Column widths for cols should be the computed size of the cell', noneTableWithColsHtml, (width) => [ width + 2, width + 1 ]);
+  } else {
+    sTest('None Table - Column widths for cols should be the computed size of the cell', noneTableWithColsHtml, (width) => [ width + 2, width + 2 ]); // Add 2 to account for the borders
+  }
 });
 
 UnitTest.test('ColumnSizes.getPixelHeights', () => {


### PR DESCRIPTION
Related Ticket: TINY-7374

Description of Changes:
* Fix the `SandHTMLElement.isPrototypeOf` function not working when an element is constructed in another window.

**Note:** Tests were failing because of the `ColumnSizesTest` issue on Chrome 92, so I've also cherry-picked that commit as well.

Pre-checks:
* [x] ~Changelog entry added~ No changelogs on master
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
