### PR TITLE
Added types for the `advlist` to `hr` plugins

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -16,7 +16,7 @@ export interface ExecCommandEvent { command: string; ui?: boolean; value?: any }
 
 // TODO Figure out if these properties should be on the ContentArgs types
 export type GetContentEvent = GetContentArgs & { source_view?: boolean; selection?: boolean; save?: boolean };
-export type SetContentEvent = SetContentArgs & { paste?: boolean; selection?: boolean };
+export type SetContentEvent = SetContentArgs & { source_view?: boolean; paste?: boolean; selection?: boolean };
 
 export interface NewBlockEvent { newBlock: Element }
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DomQuery.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DomQuery.ts
@@ -77,7 +77,7 @@ export interface DomQueryConstructor {
   grep <T>(array: T[], callback: (item, i: number) => boolean): T[];
   unique <T>(results: T[]): T[];
   text (elem: Node): string;
-  contains (context, elem: Node): number;
+  contains (context, elem: Node): boolean;
   filter (expr: string, elems: Node[], not?: boolean);
 }
 

--- a/modules/tinymce/src/plugins/advlist/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/Plugin.ts
@@ -10,7 +10,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('advlist', (editor) => {
     if (editor.hasPlugin('lists')) {
       Buttons.register(editor);

--- a/modules/tinymce/src/plugins/advlist/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/api/Commands.ts
@@ -5,9 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Actions from '../core/Actions';
 
-const register = (editor) => {
+const register = (editor: Editor): void => {
   editor.addCommand('ApplyUnorderedListStyle', (ui, value) => {
     Actions.applyListFormat(editor, 'UL', value['list-style-type']);
   });

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/Actions.ts
@@ -5,7 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const applyListFormat = (editor, listName, styleValue) => {
+import Editor from 'tinymce/core/api/Editor';
+
+const applyListFormat = (editor: Editor, listName: string, styleValue: false | string): void => {
   const cmd = listName === 'UL' ? 'InsertUnorderedList' : 'InsertOrderedList';
   editor.execCommand(cmd, false, styleValue === false ? null : { 'list-style-type': styleValue });
 };

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -7,21 +7,21 @@
 
 import { Optional } from '@ephox/katamari';
 
-const isChildOfBody = (editor, elm) => {
+import Editor from 'tinymce/core/api/Editor';
+
+const isChildOfBody = (editor: Editor, elm: Node): boolean => {
   return editor.$.contains(editor.getBody(), elm);
 };
 
-const isTableCellNode = (node) => {
+const isTableCellNode = (node: Node | null): boolean => {
   return node && /^(TH|TD)$/.test(node.nodeName);
 };
 
-const isListNode = (editor) => {
-  return (node) => {
-    return node && (/^(OL|UL|DL)$/).test(node.nodeName) && isChildOfBody(editor, node);
-  };
+const isListNode = (editor: Editor) => (node: Node | null): boolean => {
+  return node && (/^(OL|UL|DL)$/).test(node.nodeName) && isChildOfBody(editor, node);
 };
 
-const getSelectedStyleType = (editor): Optional<string> => {
+const getSelectedStyleType = (editor: Editor): Optional<string> => {
   const listElm = editor.dom.getParent(editor.selection.getNode(), 'ol,ul');
   const style = editor.dom.getStyle(listElm, 'listStyleType');
   return Optional.from(style);

--- a/modules/tinymce/src/plugins/anchor/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/Plugin.ts
@@ -12,7 +12,7 @@ import * as FilterContent from './core/FilterContent';
 import * as Formats from './core/Formats';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('anchor', (editor) => {
     FilterContent.setup(editor);
     Commands.register(editor);

--- a/modules/tinymce/src/plugins/anchor/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/api/Commands.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Dialog from '../ui/Dialog';
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
   editor.addCommand('mceAnchor', () => {
     Dialog.open(editor);
   });

--- a/modules/tinymce/src/plugins/anchor/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/api/Settings.ts
@@ -7,7 +7,8 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const allowHtmlInNamedAnchor = (editor: Editor) => editor.getParam('allow_html_in_named_anchor', false, 'boolean');
+const allowHtmlInNamedAnchor = (editor: Editor): boolean =>
+  editor.getParam('allow_html_in_named_anchor', false, 'boolean');
 
 export {
   allowHtmlInNamedAnchor

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
@@ -12,7 +12,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from '../api/Settings';
 import * as Utils from './Utils';
 
-const removeEmptyNamedAnchorsInSelection = (editor: Editor) => {
+const removeEmptyNamedAnchorsInSelection = (editor: Editor): void => {
   const dom = editor.dom;
   RangeUtils(dom).walk(editor.selection.getRng(), (nodes) => {
     Tools.each(nodes, (node) => {
@@ -23,14 +23,14 @@ const removeEmptyNamedAnchorsInSelection = (editor: Editor) => {
   });
 };
 
-const isValidId = (id: string) =>
+const isValidId = (id: string): boolean =>
   // Follows HTML4 rules: https://www.w3.org/TR/html401/types.html#type-id
   /^[A-Za-z][A-Za-z0-9\-:._]*$/.test(id);
 
 const getNamedAnchor = (editor: Editor): HTMLAnchorElement | null =>
-  editor.dom.getParent(editor.selection.getStart(), Utils.namedAnchorSelector) as HTMLAnchorElement;
+  editor.dom.getParent<HTMLAnchorElement>(editor.selection.getStart(), Utils.namedAnchorSelector);
 
-const getId = (editor: Editor) => {
+const getId = (editor: Editor): string => {
   const anchor = getNamedAnchor(editor);
   if (anchor) {
     return Utils.getIdFromAnchor(anchor);
@@ -39,7 +39,7 @@ const getId = (editor: Editor) => {
   }
 };
 
-const createAnchor = (editor: Editor, id: string) => {
+const createAnchor = (editor: Editor, id: string): void => {
   editor.undoManager.transact(() => {
     if (!Settings.allowHtmlInNamedAnchor(editor)) {
       editor.selection.collapse(true);
@@ -66,7 +66,7 @@ const updateAnchor = (editor: Editor, id: string, anchorElement: HTMLAnchorEleme
   editor.undoManager.add();
 };
 
-const insert = (editor: Editor, id: string) => {
+const insert = (editor: Editor, id: string): void => {
   const anchor = getNamedAnchor(editor);
   if (anchor) {
     updateAnchor(editor, id, anchor);

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
@@ -12,10 +12,13 @@ import { isEmptyString } from './Utils';
 
 // Note: node.firstChild check is for the 'allow_html_in_named_anchor' setting
 // Only want to add contenteditable attributes if there is no text within the anchor
-const isNamedAnchorNode = (node: AstNode) => node && isEmptyString(node.attr('href')) && !isEmptyString(node.attr('id') || node.attr('name'));
-const isEmptyNamedAnchorNode = (node: AstNode) => isNamedAnchorNode(node) && !node.firstChild;
+const isNamedAnchorNode = (node: AstNode | undefined) =>
+  node && isEmptyString(node.attr('href')) && !isEmptyString(node.attr('id') || node.attr('name'));
 
-const setContentEditable = (state: string | null) => (nodes: AstNode[]) => {
+const isEmptyNamedAnchorNode = (node: AstNode | undefined) =>
+  isNamedAnchorNode(node) && !node.firstChild;
+
+const setContentEditable = (state: string | null) => (nodes: AstNode[]): void => {
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (isEmptyNamedAnchorNode(node)) {
@@ -24,7 +27,7 @@ const setContentEditable = (state: string | null) => (nodes: AstNode[]) => {
   }
 };
 
-const setup = (editor: Editor) => {
+const setup = (editor: Editor): void => {
   editor.on('PreInit', () => {
     editor.parser.addNodeFilter('a', setContentEditable('false'));
     editor.serializer.addNodeFilter('a', setContentEditable(null));

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Formats.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Formats.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Utils from './Utils';
 
-const registerFormats = (editor: Editor) => {
+const registerFormats = (editor: Editor): void => {
   editor.formatter.register('namedAnchor', {
     inline: 'a',
     selector: Utils.namedAnchorSelector,

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Utils.ts
@@ -14,13 +14,13 @@ const getIdFromAnchor = (elm: HTMLAnchorElement): string => {
   return id || '';
 };
 
-const isAnchor = (elm: Node): elm is HTMLAnchorElement =>
+const isAnchor = (elm: Node | null): elm is HTMLAnchorElement =>
   elm && elm.nodeName.toLowerCase() === 'a';
 
-const isNamedAnchor = (elm: Node): elm is HTMLAnchorElement =>
+const isNamedAnchor = (elm: Node | null): elm is HTMLAnchorElement =>
   isAnchor(elm) && !elm.getAttribute('href') && getIdFromAnchor(elm) !== '';
 
-const isEmptyNamedAnchor = (elm: Node): elm is HTMLAnchorElement =>
+const isEmptyNamedAnchor = (elm: Node | null): elm is HTMLAnchorElement =>
   isNamedAnchor(elm) && !elm.firstChild;
 
 export {

--- a/modules/tinymce/src/plugins/anchor/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
   editor.ui.registry.addToggleButton('anchor', {
     icon: 'bookmark',
     tooltip: 'Anchor',

--- a/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Anchor from '../core/Anchor';
 
-const insertAnchor = (editor: Editor, newId: string) => {
+const insertAnchor = (editor: Editor, newId: string): boolean => {
   if (!Anchor.isValidId(newId)) {
     editor.windowManager.alert(
       'Id should start with a letter, followed only by letters, numbers, dashes, dots, colons or underscores.'
@@ -21,7 +21,7 @@ const insertAnchor = (editor: Editor, newId: string) => {
   }
 };
 
-const open = (editor: Editor) => {
+const open = (editor: Editor): void => {
   const currentId = Anchor.getId(editor);
 
   editor.windowManager.open({

--- a/modules/tinymce/src/plugins/autolink/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/Plugin.ts
@@ -9,7 +9,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 
 import * as Keys from './core/Keys';
 
-export default () => {
+export default (): void => {
   PluginManager.add('autolink', (editor) => {
     Keys.setup(editor);
   });

--- a/modules/tinymce/src/plugins/autolink/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/api/Settings.ts
@@ -7,13 +7,14 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getAutoLinkPattern = (editor: Editor) => editor.getParam('autolink_pattern', /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+\-]+@(?!.*@))(.+)$/i);
+const getAutoLinkPattern = (editor: Editor): RegExp =>
+  editor.getParam('autolink_pattern', /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+\-]+@(?!.*@))(.+)$/i);
 
-const getDefaultLinkTarget = (editor: Editor) => {
-  return editor.getParam('default_link_target', false);
-};
+const getDefaultLinkTarget = (editor: Editor): boolean =>
+  editor.getParam('default_link_target', false);
 
-const getDefaultLinkProtocol = (editor: Editor): string => editor.getParam('link_default_protocol', 'http', 'string');
+const getDefaultLinkProtocol = (editor: Editor): string =>
+  editor.getParam('link_default_protocol', 'http', 'string');
 
 export {
   getAutoLinkPattern,

--- a/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
@@ -10,29 +10,29 @@ import Env from 'tinymce/core/api/Env';
 
 import * as Settings from '../api/Settings';
 
-const rangeEqualsDelimiterOrSpace = (rangeString, delimiter) => {
+const rangeEqualsDelimiterOrSpace = (rangeString: string, delimiter: string): boolean => {
   return rangeString === delimiter || rangeString === ' ' || rangeString.charCodeAt(0) === 160;
 };
 
-const handleEclipse = (editor) => {
+const handleEclipse = (editor: Editor): void => {
   parseCurrentLine(editor, -1, '(');
 };
 
-const handleSpacebar = (editor) => {
+const handleSpacebar = (editor: Editor): void => {
   parseCurrentLine(editor, 0, '');
 };
 
-const handleEnter = (editor) => {
+const handleEnter = (editor: Editor): void => {
   parseCurrentLine(editor, -1, '');
 };
 
-const scopeIndex = (container, index) => {
+const scopeIndex = (container: Node, index: number): number => {
   if (index < 0) {
     index = 0;
   }
 
   if (container.nodeType === 3) {
-    const len = container.data.length;
+    const len = (container as Text).data.length;
 
     if (index > len) {
       index = len;
@@ -42,7 +42,7 @@ const scopeIndex = (container, index) => {
   return index;
 };
 
-const setStart = (rng, container, offset) => {
+const setStart = (rng: Range, container: Node, offset: number): void => {
   if (container.nodeType !== 1 || container.hasChildNodes()) {
     rng.setStart(container, scopeIndex(container, offset));
   } else {
@@ -50,7 +50,7 @@ const setStart = (rng, container, offset) => {
   }
 };
 
-const setEnd = (rng, container, offset) => {
+const setEnd = (rng: Range, container: Node, offset: number): void => {
   if (container.nodeType !== 1 || container.hasChildNodes()) {
     rng.setEnd(container, scopeIndex(container, offset));
   } else {
@@ -58,7 +58,7 @@ const setEnd = (rng, container, offset) => {
   }
 };
 
-const parseCurrentLine = (editor: Editor, endOffset, delimiter) => {
+const parseCurrentLine = (editor: Editor, endOffset: number, delimiter: string): void => {
   let end, endContainer, bookmark, text, prev, len, rngText;
   const autoLinkPattern = Settings.getAutoLinkPattern(editor);
   const defaultLinkTarget = Settings.getDefaultLinkTarget(editor);
@@ -172,8 +172,8 @@ const parseCurrentLine = (editor: Editor, endOffset, delimiter) => {
   }
 };
 
-const setup = (editor: Editor) => {
-  let autoUrlDetectState;
+const setup = (editor: Editor): void => {
+  let autoUrlDetectState: boolean | undefined;
 
   editor.on('keydown', (e) => {
     if (e.keyCode === 13) {

--- a/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
@@ -19,7 +19,7 @@ import * as Resize from './core/Resize';
  * @private
  */
 
-export default () => {
+export default (): void => {
   PluginManager.add('autoresize', (editor) => {
     // If autoresize is enabled, disable resize if the user hasn't explicitly enabled it
     if (!Obj.has(editor.settings, 'resize')) {

--- a/modules/tinymce/src/plugins/autoresize/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/api/Commands.ts
@@ -11,7 +11,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Resize from '../core/Resize';
 
-const register = (editor: Editor, oldSize: Cell<number>) => {
+const register = (editor: Editor, oldSize: Cell<number>): void => {
   editor.addCommand('mceAutoResize', () => {
     Resize.resize(editor, oldSize);
   });

--- a/modules/tinymce/src/plugins/autoresize/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/api/Events.ts
@@ -6,8 +6,10 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const fireResizeEditor = (editor: Editor) => editor.fire('ResizeEditor');
+const fireResizeEditor = (editor: Editor): EditorEvent<{}> =>
+  editor.fire('ResizeEditor');
 
 export {
   fireResizeEditor

--- a/modules/tinymce/src/plugins/autoresize/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/api/Settings.ts
@@ -7,15 +7,20 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getAutoResizeMinHeight = (editor: Editor): number => editor.getParam('min_height', editor.getElement().offsetHeight, 'number');
+const getAutoResizeMinHeight = (editor: Editor): number =>
+  editor.getParam('min_height', editor.getElement().offsetHeight, 'number');
 
-const getAutoResizeMaxHeight = (editor: Editor): number => editor.getParam('max_height', 0, 'number');
+const getAutoResizeMaxHeight = (editor: Editor): number =>
+  editor.getParam('max_height', 0, 'number');
 
-const getAutoResizeOverflowPadding = (editor: Editor): number => editor.getParam('autoresize_overflow_padding', 1, 'number');
+const getAutoResizeOverflowPadding = (editor: Editor): number =>
+  editor.getParam('autoresize_overflow_padding', 1, 'number');
 
-const getAutoResizeBottomMargin = (editor: Editor): number => editor.getParam('autoresize_bottom_margin', 50, 'number');
+const getAutoResizeBottomMargin = (editor: Editor): number =>
+  editor.getParam('autoresize_bottom_margin', 50, 'number');
 
-const shouldAutoResizeOnInit = (editor: Editor): boolean => editor.getParam('autoresize_on_init', true, 'boolean');
+const shouldAutoResizeOnInit = (editor: Editor): boolean =>
+  editor.getParam('autoresize_on_init', true, 'boolean');
 
 export {
   getAutoResizeMinHeight,

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -22,13 +22,14 @@ import * as Settings from '../api/Settings';
  * @private
  */
 
-const isFullscreen = (editor: Editor) => editor.plugins.fullscreen && editor.plugins.fullscreen.isFullscreen();
+const isFullscreen = (editor: Editor): boolean =>
+  editor.plugins.fullscreen && editor.plugins.fullscreen.isFullscreen();
 
 /**
  * Calls the resize x times in 100ms intervals. We can't wait for load events since
  * the CSS files might load async.
  */
-const wait = (editor: Editor, oldSize: Cell<number>, times: number, interval: number, callback?: Function) => {
+const wait = (editor: Editor, oldSize: Cell<number>, times: number, interval: number, callback?: () => void): void => {
   Delay.setEditorTimeout(editor, () => {
     resize(editor, oldSize);
 
@@ -40,7 +41,7 @@ const wait = (editor: Editor, oldSize: Cell<number>, times: number, interval: nu
   }, interval);
 };
 
-const toggleScrolling = (editor: Editor, state: boolean) => {
+const toggleScrolling = (editor: Editor, state: boolean): void => {
   const body = editor.getBody();
   if (body) {
     body.style.overflowY = state ? '' : 'hidden';
@@ -59,7 +60,7 @@ const parseCssValueToInt = (dom: DOMUtils, elm: Element, name: string, computed:
 /**
  * This method gets executed each time the editor needs to resize.
  */
-const resize = (editor: Editor, oldSize: Cell<number>) => {
+const resize = (editor: Editor, oldSize: Cell<number>): void => {
   const dom = editor.dom;
 
   const doc = editor.getDoc();
@@ -134,7 +135,7 @@ const resize = (editor: Editor, oldSize: Cell<number>) => {
   }
 };
 
-const setup = (editor: Editor, oldSize: Cell<number>) => {
+const setup = (editor: Editor, oldSize: Cell<number>): void => {
   editor.on('init', () => {
     const overflowPadding = Settings.getAutoResizeOverflowPadding(editor);
     const dom = editor.dom;

--- a/modules/tinymce/src/plugins/autosave/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/Plugin.ts
@@ -20,7 +20,7 @@ import * as Buttons from './ui/Buttons';
  * @private
  */
 
-export default () => {
+export default (): void => {
   PluginManager.add('autosave', (editor) => {
     BeforeUnload.setup(editor);
     Buttons.register(editor);

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Api.ts
@@ -5,9 +5,19 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Storage from '../core/Storage';
 
-const get = (editor) => ({
+export interface Api {
+  readonly hasDraft: () => boolean;
+  readonly storeDraft: () => void;
+  readonly restoreDraft: () => void;
+  readonly removeDraft: (fire?: boolean) => void;
+  readonly isEmpty: () => boolean;
+}
+
+const get = (editor: Editor): Api => ({
   hasDraft: () => Storage.hasDraft(editor),
   storeDraft: () => Storage.storeDraft(editor),
   restoreDraft: () => Storage.restoreDraft(editor),

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Events.ts
@@ -5,11 +5,17 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const fireRestoreDraft = (editor) => editor.fire('RestoreDraft');
+import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const fireStoreDraft = (editor) => editor.fire('StoreDraft');
+const fireRestoreDraft = (editor: Editor): EditorEvent<{}> =>
+  editor.fire('RestoreDraft');
 
-const fireRemoveDraft = (editor) => editor.fire('RemoveDraft');
+const fireStoreDraft = (editor: Editor): EditorEvent<{}> =>
+  editor.fire('StoreDraft');
+
+const fireRemoveDraft = (editor: Editor): EditorEvent<{}> =>
+  editor.fire('RemoveDraft');
 
 export {
   fireRestoreDraft,

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Settings.ts
@@ -9,9 +9,10 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Time from '../core/Time';
 
-const shouldAskBeforeUnload = (editor: Editor) => editor.getParam('autosave_ask_before_unload', true);
+const shouldAskBeforeUnload = (editor: Editor): boolean =>
+  editor.getParam('autosave_ask_before_unload', true);
 
-const getAutoSavePrefix = (editor: Editor) => {
+const getAutoSavePrefix = (editor: Editor): string => {
   const location = document.location;
 
   return editor.getParam('autosave_prefix', 'tinymce-autosave-{path}{query}{hash}-{id}-')
@@ -21,13 +22,17 @@ const getAutoSavePrefix = (editor: Editor) => {
     .replace(/{id}/g, editor.id);
 };
 
-const shouldRestoreWhenEmpty = (editor: Editor) => editor.getParam('autosave_restore_when_empty', false);
+const shouldRestoreWhenEmpty = (editor: Editor): boolean =>
+  editor.getParam('autosave_restore_when_empty', false);
 
-const getAutoSaveInterval = (editor: Editor) => Time.parse(editor.getParam('autosave_interval'), '30s');
+const getAutoSaveInterval = (editor: Editor): number =>
+  Time.parse(editor.getParam('autosave_interval'), '30s');
 
-const getAutoSaveRetention = (editor: Editor) => Time.parse(editor.getParam('autosave_retention'), '20m');
+const getAutoSaveRetention = (editor: Editor): number =>
+  Time.parse(editor.getParam('autosave_retention'), '20m');
 
-const getForcedRootBlock = (editor: Editor) => editor.getParam('forced_root_block');
+const getForcedRootBlock = (editor: Editor): string | boolean =>
+  editor.getParam('forced_root_block');
 
 export {
   shouldAskBeforeUnload,

--- a/modules/tinymce/src/plugins/autosave/main/ts/core/BeforeUnload.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/core/BeforeUnload.ts
@@ -11,11 +11,11 @@ import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Settings from '../api/Settings';
 
-const setup = (editor: Editor) => {
+const setup = (editor: Editor): void => {
   editor.editorManager.on('BeforeUnload', (e) => {
     let msg: string;
 
-    Tools.each(EditorManager.get(), (editor: Editor) => {
+    Tools.each(EditorManager.get(), (editor) => {
       // Store a draft for each editor instance
       if (editor.plugins.autosave) {
         editor.plugins.autosave.storeDraft();

--- a/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
@@ -15,7 +15,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 import * as Events from '../api/Events';
 import * as Settings from '../api/Settings';
 
-const isEmpty = (editor: Editor, html?: string) => {
+const isEmpty = (editor: Editor, html?: string): boolean => {
   if (Type.isUndefined(html)) {
     return editor.dom.isEmpty(editor.getBody());
   } else {
@@ -30,7 +30,7 @@ const isEmpty = (editor: Editor, html?: string) => {
   }
 };
 
-const hasDraft = (editor: Editor) => {
+const hasDraft = (editor: Editor): boolean => {
   const time = parseInt(LocalStorage.getItem(Settings.getAutoSavePrefix(editor) + 'time'), 10) || 0;
 
   if (new Date().getTime() - time > Settings.getAutoSaveRetention(editor)) {
@@ -41,7 +41,7 @@ const hasDraft = (editor: Editor) => {
   return true;
 };
 
-const removeDraft = (editor: Editor, fire?: boolean) => {
+const removeDraft = (editor: Editor, fire?: boolean): void => {
   const prefix = Settings.getAutoSavePrefix(editor);
 
   LocalStorage.removeItem(prefix + 'draft');
@@ -52,7 +52,7 @@ const removeDraft = (editor: Editor, fire?: boolean) => {
   }
 };
 
-const storeDraft = (editor: Editor) => {
+const storeDraft = (editor: Editor): void => {
   const prefix = Settings.getAutoSavePrefix(editor);
 
   if (!isEmpty(editor) && editor.isDirty()) {
@@ -62,7 +62,7 @@ const storeDraft = (editor: Editor) => {
   }
 };
 
-const restoreDraft = (editor: Editor) => {
+const restoreDraft = (editor: Editor): void => {
   const prefix = Settings.getAutoSavePrefix(editor);
 
   if (hasDraft(editor)) {
@@ -71,14 +71,14 @@ const restoreDraft = (editor: Editor) => {
   }
 };
 
-const startStoreDraft = (editor: Editor) => {
+const startStoreDraft = (editor: Editor): void => {
   const interval = Settings.getAutoSaveInterval(editor);
   Delay.setEditorInterval(editor, () => {
     storeDraft(editor);
   }, interval);
 };
 
-const restoreLastDraft = (editor: Editor) => {
+const restoreLastDraft = (editor: Editor): void => {
   editor.undoManager.transact(() => {
     restoreDraft(editor);
     removeDraft(editor);

--- a/modules/tinymce/src/plugins/autosave/main/ts/core/Time.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/core/Time.ts
@@ -5,8 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const parse = (timeString: string, defaultTime: string) => {
-  const multiples = {
+const parse = (timeString: string | undefined, defaultTime: string): number => {
+  const multiples: Record<string, number> = {
     s: 1000,
     m: 60000
   };

--- a/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
@@ -6,17 +6,18 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import { Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import * as Storage from '../core/Storage';
 
-const makeSetupHandler = (editor: Editor) => (api) => {
+const makeSetupHandler = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi) => {
   api.setDisabled(!Storage.hasDraft(editor));
   const editorEventCallback = () => api.setDisabled(!Storage.hasDraft(editor));
   editor.on('StoreDraft RestoreDraft RemoveDraft', editorEventCallback);
   return () => editor.off('StoreDraft RestoreDraft RemoveDraft', editorEventCallback);
 };
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
   // TODO: This was moved from makeSetupHandler as it would only be called when the menu item was rendered?
   //       Is it safe to start this process when the plugin is registered?
   Storage.startStoreDraft(editor);

--- a/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
@@ -9,7 +9,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 
 import * as Convert from './core/Convert';
 
-export default () => {
+export default (): void => {
   PluginManager.add('bbcode', (editor) => {
     // eslint-disable-next-line no-console
     console.warn('The bbcode plugin has been deprecated and marked for removal in TinyMCE 6.0');

--- a/modules/tinymce/src/plugins/bbcode/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/api/Settings.ts
@@ -5,7 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const getDialect = (editor) => {
+import Editor from 'tinymce/core/api/Editor';
+
+const getDialect = (editor: Editor): string => {
   // Note: This option isn't even used since we only support one dialect
   return editor.getParam('bbcode_dialect', 'punbb').toLowerCase();
 };

--- a/modules/tinymce/src/plugins/bbcode/main/ts/core/Convert.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/core/Convert.ts
@@ -7,10 +7,10 @@
 
 import Tools from 'tinymce/core/api/util/Tools';
 
-const html2bbcode = (s) => {
+const html2bbcode = (s: string): string => {
   s = Tools.trim(s);
 
-  const rep = (re, str) => {
+  const rep = (re: RegExp, str: string): void => {
     s = s.replace(re, str);
   };
 
@@ -56,10 +56,10 @@ const html2bbcode = (s) => {
   return s;
 };
 
-const bbcode2html = (s) => {
+const bbcode2html = (s: string): string => {
   s = Tools.trim(s);
 
-  const rep = (re, str) => {
+  const rep = (re: RegExp, str: string): void => {
     s = s.replace(re, str);
   };
 

--- a/modules/tinymce/src/plugins/charmap/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/Plugin.ts
@@ -13,7 +13,7 @@ import * as CharMap from './core/CharMap';
 import * as Autocompletion from './ui/Autocompletion';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('charmap', (editor) => {
     const charMap = CharMap.getCharMap(editor);
     Commands.register(editor, charMap);

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Api.ts
@@ -10,7 +10,12 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Actions from '../core/Actions';
 import * as CharMap from '../core/CharMap';
 
-const get = (editor: Editor) => {
+export interface Api {
+  readonly getCharMap: () => CharMap.CharMap[];
+  readonly insertChar: (chr: string) => void;
+}
+
+const get = (editor: Editor): Api => {
   const getCharMap = () => {
     return CharMap.getCharMap(editor);
   };

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Commands.ts
@@ -12,7 +12,7 @@ import * as Dialog from '../ui/Dialog';
 
 type CharMap = CharMap.CharMap;
 
-const register = (editor: Editor, charMap: CharMap[]) => {
+const register = (editor: Editor, charMap: CharMap[]): void => {
   editor.addCommand('mceShowCharmap', () => {
     Dialog.open(editor, charMap);
   });

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Events.ts
@@ -6,8 +6,9 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const fireInsertCustomChar = (editor: Editor, chr: string) => {
+const fireInsertCustomChar = (editor: Editor, chr: string): EditorEvent<{ chr: string }> => {
   return editor.fire('insertCustomChar', { chr });
 };
 

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Settings.ts
@@ -7,9 +7,13 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getCharMap = (editor: Editor) => editor.getParam('charmap');
+type UserChar = [ number, string ];
 
-const getCharMapAppend = (editor: Editor) => editor.getParam('charmap_append');
+const getCharMap = (editor: Editor): UserChar[] | (() => UserChar[]) | undefined =>
+  editor.getParam('charmap');
+
+const getCharMapAppend = (editor: Editor): UserChar[] | undefined =>
+  editor.getParam('charmap_append');
 
 export {
   getCharMap,

--- a/modules/tinymce/src/plugins/charmap/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/Actions.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Events from '../api/Events';
 
-const insertChar = (editor: Editor, chr: string) => {
+const insertChar = (editor: Editor, chr: string): void => {
   const evtChr = Events.fireInsertCustomChar(editor, chr).chr;
   editor.execCommand('mceInsertContent', false, evtChr);
 };

--- a/modules/tinymce/src/plugins/charmap/main/ts/core/CharMap.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/CharMap.ts
@@ -16,9 +16,11 @@ const isArray = Tools.isArray;
 
 export const UserDefined = 'User Defined';
 
+export type Char = [ number, string ];
+
 export interface CharMap {
   name: string;
-  characters: [number, string][];
+  characters: Char[];
 }
 
 const getDefaultCharMap = (): CharMap[] => {
@@ -367,15 +369,15 @@ const getDefaultCharMap = (): CharMap[] => {
   ];
 };
 
-const charmapFilter = (charmap) => {
+const charmapFilter = (charmap: Char[]): Char[] => {
   return Tools.grep(charmap, (item) => {
     return isArray(item) && item.length === 2;
   });
 };
 
-const getCharsFromSetting = (settingValue) => {
+const getCharsFromSetting = (settingValue: Char[] | (() => Char[]) | undefined): Char[] => {
   if (isArray(settingValue)) {
-    return [].concat(charmapFilter(settingValue));
+    return charmapFilter(settingValue);
   }
 
   if (typeof settingValue === 'function') {
@@ -385,7 +387,7 @@ const getCharsFromSetting = (settingValue) => {
   return [];
 };
 
-const extendCharMap = (editor: Editor, charmap: CharMap[]) => {
+const extendCharMap = (editor: Editor, charmap: CharMap[]): CharMap[] => {
   const userCharMap = Settings.getCharMap(editor);
   if (userCharMap) {
     charmap = [{ name: UserDefined, characters: getCharsFromSetting(userCharMap) }];
@@ -398,7 +400,7 @@ const extendCharMap = (editor: Editor, charmap: CharMap[]) => {
       userDefinedGroup[0].characters = [].concat(userDefinedGroup[0].characters).concat(getCharsFromSetting(userCharMapAppend));
       return charmap;
     }
-    return [].concat(charmap).concat({ name: UserDefined, characters: getCharsFromSetting(userCharMapAppend) });
+    return charmap.concat({ name: UserDefined, characters: getCharsFromSetting(userCharMapAppend) });
   }
 
   return charmap;

--- a/modules/tinymce/src/plugins/charmap/main/ts/core/Scan.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/Scan.ts
@@ -7,12 +7,12 @@
 
 import { Arr, Strings } from '@ephox/katamari';
 
-import { CharMap } from './CharMap';
+import { CharMap, Char } from './CharMap';
 
 export interface CharItem {
-  value: string;
-  icon: string;
-  text: string;
+  readonly value: string;
+  readonly icon: string;
+  readonly text: string;
 }
 
 const charMatches = (charCode: number, name: string, lowerCasePattern: string): boolean => {
@@ -24,7 +24,7 @@ const charMatches = (charCode: number, name: string, lowerCasePattern: string): 
 };
 
 const scan = (group: CharMap, pattern: string): CharItem[] => {
-  const matches: [number, string][] = [];
+  const matches: Char[] = [];
   const lowerCasePattern = pattern.toLowerCase();
   Arr.each(group.characters, (g) => {
     if (charMatches(g[0], g[1], lowerCasePattern)) {

--- a/modules/tinymce/src/plugins/charmap/main/ts/ui/Autocompletion.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/ui/Autocompletion.ts
@@ -13,7 +13,7 @@ import * as Scan from '../core/Scan';
 
 type CharMap = CharMap.CharMap;
 
-const init = (editor: Editor, all: CharMap) => {
+const init = (editor: Editor, all: CharMap): void => {
   editor.ui.registry.addAutocompleter('charmap', {
     ch: ':',
     columns: 'auto',

--- a/modules/tinymce/src/plugins/charmap/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
   editor.ui.registry.addButton('charmap', {
     icon: 'insert-character',
     tooltip: 'Special character',

--- a/modules/tinymce/src/plugins/charmap/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/ui/Dialog.ts
@@ -16,7 +16,7 @@ import * as Scan from '../core/Scan';
 
 const patternName = 'pattern';
 
-const open = (editor: Editor, charMap: CharMap[]) => {
+const open = (editor: Editor, charMap: CharMap[]): void => {
   const makeGroupItems = (): Dialog.BodyComponentSpec[] => [
     {
       label: 'Search',

--- a/modules/tinymce/src/plugins/code/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/Plugin.ts
@@ -10,7 +10,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('code', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);

--- a/modules/tinymce/src/plugins/code/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/api/Commands.ts
@@ -5,9 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Dialog from '../ui/Dialog';
 
-const register = (editor) => {
+const register = (editor: Editor): void => {
   editor.addCommand('mceCodeEditor', () => {
     Dialog.open(editor);
   });

--- a/modules/tinymce/src/plugins/code/main/ts/core/Content.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/core/Content.ts
@@ -5,7 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const setContent = (editor, html) => {
+import Editor from 'tinymce/core/api/Editor';
+
+const setContent = (editor: Editor, html: string): void => {
   // We get a lovely "Wrong document" error in IE 11 if we
   // don't move the focus to the editor before creating an undo
   // transaction since it tries to make a bookmark for the current selection
@@ -19,7 +21,7 @@ const setContent = (editor, html) => {
   editor.nodeChanged();
 };
 
-const getContent = (editor) => {
+const getContent = (editor: Editor): string => {
   return editor.getContent({ source_view: true });
 };
 

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
 
   const onAction = () => editor.execCommand('mceCodeEditor');
 

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Content from '../core/Content';
 
-const open = (editor: Editor) => {
+const open = (editor: Editor): void => {
   const editorContent: string = Content.getContent(editor);
 
   editor.windowManager.open({

--- a/modules/tinymce/src/plugins/codesample/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/Plugin.ts
@@ -13,7 +13,7 @@ import * as Buttons from './ui/Buttons';
 import * as Dialog from './ui/Dialog';
 import * as Utils from './util/Utils';
 
-export default () => {
+export default (): void => {
   PluginManager.add('codesample', (editor) => {
     FilterContent.setup(editor);
     Buttons.register(editor);

--- a/modules/tinymce/src/plugins/codesample/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/api/Commands.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Dialog from '../ui/Dialog';
 import * as Utils from '../util/Utils';
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
   editor.addCommand('codesample', () => {
     const node = editor.selection.getNode();
     if (editor.selection.isCollapsed() || Utils.isCodeSample(node)) {

--- a/modules/tinymce/src/plugins/codesample/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/api/Settings.ts
@@ -7,9 +7,13 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getLanguages = (editor: Editor) => editor.getParam('codesample_languages');
+import { LanguageSpec } from '../core/Languages';
 
-const useGlobalPrismJS = (editor: Editor) => editor.getParam('codesample_global_prismjs', false, 'boolean');
+const getLanguages = (editor: Editor): LanguageSpec[] | undefined =>
+  editor.getParam('codesample_languages');
+
+const useGlobalPrismJS = (editor: Editor): boolean =>
+  editor.getParam('codesample_global_prismjs', false, 'boolean');
 
 export {
   getLanguages,

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/CodeSample.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/CodeSample.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, Optional, Optionals } from '@ephox/katamari';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -13,17 +13,12 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Utils from '../util/Utils';
 import * as Prism from './Prism';
 
-const getSelectedCodeSample = (editor: Editor) => {
+const getSelectedCodeSample = (editor: Editor): Optional<Element> => {
   const node = editor.selection ? editor.selection.getNode() : null;
-
-  if (Utils.isCodeSample(node)) {
-    return Optional.some(node);
-  }
-
-  return Optional.none<Element>();
+  return Optionals.someIf(Utils.isCodeSample(node), node);
 };
 
-const insertCodeSample = (editor: Editor, language: string, code: string) => {
+const insertCodeSample = (editor: Editor, language: string, code: string): void => {
   editor.undoManager.transact(() => {
     const node = getSelectedCodeSample(editor);
 

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Utils from '../util/Utils';
 import * as Prism from './Prism';
 
-const setup = (editor: Editor) => {
+const setup = (editor: Editor): void => {
   const $ = editor.$;
 
   editor.on('PreProcess', (e) => {

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/Languages.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/Languages.ts
@@ -11,8 +11,8 @@ import * as Settings from '../api/Settings';
 import * as CodeSample from './CodeSample';
 
 export interface LanguageSpec {
-  text: string;
-  value: string;
+  readonly text: string;
+  readonly value: string;
 }
 
 const getLanguages = (editor: Editor): LanguageSpec[] => {

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/Prism.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/Prism.ts
@@ -12,7 +12,8 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Settings from '../api/Settings';
 
-const get = (editor: Editor) => Global.Prism && Settings.useGlobalPrismJS(editor) ? Global.Prism : Prism;
+const get = (editor: Editor): Prism =>
+  Global.Prism && Settings.useGlobalPrismJS(editor) ? Global.Prism : Prism;
 
 export {
   get

--- a/modules/tinymce/src/plugins/codesample/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/ui/Buttons.ts
@@ -7,12 +7,12 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const isCodeSampleSelection = (editor: Editor) => {
+const isCodeSampleSelection = (editor: Editor): boolean => {
   const node = editor.selection.getStart();
   return editor.dom.is(node, 'pre[class*="language-"]');
 };
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
 
   const onAction = () => editor.execCommand('codesample');
 

--- a/modules/tinymce/src/plugins/codesample/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/ui/Dialog.ts
@@ -14,7 +14,7 @@ import * as Languages from '../core/Languages';
 
 type LanguageSpec = Languages.LanguageSpec;
 
-const open = (editor: Editor) => {
+const open = (editor: Editor): void => {
   const languages: LanguageSpec[] = Languages.getLanguages(editor);
   const defaultLanguage: string = Arr.head(languages).fold(Fun.constant(''), (l) => l.value);
   const currentLanguage: string = Languages.getCurrentLanguage(editor, defaultLanguage);

--- a/modules/tinymce/src/plugins/codesample/main/ts/util/Utils.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/util/Utils.ts
@@ -5,12 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const isCodeSample = (elm: Element) => {
+const isCodeSample = (elm: Element | null): boolean => {
   return elm && elm.nodeName === 'PRE' && elm.className.indexOf('language-') !== -1;
 };
 
 const trimArg = <T>(predicateFn: (a: T) => boolean) => {
-  return (arg1: any, arg2: T) => {
+  return (arg1: unknown, arg2: T): boolean => {
     return predicateFn(arg2);
   };
 };

--- a/modules/tinymce/src/plugins/directionality/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/Plugin.ts
@@ -10,7 +10,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('directionality', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);

--- a/modules/tinymce/src/plugins/directionality/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/api/Commands.ts
@@ -5,9 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Direction from '../core/Direction';
 
-const register = (editor) => {
+const register = (editor: Editor): void => {
   editor.addCommand('mceDirectionLTR', () => {
     Direction.setDir(editor, 'ltr');
   });

--- a/modules/tinymce/src/plugins/directionality/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/ui/Buttons.ts
@@ -8,9 +8,12 @@
 import { Direction, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
+import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
+import { Toolbar } from 'tinymce/core/api/ui/Ui';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const getNodeChangeHandler = (editor: Editor, dir: 'ltr' | 'rtl') => (api) => {
-  const nodeChangeHandler = (e) => {
+const getNodeChangeHandler = (editor: Editor, dir: 'ltr' | 'rtl') => (api: Toolbar.ToolbarToggleButtonInstanceApi) => {
+  const nodeChangeHandler = (e: EditorEvent<NodeChangeEvent>) => {
     const element = SugarElement.fromDom(e.element);
     api.setActive(Direction.getDirection(element) === dir);
   };
@@ -19,7 +22,7 @@ const getNodeChangeHandler = (editor: Editor, dir: 'ltr' | 'rtl') => (api) => {
   return () => editor.off('NodeChange', nodeChangeHandler);
 };
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
   editor.ui.registry.addToggleButton('ltr', {
     tooltip: 'Left to right',
     icon: 'ltr',

--- a/modules/tinymce/src/plugins/emoticons/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/Plugin.ts
@@ -21,7 +21,7 @@ import * as Buttons from './ui/Buttons';
  * @private
  */
 
-export default () => {
+export default (): void => {
   PluginManager.add('emoticons', (editor, pluginUrl) => {
     const databaseUrl = Settings.getEmoticonDatabaseUrl(editor, pluginUrl);
     const databaseId = Settings.getEmoticonDatabaseId(editor);

--- a/modules/tinymce/src/plugins/emoticons/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/api/Settings.ts
@@ -7,20 +7,30 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
+export interface UserEmojiEntry {
+  readonly keywords?: string[];
+  readonly char: string;
+  readonly category?: string;
+}
+
 const DEFAULT_ID = 'tinymce.plugins.emoticons';
 
-const getEmoticonDatabase = (editor: Editor): string => editor.getParam('emoticons_database', 'emojis', 'string');
+const getEmoticonDatabase = (editor: Editor): string =>
+  editor.getParam('emoticons_database', 'emojis', 'string');
 
 const getEmoticonDatabaseUrl = (editor: Editor, pluginUrl: string): string => {
   const database = getEmoticonDatabase(editor);
   return editor.getParam('emoticons_database_url', `${pluginUrl}/js/${database}${editor.suffix}.js`, 'string');
 };
 
-const getEmoticonDatabaseId = (editor: Editor): string => editor.getParam('emoticons_database_id', DEFAULT_ID, 'string');
+const getEmoticonDatabaseId = (editor: Editor): string =>
+  editor.getParam('emoticons_database_id', DEFAULT_ID, 'string');
 
-const getAppendedEmoticons = (editor: Editor) => editor.getParam('emoticons_append', {}, 'object');
+const getAppendedEmoticons = (editor: Editor): Record<string, UserEmojiEntry> =>
+  editor.getParam('emoticons_append', {}, 'object');
 
-const getEmotionsImageUrl = (editor: Editor) => editor.getParam('emoticons_images_url', 'https://twemoji.maxcdn.com/v/13.0.1/72x72/', 'string');
+const getEmotionsImageUrl = (editor: Editor): string =>
+  editor.getParam('emoticons_images_url', 'https://twemoji.maxcdn.com/v/13.0.1/72x72/', 'string');
 
 export {
   getEmoticonDatabase,

--- a/modules/tinymce/src/plugins/emoticons/main/ts/core/EmojiDatabase.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/core/EmojiDatabase.ts
@@ -17,13 +17,21 @@ import * as Settings from '../api/Settings';
 const ALL_CATEGORY = 'All';
 
 interface RawEmojiEntry {
-  keywords: string[];
-  char: string;
-  category: string;
+  readonly keywords: string[];
+  readonly char: string;
+  readonly category: string;
 }
 
 export interface EmojiEntry extends RawEmojiEntry {
-  title: string;
+  readonly title: string;
+}
+
+export interface EmojiDatabase {
+  readonly listCategory: (category: string) => EmojiEntry[];
+  readonly hasLoaded: () => boolean;
+  readonly waitForLoad: () => Promise<boolean>;
+  readonly listAll: () => EmojiEntry[];
+  readonly listCategories: () => string[];
 }
 
 const categoryNameMap = {
@@ -38,19 +46,12 @@ const categoryNameMap = {
   user: 'User Defined'
 };
 
-export interface EmojiDatabase {
-  listCategory: (category: string) => EmojiEntry[];
-  hasLoaded: () => boolean;
-  waitForLoad: () => Promise<boolean>;
-  listAll: () => EmojiEntry[];
-  listCategories: () => string[];
-}
+const translateCategory = (categories: Record<string, string>, name: string): string =>
+  Obj.has(categories, name) ? categories[name] : name;
 
-const translateCategory = (categories: Record<string, string>, name: string) => Obj.has(categories, name) ? categories[name] : name;
-
-const getUserDefinedEmoticons = (editor: Editor) => {
+const getUserDefinedEmoticons = (editor: Editor): Record<string, RawEmojiEntry> => {
   const userDefinedEmoticons = Settings.getAppendedEmoticons(editor);
-  return Obj.map(userDefinedEmoticons, (value: RawEmojiEntry) =>
+  return Obj.map(userDefinedEmoticons, (value) =>
     // Set some sane defaults for the custom emoji entry
     ({ keywords: [], category: 'user', ...value })
   );
@@ -73,8 +74,8 @@ const initDatabase = (editor: Editor, databaseUrl: string, databaseId: string): 
   };
 
   const processEmojis = (emojis: Record<string, RawEmojiEntry>) => {
-    const cats = {};
-    const everything = [];
+    const cats: Record<string, EmojiEntry[]> = {};
+    const everything: EmojiEntry[] = [];
 
     Obj.each(emojis, (lib: RawEmojiEntry, title: string) => {
       const entry: EmojiEntry = {

--- a/modules/tinymce/src/plugins/emoticons/main/ts/core/Filters.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/core/Filters.ts
@@ -9,7 +9,7 @@ import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
-export const setup = (editor: Editor) => {
+export const setup = (editor: Editor): void => {
   editor.on('PreInit', () => {
     editor.parser.addAttributeFilter('data-emoticon', (nodes) => {
       Arr.each(nodes, (node) => {

--- a/modules/tinymce/src/plugins/emoticons/main/ts/core/Lookup.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/core/Lookup.ts
@@ -9,9 +9,11 @@ import { Arr, Fun, Optional, Strings } from '@ephox/katamari';
 
 import { EmojiEntry } from './EmojiDatabase';
 
-const emojiMatches = (emoji: EmojiEntry, lowerCasePattern: string): boolean => Strings.contains(emoji.title.toLowerCase(), lowerCasePattern) || Arr.exists(emoji.keywords, (k) => Strings.contains(k.toLowerCase(), lowerCasePattern));
+const emojiMatches = (emoji: EmojiEntry, lowerCasePattern: string): boolean =>
+  Strings.contains(emoji.title.toLowerCase(), lowerCasePattern) ||
+  Arr.exists(emoji.keywords, (k) => Strings.contains(k.toLowerCase(), lowerCasePattern));
 
-const emojisFrom = (list: EmojiEntry[], pattern: string, maxResults: Optional<number>): Array<{value: string; icon: string; text: string }> => {
+const emojisFrom = (list: EmojiEntry[], pattern: string, maxResults: Optional<number>): Array<{ value: string; icon: string; text: string }> => {
   const matches = [];
   const lowerCasePattern = pattern.toLowerCase();
   const reachedLimit = maxResults.fold(() => Fun.never, (max) => (size) => size >= max);

--- a/modules/tinymce/src/plugins/emoticons/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/ui/Dialog.ts
@@ -14,18 +14,23 @@ import { insertEmoticon } from '../core/Actions';
 import { ALL_CATEGORY, EmojiDatabase } from '../core/EmojiDatabase';
 import { emojisFrom } from '../core/Lookup';
 
+interface DialogData {
+  readonly pattern: string;
+  readonly results: Array<{ value: string; icon: string; text: string }>;
+}
+
 const patternName = 'pattern';
 
-const open = (editor: Editor, database: EmojiDatabase) => {
+const open = (editor: Editor, database: EmojiDatabase): void => {
 
-  const initialState = {
+  const initialState: DialogData = {
     pattern: '',
     results: emojisFrom(database.listAll(), '', Optional.some(300))
   };
 
   const currentTab = Cell(ALL_CATEGORY);
 
-  const scan = (dialogApi) => {
+  const scan = (dialogApi: Dialog.DialogInstanceApi<DialogData>) => {
     const dialogData = dialogApi.getData();
     const category = currentTab.get();
     const candidates = database.listCategory(category);
@@ -52,7 +57,7 @@ const open = (editor: Editor, database: EmojiDatabase) => {
     // columns: 'auto'
   };
 
-  const getInitialState = (): Dialog.DialogSpec<typeof initialState> => {
+  const getInitialState = (): Dialog.DialogSpec<DialogData> => {
     const body: Dialog.TabPanelSpec = {
       type: 'tabpanel',
       // All tabs have the same fields.

--- a/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
@@ -13,7 +13,7 @@ import * as Commands from './api/Commands';
 import * as FilterContent from './core/FilterContent';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('fullpage', (editor) => {
     // eslint-disable-next-line no-console
     console.warn('The fullpage plugin has been deprecated and marked for removal in TinyMCE 6.0');

--- a/modules/tinymce/src/plugins/fullpage/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/api/Commands.ts
@@ -5,9 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Cell } from '@ephox/katamari';
+
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Dialog from '../ui/Dialog';
 
-const register = (editor, headState) => {
+const register = (editor: Editor, headState: Cell<string>): void => {
   editor.addCommand('mceFullPageProperties', () => {
     Dialog.open(editor, headState);
   });

--- a/modules/tinymce/src/plugins/fullpage/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/api/Settings.ts
@@ -7,23 +7,32 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const shouldHideInSourceView = (editor: Editor) => editor.getParam('fullpage_hide_in_source_view');
+const shouldHideInSourceView = (editor: Editor): boolean | undefined =>
+  editor.getParam('fullpage_hide_in_source_view');
 
-const getDefaultXmlPi = (editor: Editor) => editor.getParam('fullpage_default_xml_pi');
+const getDefaultXmlPi = (editor: Editor): boolean | undefined =>
+  editor.getParam('fullpage_default_xml_pi');
 
-const getDefaultEncoding = (editor: Editor) => editor.getParam('fullpage_default_encoding');
+const getDefaultEncoding = (editor: Editor): string | undefined =>
+  editor.getParam('fullpage_default_encoding');
 
-const getDefaultFontFamily = (editor: Editor) => editor.getParam('fullpage_default_font_family');
+const getDefaultFontFamily = (editor: Editor): string | undefined =>
+  editor.getParam('fullpage_default_font_family');
 
-const getDefaultFontSize = (editor: Editor) => editor.getParam('fullpage_default_font_size');
+const getDefaultFontSize = (editor: Editor): string | undefined =>
+  editor.getParam('fullpage_default_font_size');
 
-const getDefaultTextColor = (editor: Editor) => editor.getParam('fullpage_default_text_color');
+const getDefaultTextColor = (editor: Editor): string | undefined =>
+  editor.getParam('fullpage_default_text_color');
 
-const getDefaultTitle = (editor: Editor) => editor.getParam('fullpage_default_title');
+const getDefaultTitle = (editor: Editor): string | undefined =>
+  editor.getParam('fullpage_default_title');
 
-const getDefaultDocType = (editor: Editor) => editor.getParam('fullpage_default_doctype', '<!DOCTYPE html>');
+const getDefaultDocType = (editor: Editor): string =>
+  editor.getParam('fullpage_default_doctype', '<!DOCTYPE html>');
 
-const getProtect = (editor: Editor) => editor.getParam('protect');
+const getProtect = (editor: Editor): RegExp[] | undefined =>
+  editor.getParam('protect');
 
 export {
   shouldHideInSourceView,

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/FilterContent.ts
@@ -5,8 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Cell } from '@ephox/katamari';
+
 import Editor from 'tinymce/core/api/Editor';
-import { GetContentEvent } from 'tinymce/core/api/EventTypes';
+import { GetContentEvent, SetContentEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Settings from '../api/Settings';
@@ -15,11 +18,11 @@ import * as Protect from './Protect';
 
 const each = Tools.each;
 
-const low = (s: string) =>
+const low = (s: string): string =>
   s.replace(/<\/?[A-Z]+/g, (a: string) => a.toLowerCase());
 
-const handleSetContent = (editor: Editor, headState, footState, evt) => {
-  let startPos, endPos, content, styles = '';
+const handleSetContent = (editor: Editor, headState: Cell<string>, footState: Cell<string>, evt: EditorEvent<SetContentEvent>): void => {
+  let startPos: number, endPos: number, content: string, styles = '';
   const dom = editor.dom;
 
   if (evt.selection) {
@@ -122,7 +125,7 @@ const handleSetContent = (editor: Editor, headState, footState, evt) => {
   });
 };
 
-const getDefaultHeader = (editor) => {
+const getDefaultHeader = (editor: Editor): string => {
   let header = '', value, styles = '';
 
   if (Settings.getDefaultXmlPi(editor)) {
@@ -158,13 +161,13 @@ const getDefaultHeader = (editor) => {
   return header;
 };
 
-const handleGetContent = (editor: Editor, head, foot, evt: GetContentEvent) => {
+const handleGetContent = (editor: Editor, head: string, foot: string, evt: EditorEvent<GetContentEvent>): void => {
   if (evt.format === 'html' && !evt.selection && (!evt.source_view || !Settings.shouldHideInSourceView(editor))) {
     evt.content = Protect.unprotectHtml(Tools.trim(head) + '\n' + Tools.trim(evt.content) + '\n' + Tools.trim(foot));
   }
 };
 
-const setup = (editor: Editor, headState, footState) => {
+const setup = (editor: Editor, headState: Cell<string>, footState: Cell<string>): void => {
   editor.on('BeforeSetContent', (evt) => {
     handleSetContent(editor, headState, footState, evt);
   });

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/Parser.ts
@@ -30,7 +30,7 @@ interface Data {
   active_color?: string;
 }
 
-const parseHeader = (editor: Editor, head: string) => {
+const parseHeader = (editor: Editor, head: string): AstNode => {
   // Parse the contents with a DOM parser
   return DomParser({
     validate: false,
@@ -39,12 +39,12 @@ const parseHeader = (editor: Editor, head: string) => {
   }, editor.schema).parse(head, { format: 'xhtml' });
 };
 
-const htmlToData = (editor: Editor, head: string) => {
+const htmlToData = (editor: Editor, head: string): Data => {
   const headerFragment = parseHeader(editor, head);
   const data: Data = {};
   let elm, matches;
 
-  const getAttr = (elm, name) => {
+  const getAttr = (elm: AstNode, name: string): string => {
     const value = elm.attr(name);
 
     return value || '';
@@ -121,15 +121,15 @@ const htmlToData = (editor: Editor, head: string) => {
   return data;
 };
 
-const dataToHtml = (editor: Editor, data: Data, head) => {
-  let headElement, elm, value;
+const dataToHtml = (editor: Editor, data: Data, head: string): string => {
+  let headElement: AstNode, elm: AstNode;
   const dom = editor.dom;
 
-  const setAttr = (elm, name, value) => {
+  const setAttr = (elm: AstNode, name: string, value: string | undefined) => {
     elm.attr(name, value ? value : undefined);
   };
 
-  const addHeadNode = (node) => {
+  const addHeadNode = (node: AstNode) => {
     if (headElement.firstChild) {
       headElement.insert(node, headElement.firstChild);
     } else {
@@ -153,7 +153,7 @@ const dataToHtml = (editor: Editor, data: Data, head) => {
   // Add/update/remove XML-PI
   elm = headerFragment.firstChild;
   if (data.xml_pi) {
-    value = 'version="1.0"';
+    let value = 'version="1.0"';
 
     if (data.docencoding) {
       value += ' encoding="' + data.docencoding + '"';

--- a/modules/tinymce/src/plugins/fullpage/main/ts/core/Protect.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/core/Protect.ts
@@ -10,7 +10,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 declare const escape: any;
 declare const unescape: any;
 
-const protectHtml = (protect, html) => {
+const protectHtml = (protect: RegExp[] | undefined, html: string): string => {
   Tools.each(protect, (pattern) => {
     html = html.replace(pattern, (str) => {
       return '<!--mce:protected ' + escape(str) + '-->';
@@ -20,7 +20,7 @@ const protectHtml = (protect, html) => {
   return html;
 };
 
-const unprotectHtml = (html) => {
+const unprotectHtml = (html: string): string => {
   return html.replace(/<!--mce:protected ([\s\S]*?)-->/g, (a, m) => {
     return unescape(m);
   });

--- a/modules/tinymce/src/plugins/fullpage/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
   editor.ui.registry.addButton('fullpage', {
     // TODO: This should be title or text, with no icon?
     tooltip: 'Metadata and document properties',

--- a/modules/tinymce/src/plugins/fullpage/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/ui/Dialog.ts
@@ -12,7 +12,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Parser from '../core/Parser';
 
-const open = (editor: Editor, headState: Cell<string>) => {
+const open = (editor: Editor, headState: Cell<string>): void => {
   const data = Parser.htmlToData(editor, headState.get());
 
   const defaultData = {

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/Plugin.ts
@@ -14,7 +14,7 @@ import * as Commands from './api/Commands';
 import { ScrollInfo } from './core/Actions';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('fullscreen', (editor) => {
     const fullscreenState = Cell<ScrollInfo | null>(null);
 

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Api.ts
@@ -9,11 +9,13 @@ import { Cell } from '@ephox/katamari';
 
 import { ScrollInfo } from '../core/Actions';
 
-const get = (fullscreenState: Cell<ScrollInfo | null>) => {
-  return {
-    isFullscreen: () => fullscreenState.get() !== null
-  };
-};
+export interface Api {
+  readonly isFullscreen: () => boolean;
+}
+
+const get = (fullscreenState: Cell<ScrollInfo | null>): Api => ({
+  isFullscreen: () => fullscreenState.get() !== null
+});
 
 export {
   get

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Commands.ts
@@ -11,7 +11,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Actions from '../core/Actions';
 
-const register = (editor: Editor, fullscreenState: Cell<Actions.ScrollInfo | null>) => {
+const register = (editor: Editor, fullscreenState: Cell<Actions.ScrollInfo | null>): void => {
   editor.addCommand('mceFullScreen', () => {
     Actions.toggleFullscreen(editor, fullscreenState);
   });

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Events.ts
@@ -5,7 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const fireFullscreenStateChanged = (editor, state) => {
+import Editor from 'tinymce/core/api/Editor';
+
+const fireFullscreenStateChanged = (editor: Editor, state: boolean): void => {
   editor.fire('FullscreenStateChanged', { state });
 };
 

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Settings.ts
@@ -7,9 +7,11 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getInline = (editor: Editor) => editor.getParam('inline');
+const getInline = (editor: Editor): boolean =>
+  editor.getParam('inline');
 
-const getFullscreenNative = (editor: Editor) => editor.getParam('fullscreen_native', false, 'boolean');
+const getFullscreenNative = (editor: Editor): boolean =>
+  editor.getParam('fullscreen_native', false, 'boolean');
 
 export {
   getInline,

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
@@ -18,39 +18,34 @@ import * as Settings from '../api/Settings';
 import { exitFullscreen, getFullscreenchangeEventName, getFullscreenRoot, isFullscreenElement, requestFullscreen } from './NativeFullscreen';
 import * as Thor from './Thor';
 
+interface ScrollPos {
+  readonly x: number;
+  readonly y: number;
+}
+
 export interface ScrollInfo {
-  scrollPos: {
-    x: number;
-    y: number;
-  };
-  containerWidth: string;
-  containerHeight: string;
-  containerTop: string;
-  containerLeft: string;
-  iframeWidth: string;
-  iframeHeight: string;
-  fullscreenChangeHandler: EventUnbinder;
+  readonly scrollPos: ScrollPos;
+  readonly containerWidth: string;
+  readonly containerHeight: string;
+  readonly containerTop: string;
+  readonly containerLeft: string;
+  readonly iframeWidth: string;
+  readonly iframeHeight: string;
+  readonly fullscreenChangeHandler: EventUnbinder;
 }
 
 const DOM = DOMUtils.DOM;
 
-const getScrollPos = () => {
-  const vp = WindowVisualViewport.getBounds(window);
+const getScrollPos = (): ScrollPos =>
+  WindowVisualViewport.getBounds(window);
 
-  return {
-    x: vp.x,
-    y: vp.y
-  };
-};
-
-const setScrollPos = (pos) => {
+const setScrollPos = (pos: ScrollPos): void =>
   window.scrollTo(pos.x, pos.y);
-};
 
 const viewportUpdate = WindowVisualViewport.get().fold(
   () => ({ bind: Fun.noop, unbind: Fun.noop }),
   (visualViewport) => {
-    const editorContainer = Singleton.value<SugarElement>();
+    const editorContainer = Singleton.value<SugarElement<HTMLElement>>();
     const resizeBinder = Singleton.unbindable();
     const scrollBinder = Singleton.unbindable();
 
@@ -75,7 +70,7 @@ const viewportUpdate = WindowVisualViewport.get().fold(
       refreshVisualViewport();
     }, 50);
 
-    const bind = (element) => {
+    const bind = (element: SugarElement<HTMLElement>) => {
       editorContainer.set(element);
       update();
       resizeBinder.set(WindowVisualViewport.bind('resize', update));
@@ -97,7 +92,7 @@ const viewportUpdate = WindowVisualViewport.get().fold(
   }
 );
 
-const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | null>) => {
+const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | null>): void => {
   const body = document.body;
   const documentElement = document.documentElement;
   const editorContainer = editor.getContainer();

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Thor.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Thor.ts
@@ -20,7 +20,7 @@ const bgFallback = 'background-color:rgb(255,255,255)!important;';
 
 const isAndroid = Env.os.isAndroid();
 
-const matchColor = (editorBody: SugarElement) => {
+const matchColor = (editorBody: SugarElement<Element>): string => {
   // in iOS you can overscroll, sometimes when you overscroll you can reveal the bgcolor of an element beneath,
   // by matching the bg color and clobbering ensures any reveals are 'camouflaged' the same color
   const color = Css.get(editorBody, 'background-color');
@@ -28,22 +28,20 @@ const matchColor = (editorBody: SugarElement) => {
 };
 
 // We clobber all tags, direct ancestors to the editorBody get ancestorStyles, everything else gets siblingStyles
-const clobberStyles = (dom: DOMUtils, container: SugarElement, editorBody: SugarElement) => {
-  const gatherSiblings = (element) => {
+const clobberStyles = (dom: DOMUtils, container: SugarElement<Element>, editorBody: SugarElement<Element>): void => {
+  const gatherSiblings = (element: SugarElement<Node>): SugarElement<Element>[] => {
     return SelectorFilter.siblings(element, '*:not(.tox-silver-sink)');
   };
 
-  const clobber = (clobberStyle: string) => {
-    return (element) => {
-      const styles = Attribute.get(element, 'style');
-      const backup = styles === undefined ? 'no-styles' : styles.trim();
-      if (backup === clobberStyle) {
-        return;
-      } else {
-        Attribute.set(element, attr, backup);
-        Css.setAll(element, dom.parseStyle(clobberStyle));
-      }
-    };
+  const clobber = (clobberStyle: string) => (element: SugarElement<Element>): void => {
+    const styles = Attribute.get(element, 'style');
+    const backup = styles === undefined ? 'no-styles' : styles.trim();
+    if (backup === clobberStyle) {
+      return;
+    } else {
+      Attribute.set(element, attr, backup);
+      Css.setAll(element, dom.parseStyle(clobberStyle));
+    }
   };
 
   const ancestors = SelectorFilter.ancestors(container, '*');
@@ -58,7 +56,7 @@ const clobberStyles = (dom: DOMUtils, container: SugarElement, editorBody: Sugar
   clobber(containerStyles + ancestorStyles + bgColor)(container);
 };
 
-const restoreStyles = (dom: DOMUtils) => {
+const restoreStyles = (dom: DOMUtils): void => {
   const clobberedEls = SelectorFilter.all('[' + attr + ']');
   Arr.each(clobberedEls, (element) => {
     const restore = Attribute.get(element, attr);

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
@@ -8,27 +8,31 @@
 import { Cell } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const makeSetupHandler = (editor: Editor, fullscreenState: Cell<object>) => (api) => {
+const makeSetupHandler = (editor: Editor, fullscreenState: Cell<object>) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi) => {
   api.setActive(fullscreenState.get() !== null);
-  const editorEventCallback = (e) => api.setActive(e.state);
+  const editorEventCallback = (e: EditorEvent<{ state: boolean }>) => api.setActive(e.state);
   editor.on('FullscreenStateChanged', editorEventCallback);
   return () => editor.off('FullscreenStateChanged', editorEventCallback);
 };
 
-const register = (editor: Editor, fullscreenState: Cell<object>) => {
+const register = (editor: Editor, fullscreenState: Cell<object>): void => {
+  const onAction = () => editor.execCommand('mceFullScreen');
+
   editor.ui.registry.addToggleMenuItem('fullscreen', {
     text: 'Fullscreen',
     icon: 'fullscreen',
     shortcut: 'Meta+Shift+F',
-    onAction: () => editor.execCommand('mceFullScreen'),
+    onAction,
     onSetup: makeSetupHandler(editor, fullscreenState)
   });
 
   editor.ui.registry.addToggleButton('fullscreen', {
     tooltip: 'Fullscreen',
     icon: 'fullscreen',
-    onAction: () => editor.execCommand('mceFullScreen'),
+    onAction,
     onSetup: makeSetupHandler(editor, fullscreenState)
   });
 };

--- a/modules/tinymce/src/plugins/help/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/Plugin.ts
@@ -18,12 +18,12 @@ import * as Dialog from './ui/Dialog';
 export type TabSpecs = Record<string, DialogType.TabSpec>;
 export type CustomTabSpecs = Cell<TabSpecs>;
 
-export default () => {
+export default (): void => {
   PluginManager.add('help', (editor) => {
     const customTabs: CustomTabSpecs = Cell({});
     const api = Api.get(customTabs);
 
-    const dialogOpener: () => void = Dialog.init(editor, customTabs);
+    const dialogOpener = Dialog.init(editor, customTabs);
     Buttons.register(editor, dialogOpener);
     Commands.register(editor, dialogOpener);
     editor.shortcuts.add('Alt+0', 'Open help dialog', 'mceHelp');

--- a/modules/tinymce/src/plugins/help/main/ts/alien/ConvertShortcut.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/alien/ConvertShortcut.ts
@@ -10,7 +10,7 @@ import { Arr, Obj } from '@ephox/katamari';
 import Env from 'tinymce/core/api/Env';
 
 // Converts shortcut format to Mac/PC variants
-const convertText = (source: string) => {
+const convertText = (source: string): string => {
   const mac = {
     alt: '&#x2325;',
     ctrl: '&#x2303;',

--- a/modules/tinymce/src/plugins/help/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/api/Api.ts
@@ -9,7 +9,11 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import { CustomTabSpecs } from '../Plugin';
 
-const get = (customTabs: CustomTabSpecs) => {
+export interface Api {
+  readonly addTab: (spec: Dialog.TabSpec) => void;
+}
+
+const get = (customTabs: CustomTabSpecs): Api => {
   const addTab = (spec: Dialog.TabSpec): void => {
     const currentCustomTabs = customTabs.get();
     currentCustomTabs[spec.name] = spec;

--- a/modules/tinymce/src/plugins/help/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor, dialogOpener: () => void) => {
+const register = (editor: Editor, dialogOpener: () => void): void => {
   editor.addCommand('mceHelp', dialogOpener);
 };
 

--- a/modules/tinymce/src/plugins/help/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/api/Settings.ts
@@ -12,9 +12,11 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 export type HelpTabsSetting = (string | Dialog.TabSpec)[];
 
-const getHelpTabs = (editor: Editor): Optional<HelpTabsSetting> => Optional.from(editor.getParam('help_tabs'));
+const getHelpTabs = (editor: Editor): Optional<HelpTabsSetting> =>
+  Optional.from(editor.getParam('help_tabs'));
 
-const getForcedPlugins = (editor: Editor) => editor.getParam('forced_plugins');
+const getForcedPlugins = (editor: Editor): string[] | string | undefined =>
+  editor.getParam('forced_plugins');
 
 export {
   getHelpTabs,

--- a/modules/tinymce/src/plugins/help/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/Buttons.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor, dialogOpener: () => void) => {
+const register = (editor: Editor, dialogOpener: () => void): void => {
   editor.ui.registry.addButton('help', {
     icon: 'help',
     tooltip: 'Help',

--- a/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
@@ -18,8 +18,8 @@ import * as PluginsTab from './PluginsTab';
 import * as VersionTab from './VersionTab';
 
 interface TabData {
-  tabs: TabSpecs;
-  names: string[];
+  readonly tabs: TabSpecs;
+  readonly names: string[];
 }
 
 const parseHelpTabsSetting = (tabsFromSettings: Settings.HelpTabsSetting, tabs: TabSpecs): TabData => {
@@ -54,7 +54,7 @@ const getNamesFromTabs = (tabs: TabSpecs): TabData => {
   return { tabs, names };
 };
 
-const parseCustomTabs = (editor: Editor, customTabs: CustomTabSpecs) => {
+const parseCustomTabs = (editor: Editor, customTabs: CustomTabSpecs): TabData => {
   const shortcuts = KeyboardShortcutsTab.tab();
   const nav = KeyboardNavTab.tab();
   const plugins = PluginsTab.tab(editor);
@@ -73,7 +73,7 @@ const parseCustomTabs = (editor: Editor, customTabs: CustomTabSpecs) => {
   );
 };
 
-const init = (editor: Editor, customTabs: CustomTabSpecs): () => void => () => {
+const init = (editor: Editor, customTabs: CustomTabSpecs) => (): void => {
   // const tabSpecs: Record<string, Types.Dialog.TabApi> = customTabs.get();
   const { tabs, names } = parseCustomTabs(editor, customTabs);
   const foundTabs: Optional<Dialog.TabSpec>[] = Arr.map(names, (name) => Obj.get(tabs, name));

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -70,7 +70,7 @@ const tab = (editor: Editor): Dialog.TabSpec => {
       Arr.filter(keys, (k) => !Arr.contains(forced_plugins, k));
   };
 
-  const pluginLister = (editor) => {
+  const pluginLister = (editor: Editor) => {
     const pluginKeys = getPluginKeys(editor);
     const pluginLis = Arr.map(pluginKeys, (key) => {
       return '<li>' + maybeUrlize(editor, key) + '</li>';
@@ -84,7 +84,7 @@ const tab = (editor: Editor): Dialog.TabSpec => {
     return html;
   };
 
-  const installedPlugins = (editor) => {
+  const installedPlugins = (editor: Editor) => {
     if (editor == null) {
       return '';
     }

--- a/modules/tinymce/src/plugins/hr/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/hr/main/ts/Plugin.ts
@@ -10,7 +10,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('hr', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);

--- a/modules/tinymce/src/plugins/hr/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/hr/main/ts/api/Commands.ts
@@ -5,7 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const register = (editor) => {
+import Editor from 'tinymce/core/api/Editor';
+
+const register = (editor: Editor): void => {
   editor.addCommand('InsertHorizontalRule', () => {
     editor.execCommand('mceInsertContent', false, '<hr />');
   });

--- a/modules/tinymce/src/plugins/hr/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/hr/main/ts/ui/Buttons.ts
@@ -7,17 +7,19 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
+  const onAction = () => editor.execCommand('InsertHorizontalRule');
+
   editor.ui.registry.addButton('hr', {
     icon: 'horizontal-rule',
     tooltip: 'Horizontal line',
-    onAction: () => editor.execCommand('InsertHorizontalRule')
+    onAction
   });
 
   editor.ui.registry.addMenuItem('hr', {
     icon: 'horizontal-rule',
     text: 'Horizontal line',
-    onAction: () => editor.execCommand('InsertHorizontalRule')
+    onAction
   });
 };
 


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Added types for `advlist` -> `hr`
* Cleaned up some duplication for `onAction` in the `fullscreen` and `hr` plugins
* Cleaned up some duplication for `onSetup` in the `advlist` plugin

**Note:** This primarily only focuses on the function types, so variables inside functions may still not have types.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
