### PR TITLE
TINY-7854: Add bogus attribute to image resize backdrop

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Image resize backdrop element did not have `data-mce-bogus=all` set #TINY-7854
+
 ## 5.9.1 - 2021-08-27
 
 ### Fixed

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -324,7 +324,10 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
           startScrollWidth = rootElement.scrollWidth;
           startScrollHeight = rootElement.scrollHeight;
 
-          resizeBackdrop = dom.add(rootElement, 'div', { class: 'mce-resize-backdrop' });
+          resizeBackdrop = dom.add(rootElement, 'div', {
+            'class': 'mce-resize-backdrop',
+            'data-mce-bogus': 'all'
+          });
           dom.setStyles(resizeBackdrop, {
             position: 'fixed',
             left: '0',


### PR DESCRIPTION
Related Ticket: TINY-7854

Description of Changes:
* Super minor fix, not critical at all.
* All of the image resize temporary elements include `data-mce-bogus=all`, except the backdrop. As a result the RTC mutation observer needs to include a special case for the backdrop element. This adds a small overhead to every document mutation.
* Adding this attribute is also more consistent with other elements used for resize.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
