### PR TITLE
Fixed missing plugin import in media test

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/delete/MediaDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/MediaDeleteTest.ts
@@ -5,12 +5,13 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
+import Plugin from 'tinymce/plugins/media/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.MediaDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [ Plugin, Theme ], true);
 
   const assertEmptyEditorStructure = (editor: Editor) => TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) =>
     s.element('body', {


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* A quick fix to add a missing import that was causing this test to timeout/fail in some cases.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
