### PR TITLE
Remove UglifyJS ie8 compatibility configuration and enable 2 compression passes

### DIFF
--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -186,10 +186,10 @@ module.exports = function (grunt) {
             ascii_only: true
           },
           compress: {
+            passes: 2,
             // TINY-7720: Disable merge_vars as it has a bug that causes errors on IE 11
             merge_vars: false
-          },
-          ie8: true
+          }
         },
         core: {
           files: [


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Removed the `ie8` compatibility configuration of UglifyJS as we haven't supported IE 8 since 4.5.x.
* Enable a second compression pass to further reduce the bundle size. This does add a bit of time to the build stage. Locally, it was ~13s as it went from 157s -> 170s.

Both of the above changes helps reduce the size of the bundle by about 8kb for the minified `tinymce.js` file.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
