### PR TITLE
Fix #7093: base64 encoded images are not displayed if data value contains line breaks or spaces

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The nested menu item chevron icon was not fading when the menu item was disabled #TINY-7700
 - The table dialog did not always respect the `table_style_with_css` option #TINY-4926
 - Pasting into a table with multiple cells selected could cause the content to be pasted in the wrong location #TINY-7485
+- Base64 encoded images with spaces or line breaks in data URI were not displayed correctly. Patch contributed by RoboBurned
 
 ### Deprecated
 - The `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins have been deprecated and marked for removal in the next major release #TINY-7260

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The nested menu item chevron icon was not fading when the menu item was disabled #TINY-7700
 - The table dialog did not always respect the `table_style_with_css` option #TINY-4926
 - Pasting into a table with multiple cells selected could cause the content to be pasted in the wrong location #TINY-7485
-- Base64 encoded images with spaces or line breaks in data URI were not displayed correctly. Patch contributed by RoboBurned
+- Base64 encoded images with spaces or line breaks in the data URI were not displayed correctly. Patch contributed by RoboBurned
 
 ### Deprecated
 - The `bbcode`, `fullpage`, `legacyoutput` and `spellchecker` plugins have been deprecated and marked for removal in the next major release #TINY-7260

--- a/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
+++ b/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
@@ -22,7 +22,7 @@ export interface Base64UriParts {
 }
 
 export const extractBase64DataUris = (html: string): Base64Extract => {
-  const dataImageUri = /data:[^;]+;base64,([a-z0-9\+\/=]+)/gi;
+  const dataImageUri = /data:[^;]+;base64,([a-z0-9\+\/=\s]+)/gi;
   const chunks: string[] = [];
   const uris: UriMap = {};
   const prefix = Id.generate('img');
@@ -62,7 +62,7 @@ export const restoreDataUris = (html: string, result: Base64Extract): string =>
   );
 
 export const parseDataUri = (uri: string): Optional<Base64UriParts> => {
-  const matches = /data:([^;]+);base64,([a-z0-9\+\/=]+)/i.exec(uri);
+  const matches = /data:([^;]+);base64,([a-z0-9\+\/=\s]+)/i.exec(uri);
   if (matches) {
     return Optional.some({ type: matches[1], data: decodeURIComponent(matches[2]) });
   } else {

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -87,6 +87,17 @@ describe('atomic.tinymce.core.html.Base64UrisTest', () => {
         }
       }
     );
+
+    testExtract(
+      'Should extract base64 encoded thing with spaces, tabs and line breaks in data',
+      '<img src="data:some/thing;base64,SGVsbG8sI\r\n  Hdv		cmxkIQ==">',
+      {
+        html: '<img src="$prefix_0">',
+        uris: {
+          $prefix_0: 'data:some/thing;base64,SGVsbG8sI\r\n  Hdv		cmxkIQ=='
+        }
+      }
+    );
   });
 
   const testRestoreDataUris = (label: string, inputResult: Base64Extract, inputHtml: string, expectedHtml: string) => {
@@ -121,5 +132,6 @@ describe('atomic.tinymce.core.html.Base64UrisTest', () => {
     KAssert.eqOptional('Mime with plus', Optional.some({ type: 'image/svg+xml', data: 'R2/yw==' }), parseDataUri('data:image/svg+xml;base64,R2/yw=='));
     KAssert.eqOptional('Data uri without mime', Optional.none(), parseDataUri('data:base64,R3/yw=='));
     KAssert.eqOptional('Data uri without base64', Optional.none(), parseDataUri('data:image/svg+xml,R4/yw=='));
+    KAssert.eqOptional('Data with spaces, tabs and line breaks', Optional.some({ type: 'image/png', data: 'SGVsbG8sI\r\n  Hdv		cmxkIQ==' }), parseDataUri('data:image/png;base64,SGVsbG8sI\r\n  Hdv		cmxkIQ=='));
   });
 });


### PR DESCRIPTION
Allow spaces and line breaks inside base64 encoded data of images.

Related Ticket:
#7093
Description of Changes:
* Change regular expressions to alloow spaces and line breaks in data Uri

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #7093