### PR TITLE
TINY-7772: When no imagetools_proxy is provided buttons should be disabled for remote images

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Certain HTML content when inserted could cause the editor to crash #TINY-7756
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 - Disabled nested menu items could still be opened #TINY-7700
-- `Imagetools` buttons were enabled for remote images without `imagetools_proxy` set #TINY-7772
+- `imagetools` buttons were incorrectly enabled for remote images without `imagetools_proxy` set #TINY-7772
 - Some table operations would incorrectly cause table row attributes and styles to be lost #TINY-6666
 
 ### Deprecated

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Certain HTML content when inserted could cause the editor to crash #TINY-7756
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 - Disabled nested menu items could still be opened #TINY-7700
+- `Imagetools` buttons were enabled for remote images without `imagetools_proxy` set #TINY-7772
 
 ### Deprecated
 - The `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins have been deprecated and marked for removal in the next major release #TINY-7260

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
@@ -5,16 +5,18 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun } from '@ephox/katamari';
+import { Fun, Obj } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import * as Actions from '../core/Actions';
 
+type ButtonApiRecord = Record<string, Toolbar.ToolbarButtonInstanceApi>;
+
 const register = (editor: Editor) => {
 
-  const buttonApiMap = new Map<string, Toolbar.ToolbarButtonInstanceApi>();
+  const buttonApiRecord: ButtonApiRecord = {};
 
   const cmd = (command: string) => () => editor.execCommand(command);
 
@@ -23,14 +25,14 @@ const register = (editor: Editor) => {
       return Actions.getEditableImage(editor, element.dom).isNone();
     });
 
-    buttonApiMap.forEach((api: Toolbar.ToolbarButtonInstanceApi) => {
+    Obj.each(buttonApiRecord, (api: Toolbar.ToolbarButtonInstanceApi) => {
       api.setDisabled(disabled);
     });
   };
 
-  const addToButtonApiMap = (key: string, api: Toolbar.ToolbarButtonInstanceApi) => {
-    if (!buttonApiMap.has(key)) {
-      buttonApiMap.set(key, api);
+  const addToButtonApiRecord = (key: string, api: Toolbar.ToolbarButtonInstanceApi) => {
+    if (!Obj.has(buttonApiRecord, key)) {
+      buttonApiRecord[key] = api;
     }
   };
 
@@ -41,7 +43,7 @@ const register = (editor: Editor) => {
     icon: 'rotate-left',
     onAction: cmd('mceImageRotateLeft'),
     onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
-      addToButtonApiMap('rotateleft', buttonApi);
+      addToButtonApiRecord('rotateleft', buttonApi);
       return Fun.noop;
     }
   });
@@ -51,7 +53,7 @@ const register = (editor: Editor) => {
     icon: 'rotate-right',
     onAction: cmd('mceImageRotateRight'),
     onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
-      addToButtonApiMap('rotateright', buttonApi);
+      addToButtonApiRecord('rotateright', buttonApi);
       return Fun.noop;
     }
   });
@@ -61,7 +63,7 @@ const register = (editor: Editor) => {
     icon: 'flip-vertically',
     onAction: cmd('mceImageFlipVertical'),
     onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
-      addToButtonApiMap('flipv', buttonApi);
+      addToButtonApiRecord('flipv', buttonApi);
       return Fun.noop;
     }
   });
@@ -71,7 +73,7 @@ const register = (editor: Editor) => {
     icon: 'flip-horizontally',
     onAction: cmd('mceImageFlipHorizontal'),
     onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
-      addToButtonApiMap('fliph', buttonApi);
+      addToButtonApiRecord('fliph', buttonApi);
       return Fun.noop;
     }
   });
@@ -81,7 +83,7 @@ const register = (editor: Editor) => {
     icon: 'edit-image',
     onAction: cmd('mceEditImage'),
     onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
-      addToButtonApiMap('editimage', buttonApi);
+      addToButtonApiRecord('editimage', buttonApi);
       return Fun.noop;
     }
   });

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
@@ -5,6 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Toolbar } from '@ephox/bridge';
+
 import Editor from 'tinymce/core/api/Editor';
 
 import * as Actions from '../core/Actions';
@@ -12,7 +14,7 @@ import * as Actions from '../core/Actions';
 const register = (editor: Editor) => {
   const cmd = (command: string) => () => editor.execCommand(command);
 
-  const onSetup = (buttonApi) => {
+  const onSetup = (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
     const setDisabled = () => {
       const disabled = Actions.getSelectedImage(editor).forall((element) => {
         return Actions.getEditableImage(editor, element.dom).isNone();

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
@@ -5,9 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Toolbar } from '@ephox/bridge';
-
 import Editor from 'tinymce/core/api/Editor';
+import { Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import * as Actions from '../core/Actions';
 

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
@@ -12,48 +12,54 @@ import * as Actions from '../core/Actions';
 const register = (editor: Editor) => {
   const cmd = (command: string) => () => editor.execCommand(command);
 
+  const onSetup = (buttonApi) => {
+    const setDisabled = () => {
+      const disabled = Actions.getSelectedImage(editor).forall((element) => {
+        return Actions.getEditableImage(editor, element.dom).isNone();
+      });
+      buttonApi.setDisabled(disabled);
+    };
+
+    editor.on('NodeChange', setDisabled);
+
+    return () => {
+      editor.off('NodeChange', setDisabled);
+    };
+  };
+
   editor.ui.registry.addButton('rotateleft', {
     tooltip: 'Rotate counterclockwise',
     icon: 'rotate-left',
-    onAction: cmd('mceImageRotateLeft')
+    onAction: cmd('mceImageRotateLeft'),
+    onSetup
   });
 
   editor.ui.registry.addButton('rotateright', {
     tooltip: 'Rotate clockwise',
     icon: 'rotate-right',
-    onAction: cmd('mceImageRotateRight')
+    onAction: cmd('mceImageRotateRight'),
+    onSetup
   });
 
   editor.ui.registry.addButton('flipv', {
     tooltip: 'Flip vertically',
     icon: 'flip-vertically',
-    onAction: cmd('mceImageFlipVertical')
+    onAction: cmd('mceImageFlipVertical'),
+    onSetup
   });
 
   editor.ui.registry.addButton('fliph', {
     tooltip: 'Flip horizontally',
     icon: 'flip-horizontally',
-    onAction: cmd('mceImageFlipHorizontal')
+    onAction: cmd('mceImageFlipHorizontal'),
+    onSetup
   });
 
   editor.ui.registry.addButton('editimage', {
     tooltip: 'Edit image',
     icon: 'edit-image',
     onAction: cmd('mceEditImage'),
-    onSetup: (buttonApi) => {
-      const setDisabled = () => {
-        const disabled = Actions.getSelectedImage(editor).forall((element) => {
-          return Actions.getEditableImage(editor, element.dom).isNone();
-        });
-        buttonApi.setDisabled(disabled);
-      };
-
-      editor.on('NodeChange', setDisabled);
-
-      return () => {
-        editor.off('NodeChange', setDisabled);
-      };
-    }
+    onSetup
   });
 
   editor.ui.registry.addButton('imageoptions', {

--- a/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/ui/Buttons.ts
@@ -5,62 +5,85 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Fun } from '@ephox/katamari';
+
 import Editor from 'tinymce/core/api/Editor';
 import { Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import * as Actions from '../core/Actions';
 
 const register = (editor: Editor) => {
+
+  const buttonApiMap = new Map<string, Toolbar.ToolbarButtonInstanceApi>();
+
   const cmd = (command: string) => () => editor.execCommand(command);
 
-  const onSetup = (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
-    const setDisabled = () => {
-      const disabled = Actions.getSelectedImage(editor).forall((element) => {
-        return Actions.getEditableImage(editor, element.dom).isNone();
-      });
-      buttonApi.setDisabled(disabled);
-    };
+  const setDisabled = () => {
+    const disabled = Actions.getSelectedImage(editor).forall((element) => {
+      return Actions.getEditableImage(editor, element.dom).isNone();
+    });
 
-    editor.on('NodeChange', setDisabled);
-
-    return () => {
-      editor.off('NodeChange', setDisabled);
-    };
+    buttonApiMap.forEach((api: Toolbar.ToolbarButtonInstanceApi) => {
+      api.setDisabled(disabled);
+    });
   };
+
+  const addToButtonApiMap = (key: string, api: Toolbar.ToolbarButtonInstanceApi) => {
+    if (!buttonApiMap.has(key)) {
+      buttonApiMap.set(key, api);
+    }
+  };
+
+  editor.on('NodeChange', setDisabled);
 
   editor.ui.registry.addButton('rotateleft', {
     tooltip: 'Rotate counterclockwise',
     icon: 'rotate-left',
     onAction: cmd('mceImageRotateLeft'),
-    onSetup
+    onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
+      addToButtonApiMap('rotateleft', buttonApi);
+      return Fun.noop;
+    }
   });
 
   editor.ui.registry.addButton('rotateright', {
     tooltip: 'Rotate clockwise',
     icon: 'rotate-right',
     onAction: cmd('mceImageRotateRight'),
-    onSetup
+    onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
+      addToButtonApiMap('rotateright', buttonApi);
+      return Fun.noop;
+    }
   });
 
   editor.ui.registry.addButton('flipv', {
     tooltip: 'Flip vertically',
     icon: 'flip-vertically',
     onAction: cmd('mceImageFlipVertical'),
-    onSetup
+    onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
+      addToButtonApiMap('flipv', buttonApi);
+      return Fun.noop;
+    }
   });
 
   editor.ui.registry.addButton('fliph', {
     tooltip: 'Flip horizontally',
     icon: 'flip-horizontally',
     onAction: cmd('mceImageFlipHorizontal'),
-    onSetup
+    onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
+      addToButtonApiMap('fliph', buttonApi);
+      return Fun.noop;
+    }
   });
 
   editor.ui.registry.addButton('editimage', {
     tooltip: 'Edit image',
     icon: 'edit-image',
     onAction: cmd('mceEditImage'),
-    onSetup
+    onSetup: (buttonApi: Toolbar.ToolbarButtonInstanceApi) => {
+      addToButtonApiMap('editimage', buttonApi);
+      return Fun.noop;
+    }
   });
 
   editor.ui.registry.addButton('imageoptions', {

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
@@ -28,13 +28,13 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () 
     ImagePlugin();
   });
 
-  const assertButtonsStatus = (editor: Editor, disabled: boolean) => {
+  const assertButtonsStatus = (editor: Editor, spec: { disabled: boolean }) => {
     const container = TinyDom.container(editor);
-    UiFinder.exists(container, `${editImageButtonSelector}[aria-disabled="${disabled}"]`);
-    UiFinder.exists(container, `${flipHorizontallyImageButtonSelector}[aria-disabled="${disabled}"]`);
-    UiFinder.exists(container, `${flipVerticallyImageButtonSelector}[aria-disabled="${disabled}"]`);
-    UiFinder.exists(container, `${rotateCounterClockwiseImageButtonSelector}[aria-disabled="${disabled}"]`);
-    UiFinder.exists(container, `${rotateClockwiseImageButtonSelector}[aria-disabled="${disabled}"]`);
+    UiFinder.exists(container, `${editImageButtonSelector}[aria-disabled="${spec.disabled}"]`);
+    UiFinder.exists(container, `${flipHorizontallyImageButtonSelector}[aria-disabled="${spec.disabled}"]`);
+    UiFinder.exists(container, `${flipVerticallyImageButtonSelector}[aria-disabled="${spec.disabled}"]`);
+    UiFinder.exists(container, `${rotateCounterClockwiseImageButtonSelector}[aria-disabled="${spec.disabled}"]`);
+    UiFinder.exists(container, `${rotateClockwiseImageButtonSelector}[aria-disabled="${spec.disabled}"]`);
   };
 
   const insertRemoteImage = (editor: Editor) => {
@@ -47,8 +47,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () 
     insertRemoteImage(editor);
     TinySelections.select(editor, 'img', []);
 
-    const disabled = true;
-    assertButtonsStatus(editor, disabled);
+    assertButtonsStatus(editor, { disabled: true });
     McEditor.remove(editor);
   });
 
@@ -58,8 +57,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () 
     TinySelections.select(editor, 'img', []);
     await UiFinder.pWaitFor('Wait for edit image button to became enabled', TinyDom.container(editor), `${editImageButtonSelector}[aria-disabled="false"]`);
 
-    const disabled = false;
-    assertButtonsStatus(editor, disabled);
+    assertButtonsStatus(editor, { disabled: false });
     McEditor.remove(editor);
   });
 
@@ -67,8 +65,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () 
     const editor = await McEditor.pFromSettings<Editor>(settings);
     insertRemoteImage(editor);
 
-    const disabled = true;
-    assertButtonsStatus(editor, disabled);
+    assertButtonsStatus(editor, { disabled: true });
     McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
@@ -62,7 +62,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () 
   });
 
   it('TINY-7772: Edit, flip and rotate should be disabled when no images are selected', async () => {
-    const editor = await McEditor.pFromSettings<Editor>(settings);
+    const editor = await McEditor.pFromSettings<Editor>({ ...settings, imagetools_proxy: 'foo.php' });
     insertRemoteImage(editor);
 
     assertButtonsStatus(editor, { disabled: true });

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
@@ -1,0 +1,104 @@
+import { UiFinder, Waiter } from '@ephox/agar';
+import { before, describe, it } from '@ephox/bedrock-client';
+import { McEditor, TinyDom, TinySelections } from '@ephox/mcagar';
+import { Attribute, SugarBody } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import PromisePolyfill from 'tinymce/core/api/util/Promise';
+import ImagePlugin from 'tinymce/plugins/image/Plugin';
+import ImageToolsPlugin from 'tinymce/plugins/imagetools/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () => {
+
+  const settings = {
+    plugins: 'image imagetools',
+    toolbar: 'editimage fliph flipv rotateleft rotateright',
+    base_url: '/project/tinymce/js/tinymce',
+    height: 900
+  };
+
+  const editImageButtonSelector = '[role="toolbar"] button[title="Edit image"]';
+  const flipHorizontallyImageButtonSelector = '[role="toolbar"] button[title="Flip horizontally"]';
+  const flipVerticallyImageButtonSelector = '[role="toolbar"] button[title="Flip vertically"]';
+  const rotateCounterClockwiseImageButtonSelector = '[role="toolbar"] button[title="Rotate counterclockwise"]';
+  const rotateClockwiseImageButtonSelector = '[role="toolbar"] button[title="Rotate clockwise"]';
+
+  const assertImageToolsButtonsExist = (editor) => {
+    UiFinder.exists(TinyDom.container(editor), editImageButtonSelector);
+    UiFinder.exists(TinyDom.container(editor), flipHorizontallyImageButtonSelector);
+    UiFinder.exists(TinyDom.container(editor), flipVerticallyImageButtonSelector);
+    UiFinder.exists(TinyDom.container(editor), rotateCounterClockwiseImageButtonSelector);
+    UiFinder.exists(TinyDom.container(editor), rotateClockwiseImageButtonSelector);
+  };
+
+  const assertButtonStatus = (editor, selector: string, enabled: boolean) => {
+    UiFinder.findIn(TinyDom.container(editor), selector).map((button) => {
+      assert.equal(Attribute.get(button, 'aria-disabled'), Boolean(enabled).toString());
+    });
+  };
+
+  const pLoadRemoteImage = (editor): Promise<void> => {
+    return new PromisePolyfill((resolve, reject) => {
+      const remoteImageSrc = 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png';
+      const img = new Image();
+      img.src = remoteImageSrc;
+
+      img.onload = () => {
+        editor.setContent(`<p><img src="${remoteImageSrc}" width="50" height="50" /></p>`);
+        editor.focus();
+        resolve();
+      };
+
+      img.onerror = (e) => reject(e);
+    });
+  };
+
+  const pWaitImageToolsContextMenu = () =>
+    Waiter.pTryUntil('Wait for Image Tools context menu to open', () => UiFinder.exists(SugarBody.body(), '.tox-pop'));
+
+  before(() => {
+    Theme();
+    ImageToolsPlugin();
+    ImagePlugin();
+  });
+
+  it('TINY-7772: Edit, flip and rotate should be disabled for remote images without imagetools_proxy set', async () => {
+    try {
+      const editor = await McEditor.pFromSettings(settings);
+      await pLoadRemoteImage(editor);
+      TinySelections.select(editor, 'img', []);
+
+      assertImageToolsButtonsExist(editor);
+      const enabled = true;
+      assertButtonStatus(editor, editImageButtonSelector, enabled);
+      assertButtonStatus(editor, flipHorizontallyImageButtonSelector, enabled);
+      assertButtonStatus(editor, flipVerticallyImageButtonSelector, enabled);
+      assertButtonStatus(editor, rotateCounterClockwiseImageButtonSelector, enabled);
+      assertButtonStatus(editor, rotateClockwiseImageButtonSelector, enabled);
+      McEditor.remove(editor);
+    } catch (e) {
+      assert.fail(`Test failed: ${e.message}`);
+    }
+  });
+
+  it('TINY-7772: Edit, flip and rotate should be enabled for remote images with imagetools_proxy set', async () => {
+    try {
+      const editor = await McEditor.pFromSettings({ ...settings, imagetools_proxy: 'foo.php' });
+      await pLoadRemoteImage(editor);
+      TinySelections.select(editor, 'img', []);
+      await pWaitImageToolsContextMenu();
+
+      assertImageToolsButtonsExist(editor);
+      const enabled = false;
+      assertButtonStatus(editor, editImageButtonSelector, enabled);
+      assertButtonStatus(editor, flipHorizontallyImageButtonSelector, enabled);
+      assertButtonStatus(editor, flipVerticallyImageButtonSelector, enabled);
+      assertButtonStatus(editor, rotateCounterClockwiseImageButtonSelector, enabled);
+      assertButtonStatus(editor, rotateClockwiseImageButtonSelector, enabled);
+      McEditor.remove(editor);
+    } catch (e) {
+      assert.fail(`Test failed: ${e.message}`);
+    }
+  });
+});

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
@@ -64,41 +64,33 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () 
   });
 
   it('TINY-7772: Edit, flip and rotate should be disabled for remote images without imagetools_proxy set', async () => {
-    try {
-      const editor = await McEditor.pFromSettings(settings);
-      await pLoadRemoteImage(editor);
-      TinySelections.select(editor, 'img', []);
+    const editor = await McEditor.pFromSettings(settings);
+    await pLoadRemoteImage(editor);
+    TinySelections.select(editor, 'img', []);
 
-      assertImageToolsButtonsExist(editor);
-      const enabled = true;
-      assertButtonStatus(editor, editImageButtonSelector, enabled);
-      assertButtonStatus(editor, flipHorizontallyImageButtonSelector, enabled);
-      assertButtonStatus(editor, flipVerticallyImageButtonSelector, enabled);
-      assertButtonStatus(editor, rotateCounterClockwiseImageButtonSelector, enabled);
-      assertButtonStatus(editor, rotateClockwiseImageButtonSelector, enabled);
-      McEditor.remove(editor);
-    } catch (e) {
-      assert.fail(`Test failed: ${e.message}`);
-    }
+    assertImageToolsButtonsExist(editor);
+    const enabled = true;
+    assertButtonStatus(editor, editImageButtonSelector, enabled);
+    assertButtonStatus(editor, flipHorizontallyImageButtonSelector, enabled);
+    assertButtonStatus(editor, flipVerticallyImageButtonSelector, enabled);
+    assertButtonStatus(editor, rotateCounterClockwiseImageButtonSelector, enabled);
+    assertButtonStatus(editor, rotateClockwiseImageButtonSelector, enabled);
+    McEditor.remove(editor);
   });
 
   it('TINY-7772: Edit, flip and rotate should be enabled for remote images with imagetools_proxy set', async () => {
-    try {
-      const editor = await McEditor.pFromSettings({ ...settings, imagetools_proxy: 'foo.php' });
-      await pLoadRemoteImage(editor);
-      TinySelections.select(editor, 'img', []);
-      await pWaitImageToolsContextMenu();
+    const editor = await McEditor.pFromSettings({ ...settings, imagetools_proxy: 'foo.php' });
+    await pLoadRemoteImage(editor);
+    TinySelections.select(editor, 'img', []);
+    await pWaitImageToolsContextMenu();
 
-      assertImageToolsButtonsExist(editor);
-      const enabled = false;
-      assertButtonStatus(editor, editImageButtonSelector, enabled);
-      assertButtonStatus(editor, flipHorizontallyImageButtonSelector, enabled);
-      assertButtonStatus(editor, flipVerticallyImageButtonSelector, enabled);
-      assertButtonStatus(editor, rotateCounterClockwiseImageButtonSelector, enabled);
-      assertButtonStatus(editor, rotateClockwiseImageButtonSelector, enabled);
-      McEditor.remove(editor);
-    } catch (e) {
-      assert.fail(`Test failed: ${e.message}`);
-    }
+    assertImageToolsButtonsExist(editor);
+    const enabled = false;
+    assertButtonStatus(editor, editImageButtonSelector, enabled);
+    assertButtonStatus(editor, flipHorizontallyImageButtonSelector, enabled);
+    assertButtonStatus(editor, flipVerticallyImageButtonSelector, enabled);
+    assertButtonStatus(editor, rotateCounterClockwiseImageButtonSelector, enabled);
+    assertButtonStatus(editor, rotateClockwiseImageButtonSelector, enabled);
+    McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
@@ -1,6 +1,6 @@
-import { Mouse, UiFinder } from '@ephox/agar';
+import { UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyDom } from '@ephox/mcagar';
+import { McEditor, TinyDom, TinySelections } from '@ephox/mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';
@@ -45,18 +45,18 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () 
   it('TINY-7772: Edit, flip and rotate should be disabled for remote images without imagetools_proxy set', async () => {
     const editor = await McEditor.pFromSettings<Editor>(settings);
     insertRemoteImage(editor);
-    Mouse.clickOn(TinyDom.body(editor), 'img');
+    TinySelections.select(editor, 'img', []);
 
     const disabled = true;
     assertButtonsStatus(editor, disabled);
     McEditor.remove(editor);
-
   });
 
   it('TINY-7772: Edit, flip and rotate should be enabled for remote images with imagetools_proxy set', async () => {
     const editor = await McEditor.pFromSettings<Editor>({ ...settings, imagetools_proxy: 'foo.php' });
     insertRemoteImage(editor);
-    Mouse.clickOn(TinyDom.body(editor), 'img');
+    TinySelections.select(editor, 'img', []);
+    await UiFinder.pWaitFor('Wait for edit image button to became enabled', TinyDom.container(editor), `${editImageButtonSelector}[aria-disabled="false"]`);
 
     const disabled = false;
     assertButtonsStatus(editor, disabled);


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Disable buttons - Edit, Flip h, Flip v, Rotate counterclockwise, Rotate clockwise - when setting `imagetools_proxy` is not provided and image is remote

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
