### PR TITLE
TINY-7731: Fixed table resizing when the contents of a cell has caused it's size to change

### DIFF
--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `pixelSize` and `percentSize` functions in `TableSize` no longer require the initial width to be passed.
 
 ### Fixed
-- Resizing table cells caused incorrect widths where the content had caused the cell to grow.
+- Resizing table cells caused incorrect widths in cases where those cells had grown to fit extra content.
 - Resizing percent tables caused widths to be offset by a few pixels due to an incorrect pixel -> percent conversion.
 
 ## 9.0.0 - 2021-08-26

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - The `pixelSize` and `percentSize` functions in `TableSize` no longer require the initial width to be passed.
+- `ColumnSizes` will now use `col` elements to calculate the column width where appropriate.
+- `Sizes.redistribute` no longer requires a `TableSize` instance to be provided.
 
 ### Fixed
 - Resizing table cells caused incorrect widths in cases where those cells had grown to fit extra content.

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- The `pixelSize` and `percentSize` functions in `TableSize` no longer require the initial width to be passed.
+
+### Fixed
+- Resizing table cells caused incorrect widths where the content had caused the cell to grow.
+- Resizing percent tables caused widths to be offset by a few pixels due to an incorrect pixel -> percent conversion.
+
 ## 9.0.0 - 2021-08-26
 
 ### Added

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Changed
-- The `pixelSize` and `percentSize` functions in `TableSize` no longer require the initial width to be passed.
+- The `pixelSize` and `percentSize` functions in `TableSize` no longer require the initial width to be provided.
 - `ColumnSizes` will now use `col` elements to calculate the column width where appropriate.
 - `Sizes.redistribute` no longer requires a `TableSize` instance to be provided.
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
@@ -7,7 +7,6 @@ import * as Redistribution from '../resize/Redistribution';
 import * as Sizes from '../resize/Sizes';
 import * as CellUtils from '../util/CellUtils';
 import { DetailExt, RowDetail, Column, Detail } from './Structs';
-import { TableSize } from './TableSize';
 import { Warehouse } from './Warehouse';
 
 const redistributeToW = (newWidths: string[], cells: DetailExt[], unit: string): void => {
@@ -43,7 +42,7 @@ const getUnit = (newSize: string): 'px' | '%' => {
 
 // Procedure to resize table dimensions to optWidth x optHeight and redistribute cell and row dimensions.
 // Updates CSS of the table, rows, and cells.
-const redistribute = (table: SugarElement<HTMLTableElement>, optWidth: Optional<string>, optHeight: Optional<string>, _tableSize: TableSize): void => {
+const redistribute = (table: SugarElement<HTMLTableElement>, optWidth: Optional<string>, optHeight: Optional<string>): void => {
   const warehouse = Warehouse.fromTable(table);
   const rows = warehouse.all;
   const cells = Warehouse.justCells(warehouse);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
@@ -10,8 +10,6 @@ import { DetailExt, RowDetail, Column, Detail } from './Structs';
 import { TableSize } from './TableSize';
 import { Warehouse } from './Warehouse';
 
-type BarPositions<A> = BarPositions.BarPositions<A>;
-
 const redistributeToW = (newWidths: string[], cells: DetailExt[], unit: string): void => {
   Arr.each(cells, (cell) => {
     const widths = newWidths.slice(cell.column, cell.colspan + cell.column);
@@ -45,7 +43,7 @@ const getUnit = (newSize: string): 'px' | '%' => {
 
 // Procedure to resize table dimensions to optWidth x optHeight and redistribute cell and row dimensions.
 // Updates CSS of the table, rows, and cells.
-const redistribute = (table: SugarElement, optWidth: Optional<string>, optHeight: Optional<string>, tableSize: TableSize): void => {
+const redistribute = (table: SugarElement<HTMLTableElement>, optWidth: Optional<string>, optHeight: Optional<string>, _tableSize: TableSize): void => {
   const warehouse = Warehouse.fromTable(table);
   const rows = warehouse.all;
   const cells = Warehouse.justCells(warehouse);
@@ -54,7 +52,7 @@ const redistribute = (table: SugarElement, optWidth: Optional<string>, optHeight
   optWidth.each((newWidth) => {
     const widthUnit = getUnit(newWidth);
     const totalWidth = Width.get(table);
-    const oldWidths = ColumnSizes.getRawWidths(warehouse, table, tableSize);
+    const oldWidths = ColumnSizes.getRawWidths(warehouse, table);
     const nuWidths = Redistribution.redistribute(oldWidths, totalWidth, newWidth);
 
     if (Warehouse.hasColumns(warehouse)) {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableConversions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableConversions.ts
@@ -4,22 +4,21 @@ import { Attribute, Css, SugarElement } from '@ephox/sugar';
 import * as Sizes from '../resize/Sizes';
 import { redistribute } from './Sizes';
 import * as TableLookup from './TableLookup';
-import { TableSize } from './TableSize';
 
 // Remove legacy sizing attributes such as "width"
 const cleanupLegacyAttributes = (element: SugarElement<HTMLElement>): void => {
   Attribute.remove(element, 'width');
 };
 
-const convertToPercentSize = (table: SugarElement<HTMLTableElement>, tableSize: TableSize): void => {
+const convertToPercentSize = (table: SugarElement<HTMLTableElement>): void => {
   const newWidth = Sizes.getPercentTableWidth(table);
-  redistribute(table, Optional.some(newWidth), Optional.none(), tableSize);
+  redistribute(table, Optional.some(newWidth), Optional.none());
   cleanupLegacyAttributes(table);
 };
 
-const convertToPixelSize = (table: SugarElement<HTMLTableElement>, tableSize: TableSize): void => {
+const convertToPixelSize = (table: SugarElement<HTMLTableElement>): void => {
   const newWidth = Sizes.getPixelTableWidth(table);
-  redistribute(table, Optional.some(newWidth), Optional.none(), tableSize);
+  redistribute(table, Optional.some(newWidth), Optional.none());
   cleanupLegacyAttributes(table);
 };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
@@ -1,5 +1,6 @@
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
-import { Css, SugarElement, SugarNode, Width } from '@ephox/sugar';
+import { PlatformDetection } from '@ephox/sand';
+import { SugarElement, SugarNode, Width } from '@ephox/sugar';
 
 import { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
@@ -11,40 +12,31 @@ import * as Sizes from './Sizes';
 
 const isCol = SugarNode.isTag('col');
 
-const getRaw = (cell: SugarElement, property: string, getter: (e: SugarElement) => number): string => {
-  return Css.getRaw(cell, property).getOrThunk(() => {
-    return getter(cell) + 'px';
-  });
+const getRawW = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): string => {
+  return Sizes.getRawWidth(cell).getOrThunk(() => Sizes.getPixelWidth(cell) + 'px');
 };
 
-const getRawW = (cell: SugarElement, tableSize: TableSize): string => {
-  // For col elements use the computed width as col elements aren't affected by borders, padding, etc...
-  const fallback = (e: SugarElement) => isCol(e) ? Width.get(e) : Sizes.getPixelWidth(e, tableSize);
-  return getRaw(cell, 'width', fallback);
-};
-
-const getRawH = (cell: SugarElement): string => {
-  return getRaw(cell, 'height', Sizes.getHeight);
+const getRawH = (cell: SugarElement<HTMLTableCellElement>): string => {
+  return Sizes.getRawHeight(cell).getOrThunk(() => Sizes.getHeight(cell) + 'px');
 };
 
 const justCols = (warehouse: Warehouse): Optional<SugarElement<HTMLTableColElement>>[] =>
   Arr.map(Warehouse.justColumns(warehouse), (column) => Optional.from(column.element));
 
-const hasRawStyle = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>, prop: 'width' | 'height') =>
-  Css.getRaw(cell, prop).isSome();
+// Col elements don't have valid computed widths/positions in all browsers, so treat them as invalid in that case
+const isValidColumn = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): boolean => {
+  const browser = PlatformDetection.detect().browser;
+  return !isCol(cell) || !(browser.isIE() || browser.isEdge());
+};
 
-// Col elements don't have valid computed widths/positions, so treat them as invalid if they don't have a raw width
-const isValidColumn = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): boolean =>
-  !isCol(cell) || hasRawStyle(cell, 'width');
-
-const getDimension = <T>(
-  cellOpt: Optional<SugarElement>,
+const getDimension = <T extends HTMLElement, U>(
+  cellOpt: Optional<SugarElement<T>>,
   index: number,
   backups: Optional<number>[],
-  filter: (cell: SugarElement) => boolean,
-  getter: (cell: SugarElement) => T,
-  fallback: (deduced: Optional<number>) => T
-): T =>
+  filter: (cell: SugarElement<T>) => boolean,
+  getter: (cell: SugarElement<T>) => U,
+  fallback: (deduced: Optional<number>) => U
+): U =>
   cellOpt.filter(filter).fold(
     // Can't just read the width of a cell, so calculate.
     () => fallback(Util.deduce(backups, index)),
@@ -54,14 +46,13 @@ const getDimension = <T>(
 const getWidthFrom = <T>(
   warehouse: Warehouse,
   table: SugarElement<HTMLTableElement>,
-  getWidth: (cell: SugarElement, tableSize: TableSize) => T,
-  fallback: (deduced: Optional<number>) => T,
-  tableSize: TableSize
+  getWidth: (cell: SugarElement) => T,
+  fallback: (deduced: Optional<number>) => T
 ): T[] => {
   // Only treat a cell as being valid for a column representation if it has a raw width, otherwise we won't be able to calculate the expected width.
   // This is needed as one cell may have a width but others may not, so we need to try and use one with a specified width first.
-  const columnCells = Blocks.columns(warehouse, (cell) => hasRawStyle(cell, 'width'));
-  const columns: Optional<SugarElement>[] = Warehouse.hasColumns(warehouse) ? justCols(warehouse) : columnCells;
+  const columnCells = Blocks.columns(warehouse);
+  const columns: Optional<SugarElement<HTMLTableCellElement | HTMLTableColElement>>[] = Warehouse.hasColumns(warehouse) ? justCols(warehouse) : columnCells;
 
   const backups = [ Optional.some(width.edge(table)) ].concat(Arr.map(width.positions(columnCells, table), (pos) =>
     pos.map((p) => p.x)
@@ -73,7 +64,7 @@ const getWidthFrom = <T>(
   return Arr.map(columns, (cellOption, c) => {
     return getDimension(cellOption, c, backups, colFilter, (column) => {
       if (isValidColumn(column)) {
-        return getWidth(column, tableSize);
+        return getWidth(column);
       } else {
         // Invalid column so fallback to trying to get the computed width from the cell
         const cell = Optionals.bindFrom(columnCells[c], Fun.identity);
@@ -89,8 +80,8 @@ const getDeduced = (deduced: Optional<number>): string => {
   }).getOr('');
 };
 
-const getRawWidths = (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, tableSize: TableSize): string[] => {
-  return getWidthFrom(warehouse, table, getRawW, getDeduced, tableSize);
+const getRawWidths = (warehouse: Warehouse, table: SugarElement<HTMLTableElement>): string[] => {
+  return getWidthFrom(warehouse, table, getRawW, getDeduced);
 };
 
 const getPercentageWidths = (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, tableSize: TableSize): number[] => {
@@ -100,14 +91,14 @@ const getPercentageWidths = (warehouse: Warehouse, table: SugarElement<HTMLTable
     }, (cellWidth) => {
       return cellWidth / tableSize.pixelWidth() * 100;
     });
-  }, tableSize);
+  });
 };
 
 const getPixelWidths = (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, tableSize: TableSize): number[] => {
   return getWidthFrom(warehouse, table, Sizes.getPixelWidth, (deduced) => {
     // Minimum cell width when all else fails.
     return deduced.getOrThunk(tableSize.minCellWidth);
-  }, tableSize);
+  });
 };
 
 const getHeightFrom = <T> (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, direction: BarPositions<RowInfo>, getHeight: (cell: SugarElement) => T, fallback: (deduced: Optional<number>) => T): T[] => {

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -62,11 +62,8 @@ const get = (cell: SugarElement<HTMLTableCellElement>, type: 'rowspan' | 'colspa
 
 const getRaw = (element: SugarElement<HTMLElement>, prop: 'height' | 'width'): Optional<string> => {
   // Try to use the style first, otherwise attempt to get the value from an attribute
-  const cssWidth = Css.getRaw(element, prop);
-  return cssWidth.fold(() => {
+  return Css.getRaw(element, prop).orThunk(() => {
     return Attribute.getOpt(element, prop).map((val) => val + 'px');
-  }, (width) => {
-    return Optional.some(width);
   });
 };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/util/CellUtils.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/util/CellUtils.ts
@@ -1,5 +1,5 @@
 import { Fun } from '@ephox/katamari';
-import { Attribute, Css, SugarElement } from '@ephox/sugar';
+import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
 
 export const getAttrValue = (cell: SugarElement<Element>, name: string, fallback: number = 0): number =>
   Attribute.getOpt(cell, name).map((value) => parseInt(value, 10)).getOr(fallback);
@@ -7,8 +7,13 @@ export const getAttrValue = (cell: SugarElement<Element>, name: string, fallback
 export const getSpan = (cell: SugarElement<HTMLTableCellElement>, type: 'colspan' | 'rowspan'): number =>
   getAttrValue(cell, type, 1);
 
-export const hasColspan = (cell: SugarElement<HTMLTableCellElement>): boolean =>
-  getSpan(cell, 'colspan') > 1;
+export const hasColspan = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): boolean => {
+  if (SugarNode.isTag('col')(cell)) {
+    return getAttrValue(cell, 'span', 1) > 1;
+  } else {
+    return getSpan(cell as SugarElement<HTMLTableCellElement>, 'colspan') > 1;
+  }
+};
 
 export const hasRowspan = (cell: SugarElement<HTMLTableCellElement>): boolean =>
   getSpan(cell, 'rowspan') > 1;

--- a/modules/snooker/src/main/ts/ephox/snooker/util/CellUtils.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/util/CellUtils.ts
@@ -7,11 +7,11 @@ export const getAttrValue = (cell: SugarElement<Element>, name: string, fallback
 export const getSpan = (cell: SugarElement<HTMLTableCellElement>, type: 'colspan' | 'rowspan'): number =>
   getAttrValue(cell, type, 1);
 
-export const hasColspan = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): boolean => {
-  if (SugarNode.isTag('col')(cell)) {
-    return getAttrValue(cell, 'span', 1) > 1;
+export const hasColspan = (cellOrCol: SugarElement<HTMLTableCellElement | HTMLTableColElement>): boolean => {
+  if (SugarNode.isTag('col')(cellOrCol)) {
+    return getAttrValue(cellOrCol, 'span', 1) > 1;
   } else {
-    return getSpan(cell as SugarElement<HTMLTableCellElement>, 'colspan') > 1;
+    return getSpan(cellOrCol as SugarElement<HTMLTableCellElement>, 'colspan') > 1;
   }
 };
 

--- a/modules/snooker/src/test/ts/browser/ResizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/ResizeTest.ts
@@ -214,7 +214,7 @@ describe('ResizeTest', () => {
     Remove.remove(table);
   });
 
-  it('TINY-7731: should handle resizing a table where a cell overflows it\'s specified size', () => {
+  it('TINY-7731: should handle resizing a table where a cell overflows its specified size', () => {
     const delta = 200;
 
     const table = SugarElement.fromHtml<HTMLTableElement>(`<table style="border-collapse: collapse; width: 800px;">
@@ -244,6 +244,7 @@ describe('ResizeTest', () => {
     const warehouse = Warehouse.fromTable(table);
     const widths = tableSize.getWidths(warehouse, tableSize);
 
+    // This is the width of "thisisareallylongsentencewithoutspacesthatcausescontenttooverflow" which can vary marginally between browsers
     assert.approximately(widths[0], 483, 1, 'First column width');
     assert.approximately(widths[1], 313, 1, 'Second column width');
 

--- a/modules/snooker/src/test/ts/browser/TableAdjustmentsTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableAdjustmentsTest.ts
@@ -1,18 +1,26 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Css, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
 
 import * as ResizeBehaviour from 'ephox/snooker/api/ResizeBehaviour';
 import { TableSize } from 'ephox/snooker/api/TableSize';
 import * as Adjustments from 'ephox/snooker/resize/Adjustments';
 
-UnitTest.test('TableAdjustmentsTest', () => {
+describe('TableAdjustmentsTest', () => {
   const preserveTable = ResizeBehaviour.preserveTable();
   const resizeTable = ResizeBehaviour.resizeTable();
 
   const boundBox = '<div style="width: 800px; height: 600px; display: block;"></div>';
   const box = SugarElement.fromHtml<HTMLDivElement>(boundBox);
-  Insert.append(SugarBody.body(), box);
+
+  before(() => {
+    Insert.append(SugarBody.body(), box);
+  });
+
+  after(() => {
+    Remove.remove(box);
+  });
 
   const relativeTable = () => SugarElement.fromHtml<HTMLTableElement>(`<table style="border-collapse: collapse; width: 50%;" border="1">
   <tbody>
@@ -50,6 +58,23 @@ UnitTest.test('TableAdjustmentsTest', () => {
   <td>f</td>
   <td>g</td>
   <td>h</td>
+  </tr>
+  </tbody>
+  </table>`);
+
+  const relativeTableWithOverflow = () => SugarElement.fromHtml<HTMLTableElement>(`<table style="border-collapse: collapse; width: 50%;" border="1">
+  <tbody>
+  <tr>
+  <td style="width: 25%;"><span style="width: 120px; display: inline-block;">a</span></td>
+  <td style="width: 25%;">b</td>
+  <td style="width: 25%;">c</td>
+  <td style="width: 25%;">d</td>
+  </tr>
+  <tr>
+  <td style="width: 25%;">e</td>
+  <td style="width: 25%;">f</td>
+  <td style="width: 25%;">g</td>
+  <td style="width: 25%;">h</td>
   </tr>
   </tbody>
   </table>`);
@@ -94,6 +119,23 @@ UnitTest.test('TableAdjustmentsTest', () => {
   </tbody>
   </table>`);
 
+  const pixelTableWithOverflow = () => SugarElement.fromHtml<HTMLTableElement>(`<table style="border-collapse: collapse; width: 400px;" border="1">
+  <tbody>
+  <tr>
+  <td style="width: 96.75px;"><span style="width: 120px; display: inline-block;">a</span></td>
+  <td style="width: 96.75px;">b</td>
+  <td style="width: 96.75px;">c</td>
+  <td style="width: 96.75px;">d</td>
+  </tr>
+  <tr>
+  <td style="width: 96.75px;">e</td>
+  <td style="width: 96.75px;">f</td>
+  <td style="width: 96.75px;">g</td>
+  <td style="width: 96.75px;">h</td>
+  </tr>
+  </tbody>
+  </table>`);
+
   const percentageToStep = (percentage: number, width: number) => percentage / 100 * width;
   // Note: Will not work for tables with colspans or rowspans
   const getColumnWidths = (table: SugarElement<HTMLTableElement>, useColumns: boolean) => {
@@ -102,167 +144,243 @@ UnitTest.test('TableAdjustmentsTest', () => {
       parseFloat(Css.getRaw(SugarElement.fromDom(cell), 'width').getOr('0')));
   };
 
-  const testAdjustWidth = (msg: string, expectedWidth: number, expectedColumnWidths: number[], table: SugarElement<HTMLTableElement>, step: number, index: number, columnSizing: ResizeBehaviour.ResizeBehaviour, useColumn: boolean) => {
+  const testAdjustWidth = (expectedWidth: number, expectedColumnWidths: number[], table: SugarElement<HTMLTableElement>, step: number, index: number, columnSizing: ResizeBehaviour.ResizeBehaviour, useColumn: boolean) => () => {
     Insert.append(box, table);
-    Adjustments.adjustWidth(table, step, index, columnSizing, TableSize.getTableSize(table));
+    const sizing = TableSize.getTableSize(table);
+    Adjustments.adjustWidth(table, step, index, columnSizing, sizing);
 
     const actualTableWidth = parseFloat(Css.getRaw(table, 'width').getOrDie());
-    assert.eq(actualTableWidth, expectedWidth, `${msg} - table widths should match: expected: ${expectedWidth}, actual: ${actualTableWidth}`);
+    assert.approximately(actualTableWidth, expectedWidth, 0.25, `table widths should approx match: expected: ${expectedWidth}, actual: ${actualTableWidth}`);
 
     const widths = getColumnWidths(table, useColumn);
-    const widthDiffsPercentages = Arr.map(expectedColumnWidths, (expectedWidth, index) => (widths[index] - expectedWidth) / widths[index] * 100);
-    // Verify that the difference is less than 1% to allow for minor floating point differences
-    Arr.each(widthDiffsPercentages, (x) => {
-      assert.eq(true, Math.abs(x) < 1, `${msg} - columns widths should match: expected: ${expectedColumnWidths}, actual: ${widths}`);
+    // Verify that the difference is less than 0.5% to allow for minor floating point differences
+    Arr.each(expectedColumnWidths, (expectedWidth, index) => {
+      assert.approximately(widths[index], expectedWidth, 0.25, `columns widths should match: expected: ${expectedColumnWidths}, actual: ${widths}`);
     });
 
     Remove.remove(table);
   };
 
-  const testInnerColumnResizing = () => {
-    // 'preserveTable' column resizing
-    testAdjustWidth(`ltr step (%) - preserveTable (0-0)`, 50, [ 37.5, 12.5, 25, 25 ], relativeTable(), percentageToStep(12.5, 400), 0, preserveTable, false);
-    testAdjustWidth(`ltr step (%) - preserveTable (0-1)`, 50, [ 37.5, 12.5, 25, 25 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 0, preserveTable, true);
-    testAdjustWidth(`ltr step (%) - preserveTable (1-0)`, 50, [ 25, 37.5, 12.5, 25 ], relativeTable(), percentageToStep(12.5, 400), 1, preserveTable, false);
-    testAdjustWidth(`ltr step (%) - preserveTable (1-1)`, 50, [ 25, 37.5, 12.5, 25 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 1, preserveTable, true);
-    testAdjustWidth(`ltr step (%) - preserveTable (2-0)`, 50, [ 25, 25, 37.5, 12.5 ], relativeTable(), percentageToStep(12.5, 400), 2, preserveTable, false);
-    testAdjustWidth(`ltr step (%) - preserveTable (2-1)`, 50, [ 25, 25, 37.5, 12.5 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 2, preserveTable, true);
-    testAdjustWidth(`ltr large step (%) - preserveTable (0-0)`, 50, [ 47.5, 2.5, 25, 25 ], relativeTable(), percentageToStep(50, 400), 0, preserveTable, false);
-    testAdjustWidth(`ltr large step (%) - preserveTable (0-1)`, 50, [ 47.5, 2.5, 25, 25 ], relativeTableWithColGroup(), percentageToStep(50, 400), 0, preserveTable, true);
-    testAdjustWidth(`ltr large step (%) - preserveTable (1-0)`, 50, [ 25, 47.5, 2.5, 25 ], relativeTable(), percentageToStep(50, 400), 1, preserveTable, false);
-    testAdjustWidth(`ltr large step (%) - preserveTable (1-1)`, 50, [ 25, 47.5, 2.5, 25 ], relativeTableWithColGroup(), percentageToStep(50, 400), 1, preserveTable, true);
-    testAdjustWidth(`ltr large step (%) - preserveTable (2-0)`, 50, [ 25, 25, 47.5, 2.5 ], relativeTable(), percentageToStep(50, 400), 2, preserveTable, false);
-    testAdjustWidth(`ltr large step (%) - preserveTable (2-1)`, 50, [ 25, 25, 47.5, 2.5 ], relativeTableWithColGroup(), percentageToStep(50, 400), 2, preserveTable, true);
-    testAdjustWidth(`rtl step (%) - preserveTable (0-0)`, 50, [ 12.5, 37.5, 25, 25 ], relativeTable(), percentageToStep(-12.5, 400), 0, preserveTable, false);
-    testAdjustWidth(`rtl step (%) - preserveTable (0-1)`, 50, [ 12.5, 37.5, 25, 25 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 0, preserveTable, true);
-    testAdjustWidth(`rtl step (%) - preserveTable (1-0)`, 50, [ 25, 12.5, 37.5, 25 ], relativeTable(), percentageToStep(-12.5, 400), 1, preserveTable, false);
-    testAdjustWidth(`rtl step (%) - preserveTable (1-1)`, 50, [ 25, 12.5, 37.5, 25 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 1, preserveTable, true);
-    testAdjustWidth(`rtl step (%) - preserveTable (2-0)`, 50, [ 25, 25, 12.5, 37.5 ], relativeTable(), percentageToStep(-12.5, 400), 2, preserveTable, false);
-    testAdjustWidth(`rtl step (%) - preserveTable (2-1)`, 50, [ 25, 25, 12.5, 37.5 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 2, preserveTable, true);
-    testAdjustWidth(`rtl large step (%) - preserveTable (0-0)`, 50, [ 2.5, 47.5, 25, 25 ], relativeTable(), percentageToStep(-50, 400), 0, preserveTable, false);
-    testAdjustWidth(`rtl large step (%) - preserveTable (0-1)`, 50, [ 2.5, 47.5, 25, 25 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 0, preserveTable, true);
-    testAdjustWidth(`rtl large step (%) - preserveTable (1-0)`, 50, [ 25, 2.5, 47.5, 25 ], relativeTable(), percentageToStep(-50, 400), 1, preserveTable, false);
-    testAdjustWidth(`rtl large step (%) - preserveTable (1-1)`, 50, [ 25, 2.5, 47.5, 25 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 1, preserveTable, true);
-    testAdjustWidth(`rtl large step (%) - preserveTable (2-0)`, 50, [ 25, 25, 2.5, 47.5 ], relativeTable(), percentageToStep(-50, 400), 2, preserveTable, false);
-    testAdjustWidth(`rtl large step (%) - preserveTable (2-1)`, 50, [ 25, 25, 2.5, 47.5 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 2, preserveTable, true);
-    testAdjustWidth(`ltr step (px) - preserveTable (0-0)`, 400, [ 146, 46, 96, 96 ], pixelTable(), 50, 0, preserveTable, false);
-    testAdjustWidth(`ltr step (px) - preserveTable (0-1)`, 400, [ 150, 50, 100, 100 ], pixelTableWithColGroup(), 50, 0, preserveTable, true);
-    testAdjustWidth(`ltr step (px) - preserveTable (1-0)`, 400, [ 96, 146, 46, 96 ], pixelTable(), 50, 1, preserveTable, false);
-    testAdjustWidth(`ltr step (px) - preserveTable (1-1)`, 400, [ 100, 150, 50, 100 ], pixelTableWithColGroup(), 50, 1, preserveTable, true);
-    testAdjustWidth(`ltr step (px) - preserveTable (2-0)`, 400, [ 96, 96, 146, 46 ], pixelTable(), 50, 2, preserveTable, false);
-    testAdjustWidth(`ltr step (px) - preserveTable (2-1)`, 400, [ 100, 100, 150, 50 ], pixelTableWithColGroup(), 50, 2, preserveTable, true);
-    testAdjustWidth(`ltr large step (px) - preserveTable (0-0)`, 400, [ 182, 10, 96, 96 ], pixelTable(), 200, 0, preserveTable, false);
-    testAdjustWidth(`ltr large step (px) - preserveTable (0-1)`, 400, [ 190, 10, 100, 100 ], pixelTableWithColGroup(), 200, 0, preserveTable, true);
-    testAdjustWidth(`ltr large step (px) - preserveTable (1-0)`, 400, [ 96, 182, 10, 96 ], pixelTable(), 200, 1, preserveTable, false);
-    testAdjustWidth(`ltr large step (px) - preserveTable (1-1)`, 400, [ 100, 190, 10, 100 ], pixelTableWithColGroup(), 200, 1, preserveTable, true);
-    testAdjustWidth(`ltr large step (px) - preserveTable (2-0)`, 400, [ 96, 96, 182, 10 ], pixelTable(), 200, 2, preserveTable, false);
-    testAdjustWidth(`ltr large step (px) - preserveTable (2-1)`, 400, [ 100, 100, 190, 10 ], pixelTableWithColGroup(), 200, 2, preserveTable, true);
-    testAdjustWidth(`rtl step (px) - preserveTable (0-0)`, 400, [ 46, 146, 96, 96 ], pixelTable(), -50, 0, preserveTable, false);
-    testAdjustWidth(`rtl step (px) - preserveTable (0-1)`, 400, [ 50, 150, 100, 100 ], pixelTableWithColGroup(), -50, 0, preserveTable, true);
-    testAdjustWidth(`rtl step (px) - preserveTable (1-0)`, 400, [ 96, 46, 146, 96 ], pixelTable(), -50, 1, preserveTable, false);
-    testAdjustWidth(`rtl step (px) - preserveTable (1-1)`, 400, [ 100, 50, 150, 100 ], pixelTableWithColGroup(), -50, 1, preserveTable, true);
-    testAdjustWidth(`rtl step (px) - preserveTable (2-0)`, 400, [ 96, 96, 46, 146 ], pixelTable(), -50, 2, preserveTable, false);
-    testAdjustWidth(`rtl step (px) - preserveTable (2-1)`, 400, [ 100, 100, 50, 150 ], pixelTableWithColGroup(), -50, 2, preserveTable, true);
-    testAdjustWidth(`rtl large step (px) - preserveTable (0-0)`, 400, [ 10, 182, 96, 96 ], pixelTable(), -200, 0, preserveTable, false);
-    testAdjustWidth(`rtl large step (px) - preserveTable (0-1)`, 400, [ 10, 190, 100, 100 ], pixelTableWithColGroup(), -200, 0, preserveTable, true);
-    testAdjustWidth(`rtl large step (px) - preserveTable (1-0)`, 400, [ 96, 10, 182, 96 ], pixelTable(), -200, 1, preserveTable, false);
-    testAdjustWidth(`rtl large step (px) - preserveTable (1-1)`, 400, [ 100, 10, 190, 100 ], pixelTableWithColGroup(), -200, 1, preserveTable, true);
-    testAdjustWidth(`rtl large step (px) - preserveTable (2-0)`, 400, [ 96, 96, 10, 182 ], pixelTable(), -200, 2, preserveTable, false);
-    testAdjustWidth(`rtl large step (px) - preserveTable (2-1)`, 400, [ 100, 100, 10, 190 ], pixelTableWithColGroup(), -200, 2, preserveTable, true);
+  context('preserve table column resizing', () => {
+    context('ltr step (%)', () => {
+      it('preserveTable cells (0)', testAdjustWidth(50, [ 37.5, 12.5, 25, 25 ], relativeTable(), percentageToStep(12.5, 400), 0, preserveTable, false));
+      it('preserveTable cols (0)', testAdjustWidth(50, [ 37.5, 12.5, 25, 25 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 0, preserveTable, true));
+      it('preserveTable overflow (0)', testAdjustWidth(50, [ 43.33, 10.56, 23.06, 23.06 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 0, preserveTable, false));
+      it('preserveTable cells (1)', testAdjustWidth(50, [ 25, 37.5, 12.5, 25 ], relativeTable(), percentageToStep(12.5, 400), 1, preserveTable, false));
+      it('preserveTable cols (1)', testAdjustWidth(50, [ 25, 37.5, 12.5, 25 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 1, preserveTable, true));
+      it('preserveTable overflow (1)', testAdjustWidth(50, [ 30.83, 35.56, 10.56, 23.06 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 1, preserveTable, false));
+      it('preserveTable cells (2)', testAdjustWidth(50, [ 25, 25, 37.5, 12.5 ], relativeTable(), percentageToStep(12.5, 400), 2, preserveTable, false));
+      it('preserveTable cols (2)', testAdjustWidth(50, [ 25, 25, 37.5, 12.5 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 2, preserveTable, true));
+      it('preserveTable overflow (2)', testAdjustWidth(50, [ 30.83, 23.06, 35.56, 10.56 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 2, preserveTable, false));
+      it('preserveTable cells (3)', testAdjustWidth(56.25, [ 25, 25, 25, 25 ], relativeTable(), percentageToStep(12.5, 400), 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth(56.25, [ 25, 25, 25, 25 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 3, preserveTable, true));
+      it('preserveTable overflow (3)', testAdjustWidth(56.25, [ 30.83, 23.06, 23.06, 23.06 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 3, preserveTable, false));
+    });
 
-    // 'resizeTable' column resizing
-    testAdjustWidth(`ltr step (%) - resizeTable (0-0)`, 56.25, [ 33.33, 22.22, 22.22, 22.22 ], relativeTable(), percentageToStep(12.5, 400), 0, resizeTable, false);
-    testAdjustWidth(`ltr step (%) - resizeTable (0-1)`, 56.25, [ 33.33, 22.22, 22.22, 22.22 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 0, resizeTable, true);
-    testAdjustWidth(`ltr step (%) - resizeTable (1-0)`, 56.25, [ 22.22, 33.33, 22.22, 22.22 ], relativeTable(), percentageToStep(12.5, 400), 1, resizeTable, false);
-    testAdjustWidth(`ltr step (%) - resizeTable (1-1)`, 56.25, [ 22.22, 33.33, 22.22, 22.22 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 1, resizeTable, true);
-    testAdjustWidth(`ltr step (%) - resizeTable (2-0)`, 56.25, [ 22.22, 22.22, 33.33, 22.22 ], relativeTable(), percentageToStep(12.5, 400), 2, resizeTable, false);
-    testAdjustWidth(`ltr step (%) - resizeTable (2-1)`, 56.25, [ 22.22, 22.22, 33.33, 22.22 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 2, resizeTable, true);
-    testAdjustWidth(`ltr large step (%) - resizeTable (0-0)`, 75, [ 50, 16.67, 16.67, 16.67 ], relativeTable(), percentageToStep(50, 400), 0, resizeTable, false);
-    testAdjustWidth(`ltr large step (%) - resizeTable (0-1)`, 75, [ 50, 16.67, 16.67, 16.67 ], relativeTableWithColGroup(), percentageToStep(50, 400), 0, resizeTable, true);
-    testAdjustWidth(`ltr large step (%) - resizeTable (1-0)`, 75, [ 16.67, 50, 16.67, 16.67 ], relativeTable(), percentageToStep(50, 400), 1, resizeTable, false);
-    testAdjustWidth(`ltr large step (%) - resizeTable (1-1)`, 75, [ 16.67, 50, 16.67, 16.67 ], relativeTableWithColGroup(), percentageToStep(50, 400), 1, resizeTable, true);
-    testAdjustWidth(`ltr large step (%) - resizeTable (2-0)`, 75, [ 16.67, 16.67, 50, 16.67 ], relativeTable(), percentageToStep(50, 400), 2, resizeTable, false);
-    testAdjustWidth(`ltr large step (%) - resizeTable (2-1)`, 75, [ 16.67, 16.67, 50, 16.67 ], relativeTableWithColGroup(), percentageToStep(50, 400), 2, resizeTable, true);
-    testAdjustWidth(`rtl step (%) - resizeTable (0-0)`, 43.75, [ 14.29, 28.57, 28.57, 28.57 ], relativeTable(), percentageToStep(-12.5, 400), 0, resizeTable, false);
-    testAdjustWidth(`rtl step (%) - resizeTable (0-1)`, 43.75, [ 14.29, 28.57, 28.57, 28.57 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 0, resizeTable, true);
-    testAdjustWidth(`rtl step (%) - resizeTable (1-0)`, 43.75, [ 28.57, 14.29, 28.57, 28.57 ], relativeTable(), percentageToStep(-12.5, 400), 1, resizeTable, false);
-    testAdjustWidth(`rtl step (%) - resizeTable (1-1)`, 43.75, [ 28.57, 14.29, 28.57, 28.57 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 1, resizeTable, true);
-    testAdjustWidth(`rtl step (%) - resizeTable (2-0)`, 43.75, [ 28.57, 28.57, 14.29, 28.57 ], relativeTable(), percentageToStep(-12.5, 400), 2, resizeTable, false);
-    testAdjustWidth(`rtl step (%) - resizeTable (2-1)`, 43.75, [ 28.57, 28.57, 14.29, 28.57 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 2, resizeTable, true);
-    testAdjustWidth(`rtl large step (%) - resizeTable (0-0)`, 38.75, [ 3.23, 32.26, 32.26, 32.26 ], relativeTable(), percentageToStep(-50, 400), 0, resizeTable, false);
-    testAdjustWidth(`rtl large step (%) - resizeTable (0-1)`, 38.75, [ 3.23, 32.26, 32.26, 32.26 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 0, resizeTable, true);
-    testAdjustWidth(`rtl large step (%) - resizeTable (1-0)`, 38.75, [ 32.26, 3.23, 32.26, 32.26 ], relativeTable(), percentageToStep(-50, 400), 1, resizeTable, false);
-    testAdjustWidth(`rtl large step (%) - resizeTable (1-1)`, 38.75, [ 32.26, 3.23, 32.26, 32.26 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 1, resizeTable, true);
-    testAdjustWidth(`rtl large step (%) - resizeTable (2-0)`, 38.75, [ 32.26, 32.26, 3.23, 32.26 ], relativeTable(), percentageToStep(-50, 400), 2, resizeTable, false);
-    testAdjustWidth(`rtl large step (%) - resizeTable (2-1)`, 38.75, [ 32.26, 32.26, 3.23, 32.26 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 2, resizeTable, true);
-    testAdjustWidth(`ltr step (px) - resizeTable (0-0)`, 450, [ 146, 96, 96, 96 ], pixelTable(), 50, 0, resizeTable, false);
-    testAdjustWidth(`ltr step (px) - resizeTable (0-1)`, 450, [ 150, 100, 100, 100 ], pixelTableWithColGroup(), 50, 0, resizeTable, true);
-    testAdjustWidth(`ltr step (px) - resizeTable (1-0)`, 450, [ 96, 146, 96, 96 ], pixelTable(), 50, 1, resizeTable, false);
-    testAdjustWidth(`ltr step (px) - resizeTable (1-1)`, 450, [ 100, 150, 100, 100 ], pixelTableWithColGroup(), 50, 1, resizeTable, true);
-    testAdjustWidth(`ltr step (px) - resizeTable (2-0)`, 450, [ 96, 96, 146, 96 ], pixelTable(), 50, 2, resizeTable, false);
-    testAdjustWidth(`ltr step (px) - resizeTable (2-1)`, 450, [ 100, 100, 150, 100 ], pixelTableWithColGroup(), 50, 2, resizeTable, true);
-    testAdjustWidth(`ltr large step (px) - resizeTable (0-0)`, 600, [ 296, 96, 96, 96 ], pixelTable(), 200, 0, resizeTable, false);
-    testAdjustWidth(`ltr large step (px) - resizeTable (0-1)`, 600, [ 300, 100, 100, 100 ], pixelTableWithColGroup(), 200, 0, resizeTable, true);
-    testAdjustWidth(`ltr large step (px) - resizeTable (1-0)`, 600, [ 96, 296, 96, 96 ], pixelTable(), 200, 1, resizeTable, false);
-    testAdjustWidth(`ltr large step (px) - resizeTable (1-1)`, 600, [ 100, 300, 100, 100 ], pixelTableWithColGroup(), 200, 1, resizeTable, true);
-    testAdjustWidth(`ltr large step (px) - resizeTable (2-0)`, 600, [ 96, 96, 296, 96 ], pixelTable(), 200, 2, resizeTable, false);
-    testAdjustWidth(`ltr large step (px) - resizeTable (2-1)`, 600, [ 100, 100, 300, 100 ], pixelTableWithColGroup(), 200, 2, resizeTable, true);
-    testAdjustWidth(`rtl step (px) - resizeTable (0-0)`, 350, [ 46, 96, 96, 96 ], pixelTable(), -50, 0, resizeTable, false);
-    testAdjustWidth(`rtl step (px) - resizeTable (0-1)`, 350, [ 50, 100, 100, 100 ], pixelTableWithColGroup(), -50, 0, resizeTable, true);
-    testAdjustWidth(`rtl step (px) - resizeTable (1-0)`, 350, [ 96, 46, 96, 96 ], pixelTable(), -50, 1, resizeTable, false);
-    testAdjustWidth(`rtl step (px) - resizeTable (1-1)`, 350, [ 100, 50, 100, 100 ], pixelTableWithColGroup(), -50, 1, resizeTable, true);
-    testAdjustWidth(`rtl step (px) - resizeTable (2-0)`, 350, [ 96, 96, 46, 96 ], pixelTable(), -50, 2, resizeTable, false);
-    testAdjustWidth(`rtl step (px) - resizeTable (2-1)`, 350, [ 100, 100, 50, 100 ], pixelTableWithColGroup(), -50, 2, resizeTable, true);
-    testAdjustWidth(`rtl large step (px) - resizeTable (0-0)`, 314, [ 10, 96, 96, 96 ], pixelTable(), -200, 0, resizeTable, false);
-    testAdjustWidth(`rtl large step (px) - resizeTable (0-1)`, 310, [ 10, 100, 100, 100 ], pixelTableWithColGroup(), -200, 0, resizeTable, true);
-    testAdjustWidth(`rtl large step (px) - resizeTable (1-0)`, 314, [ 96, 10, 96, 96 ], pixelTable(), -200, 1, resizeTable, false);
-    testAdjustWidth(`rtl large step (px) - resizeTable (1-1)`, 310, [ 100, 10, 100, 100 ], pixelTableWithColGroup(), -200, 1, resizeTable, true);
-    testAdjustWidth(`rtl large step (px) - resizeTable (2-0)`, 314, [ 96, 96, 10, 96 ], pixelTable(), -200, 2, resizeTable, false);
-    testAdjustWidth(`rtl large step (px) - resizeTable (2-1)`, 310, [ 100, 100, 10, 100 ], pixelTableWithColGroup(), -200, 2, resizeTable, true);
-  };
+    context('ltr large step (%)', () => {
+      it('preserveTable cells (0)', testAdjustWidth(50, [ 47.5, 2.5, 25, 25 ], relativeTable(), percentageToStep(50, 400), 0, preserveTable, false));
+      it('preserveTable cols (0)', testAdjustWidth(50, [ 47.5, 2.5, 25, 25 ], relativeTableWithColGroup(), percentageToStep(50, 400), 0, preserveTable, true));
+      it('preserveTable cells (1)', testAdjustWidth(50, [ 25, 47.5, 2.5, 25 ], relativeTable(), percentageToStep(50, 400), 1, preserveTable, false));
+      it('preserveTable cols (1)', testAdjustWidth(50, [ 25, 47.5, 2.5, 25 ], relativeTableWithColGroup(), percentageToStep(50, 400), 1, preserveTable, true));
+      it('preserveTable cells (2)', testAdjustWidth(50, [ 25, 25, 47.5, 2.5 ], relativeTable(), percentageToStep(50, 400), 2, preserveTable, false));
+      it('preserveTable cols (2)', testAdjustWidth(50, [ 25, 25, 47.5, 2.5 ], relativeTableWithColGroup(), percentageToStep(50, 400), 2, preserveTable, true));
+      it('preserveTable cells (3)', testAdjustWidth(75, [ 25, 25, 25, 25 ], relativeTable(), percentageToStep(50, 400), 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth(75, [ 25, 25, 25, 25 ], relativeTableWithColGroup(), percentageToStep(50, 400), 3, preserveTable, true));
+    });
 
-  const testLastColumnResizing = () => {
-    // 'resizeTable' column resizing
-    testAdjustWidth(`ltr step (%) - resizeTable (3)`, 56.25, [ 22.22, 22.22, 22.22, 33.33 ], relativeTable(), percentageToStep(12.5, 400), 3, resizeTable, false);
-    testAdjustWidth(`ltr step (%) - resizeTable (3)`, 56.25, [ 22.22, 22.22, 22.22, 33.33 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 3, resizeTable, true);
-    testAdjustWidth(`ltr large step (%) - resizeTable (3)`, 75, [ 16.67, 16.67, 16.67, 50 ], relativeTable(), percentageToStep(50, 400), 3, resizeTable, false);
-    testAdjustWidth(`ltr large step (%) - resizeTable (3)`, 75, [ 16.67, 16.67, 16.67, 50 ], relativeTableWithColGroup(), percentageToStep(50, 400), 3, resizeTable, true);
-    testAdjustWidth(`rtl step (%) - resizeTable (3)`, 43.75, [ 28.57, 28.57, 28.57, 14.29 ], relativeTable(), percentageToStep(-12.5, 400), 3, resizeTable, false);
-    testAdjustWidth(`rtl step (%) - resizeTable (3)`, 43.75, [ 28.57, 28.57, 28.57, 14.29 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 3, resizeTable, true);
-    testAdjustWidth(`rtl large step (%) - resizeTable (3)`, 38.75, [ 32.26, 32.26, 32.26, 3.23 ], relativeTable(), percentageToStep(-50, 400), 3, resizeTable, false);
-    testAdjustWidth(`rtl large step (%) - resizeTable (3)`, 38.75, [ 32.26, 32.26, 32.26, 3.23 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 3, resizeTable, true);
-    testAdjustWidth(`ltr step (px) - resizeTable (3)`, 450, [ 96, 96, 96, 146 ], pixelTable(), 50, 3, resizeTable, false);
-    testAdjustWidth(`ltr step (px) - resizeTable (3)`, 450, [ 100, 100, 100, 150 ], pixelTableWithColGroup(), 50, 3, resizeTable, true);
-    testAdjustWidth(`ltr large step (px) - resizeTable (3)`, 600, [ 96, 96, 96, 296 ], pixelTable(), 200, 3, resizeTable, false);
-    testAdjustWidth(`ltr large step (px) - resizeTable (3)`, 600, [ 100, 100, 100, 300 ], pixelTableWithColGroup(), 200, 3, resizeTable, true);
-    testAdjustWidth(`rtl step (px) - resizeTable (3)`, 350, [ 96, 96, 96, 46 ], pixelTable(), -50, 3, resizeTable, false);
-    testAdjustWidth(`rtl step (px) - resizeTable (3)`, 350, [ 100, 100, 100, 50 ], pixelTableWithColGroup(), -50, 3, resizeTable, true);
-    testAdjustWidth(`rtl large step (px) - resizeTable (3)`, 314, [ 96, 96, 96, 10 ], pixelTable(), -200, 3, resizeTable, false);
-    testAdjustWidth(`rtl large step (px) - resizeTable (3)`, 310, [ 100, 100, 100, 10 ], pixelTableWithColGroup(), -200, 3, resizeTable, true);
+    context('rtl step (%)', () => {
+      it('preserveTable cells (0)', testAdjustWidth(50, [ 12.5, 37.5, 25, 25 ], relativeTable(), percentageToStep(-12.5, 400), 0, preserveTable, false));
+      it('preserveTable cols (0)', testAdjustWidth(50, [ 12.5, 37.5, 25, 25 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 0, preserveTable, true));
+      // TODO: TINY-7942: This needs design input as it should be blocked since it can't be resized smaller
+      it.skip('preserveTable overflow (0)', testAdjustWidth(50, [ 30.83, 23.06, 23.06, 23.06 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 0, preserveTable, false));
+      it('preserveTable cells (1)', testAdjustWidth(50, [ 25, 12.5, 37.5, 25 ], relativeTable(), percentageToStep(-12.5, 400), 1, preserveTable, false));
+      it('preserveTable cols (1)', testAdjustWidth(50, [ 25, 12.5, 37.5, 25 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 1, preserveTable, true));
+      it('preserveTable overflow (1)', testAdjustWidth(50, [ 30.83, 10.56, 35.56, 23.06 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 1, preserveTable, false));
+      it(' preserveTable cells (2)', testAdjustWidth(50, [ 25, 25, 12.5, 37.5 ], relativeTable(), percentageToStep(-12.5, 400), 2, preserveTable, false));
+      it('preserveTable cols (2)', testAdjustWidth(50, [ 25, 25, 12.5, 37.5 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 2, preserveTable, true));
+      it('preserveTable overflow (2)', testAdjustWidth(50, [ 30.83, 23.06, 10.56, 35.56 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 2, preserveTable, false));
+      it('preserveTable cells (3)', testAdjustWidth(43.75, [ 25, 25, 25, 25 ], relativeTable(), percentageToStep(-12.5, 400), 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth(43.75, [ 25, 25, 25, 25 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 3, preserveTable, true));
+      // TODO: TINY-7942: This needs design input as the first cell ideally shouldn't shrink
+      it('preserveTable overflow (3)', testAdjustWidth(43.75, [ 30.83, 23.06, 23.06, 23.06 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 3, preserveTable, false));
+    });
 
-    // 'preserveTable' column resizing
-    testAdjustWidth(`ltr step (%) - preserveTable (3)`, 56.25, [ 25, 25, 25, 25 ], relativeTable(), percentageToStep(12.5, 400), 3, preserveTable, false);
-    testAdjustWidth(`ltr step (%) - preserveTable (3)`, 56.25, [ 25, 25, 25, 25 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 3, preserveTable, true);
-    testAdjustWidth(`ltr large step (%) - preserveTable (3)`, 75, [ 25, 25, 25, 25 ], relativeTable(), percentageToStep(50, 400), 3, preserveTable, false);
-    testAdjustWidth(`ltr large step (%) - preserveTable (3)`, 75, [ 25, 25, 25, 25 ], relativeTableWithColGroup(), percentageToStep(50, 400), 3, preserveTable, true);
-    testAdjustWidth(`rtl step (%) - preserveTable (3)`, 43.75, [ 25, 25, 25, 25 ], relativeTable(), percentageToStep(-12.5, 400), 3, preserveTable, false);
-    testAdjustWidth(`rtl step (%) - preserveTable (3)`, 43.75, [ 25, 25, 25, 25 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 3, preserveTable, true);
-    testAdjustWidth(`rtl large step (%) - preserveTable (3)`, 25, [ 25, 25, 25, 25 ], relativeTable(), percentageToStep(-50, 400), 3, preserveTable, false);
-    testAdjustWidth(`rtl large step (%) - preserveTable (3)`, 25, [ 25, 25, 25, 25 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 3, preserveTable, true);
-    testAdjustWidth(`ltr step (px) - preserveTable (3)`, 450, [ 108, 108, 108, 108 ], pixelTable(), 50, 3, preserveTable, false);
-    testAdjustWidth(`ltr step (px) - preserveTable (3)`, 450, [ 112.5, 112.5, 112.5, 112.5 ], pixelTableWithColGroup(), 50, 3, preserveTable, true);
-    testAdjustWidth(`ltr large step (px) - preserveTable (3)`, 600, [ 146, 146, 146, 146 ], pixelTable(), 200, 3, preserveTable, false);
-    testAdjustWidth(`ltr large step (px) - preserveTable (3)`, 600, [ 150, 150, 150, 150 ], pixelTableWithColGroup(), 200, 3, preserveTable, true);
-    testAdjustWidth(`rtl step (px) - preserveTable (3)`, 350, [ 83, 83, 83, 83 ], pixelTable(), -50, 3, preserveTable, false);
-    testAdjustWidth(`rtl step (px) - preserveTable (3)`, 350, [ 87.5, 87.5, 87.5, 87.5 ], pixelTableWithColGroup(), -50, 3, preserveTable, true);
-    testAdjustWidth(`rtl large step (px) - preserveTable (3)`, 200, [ 46, 46, 46, 46 ], pixelTable(), -200, 3, preserveTable, false);
-    testAdjustWidth(`rtl large step (px) - preserveTable (3)`, 200, [ 50, 50, 50, 50 ], pixelTableWithColGroup(), -200, 3, preserveTable, true);
-    testAdjustWidth(`rtl extra large step (px) - preserveTable (3)`, 56, [ 10, 10, 10, 10 ], pixelTable(), -400, 3, preserveTable, false);
-    testAdjustWidth(`rtl extra large step (px) - preserveTable (3)`, 40, [ 10, 10, 10, 10 ], pixelTableWithColGroup(), -400, 3, preserveTable, true);
-  };
+    context('rtl large step (%)', () => {
+      it('preserveTable cells (0)', testAdjustWidth(50, [ 2.5, 47.5, 25, 25 ], relativeTable(), percentageToStep(-50, 400), 0, preserveTable, false));
+      it('preserveTable cols (0)', testAdjustWidth(50, [ 2.5, 47.5, 25, 25 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 0, preserveTable, true));
+      it('preserveTable cells (1)', testAdjustWidth(50, [ 25, 2.5, 47.5, 25 ], relativeTable(), percentageToStep(-50, 400), 1, preserveTable, false));
+      it('preserveTable cols (1)', testAdjustWidth(50, [ 25, 2.5, 47.5, 25 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 1, preserveTable, true));
+      it('preserveTable cells (2)', testAdjustWidth(50, [ 25, 25, 2.5, 47.5 ], relativeTable(), percentageToStep(-50, 400), 2, preserveTable, false));
+      it('preserveTable cols (2)', testAdjustWidth(50, [ 25, 25, 2.5, 47.5 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 2, preserveTable, true));
+      it('preserveTable cells (3)', testAdjustWidth(25, [ 25, 25, 25, 25 ], relativeTable(), percentageToStep(-50, 400), 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth(25, [ 25, 25, 25, 25 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 3, preserveTable, true));
+    });
 
-  testInnerColumnResizing();
-  testLastColumnResizing();
+    context('ltr step (px)', () => {
+      it('preserveTable cells (0)', testAdjustWidth(400, [ 146.75, 46.75, 96.75, 96.75 ], pixelTable(), 50, 0, preserveTable, false));
+      it('preserveTable cols (0)', testAdjustWidth(400, [ 150, 50, 100, 100 ], pixelTableWithColGroup(), 50, 0, preserveTable, true));
+      it('preserveTable overflow (0)', testAdjustWidth(400, [ 170, 39, 89, 89 ], pixelTableWithOverflow(), 50, 0, preserveTable, false));
+      it('preserveTable cells (1)', testAdjustWidth(400, [ 96.75, 146.75, 46.75, 96.75 ], pixelTable(), 50, 1, preserveTable, false));
+      it('preserveTable cols (1)', testAdjustWidth(400, [ 100, 150, 50, 100 ], pixelTableWithColGroup(), 50, 1, preserveTable, true));
+      it('preserveTable overflow (1)', testAdjustWidth(400, [ 120, 139, 39, 89 ], pixelTableWithOverflow(), 50, 1, preserveTable, false));
+      it('preserveTable cells (2)', testAdjustWidth(400, [ 96.75, 96.75, 146.75, 46.75 ], pixelTable(), 50, 2, preserveTable, false));
+      it('preserveTable cols (2)', testAdjustWidth(400, [ 100, 100, 150, 50 ], pixelTableWithColGroup(), 50, 2, preserveTable, true));
+      it('preserveTable overflow (2)', testAdjustWidth(400, [ 120, 89, 139, 39 ], pixelTableWithOverflow(), 50, 2, preserveTable, false));
+      it('preserveTable cells (3)', testAdjustWidth(450, [ 109.25, 109.25, 109.25, 109.25 ], pixelTable(), 50, 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth(450, [ 112.5, 112.5, 112.5, 112.5 ], pixelTableWithColGroup(), 50, 3, preserveTable, true));
+      it('preserveTable overflow (3)', testAdjustWidth(450, [ 132.5, 101.5, 101.5, 101.5 ], pixelTableWithOverflow(), 50, 3, preserveTable, false));
+    });
 
-  Remove.remove(box);
+    context('ltr large step (px)', () => {
+      it('preserveTable cells (0)', testAdjustWidth(400, [ 183.5, 10, 96.75, 96.75 ], pixelTable(), 200, 0, preserveTable, false));
+      it('preserveTable cols (0)', testAdjustWidth(400, [ 190, 10, 100, 100 ], pixelTableWithColGroup(), 200, 0, preserveTable, true));
+      it('preserveTable cells (1)', testAdjustWidth(400, [ 96.75, 183.5, 10, 96.75 ], pixelTable(), 200, 1, preserveTable, false));
+      it('preserveTable cols (1)', testAdjustWidth(400, [ 100, 190, 10, 100 ], pixelTableWithColGroup(), 200, 1, preserveTable, true));
+      it('preserveTable cells (2)', testAdjustWidth(400, [ 96.75, 96.75, 183.5, 10 ], pixelTable(), 200, 2, preserveTable, false));
+      it('preserveTable cols (2)', testAdjustWidth(400, [ 100, 100, 190, 10 ], pixelTableWithColGroup(), 200, 2, preserveTable, true));
+      it('preserveTable cells (3)', testAdjustWidth( 600, [ 146.75, 146.75, 146.75, 146.75 ], pixelTable(), 200, 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth( 600, [ 150, 150, 150, 150 ], pixelTableWithColGroup(), 200, 3, preserveTable, true));
+    });
+
+    context('rtl step (px)', () => {
+      it('preserveTable cells (0)', testAdjustWidth(400, [ 46.75, 146.75, 96.75, 96.75 ], pixelTable(), -50, 0, preserveTable, false));
+      it('preserveTable cols (0)', testAdjustWidth(400, [ 50, 150, 100, 100 ], pixelTableWithColGroup(), -50, 0, preserveTable, true));
+      // TODO: TINY-7942: This needs design input as it should be blocked since it can't be resized smaller
+      it.skip('preserveTable overflow (0)', testAdjustWidth(400, [ 120, 89, 89, 89 ], pixelTableWithOverflow(), -50, 0, preserveTable, false));
+      it('preserveTable cells (1)', testAdjustWidth(400, [ 96.75, 46.75, 146.75, 96.75 ], pixelTable(), -50, 1, preserveTable, false));
+      it('preserveTable cols (1)', testAdjustWidth(400, [ 100, 50, 150, 100 ], pixelTableWithColGroup(), -50, 1, preserveTable, true));
+      it('preserveTable overflow (1)', testAdjustWidth(400, [ 120, 39, 139, 89 ], pixelTableWithOverflow(), -50, 1, preserveTable, false));
+      it('preserveTable cells (2)', testAdjustWidth(400, [ 96.75, 96.75, 46.75, 146.75 ], pixelTable(), -50, 2, preserveTable, false));
+      it('preserveTable cols (2)', testAdjustWidth(400, [ 100, 100, 50, 150 ], pixelTableWithColGroup(), -50, 2, preserveTable, true));
+      it('preserveTable overflow (2)', testAdjustWidth(400, [ 120, 89, 39, 139 ], pixelTableWithOverflow(), -50, 2, preserveTable, false));
+      it('preserveTable cells (3)', testAdjustWidth( 350, [ 84.25, 84.25, 84.25, 84.25 ], pixelTable(), -50, 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth( 350, [ 87.5, 87.5, 87.5, 87.5 ], pixelTableWithColGroup(), -50, 3, preserveTable, true));
+      // TODO: TINY-7942: This needs design input as the first cell ideally shouldn't shrink
+      it('preserveTable overflow (3)', testAdjustWidth( 350, [ 107.5, 76.5, 76.5, 76.5 ], pixelTableWithOverflow(), -50, 3, preserveTable, false));
+    });
+
+    context('rtl large step (px)', () => {
+      it('preserveTable cells (0)', testAdjustWidth(400, [ 10, 183.5, 96.75, 96.75 ], pixelTable(), -200, 0, preserveTable, false));
+      it('preserveTable cols (0)', testAdjustWidth(400, [ 10, 190, 100, 100 ], pixelTableWithColGroup(), -200, 0, preserveTable, true));
+      it('preserveTable cells (1)', testAdjustWidth(400, [ 96.75, 10, 183.5, 96.75 ], pixelTable(), -200, 1, preserveTable, false));
+      it('preserveTable cols (1)', testAdjustWidth(400, [ 100, 10, 190, 100 ], pixelTableWithColGroup(), -200, 1, preserveTable, true));
+      it('preserveTable cells (2)', testAdjustWidth(400, [ 96.75, 96.75, 10, 183.5 ], pixelTable(), -200, 2, preserveTable, false));
+      it('preserveTable cols (2)', testAdjustWidth(400, [ 100, 100, 10, 190 ], pixelTableWithColGroup(), -200, 2, preserveTable, true));
+      it('preserveTable cells (3)', testAdjustWidth( 200, [ 46.75, 46.75, 46.75, 46.75 ], pixelTable(), -200, 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth( 200, [ 50, 50, 50, 50 ], pixelTableWithColGroup(), -200, 3, preserveTable, true));
+    });
+
+    context('rtl extra large step (px)', () => {
+      it('preserveTable cells (3)', testAdjustWidth( 53, [ 10, 10, 10, 10 ], pixelTable(), -400, 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth( 40, [ 10, 10, 10, 10 ], pixelTableWithColGroup(), -400, 3, preserveTable, true));
+    });
+  });
+
+  context('resize table column resizing', () => {
+    context('ltr step (%)', () => {
+      it('resizeTable cells (0)', testAdjustWidth(56.25, [ 33.33, 22.22, 22.22, 22.22 ], relativeTable(), percentageToStep(12.5, 400), 0, resizeTable, false));
+      it('resizeTable cols (0)', testAdjustWidth(56.25, [ 33.33, 22.22, 22.22, 22.22 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 0, resizeTable, true));
+      it('resizeTable overflow (0)', testAdjustWidth(56.25, [ 38.51, 20.50, 20.50, 20.50 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 0, resizeTable, false));
+      it('resizeTable cells (1)', testAdjustWidth(56.25, [ 22.22, 33.33, 22.22, 22.22 ], relativeTable(), percentageToStep(12.5, 400), 1, resizeTable, false));
+      it('resizeTable cols (1)', testAdjustWidth(56.25, [ 22.22, 33.33, 22.22, 22.22 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 1, resizeTable, true));
+      it('resizeTable overflow (1)', testAdjustWidth(56.25, [ 27.40, 31.61, 20.50, 20.50 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 1, resizeTable, false));
+      it('resizeTable cells (2)', testAdjustWidth(56.25, [ 22.22, 22.22, 33.33, 22.22 ], relativeTable(), percentageToStep(12.5, 400), 2, resizeTable, false));
+      it('resizeTable cols (2)', testAdjustWidth(56.25, [ 22.22, 22.22, 33.33, 22.22 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 2, resizeTable, true));
+      it('resizeTable overflow (2)', testAdjustWidth(56.25, [ 27.40, 20.50, 31.61, 20.50 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 2, resizeTable, false));
+      it('resizeTable cells (3)', testAdjustWidth( 56.25, [ 22.22, 22.22, 22.22, 33.33 ], relativeTable(), percentageToStep(12.5, 400), 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth( 56.25, [ 22.22, 22.22, 22.22, 33.33 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 3, resizeTable, true));
+      it('resizeTable overflow (3)', testAdjustWidth( 56.25, [ 27.40, 20.50, 20.50, 31.61 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 3, resizeTable, false));
+    });
+
+    context('ltr large step (%)', () => {
+      it('resizeTable cells (0)', testAdjustWidth(75, [ 50, 16.67, 16.67, 16.67 ], relativeTable(), percentageToStep(50, 400), 0, resizeTable, false));
+      it('resizeTable cols (0)', testAdjustWidth(75, [ 50, 16.67, 16.67, 16.67 ], relativeTableWithColGroup(), percentageToStep(50, 400), 0, resizeTable, true));
+      it('resizeTable cells (1)', testAdjustWidth(75, [ 16.67, 50, 16.67, 16.67 ], relativeTable(), percentageToStep(50, 400), 1, resizeTable, false));
+      it('resizeTable cols (1)', testAdjustWidth(75, [ 16.67, 50, 16.67, 16.67 ], relativeTableWithColGroup(), percentageToStep(50, 400), 1, resizeTable, true));
+      it('resizeTable cells (2)', testAdjustWidth(75, [ 16.67, 16.67, 50, 16.67 ], relativeTable(), percentageToStep(50, 400), 2, resizeTable, false));
+      it('resizeTable cols (2)', testAdjustWidth(75, [ 16.67, 16.67, 50, 16.67 ], relativeTableWithColGroup(), percentageToStep(50, 400), 2, resizeTable, true));
+      it('resizeTable cells (3)', testAdjustWidth( 75, [ 16.67, 16.67, 16.67, 50 ], relativeTable(), percentageToStep(50, 400), 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth( 75, [ 16.67, 16.67, 16.67, 50 ], relativeTableWithColGroup(), percentageToStep(50, 400), 3, resizeTable, true));
+    });
+
+    context('rtl step (%)', () => {
+      it('resizeTable cells (0)', testAdjustWidth(43.75, [ 14.29, 28.57, 28.57, 28.57 ], relativeTable(), percentageToStep(-12.5, 400), 0, resizeTable, false));
+      it('resizeTable cols (0)', testAdjustWidth(43.75, [ 14.29, 28.57, 28.57, 28.57 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 0, resizeTable, true));
+      // TODO: TINY-7942: This needs design input as it should be blocked since it can't be resized smaller
+      it.skip('resizeTable overflow (0)', testAdjustWidth(50, [ 30.83, 23.06, 23.06, 23.06 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 0, resizeTable, false));
+      it('resizeTable cells (1)', testAdjustWidth(43.75, [ 28.57, 14.29, 28.57, 28.57 ], relativeTable(), percentageToStep(-12.5, 400), 1, resizeTable, false));
+      it('resizeTable cols (1)', testAdjustWidth(43.75, [ 28.57, 14.29, 28.57, 28.57 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 1, resizeTable, true));
+      it('resizeTable overflow (1)', testAdjustWidth(43.75, [ 35.23, 12.07, 26.35, 26.35 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 1, resizeTable, false));
+      it('resizeTable cells (2)', testAdjustWidth(43.75, [ 28.57, 28.57, 14.29, 28.57 ], relativeTable(), percentageToStep(-12.5, 400), 2, resizeTable, false));
+      it('resizeTable cols (2)', testAdjustWidth(43.75, [ 28.57, 28.57, 14.29, 28.57 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 2, resizeTable, true));
+      it('resizeTable overflow (2)', testAdjustWidth(43.75, [ 35.23, 26.35, 12.07, 26.35 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 2, resizeTable, false));
+      it('resizeTable cells (3)', testAdjustWidth( 43.75, [ 28.57, 28.57, 28.57, 14.29 ], relativeTable(), percentageToStep(-12.5, 400), 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth( 43.75, [ 28.57, 28.57, 28.57, 14.29 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 3, resizeTable, true));
+      it('resizeTable overflow (3)', testAdjustWidth( 43.75, [ 35.23, 26.35, 26.35, 12.07 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 3, resizeTable, false));
+    });
+
+    context('rtl large step (%)', () => {
+      it('resizeTable cells (0)', testAdjustWidth(38.75, [ 3.23, 32.26, 32.26, 32.26 ], relativeTable(), percentageToStep(-50, 400), 0, resizeTable, false));
+      it('resizeTable cols (0)', testAdjustWidth(38.75, [ 3.23, 32.26, 32.26, 32.26 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 0, resizeTable, true));
+      it('resizeTable cells (1)', testAdjustWidth(38.75, [ 32.26, 3.23, 32.26, 32.26 ], relativeTable(), percentageToStep(-50, 400), 1, resizeTable, false));
+      it('resizeTable cols (1)', testAdjustWidth(38.75, [ 32.26, 3.23, 32.26, 32.26 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 1, resizeTable, true));
+      it('resizeTable cells (2)', testAdjustWidth(38.75, [ 32.26, 32.26, 3.23, 32.26 ], relativeTable(), percentageToStep(-50, 400), 2, resizeTable, false));
+      it('resizeTable cols (2)', testAdjustWidth(38.75, [ 32.26, 32.26, 3.23, 32.26 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 2, resizeTable, true));
+      it('resizeTable cells (3)', testAdjustWidth( 38.75, [ 32.26, 32.26, 32.26, 3.23 ], relativeTable(), percentageToStep(-50, 400), 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth( 38.75, [ 32.26, 32.26, 32.26, 3.23 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 3, resizeTable, true));
+    });
+
+    context('ltr step (px)', () => {
+      it('resizeTable cells (0)', testAdjustWidth(450, [ 146.75, 96.75, 96.75, 96.75 ], pixelTable(), 50, 0, resizeTable, false));
+      it('resizeTable cols (0)', testAdjustWidth(450, [ 150, 100, 100, 100 ], pixelTableWithColGroup(), 50, 0, resizeTable, true));
+      it('resizeTable overflow (0)', testAdjustWidth(450, [ 170, 89, 89, 89 ], pixelTableWithOverflow(), 50, 0, resizeTable, false));
+      it('resizeTable cells (1)', testAdjustWidth(450, [ 96.75, 146.75, 96.75, 96.75 ], pixelTable(), 50, 1, resizeTable, false));
+      it('resizeTable cols (1)', testAdjustWidth(450, [ 100, 150, 100, 100 ], pixelTableWithColGroup(), 50, 1, resizeTable, true));
+      it('resizeTable overflow (1)', testAdjustWidth(450, [ 120, 139, 89, 89 ], pixelTableWithOverflow(), 50, 1, resizeTable, false));
+      it('resizeTable cells (2)', testAdjustWidth(450, [ 96.75, 96.75, 146.75, 96.75 ], pixelTable(), 50, 2, resizeTable, false));
+      it('resizeTable cols (2)', testAdjustWidth(450, [ 100, 100, 150, 100 ], pixelTableWithColGroup(), 50, 2, resizeTable, true));
+      it('resizeTable overflow (2)', testAdjustWidth(450, [ 120, 89, 139, 89 ], pixelTableWithOverflow(), 50, 2, resizeTable, false));
+      it('resizeTable cells (3)', testAdjustWidth( 450, [ 96.75, 96.75, 96.75, 146.75 ], pixelTable(), 50, 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth( 450, [ 100, 100, 100, 150 ], pixelTableWithColGroup(), 50, 3, resizeTable, true));
+      it('resizeTable overflow (3)', testAdjustWidth( 450, [ 120, 89, 89, 139 ], pixelTableWithOverflow(), 50, 3, resizeTable, false));
+    });
+
+    context('ltr large step (px)', () => {
+      it('resizeTable cells (0)', testAdjustWidth(600, [ 296.75, 96.75, 96.75, 96.75 ], pixelTable(), 200, 0, resizeTable, false));
+      it('resizeTable cols (0)', testAdjustWidth(600, [ 300, 100, 100, 100 ], pixelTableWithColGroup(), 200, 0, resizeTable, true));
+      it('resizeTable cells (1)', testAdjustWidth(600, [ 96.75, 296.75, 96.75, 96.75 ], pixelTable(), 200, 1, resizeTable, false));
+      it('resizeTable cols (1)', testAdjustWidth(600, [ 100, 300, 100, 100 ], pixelTableWithColGroup(), 200, 1, resizeTable, true));
+      it('resizeTable cells (2)', testAdjustWidth(600, [ 96.75, 96.75, 296.75, 96.75 ], pixelTable(), 200, 2, resizeTable, false));
+      it('resizeTable cols (2)', testAdjustWidth(600, [ 100, 100, 300, 100 ], pixelTableWithColGroup(), 200, 2, resizeTable, true));
+      it('resizeTable cells (3)', testAdjustWidth( 600, [ 96.75, 96.75, 96.75, 296.75 ], pixelTable(), 200, 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth( 600, [ 100, 100, 100, 300 ], pixelTableWithColGroup(), 200, 3, resizeTable, true));
+    });
+
+    context('rtl step (px)', () => {
+      it('resizeTable cells (0)', testAdjustWidth(350, [ 46.75, 96.75, 96.75, 96.75 ], pixelTable(), -50, 0, resizeTable, false));
+      it('resizeTable cols (0)', testAdjustWidth(350, [ 50, 100, 100, 100 ], pixelTableWithColGroup(), -50, 0, resizeTable, true));
+      // TODO: TINY-7942: This needs design input as it should be blocked since it can't be resized smaller
+      it.skip('resizeTable overflow (0)', testAdjustWidth(400, [ 120, 89, 89, 89 ], pixelTableWithOverflow(), -50, 0, resizeTable, false));
+      it('resizeTable cells (1)', testAdjustWidth(350, [ 96.75, 46.75, 96.75, 96.75 ], pixelTable(), -50, 1, resizeTable, false));
+      it('resizeTable cols (1)', testAdjustWidth(350, [ 100, 50, 100, 100 ], pixelTableWithColGroup(), -50, 1, resizeTable, true));
+      it('resizeTable overflow (1)', testAdjustWidth(350, [ 120, 39, 89, 89 ], pixelTableWithOverflow(), -50, 1, resizeTable, false));
+      it('resizeTable cells (2)', testAdjustWidth(350, [ 96.75, 96.75, 46.75, 96.75 ], pixelTable(), -50, 2, resizeTable, false));
+      it('resizeTable cols (2)', testAdjustWidth(350, [ 100, 100, 50, 100 ], pixelTableWithColGroup(), -50, 2, resizeTable, true));
+      it('resizeTable overflow (2)', testAdjustWidth(350, [ 120, 89, 39, 89 ], pixelTableWithOverflow(), -50, 2, resizeTable, false));
+      it('resizeTable cells (3)', testAdjustWidth( 350, [ 96.75, 96.75, 96.75, 46.75 ], pixelTable(), -50, 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth( 350, [ 100, 100, 100, 50 ], pixelTableWithColGroup(), -50, 3, resizeTable, true));
+      it('resizeTable overflow (3)', testAdjustWidth( 350, [ 120, 89, 89, 39 ], pixelTableWithOverflow(), -50, 3, resizeTable, false));
+    });
+
+    context('rtl large step (px)', () => {
+      it('resizeTable cells (0)', testAdjustWidth(313.25, [ 10, 96.75, 96.75, 96.75 ], pixelTable(), -200, 0, resizeTable, false));
+      it('resizeTable cols (0)', testAdjustWidth(310, [ 10, 100, 100, 100 ], pixelTableWithColGroup(), -200, 0, resizeTable, true));
+      it('resizeTable cells (1)', testAdjustWidth(313.25, [ 96.75, 10, 96.75, 96.75 ], pixelTable(), -200, 1, resizeTable, false));
+      it('resizeTable cols (1)', testAdjustWidth(310, [ 100, 10, 100, 100 ], pixelTableWithColGroup(), -200, 1, resizeTable, true));
+      it('resizeTable cells (2)', testAdjustWidth(313.25, [ 96.75, 96.75, 10, 96.75 ], pixelTable(), -200, 2, resizeTable, false));
+      it('resizeTable cols (2)', testAdjustWidth(310, [ 100, 100, 10, 100 ], pixelTableWithColGroup(), -200, 2, resizeTable, true));
+      it('resizeTable cells (3)', testAdjustWidth( 313.25, [ 96.75, 96.75, 96.75, 10 ], pixelTable(), -200, 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth( 310, [ 100, 100, 100, 10 ], pixelTableWithColGroup(), -200, 3, resizeTable, true));
+    });
+  });
 });

--- a/modules/snooker/src/test/ts/browser/TableAdjustmentsTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableAdjustmentsTest.ts
@@ -196,7 +196,7 @@ describe('TableAdjustmentsTest', () => {
       it('preserveTable cells (1)', testAdjustWidth(50, [ 25, 12.5, 37.5, 25 ], relativeTable(), percentageToStep(-12.5, 400), 1, preserveTable, false));
       it('preserveTable cols (1)', testAdjustWidth(50, [ 25, 12.5, 37.5, 25 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 1, preserveTable, true));
       it('preserveTable overflow (1)', testAdjustWidth(50, [ 30.83, 10.56, 35.56, 23.06 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 1, preserveTable, false));
-      it(' preserveTable cells (2)', testAdjustWidth(50, [ 25, 25, 12.5, 37.5 ], relativeTable(), percentageToStep(-12.5, 400), 2, preserveTable, false));
+      it('preserveTable cells (2)', testAdjustWidth(50, [ 25, 25, 12.5, 37.5 ], relativeTable(), percentageToStep(-12.5, 400), 2, preserveTable, false));
       it('preserveTable cols (2)', testAdjustWidth(50, [ 25, 25, 12.5, 37.5 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 2, preserveTable, true));
       it('preserveTable overflow (2)', testAdjustWidth(50, [ 30.83, 23.06, 10.56, 35.56 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 2, preserveTable, false));
       it('preserveTable cells (3)', testAdjustWidth(43.75, [ 25, 25, 25, 25 ], relativeTable(), percentageToStep(-12.5, 400), 3, preserveTable, false));
@@ -238,8 +238,8 @@ describe('TableAdjustmentsTest', () => {
       it('preserveTable cols (1)', testAdjustWidth(400, [ 100, 190, 10, 100 ], pixelTableWithColGroup(), 200, 1, preserveTable, true));
       it('preserveTable cells (2)', testAdjustWidth(400, [ 96.75, 96.75, 183.5, 10 ], pixelTable(), 200, 2, preserveTable, false));
       it('preserveTable cols (2)', testAdjustWidth(400, [ 100, 100, 190, 10 ], pixelTableWithColGroup(), 200, 2, preserveTable, true));
-      it('preserveTable cells (3)', testAdjustWidth( 600, [ 146.75, 146.75, 146.75, 146.75 ], pixelTable(), 200, 3, preserveTable, false));
-      it('preserveTable cols (3)', testAdjustWidth( 600, [ 150, 150, 150, 150 ], pixelTableWithColGroup(), 200, 3, preserveTable, true));
+      it('preserveTable cells (3)', testAdjustWidth(600, [ 146.75, 146.75, 146.75, 146.75 ], pixelTable(), 200, 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth(600, [ 150, 150, 150, 150 ], pixelTableWithColGroup(), 200, 3, preserveTable, true));
     });
 
     context('rtl step (px)', () => {
@@ -253,10 +253,10 @@ describe('TableAdjustmentsTest', () => {
       it('preserveTable cells (2)', testAdjustWidth(400, [ 96.75, 96.75, 46.75, 146.75 ], pixelTable(), -50, 2, preserveTable, false));
       it('preserveTable cols (2)', testAdjustWidth(400, [ 100, 100, 50, 150 ], pixelTableWithColGroup(), -50, 2, preserveTable, true));
       it('preserveTable overflow (2)', testAdjustWidth(400, [ 120, 89, 39, 139 ], pixelTableWithOverflow(), -50, 2, preserveTable, false));
-      it('preserveTable cells (3)', testAdjustWidth( 350, [ 84.25, 84.25, 84.25, 84.25 ], pixelTable(), -50, 3, preserveTable, false));
-      it('preserveTable cols (3)', testAdjustWidth( 350, [ 87.5, 87.5, 87.5, 87.5 ], pixelTableWithColGroup(), -50, 3, preserveTable, true));
+      it('preserveTable cells (3)', testAdjustWidth(350, [ 84.25, 84.25, 84.25, 84.25 ], pixelTable(), -50, 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth(350, [ 87.5, 87.5, 87.5, 87.5 ], pixelTableWithColGroup(), -50, 3, preserveTable, true));
       // TODO: TINY-7942: This needs design input as the first cell ideally shouldn't shrink
-      it('preserveTable overflow (3)', testAdjustWidth( 350, [ 107.5, 76.5, 76.5, 76.5 ], pixelTableWithOverflow(), -50, 3, preserveTable, false));
+      it('preserveTable overflow (3)', testAdjustWidth(350, [ 107.5, 76.5, 76.5, 76.5 ], pixelTableWithOverflow(), -50, 3, preserveTable, false));
     });
 
     context('rtl large step (px)', () => {
@@ -271,8 +271,8 @@ describe('TableAdjustmentsTest', () => {
     });
 
     context('rtl extra large step (px)', () => {
-      it('preserveTable cells (3)', testAdjustWidth( 53, [ 10, 10, 10, 10 ], pixelTable(), -400, 3, preserveTable, false));
-      it('preserveTable cols (3)', testAdjustWidth( 40, [ 10, 10, 10, 10 ], pixelTableWithColGroup(), -400, 3, preserveTable, true));
+      it('preserveTable cells (3)', testAdjustWidth(53, [ 10, 10, 10, 10 ], pixelTable(), -400, 3, preserveTable, false));
+      it('preserveTable cols (3)', testAdjustWidth(40, [ 10, 10, 10, 10 ], pixelTableWithColGroup(), -400, 3, preserveTable, true));
     });
   });
 
@@ -287,9 +287,9 @@ describe('TableAdjustmentsTest', () => {
       it('resizeTable cells (2)', testAdjustWidth(56.25, [ 22.22, 22.22, 33.33, 22.22 ], relativeTable(), percentageToStep(12.5, 400), 2, resizeTable, false));
       it('resizeTable cols (2)', testAdjustWidth(56.25, [ 22.22, 22.22, 33.33, 22.22 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 2, resizeTable, true));
       it('resizeTable overflow (2)', testAdjustWidth(56.25, [ 27.40, 20.50, 31.61, 20.50 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 2, resizeTable, false));
-      it('resizeTable cells (3)', testAdjustWidth( 56.25, [ 22.22, 22.22, 22.22, 33.33 ], relativeTable(), percentageToStep(12.5, 400), 3, resizeTable, false));
-      it('resizeTable cols (3)', testAdjustWidth( 56.25, [ 22.22, 22.22, 22.22, 33.33 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 3, resizeTable, true));
-      it('resizeTable overflow (3)', testAdjustWidth( 56.25, [ 27.40, 20.50, 20.50, 31.61 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 3, resizeTable, false));
+      it('resizeTable cells (3)', testAdjustWidth(56.25, [ 22.22, 22.22, 22.22, 33.33 ], relativeTable(), percentageToStep(12.5, 400), 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth(56.25, [ 22.22, 22.22, 22.22, 33.33 ], relativeTableWithColGroup(), percentageToStep(12.5, 400), 3, resizeTable, true));
+      it('resizeTable overflow (3)', testAdjustWidth(56.25, [ 27.40, 20.50, 20.50, 31.61 ], relativeTableWithOverflow(), percentageToStep(12.5, 400), 3, resizeTable, false));
     });
 
     context('ltr large step (%)', () => {
@@ -299,8 +299,8 @@ describe('TableAdjustmentsTest', () => {
       it('resizeTable cols (1)', testAdjustWidth(75, [ 16.67, 50, 16.67, 16.67 ], relativeTableWithColGroup(), percentageToStep(50, 400), 1, resizeTable, true));
       it('resizeTable cells (2)', testAdjustWidth(75, [ 16.67, 16.67, 50, 16.67 ], relativeTable(), percentageToStep(50, 400), 2, resizeTable, false));
       it('resizeTable cols (2)', testAdjustWidth(75, [ 16.67, 16.67, 50, 16.67 ], relativeTableWithColGroup(), percentageToStep(50, 400), 2, resizeTable, true));
-      it('resizeTable cells (3)', testAdjustWidth( 75, [ 16.67, 16.67, 16.67, 50 ], relativeTable(), percentageToStep(50, 400), 3, resizeTable, false));
-      it('resizeTable cols (3)', testAdjustWidth( 75, [ 16.67, 16.67, 16.67, 50 ], relativeTableWithColGroup(), percentageToStep(50, 400), 3, resizeTable, true));
+      it('resizeTable cells (3)', testAdjustWidth(75, [ 16.67, 16.67, 16.67, 50 ], relativeTable(), percentageToStep(50, 400), 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth(75, [ 16.67, 16.67, 16.67, 50 ], relativeTableWithColGroup(), percentageToStep(50, 400), 3, resizeTable, true));
     });
 
     context('rtl step (%)', () => {
@@ -314,9 +314,9 @@ describe('TableAdjustmentsTest', () => {
       it('resizeTable cells (2)', testAdjustWidth(43.75, [ 28.57, 28.57, 14.29, 28.57 ], relativeTable(), percentageToStep(-12.5, 400), 2, resizeTable, false));
       it('resizeTable cols (2)', testAdjustWidth(43.75, [ 28.57, 28.57, 14.29, 28.57 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 2, resizeTable, true));
       it('resizeTable overflow (2)', testAdjustWidth(43.75, [ 35.23, 26.35, 12.07, 26.35 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 2, resizeTable, false));
-      it('resizeTable cells (3)', testAdjustWidth( 43.75, [ 28.57, 28.57, 28.57, 14.29 ], relativeTable(), percentageToStep(-12.5, 400), 3, resizeTable, false));
-      it('resizeTable cols (3)', testAdjustWidth( 43.75, [ 28.57, 28.57, 28.57, 14.29 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 3, resizeTable, true));
-      it('resizeTable overflow (3)', testAdjustWidth( 43.75, [ 35.23, 26.35, 26.35, 12.07 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 3, resizeTable, false));
+      it('resizeTable cells (3)', testAdjustWidth(43.75, [ 28.57, 28.57, 28.57, 14.29 ], relativeTable(), percentageToStep(-12.5, 400), 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth(43.75, [ 28.57, 28.57, 28.57, 14.29 ], relativeTableWithColGroup(), percentageToStep(-12.5, 400), 3, resizeTable, true));
+      it('resizeTable overflow (3)', testAdjustWidth(43.75, [ 35.23, 26.35, 26.35, 12.07 ], relativeTableWithOverflow(), percentageToStep(-12.5, 400), 3, resizeTable, false));
     });
 
     context('rtl large step (%)', () => {
@@ -326,8 +326,8 @@ describe('TableAdjustmentsTest', () => {
       it('resizeTable cols (1)', testAdjustWidth(38.75, [ 32.26, 3.23, 32.26, 32.26 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 1, resizeTable, true));
       it('resizeTable cells (2)', testAdjustWidth(38.75, [ 32.26, 32.26, 3.23, 32.26 ], relativeTable(), percentageToStep(-50, 400), 2, resizeTable, false));
       it('resizeTable cols (2)', testAdjustWidth(38.75, [ 32.26, 32.26, 3.23, 32.26 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 2, resizeTable, true));
-      it('resizeTable cells (3)', testAdjustWidth( 38.75, [ 32.26, 32.26, 32.26, 3.23 ], relativeTable(), percentageToStep(-50, 400), 3, resizeTable, false));
-      it('resizeTable cols (3)', testAdjustWidth( 38.75, [ 32.26, 32.26, 32.26, 3.23 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 3, resizeTable, true));
+      it('resizeTable cells (3)', testAdjustWidth(38.75, [ 32.26, 32.26, 32.26, 3.23 ], relativeTable(), percentageToStep(-50, 400), 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth(38.75, [ 32.26, 32.26, 32.26, 3.23 ], relativeTableWithColGroup(), percentageToStep(-50, 400), 3, resizeTable, true));
     });
 
     context('ltr step (px)', () => {
@@ -340,9 +340,9 @@ describe('TableAdjustmentsTest', () => {
       it('resizeTable cells (2)', testAdjustWidth(450, [ 96.75, 96.75, 146.75, 96.75 ], pixelTable(), 50, 2, resizeTable, false));
       it('resizeTable cols (2)', testAdjustWidth(450, [ 100, 100, 150, 100 ], pixelTableWithColGroup(), 50, 2, resizeTable, true));
       it('resizeTable overflow (2)', testAdjustWidth(450, [ 120, 89, 139, 89 ], pixelTableWithOverflow(), 50, 2, resizeTable, false));
-      it('resizeTable cells (3)', testAdjustWidth( 450, [ 96.75, 96.75, 96.75, 146.75 ], pixelTable(), 50, 3, resizeTable, false));
-      it('resizeTable cols (3)', testAdjustWidth( 450, [ 100, 100, 100, 150 ], pixelTableWithColGroup(), 50, 3, resizeTable, true));
-      it('resizeTable overflow (3)', testAdjustWidth( 450, [ 120, 89, 89, 139 ], pixelTableWithOverflow(), 50, 3, resizeTable, false));
+      it('resizeTable cells (3)', testAdjustWidth(450, [ 96.75, 96.75, 96.75, 146.75 ], pixelTable(), 50, 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth(450, [ 100, 100, 100, 150 ], pixelTableWithColGroup(), 50, 3, resizeTable, true));
+      it('resizeTable overflow (3)', testAdjustWidth(450, [ 120, 89, 89, 139 ], pixelTableWithOverflow(), 50, 3, resizeTable, false));
     });
 
     context('ltr large step (px)', () => {
@@ -352,8 +352,8 @@ describe('TableAdjustmentsTest', () => {
       it('resizeTable cols (1)', testAdjustWidth(600, [ 100, 300, 100, 100 ], pixelTableWithColGroup(), 200, 1, resizeTable, true));
       it('resizeTable cells (2)', testAdjustWidth(600, [ 96.75, 96.75, 296.75, 96.75 ], pixelTable(), 200, 2, resizeTable, false));
       it('resizeTable cols (2)', testAdjustWidth(600, [ 100, 100, 300, 100 ], pixelTableWithColGroup(), 200, 2, resizeTable, true));
-      it('resizeTable cells (3)', testAdjustWidth( 600, [ 96.75, 96.75, 96.75, 296.75 ], pixelTable(), 200, 3, resizeTable, false));
-      it('resizeTable cols (3)', testAdjustWidth( 600, [ 100, 100, 100, 300 ], pixelTableWithColGroup(), 200, 3, resizeTable, true));
+      it('resizeTable cells (3)', testAdjustWidth(600, [ 96.75, 96.75, 96.75, 296.75 ], pixelTable(), 200, 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth(600, [ 100, 100, 100, 300 ], pixelTableWithColGroup(), 200, 3, resizeTable, true));
     });
 
     context('rtl step (px)', () => {
@@ -367,9 +367,9 @@ describe('TableAdjustmentsTest', () => {
       it('resizeTable cells (2)', testAdjustWidth(350, [ 96.75, 96.75, 46.75, 96.75 ], pixelTable(), -50, 2, resizeTable, false));
       it('resizeTable cols (2)', testAdjustWidth(350, [ 100, 100, 50, 100 ], pixelTableWithColGroup(), -50, 2, resizeTable, true));
       it('resizeTable overflow (2)', testAdjustWidth(350, [ 120, 89, 39, 89 ], pixelTableWithOverflow(), -50, 2, resizeTable, false));
-      it('resizeTable cells (3)', testAdjustWidth( 350, [ 96.75, 96.75, 96.75, 46.75 ], pixelTable(), -50, 3, resizeTable, false));
-      it('resizeTable cols (3)', testAdjustWidth( 350, [ 100, 100, 100, 50 ], pixelTableWithColGroup(), -50, 3, resizeTable, true));
-      it('resizeTable overflow (3)', testAdjustWidth( 350, [ 120, 89, 89, 39 ], pixelTableWithOverflow(), -50, 3, resizeTable, false));
+      it('resizeTable cells (3)', testAdjustWidth(350, [ 96.75, 96.75, 96.75, 46.75 ], pixelTable(), -50, 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth(350, [ 100, 100, 100, 50 ], pixelTableWithColGroup(), -50, 3, resizeTable, true));
+      it('resizeTable overflow (3)', testAdjustWidth(350, [ 120, 89, 89, 39 ], pixelTableWithOverflow(), -50, 3, resizeTable, false));
     });
 
     context('rtl large step (px)', () => {
@@ -379,8 +379,8 @@ describe('TableAdjustmentsTest', () => {
       it('resizeTable cols (1)', testAdjustWidth(310, [ 100, 10, 100, 100 ], pixelTableWithColGroup(), -200, 1, resizeTable, true));
       it('resizeTable cells (2)', testAdjustWidth(313.25, [ 96.75, 96.75, 10, 96.75 ], pixelTable(), -200, 2, resizeTable, false));
       it('resizeTable cols (2)', testAdjustWidth(310, [ 100, 100, 10, 100 ], pixelTableWithColGroup(), -200, 2, resizeTable, true));
-      it('resizeTable cells (3)', testAdjustWidth( 313.25, [ 96.75, 96.75, 96.75, 10 ], pixelTable(), -200, 3, resizeTable, false));
-      it('resizeTable cols (3)', testAdjustWidth( 310, [ 100, 100, 100, 10 ], pixelTableWithColGroup(), -200, 3, resizeTable, true));
+      it('resizeTable cells (3)', testAdjustWidth(313.25, [ 96.75, 96.75, 96.75, 10 ], pixelTable(), -200, 3, resizeTable, false));
+      it('resizeTable cols (3)', testAdjustWidth(310, [ 100, 100, 100, 10 ], pixelTableWithColGroup(), -200, 3, resizeTable, true));
     });
   });
 });

--- a/modules/snooker/src/test/ts/browser/TableConversionsTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableConversionsTest.ts
@@ -3,7 +3,6 @@ import { Optional, OptionalInstances } from '@ephox/katamari';
 import { Css, Insert, Remove, SugarBody, SugarElement, Width } from '@ephox/sugar';
 
 import * as TableConversions from 'ephox/snooker/api/TableConversions';
-import { TableSize } from 'ephox/snooker/api/TableSize';
 import { addStyles, assertApproxCellSizes, readWidth } from 'ephox/snooker/test/SizeUtils';
 
 const tOptional = OptionalInstances.tOptional;
@@ -52,7 +51,7 @@ UnitTest.test('TableConversions.convertToPixelSize', () => {
 
   const check = (expectedTableWidth: string, expected: string[][], table: SugarElement<HTMLTableElement>, approx: boolean) => {
     Insert.append(container, table);
-    TableConversions.convertToPixelSize(table, TableSize.getTableSize(table));
+    TableConversions.convertToPixelSize(table);
     if (approx) {
       Assert.eq('Assert table width', true, Math.abs(parseFloat(expectedTableWidth) - Width.get(table)) <= 2);
       assertApproxCellSizes(expected, readWidth(table), 2);
@@ -96,7 +95,7 @@ UnitTest.test('TableConversions.convertToPercentSize', () => {
 
   const check = (expectedTableWidth: string, expected: string[][], table: SugarElement<HTMLTableElement>, approx: boolean) => {
     Insert.append(container, table);
-    TableConversions.convertToPercentSize(table, TableSize.getTableSize(table));
+    TableConversions.convertToPercentSize(table);
     if (approx) {
       const delta = parseFloat(expectedTableWidth) - parseFloat(Css.getRaw(table, 'width').getOrDie());
       Assert.eq('Assert table width', true, Math.abs(delta) <= 2);

--- a/modules/snooker/src/test/ts/browser/TableSizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableSizeTest.ts
@@ -1,6 +1,7 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, context, describe, it } from '@ephox/bedrock-client';
 import { Optional, OptionalInstances } from '@ephox/katamari';
-import { Css, Insert, Remove, SelectorFind, SugarBody, SugarElement, Width } from '@ephox/sugar';
+import { Css, Insert, InsertAll, Remove, SelectorFind, SugarBody, SugarElement, Width } from '@ephox/sugar';
+import { assert } from 'chai';
 import * as fc from 'fast-check';
 
 import { TableSize } from 'ephox/snooker/api/TableSize';
@@ -8,117 +9,200 @@ import { Warehouse } from 'ephox/snooker/api/Warehouse';
 
 const tOptional = OptionalInstances.tOptional;
 
-const pixelTableHtml = '<table style="width: 400px"><tbody><tr><td style="width: 200px"></td><td style="width: 200px"></td></tr></tbody></table>';
-const percentTableHtml = '<table style="width: 80%"><tbody><tr><td style="width: 50%"></td><td style="width: 50%"></td></tr></tbody></table>';
-const noneTableHtml = '<table><tbody><tr><td></td><td></td></tr></tbody></table>';
+describe('TableSizeTest', () => {
+  const pixelTableHtml = '<table style="width: 400px; border-collapse: collapse;"><tbody><tr><td style="width: 200px"></td><td style="width: 200px"></td></tr></tbody></table>';
+  const overflowingPixelTableHtml = '<table style="width: 400px; border-collapse: collapse;"><tbody><tr><td style="width: 200px">thisisareallylongsentencewithoutspacesthatcausescontenttooverflow</td><td style="width: 200px"></td></tr></tbody></table>';
+  const percentTableHtml = '<table style="width: 80%; border-collapse: collapse;"><tbody><tr><td style="width: 50%"></td><td style="width: 50%"></td></tr></tbody></table>';
+  const overflowingPercentTableHtml = '<table style="width: 80%; border-collapse: collapse;"><tbody><tr><td style="width: 50%">thisisareallylongsentencewithoutspacesthatcausescontenttooverflow</td><td style="width: 50%"></td></tr></tbody></table>';
+  const noneTableHtml = '<table><tbody><tr><td></td><td></td></tr></tbody></table>';
 
-UnitTest.test('TableSize.getTableSize', () => {
-  const noneTable = SugarElement.fromHtml<HTMLTableElement>(noneTableHtml);
-  const noneSizing = TableSize.getTableSize(noneTable);
-  Assert.eq('None sizing detected', 'none', noneSizing.label);
+  context('getTableSize', () => {
+    it('table with no widths should be detected as none', () => {
+      const noneTable = SugarElement.fromHtml<HTMLTableElement>(noneTableHtml);
+      const noneSizing = TableSize.getTableSize(noneTable);
+      assert.equal(noneSizing.label, 'none', 'None sizing detected');
+    });
 
-  fc.assert(fc.property(fc.integer(100, 1000), fc.float(1, 100), (pixel, percent) => {
-    const pixelTable = SugarElement.fromHtml<HTMLTableElement>(pixelTableHtml.replace('400px', pixel + 'px'));
-    const percentageTable = SugarElement.fromHtml<HTMLTableElement>(percentTableHtml.replace('80%', percent + '%'));
+    it('tables with widths should be detected as percent or pixel', () => {
+      fc.assert(fc.property(fc.integer(100, 1000), fc.float(1, 100), (pixel, percent) => {
+        const pixelTable = SugarElement.fromHtml<HTMLTableElement>(pixelTableHtml.replace('400px', pixel + 'px'));
+        const percentageTable = SugarElement.fromHtml<HTMLTableElement>(percentTableHtml.replace('80%', percent + '%'));
 
-    const pixelSizing = TableSize.getTableSize(pixelTable);
-    const percentageSizing = TableSize.getTableSize(percentageTable);
+        const pixelSizing = TableSize.getTableSize(pixelTable);
+        const percentageSizing = TableSize.getTableSize(percentageTable);
 
-    Assert.eq('Pixel sizing detected', 'pixel', pixelSizing.label);
-    Assert.eq('Percentage sizing detected', 'percent', percentageSizing.label);
-  }));
-});
+        assert.equal(pixelSizing.label, 'pixel', 'Pixel sizing detected');
+        assert.equal(percentageSizing.label, 'percent', 'Percentage sizing detected');
+      }));
+    });
+  });
 
-UnitTest.test('TableSize.pixelSizing', () => {
-  const table = SugarElement.fromHtml<HTMLTableElement>(pixelTableHtml);
-  Insert.append(SugarBody.body(), table);
+  context('pixelSize', () => {
+    it('content box sizing should return pixel based widths that exclude borders in table sizes', () => {
+      const style = SugarElement.fromHtml<HTMLStyleElement>('<style>table, tr, td { box-sizing: content-box; }</style>');
+      const table = SugarElement.fromHtml<HTMLTableElement>(pixelTableHtml);
+      InsertAll.append(SugarBody.body(), [ style, table ]);
 
-  const sizing = TableSize.getTableSize(table);
-  const warehouse = Warehouse.fromTable(table);
+      const sizing = TableSize.getTableSize(table);
+      const warehouse = Warehouse.fromTable(table);
 
-  Assert.eq('Width should be 400px', 400, sizing.width());
-  Assert.eq('Pixel width should be 400px', 400, sizing.pixelWidth());
-  Assert.eq('Cell widths should be 200px each', [ 200, 200 ], sizing.getWidths(warehouse, sizing));
-  Assert.eq('Cell min width should be at least 10px', true, sizing.minCellWidth() >= 10);
+      assert.equal(sizing.width(), 400, 'Width should be 400px');
+      assert.equal(sizing.pixelWidth(), 400, 'Pixel width should be 400px');
+      assert.deepEqual(sizing.getWidths(warehouse, sizing), [ 198, 198 ], 'Cell widths should be 198px each');
+      assert.isAtLeast(sizing.minCellWidth(), 10, 'Cell min width should be at least 10px');
 
-  fc.assert(fc.property(fc.integer(-390, 390), fc.integer(400, 1000), (delta, colWidth) => {
-    Assert.eq('Cell delta should be identity', delta, sizing.getCellDelta(delta));
-    Assert.eq('Single column delta width should be the delta', [ delta ], sizing.singleColumnWidth(colWidth, delta));
-  }));
+      fc.assert(fc.property(fc.integer(-390, 390), fc.integer(400, 1000), (delta, colWidth) => {
+        assert.equal(sizing.getCellDelta(delta), delta, 'Cell delta should be identity');
+        assert.deepEqual(sizing.singleColumnWidth(colWidth, delta), [ delta ], 'Single column delta width should be the delta');
+      }));
 
-  sizing.adjustTableWidth(-200);
-  Assert.eq('Table raw width after resizing is 200px', Optional.some('200px'), Css.getRaw(table, 'width'), tOptional());
-  Assert.eq('Table width after resizing is 200px', 200, sizing.width());
-  Assert.eq('Table pixel width after resizing is 200px', 200, sizing.pixelWidth());
+      sizing.adjustTableWidth(-200);
+      Assert.eq('Table raw width after resizing is 200px', Optional.some('200px'), Css.getRaw(table, 'width'), tOptional());
+      assert.equal(sizing.width(), 200, 'Table width after resizing is 200px');
+      assert.equal(sizing.pixelWidth(), 200, 'Table pixel width after resizing is 200px');
 
-  const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
-  sizing.setElementWidth(cell, 50);
-  Assert.eq('Cell width after resizing is 50px', Optional.some('50px'), Css.getRaw(cell, 'width'), tOptional());
+      const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
+      sizing.setElementWidth(cell, 50);
+      Assert.eq('Cell width after resizing is 50px', Optional.some('50px'), Css.getRaw(cell, 'width'), tOptional());
 
-  Remove.remove(table);
-});
+      Remove.remove(table);
+      Remove.remove(style);
+    });
 
-UnitTest.test('TableSize.percentageSizing', () => {
-  const container = SugarElement.fromHtml('<div style="position: absolute; left: 0; top: 0; width: 500px"></div>');
-  const table = SugarElement.fromHtml<HTMLTableElement>(percentTableHtml);
-  Insert.append(container, table);
-  Insert.append(SugarBody.body(), container);
+    it('border box should return pixel based widths that include borders in table sizes', () => {
+      const style = SugarElement.fromHtml<HTMLStyleElement>('<style>table, tr, td { box-sizing: border-box; }</style>');
+      const table = SugarElement.fromHtml<HTMLTableElement>(pixelTableHtml);
+      InsertAll.append(SugarBody.body(), [ style, table ]);
 
-  const sizing = TableSize.getTableSize(table);
-  const warehouse = Warehouse.fromTable(table);
+      const sizing = TableSize.getTableSize(table);
+      const warehouse = Warehouse.fromTable(table);
 
-  Assert.eq('Width should be 80', 80, sizing.width());
-  Assert.eq('Pixel width should be 400px', 400, sizing.pixelWidth());
-  Assert.eq('Cell widths should be 50% each', [ 50, 50 ], sizing.getWidths(warehouse, sizing));
-  Assert.eq('Cell min width should be at least 10px in percentage (2.5%)', true, sizing.minCellWidth() >= 2.5);
+      assert.equal(sizing.width(), 400, 'Width should be 400px');
+      assert.equal(sizing.pixelWidth(), 400, 'Pixel width should be 400px');
+      assert.deepEqual(sizing.getWidths(warehouse, sizing), [ 200, 200 ], 'Cell widths should be 200px each');
+      assert.isAtLeast(sizing.minCellWidth(), 10, 'Cell min width should be at least 10px');
 
-  fc.assert(fc.property(fc.integer(-390, 390), fc.nat(100), (delta, colWidth) => {
-    const deltaPercent = delta / 400 * 100;
-    Assert.eq('Cell delta should be the same, but in percentage', deltaPercent, sizing.getCellDelta(delta));
-    Assert.eq('Single column delta width should be 100% - percentage width', [ 100 - colWidth ], sizing.singleColumnWidth(colWidth, delta));
-  }));
+      fc.assert(fc.property(fc.integer(-390, 390), fc.integer(400, 1000), (delta, colWidth) => {
+        assert.equal(sizing.getCellDelta(delta), delta, 'Cell delta should be identity');
+        assert.deepEqual(sizing.singleColumnWidth(colWidth, delta), [ delta ], 'Single column delta width should be the delta');
+      }));
 
-  sizing.adjustTableWidth(-25);
-  Assert.eq('Table raw width after resizing is 25% less of the original 80%', Optional.some('60%'), Css.getRaw(table, 'width'), tOptional());
-  Assert.eq('Table width after resizing is 60%', 60, sizing.width());
-  Assert.eq('Table pixel width after resizing is 300px', 300, sizing.pixelWidth());
+      sizing.adjustTableWidth(-200);
+      Assert.eq('Table raw width after resizing is 200px', Optional.some('200px'), Css.getRaw(table, 'width'), tOptional());
+      assert.equal(sizing.width(), 200, 'Table width after resizing is 200px');
+      assert.equal(sizing.pixelWidth(), 200, 'Table pixel width after resizing is 200px');
 
-  const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
-  sizing.setElementWidth(cell, 25);
-  Assert.eq('Cell width after resizing is 25%', Optional.some('25%'), Css.getRaw(cell, 'width'), tOptional());
+      const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
+      sizing.setElementWidth(cell, 50);
+      Assert.eq('Cell width after resizing is 50px', Optional.some('50px'), Css.getRaw(cell, 'width'), tOptional());
 
-  Remove.remove(container);
-});
+      Remove.remove(table);
+      Remove.remove(style);
+    });
 
-UnitTest.test('TableSize.noneSizing', () => {
-  const table = SugarElement.fromHtml<HTMLTableElement>(noneTableHtml);
-  Insert.append(SugarBody.body(), table);
+    it('TINY-7731: returned widths should use the actual width, not the specified widths', () => {
+      const table = SugarElement.fromHtml<HTMLTableElement>(overflowingPixelTableHtml);
+      Insert.append(SugarBody.body(), table);
 
-  const sizing = TableSize.getTableSize(table);
-  const warehouse = Warehouse.fromTable(table);
-  const width = Width.get(table);
-  const cellWidth = SelectorFind.descendant<HTMLTableCellElement>(table, 'td')
-    .map((cell) => parseInt(Css.get(cell, 'width'), 10))
-    .getOrDie();
+      const sizing = TableSize.getTableSize(table);
+      const warehouse = Warehouse.fromTable(table);
 
-  Assert.eq('Width should be the computed size of the table', width, sizing.width());
-  Assert.eq('Pixel width should be the computed size of the table', width, sizing.pixelWidth());
-  Assert.eq('Cell widths should be the computed size of the cell', [ cellWidth, cellWidth ], sizing.getWidths(warehouse, sizing));
-  Assert.eq('Cell min width should be 0px', 0, sizing.minCellWidth());
+      assert.approximately(sizing.width(), 487, 1, 'Width should be ~487px');
+      assert.approximately(sizing.pixelWidth(), 487, 1, 'Pixel width should be ~487px');
 
-  fc.assert(fc.property(fc.integer(-390, 390), fc.integer(400, 1000), (delta, colWidth) => {
-    Assert.eq('Cell delta should be 0', 0, sizing.getCellDelta(delta));
-    Assert.eq('Single column delta width should be 0', [ 0 ], sizing.singleColumnWidth(colWidth, delta));
-  }));
+      const columnSizes = sizing.getWidths(warehouse, sizing);
+      assert.approximately(columnSizes[0], 483, 1, 'First column should be the entire size of the table, minus borders');
+      assert.approximately(columnSizes[1], 0, 1, 'Second column should be 0 as there is no room for it to render');
 
-  sizing.adjustTableWidth(-20);
-  Assert.eq('Table raw width after resizing is unchanged', Optional.none<string>(), Css.getRaw(table, 'width'), tOptional());
-  Assert.eq('Table width after resizing is unchanged', width, sizing.width());
-  Assert.eq('Table pixel width after resizing is unchanged', width, sizing.pixelWidth());
+      Remove.remove(table);
+    });
+  });
 
-  const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
-  sizing.setElementWidth(cell, 20);
-  Assert.eq('Cell width after resizing is unchanged', Optional.none<string>(), Css.getRaw(cell, 'width'), tOptional());
+  context('percentageSize', () => {
+    it('should return percentage based widths in table sizes', () => {
+      const container = SugarElement.fromHtml('<div style="position: absolute; left: 0; top: 0; width: 500px"></div>');
+      const table = SugarElement.fromHtml<HTMLTableElement>(percentTableHtml);
+      Insert.append(container, table);
+      Insert.append(SugarBody.body(), container);
 
-  Remove.remove(table);
+      const sizing = TableSize.getTableSize(table);
+      const warehouse = Warehouse.fromTable(table);
+
+      assert.equal(sizing.width(), 80, 'Width should be 80');
+      assert.equal(sizing.pixelWidth(), 400, 'Pixel width should be 400px');
+      assert.deepEqual(sizing.getWidths(warehouse, sizing), [ 50, 50 ], 'Cell widths should be 50% each');
+      assert.equal(sizing.minCellWidth() >= 2.5, true, 'Cell min width should be at least 10px in percentage (2.5%)');
+
+      fc.assert(fc.property(fc.integer(-390, 390), fc.nat(100), (delta, colWidth) => {
+        const deltaPercent = delta / 400 * 100;
+        assert.equal(sizing.getCellDelta(delta), deltaPercent, 'Cell delta should be the same, but in percentage');
+        assert.deepEqual(sizing.singleColumnWidth(colWidth, delta), [ 100 - colWidth ], 'Single column delta width should be 100% - percentage width');
+      }));
+
+      sizing.adjustTableWidth(-25);
+      Assert.eq('Table raw width after resizing is 25% less of the original 80%', Optional.some('60%'), Css.getRaw(table, 'width'), tOptional());
+      assert.equal(sizing.width(), 60, 'Table width after resizing is 60%');
+      assert.equal(sizing.pixelWidth(), 300, 'Table pixel width after resizing is 300px');
+
+      const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
+      sizing.setElementWidth(cell, 25);
+      Assert.eq('Cell width after resizing is 25%', Optional.some('25%'), Css.getRaw(cell, 'width'), tOptional());
+
+      Remove.remove(container);
+    });
+
+    it('TINY-7731: returned widths should use the actual width, not the specified widths', () => {
+      const container = SugarElement.fromHtml('<div style="position: absolute; left: 0; top: 0; width: 500px"></div>');
+      const table = SugarElement.fromHtml<HTMLTableElement>(overflowingPercentTableHtml);
+      Insert.append(container, table);
+      Insert.append(SugarBody.body(), container);
+
+      const sizing = TableSize.getTableSize(table);
+      const warehouse = Warehouse.fromTable(table);
+
+      assert.approximately(sizing.width(), 97.4, 0.5, 'Width should be ~97.4%');
+      assert.approximately(sizing.pixelWidth(), 487, 1, 'Pixel width should be ~487px');
+
+      const columnSizes = sizing.getWidths(warehouse, sizing);
+      assert.approximately(columnSizes[0], 99.5, 0.5, 'First column should be the entire size of the table, minus borders');
+      assert.approximately(columnSizes[1], 0, 0.5, 'Second column should be 0 as there is no room for it to render');
+
+      Remove.remove(container);
+    });
+  });
+
+  context('noneSize', () => {
+    it('should return 0 or the actual widths for table sizes', () => {
+      const table = SugarElement.fromHtml<HTMLTableElement>(noneTableHtml);
+      Insert.append(SugarBody.body(), table);
+
+      const sizing = TableSize.getTableSize(table);
+      const warehouse = Warehouse.fromTable(table);
+      const width = Width.get(table);
+      const cellWidth = SelectorFind.descendant<HTMLTableCellElement>(table, 'td')
+        .map((cell) => parseInt(Css.get(cell, 'width'), 10))
+        .getOrDie();
+
+      assert.equal(sizing.width(), width, 'Width should be the computed size of the table');
+      assert.equal(sizing.pixelWidth(), width, 'Pixel width should be the computed size of the table');
+      assert.deepEqual(sizing.getWidths(warehouse, sizing), [ cellWidth, cellWidth ], 'Cell widths should be the computed size of the cell');
+      assert.equal(sizing.minCellWidth(), 0, 'Cell min width should be 0px');
+
+      fc.assert(fc.property(fc.integer(-390, 390), fc.integer(400, 1000), (delta, colWidth) => {
+        assert.equal(sizing.getCellDelta(delta), 0, 'Cell delta should be 0');
+        assert.deepEqual(sizing.singleColumnWidth(colWidth, delta), [ 0 ], 'Single column delta width should be 0');
+      }));
+
+      sizing.adjustTableWidth(-20);
+      Assert.eq('Table raw width after resizing is unchanged', Optional.none<string>(), Css.getRaw(table, 'width'), tOptional());
+      assert.equal(sizing.width(), width, 'Table width after resizing is unchanged');
+      assert.equal(sizing.pixelWidth(), width, 'Table pixel width after resizing is unchanged');
+
+      const cell = SelectorFind.descendant<HTMLTableCellElement>(table, 'td').getOrDie();
+      sizing.setElementWidth(cell, 20);
+      Assert.eq('Cell width after resizing is unchanged', Optional.none<string>(), Css.getRaw(cell, 'width'), tOptional());
+
+      Remove.remove(table);
+    });
+  });
 });

--- a/modules/snooker/src/test/ts/browser/TableSizesTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableSizesTest.ts
@@ -3,7 +3,6 @@ import { Arr, Optional } from '@ephox/katamari';
 import { Css, Html, Insert, InsertAll, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 import * as Sizes from 'ephox/snooker/api/Sizes';
-import { TableSize } from 'ephox/snooker/api/TableSize';
 
 import { addStyles, readHeight, readWidth } from '../module/ephox/snooker/test/SizeUtils';
 
@@ -108,7 +107,7 @@ UnitTest.test('Table Sizes Test (fusebox)', () => {
 
   const checkWidth = (expected: string[][], table: SugarElement, newWidth: string) => {
     Insert.append(SugarBody.body(), table);
-    Sizes.redistribute(table, Optional.some(newWidth), Optional.none(), TableSize.getTableSize(table));
+    Sizes.redistribute(table, Optional.some(newWidth), Optional.none());
     assert.eq(expected, readWidth(table));
     Remove.remove(table);
   };
@@ -120,7 +119,7 @@ UnitTest.test('Table Sizes Test (fusebox)', () => {
 
   const checkHeight = (expected: string[][], table: SugarElement, newHeight: string) => {
     Insert.append(SugarBody.body(), table);
-    Sizes.redistribute(table, Optional.none(), Optional.some(newHeight), TableSize.getTableSize(table));
+    Sizes.redistribute(table, Optional.none(), Optional.some(newHeight));
     assert.eq(expected, readHeight(table));
     Remove.remove(table);
   };

--- a/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
+++ b/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
@@ -1,6 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { PlatformDetection } from '@ephox/sand';
 import { Css, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 
 import { TableSize } from 'ephox/snooker/api/TableSize';
@@ -18,8 +17,6 @@ const pixelTableMissingWidthsHtml = `<table style="width: 400px; border-collapse
 </table>`;
 const tableWithSpansHtml = '<table style="width: 400px; border-collapse: collapse"><tbody><tr><td style="width: 400px;" colspan="2">A</td></tr></tbody></table>';
 const noneTableWithColsHtml = '<table><colgroup><col><col></colgroup><tbody><tr><td>A</td><td>A</td></tr></tbody></table>';
-const browser = PlatformDetection.detect().browser;
-const isChrome92 = browser.isChrome() && browser.version.major >= 92;
 
 UnitTest.test('ColumnSizes.getPixelWidths', () => {
   const sTest = (label: string, html: string, getExpectedWidths: (cellWidth: number) => number[]) => {
@@ -39,16 +36,11 @@ UnitTest.test('ColumnSizes.getPixelWidths', () => {
     Remove.remove(table);
   };
 
-  sTest('Pixel Table - Column widths should be the raw size of the cell', pixelTableHtml, () => [ 200, 200 ]);
-  sTest('Pixel Table - Column widths with missing widths on some cells should be the raw size of the cell', pixelTableMissingWidthsHtml, () => [ 200, 200 ]);
+  sTest('Pixel Table - Column widths should be the raw size of the cell', pixelTableHtml, () => [ 198, 198 ]);
+  sTest('Pixel Table - Column widths with missing widths on some cells should be the raw size of the cell', pixelTableMissingWidthsHtml, () => [ 198, 198 ]);
   sTest('Pixel Table - Column width should be the size of the table when using colspans', tableWithSpansHtml, () => [ 0, 400 ]);
   sTest('None Table - Column widths should be the computed size of the cell', noneTableHtml, (width) => [ width, width ]);
-  if (isChrome92) {
-    // TODO: Remove this once the cell width bug introduced in Chrome 92 is fixed (see TINY-7758 for more details)
-    sTest('None Table - Column widths for cols should be the computed size of the cell', noneTableWithColsHtml, (width) => [ width + 2, width + 1 ]);
-  } else {
-    sTest('None Table - Column widths for cols should be the computed size of the cell', noneTableWithColsHtml, (width) => [ width + 2, width + 2 ]); // Add 2 to account for the borders
-  }
+  sTest('None Table - Column widths for cols should be the computed size of the cell', noneTableWithColsHtml, (width) => [ width + 2, width + 2 ]); // Add 2 to account for the borders
 });
 
 UnitTest.test('ColumnSizes.getPixelHeights', () => {

--- a/modules/sugar/CHANGELOG.md
+++ b/modules/sugar/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added new `parentElement` function to the `Traverse` API.
+
 ## 8.0.0 - 2021-08-26
 
 ### Added

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
@@ -36,6 +36,10 @@ const parent = (element: SugarElement<Node>): Optional<SugarElement<Node & Paren
 const parentNode = (element: SugarElement<Node>): Optional<SugarElement<Node>> =>
   parent(element) as any;
 
+// Note: This requires an Element since IE 11 doesn't support using `parentElement` on a `Node`
+const parentElement = (element: SugarElement<Element>): Optional<SugarElement<HTMLElement>> =>
+  Optional.from(element.dom.parentElement).map(SugarElement.fromDom);
+
 const findIndex = (element: SugarElement<Node>): Optional<number> =>
   parent(element).bind((p) => {
     // TODO: Refactor out children so we can avoid the constant unwrapping
@@ -129,6 +133,7 @@ export {
   documentElement,
   parent,
   parentNode,
+  parentElement,
   findIndex,
   parents,
   siblings,

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Resizing table columns in some scenarios would resize the column to an incorrect position #TINY-7731
+
 ## 5.9.1 - 2021-08-27
 
 ### Fixed

--- a/modules/tinymce/src/plugins/table/main/ts/actions/EnforceUnit.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/EnforceUnit.ts
@@ -9,20 +9,8 @@ import { Arr } from '@ephox/katamari';
 import { TableConversions, TableLookup, Warehouse } from '@ephox/snooker';
 import { Attribute, Css, SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-
-import * as TableSize from '../queries/TableSize';
-
-const enforcePercentage = (editor: Editor, table: SugarElement<HTMLTableElement>): void => {
-  const tableSizing = TableSize.get(editor, table);
-  TableConversions.convertToPercentSize(table, tableSizing);
-};
-
-const enforcePixels = (editor: Editor, table: SugarElement<HTMLTableElement>): void => {
-  const tableSizing = TableSize.get(editor, table);
-  TableConversions.convertToPixelSize(table, tableSizing);
-};
-
+const enforcePercentage = TableConversions.convertToPercentSize;
+const enforcePixels = TableConversions.convertToPixelSize;
 const enforceNone = TableConversions.convertToNoneSize;
 
 const syncPixels = (table: SugarElement<HTMLTableElement>): void => {

--- a/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/InsertTable.ts
@@ -59,11 +59,11 @@ const insert = (editor: Editor, columns: number, rows: number, colHeaders: numbe
   // Enforce the sizing mode of the table
   return SelectorFind.descendant<HTMLTableElement>(Util.getBody(editor), 'table[data-mce-id="__mce"]').map((table) => {
     if (isPixelsForced(editor)) {
-      enforcePixels(editor, table);
+      enforcePixels(table);
     } else if (isResponsiveForced(editor)) {
       enforceNone(table);
     } else if (isPercentagesForced(editor) || isPercentage(defaultStyles.width)) {
-      enforcePercentage(editor, table);
+      enforcePercentage(table);
     }
     Util.removeDataStyle(table);
     Attribute.remove(table, 'data-mce-id');

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -60,7 +60,7 @@ export const getResizeHandler = (editor: Editor): ResizeHandler => {
     // Responsive tables don't have a width so we need to convert it to a relative/percent
     // table instead, as that's closer to responsive sizing than fixed sizing
     if (startRawW === '') {
-      enforcePercentage(editor, table);
+      enforcePercentage(table);
     }
 
     // Adjust the column sizes and update the table width to use the right sizing, if the table changed size.
@@ -145,15 +145,15 @@ export const getResizeHandler = (editor: Editor): ResizeHandler => {
       });
 
       if (!Sizes.isPixelSizing(table) && Settings.isPixelsForced(editor)) {
-        enforcePixels(editor, table);
+        enforcePixels(table);
       } else if (!Sizes.isPercentSizing(table) && Settings.isPercentagesForced(editor)) {
-        enforcePercentage(editor, table);
+        enforcePercentage(table);
       }
 
       // TINY-6601: If resizing using a bar, then snooker will base the resizing on the initial size. So
       // when using a responsive table we need to ensure we convert to a relative table before resizing
       if (Sizes.isNoneSizing(table) && Strings.startsWith(e.origin, barResizerPrefix)) {
-        enforcePercentage(editor, table);
+        enforcePercentage(table);
       }
 
       startW = e.width;

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -62,9 +62,9 @@ const registerCommands = (editor: Editor, actions: TableActions, cellSelection: 
     if (!isForcedSizing) {
       TableLookup.table(cellOrCaption, isRoot).each((table) => {
         if (sizing === 'relative' && !Sizes.isPercentSizing(table)) {
-          enforcePercentage(editor, table);
+          enforcePercentage(table);
         } else if (sizing === 'fixed' && !Sizes.isPixelSizing(table)) {
-          enforcePixels(editor, table);
+          enforcePixels(table);
         } else if (sizing === 'responsive' && !Sizes.isNoneSizing(table)) {
           enforceNone(table);
         }

--- a/modules/tinymce/src/plugins/table/main/ts/queries/TableSize.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/TableSize.ts
@@ -5,24 +5,20 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Sizes, TableSize } from '@ephox/snooker';
-import { SugarElement, Width } from '@ephox/sugar';
+import { TableSize } from '@ephox/snooker';
+import { SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
 import { isPercentagesForced, isPixelsForced } from '../api/Settings';
-import * as Util from '../core/Util';
 
 export const get = (editor: Editor, table: SugarElement<HTMLTableElement>): TableSize => {
   // Note: We can't enforce none (responsive), as if someone manually resizes a table
   // then it must switch to either pixel (fixed) or percentage (relative) sizing
   if (isPercentagesForced(editor)) {
-    const width = Util.getRawWidth(editor, table.dom)
-      .filter(Util.isPercentage)
-      .getOrThunk(() => Sizes.getPercentTableWidth(table));
-    return TableSize.percentageSize(width, table);
+    return TableSize.percentageSize(table);
   } else if (isPixelsForced(editor)) {
-    return TableSize.pixelSize(Width.get(table), table);
+    return TableSize.pixelSize(table);
   } else {
     // Detect based on the table width
     return TableSize.getTableSize(table);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
@@ -611,7 +611,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
       it('TINY-6711: should resize table when inserting multiple columns', () => {
         const editor = hook.editor();
         const content = (`
-          <table width: 33.3433%; border="1">
+          <table style="width: 33.3433%;" border="1">
             <tbody>
               <tr>
                 <td data-mce-selected="1" data-mce-first-selected="1" style="width: 47.0386%;"></td>

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
@@ -155,12 +155,12 @@ describe('browser.tinymce.plugins.table.command.MergeCellCommandTest', () => {
       '<table style="width: 25.4582%;">' +
         '<tbody>' +
           '<tr>' +
-            '<td style="width: 42.7414%;" data-mce-selected="1" data-mce-first-selected="1"></td>' +
-            '<td style="width: 51.8049%;" data-mce-selected="1" data-mce-last-selected="1"></td>' +
+            '<td style="width: 44.9721%;" data-mce-selected="1" data-mce-first-selected="1"></td>' +
+            '<td style="width: 54.7486%;" data-mce-selected="1" data-mce-last-selected="1"></td>' +
           '</tr>' +
           '<tr>' +
-            '<td style="width: 42.7414%;"></td>' +
-            '<td style="width: 51.8049%;"></td>' +
+            '<td style="width: 44.9721%;"></td>' +
+            '<td style="width: 54.7486%;"></td>' +
           '</tr>' +
         '</tbody>' +
       '</table>'
@@ -173,7 +173,7 @@ describe('browser.tinymce.plugins.table.command.MergeCellCommandTest', () => {
     editor.selection.collapse(true);
     editor.execCommand('mceTableMergeCells');
     const colspan = SelectorFind.descendant(TinyDom.body(editor), 'td[colspan="2"]').getOrDie();
-    assert.closeTo(getWidth(colspan), totalColsWidth, 2, 'Check new cell is similar width the the two cells that were merged');
+    assert.approximately(getWidth(colspan), totalColsWidth, 2, 'Check new cell is similar width the the two cells that were merged');
   });
 
   /*

--- a/versions.txt
+++ b/versions.txt
@@ -1,3 +1,5 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 
+snooker@10.0.0
+sugar@8.1.0


### PR DESCRIPTION
Related Ticket: TINY-7731

Description of Changes:
* Update snooker width lookups to always use the actual width instead of the specified width where possible (table and cell widths/heights).
  * This is the core of the fix, as the root issue is that we always used the raw widths which may not have been accurate if the content caused the cell to grow.
* Use the `col` element offset width where safe to do so.
* Converted a number of tests to use BDD style tests.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
