### PR TITLE
TINY-7713: Fix computed line height bug

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
@@ -25,7 +25,7 @@ describe('browser.tinymce.core.commands.LineHeightTest', () => {
   });
 
   it('TINY-4843: Unspecified line-height can be read from element', function () {
-    // https://bugs.webkit.org/show_bug.cgi?id=216601
+    // TODO: TINY-7895
     if (platform.browser.isSafari()) {
       this.skip();
     }

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -1,6 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 import { Attribute } from '@ephox/sugar';
 import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -16,6 +17,7 @@ interface ToolbarOrMenuSpec {
 }
 
 describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
+  const platform = PlatformDetection.detect();
 
   const toolbarSpec: ToolbarOrMenuSpec = {
     name: 'Toolbar',
@@ -109,7 +111,11 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
           spec.close(editor, 'Line height');
         });
 
-        it(`TINY-7713: ${spec.name} updates if computed line height changes`, async () => {
+        it(`TINY-7713: ${spec.name} updates if computed line height changes`, async function () {
+          // TODO: TINY-7895
+          if (platform.browser.isSafari()) {
+            this.skip();
+          }
           const editor = hook.editor();
           editor.setContent('');
           TinySelections.setCursor(editor, [ 0 ], 0);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -108,6 +108,18 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
           await pAssertOptions(editor, spec.menuSelector, [ '1', '1.1', '1.2', '1.3', '1.4', '1.5', '2' ], Optional.some('1.1'));
           spec.close(editor, 'Line height');
         });
+
+        it(`TINY-7713: ${spec.name} updates if computed line height changes`, async () => {
+          const editor = hook.editor();
+          editor.setContent('');
+          TinySelections.setCursor(editor, [ 0 ], 0);
+          await spec.pOpen(editor, 'Line height');
+          // Our content-css will apply a default line-height of 1.4
+          await pAssertOptions(editor, spec.menuSelector, [ '1', '1.1', '1.2', '1.3', '1.4', '1.5', '2' ], Optional.some('1.4'));
+          editor.execCommand('LineHeight', false, '1.1');
+          await pAssertOptions(editor, spec.menuSelector, [ '1', '1.1', '1.2', '1.3', '1.4', '1.5', '2' ], Optional.some('1.1'));
+          spec.close(editor, 'Line height');
+        });
       });
     });
 


### PR DESCRIPTION
Related Ticket: TINY-7713

Description of Changes:
* Don't let two submenus be active at once

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] xBranch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): N/A
