### PR TITLE
TINY-7714: Updated the autolink plugin to use the Polaris link regex

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `formatter.match` API can now take an optional `similar` parameter to check if the format partial matches #TINY-7712
 - `Env.browser` now uses the User-Agent Client Hints API when it is available #TINY-7785
 - Icons with a `-rtl` suffix in their name will now automatically be used when the UI is rendered in right-to-left mode #TINY-7782
+- The `autolink` plugin link detection now permits custom protocols and improves valid link detection #TINY-7714
 
 ### Changed
 - Changed the load order so that the content css gets loaded before the editor gets populated with contents #TINY-7249

--- a/modules/tinymce/src/plugins/autolink/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/api/Settings.ts
@@ -5,10 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Regexes } from '@ephox/polaris';
+
 import Editor from 'tinymce/core/api/Editor';
 
+// Use the Polaris link detection, however for autolink we need to make it be an exact match
+const defaultLinkPattern = new RegExp('^' + Regexes.link().source + '$', 'i');
+
 const getAutoLinkPattern = (editor: Editor): RegExp =>
-  editor.getParam('autolink_pattern', /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+\-]+@(?!.*@))(.+)$/i);
+  editor.getParam('autolink_pattern', defaultLinkPattern);
 
 const getDefaultLinkTarget = (editor: Editor): boolean =>
   editor.getParam('default_link_target', false);

--- a/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
@@ -64,6 +64,10 @@ const setEnd = (rng: Range, container: Node, offset: number): void => {
 const hasProtocol = (url: string): boolean =>
   /^([A-Za-z][A-Za-z\d.+-]*:\/\/)|mailto:/.test(url);
 
+// A limited list of punctuation characters that might be used after a link
+const isPunctuation = (char: string) =>
+  /[?!,.;:]/.test(char);
+
 const parseCurrentLine = (editor: Editor, endOffset: number, delimiter: string): void => {
   let end, endContainer, bookmark, text, prev, len, rngText;
   const autoLinkPattern = Settings.getAutoLinkPattern(editor);
@@ -148,7 +152,7 @@ const parseCurrentLine = (editor: Editor, endOffset: number, delimiter: string):
 
   // Exclude last . from word like "www.site.com."
   text = rng.toString();
-  if (text.charAt(text.length - 1) === '.') {
+  if (isPunctuation(text.charAt(text.length - 1))) {
     setEnd(rng, endContainer, start - 1);
   }
 

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -1,4 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
+import { Type } from '@ephox/katamari';
 import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
 import { assert } from 'chai';
 import fc from 'fast-check';
@@ -51,8 +52,8 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assert.equal(typeUrl(editor, input), `<p>${text || input}&nbsp;</p>`, 'Should not convert to link');
   };
 
-  const assertIsLink = (editor: Editor, input: string, link: string, withDotAtTheEnd?: boolean, text?: string): void => {
-    const dot = withDotAtTheEnd ? '.' : '';
+  const assertIsLink = (editor: Editor, input: string, link: string, punctuation?: string, text?: string): void => {
+    const dot = Type.isString(punctuation) ? punctuation : '';
     assert.equal(typeUrl(editor, (input + dot)), `<p><a href="${link}">${text || input}</a>${dot}&nbsp;</p>`, 'Should be convert to link');
   };
 
@@ -65,7 +66,7 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assertIsLink(editor, 'ssh://www.domain.com', 'ssh://www.domain.com');
     assertIsLink(editor, 'ftp://www.domain.com', 'ftp://www.domain.com');
     assertIsLink(editor, 'www.domain.com', 'http://www.domain.com');
-    assertIsLink(editor, 'www.domain.com', 'http://www.domain.com', true);
+    assertIsLink(editor, 'www.domain.com', 'http://www.domain.com', '.');
     assertIsLink(editor, 'user@domain.com', 'mailto:user@domain.com');
     assertIsLink(editor, 'mailto:user@domain.com', 'mailto:user@domain.com');
     assertIsLink(editor, 'first-last@domain.com', 'mailto:first-last@domain.com');
@@ -151,7 +152,7 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assertIsLink(editor, 'ssh://www.domain.com', 'ssh://www.domain.com');
     assertIsLink(editor, 'ftp://www.domain.com', 'ftp://www.domain.com');
     assertIsLink(editor, 'www.domain.com', 'https://www.domain.com');
-    assertIsLink(editor, 'www.domain.com', 'https://www.domain.com', true);
+    assertIsLink(editor, 'www.domain.com', 'https://www.domain.com', '.');
     assertIsLink(editor, 'user@domain.com', 'mailto:user@domain.com');
     assertIsLink(editor, 'mailto:user@domain.com', 'mailto:user@domain.com');
     assertIsLink(editor, 'first-last@domain.com', 'mailto:first-last@domain.com');
@@ -162,7 +163,17 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     const editor = hook.editor();
     editor.settings.link_default_protocol = 'http';
     assertIsLink(editor, 'www.domain.com', 'http://www.domain.com');
-    assertIsLink(editor, 'www.domain.com', 'http://www.domain.com', true);
+    assertIsLink(editor, 'www.domain.com', 'http://www.domain.com', '.');
     delete editor.settings.link_default_protocol;
+  });
+
+  it('TINY-7714: should trigger with trailing punctuation', () => {
+    const editor = hook.editor();
+    assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com', '.');
+    assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com', ',');
+    assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com', '?');
+    assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com', '!');
+    assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com', ';');
+    assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com', ':');
   });
 });

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -60,6 +60,8 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     const editor = hook.editor();
     assertIsLink(editor, 'http://www.domain.com', 'http://www.domain.com');
     assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com');
+    assertIsLink(editor, 'file://www.domain.com', 'file://www.domain.com');
+    assertIsLink(editor, 'customprotocol://www.domain.com', 'customprotocol://www.domain.com');
     assertIsLink(editor, 'ssh://www.domain.com', 'ssh://www.domain.com');
     assertIsLink(editor, 'ftp://www.domain.com', 'ftp://www.domain.com');
     assertIsLink(editor, 'www.domain.com', 'http://www.domain.com');
@@ -67,13 +69,14 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assertIsLink(editor, 'user@domain.com', 'mailto:user@domain.com');
     assertIsLink(editor, 'mailto:user@domain.com', 'mailto:user@domain.com');
     assertIsLink(editor, 'first-last@domain.com', 'mailto:first-last@domain.com');
+    assertIsLink(editor, 'http://user:password@www.domain.com', 'http://user:password@www.domain.com');
   });
 
   it('TINY-4773: AutoLink: Unexpected urls ended with space', () => {
     const editor = hook.editor();
     assertIsLink(editor, 'first-last@domain', 'mailto:first-last@domain'); // No .com or similar needed.
-    assertIsLink(editor, 'first-last@()', 'mailto:first-last@()'); // Anything goes after the @.
-    assertIsLink(editor, 'first-last@¶¶KJ', 'mailto:first-last@&para;&para;KJ', false, 'first-last@&para;&para;KJ'); // Anything goes after the @
+    assertNoLink(editor, 'first-last@()', 'first-last@()');
+    assertNoLink(editor, 'first-last@¶¶KJ', 'first-last@&para;&para;KJ');
   });
 
   it('TINY-4773: AutoLink: text which should not work', () => {


### PR DESCRIPTION
Related Ticket: TINY-7714

Description of Changes:

This builds on the initial version @HAFRMO did in https://github.com/tinymce/tinymce/pull/7107, however it makes it use the Polaris link regex directly. Note that we can't use the `autolink` regex, as the autolink plugin does the punctuation detection itself before even using the regex (which it needs to due to adjusting the range). On that note, I've also updated the punctuation detection a little to handle additional common cases as it previously only handled a full stop (I didn't want to go too far on this since it's somewhat out of scope, but it was something that was obviously broken/different so I did something minimal).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
