### PR TITLE
TINY-7596: Fix all contents of cell being deleted when only part of the contents were selected

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an exception getting thrown when disabling events and setting content #TINY-7956
-- Deleting content within selections that contained content outside a table and content within a cell could result in the entire contents of the cell being incorrectly deleted #TINY-7596
+- Delete operations could behave incorrectly if the selection crossed a table boundary #TINY-7596
 
 ## 5.9.1 - 2021-08-27
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Deleting content within selections that contained content outside a table and content within a cell could result in the entire contents of the cell being incorrectly deleted #TINY-7596
+
 ## 5.9.1 - 2021-08-27
 
 ### Fixed

--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -64,6 +64,17 @@ const deleteContentInsideCell = (cell: SugarElement<HTMLTableCellElement>, rng: 
   insideTableRng.deleteContents();
 };
 
+const collapseAndRestoreCellSelection = (editor: Editor) => {
+  const selectedCells = TableCellSelection.getCellsFromEditor(editor);
+  editor.selection.collapse(true);
+  // Restore the data-mce-selected attribute if multiple cells were selected, as if it was a cef element
+  // then selection overrides would remove it as it was using an offscreen selection clone.
+  if (selectedCells.length > 1) {
+    const firstCell = Arr.find(selectedCells, (cell) => Attribute.has(cell, 'data-mce-first-selected')).getOr(selectedCells[0]);
+    Attribute.set(firstCell, 'data-mce-selected', '1');
+  }
+};
+
 /*
  * Runs when
  * - the start and end of the selection is contained within the same table (called directly from deleteRange)
@@ -102,7 +113,7 @@ const emptySingleTableCells = (editor: Editor, cells: SugarElement<HTMLTableCell
   cleanCells(cellsToClean);
 
   // Collapse the original selection after deleting everything
-  editor.selection.collapse(true);
+  collapseAndRestoreCellSelection(editor);
   return true;
 };
 
@@ -132,7 +143,7 @@ const emptyMultiTableCells = (
   betweenRng.deleteContents();
 
   // This will collapse the selection into the cell of the start table
-  editor.selection.collapse(true);
+  collapseAndRestoreCellSelection(editor);
   return true;
 };
 

--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -92,21 +92,21 @@ const emptySingleTableCells = (editor: Editor, cells: SugarElement<HTMLTableCell
   const cellsToClean = outsideDetails.bind(({ rng, isStartInTable }) => {
     /*
      * Delete all content outside of the table that is in the selection
+     * - Get the outside block before deleting the contents
+     * - Delete the contents outside
+     * - Handle the block outside the table if it is empty since rng.deleteContents leaves it
      */
-
-    // Get the outside block before deleting the contents
     const outsideBlock = getOutsideBlock(editor, isStartInTable ? rng.endContainer : rng.startContainer);
     rng.deleteContents();
-    // Handle block outside the table if it is empty since rng.deleteContents leaves it
     handleEmptyBlock(editor, isStartInTable, outsideBlock.filter(Empty.isEmpty));
 
     /*
      * The only time we can have only part of the cell contents selected is when part of the selection
      * is outside the table (otherwise we use the Darwin fake selection, which always selects entire cells),
      * in which case we need to delete the contents inside and check if the entire contents of the cell have been deleted.
+     *
+     * Note: The endPointCell is the only cell which may have only part of its contents selected.
      */
-
-    // The endPointCell is the only cell which may have only part of its contents selected.
     const endPointCell = isStartInTable ? cells[0] : cells[cells.length - 1];
     deleteContentInsideCell(endPointCell, editorRng, isStartInTable);
     if (!Empty.isEmpty(endPointCell)) {

--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -57,7 +57,7 @@ const deleteContentInsideCell = (cell: SugarElement<HTMLTableCellElement>, rng: 
     insideTableRng.setStart(rng.startContainer, rng.startOffset);
     insideTableRng.setEndAfter(cell.dom.lastChild);
   } else {
-    insideTableRng.setStart(cell.dom.firstChild, 0);
+    insideTableRng.setStartBefore(cell.dom.firstChild);
     insideTableRng.setEnd(rng.endContainer, rng.endOffset);
   }
 

--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -123,10 +123,8 @@ const emptyMultiTableCells = (
   deleteContentInsideCell(startCell, rng, true);
   deleteContentInsideCell(endCell, rng, false);
 
-  // The cursor is always collapsed back into the start cell, so we never need to clean it
-  const startTableCellsToClean = startTableCells.slice(1);
-
-  // Only clean empty cells, and the last cell has the potential to still have content
+  // Only clean empty cells, the first and last cells have the potential to still have content
+  const startTableCellsToClean = editor.dom.isEmpty(startCell.dom) ? startTableCells : startTableCells.slice(1);
   const endTableCellsToClean = editor.dom.isEmpty(endCell.dom) ? endTableCells : endTableCells.slice(0, -1);
 
   cleanCells(startTableCellsToClean.concat(endTableCellsToClean));

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { Attribute, Html, Remove, Replication, SelectorFilter } from '@ephox/sugar';
+import { Attribute, Html, Remove, Replication, SelectorFilter, SelectorFind } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -150,7 +150,9 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
         '<tr><td data-mce-selected="1">d</td><td>e</td><td>f</td></tr>' +
         '</tbody></table>'
       );
-      TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1);
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+      // When we set the selection, SelectionOverrides removes our data-mce-selected attributes. So we need to put it back
+      SelectorFind.descendant(TinyDom.body(editor), 'tr:nth-child(2) td').each((elm) => Attribute.set(elm, 'data-mce-selected', '1'));
       // Note: This uses the command to ensure it works with CefDelete
       editor.execCommand('Delete');
       TinyAssertions.assertContentPresence(editor, {

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -496,6 +496,39 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       );
     });
 
+    it('TINY-7596: Delete partial selection across cells, with entire row selected in both tables in between', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<table><tbody><tr><td>a123</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>e</td><td>f</td></tr><tr><td>g</td><td>456h</td></tr></tbody></table>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 1, [ 1, 0, 1, 1, 0 ], 3);
+      doDelete(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 1);
+      TinyAssertions.assertContent(
+        editor,
+        '<table><tbody><tr><td>a</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>h</td></tr></tbody></table>'
+      );
+    });
+
+    it('TINY-7596: Delete partial selection across cells, with entire row selected in both tables in between (with content in between)', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<table><tbody><tr><td>a123</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></tbody></table>' +
+        '<p>aa</p>' +
+        '<table><tbody><tr><td>e</td><td>f</td></tr><tr><td>g</td><td>456h</td></tr></tbody></table>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 1, [ 2, 0, 1, 1, 0 ], 3);
+      doDelete(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 1);
+      TinyAssertions.assertContent(
+        editor,
+        '<table><tbody><tr><td>a</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>h</td></tr></tbody></table>'
+      );
+    });
+
     it('TINY-7596: Delete from one table into another with partial selections in both tables and content between', () => {
       const editor = hook.editor();
       editor.setContent(

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -158,6 +158,23 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       });
       TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td><td>b</td><td>c</td></tr><tr><td>&nbsp;</td><td>e</td><td>f</td></tr></tbody></table>');
     });
+
+    it('TINY-7891: Delete multiple contenteditable=false cells in a range selection', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<table><tbody>' +
+        '<tr><td contenteditable="false" data-mce-selected="1">a</td><td contenteditable="false" data-mce-selected="1">b</td><td>c</td></tr>' +
+        '<tr><td contenteditable="false" data-mce-selected="1">d</td><td contenteditable="false" data-mce-selected="1">e</td><td>f</td></tr>' +
+        '</tbody></table>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1);
+      // Note: This uses the command to ensure it works with CefDelete
+      editor.execCommand('Delete');
+      TinyAssertions.assertContentPresence(editor, {
+        'td[data-mce-selected="1"]': 4
+      });
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td><td>&nbsp;</td><td>c</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td><td>f</td></tr></tbody></table>');
+    });
   });
 
   context('Delete all single cell content', () => {
@@ -437,7 +454,7 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       );
       TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 1, 0, 1, 1, 0 ], 1);
       doDelete(editor);
-      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0 ], 0);
       TinyAssertions.assertContent(
         editor,
         '<table><tbody><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table>' +

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -372,8 +372,8 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       editor.setContent('<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table><p>a</p>');
       TinySelections.setSelection(editor, [ 0, 0, 0, 1, 0 ], 1, [ 1, 0 ], 1);
       doDelete(editor);
-      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1 ], 0);
-      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>a</td><td>&nbsp;</td></tr></tbody></table>');
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0 ], 1);
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>');
     });
 
     it('TINY-6044: Partially select and delete from before table into table', () => {
@@ -390,8 +390,8 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       editor.setContent('<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table><p>abcd</p>');
       TinySelections.setSelection(editor, [ 0, 0, 0, 1, 0 ], 1, [ 1, 0 ], 2);
       doDelete(editor);
-      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1 ], 0);
-      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>a</td><td>&nbsp;</td></tr></tbody></table><p>cd</p>');
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0 ], 1);
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table><p>cd</p>');
     });
 
     it('TINY-6044: Delete from one table into another table', () => {
@@ -402,10 +402,10 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       );
       TinySelections.setSelection(editor, [ 0, 0, 0, 1, 0 ], 1, [ 1, 0, 0, 0, 0 ], 1);
       doDelete(editor);
-      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1 ], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0 ], 1);
       TinyAssertions.assertContent(
         editor,
-        '<table><tbody><tr><td>a</td><td>&nbsp;</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>' +
         '<table><tbody><tr><td>&nbsp;</td><td>d</td></tr></tbody></table>'
       );
     });
@@ -421,10 +421,10 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       );
       TinySelections.setSelection(editor, [ 0, 0, 0, 1, 0 ], 1, [ 4, 0, 0, 0, 0 ], 1);
       doDelete(editor);
-      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1 ], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0 ], 1);
       TinyAssertions.assertContent(
         editor,
-        '<table><tbody><tr><td>a</td><td>&nbsp;</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>' +
         '<table><tbody><tr><td>&nbsp;</td><td>f</td></tr></tbody></table>'
       );
     });
@@ -437,11 +437,60 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       );
       TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 1, 0, 1, 1, 0 ], 1);
       doDelete(editor);
-      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0 ], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       TinyAssertions.assertContent(
         editor,
         '<table><tbody><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table>' +
         '<table><tbody><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table>'
+      );
+    });
+
+    it('TINY-7596: Delete from one table into another with partial selections in both tables', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<table><tbody><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d123</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>456e</td><td>f</td></tr><tr><td>g</td><td>h</td></tr></tbody></table>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 1, 1, 0 ], 1, [ 1, 0, 0, 0, 0 ], 3);
+      doDelete(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 1, 1, 0 ], 1);
+      TinyAssertions.assertContent(
+        editor,
+        '<table><tbody><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>e</td><td>f</td></tr><tr><td>g</td><td>h</td></tr></tbody></table>'
+      );
+    });
+
+    it('TINY-7596: Delete from one table into another with partial selection and multiple cells selected in both tables', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<table><tbody><tr><td>a</td><td>b</td></tr><tr><td>c123</td><td>d</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>e</td><td>456f</td></tr><tr><td>g</td><td>h</td></tr></tbody></table>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 1, 0, 0 ], 1, [ 1, 0, 0, 1, 0 ], 3);
+      doDelete(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
+      TinyAssertions.assertContent(
+        editor,
+        '<table><tbody><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>&nbsp;</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>&nbsp;</td><td>f</td></tr><tr><td>g</td><td>h</td></tr></tbody></table>'
+      );
+    });
+
+    it('TINY-7596: Delete from one table into another with partial selections in both tables and content between', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<table><tbody><tr><td>a</td><td>b</td></tr><tr><td>c123</td><td>d</td></tr></tbody></table>' +
+        '<p>aa</p>' +
+        '<table><tbody><tr><td>e</td><td>456f</td></tr><tr><td>g</td><td>h</td></tr></tbody></table>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 1, 0, 0 ], 1, [ 2, 0, 0, 1, 0 ], 3);
+      doDelete(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
+      TinyAssertions.assertContent(
+        editor,
+        '<table><tbody><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>&nbsp;</td></tr></tbody></table>' +
+        '<table><tbody><tr><td>&nbsp;</td><td>f</td></tr><tr><td>g</td><td>h</td></tr></tbody></table>'
       );
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -404,6 +404,15 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       TinyAssertions.assertContent(editor, '<p>ab</p><table><tbody><tr><td>&nbsp;</td><td>b</td></tr></tbody></table>');
     });
 
+    it('TINY-7596: Partially select and delete from before table into table with a list to be cleaned after deletion', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>a123</p><table><tbody><tr><td><ul><li>li1</li><li>li2</li></ul><p>456</p></td><td>b</td></tr></tbody></table>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0, 0, 0, 1, 0 ], 1);
+      doDelete(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
+      TinyAssertions.assertContent(editor, '<p>a1</p><table><tbody><tr><td><p>56</p></td><td>b</td></tr></tbody></table>');
+    });
+
     it('TINY-6044: Partially select and delete from after table into table', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table><p>abcd</p>');


### PR DESCRIPTION
**Related Ticket:** TINY-7596

**Description of Changes:**

When performing delete operations on selections that contain tables, we now perform a custom delete operation on the cells in the selection that _might_ have only part of their contents selected:

1. If the start of the selection is outside a table and the end of the selection is in a table, then the last cell in the selection
2. If the start of the selection is inside a table and the end is outside a table, then the first cell in that selection
3. If the start of the selection is in a table and the end of the selection is in another table, then the first cell of the selection in the first table and the last cell of the selection in the last table

This means we create a new `Range` inside the cell, delete that, and if the cell still has content inside we do not clean it up and add the bogus `<br>` element.

Any content outside the tables was already being deleted separately. This also appears to simplify the selection/cursor positioning logic.

I found a bug where if there is a nested table inside the cell then the outer paragraph is moved inside the cell, I'm not sure if we want to fix that now or log a separate bug, it appears to not be following any of the code paths inside `TableDelete.ts`.

<img width="503" alt="Screen Shot 2021-09-06 at 1 27 37 pm" src="https://user-images.githubusercontent.com/2288242/132156626-bfe42ac9-c726-4e44-af20-508f2180f061.png">

**Pre-checks:**
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

**Review:**
* [x] Milestone set
* [x] Review comments resolved
* [x] Document bug I found that already exists

GitHub issues (if applicable):
