### PR TITLE
TINY-7782: Rework how icons are rendered

### DIFF
--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -389,13 +389,6 @@
     margin-right: @pad-xs;
   }
 
-  .tox-collection__item-icon-rtl {
-    /* stylelint-disable-next-line no-descending-specificity */
-    .tox-collection__item-icon svg {
-      transform: rotateY(180deg);
-    }
-  }
-
   .tox-collection__item-accessory {
     margin-right: @pad-md;
     text-align: left;

--- a/modules/oxide/src/less/theme/components/toolbar/toolbar.less
+++ b/modules/oxide/src/less/theme/components/toolbar/toolbar.less
@@ -95,10 +95,3 @@
     box-shadow: @pop-box-shadow;
   }
 }
-
-// RTL
-.tox[dir=rtl] {
-  .tox-tbtn__icon-rtl svg {
-    transform: rotateY(180deg);
-  }
-}

--- a/modules/oxide/src/less/theme/globals/global.less
+++ b/modules/oxide/src/less/theme/globals/global.less
@@ -56,3 +56,11 @@
 button::-moz-focus-inner {
   border: 0;
 }
+
+// RTL
+.tox[dir=rtl] {
+  // Rotates configured icons 180 degrees when rendering in RTL
+  .tox-icon--flip svg {
+    transform: rotateY(180deg);
+  }
+}

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When scrolling, the context toolbar will stick to where it was previously for large elements, such as tables #TINY-7545
 - The context toolbar will now move out of the way when it overlaps with the selection, such as in table cells #TINY-7192
 - The `formatter.match` API can now take an optional `similar` parameter to check if the format partial matches #TINY-7712
+- Icons with a `-rtl` suffix in their name will now automatically be used when the UI is rendered in right-to-left mode #TINY-7782
 
 ### Changed
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents #TINY-7249

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/ButtonSlices.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/ButtonSlices.ts
@@ -11,12 +11,12 @@ import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as Icons from '../icons/Icons';
 import { ToolbarButtonClasses } from '../toolbar/button/ButtonClasses';
 
-const renderIcon = (iconName: string, iconsProvider: Icons.IconProvider, behaviours: Array<Behaviour.NamedConfiguredBehaviour<any, any, any>>): SimpleOrSketchSpec => {
-  // If RTL, add the RTL icon class for icons that don't have a `-rtl` icon available.
-  const rtlIconClasses = Icons.needsRtlTransform(iconName) ? [ ToolbarButtonClasses.IconRtl ] : [];
-  const iconHtml = Icons.get(iconName, iconsProvider);
-  return Icons.render('span', iconHtml, [ ToolbarButtonClasses.Icon, ToolbarButtonClasses.IconWrap ].concat(rtlIconClasses), behaviours);
-};
+const renderIcon = (iconName: string, iconsProvider: Icons.IconProvider, behaviours: Array<Behaviour.NamedConfiguredBehaviour<any, any, any>>): SimpleOrSketchSpec =>
+  Icons.render(iconName, {
+    tag: 'span',
+    classes: [ ToolbarButtonClasses.Icon, ToolbarButtonClasses.IconWrap ],
+    behaviours
+  }, iconsProvider);
 
 const renderIconFromPack = (iconName: string, iconsProvider: Icons.IconProvider): SimpleOrSketchSpec =>
   renderIcon(iconName, iconsProvider, []);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/ButtonSlices.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/ButtonSlices.ts
@@ -11,17 +11,18 @@ import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as Icons from '../icons/Icons';
 import { ToolbarButtonClasses } from '../toolbar/button/ButtonClasses';
 
-const renderIcon = (iconHtml: string, behaviours: Array<Behaviour.NamedConfiguredBehaviour<any, any, any>>): SimpleOrSketchSpec =>
-  Icons.render('span', iconHtml, [ ToolbarButtonClasses.Icon, ToolbarButtonClasses.IconWrap ], behaviours);
+const renderIcon = (iconName: string, iconsProvider: Icons.IconProvider, behaviours: Array<Behaviour.NamedConfiguredBehaviour<any, any, any>>): SimpleOrSketchSpec => {
+  // If RTL, add the RTL icon class for icons that don't have a `-rtl` icon available.
+  const rtlIconClasses = Icons.needsRtlTransform(iconName) ? [ ToolbarButtonClasses.IconRtl ] : [];
+  const iconHtml = Icons.get(iconName, iconsProvider);
+  return Icons.render('span', iconHtml, [ ToolbarButtonClasses.Icon, ToolbarButtonClasses.IconWrap ].concat(rtlIconClasses), behaviours);
+};
 
 const renderIconFromPack = (iconName: string, iconsProvider: Icons.IconProvider): SimpleOrSketchSpec =>
-  renderIcon(Icons.get(iconName, iconsProvider), []);
+  renderIcon(iconName, iconsProvider, []);
 
-const renderReplacableIconFromPack = (iconName: string, iconsProvider: Icons.IconProvider): SimpleOrSketchSpec => {
-  const icon = Icons.get(iconName, iconsProvider);
-  const behaviours = [ Replacing.config({ }) ];
-  return renderIcon(icon, behaviours);
-};
+const renderReplacableIconFromPack = (iconName: string, iconsProvider: Icons.IconProvider): SimpleOrSketchSpec =>
+  renderIcon(iconName, iconsProvider, [ Replacing.config({ }) ]);
 
 const renderLabel = (text: string, prefix: string, providersBackstage: UiFactoryBackstageProviders) => ({
   dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
@@ -52,7 +52,7 @@ export const renderSelectBox = (spec: SelectBoxSpec, providersBackstage: UiFacto
   });
 
   const chevron: Optional<AlloySpec> = spec.size > 1 ? Optional.none() :
-    Optional.some(Icons.render('div', Icons.get('chevron-down', providersBackstage.icons), [ 'tox-selectfield__icon-js' ]));
+    Optional.some(Icons.render('chevron-down', { tag: 'div', classes: [ 'tox-selectfield__icon-js' ] }, providersBackstage.icons));
 
   const selectWrap: SimpleSpec = {
     dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -30,8 +30,8 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
 
   const ratioEvent = Id.generate('ratio-event');
 
-  const iconLockSpec = Icons.render('span', Icons.get('lock', providersBackstage.icons), [ 'tox-icon', 'tox-lock-icon__lock' ]);
-  const iconUnlockSpec = Icons.render('span', Icons.get('unlock', providersBackstage.icons), [ 'tox-icon', 'tox-lock-icon__unlock' ]);
+  const makeIcon = (iconName: string) =>
+    Icons.render(iconName, { tag: 'span', classes: [ 'tox-icon', 'tox-lock-icon__' + iconName ] }, providersBackstage.icons);
 
   const pLock = AlloyFormCoupledInputs.parts.lock({
     dom: {
@@ -41,7 +41,10 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
         title: providersBackstage.translate(spec.label.getOr('Constrain proportions'))  // TODO: tooltips AP-213
       }
     },
-    components: [ iconLockSpec, iconUnlockSpec ],
+    components: [
+      makeIcon('lock'),
+      makeIcon('unlock')
+    ],
     buttonBehaviours: Behaviour.derive([
       Disabling.config({
         disabled: () => spec.disabled || providersBackstage.isDisabled()

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -174,21 +174,16 @@ export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage
   const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
 
   // TODO: Consider a way of merging with Checkbox.
-  const makeIcon = (name, errId: Optional<string>, icon = name, label = name): SimpleOrSketchSpec => ({
-    dom: {
+  const makeIcon = (name, errId: Optional<string>, icon = name, label = name): SimpleOrSketchSpec =>
+    Icons.render(icon, {
       tag: 'div',
       classes: [ 'tox-icon', 'tox-control-wrap__status-icon-' + name ],
-      innerHtml: Icons.get(icon, providersBackstage.icons),
       attributes: {
         'title': providersBackstage.translate(label),
         'aria-live': 'polite',
-        ...errId.fold(() => ({ }), (id) => ({ id }))
+        ...errId.fold(() => ({}), (id) => ({ id }))
       }
-    },
-    behaviours: Behaviour.derive([
-      Icons.addFocusableBehaviour()
-    ])
-  });
+    }, providersBackstage.icons);
 
   const memInvalidIcon = Memento.record(
     makeIcon('invalid', Optional.some(errorId), 'warning')

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -103,7 +103,10 @@ const renderCommonDropdown = <T>(
     }
   );
 
-  const iconSpec = Icons.render('div', Icons.get('chevron-down', sharedBackstage.providers.icons), [ `${prefix}__select-chevron` ]);
+  const iconSpec = Icons.render('chevron-down', {
+    tag: 'div',
+    classes: [ `${prefix}__select-chevron` ]
+  }, sharedBackstage.providers.icons);
 
   const memDropdown = Memento.record(
     AlloyDropdown.sketch({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -85,7 +85,7 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
 
   const makeIcon = (className: string) => {
     const iconName = className === 'checked' ? 'selected' : 'unselected';
-    return Icons.render('span', Icons.get(iconName, providerBackstage.icons), [ 'tox-icon', 'tox-checkbox-icon__' + className ]);
+    return Icons.render(iconName, { tag: 'span', classes: [ 'tox-icon', 'tox-checkbox-icon__' + className ] }, providerBackstage.icons);
   };
 
   const memIcons = Memento.record(

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
@@ -154,25 +154,21 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
       tag: 'button',
       classes: [ 'tox-notification__dismiss', 'tox-button', 'tox-button--naked', 'tox-button--icon' ]
     },
-    components: [{
-      dom: {
+    components: [
+      Icons.render('close', {
         tag: 'div',
         classes: [ 'tox-icon' ],
-        innerHtml: Icons.get('close', detail.iconProvider),
         attributes: {
           'aria-label': detail.translationProvider('Close')
         }
-      },
-      behaviours: Behaviour.derive([
-        Icons.addFocusableBehaviour()
-      ])
-    }],
+      }, detail.iconProvider)
+    ],
     action: (comp) => {
       detail.onAction(comp);
     }
   }));
 
-  const notificationIconSpec = Icons.render('div', Icons.getFirst(iconChoices, detail.iconProvider), [ 'tox-notification__icon' ]);
+  const notificationIconSpec = Icons.renderFirst(iconChoices, { tag: 'div', classes: [ 'tox-notification__icon' ] }, detail.iconProvider);
   const notificationBodySpec = {
     dom: {
       tag: 'div',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
@@ -6,18 +6,49 @@
  */
 
 import { AddEventsBehaviour, AlloyEvents, Behaviour, SimpleOrSketchSpec } from '@ephox/alloy';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Obj, Optional, Strings } from '@ephox/katamari';
 import { Attribute, SelectorFind } from '@ephox/sugar';
+
+import I18n from 'tinymce/core/api/util/I18n';
 
 export type IconProvider = () => Record<string, string>;
 
-const defaultIcon = (icons: IconProvider): string => Optional.from(icons()['temporary-placeholder']).getOr('!not found!');
+// Icons that need to be transformed in RTL
+const rtlTransform: Record<string, boolean> = {
+  'indent': true,
+  'outdent': true,
+  'table-insert-column-after': true,
+  'table-insert-column-before': true,
+  'unordered-list': true,
+  'list-bull-circle': true,
+  'list-bull-default': true,
+  'list-bull-square': true
+};
 
-const get = (name: string, icons: IconProvider): string => Optional.from(icons()[name.toLowerCase()]).getOrThunk(() => defaultIcon(icons));
+const defaultIcon = (icons: IconProvider): string =>
+  Obj.get(icons(), 'temporary-placeholder').getOr('!not found!');
 
-const getOr = (name: string, icons: IconProvider, fallback: Optional<string>): string => Optional.from(icons()[name.toLowerCase()]).or(fallback).getOrThunk(() => defaultIcon(icons));
+const lookupIcon = (name: string, icons: IconProvider): Optional<string> => {
+  const iconList = icons();
+  const lcName = name.toLowerCase();
+  const lookup = () => Obj.get(iconList, lcName);
+  // If in rtl mode then try to see if we have a rtl icon to use instead
+  if (I18n.isRtl()) {
+    const rtlName = Strings.ensureTrailing(lcName, '-rtl');
+    return Obj.get(iconList, rtlName).orThunk(lookup);
+  } else {
+    return lookup();
+  }
+};
 
-const getFirst = (names: string[], icons: IconProvider): string => Arr.findMap(names, (name) => Optional.from(icons()[name.toLowerCase()])).getOrThunk(() => defaultIcon(icons));
+const get = (name: string, icons: IconProvider): string =>
+  lookupIcon(name, icons).getOrThunk(() => defaultIcon(icons));
+
+const getOr = (name: string, icons: IconProvider, fallback: Optional<string>): string =>
+  lookupIcon(name, icons).or(fallback).getOrThunk(() => defaultIcon(icons));
+
+const getFirst = (names: string[], icons: IconProvider): string =>
+  Arr.findMap(names, (name) => lookupIcon(name, icons)).getOrThunk(() => defaultIcon(icons));
 
 const addFocusableBehaviour = () =>
   AddEventsBehaviour.config('add-focusable', [
@@ -41,10 +72,14 @@ const render = (tagName: string, iconHtml: string, classes: string[], behaviours
   };
 };
 
+const needsRtlTransform = (iconName: string) =>
+  I18n.isRtl() ? Obj.has(rtlTransform, iconName) : false;
+
 export {
   getFirst,
   getOr,
   get,
   render,
-  addFocusableBehaviour
+  addFocusableBehaviour,
+  needsRtlTransform
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemClasses.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemClasses.ts
@@ -26,7 +26,6 @@ const accessoryClass = 'tox-collection__item-accessory';
 const caretClass = 'tox-collection__item-caret';
 const checkmarkClass = 'tox-collection__item-checkmark';
 const activeClass = 'tox-collection__item--active';
-const iconClassRtl = 'tox-collection__item-icon-rtl';
 
 const containerClass = 'tox-collection__item-container';
 const containerColumnClass = 'tox-collection__item-container--column';
@@ -54,7 +53,6 @@ export {
   accessoryClass,
   caretClass,
   checkmarkClass,
-  iconClassRtl,
   containerClass,
   containerColumnClass,
   containerRowClass,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CardMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CardMenuItem.ts
@@ -67,7 +67,7 @@ export const renderCardMenuItem = (
   });
 
   const structure = {
-    dom: renderItemDomStructure(false, spec.label),
+    dom: renderItemDomStructure(spec.label),
     optComponents: [
       Optional.some({
         dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemSlices.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemSlices.ts
@@ -15,8 +15,8 @@ import * as Icons from '../../../icons/Icons';
 import * as ConvertShortcut from '../alien/ConvertShortcut';
 import * as ItemClasses from '../ItemClasses';
 
-const renderIcon = (iconHtml: string): AlloySpec =>
-  Icons.render('div', iconHtml, [ ItemClasses.iconClass ]);
+const renderIcon = (name: string, icons: Icons.IconProvider, classes: string[] = [ ItemClasses.iconClass ]) =>
+  Icons.render(name, { tag: 'div', classes }, icons);
 
 const renderText = (text: string): AlloySpec => ({
   dom: {
@@ -64,13 +64,13 @@ const renderShortcut = (shortcut: string): AlloySpec => ({
 });
 
 const renderCheckmark = (icons: Icons.IconProvider): AlloySpec =>
-  Icons.render('div', Icons.get('checkmark', icons), [ ItemClasses.checkmarkClass ]);
+  renderIcon('checkmark', icons, [ ItemClasses.checkmarkClass ]);
 
 const renderSubmenuCaret = (icons: Icons.IconProvider): AlloySpec =>
-  Icons.render('div', Icons.get('chevron-right', icons), [ ItemClasses.caretClass ]);
+  renderIcon('chevron-right', icons, [ ItemClasses.caretClass ]);
 
 const renderDownwardsCaret = (icons: Icons.IconProvider): AlloySpec =>
-  Icons.render('div', Icons.get('chevron-down', icons), [ ItemClasses.caretClass ]);
+  renderIcon('chevron-down', icons, [ ItemClasses.caretClass ]);
 
 const renderContainer = (container: Menu.CardContainer, components: Array<AlloySpec>): AlloySpec => {
   const directionClass = container.direction === 'vertical' ? ItemClasses.containerColumnClass : ItemClasses.containerRowClass;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -7,7 +7,7 @@
 
 import { AlloySpec, RawDomSchema } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
-import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
+import { Fun, Obj, Optional } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
 import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
@@ -131,35 +131,13 @@ const renderNormalItemStructure = (info: NormalItemSpec, icon: Optional<string>,
   return menuItem;
 };
 
-// TODO TINY-3598: Implement a permanent solution to render rtl icons
-// Icons that have `-rtl` equivalents
-const rtlIcon = [
-  'list-num-default',
-  'list-num-lower-alpha',
-  'list-num-lower-greek',
-  'list-num-lower-roman',
-  'list-num-upper-alpha',
-  'list-num-upper-roman',
-  'table-row-numbering'
-];
-
-// Icons that need to be transformed in RTL
-const rtlTransform = [
-  'list-bull-circle',
-  'list-bull-default',
-  'list-bull-square'
-];
-
 // TODO: Maybe need aria-label
 const renderItemStructure = (info: ItemStructureSpec, providersBackstage: UiFactoryBackstageProviders, renderIcons: boolean, fallbackIcon: Optional<string> = Optional.none()): { dom: RawDomSchema; optComponents: Array<Optional<AlloySpec>> } => {
-  // If RTL and icon is in whitelist, add RTL icon class for icons that don't have a `-rtl` icon available.
-  // Use `-rtl` icon suffix for icons that do.
-  const getIconName = (iconName: Optional<string>): Optional<string> => iconName.map((name) => I18n.isRtl() && Arr.contains(rtlIcon, name) ? name + '-rtl' : name);
-
-  const needRtlClass = I18n.isRtl() && info.iconContent.exists((name) => Arr.contains(rtlTransform, name));
+  // If RTL, add the RTL icon class for icons that don't have a `-rtl` icon available.
+  const needsRtlClass = info.iconContent.exists(Icons.needsRtlTransform);
 
   // TODO: TINY-3036 Work out a better way of dealing with custom icons
-  const icon = getIconName(info.iconContent).map((iconName) => Icons.getOr(iconName, providersBackstage.icons, fallbackIcon));
+  const icon = info.iconContent.map((iconName) => Icons.getOr(iconName, providersBackstage.icons, fallbackIcon));
 
   // Style items and autocompleter both have meta. Need to branch on style
   // This could probably be more stable...
@@ -171,7 +149,7 @@ const renderItemStructure = (info: ItemStructureSpec, providersBackstage: UiFact
   if (info.presets === 'color') {
     return renderColorStructure(info.ariaLabel, info.value, icon, providersBackstage);
   } else {
-    return renderNormalItemStructure(info, icon, renderIcons, textRender, needRtlClass);
+    return renderNormalItemStructure(info, icon, renderIcons, textRender, needsRtlClass);
   }
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -10,11 +10,11 @@ import { Toolbar } from '@ephox/bridge';
 import { Fun, Obj, Optional } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 
+import { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
 import * as Icons from '../../../icons/Icons';
 import * as ItemClasses from '../ItemClasses';
-import { renderHtml, renderIcon, renderShortcut, renderStyledText, renderText } from './ItemSlices';
+import { renderHtml, renderShortcut, renderStyledText, renderText } from './ItemSlices';
 
 export interface ItemStructure {
   dom: RawDomSchema;
@@ -34,19 +34,13 @@ export interface ItemStructureSpec {
   meta?: Record<string, any>;
 }
 
-interface NormalItemSpec {
-  iconContent: Optional<string>;
-  textContent: Optional<string>;
-  htmlContent: Optional<string>;
-  shortcutContent: Optional<string>;
-  checkMark: Optional<AlloySpec>;
-  caret: Optional<AlloySpec>;
-  ariaLabel: Optional<string>;
-}
-
-const renderColorStructure = (itemText: Optional<string>, itemValue: string, iconSvg: Optional<string>, providerBackstage: UiFactoryBackstageProviders): ItemStructure => {
+const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFactoryBackstageProviders, fallbackIcon: Optional<string>): ItemStructure => {
   const colorPickerCommand = 'custom';
   const removeColorCommand = 'remove';
+
+  const itemText = item.ariaLabel;
+  const itemValue = item.value;
+  const iconSvg = item.iconContent.map((name) => Icons.getOr(name, providerBackstage.icons, fallbackIcon));
 
   const getDom = () => {
     const common = ItemClasses.colorClass;
@@ -92,7 +86,7 @@ const renderColorStructure = (itemText: Optional<string>, itemValue: string, ico
   };
 };
 
-const renderItemDomStructure = (rtlClass: boolean, ariaLabel: Optional<string>): RawDomSchema => {
+const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
   const domTitle = ariaLabel.map((label): {attributes?: {title: string}} => ({
     attributes: {
       // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
@@ -103,23 +97,35 @@ const renderItemDomStructure = (rtlClass: boolean, ariaLabel: Optional<string>):
 
   return {
     tag: 'div',
-    classes: [ ItemClasses.navClass, ItemClasses.selectableClass ].concat(rtlClass ? [ ItemClasses.iconClassRtl ] : []),
+    classes: [ ItemClasses.navClass, ItemClasses.selectableClass ],
     ...domTitle
   };
 };
 
-const renderNormalItemStructure = (info: NormalItemSpec, icon: Optional<string>, renderIcons: boolean, textRender: (text: string) => AlloySpec, rtlClass: boolean): ItemStructure => {
+const renderNormalItemStructure = (info: ItemStructureSpec, providersBackstage: UiFactoryBackstageProviders, renderIcons: boolean, fallbackIcon: Optional<string>): ItemStructure => {
+  // TODO: TINY-3036 Work out a better way of dealing with custom icons
+  const iconSpec = { tag: 'div', classes: [ ItemClasses.iconClass ] };
+  const renderIcon = (iconName: string) => Icons.render(iconName, iconSpec, providersBackstage.icons, fallbackIcon);
+  const renderEmptyIcon = () => Optional.some({ dom: iconSpec });
   // Note: renderIcons indicates if any icons are present in the menu - if false then the icon column will not be present for the whole menu
-  const leftIcon: Optional<AlloySpec> = renderIcons ? icon.or(Optional.some('')).map(renderIcon) : Optional.none();
+  const leftIcon = renderIcons ? info.iconContent.map(renderIcon).orThunk(renderEmptyIcon) : Optional.none();
   // TINY-3345: Dedicated columns for icon and checkmark if applicable
   const checkmark = info.checkMark;
 
-  const content = info.htmlContent.fold(() => info.textContent.map(textRender),
+  // Style items and autocompleter both have meta. Need to branch on style
+  // This could probably be more stable...
+  const textRender = Optional.from(info.meta).fold(
+    () => renderText,
+    (meta) => Obj.has(meta, 'style') ? Fun.curry(renderStyledText, meta.style) : renderText
+  );
+
+  const content = info.htmlContent.fold(
+    () => info.textContent.map(textRender),
     (html) => Optional.some(renderHtml(html, [ ItemClasses.textClass ]))
   );
 
   const menuItem = {
-    dom: renderItemDomStructure(rtlClass, info.ariaLabel),
+    dom: renderItemDomStructure(info.ariaLabel),
     optComponents: [
       leftIcon,
       content,
@@ -132,24 +138,11 @@ const renderNormalItemStructure = (info: NormalItemSpec, icon: Optional<string>,
 };
 
 // TODO: Maybe need aria-label
-const renderItemStructure = (info: ItemStructureSpec, providersBackstage: UiFactoryBackstageProviders, renderIcons: boolean, fallbackIcon: Optional<string> = Optional.none()): { dom: RawDomSchema; optComponents: Array<Optional<AlloySpec>> } => {
-  // If RTL, add the RTL icon class for icons that don't have a `-rtl` icon available.
-  const needsRtlClass = info.iconContent.exists(Icons.needsRtlTransform);
-
-  // TODO: TINY-3036 Work out a better way of dealing with custom icons
-  const icon = info.iconContent.map((iconName) => Icons.getOr(iconName, providersBackstage.icons, fallbackIcon));
-
-  // Style items and autocompleter both have meta. Need to branch on style
-  // This could probably be more stable...
-  const textRender: (text: string) => AlloySpec = Optional.from(info.meta).fold(
-    () => renderText,
-    (meta) => Obj.has(meta, 'style') ? Fun.curry(renderStyledText, meta.style) : renderText
-  );
-
+const renderItemStructure = (info: ItemStructureSpec, providersBackstage: UiFactoryBackstageProviders, renderIcons: boolean, fallbackIcon: Optional<string> = Optional.none()): ItemStructure => {
   if (info.presets === 'color') {
-    return renderColorStructure(info.ariaLabel, info.value, icon, providersBackstage);
+    return renderColorStructure(info, providersBackstage, fallbackIcon);
   } else {
-    return renderNormalItemStructure(info, icon, renderIcons, textRender, needsRtlClass);
+    return renderNormalItemStructure(info, providersBackstage, renderIcons, fallbackIcon);
   }
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Behaviour, Dragging, Focusing, Keying, SimpleSpec, Tabstopping } from '@ephox/alloy';
+import { Dragging, Focusing, Keying, SimpleSpec, Tabstopping } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SugarPosition } from '@ephox/sugar';
 
@@ -41,16 +41,13 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
     return Optional.none();
   }
 
-  return Optional.some({
-    dom: {
-      tag: 'div',
-      classes: [ 'tox-statusbar__resize-handle' ],
-      attributes: {
-        title: providersBackstage.translate('Resize'), // TODO: tooltips AP-213
-      },
-      innerHtml: Icons.get('resize-handle', providersBackstage.icons)
+  return Optional.some(Icons.render('resize-handle', {
+    tag: 'div',
+    classes: [ 'tox-statusbar__resize-handle' ],
+    attributes: {
+      title: providersBackstage.translate('Resize'), // TODO: tooltips AP-213
     },
-    behaviours: Behaviour.derive([
+    behaviours: [
       Dragging.config({
         mode: 'mouse',
         repositionTarget: false,
@@ -65,8 +62,7 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
         onDown: () => keyboardHandler(editor, resizeType, 0, 1),
       }),
       Tabstopping.config({}),
-      Focusing.config({}),
-      Icons.addFocusableBehaviour()
-    ])
-  });
+      Focusing.config({})
+    ]
+  }, providersBackstage.icons));
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ButtonClasses.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ButtonClasses.ts
@@ -11,8 +11,7 @@ export const enum ToolbarButtonClasses {
   Icon = 'tox-icon',
   Ticked = 'tox-tbtn--enabled',
   SplitButton = 'tox-split-button',
-  MatchWidth = 'tox-tbtn--select',
-  IconRtl = 'tox-tbtn__icon-rtl'
+  MatchWidth = 'tox-tbtn--select'
 }
 
 export const enum MenuButtonClasses {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -14,7 +14,6 @@ import { Toolbar } from '@ephox/bridge';
 import { Arr, Cell, Fun, Future, Id, Merger, Optional } from '@ephox/katamari';
 import { Attribute, EventArgs, SelectorFind } from '@ephox/sugar';
 
-import I18n from 'tinymce/core/api/util/I18n';
 import { ToolbarGroupSetting } from 'tinymce/themes/silver/api/Settings';
 import { UiFactoryBackstage, UiFactoryBackstageProviders, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 
@@ -71,23 +70,6 @@ interface GeneralToolbarButton<T> {
 
 const focusButtonEvent = Id.generate('focus-button');
 
-// TODO TINY-3598: Implement a permanent solution to render rtl icons
-// Icons that have `-rtl` equivalents
-const rtlIcon = [
-  'checklist',
-  'ordered-list',
-  'table-row-numbering'
-];
-
-// Icons that need to be transformed in RTL
-const rtlTransform = [
-  'indent',
-  'outdent',
-  'table-insert-column-after',
-  'table-insert-column-before',
-  'unordered-list'
-];
-
 type Behaviours = Behaviour.NamedConfiguredBehaviour<Behaviour.BehaviourConfigSpec, Behaviour.BehaviourConfigDetail>[];
 const renderCommonStructure = (
   icon: Optional<string>,
@@ -97,21 +79,14 @@ const renderCommonStructure = (
   behaviours: Optional<Behaviours>,
   providersBackstage: UiFactoryBackstageProviders
 ) => {
-
-  // If RTL and icon is in whitelist, add RTL icon class for icons that don't have a `-rtl` icon available.
-  // Use `-rtl` icon suffix for icons that do.
-
-  const getIconName = (iconName: string): string => I18n.isRtl() && Arr.contains(rtlIcon, iconName) ? iconName + '-rtl' : iconName;
-  const needsRtlClass = I18n.isRtl() && icon.exists((name) => Arr.contains(rtlTransform, name));
-
   return {
     dom: {
       tag: 'button',
-      classes: [ ToolbarButtonClasses.Button ].concat(text.isSome() ? [ ToolbarButtonClasses.MatchWidth ] : []).concat(needsRtlClass ? [ ToolbarButtonClasses.IconRtl ] : []),
+      classes: [ ToolbarButtonClasses.Button ].concat(text.isSome() ? [ ToolbarButtonClasses.MatchWidth ] : []),
       attributes: getTooltipAttributes(tooltip, providersBackstage)
     },
     components: componentRenderPipeline([
-      icon.map((iconName) => renderIconFromPack(getIconName(iconName), providersBackstage.icons)),
+      icon.map((iconName) => renderIconFromPack(iconName, providersBackstage.icons)),
       text.map((text) => renderLabel(text, ToolbarButtonClasses.Button, providersBackstage))
     ]),
 
@@ -138,7 +113,7 @@ const renderCommonStructure = (
           channel: r,
           initialData: { icon, text },
           renderComponents: (data, _state) => componentRenderPipeline([
-            data.icon.map((iconName) => renderIconFromPack(getIconName(iconName), providersBackstage.icons)),
+            data.icon.map((iconName) => renderIconFromPack(iconName, providersBackstage.icons)),
             data.text.map((text) => renderLabel(text, ToolbarButtonClasses.Button, providersBackstage))
           ])
         })).toArray()

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -33,7 +33,7 @@ const renderClose = (providersBackstage: UiFactoryBackstageProviders) => Button.
     }
   },
   components: [
-    Icons.render('div', Icons.get('close', providersBackstage.icons), [ 'tox-icon' ])
+    Icons.render('close', { tag: 'div', classes: [ 'tox-icon' ] }, providersBackstage.icons)
   ],
   action: (comp) => {
     AlloyTriggers.emit(comp, formCancelEvent);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/icons/IconsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/icons/IconsTest.ts
@@ -1,38 +1,129 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { SimpleOrSketchSpec } from '@ephox/alloy';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
 import { TinyHooks } from '@ephox/mcagar';
 import { getAll as getAllOxide } from '@tinymce/oxide-icons-default';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import I18n from 'tinymce/core/api/util/I18n';
 import Theme from 'tinymce/themes/silver/Theme';
-import { get, IconProvider } from 'tinymce/themes/silver/ui/icons/Icons';
+import * as Icons from 'tinymce/themes/silver/ui/icons/Icons';
+
+type IconProvider = Icons.IconProvider;
 
 describe('browser.tinymce.themes.silver.icons.IconsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    setup: () => {
+      I18n.add('rtllang', { _dir: 'rtl' });
+    }
   }, [ Theme ]);
 
   const iconIndent = getAllOxide().indent;
   const iconDefault = getAllOxide()['temporary-placeholder'];
   const myCustomIcon = '<svg></svg>';
+  const myCustomRtlIcon = '<svg dir="rtl"></svg>';
+  const iconSpec = { tag: 'span', classes: [ 'tox-icon' ] };
 
   const iconProvider: IconProvider = () => hook.editor().ui.registry.getAll().icons;
   const emptyIconProvider: IconProvider = () => ({ });
-  const lowerCaseProvider: IconProvider = () => ({ mycustomicon: '<svg></svg>' });
+  const lowerCaseProvider: IconProvider = () => ({ mycustomicon: myCustomIcon });
+  const rtlProvider: IconProvider = () => ({ 'mycustomicon': myCustomIcon, 'mycustomicon-rtl': myCustomRtlIcon });
 
-  it('When an icon exists as a default icon or provided, it should be returned', () => {
-    assert.equal(get('indent', iconProvider), iconIndent);
+  const assertIconSpec = (spec: SimpleOrSketchSpec, svg: string, flip: boolean = false) => {
+    assert.deepEqual(spec.dom, {
+      tag: 'span',
+      classes: [ 'tox-icon' ].concat(flip ? [ 'tox-icon--flip' ] : []),
+      attributes: {},
+      innerHtml: svg
+    });
+    assert.property(spec.behaviours, 'add-focusable');
+  };
+
+  const testWithRtl = (fn: () => void) => () => {
+    I18n.setCode('rtllang');
+    fn();
+    I18n.setCode('en');
+  };
+
+  context('get', () => {
+    it('When an icon exists as a default icon or provided, it should be returned', () => {
+      assert.equal(Icons.get('indent', iconProvider), iconIndent);
+    });
+
+    it('When a lowercase version of a mixed-case name exists, it should be returned', () => {
+      assert.equal(Icons.get('myCustomIcon', lowerCaseProvider), myCustomIcon);
+    });
+
+    it('When an icon does not exist as a default icon, the temporary placeholder or fallback icon should be returned', () => {
+      assert.equal(Icons.get('temp_icon', iconProvider), iconDefault);
+    });
+
+    it('When a default icon or fallback does not exist, !not found! should be returned', () => {
+      assert.equal(Icons.get('indent', emptyIconProvider), '!not found!');
+    });
+
+    it('TINY-7782: should use an RTL icon if present when in RTL mode', testWithRtl(() => {
+      assert.equal(Icons.get('mycustomicon', rtlProvider), myCustomRtlIcon);
+    }));
   });
 
-  it('When a lowercase version of a mixed-case name exists, it should be returned', () => {
-    assert.equal(get('myCustomIcon', lowerCaseProvider), myCustomIcon);
+  context('render', () => {
+    it('TINY-7782: should render a valid icon', () => {
+      const spec = Icons.render('indent', iconSpec, iconProvider);
+      assertIconSpec(spec, iconIndent);
+    });
+
+    it('TINY-7782: should use fallback icon html if provided', () => {
+      const spec = Icons.render('invalid', iconSpec, iconProvider, Optional.some(myCustomIcon));
+      assertIconSpec(spec, myCustomIcon);
+    });
+
+    it('TINY-7782: should fallback to rendering the placeholder for an invalid icon', () => {
+      const spec = Icons.render('invalid', iconSpec, iconProvider);
+      assertIconSpec(spec, iconDefault);
+    });
+
+    it('TINY-7782: should render with a custom icon spec', () => {
+      const spec = Icons.render('indent', {
+        tag: 'div',
+        classes: [ 'custom-class' ],
+        attributes: {
+          title: 'test title'
+        }
+      }, iconProvider);
+
+      assert.deepEqual(spec.dom, {
+        tag: 'div',
+        classes: [ 'custom-class' ],
+        attributes: {
+          title: 'test title'
+        },
+        innerHtml: iconIndent
+      });
+    });
+
+    it('TINY-7782: should render using an RTL icon if present', testWithRtl(() => {
+      const spec = Icons.render('mycustomicon', iconSpec, rtlProvider);
+      assertIconSpec(spec, myCustomRtlIcon, false);
+    }));
+
+    it('TINY-7782: should include the flip transform icon class for certain icons when in RTL mode', testWithRtl(() => {
+      const spec = Icons.render('indent', iconSpec, iconProvider);
+      assertIconSpec(spec, iconIndent, true);
+    }));
   });
 
-  it('When an icon does not exist as a default icon, the temporary placeholder or fallback icon should be returned', () => {
-    assert.equal(get('temp_icon', iconProvider), iconDefault);
-  });
+  context('renderFirst', () => {
+    it('TINY-7782: should render the first valid icon', () => {
+      const spec = Icons.renderFirst([ 'invalid', 'indent', 'outdent' ], iconSpec, iconProvider);
+      assertIconSpec(spec, iconIndent);
+    });
 
-  it('When a default icon or fallback does not exist, !not found! should be returned', () => {
-    assert.equal(get('indent', emptyIconProvider), '!not found!');
+    it('TINY-7782: should fallback to rendering the placeholder when no icons are valid', () => {
+      const spec = Icons.renderFirst([ 'invalid' ], iconSpec, iconProvider);
+      assertIconSpec(spec, iconDefault);
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-7782

Description of Changes:
This reworks how icons are rendered in Silver, so that they all go via the same path (`Icons.render` in most cases). This also ensures that the RTL logic applies to all icons being rendered, as previously a number we not being transformed, etc... correctly. The changes are as follows:
- Changed how the `Icons.render` function works so that it accepts the icon name, not the icon HTML, etc... and also added an equivalent `renderFirst` function.
- Changed the class being used to transform/rotate select icons in RTL mode. It will now add a generic `tox-icon--flip` class instead.
- Improved the icon lookup logic to automatically use an icon with the same name that includes a `-rtl` suffix (e.g. `checklist-rtl`)
- Updated all places that rendered icons to use the updated/new functions.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
