### PR TITLE
TINY-7721: Fix broken typescript types in Jax

### DIFF
--- a/modules/jax/CHANGELOG.md
+++ b/modules/jax/CHANGELOG.md
@@ -10,4 +10,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
 
 ### Improved
-- Changed `HttpError.responseText` type from `string` to `ResponseTypeMap[T]`, `T extends keyof ResponseTypeMap`.
+- Improved the `HttpError.responseText` type to track the actual `ResponseType`, instead of just `string`. This means that `HttpError` now requires a generic type that extends `keyof ResponseTypeMap`.

--- a/modules/jax/CHANGELOG.md
+++ b/modules/jax/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Improved
+- Improved the `HttpError.responseText` type to track the actual `ResponseType`, instead of just `string`. This means that `HttpError` now requires a generic type that extends `keyof ResponseTypeMap`.
+
 ### Changed
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
 
-### Improved
-- Improved the `HttpError.responseText` type to track the actual `ResponseType`, instead of just `string`. This means that `HttpError` now requires a generic type that extends `keyof ResponseTypeMap`.

--- a/modules/jax/CHANGELOG.md
+++ b/modules/jax/CHANGELOG.md
@@ -8,3 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
+
+### Improved
+- Changed `HttpError.responseText` type from `string` to `ResponseTypeMap[T]`, `T extends keyof ResponseTypeMap`.

--- a/modules/jax/src/main/ts/ephox/jax/core/Http.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/Http.ts
@@ -1,7 +1,7 @@
 import { FutureResult, Global, Obj, Optional, Result, Strings, Type } from '@ephox/katamari';
 
 import { DataType } from './DataType';
-import { RequestBody, ResponseBodyDataTypes, ResponseTypeMap, textData } from './HttpData';
+import { RequestBody, ResponseBodyDataTypes, ResponseType, ResponseTypeMap, textData } from './HttpData';
 import { HttpError, HttpErrorCode } from './HttpError';
 import * as HttpTypes from './HttpTypes';
 import * as ResponseError from './ResponseError';
@@ -36,7 +36,7 @@ const getResponseType = (responseType: ResponseBodyDataTypes): Optional<'blob' |
   }
 };
 
-const createOptions = <T extends keyof ResponseTypeMap>(init: HttpTypes.HttpRequest<T>) => {
+const createOptions = <T extends ResponseType>(init: HttpTypes.HttpRequest<T>) => {
   const contentType = getContentType(init.body);
   const credentials: Optional<boolean> = init.credentials === true ? Optional.some<boolean>(true) : Optional.none<boolean>();
   const accept = getAccept(init.responseType) + ', */*; q=0.01';
@@ -84,7 +84,7 @@ const getData = (body: RequestBody): Optional<string | FormData | Blob> =>
     }
   });
 
-const send = <T extends keyof ResponseTypeMap>(init: HttpTypes.HttpRequest<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> => FutureResult.nu((callback) => {
+const send = <T extends ResponseType>(init: HttpTypes.HttpRequest<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> => FutureResult.nu((callback) => {
   const request = new XMLHttpRequest();
   request.open(init.method, buildUrl(init.url, Optional.from(init.query)), true); // enforced async! enforced type as String!
 
@@ -120,16 +120,16 @@ const send = <T extends keyof ResponseTypeMap>(init: HttpTypes.HttpRequest<T>): 
 
 const empty = () => textData('');
 
-const post = <T extends keyof ResponseTypeMap>(init: HttpTypes.PostPutInit<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> =>
+const post = <T extends ResponseType>(init: HttpTypes.PostPutInit<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> =>
   send({ ...init, method: HttpTypes.HttpMethod.Post });
 
-const put = <T extends keyof ResponseTypeMap>(init: HttpTypes.PostPutInit<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> =>
+const put = <T extends ResponseType>(init: HttpTypes.PostPutInit<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> =>
   send({ ...init, method: HttpTypes.HttpMethod.Put });
 
-const get = <T extends keyof ResponseTypeMap>(init: HttpTypes.GetDelInit<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> =>
+const get = <T extends ResponseType>(init: HttpTypes.GetDelInit<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> =>
   send({ ...init, method: HttpTypes.HttpMethod.Get, body: empty() });
 
-const del = <T extends keyof ResponseTypeMap>(init: HttpTypes.GetDelInit<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> =>
+const del = <T extends ResponseType>(init: HttpTypes.GetDelInit<T>): FutureResult<ResponseTypeMap[T], HttpError<T>> =>
   send({ ...init, method: HttpTypes.HttpMethod.Delete, body: empty() });
 
 const sendProgress = (init: HttpTypes.DownloadHttpRequest, loaded: number) => {

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpData.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpData.ts
@@ -6,6 +6,7 @@ export interface ResponseTypeMap {
   [DataType.Text]: string;
 }
 
+export type ResponseType = keyof ResponseTypeMap;
 export type RequestBody = JsonData | BlobData | TextData | FormData | MultipartFormData;
 export type ResponseBody = Exclude<RequestBody, FormData>;
 export type ResponseBodyDataTypes = Exclude<DataType, DataType.FormData>;

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
@@ -1,6 +1,6 @@
 import { Result } from '@ephox/katamari';
 
-import { ResponseTypeMap } from './HttpData';
+import { ResponseType, ResponseTypeMap } from './HttpData';
 
 export const enum HttpErrorCode {
   Created = 201,
@@ -12,10 +12,10 @@ export const enum HttpErrorCode {
   InternalServerError = 500
 }
 
-export interface HttpError<T extends keyof ResponseTypeMap> {
+export interface HttpError<T extends ResponseType> {
   message: string;
   status: HttpErrorCode;
   responseText: ResponseTypeMap[T];
 }
 
-export const httpError = <T extends keyof ResponseTypeMap>(status: number, message: string, responseText: T): Result<T, HttpError<T>> => Result.error<T>({ message, status, responseText });
+export const httpError = <T extends ResponseType>(status: number, message: string, responseText: T): Result<T, HttpError<T>> => Result.error<T>({ message, status, responseText });

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
@@ -1,5 +1,7 @@
 import { Result } from '@ephox/katamari';
 
+import { ResponseTypeMap } from './HttpData';
+
 export const enum HttpErrorCode {
   Created = 201,
   BadRequest = 400,
@@ -10,10 +12,10 @@ export const enum HttpErrorCode {
   InternalServerError = 500
 }
 
-export interface HttpError {
+export interface HttpError<T extends keyof ResponseTypeMap> {
   message: string;
   status: HttpErrorCode;
-  responseText: string;
+  responseText: ResponseTypeMap[T];
 }
 
-export const httpError = <T>(status: number, message: string, responseText: string): Result<T, HttpError> => Result.error<T>({ message, status, responseText });
+export const httpError = <T extends keyof ResponseTypeMap>(status: number, message: string, responseText: T): Result<T, HttpError<T>> => Result.error<T>({ message, status, responseText });

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
@@ -18,4 +18,4 @@ export interface HttpError<T extends ResponseType> {
   readonly responseText: ResponseTypeMap[T];
 }
 
-export const httpError = <T extends ResponseType>(status: number, message: string, responseText: T): Result<T, HttpError<T>> => Result.error<T>({ message, status, responseText });
+export const httpError = <T extends ResponseType>(status: number, message: string, responseText: ResponseTypeMap[T]): Result<T, HttpError<T>> => Result.error<T>({ message, status, responseText });

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
@@ -13,9 +13,9 @@ export const enum HttpErrorCode {
 }
 
 export interface HttpError<T extends ResponseType> {
-  message: string;
-  status: HttpErrorCode;
-  responseText: ResponseTypeMap[T];
+  readonly message: string;
+  readonly status: HttpErrorCode;
+  readonly responseText: ResponseTypeMap[T];
 }
 
 export const httpError = <T extends ResponseType>(status: number, message: string, responseText: T): Result<T, HttpError<T>> => Result.error<T>({ message, status, responseText });

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
@@ -1,7 +1,7 @@
 import { FutureResult } from '@ephox/katamari';
 
 import * as Http from './Http';
-import { ResponseBodyDataTypes, ResponseTypeMap } from './HttpData';
+import { ResponseBodyDataTypes, ResponseType, ResponseTypeMap } from './HttpData';
 import { HttpError, HttpErrorCode } from './HttpError';
 import { GetDelInit, HttpRequest, JwtToken, JwtTokenFactory, PostPutInit } from './HttpTypes';
 
@@ -10,25 +10,25 @@ const headers = (headersInput: HttpRequest<ResponseBodyDataTypes>['headers'], to
   return headersInput ? { ...headersInput, ...authHeader } : authHeader;
 };
 
-type RunMethod<T, U extends keyof ResponseTypeMap> = (token: JwtToken) => FutureResult<T, HttpError<U>>;
+type RunMethod<T, U extends ResponseType> = (token: JwtToken) => FutureResult<T, HttpError<U>>;
 
-const requestFreshToken = <T extends keyof ResponseTypeMap>(tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError<T>> => tokenFactory(true);
-const requestCachedToken = <T extends keyof ResponseTypeMap>(tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError<T>> => tokenFactory(false);
+const requestFreshToken = <T extends ResponseType>(tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError<T>> => tokenFactory(true);
+const requestCachedToken = <T extends ResponseType>(tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError<T>> => tokenFactory(false);
 
-const tryAgain = <T, U extends keyof ResponseTypeMap>(tokenFactory: JwtTokenFactory, runMethod: RunMethod<T, U>) =>
-  (error: HttpError<U>) => error.status === HttpErrorCode.Unauthorized ? requestFreshToken(tokenFactory).bindFuture(runMethod) : FutureResult.error(error);
+const tryAgain = <T, U extends ResponseType>(tokenFactory: JwtTokenFactory, runMethod: RunMethod<T, U>) =>
+  (error: HttpError<U>) => error.status === HttpErrorCode.Unauthorized ? requestFreshToken<U>(tokenFactory).bindFuture(runMethod) : FutureResult.error(error);
 
-const runWithToken = <T extends keyof ResponseTypeMap>(runMethod: RunMethod<ResponseTypeMap[T], T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<any>> =>
-  requestCachedToken(tokenFactory)
+const runWithToken = <T extends ResponseType>(runMethod: RunMethod<ResponseTypeMap[T], T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+  requestCachedToken<T>(tokenFactory)
     .bindFuture<ResponseTypeMap[T]>(
-    (token) => runMethod(token).bind((result) => result.fold(tryAgain(tokenFactory, runMethod), FutureResult.pure))
+    (token) => runMethod(token).bind((result) => result.fold(tryAgain<T, T>(tokenFactory, runMethod), FutureResult.pure))
   );
 
-export const post = <T extends keyof ResponseTypeMap>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+export const post = <T extends ResponseType>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.post({ ...init, headers: headers(init.headers, token) }), tokenFactory);
-export const put = <T extends keyof ResponseTypeMap>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+export const put = <T extends ResponseType>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.put({ ...init, headers: headers(init.headers, token) }), tokenFactory);
-export const get = <T extends keyof ResponseTypeMap>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+export const get = <T extends ResponseType>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.get({ ...init, headers: headers(init.headers, token) }), tokenFactory);
-export const del = <T extends keyof ResponseTypeMap>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+export const del = <T extends ResponseType>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.del({ ...init, headers: headers(init.headers, token) }), tokenFactory);

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
@@ -12,22 +12,22 @@ const headers = (headersInput: HttpRequest<ResponseBodyDataTypes>['headers'], to
 
 type RunMethod<T extends ResponseType> = (token: JwtToken) => FutureResult<ResponseTypeMap[T], HttpError<T>>;
 
-const requestFreshToken = <T extends ResponseType>(tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError<T>> => tokenFactory(true);
-const requestCachedToken = <T extends ResponseType>(tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError<T>> => tokenFactory(false);
+const requestFreshToken = <T extends ResponseType>(tokenFactory: JwtTokenFactory<T>): FutureResult<JwtToken, HttpError<T>> => tokenFactory(true);
+const requestCachedToken = <T extends ResponseType>(tokenFactory: JwtTokenFactory<T>): FutureResult<JwtToken, HttpError<T>> => tokenFactory(false);
 
-const tryAgain = <T extends ResponseType>(tokenFactory: JwtTokenFactory, runMethod: RunMethod<T>) =>
+const tryAgain = <T extends ResponseType>(tokenFactory: JwtTokenFactory<T>, runMethod: RunMethod<T>) =>
   (error: HttpError<T>) => error.status === HttpErrorCode.Unauthorized ? requestFreshToken<T>(tokenFactory).bindFuture(runMethod) : FutureResult.error(error);
 
-const runWithToken = <T extends ResponseType>(runMethod: RunMethod<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+const runWithToken = <T extends ResponseType>(runMethod: RunMethod<T>, tokenFactory: JwtTokenFactory<T>): FutureResult<T, HttpError<T>> =>
   requestCachedToken<T>(tokenFactory).bindFuture(
     (token) => runMethod(token).bind((result) => result.fold(tryAgain<T>(tokenFactory, runMethod), FutureResult.pure))
   );
 
-export const post = <T extends ResponseType>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+export const post = <T extends ResponseType>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory<T>): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.post({ ...init, headers: headers(init.headers, token) }), tokenFactory);
-export const put = <T extends ResponseType>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+export const put = <T extends ResponseType>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory<T>): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.put({ ...init, headers: headers(init.headers, token) }), tokenFactory);
-export const get = <T extends ResponseType>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+export const get = <T extends ResponseType>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory<T>): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.get({ ...init, headers: headers(init.headers, token) }), tokenFactory);
-export const del = <T extends ResponseType>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
+export const del = <T extends ResponseType>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory<T>): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.del({ ...init, headers: headers(init.headers, token) }), tokenFactory);

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
@@ -16,7 +16,7 @@ const requestFreshToken = <T extends ResponseType>(tokenFactory: JwtTokenFactory
 const requestCachedToken = <T extends ResponseType>(tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError<T>> => tokenFactory(false);
 
 const tryAgain = <T extends ResponseType>(tokenFactory: JwtTokenFactory, runMethod: RunMethod<T>) =>
-  (error: HttpError<U>) => error.status === HttpErrorCode.Unauthorized ? requestFreshToken<U>(tokenFactory).bindFuture(runMethod) : FutureResult.error(error);
+  (error: HttpError<T>) => error.status === HttpErrorCode.Unauthorized ? requestFreshToken<T>(tokenFactory).bindFuture(runMethod) : FutureResult.error(error);
 
 const runWithToken = <T extends ResponseType>(runMethod: RunMethod<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
   requestCachedToken<T>(tokenFactory).bindFuture(

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
@@ -10,24 +10,25 @@ const headers = (headersInput: HttpRequest<ResponseBodyDataTypes>['headers'], to
   return headersInput ? { ...headersInput, ...authHeader } : authHeader;
 };
 
-type RunMethod<T> = (token: JwtToken) => FutureResult<T, HttpError>;
+type RunMethod<T, U extends keyof ResponseTypeMap> = (token: JwtToken) => FutureResult<T, HttpError<U>>;
 
-const requestFreshToken = (tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError> => tokenFactory(true);
-const requestCachedToken = (tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError> => tokenFactory(false);
+const requestFreshToken = <T extends keyof ResponseTypeMap>(tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError<T>> => tokenFactory(true);
+const requestCachedToken = <T extends keyof ResponseTypeMap>(tokenFactory: JwtTokenFactory): FutureResult<JwtToken, HttpError<T>> => tokenFactory(false);
 
-const tryAgain = <T>(tokenFactory: JwtTokenFactory, runMethod: RunMethod<T>) => (error: HttpError) => error.status === HttpErrorCode.Unauthorized ? requestFreshToken(tokenFactory).bindFuture(runMethod) : FutureResult.error(error);
+const tryAgain = <T, U extends keyof ResponseTypeMap>(tokenFactory: JwtTokenFactory, runMethod: RunMethod<T, U>) =>
+  (error: HttpError<U>) => error.status === HttpErrorCode.Unauthorized ? requestFreshToken(tokenFactory).bindFuture(runMethod) : FutureResult.error(error);
 
-const runWithToken = <T extends keyof ResponseTypeMap>(runMethod: RunMethod<ResponseTypeMap[T]>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError> =>
+const runWithToken = <T extends keyof ResponseTypeMap>(runMethod: RunMethod<ResponseTypeMap[T], T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<any>> =>
   requestCachedToken(tokenFactory)
     .bindFuture<ResponseTypeMap[T]>(
     (token) => runMethod(token).bind((result) => result.fold(tryAgain(tokenFactory, runMethod), FutureResult.pure))
   );
 
-export const post = <T extends keyof ResponseTypeMap>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError> =>
+export const post = <T extends keyof ResponseTypeMap>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.post({ ...init, headers: headers(init.headers, token) }), tokenFactory);
-export const put = <T extends keyof ResponseTypeMap>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError> =>
+export const put = <T extends keyof ResponseTypeMap>(init: PostPutInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.put({ ...init, headers: headers(init.headers, token) }), tokenFactory);
-export const get = <T extends keyof ResponseTypeMap>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError> =>
+export const get = <T extends keyof ResponseTypeMap>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.get({ ...init, headers: headers(init.headers, token) }), tokenFactory);
-export const del = <T extends keyof ResponseTypeMap>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError> =>
+export const del = <T extends keyof ResponseTypeMap>(init: GetDelInit<T>, tokenFactory: JwtTokenFactory): FutureResult<T, HttpError<T>> =>
   runWithToken<T>((token) => Http.del({ ...init, headers: headers(init.headers, token) }), tokenFactory);

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpTypes.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpTypes.ts
@@ -32,7 +32,7 @@ export interface HttpResponse<T extends ResponseBody> {
 }
 
 export type JwtToken = string;
-export type JwtTokenFactory = <T extends ResponseType>(fresh: boolean) => FutureResult<JwtToken, HttpError<T>>;
+export type JwtTokenFactory<T extends ResponseType> = (fresh: boolean) => FutureResult<JwtToken, HttpError<T>>;
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpTypes.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpTypes.ts
@@ -1,6 +1,6 @@
 import { FutureResult } from '@ephox/katamari';
 
-import { RequestBody, ResponseBody, ResponseBodyDataTypes, ResponseTypeMap } from './HttpData';
+import { RequestBody, ResponseBody, ResponseBodyDataTypes, ResponseType } from './HttpData';
 import { HttpError } from './HttpError';
 
 export const enum HttpMethod {
@@ -32,7 +32,7 @@ export interface HttpResponse<T extends ResponseBody> {
 }
 
 export type JwtToken = string;
-export type JwtTokenFactory = <T extends keyof ResponseTypeMap>(fresh: boolean) => FutureResult<JwtToken, HttpError<T>>;
+export type JwtTokenFactory = <T extends ResponseType>(fresh: boolean) => FutureResult<JwtToken, HttpError<T>>;
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpTypes.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpTypes.ts
@@ -1,6 +1,6 @@
 import { FutureResult } from '@ephox/katamari';
 
-import { RequestBody, ResponseBody, ResponseBodyDataTypes } from './HttpData';
+import { RequestBody, ResponseBody, ResponseBodyDataTypes, ResponseTypeMap } from './HttpData';
 import { HttpError } from './HttpError';
 
 export const enum HttpMethod {
@@ -32,7 +32,7 @@ export interface HttpResponse<T extends ResponseBody> {
 }
 
 export type JwtToken = string;
-export type JwtTokenFactory = (fresh: boolean) => FutureResult<JwtToken, HttpError>;
+export type JwtTokenFactory = <T extends keyof ResponseTypeMap>(fresh: boolean) => FutureResult<JwtToken, HttpError<T>>;
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 

--- a/modules/jax/src/main/ts/ephox/jax/core/ResponseError.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/ResponseError.ts
@@ -2,7 +2,7 @@ import { Future, Optional } from '@ephox/katamari';
 
 import { readBlobAsText } from './BlobReader';
 import { DataType } from './DataType';
-import { ResponseBodyDataTypes, ResponseTypeMap } from './HttpData';
+import { ResponseBodyDataTypes, ResponseType } from './HttpData';
 import { HttpError } from './HttpError';
 import * as JsonResponse from './JsonResponse';
 
@@ -22,7 +22,7 @@ const getResponseText = (responseType: ResponseBodyDataTypes, request: XMLHttpRe
   }
 };
 
-export const handle = <T extends keyof ResponseTypeMap>(url: string, responseType: ResponseBodyDataTypes, request: XMLHttpRequest): Future<HttpError<T>> => getResponseText(responseType, request).map((responseText) => {
+export const handle = <T extends ResponseType>(url: string, responseType: ResponseBodyDataTypes, request: XMLHttpRequest): Future<HttpError<T>> => getResponseText(responseType, request).map((responseText) => {
   const message = request.status === 0 ? 'Unknown HTTP error (possible cross-domain request)' : `Could not load url ${url}: ${request.statusText}`;
   return {
     message,

--- a/modules/jax/src/main/ts/ephox/jax/core/ResponseError.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/ResponseError.ts
@@ -2,7 +2,7 @@ import { Future, Optional } from '@ephox/katamari';
 
 import { readBlobAsText } from './BlobReader';
 import { DataType } from './DataType';
-import { ResponseBodyDataTypes } from './HttpData';
+import { ResponseBodyDataTypes, ResponseTypeMap } from './HttpData';
 import { HttpError } from './HttpError';
 import * as JsonResponse from './JsonResponse';
 
@@ -22,7 +22,7 @@ const getResponseText = (responseType: ResponseBodyDataTypes, request: XMLHttpRe
   }
 };
 
-export const handle = (url: string, responseType: ResponseBodyDataTypes, request: XMLHttpRequest): Future<HttpError> => getResponseText(responseType, request).map((responseText) => {
+export const handle = <T extends keyof ResponseTypeMap>(url: string, responseType: ResponseBodyDataTypes, request: XMLHttpRequest): Future<HttpError<T>> => getResponseText(responseType, request).map((responseText) => {
   const message = request.status === 0 ? 'Unknown HTTP error (possible cross-domain request)' : `Could not load url ${url}: ${request.statusText}`;
   return {
     message,

--- a/modules/jax/src/main/ts/ephox/jax/core/ResponseSuccess.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/ResponseSuccess.ts
@@ -1,11 +1,11 @@
 import { FutureResult } from '@ephox/katamari';
 
 import { DataType } from './DataType';
-import { ResponseBodyDataTypes, ResponseTypeMap } from './HttpData';
+import { ResponseBodyDataTypes, ResponseType, ResponseTypeMap } from './HttpData';
 import { HttpError } from './HttpError';
 import * as JsonResponse from './JsonResponse';
 
-export const validate = <T extends keyof ResponseTypeMap>(responseType: ResponseBodyDataTypes, request: XMLHttpRequest): FutureResult<ResponseTypeMap[T], HttpError<T>> => {
+export const validate = <T extends ResponseType>(responseType: ResponseBodyDataTypes, request: XMLHttpRequest): FutureResult<ResponseTypeMap[T], HttpError<T>> => {
   const normal = () => FutureResult.pure(request.response);
 
   const error = (message: string) => FutureResult.error({

--- a/modules/jax/src/main/ts/ephox/jax/core/ResponseSuccess.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/ResponseSuccess.ts
@@ -5,7 +5,7 @@ import { ResponseBodyDataTypes, ResponseTypeMap } from './HttpData';
 import { HttpError } from './HttpError';
 import * as JsonResponse from './JsonResponse';
 
-export const validate = <T extends keyof ResponseTypeMap>(responseType: ResponseBodyDataTypes, request: XMLHttpRequest): FutureResult<ResponseTypeMap[T], HttpError> => {
+export const validate = <T extends keyof ResponseTypeMap>(responseType: ResponseBodyDataTypes, request: XMLHttpRequest): FutureResult<ResponseTypeMap[T], HttpError<T>> => {
   const normal = () => FutureResult.pure(request.response);
 
   const error = (message: string) => FutureResult.error({

--- a/modules/jax/src/test/ts/browser/AjaxTest.ts
+++ b/modules/jax/src/test/ts/browser/AjaxTest.ts
@@ -8,7 +8,7 @@ import { HttpError } from 'ephox/jax/core/HttpError';
 
 /* eslint-disable no-console */
 
-const expectError = (label: string, response: FutureResult<any, HttpError>) => FutureResult.nu((callback) => {
+const expectError = (label: string, response: FutureResult<any, HttpError<DataType.JSON>>) => FutureResult.nu((callback) => {
   response.get((res) => {
     res.fold((_err) => {
       console.log(label, 'successfully failed');
@@ -19,7 +19,7 @@ const expectError = (label: string, response: FutureResult<any, HttpError>) => F
   });
 });
 
-const expectValue = (label: string, value: any, response: FutureResult<any, HttpError>) => FutureResult.nu((callback) => {
+const expectValue = (label: string, value: any, response: FutureResult<any, HttpError<DataType.JSON>>) => FutureResult.nu((callback) => {
   response.get((res) => {
     res.fold((err) => {
       callback(Result.error(new Error(err.message)));
@@ -35,7 +35,7 @@ const expectValue = (label: string, value: any, response: FutureResult<any, Http
   });
 });
 
-const expectBlobJson = (label: string, value: any, response: FutureResult<Blob, HttpError>) => FutureResult.nu((callback) => {
+const expectBlobJson = (label: string, value: any, response: FutureResult<Blob, HttpError<DataType.Blob>>) => FutureResult.nu((callback) => {
   response.get((res) => {
     res.fold((err) => {
       callback(Result.error(new Error(err.message)));

--- a/modules/jax/src/test/ts/browser/HttpJwtTest.ts
+++ b/modules/jax/src/test/ts/browser/HttpJwtTest.ts
@@ -8,7 +8,7 @@ import { JwtTokenFactory } from 'ephox/jax/core/HttpTypes';
 
 /* eslint-disable no-console */
 
-const expectError = (label: string, response: FutureResult<any, HttpError>, expectedCalls: string[], actualCalls: string[]) => FutureResult.nu((callback) => {
+const expectError = (label: string, response: FutureResult<any, HttpError<DataType.JSON>>, expectedCalls: string[], actualCalls: string[]) => FutureResult.nu((callback) => {
   response.get((res) => {
     res.fold((_err) => {
       console.log(label, 'successfully failed');
@@ -21,7 +21,7 @@ const expectError = (label: string, response: FutureResult<any, HttpError>, expe
   });
 });
 
-const expectValue = (label: string, value: any, response: FutureResult<any, HttpError>, expectedCalls: string[], actualCalls: string[]) => FutureResult.nu((callback) => {
+const expectValue = (label: string, value: any, response: FutureResult<any, HttpError<DataType.JSON>>, expectedCalls: string[], actualCalls: string[]) => FutureResult.nu((callback) => {
   response.get((res) => {
     res.fold((err) => {
       callback(Result.error(new Error(err.message)));
@@ -53,14 +53,14 @@ UnitTest.asynctest('HttpTest', (success, failure) => {
   };
 
   const responses = [
-    expectError('GET on invalid url', HttpJwt.get(
+    expectError('GET on invalid url', HttpJwt.get<DataType.JSON>(
       {
         url: '/custom/jax/sample/token/invalid',
         responseType: DataType.JSON
       },
       fakeFactory(invalidCalls)
     ), [ 'cached', 'fresh' ], invalidCalls),
-    expectValue('GET on valid url', {}, HttpJwt.get(
+    expectValue('GET on valid url', {}, HttpJwt.get<DataType.JSON>(
       {
         url: '/custom/jax/sample/token/valid',
         responseType: DataType.JSON

--- a/modules/jax/src/test/ts/browser/HttpJwtTest.ts
+++ b/modules/jax/src/test/ts/browser/HttpJwtTest.ts
@@ -42,7 +42,7 @@ const expectValue = (label: string, value: any, response: FutureResult<any, Http
 UnitTest.asynctest('HttpTest', (success, failure) => {
   const invalidCalls: string[] = [];
   const validCalls: string[] = [];
-  const fakeFactory = (calls: string[]): JwtTokenFactory => (fresh) => {
+  const fakeFactory = (calls: string[]): JwtTokenFactory<DataType.JSON> => (fresh) => {
     if (fresh) {
       calls.push('fresh');
       return FutureResult.value('token');


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Change HttpError responseText type from `string` to `ResponseTypeMap[T]` - `HttpError<T extends keyof ResponseTypeMap>`

Pre-checks:
* [x] Changelog entry added
* ~[ ] Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
