### PR TITLE
TINY-6666: Ensure the existing row is re-used where possible when doing operations

### DIFF
--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -6,8 +6,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- `Warehouse` now contains the colgroup elements from the table.
+
+### Improved
+- Rows are now stored and tracked in the table model structures.
+
 ### Changed
+- `RowDetails` has been renamed to `RowDetail` and now takes a generic argument to define what is the type of cells stored.
+- `row` and `colgroup` generators are now passed the previous element during transform or modification operations.
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
+
+### Fixed
+- Table operations that replace all cells in a row now re-use the existing row instead of creating a new row.
+
+### Removed
+- `Structs.RowData` has been merged into and replaced by `Structs.RowDetail` to remove some duplication.
+- The `cursor` function has been removed from `Generators` as it was unused and incorrectly implemented.
 
 ## 8.0.4 - 2021-06-23
 

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rows are now stored and tracked in the table model structures.
 
 ### Changed
-- `RowDetails` has been renamed to `RowDetail` and now takes a generic argument to define what is the type of cells stored.
+- `RowDetails` has been renamed to `RowDetail` and now takes a generic argument to define the type of cells stored.
 - `row` and `colgroup` generators are now passed the previous element during transform or modification operations.
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyRows.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyRows.ts
@@ -8,7 +8,7 @@ import * as Redraw from '../operate/Redraw';
 import { Generators } from './Generators';
 import { Warehouse } from './Warehouse';
 
-const copyRows = (table: SugarElement<HTMLTableElement>, target: TargetSelection, generators: Generators): Optional<SugarElement<HTMLTableRowElement>[]> => {
+const copyRows = (table: SugarElement<HTMLTableElement>, target: TargetSelection, generators: Generators): Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]> => {
   const warehouse = Warehouse.fromTable(table);
   // Cannot use onUnlockedCells like extractor here as if only cells in a locked column are selected, then this will be Optional.none and
   // there is now no way of knowing which rows are selected
@@ -23,7 +23,7 @@ const copyRows = (table: SugarElement<HTMLTableElement>, target: TargetSelection
       const newCells = Arr.filter(row.cells, (cell) => !cell.isLocked);
       return newCells.length > 0 ? [{ ...row, cells: newCells }] : [];
     });
-    const slicedDetails = toDetailList(filteredGrid, generators);
+    const slicedDetails = toDetailList(filteredGrid);
     return Optionals.someIf(slicedDetails.length > 0, slicedDetails);
   }).map((slicedDetails) => Redraw.copy(slicedDetails));
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
@@ -5,7 +5,7 @@ import * as DetailsList from '../model/DetailsList';
 import * as ColumnSizes from '../resize/ColumnSizes';
 import * as LayerSelector from '../util/LayerSelector';
 import { LOCKED_COL_ATTR } from '../util/LockedColumnUtils';
-import { DetailExt, RowData } from './Structs';
+import { Detail, DetailExt, RowDetail } from './Structs';
 import { TableSize } from './TableSize';
 import { Warehouse } from './Warehouse';
 
@@ -62,7 +62,7 @@ const findSelectedStats = (house: Warehouse, isSelected: (detail: DetailExt) => 
   return statsStruct(minRow, minCol, maxRow, maxCol, allCells, selectedCells);
 };
 
-const makeCell = <T>(list: RowData<T>[], seenSelected: boolean, rowIndex: number): void => {
+const makeCell = (list: RowDetail<Detail>[], seenSelected: boolean, rowIndex: number): void => {
   // no need to check bounds, as anything outside this index is removed in the nested for loop
   const row = list[rowIndex].element;
   const td = SugarElement.fromTag('td');
@@ -71,7 +71,7 @@ const makeCell = <T>(list: RowData<T>[], seenSelected: boolean, rowIndex: number
   f(row, td);
 };
 
-const fillInGaps = <T>(list: RowData<T>[], house: Warehouse, stats: StatsStruct, isSelected: (detail: DetailExt) => boolean) => {
+const fillInGaps = (list: RowDetail<Detail>[], house: Warehouse, stats: StatsStruct, isSelected: (detail: DetailExt) => boolean) => {
   const totalColumns = house.grid.columns;
   const totalRows = house.grid.rows;
   // unselected cells have been deleted, now fill in the gaps in the model

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
@@ -1,21 +1,25 @@
-import { Arr, Fun, Optional, Optionals, Singleton } from '@ephox/katamari';
+import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { getAttrValue } from '../util/CellUtils';
 
-export interface CellSpan {
+export interface RowData {
+  readonly element: SugarElement<HTMLTableRowElement | HTMLTableColElement>;
+}
+
+export interface CellData {
   readonly element: SugarElement<HTMLTableCellElement | HTMLTableColElement>;
   readonly colspan: number;
   readonly rowspan: number;
 }
 
 export interface Generators {
-  readonly cell: (cellSpan: CellSpan) => SugarElement<HTMLTableCellElement>;
-  readonly row: () => SugarElement<HTMLTableRowElement>;
+  readonly cell: (cellData: CellData) => SugarElement<HTMLTableCellElement>;
+  readonly row: (rowData: RowData) => SugarElement<HTMLTableRowElement>;
   readonly replace: <K extends keyof HTMLElementTagNameMap>(cell: SugarElement<HTMLTableCellElement>, tag: K, attrs: Record<string, string | number | boolean | null>) => SugarElement<HTMLElementTagNameMap[K]>;
   readonly gap: () => SugarElement<HTMLTableCellElement>;
-  readonly col: (prev: CellSpan) => SugarElement<HTMLTableColElement>;
-  readonly colgroup: () => SugarElement<HTMLTableColElement>;
+  readonly col: (prev: CellData) => SugarElement<HTMLTableColElement>;
+  readonly colgroup: (prev: RowData) => SugarElement<HTMLTableColElement>;
 }
 
 export interface SimpleGenerators extends Generators {
@@ -27,9 +31,7 @@ export interface SimpleGenerators extends Generators {
   readonly colgroup: () => SugarElement<HTMLTableColElement>;
 }
 
-export interface GeneratorsWrapper {
-  readonly cursor: () => Optional<SugarElement>;
-}
+export interface GeneratorsWrapper {}
 
 export interface GeneratorsModification extends GeneratorsWrapper {
   readonly getOrInit: (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) => SugarElement;
@@ -54,7 +56,7 @@ interface Item {
   readonly sub: SugarElement;
 }
 
-const elementToData = (element: SugarElement): CellSpan => {
+const elementToData = (element: SugarElement): CellData => {
   const colspan = getAttrValue(element, 'colspan', 1);
   const rowspan = getAttrValue(element, 'rowspan', 1);
   return {
@@ -64,11 +66,17 @@ const elementToData = (element: SugarElement): CellSpan => {
   };
 };
 
+const isCol = SugarNode.isTag('col');
+
+const isRow = (element: SugarElement): element is SugarElement<HTMLTableRowElement | HTMLTableColElement> => {
+  const name = SugarNode.name(element);
+  return name === 'tr' || name === 'colgroup';
+};
+
 // note that `toData` seems to be only for testing
 const modification = (generators: Generators, toData = elementToData): GeneratorsModification => {
-  const position = Singleton.value<SugarElement>();
 
-  const nu = (data: CellSpan) => {
+  const nuCell = (data: CellData) => {
     switch (SugarNode.name(data.element)) {
       case 'col':
         return generators.col(data);
@@ -77,18 +85,23 @@ const modification = (generators: Generators, toData = elementToData): Generator
     }
   };
 
-  const nuFrom = (element: SugarElement) => {
-    const data = toData(element);
-    return nu(data);
+  const nuRow = (data: RowData) => {
+    switch (SugarNode.name(data.element)) {
+      case 'colgroup':
+        return generators.colgroup(data);
+      default:
+        return generators.row(data);
+    }
   };
 
   const add = (element: SugarElement) => {
-    const replacement = nuFrom(element);
-    if (!position.isSet()) {
-      position.set(replacement);
+    if (isRow(element)) {
+      return nuRow({ element });
+    } else {
+      const replacement = nuCell(toData(element));
+      recent = Optional.some({ item: element, replacement });
+      return replacement;
     }
-    recent = Optional.some({ item: element, replacement });
-    return replacement;
   };
 
   let recent = Optional.none<Recent>();
@@ -101,14 +114,12 @@ const modification = (generators: Generators, toData = elementToData): Generator
   };
 
   return {
-    getOrInit,
-    cursor: position.get
+    getOrInit
   };
 };
 
 const transform = <K extends keyof HTMLElementTagNameMap> (scope: string | null, tag: K) => {
   return (generators: Generators): GeneratorsTransform => {
-    const position = Singleton.value<SugarElement>();
     const list: Item[] = [];
 
     const find = (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) => {
@@ -126,14 +137,11 @@ const transform = <K extends keyof HTMLElementTagNameMap> (scope: string | null,
         item: element,
         sub: cell
       });
-      if (!position.isSet()) {
-        position.set(cell);
-      }
       return cell;
     };
 
     const replaceOrInit = (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) => {
-      if (SugarNode.name(element) === 'col') {
+      if (isRow(element) || isCol(element)) {
         return element;
       } else {
         return find(element, comparator).fold(() => {
@@ -145,8 +153,7 @@ const transform = <K extends keyof HTMLElementTagNameMap> (scope: string | null,
     };
 
     return {
-      replaceOrInit,
-      cursor: position.get
+      replaceOrInit
     };
   };
 };
@@ -159,13 +166,7 @@ const getScopeAttribute = (cell: SugarElement) =>
   );
 
 const merging = (generators: Generators): GeneratorsMerging => {
-  const position = Singleton.value<SugarElement>();
-
   const unmerge = (cell: SugarElement) => {
-    if (!position.isSet()) {
-      position.set(cell);
-    }
-
     const scope = getScopeAttribute(cell);
 
     scope.each((attribute) => Attribute.set(cell, 'scope', attribute));
@@ -219,8 +220,7 @@ const merging = (generators: Generators): GeneratorsMerging => {
 
   return {
     unmerge,
-    merge,
-    cursor: position.get
+    merge
   };
 };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
@@ -56,6 +56,12 @@ interface Item {
   readonly sub: SugarElement;
 }
 
+const isCol = SugarNode.isTag('col');
+const isColgroup = SugarNode.isTag('colgroup');
+
+const isRow = (element: SugarElement): element is SugarElement<HTMLTableRowElement | HTMLTableColElement> =>
+  SugarNode.name(element) === 'tr' || isColgroup(element);
+
 const elementToData = (element: SugarElement): CellData => {
   const colspan = getAttrValue(element, 'colspan', 1);
   const rowspan = getAttrValue(element, 'rowspan', 1);
@@ -66,33 +72,14 @@ const elementToData = (element: SugarElement): CellData => {
   };
 };
 
-const isCol = SugarNode.isTag('col');
-
-const isRow = (element: SugarElement): element is SugarElement<HTMLTableRowElement | HTMLTableColElement> => {
-  const name = SugarNode.name(element);
-  return name === 'tr' || name === 'colgroup';
-};
-
 // note that `toData` seems to be only for testing
 const modification = (generators: Generators, toData = elementToData): GeneratorsModification => {
 
-  const nuCell = (data: CellData) => {
-    switch (SugarNode.name(data.element)) {
-      case 'col':
-        return generators.col(data);
-      default:
-        return generators.cell(data);
-    }
-  };
+  const nuCell = (data: CellData) =>
+    isCol(data.element) ? generators.col(data) : generators.cell(data);
 
-  const nuRow = (data: RowData) => {
-    switch (SugarNode.name(data.element)) {
-      case 'colgroup':
-        return generators.colgroup(data);
-      default:
-        return generators.row(data);
-    }
-  };
+  const nuRow = (data: RowData) =>
+    isColgroup(data.element) ? generators.colgroup(data) : generators.row(data);
 
   const add = (element: SugarElement) => {
     if (isRow(element)) {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/OtherCells.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/OtherCells.ts
@@ -12,10 +12,10 @@ export interface OtherCells {
   readonly downOrRightCells: SugarElement<HTMLTableCellElement>[];
 }
 
-const getUpOrLeftCells = (grid: RowCells[], selectedCells: DetailExt[], generators: Generators): SugarElement[] => {
+const getUpOrLeftCells = (grid: RowCells[], selectedCells: DetailExt[]): SugarElement[] => {
   // Get rows up or at the row of the bottom right cell
   const upGrid = grid.slice(0, selectedCells[selectedCells.length - 1].row + 1);
-  const upDetails = toDetailList(upGrid, generators);
+  const upDetails = toDetailList(upGrid);
   // Get an array of the cells up or to the left of the bottom right cell
   return Arr.bind(upDetails, (detail) => {
     const slicedCells = detail.cells.slice(0, selectedCells[selectedCells.length - 1].column + 1);
@@ -23,10 +23,10 @@ const getUpOrLeftCells = (grid: RowCells[], selectedCells: DetailExt[], generato
   });
 };
 
-const getDownOrRightCells = (grid: RowCells[], selectedCells: DetailExt[], generators: Generators): SugarElement[] => {
+const getDownOrRightCells = (grid: RowCells[], selectedCells: DetailExt[]): SugarElement[] => {
   // Get rows down or at the row of the top left cell (including rowspans)
   const downGrid = grid.slice(selectedCells[0].row + selectedCells[0].rowspan - 1, grid.length);
-  const downDetails = toDetailList(downGrid, generators);
+  const downDetails = toDetailList(downGrid);
   // Get an array of the cells down or to the right of the bottom right cell
   return Arr.bind(downDetails, (detail) => {
     const slicedCells = detail.cells.slice(selectedCells[0].column + selectedCells[0].colspan - 1, detail.cells.length);
@@ -40,8 +40,8 @@ const getOtherCells = (table: SugarElement<HTMLTableElement>, target: TargetSele
 
   return details.map((selectedCells) => {
     const grid = Transitions.toGrid(warehouse, generators, false);
-    const upOrLeftCells = getUpOrLeftCells(grid, selectedCells, generators);
-    const downOrRightCells = getDownOrRightCells(grid, selectedCells, generators);
+    const upOrLeftCells = getUpOrLeftCells(grid, selectedCells);
+    const downOrRightCells = getDownOrRightCells(grid, selectedCells);
     return {
       upOrLeftCells,
       downOrRightCells

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
@@ -6,7 +6,7 @@ import * as ColumnSizes from '../resize/ColumnSizes';
 import * as Redistribution from '../resize/Redistribution';
 import * as Sizes from '../resize/Sizes';
 import * as CellUtils from '../util/CellUtils';
-import { DetailExt, RowData, Column } from './Structs';
+import { DetailExt, RowDetail, Column, Detail } from './Structs';
 import { TableSize } from './TableSize';
 import { Warehouse } from './Warehouse';
 
@@ -27,7 +27,7 @@ const redistributeToColumns = (newWidths: string[], columns: Column[], unit: str
   });
 };
 
-const redistributeToH = <T> (newHeights: string[], rows: RowData<T>[], cells: DetailExt[], unit: string): void => {
+const redistributeToH = <T extends Detail> (newHeights: string[], rows: RowDetail<T>[], cells: DetailExt[], unit: string): void => {
   Arr.each(cells, (cell) => {
     const heights = newHeights.slice(cell.row, cell.rowspan + cell.row);
     const h = Redistribution.sum(heights, CellUtils.minHeight());

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
@@ -45,18 +45,20 @@ export interface DetailExt extends Detail {
 export type Section = 'tfoot' | 'thead' | 'tbody' | 'colgroup';
 const validSectionList: Section[] = [ 'tfoot', 'thead', 'tbody', 'colgroup' ];
 
-export interface RowCells {
-  readonly cells: ElementNew[];
-  readonly section: Section;
-}
-
-export interface RowData<T> {
-  readonly element: SugarElement;
+export interface RowDetail<T extends Detail> {
+  readonly element: SugarElement<HTMLTableRowElement | HTMLTableColElement>;
   readonly cells: T[];
   readonly section: Section;
 }
 
-export interface RowDataNew<T> extends RowData<T> {
+export interface RowDetailNew<T extends Detail> extends RowDetail<T> {
+  readonly isNew: boolean;
+}
+
+export interface RowCells {
+  readonly element: SugarElement<HTMLTableRowElement | HTMLTableColElement>;
+  readonly cells: ElementNew[];
+  readonly section: Section;
   readonly isNew: boolean;
 }
 
@@ -66,11 +68,6 @@ export interface ElementNew {
   readonly isLocked: boolean;
 }
 
-export interface RowDetails {
-  readonly details: DetailNew[];
-  readonly section: Section;
-}
-
 export interface Column {
   readonly element: SugarElement<HTMLTableColElement>;
   readonly colspan: number;
@@ -78,6 +75,11 @@ export interface Column {
 
 export interface ColumnExt extends Column {
   readonly column: number;
+}
+
+export interface Colgroup<T extends Column> {
+  readonly element: SugarElement<HTMLTableColElement>;
+  readonly columns: T[];
 }
 
 export interface Bounds {
@@ -137,10 +139,17 @@ const extended = (element: SugarElement<HTMLTableCellElement>, rowspan: number, 
   isLocked
 });
 
-const rowdata = <T> (element: SugarElement<HTMLTableRowElement | HTMLTableColElement>, cells: T[], section: Section): RowData<T> => ({
+const rowdetail = <T extends Detail> (element: SugarElement<HTMLTableRowElement | HTMLTableColElement>, cells: T[], section: Section): RowDetail<T> => ({
   element,
   cells,
   section
+});
+
+const rowdetailnew = <T extends Detail> (element: SugarElement, cells: T[], section: Section, isNew: boolean): RowDetailNew<T> => ({
+  element,
+  cells,
+  section,
+  isNew
 });
 
 const elementnew = (element: SugarElement, isNew: boolean, isLocked: boolean): ElementNew => ({
@@ -149,21 +158,11 @@ const elementnew = (element: SugarElement, isNew: boolean, isLocked: boolean): E
   isLocked
 });
 
-const rowdatanew = <T> (element: SugarElement, cells: T[], section: Section, isNew: boolean): RowDataNew<T> => ({
+const rowcells = (element: SugarElement<HTMLTableRowElement | HTMLTableColElement>, cells: ElementNew[], section: Section, isNew: boolean): RowCells => ({
   element,
   cells,
   section,
   isNew
-});
-
-const rowcells = (cells: ElementNew[], section: Section): RowCells => ({
-  cells,
-  section
-});
-
-const rowdetails = (details: DetailNew[], section: Section): RowDetails => ({
-  details,
-  section
 });
 
 const bounds = (startRow: number, startCol: number, finishRow: number, finishCol: number): Bounds => ({
@@ -179,6 +178,11 @@ const columnext = (element: SugarElement<HTMLTableColElement>, colspan: number, 
   column
 });
 
+const colgroup = <T extends Column> (element: SugarElement<HTMLTableColElement>, columns: T[]): Colgroup<T> => ({
+  element,
+  columns
+});
+
 export {
   dimension,
   dimensions,
@@ -188,12 +192,12 @@ export {
   extended,
   detail,
   detailnew,
-  rowdata,
+  rowdetail,
   elementnew,
-  rowdatanew,
+  rowdetailnew,
   rowcells,
-  rowdetails,
   bounds,
   isValidSection,
-  columnext
+  columnext,
+  colgroup
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/model/DetailsList.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/DetailsList.ts
@@ -5,14 +5,14 @@ import * as Structs from '../api/Structs';
 import * as TableLookup from '../api/TableLookup';
 import { getAttrValue } from '../util/CellUtils';
 
-const fromRowsOrColGroups = (elems: SugarElement<HTMLTableRowElement | HTMLTableColElement>[], getSection: (group: SugarElement<HTMLElement>) => Structs.Section): Structs.RowData<Structs.Detail>[] =>
+const fromRowsOrColGroups = (elems: SugarElement<HTMLTableRowElement | HTMLTableColElement>[], getSection: (group: SugarElement<HTMLElement>) => Structs.Section): Structs.RowDetail<Structs.Detail>[] =>
   Arr.map(elems, (row) => {
     if (SugarNode.name(row) === 'colgroup') {
       const cells = Arr.map(TableLookup.columns(row), (column) => {
         const colspan = getAttrValue(column, 'span', 1);
         return Structs.detail(column, 1, colspan);
       });
-      return Structs.rowdata(row, cells, 'colgroup');
+      return Structs.rowdetail(row, cells, 'colgroup');
     } else {
       const cells = Arr.map(TableLookup.cells(row), (cell) => {
         const rowspan = getAttrValue(cell, 'rowspan', 1);
@@ -20,7 +20,7 @@ const fromRowsOrColGroups = (elems: SugarElement<HTMLTableRowElement | HTMLTable
         return Structs.detail(cell, rowspan, colspan);
       });
 
-      return Structs.rowdata(row, cells, getSection(row));
+      return Structs.rowdetail(row, cells, getSection(row));
     }
   });
 
@@ -35,7 +35,7 @@ const getParentSection = (group: SugarElement<HTMLElement>): Structs.Section =>
    element: row element
    cells: (id, rowspan, colspan) structs
  */
-const fromTable = (table: SugarElement<HTMLTableElement>): Structs.RowData<Structs.Detail>[] => {
+const fromTable = (table: SugarElement<HTMLTableElement>): Structs.RowDetail<Structs.Detail>[] => {
   const rows = TableLookup.rows(table);
   const columnGroups = TableLookup.columnGroups(table);
 
@@ -43,7 +43,7 @@ const fromTable = (table: SugarElement<HTMLTableElement>): Structs.RowData<Struc
   return fromRowsOrColGroups(elems, getParentSection);
 };
 
-const fromPastedRows = (elems: SugarElement<HTMLTableRowElement | HTMLTableColElement>[], section: Structs.Section): Structs.RowData<Structs.Detail>[] =>
+const fromPastedRows = (elems: SugarElement<HTMLTableRowElement | HTMLTableColElement>[], section: Structs.Section): Structs.RowDetail<Structs.Detail>[] =>
   fromRowsOrColGroups(elems, () => section);
 
 export {

--- a/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
@@ -65,12 +65,15 @@ const generateElements = (amount: number, row: Structs.RowCells, generators: Sim
   return Arr.range(amount, (idx) => Structs.elementnew(generator(), true, isLocked(idx)));
 };
 
-const rowFill = (grid: Structs.RowCells[], amount: number, generators: SimpleGenerators, lockedColumns: Record<string, boolean>): Structs.RowCells[] =>
-  grid.concat(Arr.range(amount, () => {
-    const row = grid[grid.length - 1];
+const rowFill = (grid: Structs.RowCells[], amount: number, generators: SimpleGenerators, lockedColumns: Record<string, boolean>): Structs.RowCells[] => {
+  const exampleRow = grid[grid.length - 1];
+  return grid.concat(Arr.range(amount, () => {
+    const generator = exampleRow.section === 'colgroup' ? generators.colgroup : generators.row;
+    const row = GridRow.clone(exampleRow, generator, Fun.identity);
     const elements = generateElements(row.cells.length, row, generators, (idx) => Obj.has(lockedColumns, idx.toString()));
     return GridRow.setCells(row, elements);
   }));
+};
 
 const colFill = (grid: Structs.RowCells[], amount: number, generators: SimpleGenerators, startIndex: number): Structs.RowCells[] =>
   Arr.map(grid, (row) => {

--- a/modules/snooker/src/main/ts/ephox/snooker/model/GridRow.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/GridRow.ts
@@ -3,6 +3,9 @@ import { SugarElement } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
 
+type RowMorphism = (element: SugarElement<HTMLTableRowElement | HTMLTableColElement>) => SugarElement<HTMLTableRowElement | HTMLTableColElement>;
+type CellMorphism = (element: Structs.ElementNew, index: number) => Structs.ElementNew;
+
 const addCells = (gridRow: Structs.RowCells, index: number, cells: Structs.ElementNew[]): Structs.RowCells => {
   const existingCells = gridRow.cells;
   const before = existingCells.slice(0, index);
@@ -19,27 +22,23 @@ const mutateCell = (gridRow: Structs.RowCells, index: number, cell: Structs.Elem
   cells[index] = cell;
 };
 
-const setCells = (gridRow: Structs.RowCells, cells: Structs.ElementNew[]): Structs.RowCells => {
-  return Structs.rowcells(cells, gridRow.section);
-};
+const setCells = (gridRow: Structs.RowCells, cells: Structs.ElementNew[]): Structs.RowCells =>
+  Structs.rowcells(gridRow.element, cells, gridRow.section, gridRow.isNew);
 
-const mapCells = (gridRow: Structs.RowCells, f: (ex: Structs.ElementNew, c: number) => Structs.ElementNew): Structs.RowCells => {
+const mapCells = (gridRow: Structs.RowCells, f: CellMorphism): Structs.RowCells => {
   const cells = gridRow.cells;
   const r = Arr.map(cells, f);
-  return Structs.rowcells(r, gridRow.section);
+  return Structs.rowcells(gridRow.element, r, gridRow.section, gridRow.isNew);
 };
 
-const getCell = (gridRow: Structs.RowCells, index: number): Structs.ElementNew => {
-  return gridRow.cells[index];
-};
+const getCell = (gridRow: Structs.RowCells, index: number): Structs.ElementNew =>
+  gridRow.cells[index];
 
-const getCellElement = (gridRow: Structs.RowCells, index: number): SugarElement => {
-  return getCell(gridRow, index).element;
-};
+const getCellElement = (gridRow: Structs.RowCells, index: number): SugarElement =>
+  getCell(gridRow, index).element;
 
-const cellLength = (gridRow: Structs.RowCells): number => {
-  return gridRow.cells.length;
-};
+const cellLength = (gridRow: Structs.RowCells): number =>
+  gridRow.cells.length;
 
 const extractGridDetails = (grid: Structs.RowCells[]): { rows: Structs.RowCells[]; cols: Structs.RowCells[] } => {
   const result = Arr.partition(grid, (row) => row.section === 'colgroup');
@@ -47,6 +46,11 @@ const extractGridDetails = (grid: Structs.RowCells[]): { rows: Structs.RowCells[
     rows: result.fail,
     cols: result.pass
   };
+};
+
+const clone = (gridRow: Structs.RowCells, cloneRow: RowMorphism, cloneCell: CellMorphism): Structs.RowCells => {
+  const newCells = Arr.map(gridRow.cells, cloneCell);
+  return Structs.rowcells(cloneRow(gridRow.element), newCells, gridRow.section, true);
 };
 
 export {
@@ -58,5 +62,6 @@ export {
   getCellElement,
   mapCells,
   cellLength,
-  extractGridDetails
+  extractGridDetails,
+  clone
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/model/Transitions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/Transitions.ts
@@ -6,7 +6,7 @@ import * as Structs from '../api/Structs';
 import { Warehouse } from '../api/Warehouse';
 import * as TableGrid from './TableGrid';
 
-const toDetails = (grid: Structs.RowCells[], comparator: (a: SugarElement, b: SugarElement) => boolean): Structs.RowDetails[] => {
+const toDetails = (grid: Structs.RowCells[], comparator: (a: SugarElement, b: SugarElement) => boolean): Structs.RowDetailNew<Structs.DetailNew>[] => {
   const seen: boolean[][] = Arr.map(grid, (row) =>
     Arr.map(row.cells, Fun.never)
   );
@@ -30,20 +30,19 @@ const toDetails = (grid: Structs.RowCells[], comparator: (a: SugarElement, b: Su
         return [] as Structs.DetailNew[];
       }
     });
-    return Structs.rowdetails(details, row.section);
+    return Structs.rowdetailnew(row.element, details, row.section, row.isNew);
   });
 };
 
 const toGrid = (warehouse: Warehouse, generators: Generators, isNew: boolean): Structs.RowCells[] => {
   const grid: Structs.RowCells[] = [];
 
-  if (Warehouse.hasColumns(warehouse)) {
-    const groupElementNew = Arr.map(Warehouse.justColumns(warehouse), (column: Structs.Column): Structs.ElementNew =>
+  Arr.each(warehouse.colgroups, (colgroup) => {
+    const cols = Arr.map(colgroup.columns, (column): Structs.ElementNew =>
       Structs.elementnew(column.element, isNew, false)
     );
-
-    grid.push(Structs.rowcells(groupElementNew, 'colgroup'));
-  }
+    grid.push(Structs.rowcells(colgroup.element, cols, 'colgroup', isNew));
+  });
 
   for (let rowIndex = 0; rowIndex < warehouse.grid.rows; rowIndex++) {
     const rowCells: Structs.ElementNew[] = [];
@@ -56,7 +55,8 @@ const toGrid = (warehouse: Warehouse, generators: Generators, isNew: boolean): S
       );
       rowCells.push(element);
     }
-    const row = Structs.rowcells(rowCells, warehouse.all[rowIndex].section);
+    const rowDetail = warehouse.all[rowIndex];
+    const row = Structs.rowcells(rowDetail.element, rowCells, rowDetail.section, isNew);
     grid.push(row);
   }
 

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
@@ -1,7 +1,7 @@
 import { Arr } from '@ephox/katamari';
 import { Attribute, Insert, InsertAll, Remove, Replication, SelectorFilter, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
 
-import { Detail, DetailNew, RowDataNew, Section } from '../api/Structs';
+import { Detail, DetailNew, RowDetailNew, Section } from '../api/Structs';
 
 interface NewRowsAndCells {
   readonly newRows: SugarElement[];
@@ -41,11 +41,11 @@ const generateSection = (table: SugarElement<HTMLTableElement>, sectionName: Sec
   return section;
 };
 
-const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, grid: RowDataNew<T>[]): NewRowsAndCells => {
+const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, grid: RowDetailNew<T>[]): NewRowsAndCells => {
   const newRows: SugarElement[] = [];
   const newCells: SugarElement[] = [];
 
-  const syncRows = (gridSection: RowDataNew<T>[]) =>
+  const syncRows = (gridSection: RowDetailNew<T>[]) =>
     Arr.map(gridSection, (row) => {
       if (row.isNew) {
         newRows.push(row.element);
@@ -64,7 +64,7 @@ const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, gri
     });
 
   // Assumption we should only ever have 1 colgroup. The spec allows for multiple, however it's currently unsupported
-  const syncColGroup = (gridSection: RowDataNew<T>[]) =>
+  const syncColGroup = (gridSection: RowDetailNew<T>[]) =>
     Arr.bind(gridSection, (colGroup) =>
       Arr.map(colGroup.cells, (col) => {
         setIfNot(col.element, 'span', col.colspan, 1);
@@ -72,7 +72,7 @@ const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, gri
       })
     );
 
-  const renderSection = (gridSection: RowDataNew<T>[], sectionName: Section) => {
+  const renderSection = (gridSection: RowDetailNew<T>[], sectionName: Section) => {
     const section = generateSection(table, sectionName);
     const sync = sectionName === 'colgroup' ? syncColGroup : syncRows;
     const sectionElems = sync(gridSection);
@@ -83,7 +83,7 @@ const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, gri
     SelectorFind.child(table, sectionName).each(Remove.remove);
   };
 
-  const renderOrRemoveSection = (gridSection: RowDataNew<T>[], sectionName: Section) => {
+  const renderOrRemoveSection = (gridSection: RowDetailNew<T>[], sectionName: Section) => {
     if (gridSection.length > 0) {
       renderSection(gridSection, sectionName);
     } else {
@@ -91,10 +91,10 @@ const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, gri
     }
   };
 
-  const headSection: RowDataNew<T>[] = [];
-  const bodySection: RowDataNew<T>[] = [];
-  const footSection: RowDataNew<T>[] = [];
-  const columnGroupsSection: RowDataNew<T>[] = [];
+  const headSection: RowDetailNew<T>[] = [];
+  const bodySection: RowDetailNew<T>[] = [];
+  const footSection: RowDetailNew<T>[] = [];
+  const columnGroupsSection: RowDetailNew<T>[] = [];
 
   Arr.each(grid, (row) => {
     switch (row.section) {
@@ -124,7 +124,7 @@ const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, gri
   };
 };
 
-const copy = <T extends Detail> (grid: RowDataNew<T>[]): SugarElement<HTMLTableRowElement>[] => Arr.map(grid, (row) => {
+const copy = <T extends Detail> (grid: RowDetailNew<T>[]): SugarElement<HTMLTableRowElement | HTMLTableColElement>[] => Arr.map(grid, (row) => {
   // Shallow copy the row element
   const tr = Replication.shallow(row.element);
   Arr.each(row.cells, (cell) => {

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
@@ -2,7 +2,7 @@ import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 import { ResizeBehaviour } from '../api/ResizeBehaviour';
-import { Detail, RowData } from '../api/Structs';
+import { Detail, RowDetail } from '../api/Structs';
 import { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
 import * as Deltas from '../calc/Deltas';
@@ -68,7 +68,7 @@ const adjustHeight = (table: SugarElement, delta: number, index: number, directi
 };
 
 // Using the width of the added/removed columns gathered on extraction (pixelDelta), get and apply the new column sizes and overall table width delta
-const adjustAndRedistributeWidths = <T extends Detail> (_table: SugarElement<HTMLTableElement>, list: RowData<T>[], details: { pixelDelta: number }, tableSize: TableSize, resizeBehaviour: ResizeBehaviour): void => {
+const adjustAndRedistributeWidths = <T extends Detail> (_table: SugarElement<HTMLTableElement>, list: RowDetail<T>[], details: { pixelDelta: number }, tableSize: TableSize, resizeBehaviour: ResizeBehaviour): void => {
   const warehouse = Warehouse.generate(list);
   const sizes = tableSize.getWidths(warehouse, tableSize);
   const tablePixelWidth = tableSize.pixelWidth();
@@ -79,7 +79,7 @@ const adjustAndRedistributeWidths = <T extends Detail> (_table: SugarElement<HTM
 };
 
 // Ensure that the width of table cells match the passed in table information.
-const adjustWidthTo = <T extends Detail> (_table: SugarElement, list: RowData<T>[], _info: { }, tableSize: TableSize): void => {
+const adjustWidthTo = <T extends Detail> (_table: SugarElement, list: RowDetail<T>[], _info: { }, tableSize: TableSize): void => {
   const warehouse = Warehouse.generate(list);
   const widths = tableSize.getWidths(warehouse, tableSize);
 

--- a/modules/snooker/src/test/ts/atomic/model/TableGridTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/TableGridTest.ts
@@ -7,6 +7,7 @@ import * as TableGrid from 'ephox/snooker/model/TableGrid';
 
 UnitTest.test('TableGrid.subgrid test', () => {
   const r = Structs.rowcells;
+  const re = () => 'row' as unknown as SugarElement;
   const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement, isNew, false);
 
   const check = (expected: { colspan: number; rowspan: number }, row: number, column: number, grid: Structs.RowCells[]) => {
@@ -16,9 +17,9 @@ UnitTest.test('TableGrid.subgrid test', () => {
   };
 
   const world = [
-    r([ en('a', false), en('a', false), en('a', false) ], 'thead'),
-    r([ en('b', false), en('b', false), en('c', false) ], 'tbody'),
-    r([ en('d', false), en('e', false), en('c', false) ], 'tfoot')
+    r(re(), [ en('a', false), en('a', false), en('a', false) ], 'thead', false),
+    r(re(), [ en('b', false), en('b', false), en('c', false) ], 'tbody', false),
+    r(re(), [ en('d', false), en('e', false), en('c', false) ], 'tfoot', false)
   ];
 
   check({ colspan: 3, rowspan: 1 }, 0, 0, world);

--- a/modules/snooker/src/test/ts/atomic/model/TransitionsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/TransitionsTest.ts
@@ -8,112 +8,113 @@ import * as Transitions from 'ephox/snooker/model/Transitions';
 UnitTest.test('TableCounterTest', () => {
   const dn = (fakeElement: any, rowspan: number, colspan: number, isNew: boolean) => Structs.detailnew(fakeElement as SugarElement, rowspan, colspan, isNew);
   const r = Structs.rowcells;
-  const rd = Structs.rowdetails;
+  const rd = Structs.rowdetailnew;
+  const re = () => 'row' as unknown as SugarElement;
   const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement, isNew, false);
 
-  const check = (expected: Structs.RowDetails[], input: Structs.RowCells[]) => {
+  const check = (expected: Structs.RowDetailNew<Structs.DetailNew>[], input: Structs.RowCells[]) => {
     const actual = Transitions.toDetails(input, Fun.tripleEquals);
-    const cleaner = (obj: Structs.RowDetails[]) => {
-      return Arr.map(obj, (row) => row.details);
+    const cleaner = (obj: Structs.RowDetailNew<Structs.DetailNew>[]) => {
+      return Arr.map(obj, (row) => row.cells);
     };
     assert.eq(cleaner(expected), cleaner(actual));
   };
 
   check(
     [
-      rd([ dn('td1', 1, 3, false), dn('td2', 1, 1, false), dn('td3', 1, 1, false) ], 'tbody')
+      rd(re(), [ dn('td1', 1, 3, false), dn('td2', 1, 1, false), dn('td3', 1, 1, false) ], 'tbody', false)
     ],
     [
-      r([ en('td1', false), en('td1', false), en('td1', false), en('td2', false), en('td3', false) ], 'tbody')
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false), en('td2', false), en('td3', false) ], 'tbody', false)
     ]
   );
 
   check(
     [
-      rd([ dn('td1', 1, 3, false), dn('td2', 1, 1, false), dn('td3', 1, 1, false) ], 'thead')
+      rd(re(), [ dn('td1', 1, 3, false), dn('td2', 1, 1, false), dn('td3', 1, 1, false) ], 'thead', false)
     ],
     [
-      r([ en('td1', false), en('td1', false), en('td1', false), en('td2', false), en('td3', false) ], 'thead')
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false), en('td2', false), en('td3', false) ], 'thead', false)
     ]
   );
 
   check(
     [
-      rd([ dn('td1', 4, 3, false) ], 'tbody'),
-      rd([ ], 'tbody'),
-      rd([ ], 'tbody'),
-      rd([ ], 'tbody')
+      rd(re(), [ dn('td1', 4, 3, false) ], 'tbody', false),
+      rd(re(), [ ], 'tbody', false),
+      rd(re(), [ ], 'tbody', false),
+      rd(re(), [ ], 'tbody', false)
     ],
     [
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tbody'),
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tbody'),
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tbody'),
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tbody')
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tbody', false),
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tbody', false),
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tbody', false),
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tbody', false)
     ]
   );
 
   check(
     [
-      rd([ dn('td1', 4, 3, false) ], 'tfoot'),
-      rd([ ], 'tfoot'),
-      rd([ ], 'tfoot'),
-      rd([ ], 'tfoot')
+      rd(re(), [ dn('td1', 4, 3, false) ], 'tfoot', false),
+      rd(re(), [ ], 'tfoot', false),
+      rd(re(), [ ], 'tfoot', false),
+      rd(re(), [ ], 'tfoot', false)
     ],
     [
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tfoot'),
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tfoot'),
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tfoot'),
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tfoot')
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tfoot', false),
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tfoot', false),
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tfoot', false),
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tfoot', false)
     ]
   );
 
   check(
     [
-      rd([ dn('td1', 2, 3, false) ], 'tbody'),
-      rd([ ], 'tbody')
+      rd(re(), [ dn('td1', 2, 3, false) ], 'tbody', false),
+      rd(re(), [ ], 'tbody', false)
     ],
     [
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tbody'),
-      r([ en('td1', false), en('td1', false), en('td1', false) ], 'tbody')
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tbody', false),
+      r(re(), [ en('td1', false), en('td1', false), en('td1', false) ], 'tbody', false)
     ]
   );
 
   check(
     [
-      rd([ dn('td1', 1, 1, false) ], 'thead'),
-      rd([ dn('td2', 1, 1, false) ], 'tbody'),
-      rd([ dn('td3', 1, 1, false) ], 'tfoot')
+      rd(re(), [ dn('td1', 1, 1, false) ], 'thead', false),
+      rd(re(), [ dn('td2', 1, 1, false) ], 'tbody', false),
+      rd(re(), [ dn('td3', 1, 1, false) ], 'tfoot', false)
     ],
     [
-      r([ en('td1', false) ], 'thead'),
-      r([ en('td2', false) ], 'tbody'),
-      r([ en('td3', false) ], 'tfoot')
+      r(re(), [ en('td1', false) ], 'thead', false),
+      r(re(), [ en('td2', false) ], 'tbody', false),
+      r(re(), [ en('td3', false) ], 'tfoot', false)
     ]
   );
 
   check(
     [
-      rd([ dn('td1', 2, 2, false), dn('td3', 1, 1, false) ], 'tbody'),
-      rd([ dn('td4', 1, 1, false) ], 'tbody')
+      rd(re(), [ dn('td1', 2, 2, false), dn('td3', 1, 1, false) ], 'tbody', false),
+      rd(re(), [ dn('td4', 1, 1, false) ], 'tbody', false)
     ],
     [
-      r([ en('td1', false), en('td1', false), en('td3', false) ], 'tbody'),
-      r([ en('td1', false), en('td1', false), en('td4', false) ], 'tbody')
+      r(re(), [ en('td1', false), en('td1', false), en('td3', false) ], 'tbody', false),
+      r(re(), [ en('td1', false), en('td1', false), en('td4', false) ], 'tbody', false)
     ]
   );
 
   check(
     [
-      rd([ dn('td1', 2, 2, false), dn('td3', 1, 1, false) ], 'tbody'),
-      rd([ dn('td4', 2, 1, false) ], 'tbody'),
-      rd([ dn('td2', 1, 2, false) ], 'tbody'),
-      rd([ dn('td5', 1, 1, false), dn('td6', 1, 2, false) ], 'tbody')
+      rd(re(), [ dn('td1', 2, 2, false), dn('td3', 1, 1, false) ], 'tbody', false),
+      rd(re(), [ dn('td4', 2, 1, false) ], 'tbody', false),
+      rd(re(), [ dn('td2', 1, 2, false) ], 'tbody', false),
+      rd(re(), [ dn('td5', 1, 1, false), dn('td6', 1, 2, false) ], 'tbody', false)
     ],
     [
-      r([ en('td1', false), en('td1', false), en('td3', false) ], 'tbody'),
-      r([ en('td1', false), en('td1', false), en('td4', false) ], 'tbody'),
-      r([ en('td2', false), en('td2', false), en('td4', false) ], 'tbody'),
-      r([ en('td5', false), en('td6', false), en('td6', false) ], 'tbody')
+      r(re(), [ en('td1', false), en('td1', false), en('td3', false) ], 'tbody', false),
+      r(re(), [ en('td1', false), en('td1', false), en('td4', false) ], 'tbody', false),
+      r(re(), [ en('td2', false), en('td2', false), en('td4', false) ], 'tbody', false),
+      r(re(), [ en('td5', false), en('td6', false), en('td6', false) ], 'tbody', false)
     ]
   );
 });

--- a/modules/snooker/src/test/ts/atomic/operate/MergeOperationsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/operate/MergeOperationsTest.ts
@@ -8,6 +8,7 @@ import * as MergingOperations from 'ephox/snooker/operate/MergingOperations';
 UnitTest.test('MergeOperationsTest', () => {
   const b = Structs.bounds;
   const r = Structs.rowcells;
+  const re = () => 'row' as unknown as SugarElement;
   const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement, isNew, false);
 
   // Test basic merge.
@@ -25,59 +26,82 @@ UnitTest.test('MergeOperationsTest', () => {
     };
 
     check([], [], b(0, 0, 1, 1), 'a');
-    check([ r([ en('a', false), en('a', false) ], 'thead') ], [ r([ en('a', false), en('b', false) ], 'thead') ], b(0, 0, 0, 1), 'a');
-    check([ r([ en('a', false), en('a', false) ], 'tbody') ], [ r([ en('a', false), en('b', false) ], 'tbody') ], b(0, 0, 0, 1), 'a');
+
     check(
-      [
-        r([ en('a', false), en('a', false) ], 'thead'),
-        r([ en('a', false), en('a', false) ], 'thead')
-      ],
-      [
-        r([ en('a', false), en('b', false) ], 'thead'),
-        r([ en('c', false), en('d', false) ], 'thead')
-      ], b(0, 0, 1, 1), 'a'
+      [ r(re(), [ en('a', false), en('a', false) ], 'thead', false) ],
+      [ r(re(), [ en('a', false), en('b', false) ], 'thead', false) ],
+      b(0, 0, 0, 1),
+      'a'
     );
+
     check(
-      [
-        r([ en('a', false), en('a', false) ], 'tbody'),
-        r([ en('a', false), en('a', false) ], 'tbody')
-      ],
-      [
-        r([ en('a', false), en('b', false) ], 'tbody'),
-        r([ en('c', false), en('d', false) ], 'tbody')
-      ], b(0, 0, 1, 1), 'a'
+      [ r(re(), [ en('a', false), en('a', false) ], 'tbody', false) ],
+      [ r(re(), [ en('a', false), en('b', false) ], 'tbody', false) ],
+      b(0, 0, 0, 1),
+      'a'
     );
 
     check(
       [
-        r([ en('a', false), en('a', false), en('c', false) ], 'thead'),
-        r([ en('d', false), en('e', false), en('f', false) ], 'tbody')
+        r(re(), [ en('a', false), en('a', false) ], 'thead', false),
+        r(re(), [ en('a', false), en('a', false) ], 'thead', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('c', false) ], 'thead'),
-        r([ en('d', false), en('e', false), en('f', false) ], 'tbody')
-      ], b(0, 0, 0, 1), 'a'
+        r(re(), [ en('a', false), en('b', false) ], 'thead', false),
+        r(re(), [ en('c', false), en('d', false) ], 'thead', false)
+      ],
+      b(0, 0, 1, 1),
+      'a'
     );
+
     check(
       [
-        r([ en('a', false), en('a', false), en('c', false) ], 'tbody'),
-        r([ en('d', false), en('e', false), en('f', false) ], 'tbody')
+        r(re(), [ en('a', false), en('a', false) ], 'tbody', false),
+        r(re(), [ en('a', false), en('a', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('c', false) ], 'tbody'),
-        r([ en('d', false), en('e', false), en('f', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false) ], 'tbody', false),
+        r(re(), [ en('c', false), en('d', false) ], 'tbody', false)
+      ],
+      b(0, 0, 1, 1),
+      'a'
+    );
+
+    check(
+      [
+        r(re(), [ en('a', false), en('a', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('d', false), en('e', false), en('f', false) ], 'tbody', false)
+      ],
+      [
+        r(re(), [ en('a', false), en('b', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('d', false), en('e', false), en('f', false) ], 'tbody', false)
       ], b(0, 0, 0, 1), 'a'
     );
 
     check(
       [
-        r([ en('a', false), en('a', false), en('a', false) ], 'tbody'),
-        r([ en('a', false), en('a', false), en('a', false) ], 'tbody')
+        r(re(), [ en('a', false), en('a', false), en('c', false) ], 'tbody', false),
+        r(re(), [ en('d', false), en('e', false), en('f', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('c', false) ], 'tbody'),
-        r([ en('d', false), en('e', false), en('f', false) ], 'tbody')
-      ], b(0, 0, 1, 2), 'a'
+        r(re(), [ en('a', false), en('b', false), en('c', false) ], 'tbody', false),
+        r(re(), [ en('d', false), en('e', false), en('f', false) ], 'tbody', false)
+      ],
+      b(0, 0, 0, 1),
+      'a'
+    );
+
+    check(
+      [
+        r(re(), [ en('a', false), en('a', false), en('a', false) ], 'tbody', false),
+        r(re(), [ en('a', false), en('a', false), en('a', false) ], 'tbody', false)
+      ],
+      [
+        r(re(), [ en('a', false), en('b', false), en('c', false) ], 'tbody', false),
+        r(re(), [ en('d', false), en('e', false), en('f', false) ], 'tbody', false)
+      ],
+      b(0, 0, 1, 2),
+      'a'
     );
   })();
 
@@ -91,65 +115,83 @@ UnitTest.test('MergeOperationsTest', () => {
           assert.eq(cell.element, actual[i].cells[j].element);
           assert.eq(cell.isNew, actual[i].cells[j].isNew);
         });
-        assert.eq(row.section, actual[i].section);
+        assert.eq(row.section, actual[i].section, 'section type');
+        assert.eq(row.isNew, actual[i].isNew, 'is new row');
       });
     };
 
     check([], [], 'a');
-    check([ r([ en('a', false), en('?', true) ], 'thead') ], [ r([ en('a', false), en('a', false) ], 'thead') ], 'a');
-    check([ r([ en('a', false), en('?', true) ], 'tbody') ], [ r([ en('a', false), en('a', false) ], 'tbody') ], 'a');
+
     check(
-      [
-        r([ en('a', false), en('?', true) ], 'tbody'),
-        r([ en('?', true), en('?', true) ], 'tbody')
-      ],
-      [
-        r([ en('a', false), en('a', false) ], 'tbody'),
-        r([ en('a', false), en('a', false) ], 'tbody')
-      ], 'a'
+      [ r(re(), [ en('a', false), en('?', true) ], 'thead', false) ],
+      [ r(re(), [ en('a', false), en('a', false) ], 'thead', false) ],
+      'a'
+    );
+
+    check(
+      [ r(re(), [ en('a', false), en('?', true) ], 'tbody', false) ],
+      [ r(re(), [ en('a', false), en('a', false) ], 'tbody', false) ],
+      'a'
     );
 
     check(
       [
-        r([ en('a', false), en('b', false), en('?', true), en('c', false) ], 'thead')
+        r(re(), [ en('a', false), en('?', true) ], 'tbody', false),
+        r(re(), [ en('?', true), en('?', true) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('b', false), en('c', false) ], 'thead')
-      ], 'b'
-    );
-    check(
-      [
-        r([ en('a', false), en('b', false), en('?', true), en('c', false) ], 'tbody')
+        r(re(), [ en('a', false), en('a', false) ], 'tbody', false),
+        r(re(), [ en('a', false), en('a', false) ], 'tbody', false)
       ],
-      [
-        r([ en('a', false), en('b', false), en('b', false), en('c', false) ], 'tbody')
-      ], 'b'
+      'a'
     );
 
     check(
       [
-        r([ en('a', false), en('b', false), en('?', true), en('c', false) ], 'tbody'),
-        r([ en('a', false), en('?', true), en('?', true), en('d', false) ], 'tbody'),
-        r([ en('f', false), en('?', true), en('?', true), en('e', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('?', true), en('c', false) ], 'thead', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('b', false), en('c', false) ], 'tbody'),
-        r([ en('a', false), en('b', false), en('b', false), en('d', false) ], 'tbody'),
-        r([ en('f', false), en('b', false), en('b', false), en('e', false) ], 'tbody')
-      ], 'b'
+        r(re(), [ en('a', false), en('b', false), en('b', false), en('c', false) ], 'thead', false)
+      ],
+      'b'
     );
 
     check(
       [
-        r([ en('a', false), en('b', false), en('b', false), en('c', false) ], 'tbody'),
-        r([ en('?', true), en('b', false), en('b', false), en('d', false) ], 'tbody'),
-        r([ en('f', false), en('b', false), en('b', false), en('e', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('?', true), en('c', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('b', false), en('c', false) ], 'tbody'),
-        r([ en('a', false), en('b', false), en('b', false), en('d', false) ], 'tbody'),
-        r([ en('f', false), en('b', false), en('b', false), en('e', false) ], 'tbody')
-      ], 'a'
+        r(re(), [ en('a', false), en('b', false), en('b', false), en('c', false) ], 'tbody', false)
+      ],
+      'b'
+    );
+
+    check(
+      [
+        r(re(), [ en('a', false), en('b', false), en('?', true), en('c', false) ], 'tbody', false),
+        r(re(), [ en('a', false), en('?', true), en('?', true), en('d', false) ], 'tbody', false),
+        r(re(), [ en('f', false), en('?', true), en('?', true), en('e', false) ], 'tbody', false)
+      ],
+      [
+        r(re(), [ en('a', false), en('b', false), en('b', false), en('c', false) ], 'tbody', false),
+        r(re(), [ en('a', false), en('b', false), en('b', false), en('d', false) ], 'tbody', false),
+        r(re(), [ en('f', false), en('b', false), en('b', false), en('e', false) ], 'tbody', false)
+      ],
+      'b'
+    );
+
+    check(
+      [
+        r(re(), [ en('a', false), en('b', false), en('b', false), en('c', false) ], 'tbody', false),
+        r(re(), [ en('?', true), en('b', false), en('b', false), en('d', false) ], 'tbody', false),
+        r(re(), [ en('f', false), en('b', false), en('b', false), en('e', false) ], 'tbody', false)
+      ],
+      [
+        r(re(), [ en('a', false), en('b', false), en('b', false), en('c', false) ], 'tbody', false),
+        r(re(), [ en('a', false), en('b', false), en('b', false), en('d', false) ], 'tbody', false),
+        r(re(), [ en('f', false), en('b', false), en('b', false), en('e', false) ], 'tbody', false)
+      ],
+      'a'
     );
   })();
 });

--- a/modules/snooker/src/test/ts/atomic/operate/TransformOperationsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/operate/TransformOperationsTest.ts
@@ -32,7 +32,7 @@ UnitTest.test('TransformOperationsTest', () => {
   const mapToStructGrid = (grid: Structs.ElementNew[][]) => {
     return Arr.map(grid, (row) => {
       const hasCol = Arr.exists(row, (elementNew) => SugarNode.isTag('col')(elementNew.element));
-      return Structs.rowcells(row, hasCol ? 'colgroup' : 'tbody');
+      return Structs.rowcells('tr' as any, row, hasCol ? 'colgroup' : 'tbody', false);
     });
   };
 

--- a/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
+++ b/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
@@ -2,7 +2,7 @@ import { assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 import { Html, Insert, SugarElement } from '@ephox/sugar';
 
-import { CellSpan } from 'ephox/snooker/api/Generators';
+import { CellData } from 'ephox/snooker/api/Generators';
 import * as TableFill from 'ephox/snooker/api/TableFill';
 
 UnitTest.test('CloneFormatsTest', () => {
@@ -14,7 +14,7 @@ UnitTest.test('CloneFormatsTest', () => {
   const cellElement = SugarElement.fromTag('td');
   const cellContent = SugarElement.fromHtml('<strong contenteditable="false"><em>stuff</em></strong>');
   Insert.append(cellElement, cellContent);
-  const cell: CellSpan = {
+  const cell: CellData = {
     element: cellElement,
     colspan: 1,
     rowspan: 1

--- a/modules/snooker/src/test/ts/browser/RedrawSectionOrderTest.ts
+++ b/modules/snooker/src/test/ts/browser/RedrawSectionOrderTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Arr, Unicode } from '@ephox/katamari';
-import { Compare, SugarElement, Traverse } from '@ephox/sugar';
+import { Compare, SugarElement } from '@ephox/sugar';
 
 import * as Structs from 'ephox/snooker/api/Structs';
 import { Warehouse } from 'ephox/snooker/api/Warehouse';
@@ -12,26 +12,14 @@ import * as Bridge from 'ephox/snooker/test/Bridge';
 UnitTest.asynctest('Redraw Section Order Test', (success, failure) => {
 
   const getRowData = (table: SugarElement) => {
-    const findRow = (details: Structs.DetailNew[]) => {
-      const rowOfCells = Arr.findMap(details, (detail) =>
-        Traverse.parent(detail.element).map((row) =>
-          Structs.elementnew(row, false, false)));
-      return rowOfCells.getOrThunk(() => Structs.elementnew(Bridge.generators.row(), true, false));
-    };
-
     const warehouse = Warehouse.fromTable(table);
     const model = Transitions.toGrid(warehouse, Bridge.generators, false);
-    const rendered = Transitions.toDetails(model, Compare.eq);
-
-    return Arr.map(rendered, (details) => {
-      const row = findRow(details.details);
-      return Structs.rowdatanew(row.element, details.details, details.section, row.isNew);
-    });
+    return Transitions.toDetails(model, Compare.eq);
   };
 
   const changeTableSections = (table: SugarElement<HTMLTableElement>, rowIndex: number, newSection: Structs.Section) => {
     const updatedModelData = Arr.map(getRowData(table), (row, i) =>
-      i === rowIndex ? Structs.rowdatanew(row.element, row.cells, newSection, row.isNew) : row);
+      i === rowIndex ? Structs.rowdetailnew(row.element, row.cells, newSection, row.isNew) : row);
     Redraw.render(table, updatedModelData);
   };
 

--- a/modules/snooker/src/test/ts/browser/lookup/BlocksTest.ts
+++ b/modules/snooker/src/test/ts/browser/lookup/BlocksTest.ts
@@ -12,7 +12,7 @@ UnitTest.test('BlocksTest', () => {
     return elem;
   };
   const s = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText), rowspan, colspan);
-  const f = (cells: Structs.Detail[], section: 'tbody' | 'thead' | 'tfoot') => Structs.rowdata(SugarElement.fromTag('tr'), cells, section);
+  const f = (cells: Structs.Detail[], section: 'tbody' | 'thead' | 'tfoot') => Structs.rowdetail(SugarElement.fromTag('tr'), cells, section);
 
   const warehouse = Warehouse.generate([
     f([ s('a', 1, 1), s('b', 1, 2) ], 'thead'),

--- a/modules/snooker/src/test/ts/browser/model/WarehouseTest.ts
+++ b/modules/snooker/src/test/ts/browser/model/WarehouseTest.ts
@@ -6,7 +6,7 @@ import * as Structs from 'ephox/snooker/api/Structs';
 import { Warehouse } from 'ephox/snooker/api/Warehouse';
 
 UnitTest.test('WarehouseTest', () => {
-  const check = (expected: Record<string, string>, input: Structs.RowData<Structs.Detail>[]) => {
+  const check = (expected: Record<string, string>, input: Structs.RowDetail<Structs.Detail>[]) => {
     const actual = Warehouse.generate(input);
     assert.eq(expected, Obj.map(actual.access, (x) => TextContent.get(x.element)));
   };
@@ -17,7 +17,7 @@ UnitTest.test('WarehouseTest', () => {
     return elem;
   };
   const s = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText), rowspan, colspan);
-  const f = (cells: Structs.Detail[], section: 'tbody' | 'thead' | 'tfoot') => Structs.rowdata(SugarElement.fromTag('tr'), cells, section);
+  const f = (cells: Structs.Detail[], section: 'tbody' | 'thead' | 'tfoot') => Structs.rowdetail(SugarElement.fromTag('tr'), cells, section);
 
   const testTable = [
     f([ s('a', 1, 2), s('b', 1, 1), s('c', 1, 1), s('d', 1, 1), s('e', 1, 1), s('f', 1, 1) ], 'thead'),

--- a/modules/snooker/src/test/ts/browser/operate/ModificationOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/operate/ModificationOperationsTest.ts
@@ -10,6 +10,7 @@ import BrowserTestGenerator from 'ephox/snooker/test/BrowserTestGenerator';
 
 UnitTest.test('ModificationOperationsTest', () => {
   const r = Structs.rowcells;
+  const re = () => SugarElement.fromTag('tr');
   const en = (content: string, isNew: boolean) => {
     const elem = SugarElement.fromTag('td');
     Html.set(elem, content);
@@ -17,18 +18,21 @@ UnitTest.test('ModificationOperationsTest', () => {
   };
   const mapToStructGrid = (grid: Structs.ElementNew[][]) => {
     return Arr.map(grid, (row) => {
-      return Structs.rowcells(row, 'tbody');
+      return Structs.rowcells(re(), row, 'tbody', false);
     });
   };
 
-  const assertGrids = (expected: Structs.RowCells[], actual: Structs.RowCells[]) => {
+  const assertGrids = (expected: Structs.RowCells[], actual: Structs.RowCells[], checkIsNew: boolean) => {
     assert.eq(expected.length, actual.length);
     Arr.each(expected, (row, i) => {
       Arr.each(row.cells, (cell, j) => {
         Assertions.assertHtml('Expected elements to have the same HTML', Html.getOuter(cell.element), Html.getOuter(actual[i].cells[j].element));
         assert.eq(cell.isNew, actual[i].cells[j].isNew);
       });
-      assert.eq(row.section, actual[i].section);
+      assert.eq(row.section, actual[i].section, 'section type');
+      if (checkIsNew) {
+        assert.eq(row.isNew, actual[i].isNew, 'is new row');
+      }
     });
   };
 
@@ -36,15 +40,15 @@ UnitTest.test('ModificationOperationsTest', () => {
 
   // Test basic insert column
   (() => {
-    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], example: number, index: number) => {
+    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], example: number, index: number, checkIsNew: boolean = true) => {
       const actual = ModificationOperations.insertColumnAt(grid, index, example, compare, Generators.modification(BrowserTestGenerator()).getOrInit);
-      assertGrids(expected, actual);
+      assertGrids(expected, actual, checkIsNew);
     };
 
     const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], example: number, index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      check(structExpected, structGrid, example, index);
+      check(structExpected, structGrid, example, index, false);
     };
 
     checkBody([], [], 0, 0);
@@ -96,49 +100,49 @@ UnitTest.test('ModificationOperationsTest', () => {
 
     check(
       [
-        r([ en('a', false), en('?_0', true) ], 'thead'),
-        r([ en('b', false), en('?_1', true) ], 'tbody')
+        r(re(), [ en('a', false), en('?_0', true) ], 'thead', false),
+        r(re(), [ en('b', false), en('?_1', true) ], 'tbody', false)
       ],
       [
-        r([ en('a', false) ], 'thead'),
-        r([ en('b', false) ], 'tbody')
+        r(re(), [ en('a', false) ], 'thead', false),
+        r(re(), [ en('b', false) ], 'tbody', false)
       ], 0, 1
     );
 
     check(
       [
-        r([ en('?_0', true), en('a', false) ], 'thead'),
-        r([ en('?_1', true), en('b', false) ], 'tbody')
+        r(re(), [ en('?_0', true), en('a', false) ], 'thead', false),
+        r(re(), [ en('?_1', true), en('b', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false) ], 'thead'),
-        r([ en('b', false) ], 'tbody')
+        r(re(), [ en('a', false) ], 'thead', false),
+        r(re(), [ en('b', false) ], 'tbody', false)
       ], 0, 0
     );
 
     check(
       [
-        r([ en('a', false), en('a', false), en('a', false) ], 'thead'),
-        r([ en('b', false), en('?_0', true), en('c', false) ], 'tbody')
+        r(re(), [ en('a', false), en('a', false), en('a', false) ], 'thead', false),
+        r(re(), [ en('b', false), en('?_0', true), en('c', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('a', false) ], 'thead'),
-        r([ en('b', false), en('c', false) ], 'tbody')
+        r(re(), [ en('a', false), en('a', false) ], 'thead', false),
+        r(re(), [ en('b', false), en('c', false) ], 'tbody', false)
       ], 0, 1
     );
   })();
 
   // Test basic insert row
   (() => {
-    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], example: number, index: number) => {
+    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], example: number, index: number, checkIsNew: boolean = true) => {
       const actual = ModificationOperations.insertRowAt(grid, index, example, compare, Generators.modification(BrowserTestGenerator()).getOrInit);
-      assertGrids(expected, actual);
+      assertGrids(expected, actual, checkIsNew);
     };
 
     const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], example: number, index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      check(structExpected, structGrid, example, index);
+      check(structExpected, structGrid, example, index, false);
     };
 
     checkBody([[ en('?_0', true) ], [ en('a', false) ]], [[ en('a', false) ]], 0, 0);
@@ -159,38 +163,38 @@ UnitTest.test('ModificationOperationsTest', () => {
 
     check(
       [
-        r([ en('a', false), en('b', false), en('c', false) ], 'thead'),
-        r([ en('?_0', true), en('?_1', true), en('?_2', true) ], 'thead'),
-        r([ en('d', false), en('e', false), en('f', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('?_0', true), en('?_1', true), en('?_2', true) ], 'thead', true),
+        r(re(), [ en('d', false), en('e', false), en('f', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('c', false) ], 'thead'),
-        r([ en('d', false), en('e', false), en('f', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('d', false), en('e', false), en('f', false) ], 'tbody', false)
       ], 0, 1);
 
     check(
       [
-        r([ en('a', false), en('b', false), en('c', false) ], 'thead'),
-        r([ en('?_0', true), en('?_1', true), en('?_2', true) ], 'tbody'),
-        r([ en('d', false), en('e', false), en('f', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('?_0', true), en('?_1', true), en('?_2', true) ], 'tbody', true),
+        r(re(), [ en('d', false), en('e', false), en('f', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('c', false) ], 'thead'),
-        r([ en('d', false), en('e', false), en('f', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('d', false), en('e', false), en('f', false) ], 'tbody', false)
       ], 1, 1);
   })();
 
   // Test basic delete column
   (() => {
-    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], index: number) => {
+    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], index: number, checkIsNew: boolean = true) => {
       const actual = ModificationOperations.deleteColumnsAt(grid, [ index ]);
-      assertGrids(expected, actual);
+      assertGrids(expected, actual, checkIsNew);
     };
 
     const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      check(structExpected, structGrid, index);
+      check(structExpected, structGrid, index, false);
     };
 
     checkBody([], [[ en('a', false) ]], 0);
@@ -206,26 +210,26 @@ UnitTest.test('ModificationOperationsTest', () => {
       ], 1);
     check(
       [
-        r([ en('a', false), en('b', false) ], 'thead'),
-        r([ en('c', false), en('c', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false) ], 'thead', false),
+        r(re(), [ en('c', false), en('c', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('b', false) ], 'thead'),
-        r([ en('c', false), en('c', false), en('c', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('b', false) ], 'thead', false),
+        r(re(), [ en('c', false), en('c', false), en('c', false) ], 'tbody', false)
       ], 1);
   })();
 
   // Test delete multiple columns
   (() => {
-    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], indexes: number[]) => {
+    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], indexes: number[], checkIsNew: boolean = true) => {
       const actual = ModificationOperations.deleteColumnsAt(grid, indexes);
-      assertGrids(expected, actual);
+      assertGrids(expected, actual, checkIsNew);
     };
 
     const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], indexes: number[]) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      check(structExpected, structGrid, indexes);
+      check(structExpected, structGrid, indexes, false);
     };
 
     checkBody([], [[ en('a', false), en('b', false) ]], [ 0, 1 ]);
@@ -241,26 +245,26 @@ UnitTest.test('ModificationOperationsTest', () => {
       ], [ 1 ]);
     check(
       [
-        r([ en('a', false) ], 'thead'),
-        r([ en('c', false) ], 'tbody')
+        r(re(), [ en('a', false) ], 'thead', false),
+        r(re(), [ en('c', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('c', false) ], 'thead'),
-        r([ en('c', false), en('c', false), en('c', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('c', false), en('c', false), en('c', false) ], 'tbody', false)
       ], [ 1, 2 ]);
   })();
 
   // Test basic delete row
   (() => {
-    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], index: number) => {
+    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], index: number, checkIsNew: boolean = true) => {
       const actual = ModificationOperations.deleteRowsAt(grid, index, index);
-      assertGrids(expected, actual);
+      assertGrids(expected, actual, checkIsNew);
     };
 
     const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      check(structExpected, structGrid, index);
+      check(structExpected, structGrid, index, false);
     };
 
     checkBody([], [[ en('a', false) ]], 0);
@@ -278,26 +282,26 @@ UnitTest.test('ModificationOperationsTest', () => {
 
     check(
       [
-        r([ en('a', false), en('b', false), en('b', false) ], 'thead'),
-        r([ en('c', false), en('c', false), en('c', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('b', false) ], 'thead', false),
+        r(re(), [ en('c', false), en('c', false), en('c', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('b', false) ], 'thead'),
-        r([ en('a', false), en('b', false), en('b', false) ], 'tbody'),
-        r([ en('c', false), en('c', false), en('c', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('b', false) ], 'thead', false),
+        r(re(), [ en('a', false), en('b', false), en('b', false) ], 'tbody', false),
+        r(re(), [ en('c', false), en('c', false), en('c', false) ], 'tbody', false)
       ], 1);
   })();
 
   (() => {
-    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], exRow: number, exCol: number) => {
+    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], exRow: number, exCol: number, checkIsNew: boolean = true) => {
       const actual = ModificationOperations.splitCellIntoColumns(grid, exRow, exCol, Fun.tripleEquals, Generators.modification(BrowserTestGenerator()).getOrInit);
-      assertGrids(expected, actual);
+      assertGrids(expected, actual, checkIsNew);
     };
 
     const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], exRow: number, exCol: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      check(structExpected, structGrid, exRow, exCol);
+      check(structExpected, structGrid, exRow, exCol, false);
     };
 
     // splitting simple tables without existing colspans
@@ -460,41 +464,41 @@ UnitTest.test('ModificationOperationsTest', () => {
     );
     check(
       [
-        r([ en('a', false), en('b', false), en('c', false), en('?_0', true) ], 'thead'),
-        r([ en('d', false), en('e', false), en('e', false), en('e', false) ], 'tbody'),
-        r([ en('g', false), en('g', false), en('i', false), en('i', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('c', false), en('?_0', true) ], 'thead', false),
+        r(re(), [ en('d', false), en('e', false), en('e', false), en('e', false) ], 'tbody', false),
+        r(re(), [ en('g', false), en('g', false), en('i', false), en('i', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false), en('c', false) ], 'thead'),
-        r([ en('d', false), en('e', false), en('e', false) ], 'tbody'),
-        r([ en('g', false), en('g', false), en('i', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('d', false), en('e', false), en('e', false) ], 'tbody', false),
+        r(re(), [ en('g', false), en('g', false), en('i', false) ], 'tbody', false)
       ], 0, 2
     );
 
     check(
       [
-        r([ en('a', false), en('a', false), en('a', false), en('c', false) ], 'thead'),
-        r([ en('a', false), en('a', false), en('a', false), en('a', false) ], 'tbody'),
-        r([ en('g', false), en('?_0', true), en('h', false), en('i', false) ], 'tbody')
+        r(re(), [ en('a', false), en('a', false), en('a', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('a', false), en('a', false), en('a', false), en('a', false) ], 'tbody', false),
+        r(re(), [ en('g', false), en('?_0', true), en('h', false), en('i', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('a', false), en('c', false) ], 'thead'),
-        r([ en('a', false), en('a', false), en('a', false) ], 'tbody'),
-        r([ en('g', false), en('h', false), en('i', false) ], 'tbody')
+        r(re(), [ en('a', false), en('a', false), en('c', false) ], 'thead', false),
+        r(re(), [ en('a', false), en('a', false), en('a', false) ], 'tbody', false),
+        r(re(), [ en('g', false), en('h', false), en('i', false) ], 'tbody', false)
       ], 2, 0
     );
   })();
 
   (() => {
-    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], exRow: number, exCol: number) => {
+    const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], exRow: number, exCol: number, checkIsNew: boolean = true) => {
       const actual = ModificationOperations.splitCellIntoRows(grid, exRow, exCol, Fun.tripleEquals, Generators.modification(BrowserTestGenerator()).getOrInit);
-      assertGrids(expected, actual);
+      assertGrids(expected, actual, checkIsNew);
     };
 
     const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], exRow: number, exCol: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      check(structExpected, structGrid, exRow, exCol);
+      check(structExpected, structGrid, exRow, exCol, false);
     };
 
     // splitting simple tables without existing rowspans
@@ -674,13 +678,13 @@ UnitTest.test('ModificationOperationsTest', () => {
 
     check(
       [
-        r([ en('a', false), en('b', false) ], 'thead'),
-        r([ en('a', false), en('?_0', true) ], 'thead'),
-        r([ en('c', false), en('d', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false) ], 'thead', false),
+        r(re(), [ en('a', false), en('?_0', true) ], 'thead', true),
+        r(re(), [ en('c', false), en('d', false) ], 'tbody', false)
       ],
       [
-        r([ en('a', false), en('b', false) ], 'thead'),
-        r([ en('c', false), en('d', false) ], 'tbody')
+        r(re(), [ en('a', false), en('b', false) ], 'thead', false),
+        r(re(), [ en('c', false), en('d', false) ], 'tbody', false)
       ], 0, 1
     );
   })();

--- a/modules/snooker/src/test/ts/browser/resize/RecalculationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/resize/RecalculationsTest.ts
@@ -30,7 +30,7 @@ UnitTest.test('RecalculationsTest', () => {
     heights
   });
 
-  const check = (expected: Parts[], input: Structs.RowData<Structs.Detail>[], sizes: Structs.Dimensions) => {
+  const check = (expected: Parts[], input: Structs.RowDetail<Structs.Detail>[], sizes: Structs.Dimensions) => {
     const warehouse = Warehouse.generate(input);
     const actualCellWidth = Recalculations.recalculateWidthForCells(warehouse, sizes.width);
     const actualColumnWidth = Recalculations.recalculateWidthForColumns(warehouse, sizes.width);
@@ -60,8 +60,8 @@ UnitTest.test('RecalculationsTest', () => {
     return elem;
   };
   const makeDetail = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText), rowspan, colspan);
-  const makeRow = (cells: Structs.Detail[]) => Structs.rowdata(SugarElement.fromTag('tr'), cells, 'tbody');
-  const makeColumnGroup = (cols: Structs.Detail[]) => Structs.rowdata(SugarElement.fromTag('col'), cols, 'colgroup');
+  const makeRow = (cells: Structs.Detail[]) => Structs.rowdetail(SugarElement.fromTag('tr'), cells, 'tbody');
+  const makeColumnGroup = (cols: Structs.Detail[]) => Structs.rowdetail(SugarElement.fromTag('col'), cols, 'colgroup');
 
   check(
     [

--- a/modules/snooker/src/test/ts/browser/selection/CellBoundsTest.ts
+++ b/modules/snooker/src/test/ts/browser/selection/CellBoundsTest.ts
@@ -13,7 +13,7 @@ UnitTest.test('CellBounds.isWithin Test', () => {
     return elem;
   };
   const s = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText), rowspan, colspan);
-  const f = (cells: Structs.Detail[], section: 'tbody') => Structs.rowdata(SugarElement.fromTag('tr'), cells, section);
+  const f = (cells: Structs.Detail[], section: 'tbody') => Structs.rowdetail(SugarElement.fromTag('tr'), cells, section);
 
   const testTableA = [
     f([ s('a', 1, 1), s('b', 1, 1), s('c', 1, 1), s('d', 1, 1), s('e', 1, 1) ], 'tbody'),

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Fitment.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Fitment.ts
@@ -7,7 +7,7 @@ import * as Fitment from 'ephox/snooker/model/Fitment';
 
 const mapToStructGrid = (grid: Structs.ElementNew[][]): Structs.RowCells[] => {
   return Arr.map(grid, (row) => {
-    return Structs.rowcells(row, 'tbody');
+    return Structs.rowcells('tr' as any, row, 'tbody', false);
   });
 };
 

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
@@ -9,7 +9,7 @@ import * as Fitment from 'ephox/snooker/test/Fitment';
 
 const mapToStructGrid = (grid: Structs.ElementNew[][]): Structs.RowCells[] => {
   return Arr.map(grid, (row) => {
-    return Structs.rowcells(row, 'tbody');
+    return Structs.rowcells('tr' as any, row, 'tbody', false);
   });
 };
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using the Tab key to navigate into the editor on IE 11 would incorrectly focus the toolbar #TINY-3707
 - The editor selection could be placed in an incorrect location when undoing or redoing changes in a document containing `contenteditable="false"` elements #TINY-7663
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
+- Some table operations would incorrectly cause table row attributes and styles to be lost #TINY-6666
 
 ### Deprecated
 - The `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins have been deprecated and marked for removal in the next major release #TINY-7260

--- a/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
@@ -9,8 +9,8 @@ import { Optional, Singleton } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 export interface Clipboard {
-  getRows: () => Optional<SugarElement<HTMLTableRowElement>[]>;
-  setRows: (rows: Optional<SugarElement<HTMLTableRowElement>[]>) => void;
+  getRows: () => Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>;
+  setRows: (rows: Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>) => void;
   clearRows: () => void;
 
   getColumns: () => Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>;

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
@@ -110,11 +110,11 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
 
   const bodyMultipleChangesColumnContent = `<table>
 <tbody>
-<tr>
+<tr id="one">
 <td>text</td>
 <td>text</td>
 </tr>
-<tr>
+<tr id="two">
 <td>text</td>
 <td>text</td>
 </tr>
@@ -136,11 +136,11 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
 
   const headerMultipleChangesColumnContent = `<table>
 <tbody>
-<tr>
+<tr id="one">
 <th scope="row">text</th>
 <th scope="row">text</th>
 </tr>
-<tr>
+<tr id="two">
 <th scope="row">text</th>
 <th scope="row">text</th>
 </tr>


### PR DESCRIPTION
Related Ticket: TINY-6666

Description of Changes:
This is part 1 of this issue and unfortunately was something that we hadn't forseen. The problem was that due to how the models worked internally it would try and lookup the row by looking at the cells and then trying to find the parent row from that. However, this did not work when all cells in a row are replaced.

As such, this makes a change so that the row is maintained in the model state and passed around as required. This also then updates the relevant modification operations to generate a new row and flag it as being new, instead of trying to do this later when converting between the older/newer models.

I've also done a little bit of clean up here and removed some logic, as I found some unused functionality that was just broken. Additionally some of the `Structs` ended up being nearly identical so I merged it to avoid some confusion.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
