### PR TITLE
TINY-7724: Temporarily improve lingering cursor issue

### DIFF
--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -1,4 +1,4 @@
-import { Optional, Singleton } from '@ephox/katamari';
+import { Optional, Optionals, Singleton } from '@ephox/katamari';
 import { Compare, ContentEditable, EventArgs, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import { SelectionAnnotation } from '../api/SelectionAnnotation';
@@ -30,11 +30,10 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement<Nod
             // is also noneditable, make sure it is annotated
             const singleCell = boxes[0];
             const isNonEditableCell = ContentEditable.getRaw(singleCell) === 'false';
-            // Check if the target, which may be a child of the cell, needs to be explicitly selected instead of the whole cell
-            const isSelectableTarget = !Compare.eq(event.target, singleCell) && (ContentEditable.isEditable(event.target) || ContentEditable.getRaw(event.target) === 'false');
-            if (isNonEditableCell && !isSelectableTarget) {
+            const isCellClosestContentEditable = Optionals.is(ContentEditable.closest(event.target), singleCell, Compare.eq);
+            if (isNonEditableCell && isCellClosestContentEditable) {
               annotations.selectRange(container, boxes, singleCell, singleCell);
-              // TODO: TINY-7874 Potentially change back to bridge.selectNode when offscreen cursor issues are solved
+              // TODO: TINY-7874 This is purely a workaround until the offscreen selection issues are solved
               bridge.selectContents(singleCell);
             }
           } else if (boxes.length > 1) {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/ContentEditable.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/ContentEditable.ts
@@ -5,7 +5,7 @@ import * as SugarBody from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
 import * as SelectorFind from '../search/SelectorFind';
 
-const findClosestContentEditable = (target: SugarElement<HTMLElement>): Optional<SugarElement<HTMLElement>> =>
+const closest = (target: SugarElement<HTMLElement>): Optional<SugarElement<HTMLElement>> =>
   SelectorFind.closest(target, '[contenteditable]');
 
 const isEditable = (element: SugarElement<HTMLElement>, assumeEditable: boolean = false): boolean => {
@@ -14,7 +14,7 @@ const isEditable = (element: SugarElement<HTMLElement>, assumeEditable: boolean 
     return element.dom.isContentEditable;
   } else {
     // Find the closest contenteditable element and check if it's editable
-    return findClosestContentEditable(element).fold(
+    return closest(element).fold(
       Fun.constant(assumeEditable),
       (editable) => getRaw(editable) === 'true'
     );
@@ -34,6 +34,7 @@ const set = (element: SugarElement<HTMLElement>, editable: boolean): void => {
 export {
   get,
   getRaw,
+  closest,
   isEditable,
   set
 };

--- a/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
@@ -160,11 +160,20 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
 
   it('TINY-7724: does not select CEF cell if contenteditable=false child is selected', () => {
     const editor = hook.editor();
-    editor.setContent('<table><tr><td contenteditable="false"><p contenteditable="false">1</p></td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>');
+    editor.setContent('<table><tr><td contenteditable="false"><p contenteditable="false"><strong>1</strong></p></td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>');
 
     // Check the CEF cell is not annotated when the contenteditable="false" child is selected
     const noneditablePara = SelectorFind.descendant(TinyDom.body(editor), 'p[contenteditable="false"]').getOrDie('Could not find paragraph');
     selectWithMouse(noneditablePara, noneditablePara);
+    TinyAssertions.assertContentPresence(editor, {
+      'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 0,
+      'p[data-mce-selected="1"]': 1
+    });
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1);
+
+    // Check the CEF cell is not annotated when the strong child of contenteditable="false" paragraph is selected
+    const strongElm = SelectorFind.descendant(TinyDom.body(editor), 'strong').getOrDie('Could not find strong element');
+    selectWithMouse(strongElm, strongElm);
     TinyAssertions.assertContentPresence(editor, {
       'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 0,
       'p[data-mce-selected="1"]': 1

--- a/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
@@ -143,7 +143,8 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
     const editablePara = SelectorFind.descendant(TinyDom.body(editor), 'p[contenteditable="true"]').getOrDie('Could not find paragraph');
     selectWithMouse(editablePara, editablePara);
     TinyAssertions.assertContentPresence(editor, {
-      'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 0
+      'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 0,
+      'p[data-mce-selected="1"]': 0
     });
     TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0, 0 ], 0);
 
@@ -151,7 +152,31 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
     const noneditableCell = SelectorFind.descendant(TinyDom.body(editor), 'td[contenteditable="false"]').getOrDie('Could not find cell');
     selectWithMouse(noneditableCell, noneditableCell);
     TinyAssertions.assertContentPresence(editor, {
-      'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 1
+      'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 1,
+      'p[data-mce-selected="1"]': 0
+    });
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+  });
+
+  it('TINY-7724: does not select CEF cell if contenteditable=false child is selected', () => {
+    const editor = hook.editor();
+    editor.setContent('<table><tr><td contenteditable="false"><p contenteditable="false">1</p></td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>');
+
+    // Check the CEF cell is not annotated when the contenteditable="false" child is selected
+    const noneditablePara = SelectorFind.descendant(TinyDom.body(editor), 'p[contenteditable="false"]').getOrDie('Could not find paragraph');
+    selectWithMouse(noneditablePara, noneditablePara);
+    TinyAssertions.assertContentPresence(editor, {
+      'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 0,
+      'p[data-mce-selected="1"]': 1
+    });
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1);
+
+    // Check the CEF cell is annotated if the cell itself is selected
+    const noneditableCell = SelectorFind.descendant(TinyDom.body(editor), 'td[contenteditable="false"]').getOrDie('Could not find cell');
+    selectWithMouse(noneditableCell, noneditableCell);
+    TinyAssertions.assertContentPresence(editor, {
+      'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 1,
+      'p[data-mce-selected="1"]': 0
     });
     TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
   });


### PR DESCRIPTION
Related Ticket: TINY-7724

Description of Changes:
* Try and improve the issue where the cursor would be visible despite a noneditable cell being selected
* Fix issue where noneditable cell would be selected if a noneditable child was selected

Pre-checks:
* [X] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
