### PR TITLE
TINY-6666: Moved table cell type operations to snooker

### DIFF
--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `RowDetails` has been renamed to `RowDetail` and now takes a generic argument to define the type of cells stored.
 - `row` and `colgroup` generators are now passed the previous element during transform or modification operations.
+- Renamed `getColType` to `getColsType` in the `TableOperations` module to reflect it works with multiple columns.
+- The `getCellsType` in the `TableOperations` module has been changed to be consistent with the `getColsType` function.
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
 
 ### Fixed

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `RowDetails` has been renamed to `RowDetail` and now takes a generic argument to define the type of cells stored.
 - `row` and `colgroup` generators are now passed the previous element during transform or modification operations.
-- Renamed `getColType` to `getColsType` in the `TableOperations` module to reflect it works with multiple columns.
+- Renamed `getColType` to `getColsType` in the `TableOperations` module to reflect that it can lookup the type from multiple columns.
 - The `getCellsType` in the `TableOperations` module has been changed to be consistent with the `getColsType` function.
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
 

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `Warehouse` now contains the colgroup elements from the table.
+- `TableOperations` now includes functions to convert individual table cells to header cells (and vice-versa).
 
 ### Improved
 - Rows are now stored and tracked in the table model structures.

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
+import { Arr, Fun, Optional, Optionals, Type } from '@ephox/katamari';
 import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { getAttrValue } from '../util/CellUtils';
@@ -105,7 +105,7 @@ const modification = (generators: Generators, toData = elementToData): Generator
   };
 };
 
-const transform = <K extends keyof HTMLElementTagNameMap> (scope: string | null, tag: K) => {
+const transform = <K extends keyof HTMLElementTagNameMap> (tag: K, scope?: string | null) => {
   return (generators: Generators): GeneratorsTransform => {
     const list: Item[] = [];
 
@@ -116,9 +116,7 @@ const transform = <K extends keyof HTMLElementTagNameMap> (scope: string | null,
     };
 
     const makeNew = (element: SugarElement) => {
-      const attrs: Record<string, string | number | boolean | null> = {
-        scope
-      };
+      const attrs: Record<string, string | number | null> = Type.isUndefined(scope) ? {} : { scope };
       const cell = generators.replace(element, tag, attrs);
       list.push({
         item: element,

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -348,7 +348,7 @@ const opPasteRowsAfter = (grid: Structs.RowCells[], pasteDetails: ExtractPasteRo
 
 const isTableHeaderCell = SugarNode.isTag('th');
 
-const findCommonCellType = (cells: Structs.DetailExt[]): Optional<string> => {
+const findCommonCellType = (cells: Structs.DetailExt[]): Optional<'td' | 'th'> => {
   const headerCells = Arr.filter(cells, (cell) => isTableHeaderCell(cell.element));
   if (headerCells.length === 0) {
     return Optional.some('td');
@@ -359,7 +359,7 @@ const findCommonCellType = (cells: Structs.DetailExt[]): Optional<string> => {
   }
 };
 
-const opGetColumnsType = (table: SugarElement, target: TargetSelection): string => {
+const opGetColumnsType = (table: SugarElement<HTMLTableElement>, target: TargetSelection): string => {
   const house = Warehouse.fromTable(table);
   const details = RunOperation.onCells(house, target);
   return details.bind((selectedCells) => {
@@ -372,7 +372,7 @@ const opGetColumnsType = (table: SugarElement, target: TargetSelection): string 
   }).getOr('');
 };
 
-const opGetCellsType = (table: SugarElement, target: TargetSelection): string => {
+const opGetCellsType = (table: SugarElement<HTMLTableElement>, target: TargetSelection): string => {
   const house = Warehouse.fromTable(table);
   const details = RunOperation.onCells(house, target);
   return details.bind(findCommonCellType).getOr('');

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -161,8 +161,8 @@ const opMakeRowHeader = (grid: Structs.RowCells[], detail: Structs.DetailExt, co
 };
 
 const opMakeRowsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
-  const replacer = (currentGrid: Structs.RowCells[], row: Structs.DetailExt) =>
-    TransformOperations.replaceRow(currentGrid, row.row, comparator, genWrappers.replaceOrInit);
+  const replacer = (currentGrid: Structs.RowCells[], detail: Structs.DetailExt) =>
+    TransformOperations.replaceRow(currentGrid, detail.row, comparator, genWrappers.replaceOrInit);
 
   const rows = uniqueRows(details);
   const newGrid = Arr.foldl(rows, replacer, initialGrid);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -161,28 +161,39 @@ const opMakeRowHeader = (grid: Structs.RowCells[], detail: Structs.DetailExt, co
 };
 
 const opMakeRowsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
+  const replacer = (currentGrid: Structs.RowCells[], row: Structs.DetailExt) =>
+    TransformOperations.replaceRow(currentGrid, row.row, comparator, genWrappers.replaceOrInit);
+
   const rows = uniqueRows(details);
-
-  const replacer = (currentGrid: Structs.RowCells[], row: Structs.DetailExt) => TransformOperations.replaceRow(currentGrid, row.row, comparator, genWrappers.replaceOrInit);
-
   const newGrid = Arr.foldl(rows, replacer, initialGrid);
-
   return bundle(newGrid, details[0].row, details[0].column);
 };
 
 const opMakeColumnHeader = (initialGrid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsTransform) => {
   const newGrid = TransformOperations.replaceColumn(initialGrid, detail.column, comparator, genWrappers.replaceOrInit);
-
   return bundle(newGrid, detail.row, detail.column);
 };
 
 const opMakeColumnsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
+  const replacer = (currentGrid: Structs.RowCells[], column: Structs.DetailExt) =>
+    TransformOperations.replaceColumn(currentGrid, column.column, comparator, genWrappers.replaceOrInit);
+
   const columns = ColUtils.uniqueColumns(details);
-
-  const replacer = (currentGrid: Structs.RowCells[], column: Structs.DetailExt) => TransformOperations.replaceColumn(currentGrid, column.column, comparator, genWrappers.replaceOrInit);
-
   const newGrid = Arr.foldl(columns, replacer, initialGrid);
+  return bundle(newGrid, details[0].row, details[0].column);
+};
 
+const opMakeCellHeader = (initialGrid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsTransform) => {
+  const newGrid = TransformOperations.replaceCell(initialGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
+  return bundle(newGrid, detail.row, detail.column);
+};
+
+const opMakeCellsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
+  const replacer = (currentGrid: Structs.RowCells[], detail: Structs.DetailExt) =>
+    TransformOperations.replaceCell(currentGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
+
+  const columns = ColUtils.uniqueColumns(details);
+  const newGrid = Arr.foldl(columns, replacer, initialGrid);
   return bundle(newGrid, details[0].row, details[0].column);
 };
 
@@ -192,28 +203,39 @@ const opUnmakeRowHeader = (grid: Structs.RowCells[], detail: Structs.DetailExt, 
 };
 
 const opUnmakeRowsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
+  const replacer = (currentGrid: Structs.RowCells[], row: Structs.DetailExt) =>
+    TransformOperations.replaceRow(currentGrid, row.row, comparator, genWrappers.replaceOrInit);
+
   const rows = uniqueRows(details);
-
-  const replacer = (currentGrid: Structs.RowCells[], row: Structs.DetailExt) => TransformOperations.replaceRow(currentGrid, row.row, comparator, genWrappers.replaceOrInit);
-
   const newGrid = Arr.foldl(rows, replacer, initialGrid);
-
   return bundle(newGrid, details[0].row, details[0].column);
 };
 
 const opUnmakeColumnHeader = (initialGrid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsTransform) => {
   const newGrid = TransformOperations.replaceColumn(initialGrid, detail.column, comparator, genWrappers.replaceOrInit);
-
   return bundle(newGrid, detail.row, detail.column);
 };
 
 const opUnmakeColumnsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
+  const replacer = (currentGrid: Structs.RowCells[], column: Structs.DetailExt) =>
+    TransformOperations.replaceColumn(currentGrid, column.column, comparator, genWrappers.replaceOrInit);
+
   const columns = ColUtils.uniqueColumns(details);
-
-  const replacer = (currentGrid: Structs.RowCells[], column: Structs.DetailExt) => TransformOperations.replaceColumn(currentGrid, column.column, comparator, genWrappers.replaceOrInit);
-
   const newGrid = Arr.foldl(columns, replacer, initialGrid);
+  return bundle(newGrid, details[0].row, details[0].column);
+};
 
+const opUnmakeCellHeader = (initialGrid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsTransform) => {
+  const newGrid = TransformOperations.replaceCell(initialGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
+  return bundle(newGrid, detail.row, detail.column);
+};
+
+const opUnmakeCellsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
+  const replacer = (currentGrid: Structs.RowCells[], detail: Structs.DetailExt) =>
+    TransformOperations.replaceCell(currentGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
+
+  const columns = ColUtils.uniqueColumns(details);
+  const newGrid = Arr.foldl(columns, replacer, initialGrid);
   return bundle(newGrid, details[0].row, details[0].column);
 };
 
@@ -324,21 +346,10 @@ const opPasteRowsAfter = (grid: Structs.RowCells[], pasteDetails: ExtractPasteRo
   return outcome(mergedGrid, cursor);
 };
 
-const opGetColumnType = (table: SugarElement, target: TargetSelection): string => {
-  const house = Warehouse.fromTable(table);
-  const details = RunOperation.onCells(house, target);
-  return details.bind((selectedCells): Optional<string> => {
-    const lastSelectedCell = selectedCells[selectedCells.length - 1];
-    const minColRange = selectedCells[0].column;
-    const maxColRange = lastSelectedCell.column + lastSelectedCell.colspan;
-    const selectedColumnCells = Arr.flatten(Arr.map(house.all, (row) =>
-      Arr.filter(row.cells, (cell) => cell.column >= minColRange && cell.column < maxColRange)));
-    return getCellsType(selectedColumnCells, (cell) => SugarNode.name(cell.element) === 'th');
-  }).getOr('');
-};
+const isTableHeaderCell = SugarNode.isTag('th');
 
-export const getCellsType = <T>(cells: T[], headerPred: (x: T) => boolean): Optional<string> => {
-  const headerCells = Arr.filter(cells, headerPred);
+const findCommonCellType = (cells: Structs.DetailExt[]): Optional<string> => {
+  const headerCells = Arr.filter(cells, (cell) => isTableHeaderCell(cell.element));
   if (headerCells.length === 0) {
     return Optional.some('td');
   } else if (headerCells.length === cells.length) {
@@ -346,6 +357,25 @@ export const getCellsType = <T>(cells: T[], headerPred: (x: T) => boolean): Opti
   } else {
     return Optional.none();
   }
+};
+
+const opGetColumnsType = (table: SugarElement, target: TargetSelection): string => {
+  const house = Warehouse.fromTable(table);
+  const details = RunOperation.onCells(house, target);
+  return details.bind((selectedCells) => {
+    const lastSelectedCell = selectedCells[selectedCells.length - 1];
+    const minColRange = selectedCells[0].column;
+    const maxColRange = lastSelectedCell.column + lastSelectedCell.colspan;
+    const selectedColumnCells = Arr.flatten(Arr.map(house.all, (row) =>
+      Arr.filter(row.cells, (cell) => cell.column >= minColRange && cell.column < maxColRange)));
+    return findCommonCellType(selectedColumnCells);
+  }).getOr('');
+};
+
+const opGetCellsType = (table: SugarElement, target: TargetSelection): string => {
+  const house = Warehouse.fromTable(table);
+  const details = RunOperation.onCells(house, target);
+  return details.bind(findCommonCellType).getOr('');
 };
 
 // Only column modifications force a resizing. Everything else just tries to preserve the table as is.
@@ -412,14 +442,18 @@ export const splitCellIntoColumns = RunOperation.run(opSplitCellIntoColumns, Run
 export const splitCellIntoRows = RunOperation.run(opSplitCellIntoRows, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.modification);
 export const eraseColumns = RunOperation.run(opEraseColumns, eraseColumnsExtractor, adjustAndRedistributeWidths, prune, Generators.modification);
 export const eraseRows = RunOperation.run(opEraseRows, RunOperation.onCells, Fun.noop, prune, Generators.modification);
-export const makeColumnHeader = RunOperation.run(opMakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('row', 'th'));
-export const makeColumnsHeader = RunOperation.run(opMakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('row', 'th'));
-export const unmakeColumnHeader = RunOperation.run(opUnmakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform(null, 'td'));
-export const unmakeColumnsHeader = RunOperation.run(opUnmakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform(null, 'td'));
-export const makeRowHeader = RunOperation.run(opMakeRowHeader, RunOperation.onCell, Fun.noop, Fun.noop, Generators.transform('col', 'th'));
-export const makeRowsHeader = RunOperation.run(opMakeRowsHeader, RunOperation.onCells, Fun.noop, Fun.noop, Generators.transform('col', 'th'));
-export const unmakeRowHeader = RunOperation.run(opUnmakeRowHeader, RunOperation.onCell, Fun.noop, Fun.noop, Generators.transform(null, 'td'));
-export const unmakeRowsHeader = RunOperation.run(opUnmakeRowsHeader, RunOperation.onCells, Fun.noop, Fun.noop, Generators.transform(null, 'td'));
+export const makeColumnHeader = RunOperation.run(opMakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('th', 'row'));
+export const makeColumnsHeader = RunOperation.run(opMakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('th', 'row'));
+export const unmakeColumnHeader = RunOperation.run(opUnmakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('td', null));
+export const unmakeColumnsHeader = RunOperation.run(opUnmakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('td', null));
+export const makeRowHeader = RunOperation.run(opMakeRowHeader, RunOperation.onCell, Fun.noop, Fun.noop, Generators.transform('th', 'col'));
+export const makeRowsHeader = RunOperation.run(opMakeRowsHeader, RunOperation.onCells, Fun.noop, Fun.noop, Generators.transform('th', 'col'));
+export const unmakeRowHeader = RunOperation.run(opUnmakeRowHeader, RunOperation.onCell, Fun.noop, Fun.noop, Generators.transform('td', null));
+export const unmakeRowsHeader = RunOperation.run(opUnmakeRowsHeader, RunOperation.onCells, Fun.noop, Fun.noop, Generators.transform('td', null));
+export const makeCellHeader = RunOperation.run(opMakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('th'));
+export const makeCellsHeader = RunOperation.run(opMakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('th'));
+export const unmakeCellHeader = RunOperation.run(opUnmakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('td'));
+export const unmakeCellsHeader = RunOperation.run(opUnmakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('td'));
 export const mergeCells = RunOperation.run(opMergeCells, RunOperation.onUnlockedMergable, resize, Fun.noop, Generators.merging);
 export const unmergeCells = RunOperation.run(opUnmergeCells, RunOperation.onUnlockedUnmergable, resize, Fun.noop, Generators.merging);
 export const pasteCells = RunOperation.run(opPasteCells, RunOperation.onPaste, resize, Fun.noop, Generators.modification);
@@ -427,4 +461,6 @@ export const pasteColsBefore = RunOperation.run(opPasteColsBefore, pasteColumnsE
 export const pasteColsAfter = RunOperation.run(opPasteColsAfter, pasteColumnsExtractor(false), Fun.noop, Fun.noop, Generators.modification);
 export const pasteRowsBefore = RunOperation.run(opPasteRowsBefore, RunOperation.onPasteByEditor, Fun.noop, Fun.noop, Generators.modification);
 export const pasteRowsAfter = RunOperation.run(opPasteRowsAfter, RunOperation.onPasteByEditor, Fun.noop, Fun.noop, Generators.modification);
-export const getColumnType = opGetColumnType;
+
+export const getColumnsType = opGetColumnsType;
+export const getCellsType = opGetCellsType;

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/TransformOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/TransformOperations.ts
@@ -56,7 +56,15 @@ const replaceRow = (grid: Structs.RowCells[], index: number, comparator: CompElm
   return replaceIn(grid, targets, comparator, substitution);
 };
 
+const replaceCell = (grid: Structs.RowCells[], rowIndex: number, columnIndex: number, comparator: CompElm, substitution: Subst): Structs.RowCells[] => {
+  const rows = GridRow.extractGridDetails(grid).rows;
+  const targetRow = rows[rowIndex];
+  const targetCell = GridRow.getCell(targetRow, columnIndex);
+  return replaceIn(grid, [ targetCell ], comparator, substitution);
+};
+
 export {
   replaceColumn,
-  replaceRow
+  replaceRow,
+  replaceCell
 };

--- a/modules/snooker/src/test/ts/atomic/operate/TransformOperationsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/operate/TransformOperationsTest.ts
@@ -10,12 +10,12 @@ import * as MockStructs from 'ephox/snooker/test/MockStructs';
 import TestGenerator from 'ephox/snooker/test/TestGenerator';
 
 UnitTest.test('TransformOperationsTest', () => {
-  let originalElements: Structs.ElementNew[] = [];
-  let expectedElements: Structs.ElementNew[] = [];
+  const originalElements: Structs.ElementNew[] = [];
+  const expectedElements: Structs.ElementNew[] = [];
 
   const clearElements = () => {
-    originalElements = [];
-    expectedElements = [];
+    originalElements.length = 0;
+    expectedElements.length = 0;
   };
 
   const en = (elements: Structs.ElementNew[]) => (text: string, isNew: boolean, elemType: 'td' | 'th' | 'col' = 'td', isLocked: boolean = false) => {
@@ -42,6 +42,7 @@ UnitTest.test('TransformOperationsTest', () => {
       Arr.each(row.cells, (cell, j) => {
         const actualCell = actual[i].cells[j];
         assert.equal(TextContent.get(actualCell.element), TextContent.get(cell.element));
+        assert.equal(actualCell.isNew, cell.isNew, `${i}x${j} cell is new`);
       });
       assert.equal(actual[i].section, row.section);
     });
@@ -54,7 +55,7 @@ UnitTest.test('TransformOperationsTest', () => {
     const check = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      const actual = TransformOperations.replaceColumn(structGrid, index, comparator, Generators.transform('scope', 'td')(TestGenerator()).replaceOrInit);
+      const actual = TransformOperations.replaceColumn(structGrid, index, comparator, Generators.transform('td', 'scope')(TestGenerator()).replaceOrInit);
       assertGrids(actual, structExpected);
       clearElements();
     };
@@ -122,7 +123,7 @@ UnitTest.test('TransformOperationsTest', () => {
     const check = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      const actual = TransformOperations.replaceRow(structGrid, index, comparator, Generators.transform('scope', 'td')(TestGenerator()).replaceOrInit);
+      const actual = TransformOperations.replaceRow(structGrid, index, comparator, Generators.transform('td', 'scope')(TestGenerator()).replaceOrInit);
       assertGrids(actual, structExpected);
       clearElements();
     };
@@ -174,5 +175,34 @@ UnitTest.test('TransformOperationsTest', () => {
       [ enO('a', false), enO('a', false), enO('c', false), enO('f', false) ],
       [ enO('a', false), enO('a', false), enO('d', false), enO('f', false) ]
     ], 0);
+  })();
+
+  // Test basic changing to header (cell)
+  (() => {
+    const check = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], rowIndex: number, colIndex: number) => {
+      const structExpected = mapToStructGrid(expected);
+      const structGrid = mapToStructGrid(grid);
+      const actual = TransformOperations.replaceCell(structGrid, rowIndex, colIndex, comparator, Generators.transform('td')(TestGenerator()).replaceOrInit);
+      assertGrids(actual, structExpected);
+      clearElements();
+    };
+
+    check([[]], [[]], 0, 0);
+
+    check([
+      [ enE('h(a)_0', true) ]
+    ], [
+      [ enO('a', false) ]
+    ], 0, 0);
+
+    check([
+      [ enE('a', false), enE('b', false), enE('e', false) ],
+      [ enE('a', false), enE('h(c)_0', true), enE('f', false) ],
+      [ enE('a', false), enE('d', false), enE('f', true) ]
+    ], [
+      [ enO('a', false), enO('b', false), enO('e', false) ],
+      [ enO('a', false), enO('c', false), enO('f', false) ],
+      [ enO('a', false), enO('d', false), enO('f', false) ]
+    ], 1, 1);
   })();
 });

--- a/modules/snooker/src/test/ts/browser/HeaderOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/HeaderOperationsTest.ts
@@ -1004,8 +1004,152 @@ UnitTest.test('HeaderOperationsTest', () => {
     );
   };
 
+  const testSingleCellHeader = () => {
+    Assertions.checkOld(
+      'Convert single regular cell to header cell',
+      Optional.some({ section: 0, row: 0, column: 1 }),
+      '<table><tbody>' +
+      '<tr><td>A1</td><th>B1</th><td>C1</td><td>D1</td></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeCellHeader, 0, 0, 1
+    );
+
+    Assertions.checkOld(
+      'Convert single regular cell with colspan to header cell',
+      Optional.some({ section: 0, row: 0, column: 1 }),
+      '<table><tbody>' +
+      '<tr><td>A1</td><th colspan="2">B1</th><td>D1</td></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><td>A1</td><td colspan="2">B1</td><td>D1</td></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeCellHeader, 0, 0, 1
+    );
+
+    Assertions.checkOld(
+      'Convert single header cell to regular cell',
+      Optional.some({ section: 1, row: 0, column: 1 }),
+      '<table><thead>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><th>A2</th><td>B2</td><th>C2</th><th>D2</th></tr>' +
+      '</tbody></table>',
+
+      '<table><thead>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><th>A2</th><th>B2</th><th>C2</th><th>D2</th></tr>' +
+      '</tbody></table>',
+
+      TableOperations.unmakeCellHeader, 1, 0, 1
+    );
+
+    Assertions.checkOld(
+      'Convert single header cell with scope to regular cell',
+      Optional.some({ section: 1, row: 0, column: 1 }),
+      '<table><thead>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><th scope="col">A2</th><td scope="col">B2</td><th scope="col">C2</th><th scope="col">D2</th></tr>' +
+      '</tbody></table>',
+
+      '<table><thead>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><th scope="col">A2</th><th scope="col">B2</th><th scope="col">C2</th><th scope="col">D2</th></tr>' +
+      '</tbody></table>',
+
+      TableOperations.unmakeCellHeader, 1, 0, 1
+    );
+  };
+
+  const testMultipleCellHeader = () => {
+    Assertions.checkOldMultiple(
+      'Convert multiple regular cells to header cells',
+      Optional.some({ section: 0, row: 0, column: 1 }),
+      '<table><tbody>' +
+      '<tr><td>A1</td><th>B1</th><th>C1</th><th>D1</th></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeCellsHeader, [
+        { section: 0, row: 0, column: 1 },
+        { section: 0, row: 0, column: 2 },
+        { section: 0, row: 0, column: 3 }
+      ]
+    );
+
+    Assertions.checkOldMultiple(
+      'Convert multiple header cells to regular cells',
+      Optional.some({ section: 0, row: 0, column: 2 }),
+      '<table><thead>' +
+      '<tr><th>A1</th><th>B1</th><td>C1</td><td>D1</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      '<table><thead>' +
+      '<tr><th>A1</th><th>B1</th><th>C1</th><th>D1</th></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.unmakeCellsHeader, [
+        { section: 0, row: 0, column: 2 },
+        { section: 0, row: 0, column: 3 }
+      ]
+    );
+
+    Assertions.checkOldMultiple(
+      'Convert multiple header cells with scope to regular cell',
+      Optional.some({ section: 1, row: 0, column: 0 }),
+      '<table><thead>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><td scope="col">A2</td><td scope="col">B2</td><th scope="col">C2</th><th scope="col">D2</th></tr>' +
+      '</tbody></table>',
+
+      '<table><thead>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '</thead>' +
+      '<tbody>' +
+      '<tr><th scope="col">A2</th><th scope="col">B2</th><th scope="col">C2</th><th scope="col">D2</th></tr>' +
+      '</tbody></table>',
+
+      TableOperations.unmakeCellsHeader, [
+        { section: 1, row: 0, column: 0 },
+        { section: 1, row: 0, column: 1 }
+      ]
+    );
+  };
+
   testSingleRowHeader();
   testMultipleRowHeader();
   testSingleColumnHeader();
   testMultipleColumnHeader();
+  testSingleCellHeader();
+  testMultipleCellHeader();
 });

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 - Disabled nested menu items could still be opened #TINY-7700
 - Some table operations would incorrectly cause table row attributes and styles to be lost #TINY-6666
+- The selection was incorrectly lost when using the `mceTableCellType` command #TINY-6666
 
 ### Deprecated
 - The `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins have been deprecated and marked for removal in the next major release #TINY-7260

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -33,7 +33,7 @@ const Plugin = (editor: Editor) => {
   const selectionTargets = getSelectionTargets(editor, selections);
   const resizeHandler = getResizeHandler(editor);
   const cellSelection = CellSelection(editor, resizeHandler.lazyResize, selectionTargets);
-  const actions = TableActions(editor, resizeHandler.lazyWire, selections);
+  const actions = TableActions(editor, resizeHandler.lazyWire);
   const clipboard = FakeClipboard();
 
   Commands.registerCommands(editor, actions, cellSelection, selections, clipboard);

--- a/modules/tinymce/src/plugins/table/main/ts/api/QueryCommands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/QueryCommands.ts
@@ -6,30 +6,31 @@
  */
 
 import { Selections } from '@ephox/darwin';
-import { Obj, Optional } from '@ephox/katamari';
+import { Obj } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
-import { SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-import { TableActions } from '../actions/TableActions';
+import { LookupAction, TableActions } from '../actions/TableActions';
 import * as Util from '../core/Util';
 import * as TableTargets from '../queries/TableTargets';
 import * as TableSelection from '../selection/TableSelection';
 
 const registerQueryCommands = (editor: Editor, actions: TableActions, selections: Selections) => {
   const isRoot = Util.getIsRoot(editor);
-  const getTableFromCell = (cell: SugarElement): Optional<SugarElement> => TableLookup.table(cell, isRoot);
+
+  const lookupOnSelection = (action: LookupAction): string =>
+    TableSelection.getSelectionStartCell(Util.getSelectionStart(editor)).bind((cell) =>
+      TableLookup.table(cell, isRoot).map((table) => {
+        const targets = TableTargets.forMenu(selections, table, cell);
+        return action(table, targets);
+      })
+    ).getOr('');
 
   Obj.each({
     mceTableRowType: () => actions.getTableRowType(editor),
-    mceTableCellType: () => actions.getTableCellType(editor),
-    mceTableColType: () => TableSelection.getSelectionStartCell(Util.getSelectionStart(editor)).bind((cell) =>
-      getTableFromCell(cell).map((table): string => {
-        const targets = TableTargets.forMenu(selections, table, cell);
-        return actions.getTableColType(table, targets);
-      })
-    ).getOr('')
+    mceTableCellType: () => lookupOnSelection(actions.getTableCellType),
+    mceTableColType: () => lookupOnSelection(actions.getTableColType)
   }, (func, name) => editor.addQueryValueHandler(name, func));
 
 };

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -16,7 +16,6 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 import * as Styles from '../actions/Styles';
 import * as Events from '../api/Events';
 import { hasAdvancedCellTab } from '../api/Settings';
-import { switchCellType } from '../core/TableSections';
 import * as Util from '../core/Util';
 import * as TableSelection from '../selection/TableSelection';
 import * as CellDialogGeneralTab from './CellDialogGeneralTab';
@@ -30,23 +29,22 @@ interface SelectedCell {
   column: Optional<HTMLTableColElement>;
 }
 
-const getSelectedCells = (cells: SugarElement<HTMLTableCellElement>[]): Optional<SelectedCell[]> =>
-  TableLookup.table(cells[0]).map((table) => {
-    const warehouse = Warehouse.fromTable(table);
+const getSelectedCells = (table: SugarElement<HTMLTableElement>, cells: SugarElement<HTMLTableCellElement>[]): SelectedCell[] => {
+  const warehouse = Warehouse.fromTable(table);
 
-    const allCells = Warehouse.justCells(warehouse);
+  const allCells = Warehouse.justCells(warehouse);
 
-    const filtered = Arr.filter(allCells, (cellA) =>
-      Arr.exists(cells, (cellB) =>
-        Compare.eq(cellA.element, cellB)
-      )
-    );
+  const filtered = Arr.filter(allCells, (cellA) =>
+    Arr.exists(cells, (cellB) =>
+      Compare.eq(cellA.element, cellB)
+    )
+  );
 
-    return Arr.map(filtered, (cell) => ({
-      element: cell.element.dom,
-      column: Warehouse.getColumnAt(warehouse, cell.column).map((col) => col.element.dom)
-    }));
-  });
+  return Arr.map(filtered, (cell) => ({
+    element: cell.element.dom,
+    column: Warehouse.getColumnAt(warehouse, cell.column).map((col) => col.element.dom)
+  }));
+};
 
 const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data: CellData) => {
   modifier.setAttrib('scope', data.scope);
@@ -62,73 +60,85 @@ const updateAdvancedProps = (modifier: DomModifier, data: CellData) => {
   modifier.setFormat('tablecellborderwidth', Util.addPxSuffix(data.borderwidth));
 };
 
-// NOTES:
+/*
+  NOTES:
 
-// When applying to a single cell, values can be falsy. That is
-// because there should be a consistent value across the cell
-// selection, so it should also be possible to toggle things off.
+  When applying to a single cell, values can be falsy. That is
+  because there should be a consistent value across the cell
+  selection, so it should also be possible to toggle things off.
 
-// When applying to multiple cells, values must be truthy to be set.
-// This is because multiple cells might have different values, and you
-// don't want a blank value to wipe out their original values. Note,
-// how as part of this, it doesn't remove any original alignment before
-// applying any specified alignment.
+  When applying to multiple cells, values must be truthy to be set.
+  This is because multiple cells might have different values, and you
+  don't want a blank value to wipe out their original values. Note,
+  how as part of this, it doesn't remove any original alignment before
+  applying any specified alignment.
+ */
+const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData) => {
+  const isSingleCell = cells.length === 1;
+  Arr.each(cells, (item) => {
+    const cellElm = item.element;
+    const modifier = isSingleCell ? DomModifier.normal(editor, cellElm) : DomModifier.ifTruthy(editor, cellElm);
+    const colModifier = item.column.map((col) =>
+      isSingleCell ? DomModifier.normal(editor, col) : DomModifier.ifTruthy(editor, col)
+    ).getOr(modifier);
+
+    updateSimpleProps(modifier, colModifier, data);
+
+    if (hasAdvancedCellTab(editor)) {
+      updateAdvancedProps(modifier, data);
+    }
+
+    // Remove alignment
+    if (isSingleCell) {
+      Styles.unApplyAlign(editor, cellElm);
+      Styles.unApplyVAlign(editor, cellElm);
+    }
+
+    // Apply alignment
+    if (data.halign) {
+      Styles.applyAlign(editor, cellElm, data.halign);
+    }
+
+    // Apply vertical alignment
+    if (data.valign) {
+      Styles.applyVAlign(editor, cellElm, data.valign);
+    }
+  });
+};
+
+const applyStructureData = (editor: Editor, data: CellData) => {
+  // Switch cell type if applicable. This will also fire a table modified event for the structure change
+  editor.execCommand('mceTableCellType', false, { type: data.celltype, no_events: true });
+};
 
 const applyCellData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[], oldData: CellData, data: CellData) => {
-  const isSingleCell = cells.length === 1;
-
   const modifiedData = Obj.filter(data, (value, key) => oldData[key] !== value);
 
   if (Obj.size(modifiedData) > 0 && cells.length >= 1) {
-    /*
-      Retrieve the table before the cells are modified
-      as there is a case where cells are replaced and
-      the reference will be lost when trying to fire events.
-    */
-    const tableOpt = TableLookup.table(cells[0]);
+    // Retrieve the table before the cells are modified as there is a case where cells
+    // are replaced and the reference will be lost when trying to fire events.
+    TableLookup.table(cells[0]).each((table) => {
+      const selectedCells = getSelectedCells(table, cells);
 
-    getSelectedCells(cells).each((selectedCells) => {
-      Arr.each(selectedCells, (item) => {
-        // Switch cell type if applicable
-        const cellElm = switchCellType(editor, item.element, data.celltype);
-        const modifier = isSingleCell ? DomModifier.normal(editor, cellElm) : DomModifier.ifTruthy(editor, cellElm);
-        const colModifier = item.column.map((col) =>
-          isSingleCell ? DomModifier.normal(editor, col) : DomModifier.ifTruthy(editor, col)
-        ).getOr(modifier);
+      // style modified if there's at least one other change apart from 'celltype' and 'scope'
+      const styleModified = Obj.size(Obj.filter(modifiedData, (_value, key) => key !== 'scope' && key !== 'celltype')) > 0;
+      const structureModified = Obj.has(modifiedData, 'celltype');
 
-        updateSimpleProps(modifier, colModifier, data);
+      // Update the cells styling using the dialog data
+      if (styleModified || Obj.has(modifiedData, 'scope')) {
+        applyStyleData(editor, selectedCells, data);
+      }
 
-        if (hasAdvancedCellTab(editor)) {
-          updateAdvancedProps(modifier, data);
-        }
+      // Update the cells structure using the dialog data
+      if (structureModified) {
+        applyStructureData(editor, data);
+      }
 
-        // Remove alignment
-        if (isSingleCell) {
-          Styles.unApplyAlign(editor, cellElm);
-          Styles.unApplyVAlign(editor, cellElm);
-        }
-
-        // Apply alignment
-        if (data.halign) {
-          Styles.applyAlign(editor, cellElm, data.halign);
-        }
-
-        // Apply vertical alignment
-        if (data.valign) {
-          Styles.applyVAlign(editor, cellElm, data.valign);
-        }
+      Events.fireTableModified(editor, table.dom, {
+        structure: structureModified,
+        style: styleModified,
       });
     });
-
-    // style modified if there's at least one other change apart from 'celltype' and 'scope'
-    const styleModified = Obj.size(Obj.filter(modifiedData, (_value, key) => key !== 'scope' && key !== 'celltype')) > 0;
-
-    tableOpt.each(
-      (table) => Events.fireTableModified(editor, table.dom, {
-        structure: Obj.has(modifiedData, 'celltype'),
-        style: styleModified,
-      })
-    );
   }
 };
 
@@ -143,8 +153,8 @@ const onSubmitCellForm = (editor: Editor, cells: SugarElement<HTMLTableCellEleme
 };
 
 const getData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[]) => {
-  const cellsData = getSelectedCells(cells).map((selectedCells) =>
-    Arr.map(selectedCells, (item) =>
+  const cellsData = TableLookup.table(cells[0]).map((table) =>
+    Arr.map(getSelectedCells(table, cells), (item) =>
       Helpers.extractDataFromCellElement(editor, item.element, hasAdvancedCellTab(editor), item.column)
     )
   );

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -107,7 +107,8 @@ const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData) =
 };
 
 const applyStructureData = (editor: Editor, data: CellData) => {
-  // Switch cell type if applicable. This will also fire a table modified event for the structure change
+  // Switch cell type if applicable. Note that we specifically tell the command to not fire events
+  // as we'll batch the events and fire a `TableModified` event at the end of the updates.
   editor.execCommand('mceTableCellType', false, { type: data.celltype, no_events: true });
 };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
@@ -199,6 +199,12 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
     editor.execCommand(command, false, { type });
     assertEvents('TINY-6629: Assert table modified events', expectedEvents);
     TinyAssertions.assertContent(editor, expectedContent);
+    // Ensure the selection hasn't been lost and is still within a cell
+    // TODO: TINY-6666 fix selection getting lost for rows
+    if (command !== 'mceTableRowType') {
+      assert.isTrue(editor.selection.isCollapsed(), 'selection should be collapsed');
+      assert.match(editor.selection.getNode().nodeName, /^(TD|TH)$/, 'selection should be within a cell');
+    }
   };
 
   const switchMultipleColumnsType = (editor: Editor, startContent: string, expectedContent: string, command: string, type: 'td' | 'th', expectedEvents: string[] = defaultEvents) => {


### PR DESCRIPTION
Related Ticket: TINY-6666

Description of Changes:
* Move the `mceTableCellType` logic to snooker.
* Clean up the existing query command logic and made `getCellsType` consistent with `getColsType` in snooker.
* Update the dialog to use the cell type command instead of using the able update cell type logic.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
