### PR TITLE
TINY-7871: Disable the media object tests on Safari

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/delete/MediaDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/MediaDeleteTest.ts
@@ -33,7 +33,8 @@ describe('browser.tinymce.core.delete.MediaDeleteTest', () => {
     { type: 'audio', content: '<audio controls="controls"><source src="custom/audio.mp3" /></audio>', skip: false },
     // Firefox won't render without a valid embed/object, so skip
     { type: 'embed', content: '<embed src="custom/video.mp4" />', skip: Env.browser.isFirefox() },
-    { type: 'object', content: '<object data="custom/file.pdf"></object>', skip: Env.browser.isFirefox() }
+    // TINY-7871: Safari 14.1 also appears to have a bug that causes it to freeze without a valid object
+    { type: 'object', content: '<object data="custom/file.pdf"></object>', skip: Env.browser.isFirefox() || Env.browser.isSafari() }
   ], (test) => {
     const { type, content } = test;
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/MediaNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/MediaNavigationTest.ts
@@ -32,7 +32,8 @@ describe('browser.tinymce.core.keyboard.MediaNavigationTest', () => {
     { type: 'audio', content: '<audio controls="controls"><source src="custom/audio.mp3" /></audio>', skip: false },
     // Firefox won't render without a valid embed/object, so skip
     { type: 'embed', content: '<embed src="custom/video.mp4" />', skip: Env.browser.isFirefox() },
-    { type: 'object', content: '<object data="custom/file.pdf"></object>', skip: Env.browser.isFirefox() }
+    // TINY-7871: Safari 14.1 also appears to have a bug that causes it to freeze without a valid object
+    { type: 'object', content: '<object data="custom/file.pdf"></object>', skip: Env.browser.isFirefox() || Env.browser.isSafari() }
   ], (test) => {
     const { type, content } = test;
 


### PR DESCRIPTION
Related Ticket: TINY-7871

Description of Changes:
Okay, after investigating more it seems we've stumbled upon a Safari bug on newer versions. It's causing things to lockup when providing an invalid object, so just disable the relevant test on Safari for now until we can investigate the root cause.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
