### PR TITLE
Added types for the `save` to `wordcount` plugins

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -8,6 +8,7 @@
 import { GetContentArgs, SetContentArgs } from '../content/ContentTypes';
 import { UndoLevel } from '../undo/UndoManagerTypes';
 import Editor from './Editor';
+import { ParserArgs } from './html/DomParser';
 import { Dialog } from './ui/Ui';
 import { NativeEventMap } from './util/EventDispatcher';
 import { InstanceApi } from './WindowManager';
@@ -46,6 +47,9 @@ export interface AfterProgressStateEvent { state: boolean }
 export interface PlaceholderToggleEvent { state: boolean }
 
 export interface LoadErrorEvent { message: string }
+
+export interface PreProcessEvent extends ParserArgs { node: Element }
+export interface PostProcessEvent extends ParserArgs { content: string }
 
 export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
   'activate': { relatedTarget: Editor };
@@ -104,6 +108,8 @@ export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
   'tap': TouchEvent;
   'longpress': TouchEvent;
   'longpresscancel': { };
+  'PreProcess': PreProcessEvent;
+  'PostProcess': PostProcessEvent;
 }
 
 export interface EditorManagerEventMap {

--- a/modules/tinymce/src/core/main/ts/api/Events.ts
+++ b/modules/tinymce/src/core/main/ts/api/Events.ts
@@ -6,10 +6,11 @@
  */
 
 import Editor from './Editor';
+import { ParserArgs } from './html/DomParser';
 
-const firePreProcess = (editor: Editor, args) => editor.fire('PreProcess', args);
+const firePreProcess = (editor: Editor, args: ParserArgs & { node: Element }) => editor.fire('PreProcess', args);
 
-const firePostProcess = (editor: Editor, args) => editor.fire('PostProcess', args);
+const firePostProcess = (editor: Editor, args: ParserArgs & { content: string }) => editor.fire('PostProcess', args);
 
 const fireRemove = (editor: Editor) => editor.fire('remove');
 

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerPreProcess.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerPreProcess.ts
@@ -14,7 +14,7 @@ const preProcess = (editor: Editor, node: Element, args: ParserArgs): Node => {
   let oldDoc: Document;
   const dom = editor.dom;
 
-  let clonedNode = node.cloneNode(true);
+  let clonedNode = node.cloneNode(true) as Element;
 
   // Nodes needs to be attached to something in WebKit/Opera
   // This fix will make DOM ranges and make Sizzle happy!
@@ -30,7 +30,8 @@ const preProcess = (editor: Editor, node: Element, args: ParserArgs): Node => {
 
     // Grab first child or body element for serialization
     if (clonedNode.nodeName !== 'BODY') {
-      clonedNode = doc.body.firstChild;
+      // We cast to a Element here, as this will be the cloned node imported and appended above
+      clonedNode = doc.body.firstChild as Element;
     } else {
       clonedNode = doc.body;
     }

--- a/modules/tinymce/src/plugins/save/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/Plugin.ts
@@ -10,7 +10,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('save', (editor) => {
     Buttons.register(editor);
     Commands.register(editor);

--- a/modules/tinymce/src/plugins/save/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/api/Commands.ts
@@ -5,9 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Actions from '../core/Actions';
 
-const register = (editor) => {
+const register = (editor: Editor): void => {
   editor.addCommand('mceSave', () => {
     Actions.save(editor);
   });

--- a/modules/tinymce/src/plugins/save/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/api/Settings.ts
@@ -5,17 +5,16 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const enableWhenDirty = (editor) => {
-  return editor.getParam('save_enablewhendirty', true);
-};
+import Editor from 'tinymce/core/api/Editor';
 
-const hasOnSaveCallback = (editor) => {
-  return !!editor.getParam('save_onsavecallback');
-};
+const enableWhenDirty = (editor: Editor): boolean =>
+  editor.getParam('save_enablewhendirty', true);
 
-const hasOnCancelCallback = (editor) => {
-  return !!editor.getParam('save_oncancelcallback');
-};
+const hasOnSaveCallback = (editor: Editor): boolean =>
+  !!editor.getParam('save_onsavecallback');
+
+const hasOnCancelCallback = (editor: Editor): boolean =>
+  !!editor.getParam('save_oncancelcallback');
 
 export {
   enableWhenDirty,

--- a/modules/tinymce/src/plugins/save/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/core/Actions.ts
@@ -6,19 +6,20 @@
  */
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Settings from '../api/Settings';
 
-const displayErrorMessage = (editor, message) => {
+const displayErrorMessage = (editor: Editor, message: string): void => {
   editor.notificationManager.open({
     text: message,
     type: 'error'
   });
 };
 
-const save = (editor) => {
-  const formObj = DOMUtils.DOM.getParent(editor.id, 'form') as HTMLFormElement;
+const save = (editor: Editor): void => {
+  const formObj = DOMUtils.DOM.getParent(editor.id, 'form');
 
   if (Settings.enableWhenDirty(editor) && !editor.isDirty()) {
     return;
@@ -52,7 +53,7 @@ const save = (editor) => {
   }
 };
 
-const cancel = (editor) => {
+const cancel = (editor: Editor): void => {
   const h = Tools.trim(editor.startContent);
 
   // Use callback instead

--- a/modules/tinymce/src/plugins/save/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/ui/Buttons.ts
@@ -6,21 +6,21 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import { Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import * as Settings from '../api/Settings';
 
-const stateToggle = (editor: Editor) => {
-  return (api) => {
-    const handler = () => {
-      api.setDisabled(Settings.enableWhenDirty(editor) && !editor.isDirty());
-    };
-
-    editor.on('NodeChange dirty', handler);
-    return () => editor.off('NodeChange dirty', handler);
+const stateToggle = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi) => {
+  const handler = () => {
+    api.setDisabled(Settings.enableWhenDirty(editor) && !editor.isDirty());
   };
+
+  handler();
+  editor.on('NodeChange dirty', handler);
+  return () => editor.off('NodeChange dirty', handler);
 };
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
   editor.ui.registry.addButton('save', {
     icon: 'save',
     tooltip: 'Save',

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/Plugin.ts
@@ -14,7 +14,7 @@ import * as Commands from './api/Commands';
 import { SearchState } from './core/Actions';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('searchreplace', (editor) => {
     const currentSearchState = Cell<SearchState>({
       index: -1,

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/api/Api.ts
@@ -11,7 +11,15 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Actions from '../core/Actions';
 
-const get = (editor: Editor, currentState: Cell<Actions.SearchState>) => {
+export interface Api {
+  readonly done: (keepEditorSelection?: boolean) => Range | undefined;
+  readonly find: (text: string, matchCase: boolean, wholeWord: boolean, inSelection?: boolean) => number;
+  readonly next: () => void;
+  readonly prev: () => void;
+  readonly replace: (text: string, forward?: boolean, all?: boolean) => boolean;
+}
+
+const get = (editor: Editor, currentState: Cell<Actions.SearchState>): Api => {
   const done = (keepEditorSelection?: boolean) => {
     return Actions.done(editor, currentState, keepEditorSelection);
   };

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/api/Commands.ts
@@ -12,7 +12,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { SearchState } from '../core/Actions';
 import * as Dialog from '../ui/Dialog';
 
-const register = (editor: Editor, currentSearchState: Cell<SearchState>) => {
+const register = (editor: Editor, currentSearchState: Cell<SearchState>): void => {
   editor.addCommand('SearchReplace', () => {
     Dialog.open(editor, currentSearchState);
   });

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/Actions.ts
@@ -16,15 +16,15 @@ import * as FindMark from './FindMark';
 import { Pattern } from './Types';
 
 export interface SearchState {
-  index: number;
-  count: number;
-  text: string;
-  matchCase: boolean;
-  wholeWord: boolean;
-  inSelection: boolean;
+  readonly index: number;
+  readonly count: number;
+  readonly text: string;
+  readonly matchCase: boolean;
+  readonly wholeWord: boolean;
+  readonly inSelection: boolean;
 }
 
-const getElmIndex = (elm: Element) => {
+const getElmIndex = (elm: Element): string => {
   const value = elm.getAttribute('data-mce-index');
 
   if (typeof value === 'number') {
@@ -34,7 +34,7 @@ const getElmIndex = (elm: Element) => {
   return value;
 };
 
-const markAllMatches = (editor: Editor, currentSearchState: Cell<SearchState>, pattern: Pattern, inSelection: boolean) => {
+const markAllMatches = (editor: Editor, currentSearchState: Cell<SearchState>, pattern: Pattern, inSelection: boolean): number => {
   const marker = editor.dom.create('span', {
     'data-mce-bogus': 1
   });
@@ -51,7 +51,7 @@ const markAllMatches = (editor: Editor, currentSearchState: Cell<SearchState>, p
   }
 };
 
-const unwrap = (node: Node) => {
+const unwrap = (node: Node): void => {
   const parentNode = node.parentNode;
 
   if (node.firstChild) {
@@ -61,8 +61,8 @@ const unwrap = (node: Node) => {
   node.parentNode.removeChild(node);
 };
 
-const findSpansByIndex = (editor: Editor, index: number) => {
-  const spans = [];
+const findSpansByIndex = (editor: Editor, index: number): HTMLSpanElement[] => {
+  const spans: HTMLSpanElement[] = [];
 
   const nodes = Tools.toArray(editor.getBody().getElementsByTagName('span'));
   if (nodes.length) {
@@ -82,7 +82,7 @@ const findSpansByIndex = (editor: Editor, index: number) => {
   return spans;
 };
 
-const moveSelection = (editor: Editor, currentSearchState: Cell<SearchState>, forward: boolean) => {
+const moveSelection = (editor: Editor, currentSearchState: Cell<SearchState>, forward: boolean): number => {
   const searchState = currentSearchState.get();
   let testIndex = searchState.index;
   const dom = editor.dom;
@@ -115,7 +115,7 @@ const moveSelection = (editor: Editor, currentSearchState: Cell<SearchState>, fo
   return -1;
 };
 
-const removeNode = (dom: DOMUtils, node: Node) => {
+const removeNode = (dom: DOMUtils, node: Node): void => {
   const parent = node.parentNode;
 
   dom.remove(node);
@@ -125,13 +125,13 @@ const removeNode = (dom: DOMUtils, node: Node) => {
   }
 };
 
-const escapeSearchText = (text: string, wholeWord: boolean) => {
+const escapeSearchText = (text: string, wholeWord: boolean): string => {
   const escapedText = text.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&').replace(/\s/g, '[^\\S\\r\\n\\uFEFF]');
   const wordRegex = '(' + escapedText + ')';
   return wholeWord ? `(?:^|\\s|${PolarisPattern.punctuation()})` + wordRegex + `(?=$|\\s|${PolarisPattern.punctuation()})` : wordRegex;
 };
 
-const find = (editor: Editor, currentSearchState: Cell<SearchState>, text: string, matchCase: boolean, wholeWord: boolean, inSelection: boolean) => {
+const find = (editor: Editor, currentSearchState: Cell<SearchState>, text: string, matchCase: boolean, wholeWord: boolean, inSelection: boolean): number => {
   const escapedText = escapeSearchText(text, wholeWord);
 
   const pattern = {
@@ -155,23 +155,23 @@ const find = (editor: Editor, currentSearchState: Cell<SearchState>, text: strin
   return count;
 };
 
-const next = (editor: Editor, currentSearchState: Cell<SearchState>) => {
+const next = (editor: Editor, currentSearchState: Cell<SearchState>): void => {
   const index = moveSelection(editor, currentSearchState, true);
   currentSearchState.set({ ...currentSearchState.get(), index });
 };
 
-const prev = (editor: Editor, currentSearchState: Cell<SearchState>) => {
+const prev = (editor: Editor, currentSearchState: Cell<SearchState>): void => {
   const index = moveSelection(editor, currentSearchState, false);
   currentSearchState.set({ ...currentSearchState.get(), index });
 };
 
-const isMatchSpan = (node: Element) => {
+const isMatchSpan = (node: Element): boolean => {
   const matchIndex = getElmIndex(node);
 
   return matchIndex !== null && matchIndex.length > 0;
 };
 
-const replace = (editor: Editor, currentSearchState: Cell<SearchState>, text: string, forward?: boolean, all?: boolean) => {
+const replace = (editor: Editor, currentSearchState: Cell<SearchState>, text: string, forward?: boolean, all?: boolean): boolean => {
   const searchState = currentSearchState.get();
   const currentIndex = searchState.index;
   let currentMatchIndex, nextIndex = currentIndex;
@@ -226,12 +226,12 @@ const replace = (editor: Editor, currentSearchState: Cell<SearchState>, text: st
   return !all && currentSearchState.get().count > 0;
 };
 
-const done = (editor: Editor, currentSearchState: Cell<SearchState>, keepEditorSelection?: boolean) => {
-  let i, startContainer, endContainer;
+const done = (editor: Editor, currentSearchState: Cell<SearchState>, keepEditorSelection?: boolean): Range | undefined => {
+  let startContainer, endContainer;
   const searchState = currentSearchState.get();
 
   const nodes = Tools.toArray(editor.getBody().getElementsByTagName('span'));
-  for (i = 0; i < nodes.length; i++) {
+  for (let i = 0; i < nodes.length; i++) {
     const nodeIndex = getElmIndex(nodes[i]);
 
     if (nodeIndex !== null && nodeIndex.length) {
@@ -268,8 +268,8 @@ const done = (editor: Editor, currentSearchState: Cell<SearchState>, keepEditorS
   }
 };
 
-const hasNext = (editor: Editor, currentSearchState: Cell<SearchState>) => currentSearchState.get().count > 1;
-const hasPrev = (editor: Editor, currentSearchState: Cell<SearchState>) => currentSearchState.get().count > 1;
+const hasNext = (editor: Editor, currentSearchState: Cell<SearchState>): boolean => currentSearchState.get().count > 1;
+const hasPrev = (editor: Editor, currentSearchState: Cell<SearchState>): boolean => currentSearchState.get().count > 1;
 
 export {
   done,

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/FindMark.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/FindMark.ts
@@ -15,14 +15,15 @@ import * as TextCollect from './TextCollect';
 import * as TextPosition from './TextPosition';
 import { Pattern, TextMatch, TextSection } from './Types';
 
-const find = (pattern: Pattern, sections: TextSection[]) => Arr.bind(sections, (section) => {
-  const elements = section.elements;
-  const content = Arr.map(elements, SugarText.get).join('');
-  const positions = TextPosition.find(content, pattern, section.sOffset, content.length - section.fOffset);
-  return TextPosition.extract(elements, positions);
-});
+const find = (pattern: Pattern, sections: TextSection[]): TextMatch[][] =>
+  Arr.bind(sections, (section) => {
+    const elements = section.elements;
+    const content = Arr.map(elements, SugarText.get).join('');
+    const positions = TextPosition.find(content, pattern, section.sOffset, content.length - section.fOffset);
+    return TextPosition.extract(elements, positions);
+  });
 
-const mark = (matches: TextMatch[][], replacementNode: HTMLElement) => {
+const mark = (matches: TextMatch[][], replacementNode: HTMLElement): void => {
   // Walk backwards and mark the positions
   // Note: We need to walk backwards so the position indexes don't change
   Arr.eachr(matches, (match, idx) => {
@@ -43,14 +44,14 @@ const mark = (matches: TextMatch[][], replacementNode: HTMLElement) => {
   });
 };
 
-const findAndMark = (dom: DOMUtils, pattern: Pattern, node: Node, replacementNode: HTMLElement) => {
+const findAndMark = (dom: DOMUtils, pattern: Pattern, node: Node, replacementNode: HTMLElement): number => {
   const textSections = TextCollect.fromNode(dom, node);
   const matches = find(pattern, textSections);
   mark(matches, replacementNode);
   return matches.length;
 };
 
-const findAndMarkInSelection = (dom: DOMUtils, pattern: Pattern, selection: EditorSelection, replacementNode: HTMLElement) => {
+const findAndMarkInSelection = (dom: DOMUtils, pattern: Pattern, selection: EditorSelection, replacementNode: HTMLElement): number => {
   const bookmark = selection.getBookmark();
 
   // Handle table cell selection as the table plugin enables

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
@@ -15,14 +15,14 @@ import DomTreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import { TextSection } from './Types';
 
 interface WalkerCallbacks {
-  boundary: (node: Node) => boolean;
-  cef: (node: Node) => boolean;
-  text: (node: Text) => void;
+  readonly boundary: (node: Node) => boolean;
+  readonly cef: (node: Node) => boolean;
+  readonly text: (node: Text) => void;
 }
 
 interface CollectCallbacks {
-  cef: (node: Node) => TextSection[];
-  text: (node: Text, section: TextSection) => void;
+  readonly cef: (node: Node) => TextSection[];
+  readonly text: (node: Text, section: TextSection) => void;
 }
 
 const isSimpleBoundary = (dom: DOMUtils, node: Node) => dom.isBlock(node) || Obj.has(dom.schema.getShortEndedElements(), node.nodeName);
@@ -38,9 +38,10 @@ const nuSection = (): TextSection => ({
   elements: []
 });
 
-const toLeaf = (node: Node, offset: number) => Traverse.leaf(SugarElement.fromDom(node), offset);
+const toLeaf = (node: Node, offset: number): Traverse.ElementAndOffset<Node> =>
+  Traverse.leaf(SugarElement.fromDom(node), offset);
 
-const walk = (dom: DOMUtils, walkerFn: (shallow?: boolean) => Node, startNode: Node, callbacks: WalkerCallbacks, endNode?: Node, skipStart: boolean = true) => {
+const walk = (dom: DOMUtils, walkerFn: (shallow?: boolean) => Node, startNode: Node, callbacks: WalkerCallbacks, endNode?: Node, skipStart: boolean = true): void => {
   let next = skipStart ? walkerFn(false) : startNode;
   while (next) {
     // Walk over content editable or hidden elements
@@ -69,7 +70,7 @@ const walk = (dom: DOMUtils, walkerFn: (shallow?: boolean) => Node, startNode: N
   }
 };
 
-const collectTextToBoundary = (dom: DOMUtils, section: TextSection, node: Node, rootNode: Node, forwards: boolean) => {
+const collectTextToBoundary = (dom: DOMUtils, section: TextSection, node: Node, rootNode: Node, forwards: boolean): void => {
   // Don't bother collecting text nodes if we're already at a boundary
   if (isBoundary(dom, node)) {
     return;
@@ -95,7 +96,7 @@ const collectTextToBoundary = (dom: DOMUtils, section: TextSection, node: Node, 
   });
 };
 
-const collect = (dom: DOMUtils, rootNode: Node, startNode: Node, endNode?: Node, callbacks?: CollectCallbacks, skipStart: boolean = true) => {
+const collect = (dom: DOMUtils, rootNode: Node, startNode: Node, endNode?: Node, callbacks?: CollectCallbacks, skipStart: boolean = true): TextSection[] => {
   const walker = new DomTreeWalker(startNode, rootNode);
   const sections: TextSection[] = [];
   let current: TextSection = nuSection();
@@ -167,7 +168,8 @@ const collectRangeSections = (dom: DOMUtils, rng: Range): TextSection[] => {
   }, false);
 };
 
-const fromRng = (dom: DOMUtils, rng: Range): TextSection[] => rng.collapsed ? [] : collectRangeSections(dom, rng);
+const fromRng = (dom: DOMUtils, rng: Range): TextSection[] =>
+  rng.collapsed ? [] : collectRangeSections(dom, rng);
 
 const fromNode = (dom: DOMUtils, node: Node): TextSection[] => {
   const rng = dom.createRng();
@@ -175,7 +177,8 @@ const fromNode = (dom: DOMUtils, node: Node): TextSection[] => {
   return fromRng(dom, rng);
 };
 
-const fromNodes = (dom: DOMUtils, nodes: Node[]): TextSection[] => Arr.bind(nodes, (node) => fromNode(dom, node));
+const fromNodes = (dom: DOMUtils, nodes: Node[]): TextSection[] =>
+  Arr.bind(nodes, (node) => fromNode(dom, node));
 
 export {
   fromNode,

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Buttons.ts
@@ -12,13 +12,11 @@ import Editor from 'tinymce/core/api/Editor';
 import { SearchState } from '../core/Actions';
 import * as Dialog from './Dialog';
 
-const showDialog = (editor: Editor, currentSearchState: Cell<SearchState>) => {
-  return () => {
-    Dialog.open(editor, currentSearchState);
-  };
+const showDialog = (editor: Editor, currentSearchState: Cell<SearchState>) => (): void => {
+  Dialog.open(editor, currentSearchState);
 };
 
-const register = (editor: Editor, currentSearchState: Cell<SearchState>) => {
+const register = (editor: Editor, currentSearchState: Cell<SearchState>): void => {
   editor.ui.registry.addMenuItem('searchreplace', {
     text: 'Find and replace...',
     shortcut: 'Meta+F',

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
@@ -15,27 +15,27 @@ import Tools from 'tinymce/core/api/util/Tools';
 import * as Actions from '../core/Actions';
 
 export interface DialogData {
-  findtext: string;
-  replacetext: string;
-  matchcase: boolean;
-  wholewords: boolean;
-  inselection: boolean;
+  readonly findtext: string;
+  readonly replacetext: string;
+  readonly matchcase: boolean;
+  readonly wholewords: boolean;
+  readonly inselection: boolean;
 }
 
-const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>) => {
+const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>): void => {
   const dialogApi = Singleton.value<Dialog.DialogInstanceApi<DialogData>>();
   editor.undoManager.add();
 
   const selectedText = Tools.trim(editor.selection.getContent({ format: 'text' }));
 
-  const updateButtonStates = (api: Dialog.DialogInstanceApi<DialogData>) => {
+  const updateButtonStates = (api: Dialog.DialogInstanceApi<DialogData>): void => {
     const updateNext = Actions.hasNext(editor, currentSearchState) ? api.enable : api.disable;
     updateNext('next');
     const updatePrev = Actions.hasPrev(editor, currentSearchState) ? api.enable : api.disable;
     updatePrev('prev');
   };
 
-  const updateSearchState = (api: Dialog.DialogInstanceApi<DialogData>) => {
+  const updateSearchState = (api: Dialog.DialogInstanceApi<DialogData>): void => {
     const data = api.getData();
     const current = currentSearchState.get();
 
@@ -47,13 +47,13 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>) => 
     });
   };
 
-  const disableAll = (api: Dialog.DialogInstanceApi<DialogData>, disable: boolean) => {
+  const disableAll = (api: Dialog.DialogInstanceApi<DialogData>, disable: boolean): void => {
     const buttons = [ 'replace', 'replaceall', 'prev', 'next' ];
     const toggle = disable ? api.disable : api.enable;
     Arr.each(buttons, toggle);
   };
 
-  const notFoundAlert = (api: Dialog.DialogInstanceApi<DialogData>) => {
+  const notFoundAlert = (api: Dialog.DialogInstanceApi<DialogData>): void => {
     editor.windowManager.alert('Could not find the specified string.', () => {
       api.focus('findtext');
     });
@@ -61,13 +61,13 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>) => 
 
   // Temporarily workaround for iOS/iPadOS dialog placement to hide the keyboard
   // TODO: Remove in 5.2 once iOS fixed positioning is fixed. See TINY-4441
-  const focusButtonIfRequired = (api: Dialog.DialogInstanceApi<DialogData>, name: string) => {
+  const focusButtonIfRequired = (api: Dialog.DialogInstanceApi<DialogData>, name: string): void => {
     if (Env.browser.isSafari() && Env.deviceType.isTouch() && (name === 'find' || name === 'replace' || name === 'replaceall')) {
       api.focus(name);
     }
   };
 
-  const reset = (api: Dialog.DialogInstanceApi<DialogData>) => {
+  const reset = (api: Dialog.DialogInstanceApi<DialogData>): void => {
     // Clean up the markers if required
     Actions.done(editor, currentSearchState, false);
 
@@ -76,7 +76,7 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>) => 
     updateButtonStates(api);
   };
 
-  const doFind = (api: Dialog.DialogInstanceApi<DialogData>) => {
+  const doFind = (api: Dialog.DialogInstanceApi<DialogData>): void => {
     const data = api.getData();
     const last = currentSearchState.get();
 

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
@@ -17,7 +17,7 @@ import { LastSuggestion } from './core/Actions';
 import * as Buttons from './ui/Buttons';
 import * as SuggestionsMenu from './ui/SuggestionsMenu';
 
-export default () => {
+export default (): void => {
   PluginManager.add('spellchecker', (editor, pluginUrl) => {
     if (DetectProPlugin.hasProPlugin(editor) === false) {
       // eslint-disable-next-line no-console
@@ -31,7 +31,7 @@ export default () => {
       SuggestionsMenu.setup(editor, pluginUrl, lastSuggestionsState, startedState, textMatcherState, currentLanguageState);
       Commands.register(editor, pluginUrl, startedState, textMatcherState, lastSuggestionsState, currentLanguageState);
 
-      return Api.get(editor, startedState, lastSuggestionsState, textMatcherState, currentLanguageState, pluginUrl);
+      return Api.get(editor, startedState, lastSuggestionsState, textMatcherState, currentLanguageState);
     }
   });
 };

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/alien/DetectProPlugin.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/alien/DetectProPlugin.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const hasProPlugin = (editor: Editor) => {
+const hasProPlugin = (editor: Editor): boolean => {
   // draw back if power version is requested and registered
   if (editor.hasPlugin('tinymcespellchecker', true)) {
 

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/api/Api.ts
@@ -16,7 +16,14 @@ import * as Settings from './Settings';
 type LastSuggestion = Actions.LastSuggestion;
 type Data = Actions.Data;
 
-const get = (editor: Editor, startedState: Cell<boolean>, lastSuggestionsState: Cell<LastSuggestion>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, _url: string) => {
+export interface Api {
+  readonly getTextMatcher: () => DomTextMatcher;
+  readonly getWordCharPattern: () => RegExp;
+  readonly markErrors: (data: Data) => void;
+  readonly getLanguage: () => string;
+}
+
+const get = (editor: Editor, startedState: Cell<boolean>, lastSuggestionsState: Cell<LastSuggestion>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>): Api => {
   const getWordCharPattern = () => {
     return Settings.getSpellcheckerWordcharPattern(editor);
   };

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/api/Commands.ts
@@ -14,7 +14,7 @@ import { DomTextMatcher } from '../core/DomTextMatcher';
 
 type LastSuggestion = Actions.LastSuggestion;
 
-const register = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, currentLanguageState: Cell<string>) => {
+const register = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, currentLanguageState: Cell<string>): void => {
   editor.addCommand('mceSpellCheck', () => {
     Actions.spellcheck(editor, pluginUrl, startedState, textMatcherState, lastSuggestionsState, currentLanguageState);
   });

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/api/Events.ts
@@ -6,14 +6,13 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const fireSpellcheckStart = (editor: Editor) => {
-  return editor.fire('SpellcheckStart');
-};
+const fireSpellcheckStart = (editor: Editor): EditorEvent<{}> =>
+  editor.fire('SpellcheckStart');
 
-const fireSpellcheckEnd = (editor: Editor) => {
-  return editor.fire('SpellcheckEnd');
-};
+const fireSpellcheckEnd = (editor: Editor): EditorEvent<{}> =>
+  editor.fire('SpellcheckEnd');
 
 export {
   fireSpellcheckStart,

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/api/Settings.ts
@@ -7,25 +7,25 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
+type SpellcheckCallback = (method: string, text: string, success: () => void, failure: (message: string) => void) => void;
+
 const getLanguages = (editor: Editor): string => {
   const defaultLanguages = 'English=en,Danish=da,Dutch=nl,Finnish=fi,French=fr_FR,German=de,Italian=it,Polish=pl,Portuguese=pt_BR,Spanish=es,Swedish=sv';
   return editor.getParam('spellchecker_languages', defaultLanguages);
 };
 
-const getLanguage = (editor: Editor) => {
+const getLanguage = (editor: Editor): string => {
   const defaultLanguage = editor.getParam('language', 'en');
   return editor.getParam('spellchecker_language', defaultLanguage);
 };
 
-const getRpcUrl = (editor: Editor) => {
-  return editor.getParam('spellchecker_rpc_url');
-};
+const getRpcUrl = (editor: Editor): string =>
+  editor.getParam('spellchecker_rpc_url');
 
-const getSpellcheckerCallback = (editor: Editor) => {
-  return editor.getParam('spellchecker_callback');
-};
+const getSpellcheckerCallback = (editor: Editor): SpellcheckCallback =>
+  editor.getParam('spellchecker_callback');
 
-const getSpellcheckerWordcharPattern = (editor: Editor) => {
+const getSpellcheckerWordcharPattern = (editor: Editor): RegExp => {
   const defaultPattern = new RegExp('[^' +
   '\\s!"#$%&()*+,-./:;<=>?@[\\]^_{|}`' +
   '\u00a7\u00a9\u00ab\u00ae\u00b1\u00b6\u00b7\u00b8\u00bb' +

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/core/Actions.ts
@@ -17,11 +17,16 @@ import * as Settings from '../api/Settings';
 import { DomTextMatcher } from './DomTextMatcher';
 
 export interface Data {
-  words: Record<string, string[]>;
-  dictionary?: any;
+  readonly words: Record<string, string[]>;
+  readonly dictionary?: any;
 }
 
-const getTextMatcher = (editor, textMatcherState) => {
+export interface LastSuggestion {
+  readonly suggestions: Record<string, string[]>;
+  readonly hasDictionarySupport: boolean;
+}
+
+const getTextMatcher = (editor: Editor, textMatcherState) => {
   if (!textMatcherState.get()) {
     const textMatcher = DomTextMatcher(editor.getBody(), editor);
     textMatcherState.set(textMatcher);
@@ -71,13 +76,13 @@ const defaultSpellcheckCallback = (editor: Editor, pluginUrl: string, currentLan
   };
 };
 
-const sendRpcCall = (editor: Editor, pluginUrl: string, currentLanguageState: Cell<string>, name: string, data: string, successCallback: Function, errorCallback?: Function) => {
+const sendRpcCall = (editor: Editor, pluginUrl: string, currentLanguageState: Cell<string>, name: string, data: string, successCallback: Function, errorCallback?: Function): void => {
   const userSpellcheckCallback = Settings.getSpellcheckerCallback(editor);
   const spellCheckCallback = userSpellcheckCallback ? userSpellcheckCallback : defaultSpellcheckCallback(editor, pluginUrl, currentLanguageState);
   spellCheckCallback.call(editor.plugins.spellchecker, name, data, successCallback, errorCallback);
 };
 
-const spellcheck = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, currentLanguageState: Cell<string>) => {
+const spellcheck = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, currentLanguageState: Cell<string>): void => {
   if (finish(editor, startedState, textMatcherState)) {
     return;
   }
@@ -97,13 +102,13 @@ const spellcheck = (editor: Editor, pluginUrl: string, startedState: Cell<boolea
   editor.focus();
 };
 
-const checkIfFinished = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>) => {
+const checkIfFinished = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>): void => {
   if (!editor.dom.select('span.mce-spellchecker-word').length) {
     finish(editor, startedState, textMatcherState);
   }
 };
 
-const addToDictionary = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, word: string, spans: Element[]) => {
+const addToDictionary = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, word: string, spans: Element[]): void => {
   editor.setProgressState(true);
 
   sendRpcCall(editor, pluginUrl, currentLanguageState, 'addToDictionary', word, () => {
@@ -116,7 +121,7 @@ const addToDictionary = (editor: Editor, pluginUrl: string, startedState: Cell<b
   });
 };
 
-const ignoreWord = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, word: string, spans: Element[], all?: boolean) => {
+const ignoreWord = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, word: string, spans: Element[], all?: boolean): void => {
   editor.selection.collapse();
 
   if (all) {
@@ -146,7 +151,7 @@ const finish = (editor: Editor, startedState: Cell<boolean>, textMatcherState: C
   }
 };
 
-const getElmIndex = (elm: HTMLElement) => {
+const getElmIndex = (elm: HTMLElement): string => {
   const value = elm.getAttribute('data-mce-index');
 
   if (typeof value === 'number') {
@@ -177,12 +182,7 @@ const findSpansByIndex = (editor: Editor, index: string): HTMLSpanElement[] => {
   return spans;
 };
 
-export interface LastSuggestion {
-  suggestions: Record<string, string[]>;
-  hasDictionarySupport: boolean;
-}
-
-const markErrors = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, data: Data) => {
+const markErrors = (editor: Editor, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, lastSuggestionsState: Cell<LastSuggestion>, data: Data): void => {
   const hasDictionarySupport = !!data.dictionary;
   const suggestions = data.words;
 

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/ui/Buttons.ts
@@ -18,8 +18,8 @@ import { DomTextMatcher } from '../core/DomTextMatcher';
 type LastSuggestion = Actions.LastSuggestion;
 
 interface LanguageValue {
-  name: string;
-  value: string;
+  readonly name: string;
+  readonly value: string;
 }
 
 const spellcheckerEvents = 'SpellcheckStart SpellcheckEnd';
@@ -49,7 +49,7 @@ const getItems = (editor: Editor): LanguageValue[] => {
   });
 };
 
-const register = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, lastSuggestionsState: Cell<LastSuggestion>) => {
+const register = (editor: Editor, pluginUrl: string, startedState: Cell<boolean>, textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, lastSuggestionsState: Cell<LastSuggestion>): void => {
   const languageMenuItems = buildMenuItems('Language', getItems(editor));
   const startSpellchecking = () => {
     Actions.spellcheck(editor, pluginUrl, startedState, textMatcherState, lastSuggestionsState, currentLanguageState);

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/ui/SuggestionsMenu.ts
@@ -8,6 +8,7 @@
 import { Cell } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+import { Menu } from 'tinymce/core/api/ui/Ui';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Actions from '../core/Actions';
@@ -18,8 +19,8 @@ type LastSuggestion = Actions.LastSuggestion;
 const ignoreAll = true;
 
 const getSuggestions = (editor: Editor, pluginUrl: string, lastSuggestionsState: Cell<LastSuggestion>, startedState: Cell<boolean>,
-                        textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, word: string, spans: HTMLSpanElement[]) => {
-  const items = [];
+                        textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>, word: string, spans: HTMLSpanElement[]): Menu.ContextMenuContents[] => {
+  const items: Menu.ContextMenuContents[] = [];
   const suggestions = lastSuggestionsState.get().suggestions[word];
 
   Tools.each(suggestions, (suggestion) => {
@@ -66,8 +67,8 @@ const getSuggestions = (editor: Editor, pluginUrl: string, lastSuggestionsState:
 };
 
 const setup = (editor: Editor, pluginUrl: string, lastSuggestionsState: Cell<LastSuggestion>, startedState: Cell<boolean>,
-               textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>) => {
-  const update = (element: HTMLElement) => {
+               textMatcherState: Cell<DomTextMatcher>, currentLanguageState: Cell<string>): void => {
+  const update = (element: HTMLElement): Menu.ContextMenuContents[] => {
     const target = element;
     if (target.className === 'mce-spellchecker-word') {
       const spans = Actions.findSpansByIndex(editor, Actions.getElmIndex(target));

--- a/modules/tinymce/src/plugins/tabfocus/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/tabfocus/main/ts/Plugin.ts
@@ -9,7 +9,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 
 import * as Keyboard from './core/Keyboard';
 
-export default () => {
+export default (): void => {
   PluginManager.add('tabfocus', (editor) => {
     Keyboard.setup(editor);
   });

--- a/modules/tinymce/src/plugins/tabfocus/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/tabfocus/main/ts/api/Settings.ts
@@ -5,13 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const getTabFocusElements = (editor) => {
-  return editor.getParam('tabfocus_elements', ':prev,:next');
-};
+import Editor from 'tinymce/core/api/Editor';
 
-const getTabFocus = (editor) => {
-  return editor.getParam('tab_focus', getTabFocusElements(editor));
-};
+const getTabFocusElements = (editor: Editor): string =>
+  editor.getParam('tabfocus_elements', ':prev,:next');
+
+const getTabFocus = (editor: Editor): string =>
+  editor.getParam('tab_focus', getTabFocusElements(editor));
 
 export {
   getTabFocus

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -13,7 +13,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Clipboard from './actions/Clipboard';
 import { getResizeHandler } from './actions/ResizeHandler';
 import { TableActions } from './actions/TableActions';
-import { getApi } from './api/Api';
+import { Api, getApi } from './api/Api';
 import * as Commands from './api/Commands';
 import * as QueryCommands from './api/QueryCommands';
 import { hasTabNavigation } from './api/Settings';
@@ -28,7 +28,7 @@ import { getSelectionCell } from './selection/TableSelection';
 import * as Buttons from './ui/Buttons';
 import * as MenuItems from './ui/MenuItems';
 
-const Plugin = (editor: Editor) => {
+const Plugin = (editor: Editor): Api => {
   const selections = Selections(() => Util.getBody(editor), () => getSelectionCell(Util.getSelectionStart(editor), Util.getIsRoot(editor)), ephemera.selectedSelector);
   const selectionTargets = getSelectionTargets(editor, selections);
   const resizeHandler = getResizeHandler(editor);
@@ -63,6 +63,6 @@ const Plugin = (editor: Editor) => {
   return getApi(editor, clipboard, resizeHandler, selectionTargets);
 };
 
-export default () => {
+export default (): void => {
   PluginManager.add('table', Plugin);
 };

--- a/modules/tinymce/src/plugins/table/main/ts/actions/EnforceUnit.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/EnforceUnit.ts
@@ -13,19 +13,19 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as TableSize from '../queries/TableSize';
 
-const enforcePercentage = (editor: Editor, table: SugarElement<HTMLTableElement>) => {
+const enforcePercentage = (editor: Editor, table: SugarElement<HTMLTableElement>): void => {
   const tableSizing = TableSize.get(editor, table);
   TableConversions.convertToPercentSize(table, tableSizing);
 };
 
-const enforcePixels = (editor: Editor, table: SugarElement<HTMLTableElement>) => {
+const enforcePixels = (editor: Editor, table: SugarElement<HTMLTableElement>): void => {
   const tableSizing = TableSize.get(editor, table);
   TableConversions.convertToPixelSize(table, tableSizing);
 };
 
 const enforceNone = TableConversions.convertToNoneSize;
 
-const syncPixels = (table: SugarElement<HTMLTableElement>) => {
+const syncPixels = (table: SugarElement<HTMLTableElement>): void => {
   const warehouse = Warehouse.fromTable(table);
   if (!Warehouse.hasColumns(warehouse)) {
     // Ensure the specified width matches the actual cell width
@@ -37,5 +37,10 @@ const syncPixels = (table: SugarElement<HTMLTableElement>) => {
   }
 };
 
-export { enforcePercentage, enforcePixels, enforceNone, syncPixels };
+export {
+  enforcePercentage,
+  enforcePixels,
+  enforceNone,
+  syncPixels
+};
 

--- a/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
@@ -7,7 +7,7 @@
 
 import { Arr, Fun, Type } from '@ephox/katamari';
 import { TableRender } from '@ephox/snooker';
-import { Attribute, Html, SelectorFilter, SelectorFind } from '@ephox/sugar';
+import { Attribute, Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -16,26 +16,27 @@ import { getDefaultAttributes, getDefaultStyles, getTableHeaderType, isPercentag
 import * as Util from '../core/Util';
 import { enforceNone, enforcePercentage, enforcePixels } from './EnforceUnit';
 
-const placeCaretInCell = (editor: Editor, cell) => {
+const placeCaretInCell = (editor: Editor, cell: SugarElement<HTMLTableCellElement>): void => {
   editor.selection.select(cell.dom, true);
   editor.selection.collapse(true);
 };
 
-const selectFirstCellInTable = (editor: Editor, tableElm) => {
-  SelectorFind.descendant<HTMLTableDataCellElement | HTMLTableHeaderCellElement>(tableElm, 'td,th').each(Fun.curry(placeCaretInCell, editor));
+const selectFirstCellInTable = (editor: Editor, tableElm: SugarElement<HTMLTableElement>): void => {
+  SelectorFind.descendant<HTMLTableCellElement>(tableElm, 'td,th').each(Fun.curry(placeCaretInCell, editor));
 };
 
-const fireEvents = (editor: Editor, table) => {
+const fireEvents = (editor: Editor, table: SugarElement<HTMLTableElement>): void => {
   Arr.each(SelectorFilter.descendants<HTMLTableRowElement>(table, 'tr'), (row) => {
     fireNewRow(editor, row.dom);
 
-    Arr.each(SelectorFilter.descendants<HTMLTableDataCellElement | HTMLTableHeaderCellElement>(row, 'th,td'), (cell) => {
+    Arr.each(SelectorFilter.descendants<HTMLTableDataCellElement>(row, 'th,td'), (cell) => {
       fireNewCell(editor, cell.dom);
     });
   });
 };
 
-const isPercentage = (width: string) => Type.isString(width) && width.indexOf('%') !== -1;
+const isPercentage = (width: string): boolean =>
+  Type.isString(width) && width.indexOf('%') !== -1;
 
 const insert = (editor: Editor, columns: number, rows: number, colHeaders: number, rowHeaders: number): HTMLTableElement => {
   const defaultStyles = getDefaultStyles(editor);
@@ -72,7 +73,7 @@ const insert = (editor: Editor, columns: number, rows: number, colHeaders: numbe
   }).getOr(null);
 };
 
-const insertTableWithDataValidation = (editor: Editor, rows: number, columns: number, options: Record<string, number> = {}, errorMsg: string) => {
+const insertTableWithDataValidation = (editor: Editor, rows: number, columns: number, options: Record<string, number> = {}, errorMsg: string): HTMLTableElement | null => {
   const checkInput = (val: any) => Type.isNumber(val) && val > 0;
 
   if (checkInput(rows) && checkInput(columns)) {

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -19,9 +19,9 @@ import { enforcePercentage, enforcePixels, syncPixels } from './EnforceUnit';
 import * as TableWire from './TableWire';
 
 export interface ResizeHandler {
-  lazyResize: () => Optional<TableResize>;
-  lazyWire: () => any;
-  destroy: () => void;
+  readonly lazyResize: () => Optional<TableResize>;
+  readonly lazyWire: () => any;
+  readonly destroy: () => void;
 }
 
 const barResizerPrefix = 'bar-';

--- a/modules/tinymce/src/plugins/table/main/ts/actions/Styles.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/Styles.ts
@@ -11,9 +11,9 @@ import Tools from 'tinymce/core/api/util/Tools';
 
 const getTDTHOverallStyle = (dom: DOMUtils, elm: Element, name: string): string => {
   const cells = dom.select('td,th', elm);
-  let firstChildStyle: string;
+  let firstChildStyle: string | undefined;
 
-  const checkChildren = (firstChildStyle: string, elms: Element[]) => {
+  const checkChildren = (firstChildStyle: string | undefined, elms: Element[]) => {
     for (let i = 0; i < elms.length; i++) {
       const currentStyle = dom.getStyle(elms[i], name);
       if (typeof firstChildStyle === 'undefined') {
@@ -29,25 +29,25 @@ const getTDTHOverallStyle = (dom: DOMUtils, elm: Element, name: string): string 
   return checkChildren(firstChildStyle, cells);
 };
 
-const applyAlign = (editor: Editor, elm: Element, name: string) => {
+const applyAlign = (editor: Editor, elm: Element, name: string | undefined): void => {
   if (name) {
     editor.formatter.apply('align' + name, {}, elm);
   }
 };
 
-const applyVAlign = (editor: Editor, elm: Element, name: string) => {
+const applyVAlign = (editor: Editor, elm: Element, name: string | undefined): void => {
   if (name) {
     editor.formatter.apply('valign' + name, {}, elm);
   }
 };
 
-const unApplyAlign = (editor: Editor, elm: Element) => {
+const unApplyAlign = (editor: Editor, elm: Element): void => {
   Tools.each('left center right'.split(' '), (name) => {
     editor.formatter.remove('align' + name, {}, elm);
   });
 };
 
-const unApplyVAlign = (editor: Editor, elm: Element) => {
+const unApplyVAlign = (editor: Editor, elm: Element): void => {
   Tools.each('top middle bottom'.split(' '), (name) => {
     editor.formatter.remove('valign' + name, {}, elm);
   });

--- a/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
@@ -31,38 +31,39 @@ type GuardFn = (table: SugarElement<HTMLTableElement>) => boolean;
 type MutateFn = (e1: SugarElement<any>, e2: SugarElement<any>) => void;
 
 export interface TableActions {
-  deleteRow: CombinedTargetsTableAction;
-  deleteColumn: CombinedTargetsTableAction;
-  insertRowsBefore: CombinedTargetsTableAction;
-  insertRowsAfter: CombinedTargetsTableAction;
-  insertColumnsBefore: CombinedTargetsTableAction;
-  insertColumnsAfter: CombinedTargetsTableAction;
-  mergeCells: CombinedTargetsTableAction;
-  unmergeCells: CombinedTargetsTableAction;
-  pasteCells: PasteTableAction;
-  pasteColsBefore: AdvancedPasteTableAction;
-  pasteColsAfter: AdvancedPasteTableAction;
-  pasteRowsBefore: AdvancedPasteTableAction;
-  pasteRowsAfter: AdvancedPasteTableAction;
-  makeCellsHeader: CombinedTargetsTableAction;
-  unmakeCellsHeader: CombinedTargetsTableAction;
-  makeColumnsHeader: CombinedTargetsTableAction;
-  unmakeColumnsHeader: CombinedTargetsTableAction;
-  makeRowsHeader: CombinedTargetsTableAction;
-  makeRowsBody: CombinedTargetsTableAction;
-  makeRowsFooter: CombinedTargetsTableAction;
-  getTableRowType: LookupAction;
-  getTableCellType: LookupAction;
-  getTableColType: LookupAction;
+  readonly deleteRow: CombinedTargetsTableAction;
+  readonly deleteColumn: CombinedTargetsTableAction;
+  readonly insertRowsBefore: CombinedTargetsTableAction;
+  readonly insertRowsAfter: CombinedTargetsTableAction;
+  readonly insertColumnsBefore: CombinedTargetsTableAction;
+  readonly insertColumnsAfter: CombinedTargetsTableAction;
+  readonly mergeCells: CombinedTargetsTableAction;
+  readonly unmergeCells: CombinedTargetsTableAction;
+  readonly pasteCells: PasteTableAction;
+  readonly pasteColsBefore: AdvancedPasteTableAction;
+  readonly pasteColsAfter: AdvancedPasteTableAction;
+  readonly pasteRowsBefore: AdvancedPasteTableAction;
+  readonly pasteRowsAfter: AdvancedPasteTableAction;
+  readonly makeCellsHeader: CombinedTargetsTableAction;
+  readonly unmakeCellsHeader: CombinedTargetsTableAction;
+  readonly makeColumnsHeader: CombinedTargetsTableAction;
+  readonly unmakeColumnsHeader: CombinedTargetsTableAction;
+  readonly makeRowsHeader: CombinedTargetsTableAction;
+  readonly makeRowsBody: CombinedTargetsTableAction;
+  readonly makeRowsFooter: CombinedTargetsTableAction;
+  readonly getTableRowType: LookupAction;
+  readonly getTableCellType: LookupAction;
+  readonly getTableColType: LookupAction;
 }
 
 export const TableActions = (editor: Editor, lazyWire: () => ResizeWire): TableActions => {
-  const isTableBody = (editor: Editor) => SugarNode.name(Util.getBody(editor)) === 'table';
+  const isTableBody = (editor: Editor): boolean =>
+    SugarNode.name(Util.getBody(editor)) === 'table';
 
-  const lastRowGuard = (table: SugarElement<HTMLTableElement>) =>
+  const lastRowGuard = (table: SugarElement<HTMLTableElement>): boolean =>
     isTableBody(editor) === false || TableGridSize.getGridSize(table).rows > 1;
 
-  const lastColumnGuard = (table: SugarElement<HTMLTableElement>) =>
+  const lastColumnGuard = (table: SugarElement<HTMLTableElement>): boolean =>
     isTableBody(editor) === false || TableGridSize.getGridSize(table).columns > 1;
 
   // Optional.none gives the default cloneFormats.

--- a/modules/tinymce/src/plugins/table/main/ts/actions/TableWire.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/TableWire.ts
@@ -12,7 +12,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Util from '../core/Util';
 
-const createContainer = () => {
+const createContainer = (): SugarElement<HTMLDivElement> => {
   const container = SugarElement.fromTag('div');
 
   Css.setAll(container, {
@@ -29,11 +29,11 @@ const createContainer = () => {
   return container;
 };
 
-const get = (editor: Editor, isResizable: (elm: SugarElement<Element>) => boolean) => {
+const get = (editor: Editor, isResizable: (elm: SugarElement<Element>) => boolean): ResizeWire => {
   return editor.inline ? ResizeWire.body(Util.getBody(editor), createContainer(), isResizable) : ResizeWire.only(SugarElement.fromDom(editor.getDoc()), isResizable);
 };
 
-const remove = (editor: Editor, wire: ResizeWire) => {
+const remove = (editor: Editor, wire: ResizeWire): void => {
   if (editor.inline) {
     Remove.remove(wire.parent());
   }

--- a/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Api.ts
@@ -15,23 +15,34 @@ import { ResizeHandler } from '../actions/ResizeHandler';
 import { Clipboard } from '../core/Clipboard';
 import { SelectionTargets } from '../selection/SelectionTargets';
 
-const getClipboardElements = (getClipboard: () => Optional<SugarElement[]>) => (): HTMLElement[] => getClipboard().fold(
+export interface Api {
+  readonly insertTable: (columns: number, rows: number, options?: Record<string, number>) => HTMLTableElement | null;
+  readonly setClipboardRows: (rows: Array<HTMLTableRowElement | HTMLTableColElement>) => void;
+  readonly getClipboardRows: () => Array<HTMLTableRowElement | HTMLTableColElement>;
+  readonly setClipboardCols: (cols: Array<HTMLTableRowElement | HTMLTableColElement>) => void;
+  readonly getClipboardCols: () => Array<HTMLTableRowElement | HTMLTableColElement>;
+  // Internal Apis
+  readonly resizeHandler: ResizeHandler;
+  readonly selectionTargets: SelectionTargets;
+}
+
+const getClipboardElements = <T extends HTMLElement>(getClipboard: () => Optional<SugarElement<T>[]>) => (): T[] => getClipboard().fold(
   () => [],
   (elems) => Arr.map(elems, (e) => e.dom)
 );
 
-const setClipboardElements = (setClipboard: (elems: Optional<SugarElement[]>) => void) => (elems: HTMLElement[]): void => {
+const setClipboardElements = <T extends HTMLElement>(setClipboard: (elems: Optional<SugarElement<T>[]>) => void) => (elems: T[]): void => {
   const elmsOpt = elems.length > 0 ? Optional.some(SugarElements.fromDom(elems)) : Optional.none<SugarElement[]>();
   setClipboard(elmsOpt);
 };
 
-const insertTable = (editor: Editor) => (columns: number, rows: number, options: Record<string, number> = {}) => {
+const insertTable = (editor: Editor) => (columns: number, rows: number, options: Record<string, number> = {}): HTMLTableElement | null => {
   const table = insertTableWithDataValidation(editor, rows, columns, options, 'Invalid values for insertTable - rows and columns values are required to insert a table.');
   editor.undoManager.add();
   return table;
 };
 
-const getApi = (editor: Editor, clipboard: Clipboard, resizeHandler: ResizeHandler, selectionTargets: SelectionTargets) => ({
+const getApi = (editor: Editor, clipboard: Clipboard, resizeHandler: ResizeHandler, selectionTargets: SelectionTargets): Api => ({
   insertTable: insertTable(editor),
   setClipboardRows: setClipboardElements(clipboard.setRows),
   getClipboardRows: getClipboardElements(clipboard.getRows),

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -29,11 +29,13 @@ import { isPercentagesForced, isPixelsForced, isResponsiveForced } from './Setti
 
 type ExecuteAction<T> = (table: SugarElement<HTMLTableElement>, startCell: SugarElement<HTMLTableCellElement>) => T;
 
-const getSelectionStartCellOrCaption = (editor: Editor) => TableSelection.getSelectionCellOrCaption(Util.getSelectionStart(editor), Util.getIsRoot(editor));
+const getSelectionStartCellOrCaption = (editor: Editor): Optional<SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>> =>
+  TableSelection.getSelectionCellOrCaption(Util.getSelectionStart(editor), Util.getIsRoot(editor));
 
-const getSelectionStartCell = (editor: Editor) => TableSelection.getSelectionCell(Util.getSelectionStart(editor), Util.getIsRoot(editor));
+const getSelectionStartCell = (editor: Editor): Optional<SugarElement<HTMLTableCellElement>> =>
+  TableSelection.getSelectionCell(Util.getSelectionStart(editor), Util.getIsRoot(editor));
 
-const registerCommands = (editor: Editor, actions: TableActions, cellSelection: CellSelectionApi, selections: Selections, clipboard: Clipboard) => {
+const registerCommands = (editor: Editor, actions: TableActions, cellSelection: CellSelectionApi, selections: Selections, clipboard: Clipboard): void => {
   const isRoot = Util.getIsRoot(editor);
   const eraseTable = () => getSelectionStartCellOrCaption(editor).each((cellOrCaption) => {
     TableLookup.table(cellOrCaption, isRoot).filter(Fun.not(isRoot)).each((table) => {

--- a/modules/tinymce/src/plugins/table/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Events.ts
@@ -5,9 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Optional } from '@ephox/katamari';
+import { OtherCells } from '@ephox/snooker';
 import { SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 export interface TableEventData {
   readonly structure: boolean;
@@ -18,18 +21,27 @@ export interface TableModifiedEvent extends TableEventData {
   readonly table: HTMLTableElement;
 }
 
-const fireNewRow = (editor: Editor, row: HTMLElement) => editor.fire('newrow', { node: row });
-const fireNewCell = (editor: Editor, cell: HTMLElement) => editor.fire('newcell', { node: cell });
+const fireNewRow = (editor: Editor, row: HTMLTableRowElement): EditorEvent<{ node: HTMLTableRowElement }> =>
+  editor.fire('newrow', { node: row });
 
-const fireObjectResizeStart = (editor: Editor, target: HTMLElement, width: number, height: number, origin: string) => {
+const fireNewCell = (editor: Editor, cell: HTMLTableCellElement): EditorEvent<{ node: HTMLTableCellElement }> =>
+  editor.fire('newcell', { node: cell });
+
+const fireObjectResizeStart = (editor: Editor, target: HTMLElement, width: number, height: number, origin: string): void => {
   editor.fire('ObjectResizeStart', { target, width, height, origin });
 };
 
-const fireObjectResized = (editor: Editor, target: HTMLElement, width: number, height: number, origin: string) => {
+const fireObjectResized = (editor: Editor, target: HTMLElement, width: number, height: number, origin: string): void => {
   editor.fire('ObjectResized', { target, width, height, origin });
 };
 
-const fireTableSelectionChange = (editor: Editor, cells: SugarElement[], start: SugarElement, finish: SugarElement, otherCells) => {
+const fireTableSelectionChange = (
+  editor: Editor,
+  cells: SugarElement<HTMLTableCellElement>[],
+  start: SugarElement<HTMLTableCellElement>,
+  finish: SugarElement<HTMLTableCellElement>,
+  otherCells: Optional<OtherCells.OtherCells>
+): void => {
   editor.fire('TableSelectionChange', {
     cells,
     start,
@@ -38,11 +50,11 @@ const fireTableSelectionChange = (editor: Editor, cells: SugarElement[], start: 
   });
 };
 
-const fireTableSelectionClear = (editor: Editor) => {
+const fireTableSelectionClear = (editor: Editor): void => {
   editor.fire('TableSelectionClear');
 };
 
-const fireTableModified = (editor: Editor, table: HTMLTableElement, data: TableEventData) => {
+const fireTableModified = (editor: Editor, table: HTMLTableElement, data: TableEventData): void => {
   editor.fire('TableModified', { ...data, table });
 };
 

--- a/modules/tinymce/src/plugins/table/main/ts/api/QueryCommands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/QueryCommands.ts
@@ -16,7 +16,7 @@ import * as Util from '../core/Util';
 import * as TableTargets from '../queries/TableTargets';
 import * as TableSelection from '../selection/TableSelection';
 
-const registerQueryCommands = (editor: Editor, actions: TableActions, selections: Selections) => {
+const registerQueryCommands = (editor: Editor, actions: TableActions, selections: Selections): void => {
   const isRoot = Util.getIsRoot(editor);
 
   const lookupOnSelection = (action: LookupAction): string =>
@@ -32,7 +32,6 @@ const registerQueryCommands = (editor: Editor, actions: TableActions, selections
     mceTableCellType: () => lookupOnSelection(actions.getTableCellType),
     mceTableColType: () => lookupOnSelection(actions.getTableColType)
   }, (func, name) => editor.addQueryValueHandler(name, func));
-
 };
 
 export { registerQueryCommands };

--- a/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
@@ -15,8 +15,8 @@ export interface StringMap {
   [key: string]: string;
 }
 
-export type ClassList = Array<{title: string; value: string}>;
-export type MenuItemList = Array<{text: string; value: string}>;
+export type ClassList = Array<{ title: string; value: string }>;
+export type MenuItemList = Array<{ text: string; value: string }>;
 
 type TableSizingMode = 'fixed' | 'relative' | 'responsive' | 'auto';
 
@@ -36,7 +36,7 @@ const defaultCellBorderStyles = Arr.map([ 'Solid', 'Dotted', 'Dashed', 'Double',
   return { text: type, value: type.toLowerCase() };
 });
 
-const determineDefaultStyles = (editor: Editor) => {
+const determineDefaultStyles = (editor: Editor): Record<string, string> => {
   if (isPixelsForced(editor)) {
     const editorWidth = editor.getBody().offsetWidth;
     return { ...defaultStyles, width: editorWidth + 'px' };
@@ -53,32 +53,71 @@ const defaultAttributes = {
 
 const defaultColumnResizingBehaviour = 'preservetable';
 
-const getTableSizingMode = (editor: Editor): TableSizingMode => editor.getParam('table_sizing_mode', 'auto');
-const getTableResponseWidth = (editor: Editor): boolean | undefined => editor.getParam('table_responsive_width');
+const getTableSizingMode = (editor: Editor): TableSizingMode =>
+  editor.getParam('table_sizing_mode', 'auto');
 
-const getTableBorderWidths = (editor: Editor): ClassList => editor.getParam('table_border_widths', defaultCellBorderWidths, 'array');
+const getTableResponseWidth = (editor: Editor): boolean | undefined =>
+  editor.getParam('table_responsive_width');
 
-const getTableBorderStyles = (editor: Editor): MenuItemList => editor.getParam('table_border_styles', defaultCellBorderStyles, 'array');
+const getTableBorderWidths = (editor: Editor): ClassList =>
+  editor.getParam('table_border_widths', defaultCellBorderWidths, 'array');
 
-const getDefaultAttributes = (editor: Editor): StringMap => editor.getParam('table_default_attributes', defaultAttributes, 'object');
-const getDefaultStyles = (editor: Editor): StringMap => editor.getParam('table_default_styles', determineDefaultStyles(editor), 'object');
-const hasTableResizeBars = (editor: Editor): boolean => editor.getParam('table_resize_bars', true, 'boolean');
-const hasTabNavigation = (editor: Editor): boolean => editor.getParam('table_tab_navigation', true, 'boolean');
-const hasAdvancedCellTab = (editor: Editor): boolean => editor.getParam('table_cell_advtab', true, 'boolean');
-const hasAdvancedRowTab = (editor: Editor): boolean => editor.getParam('table_row_advtab', true, 'boolean');
-const hasAdvancedTableTab = (editor: Editor): boolean => editor.getParam('table_advtab', true, 'boolean');
-const hasAppearanceOptions = (editor: Editor): boolean => editor.getParam('table_appearance_options', true, 'boolean');
-const hasTableGrid = (editor: Editor): boolean => editor.getParam('table_grid', true, 'boolean');
-const shouldStyleWithCss = (editor: Editor): boolean => editor.getParam('table_style_by_css', false, 'boolean');
-const getCellClassList = (editor: Editor): ClassList => editor.getParam('table_cell_class_list', [], 'array');
-const getRowClassList = (editor: Editor): ClassList => editor.getParam('table_row_class_list', [], 'array');
-const getTableClassList = (editor: Editor): ClassList => editor.getParam('table_class_list', [], 'array');
-const isPercentagesForced = (editor: Editor): boolean => getTableSizingMode(editor) === 'relative' || getTableResponseWidth(editor) === true;
-const isPixelsForced = (editor: Editor): boolean => getTableSizingMode(editor) === 'fixed' || getTableResponseWidth(editor) === false;
-const isResponsiveForced = (editor: Editor): boolean => getTableSizingMode(editor) === 'responsive';
-const getToolbar = (editor: Editor): string => editor.getParam('table_toolbar', defaultTableToolbar);
+const getTableBorderStyles = (editor: Editor): MenuItemList =>
+  editor.getParam('table_border_styles', defaultCellBorderStyles, 'array');
 
-const useColumnGroup = (editor: Editor): boolean => editor.getParam('table_use_colgroups', false, 'boolean');
+const getDefaultAttributes = (editor: Editor): StringMap =>
+  editor.getParam('table_default_attributes', defaultAttributes, 'object');
+
+const getDefaultStyles = (editor: Editor): StringMap =>
+  editor.getParam('table_default_styles', determineDefaultStyles(editor), 'object');
+
+const hasTableResizeBars = (editor: Editor): boolean =>
+  editor.getParam('table_resize_bars', true, 'boolean');
+
+const hasTabNavigation = (editor: Editor): boolean =>
+  editor.getParam('table_tab_navigation', true, 'boolean');
+
+const hasAdvancedCellTab = (editor: Editor): boolean =>
+  editor.getParam('table_cell_advtab', true, 'boolean');
+
+const hasAdvancedRowTab = (editor: Editor): boolean =>
+  editor.getParam('table_row_advtab', true, 'boolean');
+
+const hasAdvancedTableTab = (editor: Editor): boolean =>
+  editor.getParam('table_advtab', true, 'boolean');
+
+const hasAppearanceOptions = (editor: Editor): boolean =>
+  editor.getParam('table_appearance_options', true, 'boolean');
+
+const hasTableGrid = (editor: Editor): boolean =>
+  editor.getParam('table_grid', true, 'boolean');
+
+const shouldStyleWithCss = (editor: Editor): boolean =>
+  editor.getParam('table_style_by_css', false, 'boolean');
+
+const getCellClassList = (editor: Editor): ClassList =>
+  editor.getParam('table_cell_class_list', [], 'array');
+
+const getRowClassList = (editor: Editor): ClassList =>
+  editor.getParam('table_row_class_list', [], 'array');
+
+const getTableClassList = (editor: Editor): ClassList =>
+  editor.getParam('table_class_list', [], 'array');
+
+const isPercentagesForced = (editor: Editor): boolean =>
+  getTableSizingMode(editor) === 'relative' || getTableResponseWidth(editor) === true;
+
+const isPixelsForced = (editor: Editor): boolean =>
+  getTableSizingMode(editor) === 'fixed' || getTableResponseWidth(editor) === false;
+
+const isResponsiveForced = (editor: Editor): boolean =>
+  getTableSizingMode(editor) === 'responsive';
+
+const getToolbar = (editor: Editor): string =>
+  editor.getParam('table_toolbar', defaultTableToolbar);
+
+const useColumnGroup = (editor: Editor): boolean =>
+  editor.getParam('table_use_colgroups', false, 'boolean');
 
 const getTableHeaderType = (editor: Editor): string => {
   const defaultValue = 'section';
@@ -97,8 +136,11 @@ const getColumnResizingBehaviour = (editor: Editor): 'preservetable' | 'resizeta
   return Arr.find(validModes, (mode) => mode === givenMode).getOr(defaultColumnResizingBehaviour);
 };
 
-const isPreserveTableColumnResizing = (editor: Editor) => getColumnResizingBehaviour(editor) === 'preservetable';
-const isResizeTableColumnResizing = (editor: Editor) => getColumnResizingBehaviour(editor) === 'resizetable';
+const isPreserveTableColumnResizing = (editor: Editor): boolean =>
+  getColumnResizingBehaviour(editor) === 'preservetable';
+
+const isResizeTableColumnResizing = (editor: Editor): boolean =>
+  getColumnResizingBehaviour(editor) === 'resizetable';
 
 const getCloneElements = (editor: Editor): Optional<string[]> => {
   const cloneElements = editor.getParam('table_clone_elements');

--- a/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Clipboard.ts
@@ -9,22 +9,22 @@ import { Optional, Singleton } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 export interface Clipboard {
-  getRows: () => Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>;
-  setRows: (rows: Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>) => void;
-  clearRows: () => void;
+  readonly getRows: () => Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>;
+  readonly setRows: (rows: Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>) => void;
+  readonly clearRows: () => void;
 
-  getColumns: () => Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>;
-  setColumns: (columns: Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>) => void;
-  clearColumns: () => void;
+  readonly getColumns: () => Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>;
+  readonly setColumns: (columns: Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>) => void;
+  readonly clearColumns: () => void;
 }
 
 export const Clipboard = (): Clipboard => {
-  const rows = Singleton.value<SugarElement<HTMLTableRowElement>[]>();
+  const rows = Singleton.value<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>();
   const cols = Singleton.value<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>();
 
   return {
     getRows: rows.get,
-    setRows: (r: Optional<SugarElement<HTMLTableRowElement>[]>) => {
+    setRows: (r: Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]>) => {
       r.fold(rows.clear, rows.set);
       cols.clear();
     },

--- a/modules/tinymce/src/plugins/table/main/ts/core/TableFormats.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/TableFormats.ts
@@ -50,7 +50,7 @@ const cellFormats = {
   }
 };
 
-const registerFormats = (editor: Editor) => {
+const registerFormats = (editor: Editor): void => {
   editor.formatter.register(cellFormats);
 };
 

--- a/modules/tinymce/src/plugins/table/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Util.ts
@@ -11,21 +11,28 @@ import { Attribute, Compare, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getNodeName = (elm: Node) => elm.nodeName.toLowerCase();
+const getNodeName = (elm: Node): string =>
+  elm.nodeName.toLowerCase();
 
-const getBody = (editor: Editor) => SugarElement.fromDom(editor.getBody());
+const getBody = (editor: Editor): SugarElement<HTMLElement> =>
+  SugarElement.fromDom(editor.getBody());
 
-const getPixelWidth = (elm: HTMLElement) => elm.getBoundingClientRect().width;
+const getPixelWidth = (elm: HTMLElement): number =>
+  elm.getBoundingClientRect().width;
 
-const getPixelHeight = (elm: HTMLElement) => elm.getBoundingClientRect().height;
+const getPixelHeight = (elm: HTMLElement): number =>
+  elm.getBoundingClientRect().height;
 
-const getIsRoot = (editor: Editor) => (element: SugarElement) => Compare.eq(element, getBody(editor));
+const getIsRoot = (editor: Editor) => (element: SugarElement<Node>): boolean =>
+  Compare.eq(element, getBody(editor));
 
-const removePxSuffix = (size: string) => size ? size.replace(/px$/, '') : '';
+const removePxSuffix = (size: string): string =>
+  size ? size.replace(/px$/, '') : '';
 
-const addPxSuffix = (size: string): string => /^\d+(\.\d+)?$/.test(size) ? size + 'px' : size;
+const addPxSuffix = (size: string): string =>
+  /^\d+(\.\d+)?$/.test(size) ? size + 'px' : size;
 
-const removeDataStyle = (table: SugarElement<HTMLElement>): void => {
+const removeDataStyle = (table: SugarElement<HTMLTableElement>): void => {
   Attribute.remove(table, 'data-mce-style');
 
   const removeStyleAttribute = (element: SugarElement<HTMLElement>) => Attribute.remove(element, 'data-mce-style');
@@ -42,11 +49,14 @@ const getRawWidth = (editor: Editor, elm: HTMLElement): Optional<string> => {
 const isPercentage = (value: string): boolean => /^(\d+(\.\d+)?)%$/.test(value);
 const isPixel = (value: string): boolean => /^(\d+(\.\d+)?)px$/.test(value);
 
-const getSelectionStart = (editor: Editor) => SugarElement.fromDom(editor.selection.getStart());
+const getSelectionStart = (editor: Editor): SugarElement<Element> =>
+  SugarElement.fromDom(editor.selection.getStart());
 
-const getSelectionEnd = (editor: Editor) => SugarElement.fromDom(editor.selection.getEnd());
+const getSelectionEnd = (editor: Editor): SugarElement<Element> =>
+  SugarElement.fromDom(editor.selection.getEnd());
 
-const getThunkedSelectionStart = (editor: Editor) => () => SugarElement.fromDom(editor.selection.getStart());
+const getThunkedSelectionStart = (editor: Editor) => (): SugarElement<Element> =>
+  getSelectionStart(editor);
 
 export {
   getNodeName,

--- a/modules/tinymce/src/plugins/table/main/ts/queries/TabContext.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/TabContext.ts
@@ -15,20 +15,18 @@ import VK from 'tinymce/core/api/util/VK';
 import * as Util from '../core/Util';
 import { CellSelectionApi } from '../selection/CellSelection';
 
-const forward = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: SugarElement<HTMLTableCellElement>) => {
-  return go(editor, isRoot, CellNavigation.next(cell, ContentEditable.isEditable));
-};
+const forward = (editor: Editor, isRoot: (e: SugarElement<Node>) => boolean, cell: SugarElement<HTMLTableCellElement>) =>
+  go(editor, isRoot, CellNavigation.next(cell, ContentEditable.isEditable));
 
-const backward = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: SugarElement<HTMLTableCellElement>) => {
-  return go(editor, isRoot, CellNavigation.prev(cell, ContentEditable.isEditable));
-};
+const backward = (editor: Editor, isRoot: (e: SugarElement<Node>) => boolean, cell: SugarElement<HTMLTableCellElement>) =>
+  go(editor, isRoot, CellNavigation.prev(cell, ContentEditable.isEditable));
 
 const getCellFirstCursorPosition = (editor: Editor, cell: SugarElement<Node>): Range => {
   const selection = SimSelection.exact(cell, 0, cell, 0);
   return WindowSelection.toNative(selection);
 };
 
-const go = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: CellLocation): Optional<Range> => {
+const go = (editor: Editor, isRoot: (e: SugarElement<Node>) => boolean, cell: CellLocation): Optional<Range> => {
   return cell.fold<Optional<Range>>(Optional.none, Optional.none, (current, next) => {
     return CursorPosition.first(next).map((cell) => {
       return getCellFirstCursorPosition(editor, cell);
@@ -42,10 +40,10 @@ const go = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: CellLoca
 
 const rootElements = [ 'table', 'li', 'dl' ];
 
-const handle = (event: KeyboardEvent, editor: Editor, cellSelection: CellSelectionApi) => {
+const handle = (event: KeyboardEvent, editor: Editor, cellSelection: CellSelectionApi): void => {
   if (event.keyCode === VK.TAB) {
     const body = Util.getBody(editor);
-    const isRoot = (element) => {
+    const isRoot = (element: SugarElement<Node>) => {
       const name = SugarNode.name(element);
       return Compare.eq(element, body) || Arr.contains(rootElements, name);
     };

--- a/modules/tinymce/src/plugins/table/main/ts/queries/TableSize.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/TableSize.ts
@@ -13,7 +13,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { isPercentagesForced, isPixelsForced } from '../api/Settings';
 import * as Util from '../core/Util';
 
-export const get = (editor: Editor, table: SugarElement<HTMLTableElement>) => {
+export const get = (editor: Editor, table: SugarElement<HTMLTableElement>): TableSize => {
   // Note: We can't enforce none (responsive), as if someone manually resizes a table
   // then it must switch to either pixel (fixed) or percentage (relative) sizing
   if (isPercentagesForced(editor)) {

--- a/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
@@ -21,14 +21,15 @@ import * as Util from '../core/Util';
 import { ephemera } from './Ephemera';
 import { SelectionTargets } from './SelectionTargets';
 
-const hasInternalTarget = (e: Event) => Class.has(SugarElement.fromDom(e.target as HTMLElement), 'ephox-snooker-resizer-bar') === false;
+const hasInternalTarget = (e: Event): boolean =>
+  Class.has(SugarElement.fromDom(e.target as Node), 'ephox-snooker-resizer-bar') === false;
 
 export interface CellSelectionApi {
-  clear: (container: SugarElement) => void;
+  readonly clear: (container: SugarElement<Node>) => void;
 }
 
 export default (editor: Editor, lazyResize: () => Optional<TableResize>, selectionTargets: SelectionTargets): CellSelectionApi => {
-  const onSelection = (cells: SugarElement[], start: SugarElement, finish: SugarElement) => {
+  const onSelection = (cells: SugarElement<HTMLTableCellElement>[], start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => {
     selectionTargets.targets().each((targets) => {
       const tableOpt = TableLookup.table(start);
       tableOpt.each((table) => {
@@ -62,7 +63,7 @@ export default (editor: Editor, lazyResize: () => Optional<TableResize>, selecti
     const mouseHandlers = InputHandlers.mouse(win, body, isRoot, annotations);
     const keyHandlers = InputHandlers.keyboard(win, body, isRoot, annotations);
     const external = InputHandlers.external(win, body, isRoot, annotations);
-    const hasShiftKey = (event) => event.raw.shiftKey === true;
+    const hasShiftKey = (event: EventArgs<KeyboardEvent>) => event.raw.shiftKey === true;
 
     editor.on('TableSelectorChange', (e) => external(e.start, e.finish));
 

--- a/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
@@ -197,6 +197,6 @@ export const getSelectionTargets = (editor: Editor, selections: Selections): Sel
     onSetupTableWithCaption,
     onSetupTableRowHeaders,
     onSetupTableColumnHeaders,
-    targets: () => targets.get()
+    targets: targets.get
   };
 };

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
@@ -15,14 +15,14 @@ import { SelectionTargets, LockedDisable } from '../selection/SelectionTargets';
 import { verticalAlignValues } from './CellAlignValues';
 import { applyTableCellStyle, changeColumnHeader, changeRowHeader, filterNoneItem, generateColorSelector, generateItemsCallback } from './UiUtils';
 
-const addButtons = (editor: Editor, selections: Selections, selectionTargets: SelectionTargets, clipboard: Clipboard) => {
+const addButtons = (editor: Editor, selections: Selections, selectionTargets: SelectionTargets, clipboard: Clipboard): void => {
   editor.ui.registry.addMenuButton('table', {
     tooltip: 'Table',
     icon: 'table',
     fetch: (callback) => callback('inserttable | cell row column | advtablesort | tableprops deletetable')
   });
 
-  const cmd = (command) => () => editor.execCommand(command);
+  const cmd = (command: string) => () => editor.execCommand(command);
 
   editor.ui.registry.addButton('tableprops', {
     tooltip: 'Table properties',
@@ -286,7 +286,7 @@ const addButtons = (editor: Editor, selections: Selections, selectionTargets: Se
   });
 };
 
-const addToolbars = (editor: Editor) => {
+const addToolbars = (editor: Editor): void => {
   const isTable = (table: Node) => editor.dom.is(table, 'table') && editor.getBody().contains(table);
 
   const toolbar = getToolbar(editor);

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -24,14 +24,14 @@ import { DomModifier } from './DomModifier';
 import * as Helpers from './Helpers';
 
 type CellData = Helpers.CellData;
+
 interface SelectedCell {
-  element: HTMLTableCellElement;
-  column: Optional<HTMLTableColElement>;
+  readonly element: HTMLTableCellElement;
+  readonly column: Optional<HTMLTableColElement>;
 }
 
 const getSelectedCells = (table: SugarElement<HTMLTableElement>, cells: SugarElement<HTMLTableCellElement>[]): SelectedCell[] => {
   const warehouse = Warehouse.fromTable(table);
-
   const allCells = Warehouse.justCells(warehouse);
 
   const filtered = Arr.filter(allCells, (cellA) =>
@@ -46,14 +46,14 @@ const getSelectedCells = (table: SugarElement<HTMLTableElement>, cells: SugarEle
   }));
 };
 
-const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data: CellData) => {
+const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data: CellData): void => {
   modifier.setAttrib('scope', data.scope);
   modifier.setAttrib('class', data.class);
   modifier.setStyle('height', Util.addPxSuffix(data.height));
   colModifier.setStyle('width', Util.addPxSuffix(data.width));
 };
 
-const updateAdvancedProps = (modifier: DomModifier, data: CellData) => {
+const updateAdvancedProps = (modifier: DomModifier, data: CellData): void => {
   modifier.setFormat('tablecellbackgroundcolor', data.backgroundcolor);
   modifier.setFormat('tablecellbordercolor', data.bordercolor);
   modifier.setFormat('tablecellborderstyle', data.borderstyle);
@@ -73,7 +73,7 @@ const updateAdvancedProps = (modifier: DomModifier, data: CellData) => {
   how as part of this, it doesn't remove any original alignment before
   applying any specified alignment.
  */
-const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData) => {
+const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData): void => {
   const isSingleCell = cells.length === 1;
   Arr.each(cells, (item) => {
     const cellElm = item.element;
@@ -106,13 +106,13 @@ const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData) =
   });
 };
 
-const applyStructureData = (editor: Editor, data: CellData) => {
+const applyStructureData = (editor: Editor, data: CellData): void => {
   // Switch cell type if applicable. Note that we specifically tell the command to not fire events
   // as we'll batch the events and fire a `TableModified` event at the end of the updates.
   editor.execCommand('mceTableCellType', false, { type: data.celltype, no_events: true });
 };
 
-const applyCellData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[], oldData: CellData, data: CellData) => {
+const applyCellData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[], oldData: CellData, data: CellData): void => {
   const modifiedData = Obj.filter(data, (value, key) => oldData[key] !== value);
 
   if (Obj.size(modifiedData) > 0 && cells.length >= 1) {
@@ -143,8 +143,8 @@ const applyCellData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>
   }
 };
 
-const onSubmitCellForm = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[], oldData: CellData, api) => {
-  const data: CellData = api.getData();
+const onSubmitCellForm = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[], oldData: CellData, api: Dialog.DialogInstanceApi<CellData>): void => {
+  const data = api.getData();
   api.close();
 
   editor.undoManager.transact(() => {
@@ -153,7 +153,7 @@ const onSubmitCellForm = (editor: Editor, cells: SugarElement<HTMLTableCellEleme
   });
 };
 
-const getData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[]) => {
+const getData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[]): CellData => {
   const cellsData = TableLookup.table(cells[0]).map((table) =>
     Arr.map(getSelectedCells(table, cells), (item) =>
       Helpers.extractDataFromCellElement(editor, item.element, hasAdvancedCellTab(editor), item.column)
@@ -163,7 +163,7 @@ const getData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[]) =>
   return Helpers.getSharedValues<CellData>(cellsData.getOrDie());
 };
 
-const open = (editor: Editor, selections: Selections) => {
+const open = (editor: Editor, selections: Selections): void => {
   const cells = TableSelection.getCellsFromSelection(selections);
 
   // Check if there are any cells to operate on

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
@@ -78,7 +78,8 @@ const children: Dialog.BodyComponentSpec[] = [
   }
 ];
 
-const getItems = (editor: Editor): Dialog.BodyComponentSpec[] => children.concat(getClassList(editor).toArray());
+const getItems = (editor: Editor): Dialog.BodyComponentSpec[] =>
+  children.concat(getClassList(editor).toArray());
 
 export {
   getItems

--- a/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
@@ -11,20 +11,20 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 import { getTableBorderStyles } from '../api/Settings';
 
 interface ClassListValue {
-  title?: string;
-  text?: string;
-  value: string;
+  readonly title?: string;
+  readonly text?: string;
+  readonly value: string;
 }
 
 interface ClassListGroup {
-  title?: string;
-  text?: string;
-  menu: ClassListItem[];
+  readonly title?: string;
+  readonly text?: string;
+  readonly menu: ClassListItem[];
 }
 
 type ClassListItem = ClassListValue | ClassListGroup;
 
-const getAdvancedTab = (editor: Editor, dialogName: 'table' | 'row' | 'cell') => {
+const getAdvancedTab = (editor: Editor, dialogName: 'table' | 'row' | 'cell'): Dialog.TabSpec => {
   const advTabItems: Dialog.BodyComponentSpec[] = [
     {
       name: 'borderstyle',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/DomModifier.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/DomModifier.ts
@@ -8,9 +8,9 @@
 import Editor from 'tinymce/core/api/Editor';
 
 export interface DomModifier {
-  setAttrib: (attr: string, value: string) => void;
-  setStyle: (prop: string, value: string) => void;
-  setFormat: (formatName: string, value: string) => void;
+  readonly setAttrib: (attr: string, value: string) => void;
+  readonly setStyle: (prop: string, value: string) => void;
+  readonly setFormat: (formatName: string, value: string) => void;
 }
 
 // The get node is required here because it can be transformed

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -22,17 +22,24 @@ import * as Util from '../core/Util';
  * @private
  */
 
+interface AdvancedStyles {
+  readonly borderwidth: string;
+  readonly borderstyle: string;
+  readonly bordercolor: string;
+  readonly backgroundcolor: string;
+}
+
 // Note: Need to use a types here, as types are iterable whereas interfaces are not
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type TableData = {
-  height: string;
-  width: string;
-  cellspacing: string;
-  cellpadding: string;
-  caption: boolean;
+  readonly height: string;
+  readonly width: string;
+  readonly cellspacing: string;
+  readonly cellpadding: string;
+  readonly caption: boolean;
+  readonly align: string;
+  readonly border: string;
   class?: string;
-  align: string;
-  border: string;
   cols?: string;
   rows?: string;
   borderstyle?: string;
@@ -42,47 +49,48 @@ export type TableData = {
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type RowData = {
-  height: string;
-  class: string;
-  align: string;
-  type: string;
-  borderstyle?: string;
-  bordercolor?: string;
-  backgroundcolor?: string;
+  readonly height: string;
+  readonly class: string;
+  readonly align: string;
+  readonly type: string;
+  readonly borderstyle?: string;
+  readonly bordercolor?: string;
+  readonly backgroundcolor?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type CellData = {
-  width: string;
-  height: string;
-  scope: string;
-  celltype: 'td' | 'th';
-  class: string;
-  halign: string;
-  valign: string;
-  borderwidth?: string;
-  borderstyle?: string;
-  bordercolor?: string;
-  backgroundcolor?: string;
+  readonly width: string;
+  readonly height: string;
+  readonly scope: string;
+  readonly celltype: 'td' | 'th';
+  readonly class: string;
+  readonly halign: string;
+  readonly valign: string;
+  readonly borderwidth?: string;
+  readonly borderstyle?: string;
+  readonly bordercolor?: string;
+  readonly backgroundcolor?: string;
 };
 
 interface ClassListValue {
-  title?: string;
-  text?: string;
-  value: string;
+  readonly title?: string;
+  readonly text?: string;
+  readonly value: string;
 }
 
 interface ClassListGroup {
-  title?: string;
-  text?: string;
-  menu: ClassListItem[];
+  readonly title?: string;
+  readonly text?: string;
+  readonly menu: ClassListItem[];
 }
 
 type ClassListItem = ClassListValue | ClassListGroup;
 
 type InternalClassListItem = Dialog.ListBoxItemSpec;
 
-const isListGroup = (item: ClassListItem): item is ClassListGroup => Obj.hasNonNullableKey(item as Record<string, any>, 'menu');
+const isListGroup = (item: ClassListItem): item is ClassListGroup =>
+  Obj.hasNonNullableKey(item as Record<string, any>, 'menu');
 
 const buildListItems = (inputList: ClassListItem[], startItems?: InternalClassListItem[]): InternalClassListItem[] => {
   // Used to also take a callback (that in all instances applied an item.textStyles property using Formatter)
@@ -109,9 +117,10 @@ const buildListItems = (inputList: ClassListItem[], startItems?: InternalClassLi
   return appendItems(inputList, startItems || []);
 };
 
-const rgbToHex = (dom: DOMUtils) => (value: string) => Strings.startsWith(value, 'rgb') ? dom.toHex(value) : value;
+const rgbToHex = (dom: DOMUtils) => (value: string): string =>
+  Strings.startsWith(value, 'rgb') ? dom.toHex(value) : value;
 
-const extractAdvancedStyles = (dom: DOMUtils, elm: Node) => {
+const extractAdvancedStyles = (dom: DOMUtils, elm: Node): AdvancedStyles => {
   const element = SugarElement.fromDom(elm);
   return {
     borderwidth: Css.getRaw(element, 'border-width').getOr(''),
@@ -121,7 +130,7 @@ const extractAdvancedStyles = (dom: DOMUtils, elm: Node) => {
   };
 };
 
-const getSharedValues = <T>(data: Array<T>) => {
+const getSharedValues = <T>(data: T[]): T => {
   // TODO surely there's a better way to do this??
   // Mutates baseData to return an object that contains only the values
   // that were the same across all objects in data
@@ -147,7 +156,7 @@ const getSharedValues = <T>(data: Array<T>) => {
 // The extractDataFrom... functions are in this file partly for code reuse and partly so we can test them,
 // because some of these are crazy complicated
 
-const getAlignment = (formats: string[], formatName: string, editor: Editor, elm: Node) =>
+const getAlignment = (formats: string[], formatName: string, editor: Editor, elm: Node): string =>
   Arr.find(formats, (name) => !Type.isUndefined(editor.formatter.matchNode(elm, formatName + name))).getOr('');
 const getHAlignment = Fun.curry(getAlignment, [ 'left', 'center', 'right' ], 'align');
 const getVAlignment = Fun.curry(getAlignment, [ 'top', 'middle', 'bottom' ], 'valign');
@@ -276,5 +285,13 @@ const extractDataFromCellElement = (editor: Editor, cell: HTMLTableCellElement, 
   };
 };
 
-export { buildListItems, extractAdvancedStyles, getSharedValues, extractDataFromTableElement, extractDataFromRowElement, extractDataFromCellElement, extractDataFromSettings };
+export {
+  buildListItems,
+  extractAdvancedStyles,
+  getSharedValues,
+  extractDataFromTableElement,
+  extractDataFromRowElement,
+  extractDataFromCellElement,
+  extractDataFromSettings
+};
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -18,7 +18,7 @@ import { SelectionTargets, LockedDisable } from '../selection/SelectionTargets';
 import { verticalAlignValues } from './CellAlignValues';
 import { applyTableCellStyle, changeColumnHeader, changeRowHeader, filterNoneItem, generateColorSelector, generateItems } from './UiUtils';
 
-const addMenuItems = (editor: Editor, selections: Selections, selectionTargets: SelectionTargets, clipboard: Clipboard) => {
+const addMenuItems = (editor: Editor, selections: Selections, selectionTargets: SelectionTargets, clipboard: Clipboard): void => {
   const cmd = (command: string) => () => editor.execCommand(command);
 
   const insertTableAction = (data: { numRows: number; numColumns: number }) => {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -25,18 +25,18 @@ import * as RowDialogGeneralTab from './RowDialogGeneralTab';
 
 type RowData = Helpers.RowData;
 
-const updateSimpleProps = (modifier: DomModifier, data: RowData) => {
+const updateSimpleProps = (modifier: DomModifier, data: RowData): void => {
   modifier.setAttrib('class', data.class);
   modifier.setStyle('height', Util.addPxSuffix(data.height));
 };
 
-const updateAdvancedProps = (modifier: DomModifier, data: RowData) => {
+const updateAdvancedProps = (modifier: DomModifier, data: RowData): void => {
   modifier.setStyle('background-color', data.backgroundcolor);
   modifier.setStyle('border-color', data.bordercolor);
   modifier.setStyle('border-style', data.borderstyle);
 };
 
-const applyStyleData = (editor: Editor, rows: HTMLTableRowElement[], data: RowData, oldData: RowData) => {
+const applyStyleData = (editor: Editor, rows: HTMLTableRowElement[], data: RowData, oldData: RowData): void => {
   const isSingleRow = rows.length === 1;
   Arr.each(rows, (rowElm) => {
     const modifier = isSingleRow ? DomModifier.normal(editor, rowElm) : DomModifier.ifTruthy(editor, rowElm);
@@ -54,13 +54,13 @@ const applyStyleData = (editor: Editor, rows: HTMLTableRowElement[], data: RowDa
   });
 };
 
-const applyStructureData = (editor: Editor, data: RowData) => {
+const applyStructureData = (editor: Editor, data: RowData): void => {
   // Switch cell type if applicable. Note that we specifically tell the command to not fire events
   // as we'll batch the events and fire a `TableModified` event at the end of the updates.
   editor.execCommand('mceTableRowType', false, { type: data.type, no_events: true });
 };
 
-const applyRowData = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowData, data: RowData) => {
+const applyRowData = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowData, data: RowData): void => {
   const modifiedData = Obj.filter(data, (value, key) => oldData[key] !== value);
 
   if (Obj.size(modifiedData) > 0) {
@@ -87,8 +87,8 @@ const applyRowData = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowD
   }
 };
 
-const onSubmitRowForm = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowData, api) => {
-  const data: RowData = api.getData();
+const onSubmitRowForm = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowData, api: Dialog.DialogInstanceApi<RowData>): void => {
+  const data = api.getData();
   api.close();
 
   editor.undoManager.transact(() => {
@@ -97,7 +97,7 @@ const onSubmitRowForm = (editor: Editor, rows: HTMLTableRowElement[], oldData: R
   });
 };
 
-const open = (editor: Editor) => {
+const open = (editor: Editor): void => {
   const rows = TableSelection.getRowsFromSelection(Util.getSelectionStart(editor), ephemera.selected);
 
   // Check if there are any rows to operate on
@@ -106,7 +106,7 @@ const open = (editor: Editor) => {
   }
 
   // Get current data and find shared values between rows
-  const rowsData: RowData[] = Arr.map(rows, (rowElm) => Helpers.extractDataFromRowElement(editor, rowElm.dom, hasAdvancedRowTab(editor)));
+  const rowsData = Arr.map(rows, (rowElm) => Helpers.extractDataFromRowElement(editor, rowElm.dom, hasAdvancedRowTab(editor)));
   const data = Helpers.getSharedValues<RowData>(rowsData);
 
   const dialogTabPanel: Dialog.TabPanelSpec = {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
@@ -55,7 +55,8 @@ const formChildren: Dialog.BodyComponentSpec[] = [
   }
 ];
 
-const getItems = (editor: Editor) => formChildren.concat(getClassList(editor).toArray());
+const getItems = (editor: Editor): Dialog.BodyComponentSpec[] =>
+  formChildren.concat(getClassList(editor).toArray());
 
 export {
   getItems

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -24,7 +24,7 @@ import * as TableDialogGeneralTab from './TableDialogGeneralTab';
 type TableData = Helpers.TableData;
 
 // Explore the layers of the table till we find the first layer of tds or ths
-const styleTDTH = (dom: DOMUtils, elm: Element, name: string | StyleMap, value?: string | number) => {
+const styleTDTH = (dom: DOMUtils, elm: Element, name: string | StyleMap, value?: string | number): void => {
   if (elm.tagName === 'TD' || elm.tagName === 'TH') {
     if (Type.isString(name)) {
       dom.setStyle(elm, name, value);
@@ -40,7 +40,7 @@ const styleTDTH = (dom: DOMUtils, elm: Element, name: string | StyleMap, value?:
   }
 };
 
-const applyDataToElement = (editor: Editor, tableElm, data: TableData) => {
+const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: TableData): void => {
   const dom = editor.dom;
   const attrs: any = {};
   const styles: any = {};
@@ -91,9 +91,8 @@ const applyDataToElement = (editor: Editor, tableElm, data: TableData) => {
 
 };
 
-const onSubmitTableForm = (editor: Editor, tableElm: HTMLTableElement, oldData: TableData, api: Dialog.DialogInstanceApi<TableData>) => {
+const onSubmitTableForm = (editor: Editor, tableElm: HTMLTableElement | undefined, oldData: TableData, api: Dialog.DialogInstanceApi<TableData>): void => {
   const dom = editor.dom;
-  let captionElm;
   const data = api.getData();
   const modifiedData = Obj.filter(data, (value, key) => oldData[key] !== value);
 
@@ -115,7 +114,7 @@ const onSubmitTableForm = (editor: Editor, tableElm: HTMLTableElement, oldData: 
       applyDataToElement(editor, tableElm, data);
 
       // Toggle caption on/off
-      captionElm = dom.select('caption', tableElm)[0];
+      const captionElm = dom.select('caption', tableElm)[0];
 
       if (captionElm && !data.caption || !captionElm && data.caption) {
         editor.execCommand('mceTableToggleCaption');
@@ -141,7 +140,7 @@ const onSubmitTableForm = (editor: Editor, tableElm: HTMLTableElement, oldData: 
   });
 };
 
-const open = (editor: Editor, insertNewTable: boolean) => {
+const open = (editor: Editor, insertNewTable: boolean): void => {
   const dom = editor.dom;
   let tableElm: Element;
   let data = Helpers.extractDataFromSettings(editor, hasAdvancedTableTab(editor));

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialogGeneralTab.ts
@@ -10,7 +10,7 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import { hasAppearanceOptions } from '../api/Settings';
 
-const getItems = (editor: Editor, classes: Dialog.ListBoxItemSpec[], insertNewTable: boolean) => {
+const getItems = (editor: Editor, classes: Dialog.ListBoxItemSpec[], insertNewTable: boolean): Dialog.BodyComponentSpec[] => {
   const rowColCountItems: Dialog.BodyComponentSpec[] = !insertNewTable ? [] : [
     {
       type: 'input',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -19,7 +19,7 @@ interface Item {
 }
 
 const onSetupToggle = (editor: Editor, selections: Selections, formatName: string, formatValue: string) => {
-  return (api: Toolbar.ToolbarMenuButtonInstanceApi) => {
+  return (api: Toolbar.ToolbarMenuButtonInstanceApi): () => void => {
     const boundCallback = Singleton.unbindable();
     const isNone = Strings.isEmpty(formatValue);
 
@@ -47,11 +47,11 @@ const onSetupToggle = (editor: Editor, selections: Selections, formatName: strin
   };
 };
 
-const applyTableCellStyle = <T extends Item>(editor: Editor, style: string) =>
-  (item: T) =>
-    editor.execCommand('mceTableApplyCellStyle', false, { [style]: item.value });
+const applyTableCellStyle = <T extends Item>(editor: Editor, style: string) => (item: T): void => {
+  editor.execCommand('mceTableApplyCellStyle', false, { [style]: item.value });
+};
 
-const filterNoneItem = <T extends Item>(list: T[]) =>
+const filterNoneItem = <T extends Item>(list: T[]): T[] =>
   Arr.filter(list, (item) => Strings.isNotEmpty(item.value));
 
 const generateItem = <T extends Item>(editor: Editor, selections: Selections, item: T, format: string, extractText: (item: T) => string, onAction: (item: T) => void): Menu.ToggleMenuItemSpec => ({
@@ -65,10 +65,10 @@ const generateItems = <T extends Item>(editor: Editor, selections: Selections, i
   Arr.map(items, (item) => generateItem(editor, selections, item, format, extractText, onAction));
 
 const generateItemsCallback = <T extends Item>(editor: Editor, selections: Selections, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void) =>
-  (callback: (items: Menu.ToggleMenuItemSpec[]) => void) =>
+  (callback: (items: Menu.ToggleMenuItemSpec[]) => void): void =>
     callback(generateItems(editor, selections, items, format, extractText, onAction));
 
-const fixColorValue = (value: string, setColor: (colorValue: string) => void) => {
+const fixColorValue = (value: string, setColor: (colorValue: string) => void): void => {
   if (value === 'remove') {
     setColor('');
   } else {
@@ -90,13 +90,13 @@ const generateColorSelector = (editor: Editor, colorList: Menu.ChoiceMenuItemSpe
   }
 }];
 
-const changeRowHeader = (editor: Editor) => () => {
+const changeRowHeader = (editor: Editor) => (): void => {
   const currentType = editor.queryCommandValue('mceTableRowType');
   const newType = currentType === 'header' ? 'body' : 'header';
   editor.execCommand('mceTableRowType', false, { type: newType });
 };
 
-const changeColumnHeader = (editor: Editor) => () => {
+const changeColumnHeader = (editor: Editor) => (): void => {
   const currentType = editor.queryCommandValue('mceTableColType');
   const newType = currentType === 'th' ? 'td' : 'th';
   editor.execCommand('mceTableColType', false, { type: newType });

--- a/modules/tinymce/src/plugins/template/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/Plugin.ts
@@ -11,7 +11,7 @@ import * as Commands from './api/Commands';
 import * as FilterContent from './core/FilterContent';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('template', (editor) => {
     Buttons.register(editor);
     Commands.register(editor);

--- a/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/api/Commands.ts
@@ -10,15 +10,14 @@ import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 import * as Templates from '../core/Templates';
+import { ExternalTemplate } from '../core/Types';
 import * as Dialog from '../ui/Dialog';
 
-const showDialog = (editor: Editor) => {
-  return (templates) => {
-    Dialog.open(editor, templates);
-  };
+const showDialog = (editor: Editor) => (templates: ExternalTemplate[]): void => {
+  Dialog.open(editor, templates);
 };
 
-const register = (editor) => {
+const register = (editor: Editor): void => {
   editor.addCommand('mceInsertTemplate', Fun.curry(Templates.insertTemplate, editor));
   editor.addCommand('mceTemplate', Templates.createTemplateList(editor, showDialog(editor)));
 };

--- a/modules/tinymce/src/plugins/template/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/api/Settings.ts
@@ -7,32 +7,46 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const getCreationDateClasses = (editor: Editor) => editor.getParam('template_cdate_classes', 'cdate');
+import { ExternalTemplate, TemplateValues } from '../core/Types';
 
-const getModificationDateClasses = (editor: Editor) => editor.getParam('template_mdate_classes', 'mdate');
+type TemplateCallback = (callback: (templates: ExternalTemplate[]) => void) => void;
 
-const getSelectedContentClasses = (editor: Editor) => editor.getParam('template_selected_content_classes', 'selcontent');
+const getCreationDateClasses = (editor: Editor): string =>
+  editor.getParam('template_cdate_classes', 'cdate');
 
-const getPreviewReplaceValues = (editor: Editor) => editor.getParam('template_preview_replace_values');
+const getModificationDateClasses = (editor: Editor): string =>
+  editor.getParam('template_mdate_classes', 'mdate');
 
-const getContentStyle = (editor: Editor): string => editor.getParam('content_style', '', 'string');
+const getSelectedContentClasses = (editor: Editor): string =>
+  editor.getParam('template_selected_content_classes', 'selcontent');
 
-const shouldUseContentCssCors = (editor: Editor): boolean => editor.getParam('content_css_cors', false, 'boolean');
+const getPreviewReplaceValues = (editor: Editor): TemplateValues | undefined =>
+  editor.getParam('template_preview_replace_values');
 
-const getTemplateReplaceValues = (editor: Editor) => editor.getParam('template_replace_values');
+const getContentStyle = (editor: Editor): string =>
+  editor.getParam('content_style', '', 'string');
 
-const getTemplates = (editor: Editor) => editor.getParam('templates');
+const shouldUseContentCssCors = (editor: Editor): boolean =>
+  editor.getParam('content_css_cors', false, 'boolean');
 
-const getCdateFormat = (editor: Editor) => editor.getParam('template_cdate_format', editor.translate('%Y-%m-%d'));
+const getTemplateReplaceValues = (editor: Editor): TemplateValues | undefined =>
+  editor.getParam('template_replace_values');
 
-const getMdateFormat = (editor: Editor) => editor.getParam('template_mdate_format', editor.translate('%Y-%m-%d'));
+const getTemplates = (editor: Editor): string | ExternalTemplate[] | TemplateCallback | undefined =>
+  editor.getParam('templates');
 
-const getBodyClassFromHash = (editor: Editor) => {
+const getCdateFormat = (editor: Editor): string =>
+  editor.getParam('template_cdate_format', editor.translate('%Y-%m-%d'));
+
+const getMdateFormat = (editor: Editor): string =>
+  editor.getParam('template_mdate_format', editor.translate('%Y-%m-%d'));
+
+const getBodyClassFromHash = (editor: Editor): string => {
   const bodyClass = editor.getParam('body_class', '', 'hash');
   return bodyClass[editor.id] || '';
 };
 
-const getBodyClass = (editor: Editor) => {
+const getBodyClass = (editor: Editor): string => {
   const bodyClass = editor.getParam('body_class', '', 'string');
 
   if (bodyClass.indexOf('=') === -1) {

--- a/modules/tinymce/src/plugins/template/main/ts/core/DateTimeHelper.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/DateTimeHelper.ts
@@ -5,7 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const addZeros = (value, len) => {
+import Editor from 'tinymce/core/api/Editor';
+
+const addZeros = (value: string | number, len: number): string => {
   value = '' + value;
 
   if (value.length < len) {
@@ -17,18 +19,16 @@ const addZeros = (value, len) => {
   return value;
 };
 
-const getDateTime = (editor, fmt, date?) => {
+const getDateTime = (editor: Editor, fmt: string, date: Date = new Date()): string => {
   const daysShort = 'Sun Mon Tue Wed Thu Fri Sat Sun'.split(' ');
   const daysLong = 'Sunday Monday Tuesday Wednesday Thursday Friday Saturday Sunday'.split(' ');
   const monthsShort = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ');
   const monthsLong = 'January February March April May June July August September October November December'.split(' ');
 
-  date = date || new Date();
-
   fmt = fmt.replace('%D', '%m/%d/%Y');
   fmt = fmt.replace('%r', '%I:%M:%S %p');
   fmt = fmt.replace('%Y', '' + date.getFullYear());
-  fmt = fmt.replace('%y', '' + date.getYear());
+  fmt = fmt.replace('%y', '' + (date as any).getYear());
   fmt = fmt.replace('%m', addZeros(date.getMonth() + 1, 2));
   fmt = fmt.replace('%d', addZeros(date.getDate(), 2));
   fmt = fmt.replace('%H', '' + addZeros(date.getHours(), 2));

--- a/modules/tinymce/src/plugins/template/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/FilterContent.ts
@@ -12,7 +12,7 @@ import * as Settings from '../api/Settings';
 import * as DateTimeHelper from './DateTimeHelper';
 import * as Templates from './Templates';
 
-const setup = (editor: Editor) => {
+const setup = (editor: Editor): void => {
   editor.on('PreProcess', (o) => {
     const dom = editor.dom, dateFormat = Settings.getMdateFormat(editor);
 

--- a/modules/tinymce/src/plugins/template/main/ts/core/Types.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/Types.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Optional } from '@ephox/katamari';
+
+export interface UrlTemplate {
+  readonly title: string;
+  readonly description: string;
+  readonly url: string;
+}
+
+export interface ContentTemplate {
+  readonly title: string;
+  readonly description: string;
+  readonly content: string;
+}
+
+export type ExternalTemplate = UrlTemplate | ContentTemplate;
+
+export interface InternalTemplate {
+  readonly selected: boolean;
+  readonly text: string;
+  readonly value: {
+    readonly url: Optional<string>;
+    readonly content: Optional<string>;
+    readonly description: string;
+  };
+}
+
+export interface DialogData {
+  readonly template: string;
+  readonly preview: string;
+}
+
+export type TemplateValues = Record<string, string | ((name: string) => string)>;

--- a/modules/tinymce/src/plugins/template/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/Utils.ts
@@ -7,7 +7,7 @@
 
 import { Obj } from '@ephox/katamari';
 
-const entitiesAttr = {
+const entitiesAttr: Record<string, string> = {
   '"': '&quot;',
   '<': '&lt;',
   '>': '&gt;',
@@ -15,7 +15,8 @@ const entitiesAttr = {
   '\'': '&#039;'
 };
 
-const htmlEscape = (html: string): string => html.replace(/["'<>&]/g, (match: string) => Obj.get<Record<string, string>, string>(entitiesAttr, match).getOr(match));
+const htmlEscape = (html: string): string =>
+  html.replace(/["'<>&]/g, (match) => Obj.get(entitiesAttr, match).getOr(match));
 
 export {
   htmlEscape

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
@@ -7,8 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor) => {
-
+const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceTemplate');
 
   editor.ui.registry.addButton('template', {

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
@@ -16,40 +16,12 @@ import XHR from 'tinymce/core/api/util/XHR';
 
 import * as Settings from '../api/Settings';
 import * as Templates from '../core/Templates';
+import { DialogData, ExternalTemplate, InternalTemplate, UrlTemplate } from '../core/Types';
 import * as Utils from '../core/Utils';
-
-interface UrlTemplate {
-  title: string;
-  description: string;
-  url: string;
-}
-
-interface ContentTemplate {
-  title: string;
-  description: string;
-  content: string;
-}
-
-type ExternalTemplate = UrlTemplate | ContentTemplate;
-
-interface InternalTemplate {
-  selected: boolean;
-  text: string;
-  value: {
-    url: Optional<string>;
-    content: Optional<string>;
-    description: string;
-  };
-}
-
-interface DialogData {
-  template: string;
-  preview: string;
-}
 
 type UpdateDialogCallback = (dialogApi: Dialog.DialogInstanceApi<DialogData>, template: InternalTemplate, previewHtml: string) => void;
 
-const getPreviewContent = (editor: Editor, html: string) => {
+const getPreviewContent = (editor: Editor, html: string): string => {
   if (html.indexOf('<html>') === -1) {
     let contentCssEntries = '';
     const contentStyle = Settings.getContentStyle(editor);
@@ -105,7 +77,7 @@ const getPreviewContent = (editor: Editor, html: string) => {
   return Templates.replaceTemplateValues(html, Settings.getPreviewReplaceValues(editor));
 };
 
-const open = (editor: Editor, templateList: ExternalTemplate[]) => {
+const open = (editor: Editor, templateList: ExternalTemplate[]): void => {
   const createTemplates = (): Optional<Array<InternalTemplate>> => {
     if (!templateList || templateList.length === 0) {
       const message = editor.translate('No templates defined.');

--- a/modules/tinymce/src/plugins/textpattern/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/Plugin.ts
@@ -13,7 +13,7 @@ import * as Api from './api/Api';
 import * as Settings from './api/Settings';
 import * as Keyboard from './keyboard/Keyboard';
 
-export default () => {
+export default (): void => {
   PluginManager.add('textpattern', (editor) => {
     const patternsState = Cell(Settings.getPatternSet(editor));
 

--- a/modules/tinymce/src/plugins/textpattern/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/api/Api.ts
@@ -10,7 +10,12 @@ import { Arr, Cell, Results } from '@ephox/katamari';
 import { PatternSet, RawPattern } from '../core/PatternTypes';
 import { createPatternSet, denormalizePattern, normalizePattern } from './Pattern';
 
-const get = (patternsState: Cell<PatternSet>) => {
+export interface Api {
+  readonly setPatterns: (newPatterns: RawPattern[]) => void;
+  readonly getPatterns: () => RawPattern[];
+}
+
+const get = (patternsState: Cell<PatternSet>): Api => {
   const setPatterns = (newPatterns: RawPattern[]) => {
     const normalized = Results.partition(Arr.map(newPatterns, normalizePattern));
     if (normalized.errors.length > 0) {

--- a/modules/tinymce/src/plugins/textpattern/main/ts/api/Pattern.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/api/Pattern.ts
@@ -9,9 +9,11 @@ import { Arr, Result, Type } from '@ephox/katamari';
 
 import { BlockPattern, InlineCmdPattern, InlinePattern, Pattern, PatternError, PatternSet, RawPattern } from '../core/PatternTypes';
 
-const isInlinePattern = (pattern: Pattern): pattern is InlinePattern => pattern.type === 'inline-command' || pattern.type === 'inline-format';
+const isInlinePattern = (pattern: Pattern): pattern is InlinePattern =>
+  pattern.type === 'inline-command' || pattern.type === 'inline-format';
 
-const isBlockPattern = (pattern: Pattern): pattern is BlockPattern => pattern.type === 'block-command' || pattern.type === 'block-format';
+const isBlockPattern = (pattern: Pattern): pattern is BlockPattern =>
+  pattern.type === 'block-command' || pattern.type === 'block-format';
 
 const sortPatterns = <T extends Pattern>(patterns: T[]): T[] => Arr.sort(patterns, (a, b) => {
   if (a.start.length === b.start.length) {

--- a/modules/tinymce/src/plugins/textpattern/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/api/Settings.ts
@@ -12,13 +12,13 @@ import Editor from 'tinymce/core/api/Editor';
 import { PatternSet } from '../core/PatternTypes';
 import { createPatternSet, normalizePattern } from './Pattern';
 
-const error = (...args: Parameters<Console['error']>) => {
+const error = (...args: Parameters<Console['error']>): void => {
   const console: Console = Global.console;
   if (console) { // Skip test env
-    if (console.error) { // tslint:disable-line:no-console
-      console.error.apply(console, args); // tslint:disable-line:no-console
+    if (console.error) {
+      console.error.apply(console, args);
     } else {
-      console.log.apply(console, args); // tslint:disable-line:no-console
+      console.log.apply(console, args);
     }
   }
 };

--- a/modules/tinymce/src/plugins/textpattern/main/ts/core/BlockPattern.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/core/BlockPattern.ts
@@ -17,7 +17,7 @@ import { generatePathRange, resolvePathRange } from '../utils/PathRange';
 import * as Utils from '../utils/Utils';
 import { BlockPattern, BlockPatternMatch, Pattern } from './PatternTypes';
 
-const stripPattern = (dom: DOMUtils, block: Node, pattern: BlockPattern) => {
+const stripPattern = (dom: DOMUtils, block: Node, pattern: BlockPattern): void => {
   // The pattern could be across fragmented text nodes, so we need to find the end
   // of the pattern and then remove all elements between the start/end range
   const firstTextNode = TextSearch.textAfter(block, 0, block);
@@ -90,7 +90,7 @@ const findPatterns = (editor: Editor, patterns: BlockPattern[]): BlockPatternMat
   }).getOr([]);
 };
 
-const applyMatches = (editor: Editor, matches: BlockPatternMatch[]) => {
+const applyMatches = (editor: Editor, matches: BlockPatternMatch[]): void => {
   if (matches.length === 0) {
     return;
   }

--- a/modules/tinymce/src/plugins/textpattern/main/ts/core/PatternTypes.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/core/PatternTypes.ts
@@ -17,41 +17,41 @@ export interface RawPattern {
 }
 
 export interface PatternError {
-  message: string;
-  pattern: RawPattern;
+  readonly message: string;
+  readonly pattern: RawPattern;
 }
 
 interface InlineBasePattern {
-  start: string;
-  end: string;
+  readonly start: string;
+  readonly end: string;
 }
 
 export interface InlineFormatPattern extends InlineBasePattern {
-  type: 'inline-format';
-  format: string[];
+  readonly type: 'inline-format';
+  readonly format: string[];
 }
 
 export interface InlineCmdPattern extends InlineBasePattern {
-  type: 'inline-command';
-  cmd: string;
-  value?: any;
+  readonly type: 'inline-command';
+  readonly cmd: string;
+  readonly value?: any;
 }
 
 export type InlinePattern = InlineFormatPattern | InlineCmdPattern;
 
 interface BlockBasePattern {
-  start: string;
+  readonly start: string;
 }
 
 export interface BlockFormatPattern extends BlockBasePattern {
-  type: 'block-format';
-  format: string;
+  readonly type: 'block-format';
+  readonly format: string;
 }
 
 export interface BlockCmdPattern extends BlockBasePattern {
-  type: 'block-command';
-  cmd: string;
-  value?: any;
+  readonly type: 'block-command';
+  readonly cmd: string;
+  readonly value?: any;
 }
 
 export type BlockPattern = BlockFormatPattern | BlockCmdPattern;
@@ -59,19 +59,19 @@ export type BlockPattern = BlockFormatPattern | BlockCmdPattern;
 export type Pattern = InlinePattern | BlockPattern;
 
 export interface PatternSet {
-  inlinePatterns: InlinePattern[];
-  blockPatterns: BlockPattern[];
+  readonly inlinePatterns: InlinePattern[];
+  readonly blockPatterns: BlockPattern[];
 }
 
 interface PatternMatch<T extends Pattern> {
-  pattern: T;
+  readonly pattern: T;
 }
 
 export interface BlockPatternMatch extends PatternMatch<BlockPattern> {
-  range: PathRange;
+  readonly range: PathRange;
 }
 
 export interface InlinePatternMatch extends PatternMatch<InlinePattern> {
-  startRng: PathRange;
-  endRng: PathRange;
+  readonly startRng: PathRange;
+  readonly endRng: PathRange;
 }

--- a/modules/tinymce/src/plugins/textpattern/main/ts/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/keyboard/KeyHandler.ts
@@ -64,21 +64,24 @@ const handleInlineKey = (editor: Editor, patternSet: PatternSet): void => {
   }
 };
 
-const checkKeyEvent = (codes, event, predicate) => {
+const checkKeyEvent = <T>(codes: T[], event: KeyboardEvent, predicate: (code: T, event: KeyboardEvent) => boolean): boolean => {
   for (let i = 0; i < codes.length; i++) {
     if (predicate(codes[i], event)) {
       return true;
     }
   }
+  return false;
 };
 
-const checkKeyCode = (codes, event) => checkKeyEvent(codes, event, (code, event) => {
-  return code === event.keyCode && VK.modifierPressed(event) === false;
-});
+const checkKeyCode = (codes: number[], event: KeyboardEvent): boolean =>
+  checkKeyEvent(codes, event, (code, event) => {
+    return code === event.keyCode && VK.modifierPressed(event) === false;
+  });
 
-const checkCharCode = (chars, event) => checkKeyEvent(chars, event, (chr, event) => {
-  return chr.charCodeAt(0) === event.charCode;
-});
+const checkCharCode = (chars: string[], event: KeyboardEvent): boolean =>
+  checkKeyEvent(chars, event, (chr, event) => {
+    return chr.charCodeAt(0) === event.charCode;
+  });
 
 export {
   handleEnter,

--- a/modules/tinymce/src/plugins/textpattern/main/ts/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/keyboard/Keyboard.ts
@@ -9,17 +9,16 @@ import { Cell } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import VK from 'tinymce/core/api/util/VK';
 
 import { PatternSet } from '../core/PatternTypes';
 import * as KeyHandler from './KeyHandler';
 
-const setup = (editor: Editor, patternsState: Cell<PatternSet>) => {
+const setup = (editor: Editor, patternsState: Cell<PatternSet>): void => {
   const charCodes = [ ',', '.', ';', ':', '!', '?' ];
   const keyCodes = [ 32 ];
 
-  editor.on('keydown', (e: EditorEvent<KeyboardEvent>) => {
+  editor.on('keydown', (e) => {
     if (e.keyCode === 13 && !VK.modifierPressed(e)) {
       if (KeyHandler.handleEnter(editor, patternsState.get())) {
         e.preventDefault();
@@ -27,13 +26,13 @@ const setup = (editor: Editor, patternsState: Cell<PatternSet>) => {
     }
   }, true);
 
-  editor.on('keyup', (e: EditorEvent<KeyboardEvent>) => {
+  editor.on('keyup', (e) => {
     if (KeyHandler.checkKeyCode(keyCodes, e)) {
       KeyHandler.handleInlineKey(editor, patternsState.get());
     }
   });
 
-  editor.on('keypress', (e: EditorEvent<KeyboardEvent>) => {
+  editor.on('keypress', (e) => {
     if (KeyHandler.checkCharCode(charCodes, e)) {
       Delay.setEditorTimeout(editor, () => {
         KeyHandler.handleInlineKey(editor, patternsState.get());

--- a/modules/tinymce/src/plugins/textpattern/main/ts/text/TextSearch.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/text/TextSearch.ts
@@ -17,11 +17,13 @@ const DOM = DOMUtils.DOM;
 
 export type ProcessCallback = (element: Text, offset: number) => number;
 
-const alwaysNext = (startNode: Node) => (node: Node) => startNode === node ? -1 : 0;
+const alwaysNext = (startNode: Node) => (node: Node): number =>
+  startNode === node ? -1 : 0;
 
 // This largely is derived from robins isBoundary check, however it also treats contenteditable=false elements as a boundary
 // See robins `Structure.isEmptyTag` for the list of quasi block elements
-const isBoundary = (dom: DOMUtils) => (node: Node) => dom.isBlock(node) || Arr.contains([ 'BR', 'IMG', 'HR', 'INPUT' ], node.nodeName) || dom.getContentEditable(node) === 'false';
+const isBoundary = (dom: DOMUtils) => (node: Node): boolean =>
+  dom.isBlock(node) || Arr.contains([ 'BR', 'IMG', 'HR', 'INPUT' ], node.nodeName) || dom.getContentEditable(node) === 'false';
 
 // Finds the text node before the specified node, or just returns the node if it's already on a text node
 const textBefore = (node: Node, offset: number, rootNode: Node): Optional<Spot.SpotPoint<Text>> => {

--- a/modules/tinymce/src/plugins/textpattern/main/ts/utils/Marker.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/utils/Marker.ts
@@ -11,12 +11,13 @@ import { PathRange, resolvePathRange } from './PathRange';
 import * as Utils from './Utils';
 
 export interface Marker {
-  prefix: string;
-  start: Node;
-  end: Node;
+  readonly prefix: string;
+  readonly start: Node;
+  readonly end: Node;
 }
 
-const newMarker = (dom: DOMUtils, id: string) => dom.create('span', { 'data-mce-type': 'bookmark', id });
+const newMarker = (dom: DOMUtils, id: string): HTMLSpanElement =>
+  dom.create('span', { 'data-mce-type': 'bookmark', id });
 
 const rangeFromMarker = (dom: DOMUtils, marker: Marker): Range => {
   const rng = dom.createRng();
@@ -41,7 +42,7 @@ const createMarker = (dom: DOMUtils, markerPrefix: string, pathRange: PathRange)
   };
 };
 
-const removeMarker = (dom: DOMUtils, marker: Marker, isRoot: (node: Node) => boolean) => {
+const removeMarker = (dom: DOMUtils, marker: Marker, isRoot: (node: Node) => boolean): void => {
   // Note: Use dom.get() here instead of marker.end/start, as applying the format/command can
   // clone the nodes meaning the old reference isn't usable
   Utils.cleanEmptyNodes(dom, dom.get(marker.prefix + '-end'), isRoot);

--- a/modules/tinymce/src/plugins/textpattern/main/ts/utils/PathRange.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/utils/PathRange.ts
@@ -10,8 +10,8 @@ import { Arr, Optional } from '@ephox/katamari';
 import * as Utils from './Utils';
 
 export interface PathRange {
-  start: number[];
-  end: number[];
+  readonly start: number[];
+  readonly end: number[];
 }
 
 const generatePath = (root: Node, node: Node, offset: number): number[] => {
@@ -39,7 +39,7 @@ const generatePathRange = (root: Node, startNode: Node, startOffset: number, end
   return { start, end };
 };
 
-const resolvePath = (root: Node, path: number[]): Optional<{node: Node; offset: number}> => {
+const resolvePath = (root: Node, path: number[]): Optional<{ node: Node; offset: number }> => {
   const nodePath = path.slice();
   const offset = nodePath.pop();
   const resolvedNode = Arr.foldl(nodePath, (optNode: Optional<Node>, index: number) => optNode.bind((node) => Optional.from(node.childNodes[index])), Optional.some(root));

--- a/modules/tinymce/src/plugins/textpattern/main/ts/utils/Spot.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/utils/Spot.ts
@@ -6,8 +6,8 @@
  */
 
 export interface SpotPoint<T> {
-  container: T;
-  offset: number;
+  readonly container: T;
+  readonly offset: number;
 }
 
 const point = <T>(container: T, offset: number): SpotPoint<T> => ({

--- a/modules/tinymce/src/plugins/textpattern/main/ts/utils/Utils.ts
+++ b/modules/tinymce/src/plugins/textpattern/main/ts/utils/Utils.ts
@@ -17,7 +17,7 @@ import { InlinePattern } from '../core/PatternTypes';
 const isElement = (node: Node): node is HTMLElement => node.nodeType === Node.ELEMENT_NODE;
 const isText = (node: Node): node is Text => node.nodeType === Node.TEXT_NODE;
 
-const cleanEmptyNodes = (dom: DOMUtils, node: Node, isRoot: (e: Node) => boolean) => {
+const cleanEmptyNodes = (dom: DOMUtils, node: Node, isRoot: (e: Node) => boolean): void => {
   // Recursively walk up the tree while we have a parent and the node is empty. If the node is empty, then remove it.
   if (node && dom.isEmpty(node) && !isRoot(node)) {
     const parent = node.parentNode;
@@ -26,7 +26,7 @@ const cleanEmptyNodes = (dom: DOMUtils, node: Node, isRoot: (e: Node) => boolean
   }
 };
 
-const deleteRng = (dom: DOMUtils, rng: Range, isRoot: (e: Node) => boolean, clean = true) => {
+const deleteRng = (dom: DOMUtils, rng: Range, isRoot: (e: Node) => boolean, clean = true): void => {
   const startParent = rng.startContainer.parentNode;
   const endParent = rng.endContainer.parentNode;
   rng.deleteContents();
@@ -51,9 +51,10 @@ const isBlockFormatName = (name: string, formatter: Formatter): boolean => {
   return Type.isArray(formatSet) && Arr.head(formatSet).exists((format) => Obj.has(format as any, 'block'));
 };
 
-const isReplacementPattern = (pattern: InlinePattern) => pattern.start.length === 0;
+const isReplacementPattern = (pattern: InlinePattern): boolean =>
+  pattern.start.length === 0;
 
-const getParentBlock = (editor: Editor, rng: Range) => {
+const getParentBlock = (editor: Editor, rng: Range): Optional<Element> => {
   const parentBlockOpt = Optional.from(editor.dom.getParent(rng.startContainer, editor.dom.isBlock));
   if (Settings.getForcedRootBlock(editor) === '') {
     return parentBlockOpt.orThunk(() => Optional.some(editor.getBody()));
@@ -62,4 +63,12 @@ const getParentBlock = (editor: Editor, rng: Range) => {
   }
 };
 
-export { cleanEmptyNodes, deleteRng, getParentBlock, isBlockFormatName, isElement, isReplacementPattern, isText };
+export {
+  cleanEmptyNodes,
+  deleteRng,
+  getParentBlock,
+  isBlockFormatName,
+  isElement,
+  isReplacementPattern,
+  isText
+};

--- a/modules/tinymce/src/plugins/toc/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/Plugin.ts
@@ -11,7 +11,7 @@ import * as Commands from './api/Commands';
 import * as FilterContent from './core/FilterContent';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('toc', (editor) => {
     Commands.register(editor);
     Buttons.register(editor);

--- a/modules/tinymce/src/plugins/toc/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/api/Commands.ts
@@ -5,9 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Toc from '../core/Toc';
 
-const register = (editor) => {
+const register = (editor: Editor): void => {
   editor.addCommand('mceInsertToc', () => {
     Toc.insertToc(editor);
   });

--- a/modules/tinymce/src/plugins/toc/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/api/Settings.ts
@@ -5,16 +5,17 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const getTocClass = (editor) => {
-  return editor.getParam('toc_class', 'mce-toc');
-};
+import Editor from 'tinymce/core/api/Editor';
 
-const getTocHeader = (editor) => {
+const getTocClass = (editor: Editor): string =>
+  editor.getParam('toc_class', 'mce-toc');
+
+const getTocHeader = (editor: Editor): string => {
   const tagName = editor.getParam('toc_header', 'h2');
   return /^h[1-6]$/.test(tagName) ? tagName : 'h2';
 };
 
-const getTocDepth = (editor) => {
+const getTocDepth = (editor: Editor): number => {
   const depth = parseInt(editor.getParam('toc_depth', '3'), 10);
   return depth >= 1 && depth <= 9 ? depth : 3;
 };

--- a/modules/tinymce/src/plugins/toc/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/core/FilterContent.ts
@@ -5,9 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Settings from '../api/Settings';
 
-const setup = (editor) => {
+const setup = (editor: Editor): void => {
   const $ = editor.$, tocClass = Settings.getTocClass(editor);
 
   editor.on('PreProcess', (e) => {

--- a/modules/tinymce/src/plugins/toc/main/ts/core/Guid.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/core/Guid.ts
@@ -5,10 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const create = (prefix) => {
+const create = (prefix: string): () => string => {
   let counter = 0;
 
-  return () => {
+  return (): string => {
     const guid = new Date().getTime().toString(32);
     return prefix + guid + (counter++).toString(32);
   };

--- a/modules/tinymce/src/plugins/toc/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/ui/Buttons.ts
@@ -19,13 +19,16 @@ const toggleState = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi) 
   return () => editor.on('LoadContent SetContent change', toggleDisabledState);
 };
 
-const isToc = (editor: Editor) => (elm) => elm && editor.dom.is(elm, '.' + Settings.getTocClass(editor)) && editor.getBody().contains(elm);
+const isToc = (editor: Editor) => (elm: Element | null) =>
+  elm && editor.dom.is(elm, '.' + Settings.getTocClass(editor)) && editor.getBody().contains(elm);
 
-const register = (editor: Editor) => {
+const register = (editor: Editor): void => {
+  const insertTocAction = () => editor.execCommand('mceInsertToc');
+
   editor.ui.registry.addButton('toc', {
     icon: 'toc',
     tooltip: 'Table of contents',
-    onAction: () => editor.execCommand('mceInsertToc'),
+    onAction: insertTocAction,
     onSetup: toggleState(editor)
   });
 
@@ -38,7 +41,7 @@ const register = (editor: Editor) => {
   editor.ui.registry.addMenuItem('toc', {
     icon: 'toc',
     text: 'Table of contents',
-    onAction: () => editor.execCommand('mceInsertToc'),
+    onAction: insertTocAction,
     onSetup: toggleState(editor)
   });
 

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/Plugin.ts
@@ -13,7 +13,7 @@ import * as Commands from './api/Commands';
 import * as Bindings from './core/Bindings';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('visualblocks', (editor, pluginUrl) => {
     const enabledState = Cell(false);
 

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/api/Commands.ts
@@ -11,7 +11,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as VisualBlocks from '../core/VisualBlocks';
 
-const register = (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>) => {
+const register = (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>): void => {
   editor.addCommand('mceVisualBlocks', () => {
     VisualBlocks.toggleVisualBlocks(editor, pluginUrl, enabledState);
   });

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/api/Events.ts
@@ -7,7 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const fireVisualBlocks = (editor: Editor, state: boolean) => {
+const fireVisualBlocks = (editor: Editor, state: boolean): void => {
   editor.fire('VisualBlocks', { state });
 };
 

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/api/Settings.ts
@@ -7,9 +7,8 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const isEnabledByDefault = (editor: Editor) => {
-  return editor.getParam('visualblocks_default_state', false, 'boolean');
-};
+const isEnabledByDefault = (editor: Editor): boolean =>
+  editor.getParam('visualblocks_default_state', false, 'boolean');
 
 export {
   isEnabledByDefault

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/core/Bindings.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/core/Bindings.ts
@@ -12,7 +12,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Settings from '../api/Settings';
 import * as VisualBlocks from './VisualBlocks';
 
-const setup = (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>) => {
+const setup = (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>): void => {
   // Prevents the visualblocks from being presented in the preview of formats when that is computed
   editor.on('PreviewFormats AfterPreviewFormats', (e) => {
     if (enabledState.get()) {

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/core/VisualBlocks.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/core/VisualBlocks.ts
@@ -11,7 +11,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Events from '../api/Events';
 
-const toggleVisualBlocks = (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>) => {
+const toggleVisualBlocks = (editor: Editor, pluginUrl: string, enabledState: Cell<boolean>): void => {
   const dom = editor.dom;
 
   dom.toggleClass(editor.getBody(), 'mce-visualblocks');

--- a/modules/tinymce/src/plugins/visualblocks/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/visualblocks/main/ts/ui/Buttons.ts
@@ -8,26 +8,30 @@
 import { Cell } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const toggleActiveState = (editor: Editor, enabledState: Cell<boolean>) => (api) => {
+const toggleActiveState = (editor: Editor, enabledState: Cell<boolean>) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi) => {
   api.setActive(enabledState.get());
-  const editorEventCallback = (e) => api.setActive(e.state);
+  const editorEventCallback = (e: EditorEvent<{ state: boolean }>) => api.setActive(e.state);
   editor.on('VisualBlocks', editorEventCallback);
   return () => editor.off('VisualBlocks', editorEventCallback);
 };
 
-const register = (editor: Editor, enabledState: Cell<boolean>) => {
+const register = (editor: Editor, enabledState: Cell<boolean>): void => {
+  const onAction = () => editor.execCommand('mceVisualBlocks');
+
   editor.ui.registry.addToggleButton('visualblocks', {
     icon: 'visualblocks',
     tooltip: 'Show blocks',
-    onAction: () => editor.execCommand('mceVisualBlocks'),
+    onAction,
     onSetup: toggleActiveState(editor, enabledState)
   });
 
   editor.ui.registry.addToggleMenuItem('visualblocks', {
     text: 'Show blocks',
     icon: 'visualblocks',
-    onAction: () => editor.execCommand('mceVisualBlocks'),
+    onAction,
     onSetup: toggleActiveState(editor, enabledState)
   });
 };

--- a/modules/tinymce/src/plugins/visualchars/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/Plugin.ts
@@ -16,7 +16,7 @@ import * as Bindings from './core/Bindings';
 import * as Keyboard from './core/Keyboard';
 import * as Buttons from './ui/Buttons';
 
-export default () => {
+export default (): void => {
   PluginManager.add('visualchars', (editor) => {
     const toggleState = Cell(Settings.isEnabledByDefault(editor));
 

--- a/modules/tinymce/src/plugins/visualchars/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/api/Api.ts
@@ -5,7 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const get = (toggleState) => {
+import { Cell } from '@ephox/katamari';
+
+export interface Api {
+  readonly isEnabled: () => boolean;
+}
+
+const get = (toggleState: Cell<boolean>): Api => {
   const isEnabled = () => {
     return toggleState.get();
   };

--- a/modules/tinymce/src/plugins/visualchars/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/api/Commands.ts
@@ -5,9 +5,13 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Cell } from '@ephox/katamari';
+
+import Editor from 'tinymce/core/api/Editor';
+
 import * as Actions from '../core/Actions';
 
-const register = (editor, toggleState) => {
+const register = (editor: Editor, toggleState: Cell<boolean>): void => {
   editor.addCommand('mceVisualChars', () => {
     Actions.toggleVisualChars(editor, toggleState);
   });

--- a/modules/tinymce/src/plugins/visualchars/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/api/Events.ts
@@ -5,7 +5,10 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-const fireVisualChars = (editor, state) => {
+import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+
+const fireVisualChars = (editor: Editor, state: boolean): EditorEvent<{ state: boolean }> => {
   return editor.fire('VisualChars', { state });
 };
 

--- a/modules/tinymce/src/plugins/visualchars/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/api/Settings.ts
@@ -7,9 +7,11 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const isEnabledByDefault = (editor: Editor) => editor.getParam('visualchars_default_state', false);
+const isEnabledByDefault = (editor: Editor): boolean =>
+  editor.getParam('visualchars_default_state', false);
 
-const hasForcedRootBlock = (editor: Editor): boolean => editor.getParam('forced_root_block') !== false;
+const hasForcedRootBlock = (editor: Editor): boolean =>
+  editor.getParam('forced_root_block') !== false;
 
 export {
   isEnabledByDefault,

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Actions.ts
@@ -12,7 +12,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Events from '../api/Events';
 import * as VisualChars from './VisualChars';
 
-const applyVisualChars = (editor: Editor, toggleState: Cell<boolean>) => {
+const applyVisualChars = (editor: Editor, toggleState: Cell<boolean>): void => {
   Events.fireVisualChars(editor, toggleState.get());
 
   const body = editor.getBody();
@@ -24,7 +24,7 @@ const applyVisualChars = (editor: Editor, toggleState: Cell<boolean>) => {
 };
 
 // Toggle state and save selection bookmark before applying visualChars
-const toggleVisualChars = (editor: Editor, toggleState: Cell<boolean>) => {
+const toggleVisualChars = (editor: Editor, toggleState: Cell<boolean>): void => {
   toggleState.set(!toggleState.get());
 
   const bookmark = editor.selection.getBookmark();

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Bindings.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Bindings.ts
@@ -11,7 +11,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Actions from './Actions';
 
-const setup = (editor: Editor, toggleState: Cell<boolean>) => {
+const setup = (editor: Editor, toggleState: Cell<boolean>): void => {
   /*
     Note: applyVisualChars does not place a bookmark before modifying the DOM on init.
     This will cause a loss of selection if the following conditions are met:

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Data.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Data.ts
@@ -7,12 +7,14 @@
 
 import { Obj } from '@ephox/katamari';
 
-export const charMap = {
+type CharMap = Record<string, string>;
+
+export const charMap: CharMap = {
   '\u00a0': 'nbsp',
   '\u00ad': 'shy'
 };
 
-export const charMapToRegExp = (charMap, global?) => {
+export const charMapToRegExp = (charMap: CharMap, global?: boolean): RegExp => {
   let regExp = '';
 
   Obj.each(charMap, (_value, key) => {
@@ -22,7 +24,7 @@ export const charMapToRegExp = (charMap, global?) => {
   return new RegExp('[' + regExp + ']', global ? 'g' : '');
 };
 
-export const charMapToSelector = (charMap) => {
+export const charMapToSelector = (charMap: CharMap): string => {
   let selector = '';
   Obj.each(charMap, (value) => {
     if (selector) {

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Html.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Html.ts
@@ -7,9 +7,8 @@
 
 import * as Data from './Data';
 
-const wrapCharWithSpan = (value) => {
-  return '<span data-mce-bogus="1" class="mce-' + Data.charMap[value] + '">' + value + '</span>';
-};
+const wrapCharWithSpan = (value: string): string =>
+  '<span data-mce-bogus="1" class="mce-' + Data.charMap[value] + '">' + value + '</span>';
 
 export {
   wrapCharWithSpan

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Keyboard.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Keyboard.ts
@@ -5,13 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Cell } from '@ephox/katamari';
+
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
 
 import * as Settings from '../api/Settings';
 import * as VisualChars from './VisualChars';
 
-const setup = (editor: Editor, toggleState) => {
+const setup = (editor: Editor, toggleState: Cell<boolean>): void => {
   const debouncedToggle = Delay.debounce(() => {
     VisualChars.toggle(editor);
   }, 300);

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Nodes.ts
@@ -11,7 +11,7 @@ import { SugarElement, SugarNode } from '@ephox/sugar';
 import * as Data from './Data';
 import * as Html from './Html';
 
-const isMatch = (n: SugarElement) => {
+const isMatch = (n: SugarElement<Node>): n is SugarElement<Text> => {
   const value = SugarNode.value(n);
   return SugarNode.isText(n) &&
     value !== undefined &&
@@ -19,8 +19,8 @@ const isMatch = (n: SugarElement) => {
 };
 
 // inlined sugars PredicateFilter.descendants for file size
-const filterDescendants = (scope: SugarElement, predicate: (x: SugarElement) => boolean) => {
-  let result: SugarElement[] = [];
+const filterDescendants = <T extends Node>(scope: SugarElement<Node>, predicate: (x: SugarElement<Node>) => x is SugarElement<T>): SugarElement<T>[] => {
+  let result: SugarElement<T>[] = [];
   const dom = scope.dom;
   const children = Arr.map(dom.childNodes, SugarElement.fromDom);
 
@@ -33,7 +33,7 @@ const filterDescendants = (scope: SugarElement, predicate: (x: SugarElement) => 
   return result;
 };
 
-const findParentElm = (elm: Node, rootElm: Node) => {
+const findParentElm = (elm: Node, rootElm: Node): Node | undefined => {
   while (elm.parentNode) {
     if (elm.parentNode === rootElm) {
       return elm;
@@ -42,7 +42,8 @@ const findParentElm = (elm: Node, rootElm: Node) => {
   }
 };
 
-const replaceWithSpans = (text: string) => text.replace(Data.regExpGlobal, Html.wrapCharWithSpan);
+const replaceWithSpans = (text: string): string =>
+  text.replace(Data.regExpGlobal, Html.wrapCharWithSpan);
 
 export {
   isMatch,

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/VisualChars.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/VisualChars.ts
@@ -13,9 +13,10 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Data from './Data';
 import * as Nodes from './Nodes';
 
-const isWrappedNbsp = (node) => node.nodeName.toLowerCase() === 'span' && node.classList.contains('mce-nbsp-wrap');
+const isWrappedNbsp = (node: Node): node is HTMLSpanElement =>
+  node.nodeName.toLowerCase() === 'span' && (node as HTMLSpanElement).classList.contains('mce-nbsp-wrap');
 
-const show = (editor: Editor, rootElm: Node) => {
+const show = (editor: Editor, rootElm: Node): void => {
   const nodeList = Nodes.filterDescendants(SugarElement.fromDom(rootElm), Nodes.isMatch);
 
   Arr.each(nodeList, (n) => {
@@ -36,7 +37,7 @@ const show = (editor: Editor, rootElm: Node) => {
   });
 };
 
-const hide = (editor: Editor, rootElm: Node) => {
+const hide = (editor: Editor, rootElm: Node): void => {
   const nodeList = editor.dom.select(Data.selector, rootElm);
 
   Arr.each(nodeList, (node) => {
@@ -48,7 +49,7 @@ const hide = (editor: Editor, rootElm: Node) => {
   });
 };
 
-const toggle = (editor: Editor) => {
+const toggle = (editor: Editor): void => {
   const body = editor.getBody();
   const bookmark = editor.selection.getBookmark();
   let parentNode = Nodes.findParentElm(editor.selection.getNode(), body);

--- a/modules/tinymce/src/plugins/visualchars/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/ui/Buttons.ts
@@ -8,26 +8,30 @@
 import { Cell } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const toggleActiveState = (editor: Editor, enabledStated: Cell<boolean>) => (api) => {
+const toggleActiveState = (editor: Editor, enabledStated: Cell<boolean>) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi) => {
   api.setActive(enabledStated.get());
-  const editorEventCallback = (e) => api.setActive(e.state);
+  const editorEventCallback = (e: EditorEvent<{ state: boolean }>) => api.setActive(e.state);
   editor.on('VisualChars', editorEventCallback);
   return () => editor.off('VisualChars', editorEventCallback);
 };
 
-const register = (editor: Editor, toggleState: Cell<boolean>) => {
+const register = (editor: Editor, toggleState: Cell<boolean>): void => {
+  const onAction = () => editor.execCommand('mceVisualChars');
+
   editor.ui.registry.addToggleButton('visualchars', {
     tooltip: 'Show invisible characters',
     icon: 'visualchars',
-    onAction: () => editor.execCommand('mceVisualChars'),
+    onAction,
     onSetup: toggleActiveState(editor, toggleState)
   });
 
   editor.ui.registry.addToggleMenuItem('visualchars', {
     text: 'Show invisible characters',
     icon: 'visualchars',
-    onAction: () => editor.execCommand('mceVisualChars'),
+    onAction,
     onSetup: toggleActiveState(editor, toggleState)
   });
 };

--- a/modules/tinymce/src/plugins/wordcount/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/Plugin.ts
@@ -12,7 +12,7 @@ import * as Commands from './api/Commands';
 import * as Wordcounter from './core/WordCounter';
 import * as Buttons from './ui/Buttons';
 
-export default (delay: number = 300) => {
+export default (delay: number = 300): void => {
   PluginManager.add('wordcount', (editor) => {
     const api = Api.get(editor);
 

--- a/modules/tinymce/src/plugins/wordcount/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/api/Api.ts
@@ -12,22 +12,25 @@ import { countCharacters, countCharactersWithoutSpaces, Counter, countWords } fr
 export type CountGetter = () => number;
 
 interface CountGetters {
-  getWordCount: CountGetter;
-  getCharacterCount: CountGetter;
-  getCharacterCountWithoutSpaces: CountGetter;
+  readonly getWordCount: CountGetter;
+  readonly getCharacterCount: CountGetter;
+  readonly getCharacterCountWithoutSpaces: CountGetter;
 }
 
 export interface WordCountApi {
-  body: CountGetters;
-  selection: CountGetters;
-  getCount: CountGetter; // TODO: Deprecate
+  readonly body: CountGetters;
+  readonly selection: CountGetters;
+  readonly getCount: CountGetter; // TODO: Deprecate
 }
 
-const createBodyCounter = (editor: Editor, count: Counter): CountGetter => () => count(editor.getBody(), editor.schema);
+const createBodyCounter = (editor: Editor, count: Counter): CountGetter => (): number =>
+  count(editor.getBody(), editor.schema);
 
-const createSelectionCounter = (editor: Editor, count: Counter): CountGetter => () => count(editor.selection.getRng().cloneContents(), editor.schema);
+const createSelectionCounter = (editor: Editor, count: Counter): CountGetter => (): number =>
+  count(editor.selection.getRng().cloneContents(), editor.schema);
 
-const createBodyWordCounter = (editor: Editor): CountGetter => createBodyCounter(editor, countWords);
+const createBodyWordCounter = (editor: Editor): CountGetter =>
+  createBodyCounter(editor, countWords);
 
 const get = (editor: Editor): WordCountApi => ({
   body: {

--- a/modules/tinymce/src/plugins/wordcount/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/api/Events.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import { WordCountApi } from './Api';
 
-const fireWordCountUpdate = (editor: Editor, api: WordCountApi) => {
+const fireWordCountUpdate = (editor: Editor, api: WordCountApi): void => {
   editor.fire('wordCountUpdate', {
     wordCount: {
       words: api.body.getWordCount(),

--- a/modules/tinymce/src/plugins/wordcount/main/ts/core/Count.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/core/Count.ts
@@ -14,19 +14,20 @@ import { getText } from './GetText';
 
 export type Counter = (node: Node, schema: Schema) => number;
 
-const strLen = (str: string): number => str.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length;
+const strLen = (str: string): number =>
+  str.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length;
 
-const countWords: Counter = (node: Node, schema: Schema) => {
+const countWords: Counter = (node: Node, schema: Schema): number => {
   const text = getText(node, schema).join('\n');
   return Words.getWords(text.split(''), Fun.identity).length;
 };
 
-const countCharacters: Counter = (node: Node, schema: Schema) => {
+const countCharacters: Counter = (node: Node, schema: Schema): number => {
   const text = getText(node, schema).join('');
   return strLen(text);
 };
 
-const countCharactersWithoutSpaces: Counter = (node: Node, schema: Schema) => {
+const countCharactersWithoutSpaces: Counter = (node: Node, schema: Schema): number => {
   const text = getText(node, schema).join('').replace(/\s/g, '');
   return strLen(text);
 };

--- a/modules/tinymce/src/plugins/wordcount/main/ts/core/WordCounter.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/core/WordCounter.ts
@@ -11,11 +11,11 @@ import Delay from 'tinymce/core/api/util/Delay';
 import { WordCountApi } from '../api/Api';
 import * as Events from '../api/Events';
 
-const updateCount = (editor: Editor, api: WordCountApi) => {
+const updateCount = (editor: Editor, api: WordCountApi): void => {
   Events.fireWordCountUpdate(editor, api);
 };
 
-const setup = (editor: Editor, api: WordCountApi, delay: number) => {
+const setup = (editor: Editor, api: WordCountApi, delay: number): void => {
   const debouncedUpdate = Delay.debounce(() => updateCount(editor, api), delay);
 
   editor.on('init', () => {

--- a/modules/tinymce/src/plugins/wordcount/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/ui/Buttons.ts
@@ -7,8 +7,7 @@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const register = (editor: Editor) => {
-
+const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceWordCount');
 
   editor.ui.registry.addButton('wordcount', {

--- a/modules/tinymce/src/plugins/wordcount/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/ui/Dialog.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import { WordCountApi } from '../api/Api';
 
-const open = (editor: Editor, api: WordCountApi) => {
+const open = (editor: Editor, api: WordCountApi): void => {
   editor.windowManager.open({
     title: 'Word Count',
     body: {


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Added types for `save` -> `wordcount`. Note that for `spellchecker` I only did the bare minimum since it's going away in 6.0.
* Cleaned up some duplication for `onAction` in the `visualblocks` and `visualchars` plugins

**Note:** This primarily only focuses on the function types, so variables inside functions may still not have types.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
