### PR TITLE
TINY-7956: Fixed an exception getting thrown when disabling events and setting content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed an exception getting thrown when disabling events and setting content #TINY-7956
+
 ## 5.9.1 - 2021-08-27
 
 ### Fixed

--- a/modules/tinymce/src/core/main/ts/content/GetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/GetContentImpl.ts
@@ -23,13 +23,16 @@ const trimEmptyContents = (editor: Editor, html: string): string => {
   return html.replace(emptyRegExp, '');
 };
 
+const setupArgs = (args: Partial<GetContentArgs>, format: ContentFormat): GetContentArgs => ({
+  ...args,
+  format,
+  get: true,
+  getInner: true
+});
+
 const getContentFromBody = (editor: Editor, args: GetContentArgs, format: ContentFormat, body: HTMLElement): Content => {
-  const updatedArgs = args.no_events ? args : editor.fire('BeforeGetContent', {
-    ...args,
-    format,
-    get: true,
-    getInner: true
-  });
+  const defaultedArgs = setupArgs(args, format);
+  const updatedArgs = args.no_events ? defaultedArgs : editor.fire('BeforeGetContent', defaultedArgs);
 
   let content: string;
   if (updatedArgs.format === 'raw') {

--- a/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
@@ -105,13 +105,16 @@ const setContentTree = (editor: Editor, body: HTMLElement, content: AstNode, arg
   return content;
 };
 
+const setupArgs = (args: Partial<SetContentArgs>, content: Content): SetContentArgs => ({
+  format: defaultFormat,
+  ...args,
+  set: true,
+  content: isTreeNode(content) ? '' : content
+});
+
 export const setContentInternal = (editor: Editor, content: Content, args: SetContentArgs): Content => {
-  const updatedArgs = args.no_events ? args : editor.fire('BeforeSetContent', {
-    format: defaultFormat,
-    ...args,
-    set: true,
-    content: isTreeNode(content) ? '' : content
-  });
+  const defaultedArgs = setupArgs(args, content);
+  const updatedArgs = args.no_events ? defaultedArgs : editor.fire('BeforeSetContent', defaultedArgs);
 
   if (!isTreeNode(content)) {
     content = updatedArgs.content;

--- a/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
@@ -86,13 +86,16 @@ const getSerializedContent = (editor: Editor, args: GetSelectionContentArgs): Co
   return editor.selection.serializer.serialize(tmpElm, args);
 };
 
+const setupArgs = (args: Partial<GetSelectionContentArgs>, format: ContentFormat): GetSelectionContentArgs => ({
+  ...args,
+  format,
+  get: true,
+  selection: true
+});
+
 export const getSelectedContentInternal = (editor: Editor, format: ContentFormat, args: GetSelectionContentArgs = {}): Content => {
-  const updatedArgs = editor.fire('BeforeGetContent', {
-    ...args,
-    format,
-    get: true,
-    selection: true
-  });
+  const defaultedArgs = setupArgs(args, format);
+  const updatedArgs = editor.fire('BeforeGetContent', defaultedArgs);
 
   if (updatedArgs.isDefaultPrevented()) {
     editor.fire('GetContent', updatedArgs);

--- a/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
@@ -113,11 +113,11 @@ const cleanContent = (editor: Editor, args: SelectionSetContentArgs) => {
 };
 
 const setContent = (editor: Editor, content: string, args: SelectionSetContentArgs = {}) => {
-  const contentArgs = setupArgs(args, content);
+  const defaultedArgs = setupArgs(args, content);
 
-  let updatedArgs = contentArgs;
-  if (!contentArgs.no_events) {
-    const eventArgs = editor.fire('BeforeSetContent', contentArgs);
+  let updatedArgs = defaultedArgs;
+  if (!defaultedArgs.no_events) {
+    const eventArgs = editor.fire('BeforeSetContent', defaultedArgs);
     if (eventArgs.isDefaultPrevented()) {
       editor.fire('SetContent', eventArgs);
       return;

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -180,4 +180,19 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       'getcontent'
     ]);
   });
+
+  it('TINY-7956: Get content without firing events', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>html</p>');
+    clearEvents();
+    const html = editor.getContent({ no_events: true });
+    Assertions.assertHtml('Should be expected html', '<p>html</p>', html);
+    assertEventsFiredInOrder([]);
+  });
+
+  it('TINY-7956: Set content without firing events', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>html</p>', { no_events: true });
+    assertEventsFiredInOrder([]);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7956

Description of Changes:

Fixes an issue where the default args weren't set if `no_events: true` was passed in the get/set content APIs. This in turn also caused an exception since when setting the content the `content` variable ended up being `undefined`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes https://github.com/tinymce/tinymce-react/issues/283
