### PR TITLE
TINY-7192: Simplify get selection bounds logic

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
@@ -8,7 +8,7 @@
 import { Bounds, Boxes } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
-import { Scroll, SelectorFind, SugarBody, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
+import { Scroll, SelectorFind, SugarBody, SugarElement, WindowVisualViewport } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -19,24 +19,8 @@ import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 const isVerticalOverlap = (a: Bounds, b: Bounds, threshold: number = 0.01): boolean =>
   b.bottom - a.y >= threshold && a.bottom - b.y >= threshold;
 
-const getRangeRect = (rng: Range): DOMRect => {
-  const rect = rng.getBoundingClientRect();
-  // Some ranges (eg <td><br></td>) will return a 0x0 rect, so we'll need to calculate it from the leaf instead
-  if (rect.height <= 0 && rect.width <= 0) {
-    const leaf = Traverse.leaf(SugarElement.fromDom(rng.startContainer), rng.startOffset).element;
-    const elm = SugarNode.isText(leaf) ? Traverse.parent(leaf) : Optional.some(leaf);
-    return elm.filter(SugarNode.isElement)
-      .map((e) => e.dom.getBoundingClientRect())
-      // We have nothing valid, so just fallback to the original rect
-      .getOr(rect);
-  } else {
-    return rect;
-  }
-};
-
 const getSelectionBounds = (editor: Editor): Bounds => {
-  const rng = editor.selection.getRng();
-  const rect = getRangeRect(rng);
+  const rect = editor.selection.getBoundingClientRect();
   if (editor.inline) {
     const scroll = Scroll.get();
     return Boxes.bounds(scroll.left + rect.left, scroll.top + rect.top, rect.width, rect.height);


### PR DESCRIPTION
Related Ticket: TINY-7192

Description of Changes:
This is a small optimisation to the implementation done in https://github.com/tinymce/tinymce/pull/6965, as while fixing the 4.4 types I found an API in core I wasn't aware of that does what I'd implemented in `ContextToolbarBounds`. So this just switches to that to remove duplication.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~ Covered by existing tests
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
