### PR TITLE
TINY-7957: Fixed McAgar setting up modules before TinyMCE was available in TinyHooks

### DIFF
--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 7.0.2 - 2021-09-08
+
+### Fixed
+- `TinyHooks` setup modules were incorrectly executed before TinyMCE was loaded #TINY-7957
+
 ## 7.0.0 - 2021-08-26
 
 ### Added

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyHooks.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyHooks.ts
@@ -35,10 +35,12 @@ const setupHooks = <T extends EditorType = EditorType>(
   before(function (done) {
     // TINY-7039: Double the timeout as sometimes 2s wasn't enough for more complex editor loads
     this.timeout(4000);
-    Arr.each(setupModules, Fun.call);
     setup = setupElement();
     Loader.setup({
-      preInit: setupTinymceBaseUrl,
+      preInit: (tinymce, settings) => {
+        setupTinymceBaseUrl(tinymce, settings);
+        Arr.each(setupModules, Fun.call);
+      },
       run: (ed, success) => {
         lazyEditor = Fun.constant(ed);
         teardownEditor = success;

--- a/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/Plugin.ts
@@ -38,7 +38,7 @@ const Plugin = (editor: Editor): Api => {
 
   Commands.registerCommands(editor, actions, cellSelection, selections, clipboard);
   QueryCommands.registerQueryCommands(editor, actions, selections);
-  Clipboard.registerEvents(editor, selections, actions, cellSelection);
+  Clipboard.registerEvents(editor, selections, actions);
 
   MenuItems.addMenuItems(editor, selections, selectionTargets, clipboard);
   Buttons.addButtons(editor, selections, selectionTargets, clipboard);

--- a/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/Clipboard.ts
@@ -14,7 +14,6 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Util from '../core/Util';
 import * as TableTargets from '../queries/TableTargets';
-import { CellSelectionApi } from '../selection/CellSelection';
 import * as Ephemera from '../selection/Ephemera';
 import * as TableSelection from '../selection/TableSelection';
 import { TableActions } from './TableActions';
@@ -36,7 +35,7 @@ const serializeElements = (editor: Editor, elements: SugarElement[]): string =>
 const getTextContent = (elements: SugarElement[]): string =>
   Arr.map(elements, (element) => element.dom.innerText).join('');
 
-const registerEvents = (editor: Editor, selections: Selections, actions: TableActions, cellSelection: CellSelectionApi): void => {
+const registerEvents = (editor: Editor, selections: Selections, actions: TableActions): void => {
   editor.on('BeforeGetContent', (e) => {
     const multiCellContext = (cells: SugarElement<HTMLTableCellElement>[]) => {
       e.preventDefault();


### PR DESCRIPTION
Related Ticket: TINY-7957

Description of Changes:
* Fixes the module setup logic running before TinyMCE was available.
* Fixes an unused argument that was missed in https://github.com/tinymce/tinymce/pull/7162 and ESLint was printing warnings about.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ Unfortunately we don't have any tests for this atm
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
