### PR TITLE
TINY-7224: Clicking on a noneditable table cell did not show a visual selection

### DIFF
--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -1,5 +1,5 @@
 import { Optional, Singleton } from '@ephox/katamari';
-import { EventArgs, SelectorFind, SugarElement } from '@ephox/sugar';
+import { ContentEditable, EventArgs, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import { SelectionAnnotation } from '../api/SelectionAnnotation';
 import { WindowBridge } from '../api/WindowBridge';
@@ -25,8 +25,15 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement<Nod
       findCell(event.target, isRoot).each((finish) => {
         CellSelection.identify(start, finish, isRoot).each((cellSel) => {
           const boxes = cellSel.boxes.getOr([]);
-          // Wait until we have more than one, otherwise you can't do text selection inside a cell.
-          if (boxes.length > 1) {
+          if (boxes.length === 1) {
+            // If a single CEF cell is selected, make sure it is annotated
+            const singleCell = boxes[0];
+            if (ContentEditable.getRaw(singleCell) === 'false') {
+              annotations.selectRange(container, boxes, singleCell, singleCell);
+              bridge.selectContents(singleCell);
+            }
+          } else if (boxes.length > 1) {
+            // Wait until we have more than one, otherwise you can't do text selection inside a cell.
             annotations.selectRange(container, boxes, cellSel.start, cellSel.finish);
 
             // stop the browser from creating a big text selection, select the cell where the cursor is

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `imagetools` buttons were incorrectly enabled for remote images without `imagetools_proxy` set #TINY-7772
 - Removing a table row or column could result in the cursor getting placed in an invalid location #TINY-7695
 - Pressing the Tab key to navigate through table cells did not skip noneditable cells #TINY-7705
+- Clicking on a noneditable table cell did not show a visual selection like other noneditable elements #TINY-7224
 - Some table operations would incorrectly cause table row attributes and styles to be lost #TINY-6666
 - The selection was incorrectly lost when using the `mceTableCellType` and `mceTableRowType` commands #TINY-6666
 - The `mceTableRowType` was reversing the order of the rows when converting multiple header rows back to body rows #TINY-6666

--- a/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
@@ -1,7 +1,7 @@
-import { Assertions } from '@ephox/agar';
+import { Assertions, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -109,5 +109,47 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
     const editor = hook.editor();
     editor.setContent('<table><tr><td data-mce-selected="1">a</td><td>b</td></tr><tr><td data-mce-selected="1">c</td><td>d</td></tr></table>', { format: 'raw' });
     assertSelectionContent(editor, '<table><tbody><tr><td>a</td></tr><tr><td>c</td></tr></tbody></table>');
+  });
+
+  it('TINY-7224: can select single CEF cell', () => {
+    const editor = hook.editor();
+    assertTableSelection(
+      editor,
+      '<table><tr><td contenteditable="false">1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>',
+      [ '1', '1' ],
+      [ '1' ]
+    );
+    TinyAssertions.assertContentPresence(editor, {
+      'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 1
+    });
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+  });
+
+  it('TINY-7224: select CEF cell and normal cell', () => {
+    const editor = hook.editor();
+    assertTableSelection(
+      editor,
+      '<table><tr><td contenteditable="false">1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>',
+      [ '1', '3' ],
+      [ '1', '3' ]
+    );
+  });
+
+  it('TINY-7224: can select other cells from CEF cell selection', () => {
+    const editor = hook.editor();
+    assertTableSelection(
+      hook.editor(),
+      '<table><tr><td contenteditable="false">1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>',
+      [ '1', '1' ],
+      [ '1' ]
+    );
+
+    TinyContentActions.keydown(editor, Keys.right(), { shiftKey: true });
+    TinyContentActions.keyup(editor, Keys.right(), { shiftKey: true });
+    assertSelectedCells(editor, [ '1', '2' ], Html.get);
+    TinyAssertions.assertContentPresence(editor, {
+      'td[contenteditable="false"][data-mce-first-selected="1"]:not([data-mce-last-selected="1"])': 1,
+      'td:not([contenteditable="false"][data-mce-first-selected="1"])[data-mce-last-selected="1"]': 1
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-7224

Description of Changes:
* Update MouseSelection logic in Darwin to add the `selected` attributes when a single CEF cell is clicked

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
