### PR TITLE
TINY-7739: Fix inset layouts incorrectly used for selection context toolbars

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -81,11 +81,14 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
     if (!canLaunchToolbar()) {
       return true;
     } else {
-      const lastElementBounds = ContextToolbarBounds.getAnchorElementBounds(editor, lastElement.get());
       const contextToolbarBounds = getBounds();
+      // Get the anchor bounds. For node anchors we should always try to use the last element bounds
+      const anchorBounds = Optionals.is(lastContextPosition.get(), 'node') ?
+        ContextToolbarBounds.getAnchorElementBounds(editor, lastElement.get()) :
+        ContextToolbarBounds.getSelectionBounds(editor);
 
-      // If the element bound isn't overlapping with the context toolbar bounds, the context toolbar should hide
-      return !ContextToolbarBounds.isVerticalOverlap(lastElementBounds, contextToolbarBounds);
+      // If the anchor bounds aren't overlapping with the context toolbar bounds, then the context toolbar should hide
+      return !ContextToolbarBounds.isVerticalOverlap(anchorBounds, contextToolbarBounds);
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -88,7 +88,8 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
         ContextToolbarBounds.getSelectionBounds(editor);
 
       // If the anchor bounds aren't overlapping with the context toolbar bounds, then the context toolbar should hide
-      return !ContextToolbarBounds.isVerticalOverlap(anchorBounds, contextToolbarBounds);
+      // Note: We want to avoid showing with small difference such as 0.001px so we ensure at least 0.5px is visible
+      return !ContextToolbarBounds.isVerticalOverlap(anchorBounds, contextToolbarBounds, 0.5);
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
@@ -15,8 +15,9 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../../api/Settings';
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 
+// Note: We round the values here as we are looking for changes that aren't just 0.001px difference
 const isVerticalOverlap = (a: Bounds, b: Bounds): boolean =>
-  a.y < b.bottom && a.bottom > b.y;
+  Math.round(a.y) < Math.round(b.bottom) && Math.round(a.bottom) > Math.round(b.y);
 
 const getRangeRect = (rng: Range): DOMRect => {
   const rect = rng.getBoundingClientRect();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
@@ -16,7 +16,7 @@ import * as Settings from '../../api/Settings';
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 
 const isVerticalOverlap = (a: Bounds, b: Bounds): boolean =>
-  Math.max(a.y, b.y) <= Math.min(a.bottom, b.bottom);
+  a.y < b.bottom && a.bottom > b.y;
 
 const getRangeRect = (rng: Range): DOMRect => {
   const rect = rng.getBoundingClientRect();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
@@ -15,9 +15,9 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../../api/Settings';
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 
-// Note: We round the values here as we are looking for changes that aren't just 0.001px difference
+// Note: We want to avoid a small difference such as 0.001px so we ensure at least 1px is visible
 const isVerticalOverlap = (a: Bounds, b: Bounds): boolean =>
-  Math.round(a.y) < Math.round(b.bottom) && Math.round(a.bottom) > Math.round(b.y);
+  b.bottom - a.y >= 1 && a.bottom - b.y >= 1;
 
 const getRangeRect = (rng: Range): DOMRect => {
   const rect = rng.getBoundingClientRect();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
@@ -15,9 +15,8 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../../api/Settings';
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 
-// Note: We want to avoid a small difference such as 0.001px so we ensure at least 1px is visible
-const isVerticalOverlap = (a: Bounds, b: Bounds): boolean =>
-  b.bottom - a.y >= 1 && a.bottom - b.y >= 1;
+const isVerticalOverlap = (a: Bounds, b: Bounds, threshold: number = 0): boolean =>
+  b.bottom - a.y >= threshold && a.bottom - b.y >= threshold;
 
 const getRangeRect = (rng: Range): DOMRect => {
   const rect = rng.getBoundingClientRect();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -39,7 +39,8 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     toolbar: 'fullscreen',
     height: 400,
     base_url: '/project/tinymce/js/tinymce',
-    content_style: 'body, p { margin: 0; line-height: 22px; font-family: sans-serif; } tr { height: 36px; }',
+    // Note: We provide overrides to keep consistent positions across all browsers/os's
+    content_style: 'body, p { margin: 0; line-height: 22px; font-family: Arial,sans-serif; } tr { height: 36px; }',
     setup: (ed: Editor) => {
       ed.ui.registry.addButton('alpha', {
         text: 'Alpha',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -254,12 +254,12 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     const editor = hook.editor();
     editor.setContent('<p style="padding-top: 100px;"></p><p style="padding-top: 100px;"></p><p style="padding-top: 100px;"></p>text</p>');
     TinySelections.setSelection(editor, [ 3, 0 ], 1, [ 3, 0 ], 3);
-    // Place the selected text right at the bottom of the editor so only 1px of the selection is visible
+    // Place the selected text right at the bottom of the editor so only ~1px of the selection is visible
     // Note: IE 11 uses a different selection height (22px vs 17px)
     scrollTo(editor, 0, browser.isIE() ? 65 : 67);
     await UiFinder.pWaitForVisible('Waiting for toolbar to appear above the content', SugarBody.body(), topSelector);
-    // Moving 1px more the selected text is now offscreen so the context toolbar should hide
-    scrollTo(editor, 0, browser.isIE() ? 64 : 66);
+    // Moving 2px more the selected text is now offscreen so the context toolbar should hide
+    scrollTo(editor, 0, browser.isIE() ? 63 : 65);
     await UiFinder.pWaitForHidden('Waiting for toolbar to be hidden', SugarBody.body(), '.tox-pop');
   });
 


### PR DESCRIPTION
Related Ticket: TINY-7739

Description of Changes:
So there were 3 parts to this in the end:

1. There was an issue with using the wrong anchor position lookup when trying to see if the toolbar should hide. This was because it was using the element position (e.g. the `p` element) for selection toolbars which isn't the same as the selection and in most cases was off by 1px. That off by 1 is what caused the "north" layout to say it didn't fit as part of it was deemed to be offscreen.
2. The was an issue with the overlap detection logic as if it was the same value (e.g. the anchor was `y` 400 and the `bottom` bounds was 400) than nothing was visible so it should have been hidden. It also had an issue when one of the bounds had a height of zero.
3. I've also improved the context toolbar layout decisions to not use an inset layout for a context toolbar placed on a selection. We don't want that as it'd cover the selection at all times and we wouldn't be able to see the selection content like we can with say tables.

Pre-checks:
* [x] ~Changelog entry added~ No changelog as this was caused by changes in 5.9
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
