### PR TITLE
TINY-7851: Fixed the table paste column before/after icons not flipped in RTL mode

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The table dialog did not always respect the `table_style_with_css` option #TINY-4926
 - Pasting into a table with multiple cells selected could cause the content to be pasted in the wrong location #TINY-7485
 - The `TableModified` event was not fired when pasting cells into a table #TINY-6939
+- The table paste column before and after icons were not flipped in RTL mode #TINY-7851
 - Base64 encoded images with spaces or line breaks in the data URI were not displayed correctly. Patch contributed by RoboBurned
 
 ### Deprecated

--- a/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
@@ -26,6 +26,8 @@ const rtlTransform: Record<string, boolean> = {
   'outdent': true,
   'table-insert-column-after': true,
   'table-insert-column-before': true,
+  'paste-column-after': true,
+  'paste-column-before': true,
   'unordered-list': true,
   'list-bull-circle': true,
   'list-bull-default': true,


### PR DESCRIPTION
Related Ticket: TINY-7851

Description of Changes:
* Added the `paste-column-after` and `paste-column-before` icons to the list that needs to be flipped in RTL mode. This was missed when they were added in 5.4.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ As discussed in slack we're skipping this for this change
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
