### PR TITLE
TINY-6666: Fixed `mceTableCellType` not updating multiple cells in the same column

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -187,8 +187,7 @@ const opMakeCellsHeader = (initialGrid: Structs.RowCells[], details: Structs.Det
   const replacer = (currentGrid: Structs.RowCells[], detail: Structs.DetailExt) =>
     TransformOperations.replaceCell(currentGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
 
-  const columns = ColUtils.uniqueColumns(details);
-  const newGrid = Arr.foldl(columns, replacer, initialGrid);
+  const newGrid = Arr.foldl(details, replacer, initialGrid);
   return bundle(newGrid, details[0].row, details[0].column);
 };
 
@@ -215,8 +214,7 @@ const opUnmakeCellsHeader = (initialGrid: Structs.RowCells[], details: Structs.D
   const replacer = (currentGrid: Structs.RowCells[], detail: Structs.DetailExt) =>
     TransformOperations.replaceCell(currentGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
 
-  const columns = ColUtils.uniqueColumns(details);
-  const newGrid = Arr.foldl(columns, replacer, initialGrid);
+  const newGrid = Arr.foldl(details, replacer, initialGrid);
   return bundle(newGrid, details[0].row, details[0].column);
 };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
@@ -157,6 +157,16 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
 </tr>
 </tbody>
 </table>`;
+  const multipleHeaderCellContent = `<table>
+<tbody>
+<tr id="one">
+<th>text</th>
+</tr>
+<tr id="two">
+<th>text</th>
+</tr>
+</tbody>
+</table>`;
 
   let events = [];
   const logEvent = (event: EditorEvent<TableModifiedEvent>) => {
@@ -204,7 +214,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
     assert.match(editor.selection.getNode().nodeName, /^(TD|TH)$/, 'selection should be within a cell');
   };
 
-  const switchMultipleColumnsType = (editor: Editor, startContent: string, expectedContent: string, command: string, type: 'td' | 'th', expectedEvents: string[] = defaultEvents) => {
+  const switchMultipleItemsType = (editor: Editor, startContent: string, expectedContent: string, command: string, type: 'td' | 'th', expectedEvents: string[] = defaultEvents) => {
     editor.setContent(startContent);
     selectAllCells(editor, type);
     clearEvents();
@@ -314,7 +324,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
       );
 
       it('TINY-6326: Switch multiple body columns to header columns', () =>
-        switchMultipleColumnsType(hook.editor(), bodyMultipleChangesColumnContent, headerMultipleChangesColumnContent, 'mceTableColType', 'th', [ 'newcell', 'newcell', 'newcell', 'newcell', 'tablemodified' ])
+        switchMultipleItemsType(hook.editor(), bodyMultipleChangesColumnContent, headerMultipleChangesColumnContent, 'mceTableColType', 'th', [ 'newcell', 'newcell', 'newcell', 'newcell', 'tablemodified' ])
       );
 
       it('TINY-6150: Switch header column to body column', () =>
@@ -322,7 +332,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
       );
 
       it('TINY-6326: Switch multiple header columns to body columns', () =>
-        switchMultipleColumnsType(hook.editor(), headerMultipleChangesColumnContent, bodyMultipleChangesColumnContent, 'mceTableColType', 'td', [ 'newcell', 'newcell', 'newcell', 'newcell', 'tablemodified' ])
+        switchMultipleItemsType(hook.editor(), headerMultipleChangesColumnContent, bodyMultipleChangesColumnContent, 'mceTableColType', 'td', [ 'newcell', 'newcell', 'newcell', 'newcell', 'tablemodified' ])
       );
     });
 
@@ -333,6 +343,14 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
 
       it('TINY-6150: Switch header cell to body cell', () =>
         switchType(hook.editor(), headerCellContent, bodyContent, 'mceTableCellType', 'td', [ 'newcell', 'tablemodified' ], 'tr#one th')
+      );
+
+      it('TINY-6150: Switch multiple body cells to header cells', () =>
+        switchMultipleItemsType(hook.editor(), bodyContent, multipleHeaderCellContent, 'mceTableCellType', 'th', [ 'newcell', 'newcell', 'tablemodified' ])
+      );
+
+      it('TINY-6150: Switch multiple header cells to body cells', () =>
+        switchMultipleItemsType(hook.editor(), multipleHeaderCellContent, bodyContent, 'mceTableCellType', 'td', [ 'newcell', 'newcell', 'tablemodified' ])
       );
     });
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
@@ -157,6 +157,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
 </tr>
 </tbody>
 </table>`;
+
   const multipleHeaderCellContent = `<table>
 <tbody>
 <tr id="one">


### PR DESCRIPTION
Related Ticket: TINY-6666

Description of Changes:
Fixed the cell type operations in snooker only working on the first cell in a column due to incorrectly using `uniqueColumns` to filter out other cells in the same column (was a copy/paste fail on my part in the earlier PRs).

Pre-checks:
* [x] ~Changelog entry added~ Not needed as this only broke in recent changes
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
