### PR TITLE
TINY-7695: Fixed table operations placing the cursor in an invalid position

### DIFF
--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Improved
 - Rows are now stored and tracked in the table model structures.
+- Table operations will now ensure the cursor is placed in an editable cell.
 
 ### Changed
 - `RowDetails` has been renamed to `RowDetail` and now takes a generic argument to define the type of cells stored.
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Table operations that replace all cells in a row now re-use the existing row instead of creating a new row.
+- Table erase operations could place the cursor in an invalid location if erasing the last row or column.
 
 ### Removed
 - `Structs.RowData` has been merged into and replaced by `Structs.RowDetail` to remove some duplication.

--- a/modules/snooker/src/test/ts/browser/EraseOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/EraseOperationsTest.ts
@@ -972,19 +972,52 @@ UnitTest.test('EraseOperationsTest', () => {
     platform
   );
 
-  const deleteExpectedContent30 = '<table>' +
-    '<tbody>' +
-      '<tr><td contenteditable="false">A1</td><td>B1</td></tr>' +
-    '</tbody>' +
-  '</table>';
+  const deleteExpectedContent30 =
+    '<table><tbody>' +
+    '<tr><td rowspan="2">row 0 cell 0 row 1 cell 0 </td><td>row 0 cell 1</td><td rowspan="3">row 0 cell 2 row 1 cell 2 row 2 cell 2 </td></tr>' +
+    '<tr><td>row 1 cell 1</td></tr>' +
+    '<tr><td>row 2 cell 0</td><td>row 2 cell 1</td></tr>' +
+    '</tbody></table>';
   const deleteExpected30 = {
     normal: deleteExpectedContent30,
     ie: deleteExpectedContent30
   };
   Assertions.checkDelete(
+    'TINY-7695: Deleting the last 2 rows should keep the cursor in the last row',
+    Optional.some({ section: 0, row: 2, column: 1 }),
+    Optional.some(deleteExpected30),
+
+    '<table><tbody>' +
+    '<tr><td rowspan="2">row 0 cell 0 row 1 cell 0 </td><td>row 0 cell 1</td><td rowspan="3">row 0 cell 2 row 1 cell 2 row 2 cell 2 </td></tr>' +
+    '<tr><td>row 1 cell 1</td></tr>' +
+    '<tr><td>row 2 cell 0</td><td>row 2 cell 1</td></tr>' +
+    '<tr><td>row 3 cell 0</td><td>row 3 cell 1</td><td>row 3 cell 2</td></tr>' +
+    '<tr><td>row 4 cell 0</td><td>row 4 cell 1</td><td>row 4 cell 2</td></tr>' +
+    '</tbody></table>',
+
+    TableOperations.eraseRows,
+    [
+      { section: 0, row: 3, column: 1 },
+      { section: 0, row: 3, column: 2 },
+      { section: 0, row: 4, column: 1 },
+      { section: 0, row: 4, column: 2 },
+    ],
+    platform
+  );
+
+  const deleteExpectedContent31 = '<table>' +
+    '<tbody>' +
+      '<tr><td contenteditable="false">A1</td><td>B1</td></tr>' +
+    '</tbody>' +
+  '</table>';
+  const deleteExpected31 = {
+    normal: deleteExpectedContent31,
+    ie: deleteExpectedContent31
+  };
+  Assertions.checkDelete(
     'TINY-7695: Deleting the last row should not move the selection into a cef element',
     Optional.some({ section: 0, row: 0, column: 1 }),
-    Optional.some(deleteExpected30),
+    Optional.some(deleteExpected31),
 
     '<table>' +
       '<tbody>' +
@@ -1001,20 +1034,20 @@ UnitTest.test('EraseOperationsTest', () => {
     platform
   );
 
-  const deleteExpectedContent31 = '<table>' +
+  const deleteExpectedContent32 = '<table>' +
     '<tbody>' +
     '<tr><td contenteditable="false">A1</td></tr>' +
     '<tr><td>A2</td></tr>' +
     '</tbody>' +
     '</table>';
-  const deleteExpected31 = {
-    normal: deleteExpectedContent31,
-    ie: deleteExpectedContent31
+  const deleteExpected32 = {
+    normal: deleteExpectedContent32,
+    ie: deleteExpectedContent32
   };
   Assertions.checkDelete(
     'TINY-7695: Deleting the last column should not move the selection into a cef element',
     Optional.some({ section: 0, row: 1, column: 0 }),
-    Optional.some(deleteExpected31),
+    Optional.some(deleteExpected32),
 
     '<table>' +
     '<tbody>' +

--- a/modules/snooker/src/test/ts/browser/EraseOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/EraseOperationsTest.ts
@@ -580,7 +580,7 @@ UnitTest.test('EraseOperationsTest', () => {
   };
   Assertions.checkDelete(
     'TBA',
-    Optional.some({ section: 0, row: 0, column: 0 }),
+    Optional.some({ section: 0, row: 2, column: 0 }),
     Optional.some(deleteExpected18),
 
     '<table border="1"><tbody>' +
@@ -968,6 +968,65 @@ UnitTest.test('EraseOperationsTest', () => {
       { section: 1, row: 0, column: 1 },
       { section: 1, row: 0, column: 2 },
       { section: 1, row: 0, column: 3 },
+    ],
+    platform
+  );
+
+  const deleteExpectedContent30 = '<table>' +
+    '<tbody>' +
+      '<tr><td contenteditable="false">A1</td><td>B1</td></tr>' +
+    '</tbody>' +
+  '</table>';
+  const deleteExpected30 = {
+    normal: deleteExpectedContent30,
+    ie: deleteExpectedContent30
+  };
+  Assertions.checkDelete(
+    'TINY-7695: Deleting the last row should not move the selection into a cef element',
+    Optional.some({ section: 0, row: 0, column: 1 }),
+    Optional.some(deleteExpected30),
+
+    '<table>' +
+      '<tbody>' +
+        '<tr><td contenteditable="false">A1</td><td>B1</td></tr>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+      '</tbody>' +
+    '</table>',
+
+    TableOperations.eraseRows,
+    [
+      { section: 0, row: 1, column: 0 },
+      { section: 0, row: 1, column: 1 }
+    ],
+    platform
+  );
+
+  const deleteExpectedContent31 = '<table>' +
+    '<tbody>' +
+    '<tr><td contenteditable="false">A1</td></tr>' +
+    '<tr><td>A2</td></tr>' +
+    '</tbody>' +
+    '</table>';
+  const deleteExpected31 = {
+    normal: deleteExpectedContent31,
+    ie: deleteExpectedContent31
+  };
+  Assertions.checkDelete(
+    'TINY-7695: Deleting the last column should not move the selection into a cef element',
+    Optional.some({ section: 0, row: 1, column: 0 }),
+    Optional.some(deleteExpected31),
+
+    '<table>' +
+    '<tbody>' +
+    '<tr><td contenteditable="false">A1</td><td>B1</td></tr>' +
+    '<tr><td>A2</td><td>B2</td></tr>' +
+    '</tbody>' +
+    '</table>',
+
+    TableOperations.eraseColumns,
+    [
+      { section: 0, row: 0, column: 1 },
+      { section: 0, row: 1, column: 1 }
     ],
     platform
   );

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 - Disabled nested menu items could still be opened #TINY-7700
 - `imagetools` buttons were incorrectly enabled for remote images without `imagetools_proxy` set #TINY-7772
+- Removing a table row or column could result in the cursor getting placed in an invalid location #TINY-7695
 - Some table operations would incorrectly cause table row attributes and styles to be lost #TINY-6666
 - The selection was incorrectly lost when using the `mceTableCellType` and `mceTableRowType` commands #TINY-6666
 - The `mceTableRowType` was reversing the order of the rows when converting multiple header rows back to body rows #TINY-6666


### PR DESCRIPTION
Related Ticket: TINY-7695

Description of Changes:
* Ensure that when erasing columns/rows we try to ensure the cursor position used is within the grid. This means that when deleting the last row/column it'll move to the previous row/column instead of the first cell in the table.
* Update snooker to attempt to find a different cursor position that's editable if the one provided by the operation isn't valid/editable.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
