### PR TITLE
Fix the color contrast issues for axe a11y audit

### DIFF
--- a/modules/oxide/src/less/theme/components/menubar/menubar.less
+++ b/modules/oxide/src/less/theme/components/menubar/menubar.less
@@ -10,7 +10,6 @@
 //
 
 @menubar-background-color: @background-color;
-@menubar-background: url("data:image/svg+xml;charset=utf8,%3Csvg height='@{_menubar-height}' viewBox='0 0 40 @{_menubar-height}' width='40' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0' y='@{_menubar-divider-height}' width='100' height='1' fill='@{_menubar-row-separator-color}'/%3E%3C/svg%3E") left 0 top 0 @menubar-background-color;
 @menubar-padding-x: @toolbar-group-padding-x;
 @menubar-separator-color: @border-color;
 @menubar-row-separator-color: @border-color;
@@ -22,8 +21,8 @@
 
 .tox {
   .tox-menubar {
-    background: @menubar-background;
     background-color: @menubar-background-color;
+    border-bottom: 1px solid @menubar-row-separator-color;
     display: flex;
     flex: 0 0 auto;
     flex-shrink: 0;

--- a/modules/oxide/src/less/theme/components/toolbar/toolbar.less
+++ b/modules/oxide/src/less/theme/components/toolbar/toolbar.less
@@ -10,7 +10,6 @@
 //
 
 @toolbar-background-color: @background-color;
-@toolbar-background: url("data:image/svg+xml;charset=utf8,%3Csvg height='@{_toolbar-height}' viewBox='0 0 40 @{_toolbar-height}' width='40' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0' y='@{_toolbar-divider-height}' width='100' height='1' fill='@{_toolbar-row-separator-color}'/%3E%3C/svg%3E") left 0 top @toolbar-padding-y @toolbar-background-color;
 @toolbar-row-separator-color: @toolbar-group-separator-color;
 @toolbar-separator-color: @border-color;
 @toolbar-padding-y: 0; // Note that a positive value doesn't work with toolbar collapsing into multiple rows. Will cause issues with the toolbar row separator
@@ -29,8 +28,8 @@
   .tox-toolbar,
   .tox-toolbar__primary,
   .tox-toolbar__overflow {
-    background: @toolbar-background;
     background-color: @toolbar-background-color;
+    border-bottom: 1px solid @toolbar-row-separator-color;
     display: flex;
     flex: 0 0 auto;
     flex-shrink: 0;


### PR DESCRIPTION
Elements with the following CSS classes fire the "Text elements must have sufficient color contrast against the background" a11y violation in the axe DevTools:

- [`tox-mbtn__select-label`](https://axe.deque.com/issues/7babe2d7-8d6f-4f82-a3f9-9f38e3d6ab09)
<img width="1792" alt="Screen Shot 2021-07-29 at 12 40 26 am" src="https://user-images.githubusercontent.com/33809585/127403206-a4971ab2-bae6-43d7-88cb-2bc5a0fa031d.png">

- [`tox-tbtn__select-label`](https://axe.deque.com/issues/a190e94d-b8fe-41f5-aa4c-ad14ef6fef4d)
<img width="1792" alt="Screen Shot 2021-07-29 at 12 41 26 am" src="https://user-images.githubusercontent.com/33809585/127403278-32ad97af-b5b2-4075-b81d-408fccb992d1.png">

https://dequeuniversity.com/rules/axe/4.3/color-contrast?application=AxeChrome

As far as I understand the only purpose of `@toolbar-background` and `@menubar-background` is to dynamically generate a transparent SVG background with a 1px bottom line.

So I'd suggest achieving absolutely the same result by setting the `border-bottom` property and as a benefit improve accessibility.

<img width="1792" alt="Screen Shot 2021-07-29 at 12 46 27 am" src="https://user-images.githubusercontent.com/33809585/127403337-4cadc551-c6c6-4ed5-87ca-aa3b788766d8.png">