### PR TITLE
TINY-7781: Ensure the template dialog inserts content via the `mceInsertTemplate` command

### DIFF
--- a/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
@@ -171,7 +171,7 @@ const open = (editor: Editor, templateList: ExternalTemplate[]) => {
     const data = api.getData();
     findTemplate(templates, data.template).each((t) => {
       getTemplateContent(t).then((previewHtml) => {
-        Templates.insertTemplate(editor, false, previewHtml);
+        editor.execCommand('mceInsertTemplate', false, previewHtml);
         api.close();
       }).catch(() => {
         api.disable('save');


### PR DESCRIPTION
Related Ticket: TINY-7781

Description of Changes:
* Ensure the dialog uses the `mceInsertTemplate` command rather than inserting directly using internal modules.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
