### PR TITLE
TINY-7705: Fixed edge case for table tab navigation

### DIFF
--- a/modules/tinymce/src/plugins/table/main/ts/queries/TabContext.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/TabContext.ts
@@ -7,9 +7,7 @@
 
 import { Arr, Optional } from '@ephox/katamari';
 import { CellLocation, CellNavigation, TableLookup } from '@ephox/snooker';
-import {
-  Compare, ContentEditable, CursorPosition, SelectorFilter, SelectorFind, SimSelection, SugarElement, SugarNode, WindowSelection
-} from '@ephox/sugar';
+import { Compare, ContentEditable, CursorPosition, SimSelection, SugarElement, SugarNode, WindowSelection } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import VK from 'tinymce/core/api/util/VK';
@@ -30,25 +28,15 @@ const getCellFirstCursorPosition = (editor: Editor, cell: SugarElement<Node>): R
   return WindowSelection.toNative(selection);
 };
 
-const getNewRowCursorPosition = (editor: Editor, table: SugarElement<HTMLTableElement>): Optional<Range> => {
-  const rows = SelectorFilter.descendants<HTMLTableRowElement>(table, 'tr');
-  return Arr.last(rows).bind((last) => {
-    return SelectorFind.descendant<HTMLTableCellElement>(last, 'td,th').map((first) => {
-      return getCellFirstCursorPosition(editor, first);
-    });
-  });
-};
-
 const go = (editor: Editor, isRoot: (e: SugarElement) => boolean, cell: CellLocation): Optional<Range> => {
   return cell.fold<Optional<Range>>(Optional.none, Optional.none, (current, next) => {
     return CursorPosition.first(next).map((cell) => {
       return getCellFirstCursorPosition(editor, cell);
     });
   }, (current) => {
-    return TableLookup.table(current, isRoot).bind((table) => {
-      editor.execCommand('mceTableInsertRowAfter');
-      return getNewRowCursorPosition(editor, table);
-    });
+    editor.execCommand('mceTableInsertRowAfter');
+    // Move forward from the last cell so that we move into the first valid position in the new row
+    return forward(editor, isRoot, current);
   });
 };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/KeyboardCellNavigationTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/KeyboardCellNavigationTest.ts
@@ -53,15 +53,22 @@ describe('browser.tinymce.plugins.table.quirks.KeyboardCellNavigationTest', () =
       '</tbody></table>'
     );
     TinySelections.setCursor(editor, [ 0, 0, 0, 1, 0 ], 0);
+
+    // Hook up the editor to make the first cell in the row noneditable when a new row is created while tabbing
+    editor.once('NewCell', (e) => {
+      e.node.contentEditable = 'false';
+    });
+
     // Move to cell "c"
     TinyContentActions.keydown(editor, Keys.tab());
     TinyAssertions.assertCursor(editor, [ 0, 0, 0, 2, 0 ], 0);
     // Move to cell "e"
     TinyContentActions.keydown(editor, Keys.tab());
     TinyAssertions.assertCursor(editor, [ 0, 0, 1, 1, 0 ], 0);
-    // Inserts a new row and moves to it
+    // Inserts a new row and moves to it. It should be in the second column
+    // as we made the first cell noneditable above
     TinyContentActions.keydown(editor, Keys.tab());
-    TinyAssertions.assertCursor(editor, [ 0, 0, 2, 0 ], 0);
+    TinyAssertions.assertCursor(editor, [ 0, 0, 2, 1 ], 0);
   });
 
   it('TINY-7705: Tabbing backwards should ignore cef cells', () => {


### PR DESCRIPTION
Related Ticket: TINY-7705

Description of Changes:
This fixes an edge case I'd missed in local testing and only became obvious when using Advanced Tables. When the new row is inserted, the cells maybe changed to non-editable so we can't just find the first position and need to walk again. So this updates that logic to walk forward from the last cell to the next viable position.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
