### PR TITLE
TINY-7785: Use `navigator.userAgentData` for browser detection when supported

### DIFF
--- a/modules/sand/CHANGELOG.md
+++ b/modules/sand/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Improved
+- Detection logic has been updated to use `navigator.userAgentData` for browser detection if it is available.
+
 ### Changed
 - Upgraded to Katamari 8.0, which is incompatible with Katamari 7.0 if used in the same bundle.
-- Detection logic has been updated to use `navigator.userAgentData` for browser detection if it is available.
+

--- a/modules/sand/CHANGELOG.md
+++ b/modules/sand/CHANGELOG.md
@@ -8,3 +8,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Upgraded to Katamari 8.0, which is incompatible with Katamari 7.0 if used in the same bundle.
+- Detection logic has been updated to use `navigator.userAgentData` for browser detection if it is available.

--- a/modules/sand/src/main/ts/ephox/sand/api/PlatformDetection.ts
+++ b/modules/sand/src/main/ts/ephox/sand/api/PlatformDetection.ts
@@ -1,4 +1,4 @@
-import { Fun, Thunk } from '@ephox/katamari';
+import { Fun, Optional, Thunk } from '@ephox/katamari';
 
 import { Browser as BrowserCore } from '../core/Browser';
 import { OperatingSystem as OperatingSystemCore } from '../core/OperatingSystem';
@@ -13,7 +13,8 @@ const mediaMatch = (query: string) => window.matchMedia(query).matches;
 
 // IMPORTANT: Must be in a thunk, otherwise rollup thinks calling this immediately
 // causes side effects and won't tree shake this away
-let platform = Thunk.cached(() => PlatformDetection.detect(navigator.userAgent, mediaMatch));
+// Note: navigator.userAgentData is not part of the native typescript types yet
+let platform = Thunk.cached(() => PlatformDetection.detect(navigator.userAgent, Optional.from(((navigator as any).userAgentData)), mediaMatch));
 
 export const detect = (): PlatformDetection => platform();
 

--- a/modules/sand/src/main/ts/ephox/sand/core/Browser.ts
+++ b/modules/sand/src/main/ts/ephox/sand/core/Browser.ts
@@ -1,7 +1,7 @@
 import { Fun } from '@ephox/katamari';
 
-import { UaString } from '../detect/UaString';
 import { Version } from '../detect/Version';
+import { UaInfo } from '../info/UaInfo';
 
 const edge = 'Edge';
 const chrome = 'Chrome';
@@ -10,9 +10,7 @@ const opera = 'Opera';
 const firefox = 'Firefox';
 const safari = 'Safari';
 
-export interface Browser {
-  readonly current: string | undefined;
-  readonly version: Version;
+export interface Browser extends UaInfo {
   readonly isEdge: () => boolean;
   readonly isChrome: () => boolean;
   readonly isIE: () => boolean;
@@ -28,7 +26,7 @@ const unknown = (): Browser => {
   });
 };
 
-const nu = (info: UaString): Browser => {
+const nu = (info: UaInfo): Browser => {
   const current = info.current;
   const version = info.version;
 

--- a/modules/sand/src/main/ts/ephox/sand/core/OperatingSystem.ts
+++ b/modules/sand/src/main/ts/ephox/sand/core/OperatingSystem.ts
@@ -1,11 +1,9 @@
 import { Fun } from '@ephox/katamari';
 
-import { UaString } from '../detect/UaString';
 import { Version } from '../detect/Version';
+import { UaInfo } from '../info/UaInfo';
 
-export interface OperatingSystem {
-  readonly current: string | undefined;
-  readonly version: Version;
+export interface OperatingSystem extends UaInfo {
   readonly isWindows: () => boolean;
   readonly isiOS: () => boolean;
   readonly isAndroid: () => boolean;
@@ -35,7 +33,7 @@ const unknown = (): OperatingSystem => {
   });
 };
 
-const nu = (info: UaString): OperatingSystem => {
+const nu = (info: UaInfo): OperatingSystem => {
   const current = info.current;
   const version = info.version;
 

--- a/modules/sand/src/main/ts/ephox/sand/core/PlatformDetection.ts
+++ b/modules/sand/src/main/ts/ephox/sand/core/PlatformDetection.ts
@@ -1,8 +1,8 @@
 import { Optional } from '@ephox/katamari';
 
 import { DeviceType } from '../detect/DeviceType';
-import { UaData, UserAgentData } from '../detect/UaData';
-import { UaString } from '../detect/UaString';
+import * as UaData from '../detect/UaData';
+import * as UaString from '../detect/UaString';
 import { PlatformInfo } from '../info/PlatformInfo';
 import { Browser } from './Browser';
 import { OperatingSystem } from './OperatingSystem';
@@ -13,7 +13,7 @@ export interface PlatformDetection {
   readonly deviceType: DeviceType;
 }
 
-const detect = (userAgent: string, userAgentDataOpt: Optional<UserAgentData>, mediaMatch: (query: string) => boolean): PlatformDetection => {
+const detect = (userAgent: string, userAgentDataOpt: Optional<UaData.UserAgentData>, mediaMatch: (query: string) => boolean): PlatformDetection => {
   const browsers = PlatformInfo.browsers();
   const oses = PlatformInfo.oses();
 

--- a/modules/sand/src/main/ts/ephox/sand/core/PlatformDetection.ts
+++ b/modules/sand/src/main/ts/ephox/sand/core/PlatformDetection.ts
@@ -1,23 +1,26 @@
+import { Optional } from '@ephox/katamari';
+
 import { DeviceType } from '../detect/DeviceType';
+import { UaData, UserAgentData } from '../detect/UaData';
 import { UaString } from '../detect/UaString';
 import { PlatformInfo } from '../info/PlatformInfo';
 import { Browser } from './Browser';
 import { OperatingSystem } from './OperatingSystem';
 
 export interface PlatformDetection {
-  browser: Browser;
-  os: OperatingSystem;
-  deviceType: DeviceType;
+  readonly browser: Browser;
+  readonly os: OperatingSystem;
+  readonly deviceType: DeviceType;
 }
 
-const detect = (userAgent: string, mediaMatch: (query: string) => boolean): PlatformDetection => {
+const detect = (userAgent: string, userAgentDataOpt: Optional<UserAgentData>, mediaMatch: (query: string) => boolean): PlatformDetection => {
   const browsers = PlatformInfo.browsers();
   const oses = PlatformInfo.oses();
 
-  const browser = UaString.detectBrowser(browsers, userAgent).fold(
-    Browser.unknown,
-    Browser.nu
-  );
+  const browser = userAgentDataOpt.bind((userAgentData) => UaData.detectBrowser(browsers, userAgentData))
+    .orThunk(() => UaString.detectBrowser(browsers, userAgent))
+    .fold(Browser.unknown, Browser.nu);
+
   const os = UaString.detectOs(oses, userAgent).fold(
     OperatingSystem.unknown,
     OperatingSystem.nu

--- a/modules/sand/src/main/ts/ephox/sand/detect/UaData.ts
+++ b/modules/sand/src/main/ts/ephox/sand/detect/UaData.ts
@@ -1,0 +1,34 @@
+import { Arr, Optional } from '@ephox/katamari';
+
+import { PlatformInfo } from '../info/PlatformInfo';
+import { UaInfo } from '../info/UaInfo';
+import { Version } from './Version';
+
+// There are no native typescript types for navigator.UserAgentData at this stage so have to manually define it
+
+export interface UserAgentDataBrand {
+  readonly brand: string;
+  readonly version: string;
+}
+
+export interface UserAgentData {
+  readonly brands: UserAgentDataBrand[];
+  readonly mobile: boolean;
+}
+
+const detectBrowser = (browsers: PlatformInfo[], userAgentData: UserAgentData): Optional<UaInfo> => {
+  return Arr.findMap<UserAgentDataBrand, UaInfo>(userAgentData.brands, (uaBrand) => {
+    const lcBrand = uaBrand.brand.toLowerCase();
+    return Arr.find(browsers, (browser) => lcBrand === browser.brand?.toLowerCase())
+      .map((info) => {
+        return {
+          current: info.name,
+          version: Version.nu(parseInt(uaBrand.version, 10), 0)
+        };
+      });
+  });
+};
+
+export const UaData = {
+  detectBrowser
+};

--- a/modules/sand/src/main/ts/ephox/sand/detect/UaData.ts
+++ b/modules/sand/src/main/ts/ephox/sand/detect/UaData.ts
@@ -20,15 +20,13 @@ const detectBrowser = (browsers: PlatformInfo[], userAgentData: UserAgentData): 
   return Arr.findMap<UserAgentDataBrand, UaInfo>(userAgentData.brands, (uaBrand) => {
     const lcBrand = uaBrand.brand.toLowerCase();
     return Arr.find(browsers, (browser) => lcBrand === browser.brand?.toLowerCase())
-      .map((info) => {
-        return {
-          current: info.name,
-          version: Version.nu(parseInt(uaBrand.version, 10), 0)
-        };
-      });
+      .map((info) => ({
+        current: info.name,
+        version: Version.nu(parseInt(uaBrand.version, 10), 0)
+      }));
   });
 };
 
-export const UaData = {
+export {
   detectBrowser
 };

--- a/modules/sand/src/main/ts/ephox/sand/detect/UaString.ts
+++ b/modules/sand/src/main/ts/ephox/sand/detect/UaString.ts
@@ -1,12 +1,8 @@
 import { Arr, Optional } from '@ephox/katamari';
 
 import { PlatformInfo } from '../info/PlatformInfo';
+import { UaInfo } from '../info/UaInfo';
 import { Version } from './Version';
-
-export interface UaString {
-  current: string | undefined;
-  version: Version;
-}
 
 const detect = (candidates: PlatformInfo[], userAgent: any): Optional<PlatformInfo> => {
   const agent = String(userAgent).toLowerCase();
@@ -17,8 +13,8 @@ const detect = (candidates: PlatformInfo[], userAgent: any): Optional<PlatformIn
 
 // They (browser and os) are the same at the moment, but they might
 // not stay that way.
-const detectBrowser = (browsers: PlatformInfo[], userAgent: any): Optional<UaString> => {
-  return detect(browsers, userAgent).map((browser): UaString => {
+const detectBrowser = (browsers: PlatformInfo[], userAgent: any): Optional<UaInfo> => {
+  return detect(browsers, userAgent).map((browser): UaInfo => {
     const version = Version.detect(browser.versionRegexes, userAgent);
     return {
       current: browser.name,
@@ -27,8 +23,8 @@ const detectBrowser = (browsers: PlatformInfo[], userAgent: any): Optional<UaStr
   });
 };
 
-const detectOs = (oses: PlatformInfo[], userAgent: any): Optional<UaString> => {
-  return detect(oses, userAgent).map((os): UaString => {
+const detectOs = (oses: PlatformInfo[], userAgent: any): Optional<UaInfo> => {
+  return detect(oses, userAgent).map((os): UaInfo => {
     const version = Version.detect(os.versionRegexes, userAgent);
     return {
       current: os.name,

--- a/modules/sand/src/main/ts/ephox/sand/detect/UaString.ts
+++ b/modules/sand/src/main/ts/ephox/sand/detect/UaString.ts
@@ -33,7 +33,7 @@ const detectOs = (oses: PlatformInfo[], userAgent: any): Optional<UaInfo> => {
   });
 };
 
-export const UaString = {
+export {
   detectBrowser,
   detectOs
 };

--- a/modules/sand/src/main/ts/ephox/sand/detect/Version.ts
+++ b/modules/sand/src/main/ts/ephox/sand/detect/Version.ts
@@ -1,6 +1,6 @@
 export interface Version {
-  major: number;
-  minor: number;
+  readonly major: number;
+  readonly minor: number;
 }
 
 const firstMatch = (regexes: RegExp[], s: string): RegExp | undefined => {

--- a/modules/sand/src/main/ts/ephox/sand/info/PlatformInfo.ts
+++ b/modules/sand/src/main/ts/ephox/sand/info/PlatformInfo.ts
@@ -1,9 +1,10 @@
 import { Fun, Strings } from '@ephox/katamari';
 
 export interface PlatformInfo {
-  name: string;
-  versionRegexes: RegExp[];
-  search: (uastring: string) => boolean;
+  readonly name: string;
+  readonly versionRegexes: RegExp[];
+  readonly search: (uastring: string) => boolean;
+  readonly brand?: string;
 }
 
 const normalVersionRegex = /.*?version\/\ ?([0-9]+)\.([0-9]+).*/;
@@ -15,6 +16,7 @@ const checkContains = (target: string) => {
 };
 
 const browsers: PlatformInfo[] = [
+  // This is legacy Edge
   {
     name: 'Edge',
     versionRegexes: [ /.*?edge\/ ?([0-9]+)\.([0-9]+)$/ ],
@@ -22,8 +24,10 @@ const browsers: PlatformInfo[] = [
       return Strings.contains(uastring, 'edge/') && Strings.contains(uastring, 'chrome') && Strings.contains(uastring, 'safari') && Strings.contains(uastring, 'applewebkit');
     }
   },
+  // This is Google Chrome and Chromium Edge
   {
     name: 'Chrome',
+    brand: 'Chromium',
     versionRegexes: [ /.*?chrome\/([0-9]+)\.([0-9]+).*/, normalVersionRegex ],
     search: (uastring) => {
       return Strings.contains(uastring, 'chrome') && !Strings.contains(uastring, 'chromeframe');

--- a/modules/sand/src/main/ts/ephox/sand/info/UaInfo.ts
+++ b/modules/sand/src/main/ts/ephox/sand/info/UaInfo.ts
@@ -1,0 +1,6 @@
+import { Version } from '../detect/Version';
+
+export interface UaInfo {
+  readonly current: string | undefined;
+  readonly version: Version;
+}

--- a/modules/sand/src/test/ts/atomic/core/DeviceTypeTest.ts
+++ b/modules/sand/src/test/ts/atomic/core/DeviceTypeTest.ts
@@ -1,12 +1,12 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { Fun } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import { PlatformDetection } from 'ephox/sand/core/PlatformDetection';
 
 describe('DeviceTypeTest', () => {
   const getPlatform = (userAgent: string) => {
-    return PlatformDetection.detect(userAgent, Fun.never);
+    return PlatformDetection.detect(userAgent, Optional.none(), Fun.never);
   };
 
   const checkTablet = (expected: boolean, userAgent: string) => {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When scrolling, the context toolbar will stick to where it was previously for large elements, such as tables #TINY-7545
 - The context toolbar will now move out of the way when it overlaps with the selection, such as in table cells #TINY-7192
 - The `formatter.match` API can now take an optional `similar` parameter to check if the format partial matches #TINY-7712
+- `Env.browser` now uses the User-Agent Client Hints API when it is available #TINY-7785
 - Icons with a `-rtl` suffix in their name will now automatically be used when the UI is rendered in right-to-left mode #TINY-7782
 
 ### Changed


### PR DESCRIPTION
Related Ticket: TINY-7785

Description of Changes:
* Use new userAgentData API to detect browser type and major version in Sand

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
