### PR TITLE
TINY-7853: Fixed the new table buttons/settings not using the right properties or not working with nested menus

### DIFF
--- a/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
@@ -5,18 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Transformations } from '@ephox/acid';
 import { Arr, Obj, Optional, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+
+import { UserListItem, UserListValue } from '../ui/UiUtils';
 
 export interface StringMap {
   [key: string]: string;
 }
-
-export type ClassList = Array<{ title: string; value: string }>;
-export type MenuItemList = Array<{ text: string; value: string }>;
 
 type TableSizingMode = 'fixed' | 'relative' | 'responsive' | 'auto';
 
@@ -33,7 +30,7 @@ const defaultCellBorderWidths = Arr.range(5, (i) => {
 });
 
 const defaultCellBorderStyles = Arr.map([ 'Solid', 'Dotted', 'Dashed', 'Double', 'Groove', 'Ridge', 'Inset', 'Outset', 'None', 'Hidden' ], (type) => {
-  return { text: type, value: type.toLowerCase() };
+  return { title: type, value: type.toLowerCase() };
 });
 
 const determineDefaultStyles = (editor: Editor): Record<string, string> => {
@@ -59,10 +56,10 @@ const getTableSizingMode = (editor: Editor): TableSizingMode =>
 const getTableResponseWidth = (editor: Editor): boolean | undefined =>
   editor.getParam('table_responsive_width');
 
-const getTableBorderWidths = (editor: Editor): ClassList =>
+const getTableBorderWidths = (editor: Editor): UserListItem[] =>
   editor.getParam('table_border_widths', defaultCellBorderWidths, 'array');
 
-const getTableBorderStyles = (editor: Editor): MenuItemList =>
+const getTableBorderStyles = (editor: Editor): UserListValue[] =>
   editor.getParam('table_border_styles', defaultCellBorderStyles, 'array');
 
 const getDefaultAttributes = (editor: Editor): StringMap =>
@@ -95,13 +92,13 @@ const hasTableGrid = (editor: Editor): boolean =>
 const shouldStyleWithCss = (editor: Editor): boolean =>
   editor.getParam('table_style_by_css', false, 'boolean');
 
-const getCellClassList = (editor: Editor): ClassList =>
+const getCellClassList = (editor: Editor): UserListItem[] =>
   editor.getParam('table_cell_class_list', [], 'array');
 
-const getRowClassList = (editor: Editor): ClassList =>
+const getRowClassList = (editor: Editor): UserListItem[] =>
   editor.getParam('table_row_class_list', [], 'array');
 
-const getTableClassList = (editor: Editor): ClassList =>
+const getTableClassList = (editor: Editor): UserListItem[] =>
   editor.getParam('table_class_list', [], 'array');
 
 const isPercentagesForced = (editor: Editor): boolean =>
@@ -159,21 +156,11 @@ const hasObjectResizing = (editor: Editor): boolean => {
   return Type.isString(objectResizing) ? objectResizing === 'table' : objectResizing;
 };
 
-const generateColorMenuItems = (editor: Editor, setting: string): Menu.ChoiceMenuItemSpec[] => {
-  const colorMap: ClassList = editor.getParam(setting, [], 'array');
+const getTableCellBackgroundColors = (editor: Editor): UserListValue[] =>
+  editor.getParam('table_cell_background_color_map', [], 'array');
 
-  return Arr.map(colorMap, (entry): Menu.ChoiceMenuItemSpec => ({
-    text: entry.title,
-    value: '#' + Transformations.anyToHex(entry.value).value,
-    type: 'choiceitem'
-  }));
-};
-
-const getTableCellBackgroundColors = (editor: Editor): Menu.ChoiceMenuItemSpec[] =>
-  generateColorMenuItems(editor, 'table_cell_background_color_map');
-
-const getTableCellBorderColors = (editor: Editor): Menu.ChoiceMenuItemSpec[] =>
-  generateColorMenuItems(editor, 'table_cell_border_color_map');
+const getTableCellBorderColors = (editor: Editor): UserListValue[] =>
+  editor.getParam('table_cell_border_color_map', [], 'array');
 
 export {
   getDefaultAttributes,

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
@@ -13,7 +13,7 @@ import { getCellClassList, getTableBorderStyles, getTableBorderWidths, getTableC
 import { Clipboard } from '../core/Clipboard';
 import { SelectionTargets, LockedDisable } from '../selection/SelectionTargets';
 import { verticalAlignValues } from './CellAlignValues';
-import { applyTableCellStyle, changeColumnHeader, changeRowHeader, filterNoneItem, generateColorSelector, generateItemsCallback } from './UiUtils';
+import { applyTableCellStyle, changeColumnHeader, changeRowHeader, filterNoneItem, buildColorMenu, generateMenuItemsCallback } from './UiUtils';
 
 const addButtons = (editor: Editor, selections: Selections, selectionTargets: SelectionTargets, clipboard: Clipboard): void => {
   editor.ui.registry.addMenuButton('table', {
@@ -175,13 +175,12 @@ const addButtons = (editor: Editor, selections: Selections, selectionTargets: Se
     editor.ui.registry.addMenuButton('tableclass', {
       icon: 'table-classes',
       tooltip: 'Table styles',
-      fetch: generateItemsCallback(
+      fetch: generateMenuItemsCallback(
         editor,
         selections,
         tableClassList,
         'tableclass',
-        (item) => item.title,
-        (item) => editor.execCommand('mceTableToggleClass', false, item.value)
+        (value) => editor.execCommand('mceTableToggleClass', false, value)
       ),
       onSetup: selectionTargets.onSetupTable
     });
@@ -192,13 +191,12 @@ const addButtons = (editor: Editor, selections: Selections, selectionTargets: Se
     editor.ui.registry.addMenuButton('tablecellclass', {
       icon: 'table-cell-classes',
       tooltip: 'Cell styles',
-      fetch: generateItemsCallback(
+      fetch: generateMenuItemsCallback(
         editor,
         selections,
         tableCellClassList,
         'tablecellclass',
-        (item) => item.title,
-        (item) => editor.execCommand('mceTableCellToggleClass', false, item.value)
+        (value) => editor.execCommand('mceTableCellToggleClass', false, value)
       ),
       onSetup: selectionTargets.onSetupCellOrRow
     });
@@ -207,42 +205,37 @@ const addButtons = (editor: Editor, selections: Selections, selectionTargets: Se
   editor.ui.registry.addMenuButton('tablecellvalign', {
     icon: 'vertical-align',
     tooltip: 'Vertical align',
-    fetch: generateItemsCallback(
+    fetch: generateMenuItemsCallback(
       editor,
       selections,
       verticalAlignValues,
       'tablecellverticalalign',
-      (item) => item.text,
       applyTableCellStyle(editor, 'vertical-align')
     ),
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
-  const tableCellBorderWidthsList = getTableBorderWidths(editor);
   editor.ui.registry.addMenuButton('tablecellborderwidth', {
     icon: 'border-width',
     tooltip: 'Border width',
-    fetch: generateItemsCallback(
+    fetch: generateMenuItemsCallback(
       editor,
       selections,
-      tableCellBorderWidthsList,
+      getTableBorderWidths(editor),
       'tablecellborderwidth',
-      (item) => item.title,
       applyTableCellStyle(editor, 'border-width')
     ),
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
-  const tableCellBorderStylesList = getTableBorderStyles(editor);
   editor.ui.registry.addMenuButton('tablecellborderstyle', {
     icon: 'border-style',
     tooltip: 'Border style',
-    fetch: generateItemsCallback(
+    fetch: generateMenuItemsCallback(
       editor,
       selections,
-      tableCellBorderStylesList,
+      getTableBorderStyles(editor),
       'tablecellborderstyle',
-      (item) => item.text,
       applyTableCellStyle(editor, 'border-style')
     ),
     onSetup: selectionTargets.onSetupCellOrRow
@@ -255,19 +248,17 @@ const addButtons = (editor: Editor, selections: Selections, selectionTargets: Se
     onSetup: selectionTargets.onSetupTableWithCaption
   });
 
-  const tableCellBackgroundColors = getTableCellBackgroundColors(editor);
   editor.ui.registry.addMenuButton('tablecellbackgroundcolor', {
     icon: 'cell-background-color',
     tooltip: 'Background color',
-    fetch: (callback) => callback(generateColorSelector(editor, tableCellBackgroundColors, 'background-color')),
+    fetch: (callback) => callback(buildColorMenu(editor, getTableCellBackgroundColors(editor), 'background-color')),
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
-  const tableCellBorderColors = getTableCellBorderColors(editor);
   editor.ui.registry.addMenuButton('tablecellbordercolor', {
     icon: 'cell-border-color',
     tooltip: 'Border color',
-    fetch: (callback) => callback(generateColorSelector(editor, tableCellBorderColors, 'border-color')),
+    fetch: (callback) => callback(buildColorMenu(editor, getTableCellBorderColors(editor), 'border-color')),
     onSetup: selectionTargets.onSetupCellOrRow
   });
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
@@ -12,10 +12,10 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import { getCellClassList } from '../api/Settings';
 import { verticalAlignValues } from './CellAlignValues';
-import * as Helpers from './Helpers';
+import * as UiUtils from './UiUtils';
 
 const getClassList = (editor: Editor): Optional<Dialog.ListBoxSpec> => {
-  const classes = Helpers.buildListItems(getCellClassList(editor));
+  const classes = UiUtils.buildListItems(getCellClassList(editor));
   if (classes.length > 0) {
     return Optional.some({
       name: 'class',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
@@ -9,30 +9,17 @@ import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import { getTableBorderStyles } from '../api/Settings';
-
-interface ClassListValue {
-  readonly title?: string;
-  readonly text?: string;
-  readonly value: string;
-}
-
-interface ClassListGroup {
-  readonly title?: string;
-  readonly text?: string;
-  readonly menu: ClassListItem[];
-}
-
-type ClassListItem = ClassListValue | ClassListGroup;
+import { buildListItems } from './UiUtils';
 
 const getAdvancedTab = (editor: Editor, dialogName: 'table' | 'row' | 'cell'): Dialog.TabSpec => {
+  const emptyBorderStyle: Dialog.ListBoxItemSpec[] = [{ text: 'Select...', value: '' }];
+
   const advTabItems: Dialog.BodyComponentSpec[] = [
     {
       name: 'borderstyle',
       type: 'listbox',
       label: 'Border style',
-      items: [
-        { text: 'Select...', value: '' },
-      ].concat(getTableBorderStyles(editor))
+      items: emptyBorderStyle.concat(buildListItems(getTableBorderStyles(editor)))
     },
     {
       name: 'bordercolor',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -11,7 +11,6 @@ import { Css, SugarElement, SugarElements } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import * as Styles from '../actions/Styles';
 import { getDefaultAttributes, getDefaultStyles, shouldStyleWithCss } from '../api/Settings';
@@ -71,50 +70,6 @@ export type CellData = {
   readonly borderstyle?: string;
   readonly bordercolor?: string;
   readonly backgroundcolor?: string;
-};
-
-interface ClassListValue {
-  readonly title?: string;
-  readonly text?: string;
-  readonly value: string;
-}
-
-interface ClassListGroup {
-  readonly title?: string;
-  readonly text?: string;
-  readonly menu: ClassListItem[];
-}
-
-type ClassListItem = ClassListValue | ClassListGroup;
-
-type InternalClassListItem = Dialog.ListBoxItemSpec;
-
-const isListGroup = (item: ClassListItem): item is ClassListGroup =>
-  Obj.hasNonNullableKey(item as Record<string, any>, 'menu');
-
-const buildListItems = (inputList: ClassListItem[], startItems?: InternalClassListItem[]): InternalClassListItem[] => {
-  // Used to also take a callback (that in all instances applied an item.textStyles property using Formatter)
-  // to each item but seems to have been an undocumented TinyMCE 4 or even 3 feature and doesn't work with
-  // TinyMCE 5 selectboxes so deleted
-  const appendItems = (values: ClassListItem[], acc: InternalClassListItem[]) =>
-    // item.text is not documented - maybe deprecated option we can delete??
-    acc.concat(Arr.map(values, (item) => {
-      const text = item.text || item.title;
-
-      if (isListGroup(item)) {
-        return {
-          text,
-          items: buildListItems(item.menu)
-        };
-      } else {
-        return {
-          text,
-          value: item.value
-        };
-      }
-    }));
-
-  return appendItems(inputList, startItems || []);
 };
 
 const rgbToHex = (dom: DOMUtils) => (value: string): string =>
@@ -286,7 +241,6 @@ const extractDataFromCellElement = (editor: Editor, cell: HTMLTableCellElement, 
 };
 
 export {
-  buildListItems,
   extractAdvancedStyles,
   getSharedValues,
   extractDataFromTableElement,

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -16,7 +16,7 @@ import { getCellClassList, getTableBorderStyles, getTableBorderWidths, getTableC
 import { Clipboard } from '../core/Clipboard';
 import { SelectionTargets, LockedDisable } from '../selection/SelectionTargets';
 import { verticalAlignValues } from './CellAlignValues';
-import { applyTableCellStyle, changeColumnHeader, changeRowHeader, filterNoneItem, generateColorSelector, generateItems } from './UiUtils';
+import { applyTableCellStyle, changeColumnHeader, changeRowHeader, filterNoneItem, buildColorMenu, buildMenuItems } from './UiUtils';
 
 const addMenuItems = (editor: Editor, selections: Selections, selectionTargets: SelectionTargets, clipboard: Clipboard): void => {
   const cmd = (command: string) => () => editor.execCommand(command);
@@ -222,13 +222,12 @@ const addMenuItems = (editor: Editor, selections: Selections, selectionTargets: 
     editor.ui.registry.addNestedMenuItem('tableclass', {
       icon: 'table-classes',
       text: 'Table styles',
-      getSubmenuItems: () => generateItems(
+      getSubmenuItems: () => buildMenuItems(
         editor,
         selections,
         tableClassList,
         'tableclass',
-        (item) => item.title,
-        (item) => editor.execCommand('mceTableToggleClass', false, item.value)
+        (value) => editor.execCommand('mceTableToggleClass', false, value)
       ),
       onSetup: selectionTargets.onSetupTable
     });
@@ -236,16 +235,15 @@ const addMenuItems = (editor: Editor, selections: Selections, selectionTargets: 
 
   const tableCellClassList = filterNoneItem(getCellClassList(editor));
   if (tableCellClassList.length !== 0) {
-    editor.ui.registry.addNestedMenuItem('tablecellclasss', {
+    editor.ui.registry.addNestedMenuItem('tablecellclass', {
       icon: 'table-cell-classes',
       text: 'Cell styles',
-      getSubmenuItems: () => generateItems(
+      getSubmenuItems: () => buildMenuItems(
         editor,
         selections,
         tableCellClassList,
         'tablecellclass',
-        (item) => item.title,
-        (item) => editor.execCommand('mceTableCellToggleClass', false, item.value)
+        (value) => editor.execCommand('mceTableCellToggleClass', false, value)
       ),
       onSetup: selectionTargets.onSetupCellOrRow
     });
@@ -254,42 +252,37 @@ const addMenuItems = (editor: Editor, selections: Selections, selectionTargets: 
   editor.ui.registry.addNestedMenuItem('tablecellvalign', {
     icon: 'vertical-align',
     text: 'Vertical align',
-    getSubmenuItems: () => generateItems(
+    getSubmenuItems: () => buildMenuItems(
       editor,
       selections,
       verticalAlignValues,
       'tablecellverticalalign',
-      (item) => item.text,
       applyTableCellStyle(editor, 'vertical-align')
     ),
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
-  const tableCellBorderWidthsList = getTableBorderWidths(editor);
   editor.ui.registry.addNestedMenuItem('tablecellborderwidth', {
     icon: 'border-width',
     text: 'Border width',
-    getSubmenuItems: () => generateItems(
+    getSubmenuItems: () => buildMenuItems(
       editor,
       selections,
-      tableCellBorderWidthsList,
+      getTableBorderWidths(editor),
       'tablecellborderwidth',
-      (item) => item.title,
       applyTableCellStyle(editor, 'border-width')
     ),
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
-  const tableCellBorderStylesList = getTableBorderStyles(editor);
   editor.ui.registry.addNestedMenuItem('tablecellborderstyle', {
     icon: 'border-style',
     text: 'Border style',
-    getSubmenuItems: () => generateItems(
+    getSubmenuItems: () => buildMenuItems(
       editor,
       selections,
-      tableCellBorderStylesList,
+      getTableBorderStyles(editor),
       'tablecellborderstyle',
-      (item) => item.text,
       applyTableCellStyle(editor, 'border-style')
     ),
     onSetup: selectionTargets.onSetupCellOrRow
@@ -302,19 +295,17 @@ const addMenuItems = (editor: Editor, selections: Selections, selectionTargets: 
     onSetup: selectionTargets.onSetupTableWithCaption
   });
 
-  const tableCellBackgroundColors = getTableCellBackgroundColors(editor);
   editor.ui.registry.addNestedMenuItem('tablecellbackgroundcolor', {
     icon: 'cell-background-color',
     text: 'Background color',
-    getSubmenuItems: () => generateColorSelector(editor, tableCellBackgroundColors, 'background-color'),
+    getSubmenuItems: () => buildColorMenu(editor, getTableCellBackgroundColors(editor), 'background-color'),
     onSetup: selectionTargets.onSetupCellOrRow
   });
 
-  const tableCellBorderColors = getTableCellBorderColors(editor);
   editor.ui.registry.addNestedMenuItem('tablecellbordercolor', {
     icon: 'cell-border-color',
     text: 'Border color',
-    getSubmenuItems: () => generateColorSelector(editor, tableCellBorderColors, 'border-color'),
+    getSubmenuItems: () => buildColorMenu(editor, getTableCellBorderColors(editor), 'border-color'),
     onSetup: selectionTargets.onSetupCellOrRow
   });
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
@@ -11,10 +11,10 @@ import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import { getRowClassList } from '../api/Settings';
-import * as Helpers from './Helpers';
+import * as UiUtils from './UiUtils';
 
 const getClassList = (editor: Editor): Optional<Dialog.ListBoxSpec> => {
-  const classes = Helpers.buildListItems(getRowClassList(editor));
+  const classes = UiUtils.buildListItems(getRowClassList(editor));
   if (classes.length > 0) {
     return Optional.some({
       name: 'class',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -20,6 +20,7 @@ import * as Util from '../core/Util';
 import { getAdvancedTab } from './DialogAdvancedTab';
 import * as Helpers from './Helpers';
 import * as TableDialogGeneralTab from './TableDialogGeneralTab';
+import * as UiUtils from './UiUtils';
 
 type TableData = Helpers.TableData;
 
@@ -175,7 +176,7 @@ const open = (editor: Editor, insertNewTable: boolean): void => {
     }
   }
 
-  const classes = Helpers.buildListItems(getTableClassList(editor));
+  const classes = UiUtils.buildListItems(getTableClassList(editor));
 
   if (classes.length > 0) {
     if (data.class) {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -5,18 +5,29 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Transformations } from '@ephox/acid';
 import { Selections } from '@ephox/darwin';
-import { Arr, Singleton, Strings } from '@ephox/katamari';
+import { Arr, Obj, Singleton, Strings } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
-import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+import { Dialog, Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import * as TableSelection from '../selection/TableSelection';
 
-interface Item {
+export interface UserListValue {
+  readonly title?: string;
+  readonly text?: string;
   readonly value: string;
 }
+
+export interface UserListGroup {
+  readonly title?: string;
+  readonly text?: string;
+  readonly menu: UserListItem[];
+}
+
+export type UserListItem = UserListValue | UserListGroup;
 
 const onSetupToggle = (editor: Editor, selections: Selections, formatName: string, formatValue: string) => {
   return (api: Toolbar.ToolbarMenuButtonInstanceApi): () => void => {
@@ -47,48 +58,89 @@ const onSetupToggle = (editor: Editor, selections: Selections, formatName: strin
   };
 };
 
-const applyTableCellStyle = <T extends Item>(editor: Editor, style: string) => (item: T): void => {
-  editor.execCommand('mceTableApplyCellStyle', false, { [style]: item.value });
+export const isListGroup = (item: UserListItem): item is UserListGroup =>
+  Obj.hasNonNullableKey(item as Record<string, any>, 'menu');
+
+const buildListItems = (items: UserListItem[]): Dialog.ListBoxItemSpec[] =>
+  Arr.map(items, (item) => {
+    // item.text is not documented - maybe deprecated option we can delete??
+    const text = item.text || item.title;
+    if (isListGroup(item)) {
+      return {
+        text,
+        items: buildListItems(item.menu)
+      };
+    } else {
+      return {
+        text,
+        value: item.value
+      };
+    }
+  });
+
+const buildMenuItems = (
+  editor: Editor,
+  selections: Selections,
+  items: UserListItem[],
+  format: string,
+  onAction: (value: string) => void
+): Menu.NestedMenuItemContents[] =>
+  Arr.map(items, (item): Menu.NestedMenuItemContents => {
+    // item.text is not documented - maybe deprecated option we can delete??
+    const text = item.text || item.title;
+    if (isListGroup(item)) {
+      return {
+        type: 'nestedmenuitem',
+        text,
+        getSubmenuItems: () => buildMenuItems(editor, selections, item.menu, format, onAction)
+      };
+    } else {
+      return {
+        text,
+        type: 'togglemenuitem',
+        onAction: () => onAction(item.value),
+        onSetup: onSetupToggle(editor, selections, format, item.value)
+      };
+    }
+  });
+
+const applyTableCellStyle = (editor: Editor, style: string) => (value: string): void => {
+  editor.execCommand('mceTableApplyCellStyle', false, { [style]: value });
 };
 
-const filterNoneItem = <T extends Item>(list: T[]): T[] =>
-  Arr.filter(list, (item) => Strings.isNotEmpty(item.value));
+const filterNoneItem = (list: UserListItem[]): UserListItem[] =>
+  Arr.bind(list, (item): UserListItem[] => {
+    if (isListGroup(item)) {
+      return [{ ...item, menu: filterNoneItem(item.menu) }];
+    } else {
+      return Strings.isNotEmpty(item.value) ? [ item ] : [];
+    }
+  });
 
-const generateItem = <T extends Item>(editor: Editor, selections: Selections, item: T, format: string, extractText: (item: T) => string, onAction: (item: T) => void): Menu.ToggleMenuItemSpec => ({
-  text: extractText(item),
-  type: 'togglemenuitem',
-  onAction: () => onAction(item),
-  onSetup: onSetupToggle(editor, selections, format, item.value)
-});
+const generateMenuItemsCallback = (editor: Editor, selections: Selections, items: UserListItem[], format: string, onAction: (value: string) => void) =>
+  (callback: (items: Menu.NestedMenuItemContents[]) => void): void =>
+    callback(buildMenuItems(editor, selections, items, format, onAction));
 
-const generateItems = <T extends Item>(editor: Editor, selections: Selections, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void): Menu.ToggleMenuItemSpec[] =>
-  Arr.map(items, (item) => generateItem(editor, selections, item, format, extractText, onAction));
+const buildColorMenu = (editor: Editor, colorList: UserListValue[], style: string): Menu.FancyMenuItemSpec[] => {
+  const colorMap = Arr.map(colorList, (entry): Menu.ChoiceMenuItemSpec => ({
+    text: entry.title,
+    value: '#' + Transformations.anyToHex(entry.value).value,
+    type: 'choiceitem'
+  }));
 
-const generateItemsCallback = <T extends Item>(editor: Editor, selections: Selections, items: T[], format: string, extractText: (item: T) => string, onAction: (item: T) => void) =>
-  (callback: (items: Menu.ToggleMenuItemSpec[]) => void): void =>
-    callback(generateItems(editor, selections, items, format, extractText, onAction));
-
-const fixColorValue = (value: string, setColor: (colorValue: string) => void): void => {
-  if (value === 'remove') {
-    setColor('');
-  } else {
-    setColor(value);
-  }
-};
-
-const generateColorSelector = (editor: Editor, colorList: Menu.ChoiceMenuItemSpec[], style: string): Menu.FancyMenuItemSpec[] => [{
-  type: 'fancymenuitem',
-  fancytype: 'colorswatch',
-  initData: {
-    colors: colorList.length > 0 ? colorList : undefined,
-    allowCustomColors: false
-  },
-  onAction: (data) => {
-    fixColorValue(data.value, (value) => {
+  return [{
+    type: 'fancymenuitem',
+    fancytype: 'colorswatch',
+    initData: {
+      colors: colorMap.length > 0 ? colorMap : undefined,
+      allowCustomColors: false
+    },
+    onAction: (data) => {
+      const value = data.value === 'remove' ? '' : data.value;
       editor.execCommand('mceTableApplyCellStyle', false, { [style]: value });
-    });
-  }
-}];
+    }
+  }];
+};
 
 const changeRowHeader = (editor: Editor) => (): void => {
   const currentType = editor.queryCommandValue('mceTableRowType');
@@ -104,10 +156,11 @@ const changeColumnHeader = (editor: Editor) => (): void => {
 
 export {
   onSetupToggle,
-  generateItems,
-  generateItemsCallback,
+  buildMenuItems,
+  buildListItems,
+  buildColorMenu,
+  generateMenuItemsCallback,
   filterNoneItem,
-  generateColorSelector,
   changeRowHeader,
   changeColumnHeader,
   applyTableCellStyle

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderStyleTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderStyleTest.ts
@@ -5,13 +5,14 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-import { pAssertStyleCanBeToggledOnAndOff } from '../../module/test/TableModifiersTestUtils';
+import { pAssertStyleCanBeToggledOnAndOff, setEditorContentTableAndSelection } from '../../module/test/TableModifiersTestUtils';
+import * as TableTestUtils from '../../module/test/TableTestUtils';
 
 describe('browser.tinymce.plugins.table.ui.TableBorderStyleTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     indent: false,
-    toolbar: 'tablecellborderstyle',
+    toolbar: 'tableprops tablecellborderstyle',
     base_url: '/project/tinymce/js/tinymce',
     menu: {
       table: { title: 'Table', items: 'tablecellborderstyle' },
@@ -19,11 +20,11 @@ describe('browser.tinymce.plugins.table.ui.TableBorderStyleTest', () => {
     menubar: 'table',
     table_border_styles: [
       {
-        text: 'Solid',
+        title: 'Solid',
         value: 'solid'
       },
       {
-        text: 'None',
+        title: 'None',
         value: ''
       },
     ]
@@ -52,4 +53,21 @@ describe('browser.tinymce.plugins.table.ui.TableBorderStyleTest', () => {
       customStyle: 'border-style: solid'
     })
   );
+
+  it('TINY-7853: Table properties dialog can be updated with custom border styles', async () => {
+    const editor = hook.editor();
+    setEditorContentTableAndSelection(editor, 2, 2);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues({
+      borderstyle: '',
+      backgroundcolor: '',
+      bordercolor: ''
+    }, true, {});
+    TableTestUtils.setDialogValues({
+      borderstyle: 'dashed',
+      bordercolor: '',
+      backgroundcolor: 'red'
+    }, true, {});
+    await TableTestUtils.pClickDialogButton(editor, false);
+  });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableClassListButtonsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableClassListButtonsTest.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
@@ -16,9 +16,9 @@ describe('browser.tinymce.plugins.table.ui.TableClassListButtonsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     indent: false,
-    toolbar: 'tableclass',
+    toolbar: 'tableclass tablecellclass',
     menu: {
-      table: { title: 'Table', items: 'tableclass' },
+      table: { title: 'Table', items: 'tableclass tablecellclass' },
     },
     menubar: 'table edit',
     base_url: '/project/tinymce/js/tinymce',
@@ -30,6 +30,34 @@ describe('browser.tinymce.plugins.table.ui.TableClassListButtonsTest', () => {
       {
         title: 'B',
         value: 'b'
+      },
+      {
+        title: 'submenu',
+        menu: [
+          {
+            title: 'C',
+            value: 'c'
+          }
+        ]
+      }
+    ],
+    table_cell_class_list: [
+      {
+        title: 'D',
+        value: 'd'
+      },
+      {
+        title: 'E',
+        value: 'e'
+      },
+      {
+        title: 'submenu',
+        menu: [
+          {
+            title: 'F',
+            value: 'f'
+          }
+        ]
       }
     ],
     setup: (editor: Editor) => {
@@ -42,47 +70,47 @@ describe('browser.tinymce.plugins.table.ui.TableClassListButtonsTest', () => {
     events.push(event);
   };
 
-  afterEach(() => {
-    events = [];
-  });
-
-  const toggleClasses = (editor: Editor, classes: string[]) => {
-    Arr.each(classes, (clazz) =>
-      editor.execCommand('mceTableToggleClass', false, clazz)
-    );
-
-    assert.lengthOf(events, classes.length, 'Command executed successfully.');
+  const toggleClasses = (editor: Editor, classes: string[], commandName: string) => {
+    Arr.each(classes, (clazz) => editor.execCommand(commandName, false, clazz));
+    assert.lengthOf(events, classes.length, 'Command executed successfully');
   };
 
-  const pPerformToggleClassSetup = async (classList: string[], trueMarked: number, falseMarked: number, useMenuOrToolbar: 'toolbar' | 'menuitem') => {
+  const pPerformToggleClassSetup = async (classList: string[], trueMarked: number, falseMarked: number, useMenuOrToolbar: 'toolbar' | 'menuitem', type: 'table' | 'cell') => {
     const editor = hook.editor();
     const sugarContainer = SugarBody.body();
+    const title = type === 'table' ? 'Table styles' : 'Cell styles';
 
     setEditorContentTableAndSelection(editor, 1, 1);
-    await pAssertNoCheckmarksInMenu(editor, 'Table styles', 2, sugarContainer, useMenuOrToolbar);
-    toggleClasses(editor, classList);
+    await pAssertNoCheckmarksInMenu(editor, title, 2, sugarContainer, useMenuOrToolbar);
+    toggleClasses(editor, classList, type === 'table' ? 'mceTableToggleClass' : 'mceTableCellToggleClass');
 
     const expected = {
       '.tox-menu': useMenuOrToolbar === 'toolbar' ? 1 : 2,
       '.tox-collection__item[aria-checked="true"]': trueMarked,
-      '.tox-collection__item[aria-checked="false"]': falseMarked
+      '.tox-collection__item[aria-checked="false"]': falseMarked,
+      '.tox-collection__item[aria-expanded="false"]:contains("submenu")': 1
     };
-    await pAssertMenuPresence(editor, `There should be ${trueMarked} checkmark(s)`, 'Table styles', expected, sugarContainer, useMenuOrToolbar);
+    await pAssertMenuPresence(editor, `There should be ${trueMarked} checkmark(s)`, title, expected, sugarContainer, useMenuOrToolbar);
+    events = [];
   };
 
   it('TINY-7476: Ensure that the checkmark appears for a single class in toolbar', async () => {
-    await pPerformToggleClassSetup([ 'a' ], 1, 1, 'toolbar');
+    await pPerformToggleClassSetup([ 'a' ], 1, 1, 'toolbar', 'table');
+    await pPerformToggleClassSetup([ 'd' ], 1, 1, 'toolbar', 'cell');
   });
 
   it('TINY-7476: Ensure that the checkmark appears for a single class in menu', async () => {
-    await pPerformToggleClassSetup([ 'a' ], 1, 1, 'menuitem');
+    await pPerformToggleClassSetup([ 'a' ], 1, 1, 'menuitem', 'table');
+    await pPerformToggleClassSetup([ 'd' ], 1, 1, 'menuitem', 'cell');
   });
 
   it('TINY-7476: Ensure that the checkmark appears for two classes in toolbar', async () => {
-    await pPerformToggleClassSetup([ 'a', 'b' ], 2, 0, 'toolbar');
+    await pPerformToggleClassSetup([ 'a', 'b' ], 2, 0, 'toolbar', 'table');
+    await pPerformToggleClassSetup([ 'd', 'e' ], 2, 0, 'toolbar', 'cell');
   });
 
   it('TINY-7476: Ensure that the checkmark appears for two classes in menu', async () => {
-    await pPerformToggleClassSetup([ 'a', 'b' ], 2, 0, 'menuitem');
+    await pPerformToggleClassSetup([ 'a', 'b' ], 2, 0, 'menuitem', 'table');
+    await pPerformToggleClassSetup([ 'd', 'e' ], 2, 0, 'menuitem', 'cell');
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableClassListButtonsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableClassListButtonsTest.ts
@@ -82,7 +82,8 @@ describe('browser.tinymce.plugins.table.ui.TableClassListButtonsTest', () => {
 
     setEditorContentTableAndSelection(editor, 1, 1);
     await pAssertNoCheckmarksInMenu(editor, title, 2, sugarContainer, useMenuOrToolbar);
-    toggleClasses(editor, classList, type === 'table' ? 'mceTableToggleClass' : 'mceTableCellToggleClass');
+    const commandName = type === 'table' ? 'mceTableToggleClass' : 'mceTableCellToggleClass';
+    toggleClasses(editor, classList, commandName);
 
     const expected = {
       '.tox-menu': useMenuOrToolbar === 'toolbar' ? 1 : 2,


### PR DESCRIPTION
Related Ticket: TINY-7853

Description of Changes:
* Fixed a typo in the `tablecellclass` menu item name.
* Fixed the toolbar buttons not working with nested class lists.
* Fixed the border cell style toolbar/dialog not working and throwing errors when using `title` in the `table_border_styles` setting.
  * **Note:** Remember that `title` is the documented way to use this and the documented way for all other settings, so it shouldn't have been requiring `text` previously. 
* Moved setting -> dialog list conversion logic to `UiUtils`.
* Moved color menu item rendering from `Settings` -> `UiUtils`
* General cleanup given changes above.

Pre-checks:
* [x] ~Changelog entry added~ All issues with unreleased code
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
