### PR TITLE
DOC-865: Rework and reorder changelog entries to group similar items

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Added a new `toolbar_sticky_offset` setting to allow the toolbar to be offset from the top of the page #TINY-7337
 - Added a new `mceFocus` command that focuses the editor. Equivalent to using `editor.focus()` #TINY-7373
 - Added a new `mceTableToggleClass` command which toggles the provided class on the currently selected table #TINY-7476
 - Added a new `mceTableCellToggleClass` command which toggles the provided class on the currently selected table cells #TINY-7476
@@ -20,31 +19,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `tablecolheader` toolbar button and menu item to toggle the header state of column cells #TINY-7482
 - Added a new `tablecellbordercolor` toolbar button and menu item to select table cell border colors, with an accompanying setting `table_border_color_map` to customize the available values #TINY-7480
 - Added a new `tablecellbackgroundcolor` toolbar button and menu item to select table cell background colors, with an accompanying setting `table_background_color_map` to customize the available values #TINY-7480
-- Added a new `initData` property to `fancymenuitem` to allow custom initialization data #TINY-7480
 - Added a new `language` menu item and toolbar button to add `lang` attributes to content, with an accompanying `content_langs` setting to specify the languages available #TINY-6149
 - A new `lang` format is now available that can be used with `editor.formatter`, or applied with the `Lang` editor command #TINY-6149
 - Added a new `language` icon for the `language` toolbar button #TINY-7670
 - Added a new `table-row-numbering` icon #TINY-7327
-- Added new plugin commands: `mceEmoticons` (emoticons), `mceWordCount` (wordcount), and `mceTemplate` (template) #TINY-7619
+- Added new plugin commands: `mceEmoticons` (Emoticons), `mceWordCount` (Word Count), and `mceTemplate` (Template) #TINY-7619
 - Added a new `iframe_aria_text` setting to set the iframe title attribute #TINY-1264
 - Added a new DomParser `Node.children()` API to return all the children of a `Node` #TINY-7756
-- Added new `FormatApply` and `FormatRemove` events #TINY-7713
 
 ### Improved
+- Sticky toolbars can now be offset from the top of the page using the new `toolbar_sticky_offset` setting #TINY-7337
+- Fancy menu items now accept an `initData` property to allow custom initialization data #TINY-7480
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504
-- Improved the performance when rendering UI components #TINY-7572
-- When scrolling, the context toolbar will stick to where it was previously for large elements, such as tables #TINY-7545
+- Improved the performance when UI components are rendered #TINY-7572
+- When scrolling, the context toolbar will remain where it was previously for large elements, such as tables #TINY-7545
 - The context toolbar will now move out of the way when it overlaps with the selection, such as in table cells #TINY-7192
-- The context toolbar will now use transition animations when changing placements #TINY-7740
-- The `formatter.match` API can now take an optional `similar` parameter to check if the format partially matches #TINY-7712
-- `Env.browser` now uses the User-Agent Client Hints API when it is available #TINY-7785
+- The context toolbar now uses a short animation when transitioning between different locations #TINY-7740
+- `Env.browser` now uses the User-Agent Client Hints API where it is available #TINY-7785
 - Icons with a `-rtl` suffix in their name will now automatically be used when the UI is rendered in right-to-left mode #TINY-7782
-- `editor.formatter.formatChanged` now supports listening for changes to formats with specific variables #TINY-7713
-- The `autolink` plugin link detection now permits custom protocols and improves valid link detection #TINY-7714
+- The `formatter.match` API now accepts an optional `similar` parameter to check if the format partially matches #TINY-7712
+- The `formatter.formatChanged` API now supports providing format variables when listening for changes #TINY-7713
+- The formatter will now fire `FormatApply` and `FormatRemove` events for the relevant actions #TINY-7713
+- The `autolink` plugin link detection now permits custom protocols #TINY-7714
+- The `autolink` plugin valid link detection has been improved #TINY-7714
 
 ### Changed
-- Changed the load order so that the content CSS is loaded before the editor gets populated with content #TINY-7249
-- Changed `emoticons`, `wordcount`, `code`, `codesample`, and `template` plugins to open dialogs using commands #TINY-7619
+- Changed the load order so content CSS is loaded before the editor is populated with content #TINY-7249
+- Changed the `emoticons`, `wordcount`, `code`, `codesample`, and `template` plugins to open dialogs using commands #TINY-7619
 - The context toolbar will no longer show an arrow when it overlaps the content, such as in table cells #TINY-7665
 - The context toolbar will no longer overlap the statusbar for toolbars using `node` or `selection` positions #TINY-7666
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The context toolbar will no longer overlap the statusbar for toolbars using `node` or `selection` positions #TINY-7666
 
 ### Fixed
-- `editor.fire` was incorrectly mutating the original `args` provided #TINY-3254
+- The `editor.fire` API was incorrectly mutating the original `args` provided #TINY-3254
 - Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
 - Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
@@ -86,9 +86,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `dir` attribute was being incorrectly applied to list items #TINY-4589
 - Applying selector formats would sometimes not apply the format correctly to elements in a list #TINY-7393
 - For formats that specify an attribute or style that should be removed, the formatter `match` API incorrectly returned `false` #TINY-6149
-- The type signature on `editor.formatter.matchNode` had the wrong return type (was `boolean` but should have been `Formatter | undefined`) #TINY-6149
-- `editor.formatter.formatChanged` would ignore the `similar` parameter if another callback had already been registered for the same format #TINY-7713
-- `editor.formatter.formatChanged` would sometimes not run the callback the first time the format was removed #TINY-7713
+- The type signature on the `formatter.matchNode` API had the wrong return type (was `boolean` but should have been `Formatter | undefined`) #TINY-6149
+- The `formatter.formatChanged` API would ignore the `similar` parameter if another callback had already been registered for the same format #TINY-7713
+- The `formatter.formatChanged` API would sometimes not run the callback the first time the format was removed #TINY-7713
 - Base64 encoded images with spaces or line breaks in the data URI were not displayed correctly. Patch contributed by RoboBurned
 
 ### Deprecated

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,16 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `tablecellborderstyle` toolbar button and menu item to change table cell border style #TINY-7478
 - Added a new `tablecaption` toolbar button and menu item to toggle captions on tables #TINY-7479
 - Added a new `mceTableToggleCaption` command that toggles captions on a selected table #TINY-7479
+- Added a new `tablerowheader` toolbar button and menu item to toggle the header state of row cells #TINY-7478
+- Added a new `tablecolheader` toolbar button and menu item to toggle the header state of column cells #TINY-7482
 - Added a new `tablecellbordercolor` toolbar button and menu item to select table cell border colors, with an accompanying setting `table_border_color_map` to customize the available values #TINY-7480
 - Added a new `tablecellbackgroundcolor` toolbar button and menu item to select table cell background colors, with an accompanying setting `table_background_color_map` to customize the available values #TINY-7480
 - Added a new `initData` property to `fancymenuitem` to allow custom initialization data #TINY-7480
 - Added a new `language` menu item and toolbar button to add `lang` attributes to content, with an accompanying `content_langs` setting to specify the languages available #TINY-6149
 - A new `lang` format is now available that can be used with `editor.formatter`, or applied with the `Lang` editor command #TINY-6149
 - Added a new `language` icon for the `language` toolbar button #TINY-7670
-- Added new plugin commands: `mceEmoticons` (emoticons), `mceWordCount` (wordcount), and `mceTemplate` (template) #TINY-7619
-- Added a new `tablerowheader` toolbar button and menu item to toggle the header state of row cells #TINY-7478
-- Added a new `tablecolheader` toolbar button and menu item to toggle the header state of column cells #TINY-7482
 - Added a new `table-row-numbering` icon #TINY-7327
+- Added new plugin commands: `mceEmoticons` (emoticons), `mceWordCount` (wordcount), and `mceTemplate` (template) #TINY-7619
 - Added a new `iframe_aria_text` setting to set the iframe title attribute #TINY-1264
 - Added a new DomParser `Node.children()` API to return all the children of a `Node` #TINY-7756
 - Added new `FormatApply` and `FormatRemove` events #TINY-7713
@@ -49,45 +49,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The context toolbar will no longer overlap the statusbar for toolbars using `node` or `selection` positions #TINY-7666
 
 ### Fixed
-- The `dir` attribute was being incorrectly applied to list items #TINY-4589
 - `editor.fire` was incorrectly mutating the original `args` provided #TINY-3254
+- Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
+- Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
+- Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 - The `SetContent` event contained the incorrect `content` when using the `editor.selection.setContent()` API #TINY-3254
 - The editor content could be edited after calling `setProgressState(true)` in iframe mode #TINY-7373
 - Tabbing out of the editor after calling `setProgressState(true)` was inconsistent in iframe mode #TINY-7373
 - Flash of unstyled content while loading the editor because the content CSS was loaded after the editor content was rendered #TINY-7249
-- Only table content would be deleted when partially selecting a table and content outside the table #TINY-6044
-- Unbinding an event handler did not take effect immediately while the event was firing #TINY-7436
-- The table cell selection handling was incorrect in some cases when dealing with nested tables #TINY-6298
-- Binding an event handler incorrectly took effect immediately while the event was firing #TINY-7436
 - Partially transparent RGBA values provided in the `color_map` setting were given the wrong hex value #TINY-7163
 - HTML comments with mismatched quotes were parsed incorrectly under certain circumstances #TINY-7589
-- Links in notification text did not show the correct mouse pointer #TINY-7661
-- Applying selector formats would sometimes not apply the format correctly to elements in a list #TINY-7393
-- For formats that specify an attribute or style that should be removed, the formatter `match` API incorrectly returned `false` #TINY-6149
-- The type signature on `editor.formatter.matchNode` had the wrong return type (was `boolean` but should have been `Formatter | undefined`) #TINY-6149
-- Menus and context menus were not closed when clicking into a different editor #TINY-7399
-- Using the Tab key to navigate into the editor on Microsoft Internet Explorer 11 would incorrectly focus the toolbar #TINY-3707
-- The editor selection could be placed in an incorrect location when undoing or redoing changes in a document containing `contenteditable="false"` elements #TINY-7663
-- Context menus on Android were not displayed when more than one HTML element was selected #TINY-7688
 - The editor could crash when inserting certain HTML content #TINY-7756
 - Inserting certain HTML content into the editor could result in invalid HTML once parsed #TINY-7756
-- Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
+- Links in notification text did not show the correct mouse pointer #TINY-7661
+- Using the Tab key to navigate into the editor on Microsoft Internet Explorer 11 would incorrectly focus the toolbar #TINY-3707
+- The editor selection could be placed in an incorrect location when undoing or redoing changes in a document containing `contenteditable="false"` elements #TINY-7663
+- Menus and context menus were not closed when clicking into a different editor #TINY-7399
+- Context menus on Android were not displayed when more than one HTML element was selected #TINY-7688
 - Disabled nested menu items could still be opened #TINY-7700
+- The nested menu item chevron icon was not fading when the menu item was disabled #TINY-7700
 - `imagetools` buttons were incorrectly enabled for remote images without `imagetools_proxy` set #TINY-7772
+- Only table content would be deleted when partially selecting a table and content outside the table #TINY-6044
+- The table cell selection handling was incorrect in some cases when dealing with nested tables #TINY-6298
 - Removing a table row or column could result in the cursor getting placed in an invalid location #TINY-7695
 - Pressing the Tab key to navigate through table cells did not skip noneditable cells #TINY-7705
 - Clicking on a noneditable table cell did not show a visual selection like other noneditable elements #TINY-7724
 - Some table operations would incorrectly cause table row attributes and styles to be lost #TINY-6666
 - The selection was incorrectly lost when using the `mceTableCellType` and `mceTableRowType` commands #TINY-6666
 - The `mceTableRowType` was reversing the order of the rows when converting multiple header rows back to body rows #TINY-6666
-- The nested menu item chevron icon was not fading when the menu item was disabled #TINY-7700
 - The table dialog did not always respect the `table_style_with_css` option #TINY-4926
 - Pasting into a table with multiple cells selected could cause the content to be pasted in the wrong location #TINY-7485
-- `editor.formatter.formatChanged` would ignore the `similar` parameter if another callback had already been registered for the same format #TINY-7713
-- `editor.formatter.formatChanged` would sometimes not run the callback the first time the format was removed #TINY-7713
 - The `TableModified` event was not fired when pasting cells into a table #TINY-6939
 - The table paste column before and after icons were not flipped in RTL mode #TINY-7851
 - Fixed table corruption when deleting a `contenteditable="false"` cell #TINY-7891
+- The `dir` attribute was being incorrectly applied to list items #TINY-4589
+- Applying selector formats would sometimes not apply the format correctly to elements in a list #TINY-7393
+- For formats that specify an attribute or style that should be removed, the formatter `match` API incorrectly returned `false` #TINY-6149
+- The type signature on `editor.formatter.matchNode` had the wrong return type (was `boolean` but should have been `Formatter | undefined`) #TINY-6149
+- `editor.formatter.formatChanged` would ignore the `similar` parameter if another callback had already been registered for the same format #TINY-7713
+- `editor.formatter.formatChanged` would sometimes not run the callback the first time the format was removed #TINY-7713
 - Base64 encoded images with spaces or line breaks in the data URI were not displayed correctly. Patch contributed by RoboBurned
 
 ### Deprecated

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fancy menu items now accept an `initData` property to allow custom initialization data #TINY-7480
 - Improved the load time of the `fullpage` plugin by using the existing editor schema rather than creating a new one #TINY-6504
 - Improved the performance when UI components are rendered #TINY-7572
-- When scrolling, the context toolbar will remain where it was previously for large elements, such as tables #TINY-7545
+- The context toolbar no longer unnecessarily repositions to the top of large elements when scrolling #TINY-7545
 - The context toolbar will now move out of the way when it overlaps with the selection, such as in table cells #TINY-7192
 - The context toolbar now uses a short animation when transitioning between different locations #TINY-7740
 - `Env.browser` now uses the User-Agent Client Hints API where it is available #TINY-7785
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unbinding a native event handler inside the `remove` event caused an exception that blocked editor removal #TINY-7730
 - The `SetContent` event contained the incorrect `content` when using the `editor.selection.setContent()` API #TINY-3254
 - The editor content could be edited after calling `setProgressState(true)` in iframe mode #TINY-7373
-- Tabbing out of the editor after calling `setProgressState(true)` was inconsistent in iframe mode #TINY-7373
+- Tabbing out of the editor after calling `setProgressState(true)` behaved inconsistently in iframe mode #TINY-7373
 - Flash of unstyled content while loading the editor because the content CSS was loaded after the editor content was rendered #TINY-7249
 - Partially transparent RGBA values provided in the `color_map` setting were given the wrong hex value #TINY-7163
 - HTML comments with mismatched quotes were parsed incorrectly under certain circumstances #TINY-7589


### PR DESCRIPTION
Related Ticket: DOC-852

Description of Changes:
* Fixed some changelogs being in the incorrect groups
* Reordered changelogs to keep similar items together
* Applied feedback from Tyler and Millie on changelog wording

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
