### PR TITLE
Fix: #7093 base64 encoded images are not displayed if data value cont…

### DIFF
--- a/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
+++ b/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
@@ -22,7 +22,7 @@ export interface Base64UriParts {
 }
 
 export const extractBase64DataUris = (html: string): Base64Extract => {
-  const dataImageUri = /data:[^;]+;base64,([a-z0-9\+\/=]+)/gi;
+  const dataImageUri = /data:[^;]+;base64,([a-z0-9\+\/=\s]+)/gi;
   const chunks: string[] = [];
   const uris: UriMap = {};
   const prefix = Id.generate('img');
@@ -62,7 +62,7 @@ export const restoreDataUris = (html: string, result: Base64Extract): string =>
   );
 
 export const parseDataUri = (uri: string): Optional<Base64UriParts> => {
-  const matches = /data:([^;]+);base64,([a-z0-9\+\/=]+)/i.exec(uri);
+  const matches = /data:([^;]+);base64,([a-z0-9\+\/=\s]+)/i.exec(uri);
   if (matches) {
     return Optional.some({ type: matches[1], data: decodeURIComponent(matches[2]) });
   } else {


### PR DESCRIPTION
Allow spaces and line breaks inside base64 encoded data of images.

Related Ticket:
#7093
Description of Changes:
* Change regular expressions to alloow spaces and line breaks in data Uri

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
#7093