### PR TITLE
TINY-7650: Fix circular dependency between TinyMCE and McAgar

### DIFF
--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -12,3 +12,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Upgraded to Katamari 8.0, which is incompatible with Katamari 7.0 if used in the same bundle.
+- TinyMCE is no longer imported and is instead loaded from `node_modules` if a `tinymce` global isn't available.

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -31,6 +31,9 @@
     "@ephox/wrap-jsverify": "^2.0.1",
     "tslib": "^2.0.0"
   },
+  "peerDependencies": {
+    "tinymce": ">=4.0.0"
+  },
   "main": "./lib/main/ts/ephox/mcagar/api/Main.js",
   "module": "./lib/main/ts/ephox/mcagar/api/Main.js",
   "types": "./lib/main/ts/ephox/mcagar/api/Main.d.ts"

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyHooks.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyHooks.ts
@@ -2,7 +2,6 @@ import { after, afterEach, before } from '@ephox/bedrock-client';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Insert, Remove, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
-import 'tinymce';
 import { Editor as EditorType } from '../../alien/EditorTypes';
 import * as Loader from '../../loader/Loader';
 import { setupTinymceBaseUrl } from '../../loader/Urls';

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/RemoteTinyLoader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/RemoteTinyLoader.ts
@@ -1,6 +1,6 @@
 import { TestLogs } from '@ephox/agar';
-import { Arr, FutureResult, Optional, Result } from '@ephox/katamari';
-import { Attribute, DomEvent, Insert, SugarBody, SugarElement } from '@ephox/sugar';
+import { Arr, FutureResult, Optional } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 
 import * as Loader from '../../loader/Loader';
 import { setTinymceBaseUrl } from '../../loader/Urls';
@@ -11,27 +11,8 @@ const setupBaseUrl = (tinymce: any, settings: Record<string, any>) => {
   }
 };
 
-const loadScript = (url: string): FutureResult<string, Error> => FutureResult.nu((resolve) => {
-  const script = SugarElement.fromTag('script');
-
-  Attribute.set(script, 'referrerpolicy', 'origin');
-
-  Attribute.set(script, 'src', url);
-  const onLoad = DomEvent.bind(script, 'load', () => {
-    onLoad.unbind();
-    onError.unbind();
-    resolve(Result.value(url));
-  });
-  const onError = DomEvent.bind(script, 'error', () => {
-    onLoad.unbind();
-    onError.unbind();
-    resolve(Result.error(new Error('Failed to load script: ' + url)));
-  });
-  Insert.append(SugarBody.body(), script);
-});
-
 const loadScripts = (urls: string[], success: () => void, failure: Loader.FailureCallback) => {
-  const result = Arr.foldl(urls, (acc, url) => acc.bindFuture(() => loadScript(url)), FutureResult.pure(''));
+  const result = Arr.foldl(urls, (acc, url) => acc.bindFuture(() => Loader.loadScript(url)), FutureResult.pure(''));
 
   result.get((res) => {
     res.fold((e) => failure(e, TestLogs.init()), success);

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyLoader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyLoader.ts
@@ -2,7 +2,6 @@ import { TestLogs } from '@ephox/agar';
 import { Optional } from '@ephox/katamari';
 import { Insert, Remove, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
-import 'tinymce';
 import * as Loader from '../../loader/Loader';
 import { setupTinymceBaseUrl } from '../../loader/Urls';
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/loader/Urls.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/loader/Urls.ts
@@ -6,6 +6,9 @@ export const setTinymceBaseUrl = (tinymce: any, baseUrl: string): void => {
   tinymce.baseURI = new tinymce.util.URI(tinymce.baseURL);
 };
 
+export const detectTinymceBaseUrl = (settings: Record<string, any>): string =>
+  Type.isString(settings.base_url) ? settings.base_url : '/project/node_modules/tinymce';
+
 export const setupTinymceBaseUrl = (tinymce: any, settings: Record<string, any>): void => {
   if (Type.isString(settings.base_url)) {
     setTinymceBaseUrl(tinymce, settings.base_url);

--- a/modules/mcagar/src/test/ts/browser/api/TinyLoaderTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinyLoaderTest.ts
@@ -45,7 +45,9 @@ UnitTest.asynctest('TinyLoader.setupInBodyAndShadowRoot passes logs through', (s
   TinyLoader.setupInBodyAndShadowRoot((_editor, onSuccess, _onFailure) => {
     calls++;
     onSuccess('call' + calls, TestLogs.single('log' + calls));
-  }, {}, (v, logs) => {
+  }, {
+    base_url: '/project/tinymce/js/tinymce'
+  }, (v, logs) => {
     try {
       if (SugarShadowDom.isSupported()) {
         Assert.eq('Value should come from second call', 'call2', v);

--- a/modules/tinymce/src/core/test/ts/browser/ClickContentEditableFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ClickContentEditableFalseTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Hierarchy } from '@ephox/sugar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -1,8 +1,8 @@
 import { Assertions, DragnDrop, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Hierarchy, SugarBody, SugarNode } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
@@ -1,7 +1,7 @@
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { McEditor, TinyDom } from '@ephox/mcagar';
 import { Attribute, Remove, Truncate } from '@ephox/sugar';
+import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/EditorForcedSettingsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorForcedSettingsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/EditorPaddEmptyWithBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorPaddEmptyWithBrTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -1,6 +1,6 @@
 import { Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/EditorRtlTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRtlTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import EditorManager from 'tinymce/core/api/EditorManager';

--- a/modules/tinymce/src/core/test/ts/browser/EditorSettingsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorSettingsTest.ts
@@ -1,7 +1,7 @@
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun, Obj } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Attribute, Class, SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -1,6 +1,6 @@
 import { afterEach, before, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';

--- a/modules/tinymce/src/core/test/ts/browser/EditorViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorViewTest.ts
@@ -1,8 +1,8 @@
 import { PhantomSkipper } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Css, Scroll, SelectorFind } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun, Strings } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody, TextContent } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun, Strings } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody, TextContent } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
-import { LegacyUnit, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
@@ -1,5 +1,5 @@
 import { before, context, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/InlineEditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/InlineEditorRemoveTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/InlineEditorSaveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/InlineEditorSaveTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/ModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ModeTest.ts
@@ -1,7 +1,7 @@
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Class } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -1,7 +1,7 @@
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
 import { Focus, SugarElement } from '@ephox/sugar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Mouse, UiFinder } from '@ephox/agar';
 import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Optional, OptionalInstances } from '@ephox/katamari';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Class, Css, Scroll, SelectorFind, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -1,7 +1,7 @@
 import { PhantomSkipper } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/ShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ShortcutsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -1,7 +1,7 @@
 import { Keys } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotateTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
@@ -1,7 +1,7 @@
 import { Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationPersistenceTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationPersistenceTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyAssertions, TinySelections } from '@ephox/mcagar';
+import { McEditor, TinyAssertions, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import { AnnotatorSettings } from 'tinymce/core/api/Annotator';

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
@@ -1,6 +1,6 @@
 import { Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -1,8 +1,8 @@
 import { Assertions } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor, TinyAssertions, TinyDom, TinySelections } from '@ephox/mcagar';
 import { Hierarchy, Html, Remove, Replication, SelectorFilter, SugarElement } from '@ephox/sugar';
+import { McEditor, TinyAssertions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretContainerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretContainerTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit } from '@ephox/mcagar';
+import { LegacyUnit } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import DomQuery from 'tinymce/core/api/dom/DomQuery';

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretPositionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretPositionTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit } from '@ephox/mcagar';
+import { LegacyUnit } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import CaretPosition from 'tinymce/core/caret/CaretPosition';

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { LegacyUnit } from '@ephox/mcagar';
+import { LegacyUnit } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import $ from 'tinymce/core/api/dom/DomQuery';

--- a/modules/tinymce/src/core/test/ts/browser/caret/FirefoxFakeCaretBeforeTableTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FirefoxFakeCaretBeforeTableTypeTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/caret/LineWalkerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/LineWalkerTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit } from '@ephox/mcagar';
+import { LegacyUnit } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import $ from 'tinymce/core/api/dom/DomQuery';

--- a/modules/tinymce/src/core/test/ts/browser/commands/ContentLangTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/ContentLangTest.ts
@@ -1,5 +1,5 @@
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/commands/OutdentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/OutdentCommandTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentForcedRootBlockTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -1,6 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentWsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentWsTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyAssertions } from '@ephox/mcagar';
+import { McEditor, TinyAssertions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTextFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTextFormatTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTreeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTreeTest.ts
@@ -1,6 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import AstNode from 'tinymce/core/api/html/Node';

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorResetContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorResetContentTest.ts
@@ -1,6 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/content/HTMLDataURLsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/HTMLDataURLsTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentForcedRootFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentForcedRootFalseTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentWebKitBugs.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentWebKitBugs.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/content/PlaceholderVisuallyEmptyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/PlaceholderVisuallyEmptyTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockRangeDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockRangeDeleteTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/delete/CaretBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CaretBoundaryDeleteTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Zwsp from 'tinymce/core/text/Zwsp';

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteNoneditableTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Keyboard, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as DeleteCommands from 'tinymce/core/delete/DeleteCommands';

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteElementTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Hierarchy } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/delete/ImageBlockDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/ImageBlockDeleteTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/delete/InlineBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/InlineBoundaryDeleteTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/delete/MediaDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/MediaDeleteTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Keys } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/core/test/ts/browser/delete/OutdentForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/OutdentForcedRootBlockFalseTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/delete/OutdentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/OutdentTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -1,8 +1,8 @@
 import { Assertions, Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Attribute, Html, Remove, Replication, SelectorFilter } from '@ephox/sugar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/dom/ContentCssCorsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ContentCssCorsTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
@@ -1,8 +1,8 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Cell, Obj, Strings } from '@ephox/katamari';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Attribute, Css, Hierarchy, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/dom/DimensionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DimensionsTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { LegacyUnit } from '@ephox/mcagar';
+import { LegacyUnit } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import * as Dimensions from 'tinymce/core/dom/Dimensions';

--- a/modules/tinymce/src/core/test/ts/browser/dom/NodePathTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/NodePathTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit } from '@ephox/mcagar';
+import { LegacyUnit } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import * as NodePath from 'tinymce/core/dom/NodePath';

--- a/modules/tinymce/src/core/test/ts/browser/dom/RangePointTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/RangePointTest.ts
@@ -1,6 +1,6 @@
 import { Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/dom/ReferrerPolicyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ReferrerPolicyTest.ts
@@ -1,6 +1,6 @@
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
@@ -1,8 +1,8 @@
 import { Assertions, Cursors, PhantomSkipper, Waiter } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionEventsTest.ts
@@ -1,8 +1,8 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Cell, Fun } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionQuirksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionQuirksTest.ts
@@ -1,6 +1,6 @@
 import { Keys, Monitor, Mouse } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerEventsTest.ts
@@ -1,6 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/file/ImageScannerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/file/ImageScannerTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit } from '@ephox/mcagar';
+import { LegacyUnit } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/BlockFormatsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/BlockFormatsTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Mouse, StructAssert } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Hierarchy, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FontsizeFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FontsizeFormatTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/HooksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/HooksTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/PreviewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/PreviewTest.ts
@@ -1,6 +1,6 @@
 import { Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Format } from 'tinymce/core/fmt/FormatTypes';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveHighlightFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveHighlightFormatTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveTrailingWhitespaceFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveTrailingWhitespaceFormatTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/core/test/ts/browser/focus/CefFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/CefFocusTest.ts
@@ -1,6 +1,6 @@
 import { Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyAssertions } from '@ephox/mcagar';
+import { McEditor, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyAssertions, TinyDom, TinySelections } from '@ephox/mcagar';
 import { Focus, Hierarchy, SugarBody, SugarNode } from '@ephox/sugar';
+import { McEditor, TinyAssertions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
@@ -1,6 +1,6 @@
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';

--- a/modules/tinymce/src/core/test/ts/browser/focus/MediaFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/MediaFocusTest.ts
@@ -1,6 +1,6 @@
 import { FocusTools } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/init/ContentStylePositionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ContentStylePositionTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarElement, SugarNode } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/EditorCustomThemeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/EditorCustomThemeTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyDirectionalityTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyDirectionalityTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyFiltersTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyFiltersTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodySelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodySelectionTest.ts
@@ -1,6 +1,6 @@
 import { before, context, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyAssertions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { McEditor, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorIconTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorIconTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { getAll as getDefaultIcons } from '@tinymce/oxide-icons-default';
 import { assert } from 'chai';
 

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorNoThemeIframeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorNoThemeIframeTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { SelectorFind, SugarBody, Traverse } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorNoThemeInlineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorNoThemeInlineTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { SelectorFind, SugarBody, Traverse } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorOnHiddenElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorOnHiddenElementTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorPluginInitErrorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorPluginInitErrorTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionIframeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionIframeTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Insert, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionInlineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionInlineTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Insert, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEventsOrderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEventsOrderTest.ts
@@ -1,5 +1,5 @@
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
 import { Attribute, SugarElement } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorWithCustomAttrsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorWithCustomAttrsTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { Attribute, SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/RegisterFormatsBeforeSetContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/RegisterFormatsBeforeSetContentTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj, Singleton, Strings } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Strings } from '@ephox/katamari';
-import { McEditor, TinyHooks } from '@ephox/mcagar';
 import { Insert, Remove, SelectorFilter, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { McEditor, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysAnchorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysAnchorTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Keys, StructAssert } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
@@ -1,6 +1,6 @@
 import { Keys, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointBrModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointBrModeTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysInlineBoundariesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysInlineBoundariesTest.ts
@@ -1,7 +1,7 @@
 import { Keys } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysTableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysTableTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Keys, StructAssert } from '@ephox/agar';
 import { before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyAnchorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyAnchorTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Keys, StructAssert } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyInlineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyInlineTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyAssertions, TinyContentActions, TinySelections } from '@ephox/mcagar';
+import { McEditor, TinyAssertions, TinyContentActions, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysBrModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysBrModeTest.ts
@@ -1,5 +1,5 @@
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysTest.ts
@@ -1,9 +1,9 @@
 import { Waiter } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { Hierarchy, Insert, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/MediaNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/MediaNavigationTest.ts
@@ -1,7 +1,7 @@
 import { Keys } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/TableNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/TableNavigationTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/TypeTextAtCefTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/TypeTextAtCefTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Height, Scroll, WindowVisualViewport } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';

--- a/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/selection/MultiClickSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/MultiClickSelectionTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/selection/RangeInsertNodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/RangeInsertNodeTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarElements, SugarFragment } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { rangeInsertNode } from 'tinymce/core/selection/RangeInsertNode';

--- a/modules/tinymce/src/core/test/ts/browser/selection/RangeWalkTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/RangeWalkTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectBeforeBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectBeforeBlockTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyAssertions, TinySelections } from '@ephox/mcagar';
+import { McEditor, TinyAssertions, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkIframeEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkIframeEditorTest.ts
@@ -1,6 +1,6 @@
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
@@ -1,8 +1,8 @@
 import { Assertions, Cursors, Waiter } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { Hierarchy, Html, SimRange, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/undo/ForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/ForcedRootBlockTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/undo/LevelsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/LevelsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/util/ImageUploaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ImageUploaderTest.ts
@@ -1,6 +1,6 @@
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/module/McAgar.ts
+++ b/modules/tinymce/src/core/test/ts/module/McAgar.ts
@@ -1,0 +1,7 @@
+/*
+  This is a helper module that allows us to ensure that TinyMCE core is included/compiled
+  before mcagar loads. This ensures that the core of the editor isn't loaded from pre-built
+  files in node_modules and is always the latest version.
+ */
+import 'tinymce';
+export * from '@ephox/mcagar';

--- a/modules/tinymce/src/core/test/ts/module/test/AnnotationAsserts.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/AnnotationAsserts.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Step } from '@ephox/agar';
 import { Arr, Obj } from '@ephox/katamari';
-import { TinyAssertions } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/webdriver/PageUpDownKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/PageUpDownKeysTest.ts
@@ -1,7 +1,7 @@
 import { RealKeys } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
@@ -1,8 +1,8 @@
 import { RealKeys, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/ChangeListStyleTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/ChangeListStyleTest.ts
@@ -1,6 +1,6 @@
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SelectorFind, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/ToolbarButtonStructureTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/ToolbarButtonStructureTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/anchor/Plugin';

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAllowHtmlTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAllowHtmlTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorEditTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorEditTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/anchor/Plugin';

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorFormatsTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorFormatsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorInlineTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorInlineTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/anchor/Plugin';

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/anchor/Plugin';

--- a/modules/tinymce/src/plugins/anchor/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/module/Helpers.ts
@@ -1,6 +1,6 @@
 import { Waiter } from '@ephox/agar';
-import { TinyAssertions, TinyUiActions } from '@ephox/mcagar';
 import { SugarElement, Value } from '@ephox/sugar';
+import { TinyAssertions, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -1,6 +1,6 @@
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Type } from '@ephox/katamari';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 import fc from 'fast-check';
 

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/ConsecutiveLinkTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/ConsecutiveLinkTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/EnterKeyTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/EnterKeyTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -1,7 +1,7 @@
 import { PhantomSkipper, Waiter } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/autosave/test/ts/browser/AutoSavePluginTest.ts
+++ b/modules/tinymce/src/plugins/autosave/test/ts/browser/AutoSavePluginTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/autosave/test/ts/browser/ShouldRestoreWhenEmptyTest.ts
+++ b/modules/tinymce/src/plugins/autosave/test/ts/browser/ShouldRestoreWhenEmptyTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyAssertions } from '@ephox/mcagar';
+import { McEditor, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/bbcode/test/ts/browser/BbcodeSanityTest.ts
+++ b/modules/tinymce/src/plugins/bbcode/test/ts/browser/BbcodeSanityTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Plugin from 'tinymce/plugins/bbcode/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapAutocompletionTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapAutocompletionTest.ts
@@ -1,6 +1,6 @@
 import { Keys, PhantomSkipper } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/charmap/Plugin';

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
@@ -1,8 +1,8 @@
 import { FocusTools, Keys, UiFinder } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Css, SugarElement, SugarShadowDom, Traverse, Value } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
@@ -1,8 +1,8 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapUserDefinedTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapUserDefinedTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/charmap/Plugin';

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/InsertQuotationMarkTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/InsertQuotationMarkTest.ts
@@ -1,6 +1,6 @@
 import { Mouse } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/charmap/Plugin';

--- a/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
+++ b/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/code/test/ts/browser/CodeTextareaTest.ts
+++ b/modules/tinymce/src/plugins/code/test/ts/browser/CodeTextareaTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/ChangeCodeSampleTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/ChangeCodeSampleTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/codesample/Plugin';

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/codesample/Plugin';

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSelectionTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSelectionTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/codesample/Plugin';

--- a/modules/tinymce/src/plugins/codesample/test/ts/module/CodeSampleTestUtils.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/module/CodeSampleTestUtils.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
-import { TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Plugin from 'tinymce/plugins/directionality/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/DifferentEmojiDatabaseTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/DifferentEmojiDatabaseTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAppendTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAppendTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAutocompletionTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAutocompletionTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/emoticons/Plugin';

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonSearchTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonSearchTest.ts
@@ -1,8 +1,8 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmoticonTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmoticonTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPageDialogPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPageDialogPluginTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
+++ b/modules/tinymce/src/plugins/fullpage/test/ts/browser/FullPagePluginTest.ts
@@ -1,6 +1,6 @@
 import { Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Cell } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Classes, Css, Html, SelectorFind, SugarBody, SugarDocument, SugarShadowDom, Traverse } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullscreenPluginInlineEditorTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullscreenPluginInlineEditorTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
@@ -1,6 +1,6 @@
 import { PhantomSkipper, RealMouse, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { getFullscreenElement } from 'tinymce/plugins/fullscreen/core/NativeFullscreen';

--- a/modules/tinymce/src/plugins/help/test/ts/browser/CustomTabsTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/CustomTabsTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor } from '@ephox/mcagar';
 import { Html, SugarDocument } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys, Mouse } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/help/Plugin';

--- a/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import HelpPlugin from 'tinymce/plugins/help/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/help/test/ts/browser/MetadataTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/MetadataTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import HelpPlugin from 'tinymce/plugins/help/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/plugins/help/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/PluginTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Plugin from 'tinymce/plugins/help/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/plugins/hr/test/ts/browser/HrSanityTest.ts
+++ b/modules/tinymce/src/plugins/hr/test/ts/browser/HrSanityTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/hr/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
@@ -1,7 +1,7 @@
 import { Cursors, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, SugarBody, Value } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ContextMenuTest.ts
@@ -1,6 +1,6 @@
 import { Keys, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
@@ -1,8 +1,8 @@
 import { FocusTools, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -1,7 +1,7 @@
 import { Mouse, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
@@ -1,6 +1,6 @@
 import { Mouse } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
@@ -1,7 +1,7 @@
 import { Mouse, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Css, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageListTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageListTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -1,6 +1,6 @@
 import { Cursors } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
@@ -1,6 +1,6 @@
 import { Mouse, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -1,8 +1,8 @@
 import { Assertions, FileInput, Files, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Strings } from '@ephox/katamari';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, Value } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ImageData } from 'tinymce/plugins/image/core/ImageData';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageSelectionTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageSelectionTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ImageData } from 'tinymce/plugins/image/core/ImageData';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DimensionsFalseTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DimensionsFalseTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
@@ -1,6 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ContextToolbarTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCustomFetchTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCustomFetchTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { BlobConversions } from '@ephox/imagetools';
 import { Singleton } from '@ephox/katamari';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyDom, TinySelections } from '@ephox/mcagar';
+import { McEditor, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Mouse, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Html, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/imagetools/Plugin';

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsPluginTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsPluginTest.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/SequenceTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/SequenceTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/imagetools/Plugin';

--- a/modules/tinymce/src/plugins/imagetools/test/ts/module/test/ImageOps.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/module/test/ImageOps.ts
@@ -1,7 +1,7 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { Arr, Fun } from '@ephox/katamari';
-import { TinyUiActions } from '@ephox/mcagar';
 import { Attribute, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';

--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssGroupsPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssGroupsPluginTest.ts
@@ -1,8 +1,8 @@
 import { Assertions, Keys } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor, TinyDom, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { McEditor, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';

--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, Mouse, UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
-import { McEditor, TinyDom, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';

--- a/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/InsertDatetimeSanityTest.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/InsertDatetimeSanityTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/insertdatetime/Plugin';

--- a/modules/tinymce/src/plugins/legacyoutput/test/ts/browser/LegacyOutputPluginTest.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/test/ts/browser/LegacyOutputPluginTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
@@ -1,5 +1,5 @@
 import { describe, it, before, after, afterEach } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AnchorFalseTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AnchorFalseTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, UiFinder } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it, context, before } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
@@ -1,7 +1,7 @@
 import { Mouse, UiFinder } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkProtocolTest.ts
@@ -1,5 +1,5 @@
 import { describe, it, context, before } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkTargetTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkTargetTest.ts
@@ -1,5 +1,5 @@
 import { describe, it, before, after, afterEach } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, UiControls, UiFinder } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it, before, after, context } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
@@ -1,5 +1,5 @@
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as LinkPluginUtils from 'tinymce/plugins/link/core/Utils';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkJustFirstFieldTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkJustFirstFieldTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageLinkTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, UiFinder } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys, UiFinder } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys } from '@ephox/agar';
 import { describe, it, before, afterEach } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlInputTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlInputTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Mouse, UiControls, UiFinder, Waiter } from '@ephox/agar';
 import { Obj, Type } from '@ephox/katamari';
-import { TinyAssertions, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Class, SugarBody, SugarDocument, SugarElement, Traverse, Value } from '@ephox/sugar';
+import { TinyAssertions, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyDlTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyDlTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnParagraphWithStylesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnParagraphWithStylesTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { Html, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import DomQuery from 'tinymce/core/api/dom/DomQuery';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ChangeListStyleTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ChangeListStyleTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/InlineTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/InlineTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys, Mouse, UiControls, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockAttrsTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockAttrsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListWithEmptyLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListWithEmptyLiTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, StructAssert, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as DataToHtml from 'tinymce/plugins/media/core/DataToHtml';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataUnwrapTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataUnwrapTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DimensionsFalseEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DimensionsFalseEmbedTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, StructAssert, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Html, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/NoAdvancedTabTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/NoAdvancedTabTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, StructAssert, Waiter } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ReopenResizeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ReopenResizeTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';

--- a/modules/tinymce/src/plugins/media/test/ts/browser/UpdateMediaPosterAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/UpdateMediaPosterAttributeTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';

--- a/modules/tinymce/src/plugins/media/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/module/test/Utils.ts
@@ -1,7 +1,7 @@
 import { Mouse, UiControls, UiFinder, Waiter } from '@ephox/agar';
 import { Arr, Type } from '@ephox/katamari';
-import { TinyAssertions, TinyUiActions } from '@ephox/mcagar';
 import { Focus, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingForceTabTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingForceTabTest.ts
@@ -1,6 +1,6 @@
 import { Keyboard, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSanityTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSanityTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/nonbreaking/Plugin';

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingVisualCharsTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingVisualCharsTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingTypingTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingTypingTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, RealKeys } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingVisualCharsTypingTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingVisualCharsTypingTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, RealKeys } from '@ephox/agar';
 import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingWrapTypingTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingWrapTypingTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, RealKeys } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/plugins/noneditable/test/ts/browser/NonEditablePluginTest.ts
+++ b/modules/tinymce/src/plugins/noneditable/test/ts/browser/NonEditablePluginTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSanityTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSanityTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/pagebreak/Plugin';

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
@@ -1,7 +1,7 @@
 import { Waiter } from '@ephox/agar';
 import { afterEach, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Cell, Fun } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/InternalClipboardTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/InternalClipboardTest.ts
@@ -1,7 +1,7 @@
 import { Clipboard, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
@@ -1,6 +1,6 @@
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteFormatToggleTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteFormatToggleTest.ts
@@ -1,6 +1,6 @@
 import { Clipboard } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteStylesTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteStylesTest.ts
@@ -1,6 +1,6 @@
 import { Clipboard } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
@@ -1,7 +1,7 @@
 import { Clipboard, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
-import { McEditor, TinyAssertions, TinyDom } from '@ephox/mcagar';
+import { McEditor, TinyAssertions, TinyDom } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ProcessFiltersTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ProcessFiltersTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
@@ -1,6 +1,6 @@
 import { before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/paste/test/ts/webdriver/CutTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/webdriver/CutTest.ts
@@ -1,7 +1,7 @@
 import { PhantomSkipper, RealMouse, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/paste/Plugin';

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewSanityTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewSanityTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/preview/Plugin';

--- a/modules/tinymce/src/plugins/print/test/ts/browser/PrintSanityTest.ts
+++ b/modules/tinymce/src/plugins/print/test/ts/browser/PrintSanityTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/print/Plugin';

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/quickbars/Plugin';

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarFalseTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarFalseTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/quickbars/Plugin';

--- a/modules/tinymce/src/plugins/save/test/ts/browser/SaveSanityTest.ts
+++ b/modules/tinymce/src/plugins/save/test/ts/browser/SaveSanityTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/save/Plugin';

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogCyclingTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogCyclingTest.ts
@@ -1,7 +1,7 @@
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { Class, SelectorFilter } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceInSelectionTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceInSelectionTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
@@ -1,6 +1,6 @@
 import { UiControls, UiFinder, Waiter } from '@ephox/agar';
-import { TinyUiActions } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/AddToDictionaryTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/AddToDictionaryTest.ts
@@ -1,7 +1,7 @@
 import { Chain, Log, Mouse, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
 import { SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/wrap-mcagar';
 
 import SpellcheckerPlugin from 'tinymce/plugins/spellchecker/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerChangeLanguageTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerChangeLanguageTest.ts
@@ -1,6 +1,6 @@
 import { Log, Pipeline, Step } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
+import { TinyLoader, TinyUi } from '@ephox/wrap-mcagar';
 
 import SpellcheckerPlugin from 'tinymce/plugins/spellchecker/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerKeyboardNavigationTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keyboard, Keys, Log, Pipeline, Step } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyLoader } from '@ephox/wrap-mcagar';
 
 import Tools from 'tinymce/core/api/util/Tools';
 import * as Settings from 'tinymce/plugins/spellchecker/api/Settings';

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerManyLanguagesTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerManyLanguagesTest.ts
@@ -1,6 +1,6 @@
 import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
+import { TinyLoader, TinyUi } from '@ephox/wrap-mcagar';
 
 import SpellcheckerPlugin from 'tinymce/plugins/spellchecker/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerSingleLanguageTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerSingleLanguageTest.ts
@@ -1,6 +1,6 @@
 import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
+import { TinyLoader, TinyUi } from '@ephox/wrap-mcagar';
 
 import SpellcheckerPlugin from 'tinymce/plugins/spellchecker/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerSpanClassTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerSpanClassTest.ts
@@ -1,6 +1,6 @@
 import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader, TinyUi } from '@ephox/mcagar';
+import { TinyApis, TinyLoader, TinyUi } from '@ephox/wrap-mcagar';
 
 import SpellcheckerPlugin from 'tinymce/plugins/spellchecker/Plugin';
 import SilverTheme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerTest.ts
+++ b/modules/tinymce/src/plugins/spellchecker/test/ts/browser/SpellcheckerTest.ts
@@ -1,6 +1,6 @@
 import { Log, Pipeline, Step } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
+import { TinyLoader, TinyUi } from '@ephox/wrap-mcagar';
 
 import * as Settings from 'tinymce/plugins/spellchecker/api/Settings';
 import SpellcheckerPlugin from 'tinymce/plugins/spellchecker/Plugin';

--- a/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
+++ b/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyContentActions, TinyHooks } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyContentActions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/tabfocus/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/AlignedCellRowStyleChangeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/AlignedCellRowStyleChangeTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -1,6 +1,6 @@
 import { Clipboard } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/DragResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/DragResizeTest.ts
@@ -1,8 +1,8 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Attribute, Height, Hierarchy, SelectorFind, SugarElement, Width } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/DragSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/DragSelectionTest.ts
@@ -1,6 +1,6 @@
 import { Mouse, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
@@ -1,8 +1,8 @@
 import { Assertions, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -1,7 +1,7 @@
 import { Mouse, UiFinder } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Html, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableSizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableSizeTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { SelectorFind } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertRowTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertRowTableResizeTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { SelectorFind } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableWithColGroupsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableWithColGroupsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/KeyboardCellNavigationTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/KeyboardCellNavigationTest.ts
@@ -1,7 +1,7 @@
 import { Keys, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
@@ -1,7 +1,7 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { SelectorFind, Width } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NestedFakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NestedFakeSelectionTest.ts
@@ -1,7 +1,7 @@
 import { Cursors, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Attribute } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NewCellRowEventsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NewCellRowEventsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
@@ -1,9 +1,9 @@
 import { Mouse } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Cell } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { TableGridSize } from '@ephox/snooker';
 import { SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/SwitchTableSectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/SwitchTableSectionTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableCellPropsStyleTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableCellPropsStyleTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableFormatsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableFormatsTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableNoWidthTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableNoWidthTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Selectors, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSizingModeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSizingModeTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, StructAssert } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Type } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
@@ -1,6 +1,6 @@
 import { Mouse, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
@@ -1,8 +1,8 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyContentActions, TinyDom, TinyHooks } from '@ephox/mcagar';
 import { SelectorFind } from '@ephox/sugar';
+import { TinyContentActions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/ApplyCellStyleCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/ApplyCellStyleCommandTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarElement, SugarNode } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/CommandsOnLockedColumnsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/CommandsOnLockedColumnsTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Cursors } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarElement, SugarNode } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertCommandsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertCommandsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/mcagar';
+import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandTest.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandWithColGroupsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandWithColGroupsTest.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Css, Dimension, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandWithColGroupsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandWithColGroupsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/CustomTableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/CustomTableToolbarTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SelectorFilter } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/DefaultTableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/DefaultTableToolbarTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SelectorFilter } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableAppearanceOptionsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableAppearanceOptionsTest.ts
@@ -1,6 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableCellClassListTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableCellClassListTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableClassListTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableClassListTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesWithColGroupsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesWithColGroupsTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultStylesTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultStylesTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
@@ -1,6 +1,6 @@
 import { Assertions, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableRowClassListTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableRowClassListTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableTabNavigationDisabledTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableTabNavigationDisabledTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextMenuTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextToolbarTest.ts
@@ -1,8 +1,8 @@
 import { Assertions, FocusTools, Keys, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { Html, Remove, Replication, SelectorFilter, SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/LockedColumnDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/LockedColumnDisabledButtonsTest.ts
@@ -1,7 +1,7 @@
 import { Keys, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderStyleTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderStyleTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderWidthTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderWidthTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellBackgroundColorTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellBackgroundColorTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellBorderColorTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellBorderColorTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarElement, SugarNode } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableClassListButtonsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableClassListButtonsTest.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableColumnHeaderUiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableColumnHeaderUiTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogStyleWithCssTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogStyleWithCssTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj, Type } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Attribute, Css, Html, SelectorFilter, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarElement, SugarNode } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowHeaderUiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowHeaderUiTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableValignButtonsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableValignButtonsTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
@@ -1,7 +1,7 @@
 import { Assertions, Keys, Waiter } from '@ephox/agar';
 import { Arr, Fun } from '@ephox/katamari';
-import { TinyAssertions, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableSizingModeCommandUtil.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableSizingModeCommandUtil.ts
@@ -1,5 +1,5 @@
 import { Arr } from '@ephox/katamari';
-import { TinySelections } from '@ephox/mcagar';
+import { TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Cursors, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { Arr, Obj } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyDom, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Checked, Class, Html, SelectorFilter, SelectorFind, SugarBody, SugarElement, Value } from '@ephox/sugar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/template/test/ts/browser/DatesTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/DatesTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';

--- a/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/template/test/ts/browser/InvalidUrlTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/InvalidUrlTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';

--- a/modules/tinymce/src/plugins/template/test/ts/browser/SelectedContentTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/SelectedContentTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';

--- a/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder } from '@ephox/agar';
 import { afterEach, beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';

--- a/modules/tinymce/src/plugins/template/test/ts/module/InsertTemplate.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/module/InsertTemplate.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { Type } from '@ephox/katamari';
-import { TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/plugins/template/test/ts/module/Settings.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/module/Settings.ts
@@ -1,5 +1,5 @@
 import { Obj } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/FindInlinePatternTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/ReplacementTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/ReplacementTest.ts
@@ -1,6 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/textpattern/Plugin';

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginForcedRootBlockFalseTest.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Keys } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextSearchTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextSearchTest.ts
@@ -1,8 +1,8 @@
 import { Assertions } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TrailingPunctuationTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TrailingPunctuationTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/textpattern/Plugin';

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TriggerInlinePatternBeginningTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TriggerInlinePatternBeginningTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/textpattern/Plugin';

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/UndoTextPatternTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/UndoTextPatternTest.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/textpattern/Plugin';

--- a/modules/tinymce/src/plugins/textpattern/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/module/test/Utils.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Keys, StructAssert } from '@ephox/agar';
 import { Unicode } from '@ephox/katamari';
-import { TinyContentActions, TinySelections } from '@ephox/mcagar';
+import { TinyContentActions, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
+++ b/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
@@ -1,6 +1,6 @@
 import { Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyLoader } from '@ephox/mcagar';
+import { LegacyUnit, TinyLoader } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';

--- a/modules/tinymce/src/plugins/visualblocks/test/ts/browser/PreviewFormatTest.ts
+++ b/modules/tinymce/src/plugins/visualblocks/test/ts/browser/PreviewFormatTest.ts
@@ -1,7 +1,7 @@
 import { Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Class, Css, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/visualblocks/test/ts/browser/VisualBlocksSanityTest.ts
+++ b/modules/tinymce/src/plugins/visualblocks/test/ts/browser/VisualBlocksSanityTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/visualblocks/Plugin';

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/DefaultStateTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/DefaultStateTest.ts
@@ -1,6 +1,6 @@
 import { Keyboard, Keys, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/visualchars/Plugin';

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/InlinePluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/InlinePluginTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
@@ -1,6 +1,6 @@
 import { Assertions, GeneralSteps, Keyboard, Keys, Log, Logger, Pipeline, Step, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyDom, TinyLoader } from '@ephox/mcagar';
+import { TinyApis, TinyDom, TinyLoader } from '@ephox/wrap-mcagar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/api/ApiTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/api/ApiTest.ts
@@ -1,6 +1,6 @@
 import { Assertions, GeneralSteps, Log, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { TinyApis, TinyLoader } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { CountGetter, WordCountApi } from 'tinymce/plugins/wordcount/api/Api';

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/core/GetTextTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/core/GetTextTest.ts
@@ -1,6 +1,6 @@
 import { Pipeline, Step } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader } from '@ephox/mcagar';
+import { TinyLoader } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { getText } from 'tinymce/plugins/wordcount/core/GetText';

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/EditorRemoveTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, Chain, NamedChain, Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { McEditor, UiChains } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { Insert, Remove, Selectors, SugarBody, SugarElement } from '@ephox/sugar';
+import { McEditor, UiChains } from '@ephox/wrap-mcagar';
 
 import * as Styles from 'tinymce/themes/mobile/style/Styles';
 import mobileTheme from 'tinymce/themes/mobile/Theme';

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/SkinFalseTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/SkinFalseTest.ts
@@ -1,6 +1,6 @@
 import { Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader } from '@ephox/mcagar';
+import { TinyLoader } from '@ephox/wrap-mcagar';
 
 import Theme from 'tinymce/themes/mobile/Theme';
 

--- a/modules/tinymce/src/themes/mobile/test/ts/browser/ThemeTest.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/browser/ThemeTest.ts
@@ -1,7 +1,7 @@
 import { Pipeline, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader, TinyUi } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
+import { TinyLoader, TinyUi } from '@ephox/wrap-mcagar';
 
 import ContextMenuPlugin from 'tinymce/plugins/contextmenu/Plugin';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/themes/mobile/test/ts/module/test/theme/TestTheme.ts
+++ b/modules/tinymce/src/themes/mobile/test/ts/module/test/theme/TestTheme.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, Attachment, Behaviour, Gui, GuiFactory, Memento, Replacing } from '@ephox/alloy';
 import { Arr, Fun } from '@ephox/katamari';
-import { TinyApis, TinyLoader } from '@ephox/mcagar';
+import { TinyApis, TinyLoader } from '@ephox/wrap-mcagar';
 
 import ThemeManager from 'tinymce/core/api/ThemeManager';
 import * as Features from 'tinymce/themes/mobile/features/Features';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
@@ -2,9 +2,9 @@ import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, UiFinder, 
 import { TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun, Obj } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/DisableTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/DisableTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/EventsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/EventsTest.ts
@@ -1,7 +1,7 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyContentActions, TinyDom, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor, TinyContentActions, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { Focus, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShadowDomInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShadowDomInlineTest.ts
@@ -1,6 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Settings from 'tinymce/themes/silver/api/Settings';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCancelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCancelTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCloseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCloseTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogPopupsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogPopupsTest.ts
@@ -1,9 +1,9 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it, TestLabel } from '@ephox/bedrock-client';
 import { Result } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { SelectorExists, SugarBody, SugarDocument, SugarElement, WindowSelection } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorDirectionalityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorDirectionalityTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions, StructAssert } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyDom } from '@ephox/mcagar';
+import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -2,8 +2,8 @@
 import { ApproxStructure, Assertions, Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Cell, Fun } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerPriorityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerPriorityTest.ts
@@ -1,7 +1,7 @@
 ﻿import { Assertions } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetNotInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetNotInlineTest.ts
@@ -1,7 +1,7 @@
 ﻿import { Assertions } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetTest.ts
@@ -1,7 +1,7 @@
 ﻿import { Assertions } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -2,8 +2,8 @@
 import { ApproxStructure, Assertions, Keys, UiFinder } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Cell, Fun } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Css, SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun, Type } from '@ephox/katamari';
-import { McEditor, TinyDom } from '@ephox/mcagar';
 import { Css, Scroll, SugarBody, SugarElement } from '@ephox/sugar';
+import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -2,8 +2,8 @@ import { Mouse, UiFinder } from '@ephox/agar';
 import { Boxes } from '@ephox/alloy';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { McEditor } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Focus, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Class, Traverse } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteCancelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteCancelTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Keys, Mouse, StructAssert, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteReloadTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteReloadTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
-import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
+import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { InlineContent } from 'tinymce/core/api/ui/Ui';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
@@ -2,8 +2,8 @@ import { Keys, UiFinder, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional, Type } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SelectorFilter, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
@@ -1,6 +1,6 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorCommandsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorCommandsTest.ts
@@ -1,7 +1,7 @@
 import { afterEach, before, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuPositionTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
@@ -1,8 +1,8 @@
 import { Keyboard, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/DesktopContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/DesktopContextMenuTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/MobileContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/MobileContextMenuTest.ts
@@ -1,9 +1,9 @@
 import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Touch, UiFinder, Waiter } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -1,8 +1,8 @@
 import { Bounds, Boxes } from '@ephox/alloy';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { InlineContent } from '@ephox/bridge';
-import { McEditor, TinyDom } from '@ephox/mcagar';
 import { Css, Scroll, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Css, Scroll, SugarBody, SugarLocation } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -1,9 +1,9 @@
 import { Keys, UiFinder, Waiter } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { Css, Scroll, SugarBody } from '@ephox/sugar';
+import { TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Css, Scroll, SugarBody, SugarLocation } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Cell, Fun, Obj } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Focus, SelectorFind, SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { McEditor, TinySelections } from '@ephox/mcagar';
 import { Focus, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { McEditor, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
-import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { Attribute } from '@ephox/sugar';
+import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ContentLanguageHiddenTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ContentLanguageHiddenTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderInitialPlacementTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderInitialPlacementTest.ts
@@ -1,6 +1,6 @@
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ToolbarLocation } from 'tinymce/themes/silver/api/Settings';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderScrollIntoViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderScrollIntoViewTest.ts
@@ -1,7 +1,7 @@
 import { Cursors, PhantomSkipper, Waiter } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Scroll, SugarLocation, SugarPosition } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarSettingsTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor } from '@ephox/mcagar';
 import { SugarBody, SugarElement } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { Insert, Remove, SugarBody, SugarElement, SugarHead, TextContent, Width } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeNotInRootTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeNotInRootTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { Insert, Remove, SugarBody, SugarElement, Width } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys, Mouse, UiFinder } from '@ephox/agar';
 import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Css, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarSettingsTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor } from '@ephox/mcagar';
 import { SugarBody, SugarElement } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -1,8 +1,8 @@
 import { Keys, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Cell } from '@ephox/katamari';
-import { McEditor, TinyContentActions, TinyDom, TinySelections } from '@ephox/mcagar';
 import { Css, SugarBody, SugarLocation } from '@ephox/sugar';
+import { McEditor, TinyContentActions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarPositionTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, FocusTools, UiFinder, Waiter } from '@epho
 import { Boxes } from '@ephox/alloy';
 import { after, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Strings } from '@ephox/katamari';
-import { TinyDom, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { Css, Insert, Remove, SelectorFind, SugarBody, SugarDocument, SugarElement, Traverse } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Css, SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerFloatingPositionTest.ts
@@ -1,8 +1,8 @@
 import { Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { Css, Insert, Remove, Scroll, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -1,6 +1,6 @@
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { McEditor } from '@ephox/mcagar';
+import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarFocusTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, Keys } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyContentActions, TinyDom, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { McEditor, TinyContentActions, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/icons/IconsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/icons/IconsTest.ts
@@ -1,7 +1,7 @@
 import { SimpleOrSketchSpec } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { getAll as getAllOxide } from '@tinymce/oxide-icons-default';
 import { assert } from 'chai';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Sidebar } from 'tinymce/core/api/ui/Ui';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Mouse, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, PhantomSkipper, S
 import { TestHelpers } from '@ephox/alloy';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional, Optionals } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, StructAssert, UiF
 import { TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
@@ -1,9 +1,9 @@
 import { ApproxStructure, Assertions, FocusTools, Keys } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, PhantomSkipper } 
 import { TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, FocusTools, Keys } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, FocusTools, Keys, Mouse } from '@ephox/aga
 import { TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyDom } from '@ephox/mcagar';
+import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberEditorTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberFocusTest.ts
@@ -1,7 +1,7 @@
 import { FocusTools, UiFinder, Waiter } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Focus, Insert, Remove, SelectorFind, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Class, Focus, Insert, Remove, SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
@@ -2,8 +2,8 @@ import { Mouse, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
@@ -2,8 +2,8 @@ import { UiFinder } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, Mouse, UiFinder } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optionals } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, Height, SelectorFind, SugarBody, SugarDocument, SugarElement, SugarLocation, Width } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -1,7 +1,7 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Css, Height, Remove, Scroll, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, FocusTools, Mouse, UiFinder, Waiter } from
 import { TestHelpers } from '@ephox/alloy';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Strings } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/module/ContextMenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ContextMenuUtils.ts
@@ -1,6 +1,6 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { TinyUiActions } from '@ephox/mcagar';
 import { Css, SugarBody } from '@ephox/sugar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/module/DialogUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/DialogUtils.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
-import { TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';

--- a/modules/tinymce/src/themes/silver/test/ts/module/PageScroll.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/PageScroll.ts
@@ -1,7 +1,7 @@
 import { after, before } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { TinyDom } from '@ephox/mcagar';
 import { Insert, Remove, SugarElement } from '@ephox/sugar';
+import { TinyDom } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { after, before, context, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
@@ -1,7 +1,7 @@
 import { Waiter } from '@ephox/agar';
 import { Type } from '@ephox/katamari';
-import { TinyUiActions } from '@ephox/mcagar';
 import { Height, SugarElement, SugarLocation, Width } from '@ephox/sugar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
@@ -1,7 +1,7 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { Arr } from '@ephox/katamari';
-import { TinyDom } from '@ephox/mcagar';
 import { Scroll, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyDom } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/AutocompleteDelayedResponseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/AutocompleteDelayedResponseTest.ts
@@ -2,8 +2,8 @@ import { Keys, RealKeys, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
@@ -1,7 +1,7 @@
 import { Keys, Mouse, RealKeys, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import { Editor } from 'tinymce/core/api/PublicApi';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
@@ -1,7 +1,7 @@
 import { RealMouse, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
-import { McEditor } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/TabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/TabbingTest.ts
@@ -1,7 +1,7 @@
 import { RealKeys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyDom, TinyHooks } from '@ephox/mcagar';
 import { Focus, Insert, Remove, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
@@ -1,8 +1,8 @@
 import { FocusTools, RealKeys, UiFinder } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/mcagar';
 import { Insert, Remove, SelectorFind, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/tsconfig.json
+++ b/modules/tinymce/tsconfig.json
@@ -56,7 +56,9 @@
       "tinymce/plugins/toc/*": ["src/plugins/toc/main/ts/*"],
       "tinymce/plugins/visualblocks/*": ["src/plugins/visualblocks/main/ts/*"],
       "tinymce/plugins/visualchars/*": ["src/plugins/visualchars/main/ts/*"],
-      "tinymce/plugins/wordcount/*": ["src/plugins/wordcount/main/ts/*"]
+      "tinymce/plugins/wordcount/*": ["src/plugins/wordcount/main/ts/*"],
+
+      "@ephox/wrap-mcagar": ["src/core/test/ts/module/McAgar"]
     }
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,8 @@
       "tinymce/plugins/visualchars/*": ["modules/tinymce/src/plugins/visualchars/main/ts/*"],
       "tinymce/plugins/wordcount/*": ["modules/tinymce/src/plugins/wordcount/main/ts/*"],
 
+      "@ephox/wrap-mcagar": ["modules/tinymce/src/core/test/ts/module/McAgar"],
+
       "@ephox/oxide-icons-default": ["modules/oxide-icons-default/dist/js/Main.d.js"],
 
       "ephox/acid/test/*": ["modules/acid/src/test/ts/module/ephox/acid/test/*"],


### PR DESCRIPTION
Related Ticket: TINY-7650

Description of Changes:
* Update McAgar to not import TinyMCE and instead lazy load it when a `tinymce` global doesn't exist. It will always attempt to use the `base_url` setting provided to lazy load TinyMCE.
* Update TinyMCE tests to load from a local McAgar wrapper to ensure core is always imported

- [x] ~Before merging make sure we have a Jira to create a lint rule to make sure the new `@ephox/wrap-mcagar` alias is used.~ Logged as TINY-7865

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
