### PR TITLE
TINY-7891: Fixed table corruption when deleting cef cells

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `editor.formatter.formatChanged` would sometimes not run the callback the first time the format was removed #TINY-7713
 - The `TableModified` event was not fired when pasting cells into a table #TINY-6939
 - The table paste column before and after icons were not flipped in RTL mode #TINY-7851
+- Fixed table corruption when deleting a `contenteditable="false"` cell #TINY-7891
 - Base64 encoded images with spaces or line breaks in the data URI were not displayed correctly. Patch contributed by RoboBurned
 
 ### Deprecated

--- a/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
@@ -66,11 +66,12 @@ const backspaceDeleteRange = (editor: Editor, forward: boolean): boolean => {
   const selectedNode = editor.selection.getNode(); // is the cef node if cef is selected
 
   // Cases:
-  // 1. CEF selectedNode
+  // 1. Table cell -> return false, as this is handled by `TableDelete` instead
+  // 2. CEF selectedNode
   //    a. no ancestor CET/CEF || CET ancestor -> run delete code and return true
   //    b. CEF ancestor -> return true
-  // 2. non-CEF selectedNode -> return false
-  if (NodeType.isContentEditableFalse(selectedNode)) {
+  // 3. non-CEF selectedNode -> return false
+  if (NodeType.isContentEditableFalse(selectedNode) && !NodeType.isTableCell(selectedNode)) {
     const hasCefAncestor = getAncestorCe(editor, selectedNode.parentNode).filter(NodeType.isContentEditableFalse);
     return hasCefAncestor.fold(
       () => {

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -124,6 +124,40 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       keyboardBackspace(editor);
       assertRawNormalizedContent(editor, '<table class="mce-item-table"><tbody><tr><td><br data-mce-bogus="1"></td><td><br data-mce-bogus="1"></td><td><p>cc</p></td></tr></tbody></table>');
     });
+
+    it('TINY-7891: Delete a single contenteditable=false cell', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<table><tbody>' +
+        '<tr><td contenteditable="false" data-mce-selected="1">a</td><td>b</td><td>c</td></tr>' +
+        '<tr><td>d</td><td>e</td><td>f</td></tr>' +
+        '</tbody></table>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+      // Note: This uses the command to ensure it works with CefDelete
+      editor.execCommand('Delete');
+      TinyAssertions.assertContentPresence(editor, {
+        'td[data-mce-selected="1"]': 0
+      });
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td><td>b</td><td>c</td></tr><tr><td>d</td><td>e</td><td>f</td></tr></tbody></table>');
+    });
+
+    it('TINY-7891: Delete a contenteditable=false cell in a range selection', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<table><tbody>' +
+        '<tr><td contenteditable="false" data-mce-selected="1">a</td><td>b</td><td>c</td></tr>' +
+        '<tr><td data-mce-selected="1">d</td><td>e</td><td>f</td></tr>' +
+        '</tbody></table>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1);
+      // Note: This uses the command to ensure it works with CefDelete
+      editor.execCommand('Delete');
+      TinyAssertions.assertContentPresence(editor, {
+        'td[data-mce-selected="1"]': 2
+      });
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td><td>b</td><td>c</td></tr><tr><td>&nbsp;</td><td>e</td><td>f</td></tr></tbody></table>');
+    });
   });
 
   context('Delete all single cell content', () => {


### PR DESCRIPTION
Related Ticket: TINY-7891

Description of Changes:
Fixed how noneditable cells are deleted, as removing the `td` element leads to a corrupted table. So instead, we clear all the content and reset the editable state to make it as close to what happens with other cef elements as possible.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
