### PR TITLE
TINY-7756: Fixed attributes clobbering native document properties causing the editor to crash

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus and context menus were not closed when clicking into a different editor #TINY-7399
 - Using the Tab key to navigate into the editor on IE 11 would incorrectly focus the toolbar #TINY-3707
 - The editor selection could be placed in an incorrect location when undoing or redoing changes in a document containing `contenteditable="false"` elements #TINY-7663
+- Certain HTML content when inserted could cause the editor to crash #TINY-7756
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 
 ### Deprecated

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -70,6 +70,7 @@ export interface DomParserSettings {
   validate?: boolean;
   inline_styles?: boolean;
   blob_cache?: BlobCache;
+  document?: Document;
   images_dataimg_filter?: (img: HTMLImageElement) => boolean;
 }
 
@@ -475,6 +476,7 @@ const DomParser = (settings?: DomParserSettings, schema = Schema()): DomParser =
 
     const parser = SaxParser({
       validate,
+      document: settings.document,
       allow_html_data_urls: settings.allow_html_data_urls,
       allow_svg_data_urls: settings.allow_svg_data_urls,
       allow_script_urls: settings.allow_script_urls,

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -88,6 +88,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     root_name: getRootName(editor),
     validate: true,
     blob_cache: blobCache,
+    document: editor.getDoc(),
 
     // Deprecated
     images_dataimg_filter: settings.images_dataimg_filter

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -163,8 +163,8 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     DOM.setHTML('test', '<input type="text" value="text" length="128" maxlength="129" />');
     assert.equal(ser.serialize(DOM.get('test')), '<input type="text" value="text" length="128" maxlength="129" />');
 
-    DOM.setHTML('test', '<form method="post"><input type="hidden" name="method" value="get" /></form>');
-    assert.equal(ser.serialize(DOM.get('test')), '<form method="post"><input type="hidden" name="method" value="get" /></form>');
+    DOM.setHTML('test', '<form method="post"><input type="hidden" name="formmethod" value="get" /></form>');
+    assert.equal(ser.serialize(DOM.get('test')), '<form method="post"><input type="hidden" name="formmethod" value="get" /></form>');
 
     DOM.setHTML('test', '<label for="test">label</label>');
     assert.equal(ser.serialize(DOM.get('test')), '<label for="test">label</label>');

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -1121,4 +1121,33 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
     parser.parse(`${inner}<div data-mce-bogus="all">${inner}</div>`);
     assert.equal(writer.getContent(), inner);
   });
+
+  it('TINY-7756: should prevent dom clobbering overriding document/form properties', () => {
+    const counter = createCounter(writer);
+    const parser = SaxParser(counter, schema);
+
+    writer.reset();
+    parser.parse(
+      '<img src="x" name="getElementById" />' +
+      '<form>' +
+      '<input id="attributes" />' +
+      '<output id="style"></output>' +
+      '<button name="action"></button>' +
+      '<select name="getElementsByName"></select>' +
+      '<fieldset name="method"></fieldset>' +
+      '<textarea name="click"></textarea>' +
+      '</form>'
+    );
+    assert.equal(writer.getContent(),
+      '<img src="x" />' +
+      '<form>' +
+        '<input />' +
+        '<output></output>' +
+        '<button></button>' +
+        '<select></select>' +
+        '<fieldset></fieldset>' +
+        '<textarea></textarea>' +
+      '</form>'
+    );
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7756

Description of Changes:
This updates the parser to mark attributes as unsafe if they would clobber a document/form property. For those that aren't aware, using an id/name can cause the browser to store a reference to that element on the owner `document` or `form`. As such, using certain names/ids will cause the browser to overwrite the existing properties/functions.

Note: This is only part 1 of the issues for this Jira and I'm just creating the PR now to keep the PR size smaller as discussed earlier in the week.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
