### PR TITLE
TINY-7485: Fixed pasting into the wrong cell when multiple cells were selected

### DIFF
--- a/modules/darwin/CHANGELOG.md
+++ b/modules/darwin/CHANGELOG.md
@@ -9,3 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
 - Changed the `MouseSelection` and `KeySelection` fake selection logic to only apply if more than one cell of the same table is selected.
+
+### Fixed
+- Fixed incorrect type for single selections in the `Selections` and `CellOpSelection` modules.

--- a/modules/darwin/src/main/ts/ephox/darwin/queries/CellOpSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/queries/CellOpSelection.ts
@@ -8,7 +8,7 @@ import { Selections } from '../selection/Selections';
 import * as SelectionTypes from '../selection/SelectionTypes';
 
 // Return an array of the selected elements
-const selection = (selections: Selections): SugarElement[] =>
+const selection = (selections: Selections): SugarElement<HTMLTableCellElement>[] =>
   SelectionTypes.cata(selections.get(),
     Fun.constant([]),
     Fun.identity,
@@ -27,7 +27,7 @@ const unmergable = (selections: Selections): Optional<SugarElement[]> => {
 const mergable = (table: SugarElement<HTMLTableElement>, selections: Selections, ephemera: Ephemera): Optional<RunOperation.ExtractMergable> =>
   SelectionTypes.cata<Optional<RunOperation.ExtractMergable>>(selections.get(),
     Optional.none,
-    (cells: SugarElement<Element>[]) => {
+    (cells) => {
       if (cells.length <= 1) {
         return Optional.none();
       } else {

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/SelectionTypes.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/SelectionTypes.ts
@@ -5,12 +5,12 @@ export interface SelectionType {
   fold: <T>(
     none: () => T,
     multiple: (elements: SugarElement<HTMLTableCellElement>[]) => T,
-    single: (element: SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>) => T,
+    single: (element: SugarElement<HTMLTableCellElement>) => T,
   ) => T;
   match: <T> (branches: {
     none: () => T;
     multiple: (elements: SugarElement<HTMLTableCellElement>[]) => T;
-    single: (element: SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>) => T;
+    single: (element: SugarElement<HTMLTableCellElement>) => T;
   }) => T;
   log: (label: string) => void;
 }
@@ -18,14 +18,14 @@ export interface SelectionType {
 const type: {
   none: () => SelectionType;
   multiple: (elements: SugarElement<HTMLTableCellElement>[]) => SelectionType;
-  single: (element: SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>) => SelectionType;
+  single: (element: SugarElement<HTMLTableCellElement>) => SelectionType;
 } = Adt.generate([
   { none: [] },
   { multiple: [ 'elements' ] },
   { single: [ 'element' ] }
 ]);
 
-export const cata = <T> (subject: SelectionType, onNone: () => T, onMultiple: (multiple: SugarElement<Element>[]) => T, onSingle: (element: SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>) => T): T =>
+export const cata = <T> (subject: SelectionType, onNone: () => T, onMultiple: (multiple: SugarElement<HTMLTableCellElement>[]) => T, onSingle: (element: SugarElement<HTMLTableCellElement>) => T): T =>
   subject.fold(onNone, onMultiple, onSingle);
 
 export const none = type.none;

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Selections.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Selections.ts
@@ -5,13 +5,13 @@ import * as TableSelection from '../api/TableSelection';
 import * as SelectionTypes from './SelectionTypes';
 
 export interface Selections {
-  get: () => SelectionTypes.SelectionType;
+  readonly get: () => SelectionTypes.SelectionType;
 }
 
-export const Selections = (lazyRoot: () => SugarElement<Element>, getStart: () => Optional<SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>>, selectedSelector: string): Selections => {
+export const Selections = (lazyRoot: () => SugarElement<Element>, getStart: () => Optional<SugarElement<HTMLTableCellElement>>, selectedSelector: string): Selections => {
   const get = () => TableSelection.retrieve<HTMLTableCellElement>(lazyRoot(), selectedSelector).fold(
-    () => getStart().map(SelectionTypes.single).getOrThunk(SelectionTypes.none),
-    (cells: SugarElement<HTMLTableCellElement>[]) => SelectionTypes.multiple(cells)
+    () => getStart().fold(SelectionTypes.none, SelectionTypes.single),
+    (cells) => SelectionTypes.multiple(cells)
   );
 
   return {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `mceTableRowType` was reversing the order of the rows when converting multiple header rows back to body rows #TINY-6666
 - The nested menu item chevron icon was not fading when the menu item was disabled #TINY-7700
 - The table dialog did not always respect the `table_style_with_css` option #TINY-4926
+- Pasting into a table with multiple cells selected could cause the content to be pasted in the wrong location #TINY-7485
 
 ### Deprecated
 - The `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins have been deprecated and marked for removal in the next major release #TINY-7260

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -24,12 +24,12 @@ import * as TabContext from './queries/TabContext';
 import CellSelection from './selection/CellSelection';
 import { ephemera } from './selection/Ephemera';
 import { getSelectionTargets } from './selection/SelectionTargets';
-import { getSelectionCellOrCaption } from './selection/TableSelection';
+import { getSelectionCell } from './selection/TableSelection';
 import * as Buttons from './ui/Buttons';
 import * as MenuItems from './ui/MenuItems';
 
 const Plugin = (editor: Editor) => {
-  const selections = Selections(() => Util.getBody(editor), () => getSelectionCellOrCaption(Util.getSelectionStart(editor)), ephemera.selectedSelector);
+  const selections = Selections(() => Util.getBody(editor), () => getSelectionCell(Util.getSelectionStart(editor), Util.getIsRoot(editor)), ephemera.selectedSelector);
   const selectionTargets = getSelectionTargets(editor, selections);
   const resizeHandler = getResizeHandler(editor);
   const cellSelection = CellSelection(editor, resizeHandler.lazyResize, selectionTargets);

--- a/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
@@ -5,8 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Selections, SelectionTypes } from '@ephox/darwin';
-import { Arr, Fun, Optional } from '@ephox/katamari';
+import { CellOpSelection, Selections, SelectionTypes } from '@ephox/darwin';
+import { Arr, Fun } from '@ephox/katamari';
 import { CopySelected, TableFill, TableLookup } from '@ephox/snooker';
 import { SugarElement, SugarElements, SugarNode } from '@ephox/sugar';
 
@@ -48,16 +48,15 @@ const registerEvents = (editor: Editor, selections: Selections, actions: TableAc
 
   editor.on('BeforeSetContent', (e) => {
     if (e.selection === true && e.paste === true) {
-      const cellOpt = Optional.from(editor.dom.getParent(editor.selection.getStart(), 'th,td'));
-      cellOpt.each((domCell) => {
-        const cell = SugarElement.fromDom(domCell);
+      const selectedCells = CellOpSelection.selection(selections);
+      Arr.head(selectedCells).each((cell) => {
         TableLookup.table(cell).each((table) => {
 
           const elements = Arr.filter(SugarElements.fromHtml(e.content), (content) => {
             return SugarNode.name(content) !== 'meta';
           });
 
-          const isTable = (elm: SugarElement<Node>): elm is SugarElement<HTMLTableElement> => SugarNode.name(elm) === 'table';
+          const isTable = SugarNode.isTag('table');
           if (elements.length === 1 && isTable(elements[0])) {
             e.preventDefault();
 

--- a/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { CellOpSelection, Selections, SelectionTypes } from '@ephox/darwin';
+import { Selections, SelectionTypes } from '@ephox/darwin';
 import { Arr, Fun } from '@ephox/katamari';
 import { CopySelected, TableFill, TableLookup } from '@ephox/snooker';
 import { SugarElement, SugarElements, SugarNode } from '@ephox/sugar';
@@ -15,6 +15,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Util from '../core/Util';
 import * as TableTargets from '../queries/TableTargets';
 import * as Ephemera from '../selection/Ephemera';
+import * as TableSelection from '../selection/TableSelection';
 import { TableActions } from './TableActions';
 
 const extractSelected = (cells: SugarElement<HTMLTableCellElement>[]) => {
@@ -48,7 +49,7 @@ const registerEvents = (editor: Editor, selections: Selections, actions: TableAc
 
   editor.on('BeforeSetContent', (e) => {
     if (e.selection === true && e.paste === true) {
-      const selectedCells = CellOpSelection.selection(selections);
+      const selectedCells = TableSelection.getCellsFromSelection(selections);
       Arr.head(selectedCells).each((cell) => {
         TableLookup.table(cell).each((table) => {
 

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -74,7 +74,10 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
 
   const getTableFromCell = (cell: SugarElement<HTMLTableCellElement>) => TableLookup.table(cell, isRoot);
 
-  const performActionOnSelection = <T>(action: ExecuteAction<T>): Optional<T> => getSelectionStartCell(editor).bind((cell) => getTableFromCell(cell).map((table) => action(table, cell)));
+  const performActionOnSelection = <T>(action: ExecuteAction<T>): Optional<T> =>
+    getSelectionStartCell(editor).bind((cell) =>
+      getTableFromCell(cell).map((table) => action(table, cell))
+    );
 
   const toggleTableClass = (_ui: boolean, clazz: string) => {
     performActionOnSelection((table) => {
@@ -85,7 +88,7 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
 
   const toggleTableCellClass = (_ui: boolean, clazz: string) => {
     performActionOnSelection((table) => {
-      const selectedCells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, Util.getIsRoot(editor));
+      const selectedCells = TableSelection.getCellsFromSelection(selections);
       const allHaveClass = Arr.forall(selectedCells, (cell) => editor.formatter.match('tablecellclass', { value: clazz }, cell.dom));
       const formatterAction = allHaveClass ? editor.formatter.remove : editor.formatter.apply;
 
@@ -235,7 +238,7 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
     if (!Type.isObject(args)) {
       return;
     }
-    const cells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, isRoot);
+    const cells = TableSelection.getCellsFromSelection(selections);
     if (cells.length === 0) {
       return;
     }

--- a/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
@@ -30,10 +30,8 @@ const getSelectionCellOrCaption = getSelectionFromSelector<HTMLTableCellElement 
 
 const getSelectionCell = getSelectionFromSelector<HTMLTableCellElement>('th,td');
 
-const getCellsFromSelection = (selected: SugarElement<Node>, selections: Selections, isRoot?: (el: SugarElement<Node>) => boolean): SugarElement<HTMLTableCellElement>[] =>
-  getSelectionCell(selected, isRoot)
-    .map((_cell) => CellOpSelection.selection(selections))
-    .getOr([]);
+const getCellsFromSelection = (selections: Selections): SugarElement<HTMLTableCellElement>[] =>
+  CellOpSelection.selection(selections);
 
 const getRowsFromSelection = (selected: SugarElement<Node>, selector: string): SugarElement<HTMLTableRowElement>[] => {
   const cellOpt = getSelectionCell(selected);

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -164,7 +164,7 @@ const getData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>[]) =>
 };
 
 const open = (editor: Editor, selections: Selections) => {
-  const cells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections);
+  const cells = TableSelection.getCellsFromSelection(selections);
 
   // Check if there are any cells to operate on
   if (cells.length === 0) {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -12,7 +12,6 @@ import { SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
-import * as Util from '../core/Util';
 import * as TableSelection from '../selection/TableSelection';
 
 interface Item {
@@ -25,7 +24,7 @@ const onSetupToggle = (editor: Editor, selections: Selections, formatName: strin
     const isNone = Strings.isEmpty(formatValue);
 
     const init = () => {
-      const selectedCells = TableSelection.getCellsFromSelection(Util.getSelectionStart(editor), selections, Util.getIsRoot(editor));
+      const selectedCells = TableSelection.getCellsFromSelection(selections);
 
       const checkNode = (cell: SugarElement<Element>) =>
         editor.formatter.match(formatName, { value: formatValue }, cell.dom, isNone);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -1,21 +1,23 @@
+import { Clipboard } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
-import Plugin from 'tinymce/plugins/table/Plugin';
+import PastePlugin from 'tinymce/plugins/paste/Plugin';
+import TablePlugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.ClipboardTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
-    plugins: 'table',
+    plugins: 'paste table',
     indent: false,
     valid_styles: {
       '*': 'width,height,vertical-align,text-align,float,border-color,background-color,border,padding,border-spacing,border-collapse'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ PastePlugin, TablePlugin, Theme ], true);
 
   const cleanTableHtml = (html: string) => html.replace(/<p>(&nbsp;|<br[^>]+>)<\/p>$/, '');
 
@@ -676,6 +678,58 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
       '<tr><td>2</td><td>2</td><td>3</td></tr>' +
       '</tbody>' +
       '</table>'
+    );
+  });
+
+  it('TINY-7485: Pasting into a table with a single cells contents selected', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table><tbody>' +
+      '<tr><td>A</td><td>B</td></tr>' +
+      '<tr><td>C</td><td>D</td></tr>' +
+      '</tbody></table>'
+    );
+
+    TinySelections.setSelection(editor, [ 0, 0, 0, 1, 0 ], 0, [ 0, 0, 0, 1, 0 ], 1);
+    Clipboard.pasteItems(TinyDom.body(editor), {
+      'text/html': '<table><tbody>' +
+        '<tr><td>A</td><td>B</td></tr>' +
+        '<tr><td>C</td><td>D</td></tr>' +
+        '</tbody></table>'
+    });
+
+    TinyAssertions.assertContent(editor,
+      '<table><tbody>' +
+      '<tr><td>A</td><td>A</td><td>B</td></tr>' +
+      '<tr><td>C</td><td>C</td><td>D</td></tr>' +
+      '</tbody></table>'
+    );
+  });
+
+  it('TINY-7485: Pasting into a table with multiple cells selected should paste into the first cell', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table><tbody>' +
+      '<tr><td>A</td><td>B</td><td>&nbsp;</td></tr>' +
+      '<tr><td>C</td><td>D</td><td>&nbsp;</td></tr>' +
+      '<tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>' +
+      '</tbody></table>'
+    );
+
+    selectRangeXY(editor, 'table tr:nth-child(2) td:nth-child(2)', 'table tr:nth-child(3) td:nth-child(3)');
+    Clipboard.pasteItems(TinyDom.body(editor), {
+      'text/html': '<table><tbody>' +
+        '<tr><td>A</td><td>B</td></tr>' +
+        '<tr><td>C</td><td>D</td></tr>' +
+        '</tbody></table>'
+    });
+
+    TinyAssertions.assertContent(editor,
+      '<table><tbody>' +
+      '<tr><td>A</td><td>B</td><td>&nbsp;</td></tr>' +
+      '<tr><td>C</td><td>A</td><td>B</td></tr>' +
+      '<tr><td>&nbsp;</td><td>C</td><td>D</td></tr>' +
+      '</tbody></table>'
     );
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-7485

Description of Changes:
The paste logic incorrectly looked up the cell selection as it only ever considered the native selection, not the fake selection. So this swaps it over to use the proper way to lookup the selection in for the tables plugin. I also cleaned up a little by using the `SugarNode.isTag` function.

Additionally, I discovered that `CellOpSelection` was returning a `caption` element in some cases which was incorrect, so I've corrected the types in Darwin and feed that through. This hadn't caused an issue previously thankfully because the only place it's used is for `TableSelection` and `RunOperation`. The former had an additional guard to workaround this bug and the latter does `TableLookup.cell` on the single element passed, which in turn returns `Optional.none`.

Note: To use the table clipboard functionality the paste plugin is required, so I've also added that to the `ClipboardTest`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
