### PR TITLE
TINY-7738: Add regression test for support dialog validation workaround

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
@@ -1,8 +1,14 @@
-import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/wrap-mcagar';
+import { UiControls, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Dialog } from '@ephox/bridge';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { Tools } from 'tinymce/core/api/PublicApi';
+import LinkPlugin from 'tinymce/plugins/link/Plugin';
+import { LinkDialogData } from 'tinymce/plugins/link/ui/DialogTypes';
 import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.WindowManagerTest', () => {
@@ -40,5 +46,67 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
     assert.equal(closeWindowArgs.type, 'closewindow');
 
     editor.off('CloseWindow OpenWindow');
+  });
+
+  context('WindowManager dialog validation workaround', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      plugins: 'link',
+      toolbar: 'link',
+      setup: (editor: Editor) => {
+        editor.on('PreInit', () => {
+          const originalWindowManager = editor.windowManager;
+          editor.windowManager = Tools.extend({}, originalWindowManager, {
+            open: (spec: Dialog.DialogSpec<LinkDialogData>) => {
+              if (spec.title === 'Insert/Edit Link') {
+                const newSpec = Tools.extend({}, spec, {
+                  onChange: (api: Dialog.DialogInstanceApi<LinkDialogData>, details: Dialog.DialogChangeDetails<LinkDialogData>) => {
+                    spec.onChange(api, details);
+                    if (details.name === 'url' || details.name === 'link' || details.name === 'anchor') {
+                      const data = api.getData();
+                      if (data.url.value.length === 0) {
+                        api.disable('save');
+                      } else {
+                        api.enable('save');
+                      }
+                    }
+                  }
+                });
+                const api = originalWindowManager.open(newSpec);
+                if (spec.initialData.url.value.length === 0) {
+                  api.disable('save');
+                }
+
+                return api;
+              } else {
+                return originalWindowManager.open(spec);
+              }
+            }
+          });
+        });
+      }
+    }, [ Theme, LinkPlugin ]);
+
+    it('TINY-7738: Regression test for supported dialog validation workaround', async () => {
+      const editor = hook.editor();
+      const sugarBody = SugarBody.body();
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Insert/edit link"]');
+      await TinyUiActions.pWaitForDialog(editor);
+
+      // Assert save button disabled
+      UiFinder.exists(sugarBody, 'button[title="Save"][disabled="disabled"]');
+      const input = UiFinder.findIn(sugarBody, 'input[type="url"]').getOrDie();
+
+      // Set value and fire 'input' event
+      UiControls.setValue(input, 'https://www.google.com', 'input');
+
+      // Button is now enabled
+      UiFinder.exists(sugarBody, 'button[title="Save"]');
+      UiFinder.notExists(sugarBody, 'button[title="Save"][disabled="disabled"]');
+
+      // Button is disabled again when field is empty
+      UiControls.setValue(input, '', 'input');
+      UiFinder.exists(sugarBody, 'button[title="Save"][disabled="disabled"]');
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
@@ -1,14 +1,8 @@
-import { UiControls, UiFinder } from '@ephox/agar';
-import { context, describe, it } from '@ephox/bedrock-client';
-import { Dialog } from '@ephox/bridge';
-import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import { Tools } from 'tinymce/core/api/PublicApi';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import { LinkDialogData } from 'tinymce/plugins/link/ui/DialogTypes';
 import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.WindowManagerTest', () => {
@@ -46,67 +40,5 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
     assert.equal(closeWindowArgs.type, 'closewindow');
 
     editor.off('CloseWindow OpenWindow');
-  });
-
-  context('WindowManager dialog validation workaround', () => {
-    const hook = TinyHooks.bddSetup<Editor>({
-      base_url: '/project/tinymce/js/tinymce',
-      plugins: 'link',
-      toolbar: 'link',
-      setup: (editor: Editor) => {
-        editor.on('PreInit', () => {
-          const originalWindowManager = editor.windowManager;
-          editor.windowManager = Tools.extend({}, originalWindowManager, {
-            open: (spec: Dialog.DialogSpec<LinkDialogData>) => {
-              if (spec.title === 'Insert/Edit Link') {
-                const newSpec = Tools.extend({}, spec, {
-                  onChange: (api: Dialog.DialogInstanceApi<LinkDialogData>, details: Dialog.DialogChangeDetails<LinkDialogData>) => {
-                    spec.onChange(api, details);
-                    if (details.name === 'url' || details.name === 'link' || details.name === 'anchor') {
-                      const data = api.getData();
-                      if (data.url.value.length === 0) {
-                        api.disable('save');
-                      } else {
-                        api.enable('save');
-                      }
-                    }
-                  }
-                });
-                const api = originalWindowManager.open(newSpec);
-                if (spec.initialData.url.value.length === 0) {
-                  api.disable('save');
-                }
-
-                return api;
-              } else {
-                return originalWindowManager.open(spec);
-              }
-            }
-          });
-        });
-      }
-    }, [ Theme, LinkPlugin ]);
-
-    it('TINY-7738: Regression test for supported dialog validation workaround', async () => {
-      const editor = hook.editor();
-      const sugarBody = SugarBody.body();
-      TinyUiActions.clickOnToolbar(editor, '[aria-label="Insert/edit link"]');
-      await TinyUiActions.pWaitForDialog(editor);
-
-      // Assert save button disabled
-      UiFinder.exists(sugarBody, 'button[title="Save"][disabled="disabled"]');
-      const input = UiFinder.findIn(sugarBody, 'input[type="url"]').getOrDie();
-
-      // Set value and fire 'input' event
-      UiControls.setValue(input, 'https://www.google.com', 'input');
-
-      // Button is now enabled
-      UiFinder.exists(sugarBody, 'button[title="Save"]');
-      UiFinder.notExists(sugarBody, 'button[title="Save"][disabled="disabled"]');
-
-      // Button is disabled again when field is empty
-      UiControls.setValue(input, '', 'input');
-      UiFinder.exists(sugarBody, 'button[title="Save"][disabled="disabled"]');
-    });
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
@@ -1,0 +1,73 @@
+import { UiFinder, UiControls } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { Dialog } from '@ephox/bridge';
+import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
+import { SugarBody } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Tools from 'tinymce/core/api/util/Tools';
+import Plugin from 'tinymce/plugins/link/Plugin';
+import { LinkDialogData } from 'tinymce/plugins/link/ui/DialogTypes';
+import Theme from 'tinymce/themes/silver/Theme';
+
+describe('browser.tinymce.plugins.link.LinkDialogOverrideTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    plugins: 'link',
+    toolbar: 'link',
+    setup: (editor: Editor) => {
+      editor.on('PreInit', () => {
+        const originalWindowManager = editor.windowManager;
+        editor.windowManager = Tools.extend({}, originalWindowManager, {
+          open: (spec: Dialog.DialogSpec<LinkDialogData>) => {
+            if (spec.title === 'Insert/Edit Link') {
+              const newSpec = Tools.extend({}, spec, {
+                onChange: (api: Dialog.DialogInstanceApi<LinkDialogData>, details: Dialog.DialogChangeDetails<LinkDialogData>) => {
+                  spec.onChange(api, details);
+                  if (details.name === 'url' || details.name === 'link' || details.name === 'anchor') {
+                    const data = api.getData();
+                    if (data.url.value.length === 0) {
+                      api.disable('save');
+                    } else {
+                      api.enable('save');
+                    }
+                  }
+                }
+              });
+              const api = originalWindowManager.open(newSpec);
+              if (spec.initialData.url.value.length === 0) {
+                api.disable('save');
+              }
+
+              return api;
+            } else {
+              return originalWindowManager.open(spec);
+            }
+          }
+        });
+      });
+    }
+  }, [ Theme, Plugin ]);
+
+  it('TINY-7738: Regression test for supported dialog validation workaround', async () => {
+    const editor = hook.editor();
+    const sugarBody = SugarBody.body();
+    TinyUiActions.clickOnToolbar(editor, '[aria-label="Insert/edit link"]');
+    await TinyUiActions.pWaitForDialog(editor);
+
+    // Assert save button disabled
+    UiFinder.exists(sugarBody, 'button[title="Save"][disabled="disabled"]');
+    const input = UiFinder.findIn(sugarBody, 'input[type="url"]').getOrDie();
+
+    // Set value and fire 'input' event
+    UiControls.setValue(input, 'https://www.google.com', 'input');
+
+    // Button is now enabled
+    UiFinder.exists(sugarBody, 'button[title="Save"]:not([disabled])');
+
+    // Button is disabled again when field is empty
+    UiControls.setValue(input, '', 'input');
+    UiFinder.exists(sugarBody, 'button[title="Save"][disabled="disabled"]');
+    TinyUiActions.closeDialog(editor);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-7738

Description of Changes:
* Add regression test for support dialog validation workaround

Pre-checks:
* [x] ~Changelog entry added~ - I didn't add a changelog entry because it's just a regression test
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
