### PR TITLE
TINY-7724: Clicking on a noneditable table cell did not show a visual selection

### DIFF
--- a/modules/darwin/CHANGELOG.md
+++ b/modules/darwin/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ## Added
-- Added new `selectNode` method to `WindowBridge`.
+- Added new `selectNode` API to `WindowBridge`.
 
 ### Changed
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.

--- a/modules/darwin/CHANGELOG.md
+++ b/modules/darwin/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## Added
+- Added new `selectNode` method to `WindowBridge`.
+
 ### Changed
 - Upgraded to Katamari 8.0, which includes breaking changes to the `Optional` API used in this module.
 - Changed the `MouseSelection` and `KeySelection` fake selection logic to only apply if more than one cell of the same table is selected.
 
 ### Fixed
 - Fixed incorrect type for single selections in the `Selections` and `CellOpSelection` modules.
+- `MouseSelection` fake selection did not apply to a single selected CEF cell.

--- a/modules/darwin/src/main/ts/ephox/darwin/api/WindowBridge.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/WindowBridge.ts
@@ -15,8 +15,8 @@ export interface WindowBridge {
   collapseSelection: (toStart?: boolean) => void;
   setSelection: (sel: SimRange) => void;
   setRelativeSelection: (start: Situ, finish: Situ) => void;
-  selectContents: (element: SugarElement) => void;
-  selectNode: (element: SugarElement) => void;
+  selectContents: (element: SugarElement<Node>) => void;
+  selectNode: (element: SugarElement<Node>) => void;
   getInnerHeight: () => number;
   getScrollY: () => number;
   scrollBy: (x: number, y: number) => void;

--- a/modules/darwin/src/main/ts/ephox/darwin/api/WindowBridge.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/WindowBridge.ts
@@ -16,6 +16,7 @@ export interface WindowBridge {
   setSelection: (sel: SimRange) => void;
   setRelativeSelection: (start: Situ, finish: Situ) => void;
   selectContents: (element: SugarElement) => void;
+  selectNode: (element: SugarElement) => void;
   getInnerHeight: () => number;
   getScrollY: () => number;
   scrollBy: (x: number, y: number) => void;
@@ -71,7 +72,11 @@ export const WindowBridge = (win: Window): WindowBridge => {
     ));
   };
 
-  const selectContents = (element: SugarElement) => {
+  const selectNode = (element: SugarElement<Node>) => {
+    WindowSelection.setToElement(win, element, false);
+  };
+
+  const selectContents = (element: SugarElement<Node>) => {
     WindowSelection.setToElement(win, element);
   };
 
@@ -107,6 +112,7 @@ export const WindowBridge = (win: Window): WindowBridge => {
     collapseSelection,
     setSelection,
     setRelativeSelection,
+    selectNode,
     selectContents,
     getInnerHeight,
     getScrollY,

--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -26,9 +26,10 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement<Nod
         CellSelection.identify(start, finish, isRoot).each((cellSel) => {
           const boxes = cellSel.boxes.getOr([]);
           if (boxes.length === 1) {
-            // If a single CEF cell is selected, make sure it is annotated
+            // If a single noneditable cell is selected and the actual selection target within the cell
+            // is also noneditable, make sure it is annotated
             const singleCell = boxes[0];
-            if (ContentEditable.getRaw(singleCell) === 'false') {
+            if (ContentEditable.getRaw(singleCell) === 'false' && !ContentEditable.isEditable(event.target)) {
               annotations.selectRange(container, boxes, singleCell, singleCell);
               bridge.selectNode(singleCell);
             }

--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -1,5 +1,5 @@
 import { Optional, Singleton } from '@ephox/katamari';
-import { EventArgs, SelectorFind, SugarElement } from '@ephox/sugar';
+import { ContentEditable, EventArgs, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import { SelectionAnnotation } from '../api/SelectionAnnotation';
 import { WindowBridge } from '../api/WindowBridge';
@@ -25,8 +25,15 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement<Nod
       findCell(event.target, isRoot).each((finish) => {
         CellSelection.identify(start, finish, isRoot).each((cellSel) => {
           const boxes = cellSel.boxes.getOr([]);
-          // Wait until we have more than one, otherwise you can't do text selection inside a cell.
-          if (boxes.length > 1) {
+          if (boxes.length === 1) {
+            // If a single CEF cell is selected, make sure it is annotated
+            const singleCell = boxes[0];
+            if (ContentEditable.getRaw(singleCell) === 'false') {
+              annotations.selectRange(container, boxes, singleCell, singleCell);
+              bridge.selectNode(singleCell);
+            }
+          } else if (boxes.length > 1) {
+            // Wait until we have more than one, otherwise you can't do text selection inside a cell.
             annotations.selectRange(container, boxes, cellSel.start, cellSel.finish);
 
             // stop the browser from creating a big text selection, select the cell where the cursor is

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/WindowSelection.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/WindowSelection.ts
@@ -121,8 +121,9 @@ const doGetExact = (selection: Selection): Optional<SimRange> => {
   }
 };
 
-const setToElement = (win: Window, element: SugarElement<Node>): void => {
-  const rng = NativeRange.selectNodeContents(win, element);
+const setToElement = (win: Window, element: SugarElement<Node>, selectNodeContents: boolean = true): void => {
+  const rngGetter = selectNodeContents ? NativeRange.selectNodeContents : NativeRange.selectNode;
+  const rng = rngGetter(win, element);
   doSetNativeRange(win, rng);
 };
 

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/core/NativeRange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/core/NativeRange.ts
@@ -4,6 +4,12 @@ import { SugarElement } from '../../api/node/SugarElement';
 import { RawRect } from '../../api/selection/Rect';
 import { Situ } from '../../api/selection/Situ';
 
+const selectNode = (win: Window, element: SugarElement<Node>): Range => {
+  const rng = win.document.createRange();
+  rng.selectNode(element.dom);
+  return rng;
+};
+
 const selectNodeContents = (win: Window, element: SugarElement<Node>): Range => {
   const rng = win.document.createRange();
   selectNodeContentsUsing(rng, element);
@@ -96,6 +102,7 @@ const toString = (rng: Range): string => rng.toString();
 export {
   create,
   replaceWith,
+  selectNode,
   selectNodeContents,
   selectNodeContentsUsing,
   relativeToNative,

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `imagetools` buttons were incorrectly enabled for remote images without `imagetools_proxy` set #TINY-7772
 - Removing a table row or column could result in the cursor getting placed in an invalid location #TINY-7695
 - Pressing the Tab key to navigate through table cells did not skip noneditable cells #TINY-7705
+- Clicking on a noneditable table cell did not show a visual selection like other noneditable elements #TINY-7724
 - Some table operations would incorrectly cause table row attributes and styles to be lost #TINY-6666
 - The selection was incorrectly lost when using the `mceTableCellType` and `mceTableRowType` commands #TINY-6666
 - The `mceTableRowType` was reversing the order of the rows when converting multiple header rows back to body rows #TINY-6666

--- a/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -138,7 +138,6 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
   it('TINY-7724: does not select CEF cell if contenteditable=true child is selected', () => {
     const editor = hook.editor();
     editor.setContent('<table><tr><td contenteditable="false"><p contenteditable="true">1</p></td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>');
-    TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0, 0 ], 0);
 
     // Check the CEF cell is not annotated when the contenteditable="true" child is selected
     const editablePara = SelectorFind.descendant(TinyDom.body(editor), 'p[contenteditable="true"]').getOrDie('Could not find paragraph');

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -193,8 +193,7 @@ const selectWithMouse = (start: SugarElement<Element>, end: SugarElement<Element
 const selectWithKeyboard = (editor: Editor, cursorRange: Cursors.CursorPath, keyDirection: number): void => {
   const { startPath, soffset, finishPath, foffset } = cursorRange;
   TinySelections.setSelection(editor, startPath, soffset, finishPath, foffset);
-  TinyContentActions.keydown(editor, keyDirection, { shiftKey: true });
-  TinyContentActions.keyup(editor, keyDirection, { shiftKey: true });
+  TinyContentActions.keystroke(editor, keyDirection, { shiftKey: true });
 };
 
 const getSelectedCells = (editor: Editor): SugarElement<HTMLTableCellElement>[] =>


### PR DESCRIPTION
Related Ticket: TINY-7724

Description of Changes:
* Update MouseSelection logic in Darwin to add the selected attributes when a single CEF cell is clicked

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
