### PR TITLE
TINY-7062: Fix editor sometimes scrolling when clicking beside non-editable element

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Image resize backdrop element did not have `data-mce-bogus="all"` set #TINY-7854
+- Clicking beside a non-editable element could cause the editor to incorrectly scroll to the top of the document #TINY-7062
 
 ## 5.9.2 - 2021-09-08
 

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -214,8 +214,9 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
           if (!hasBetterMouseTarget(targetElm, fakeCaretInfo.node)) {
             e.preventDefault();
             const range = showCaret(1, fakeCaretInfo.node as HTMLElement, fakeCaretInfo.before, false);
-            editor.getBody().focus();
             setRange(range);
+            // Set the focus after the range has been set to avoid potential issues where the body has no selection
+            editor.getBody().focus();
           }
         }
       }

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -29,18 +29,20 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
     assert.equal(selectedNode.getAttribute('data-mce-caret'), caretValue);
   };
 
-  const selectBesideContentEditable = (editor: Editor, contentEditableElm: HTMLElement, clickBefore: boolean) => {
+  const selectBesideContentEditable = (editor: Editor, contentEditableElm: HTMLElement, clickPoint: 'before' | 'after') => {
     editor.selection.scrollIntoView(contentEditableElm);
 
     const scrollTop = getScrollTop(editor);
-    const bodyPaddingOffset = 8; // Default is 16 so divide by 2
+    const bodyMarginOffset = 8; // Default is 16 so divide by 2
     const rect = contentEditableElm.getBoundingClientRect();
-    const clientX = clickBefore ? rect.left - bodyPaddingOffset : rect.right + bodyPaddingOffset;
+    const clientX = clickPoint === 'before' ? rect.left - bodyMarginOffset : rect.right + bodyMarginOffset;
     const clientY = rect.top + (rect.height / 2);
 
     Mouse.point('mousedown', 0, TinyDom.documentElement(editor), clientX, clientY);
     // Check the scoll position has not changed
     assert.equal(getScrollTop(editor), scrollTop);
+    // Check fake caret has been added
+    assertSelectionIsCaretBlock(editor, clickPoint);
   };
 
   it('click on link in cE=false', () => {
@@ -272,12 +274,9 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
 
     editor.setContent(content);
     TinySelections.setCursor(editor, [ 1, 0, 0 ], 1);
-
     // Click to the left of the ce=false element
     const noneditableDiv = editor.dom.select('div[contenteditable=false]')[0];
-    selectBesideContentEditable(editor, noneditableDiv, true);
-    // Check fake caret has been added before
-    assertSelectionIsCaretBlock(editor, 'before');
+    selectBesideContentEditable(editor, noneditableDiv, 'before');
 
     TinyAssertions.assertContent(editor, content);
   });
@@ -291,9 +290,7 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
 
     // Click to the right of the ce=false element
     const noneditableDiv = editor.dom.select('div[contenteditable=false]')[0];
-    selectBesideContentEditable(editor, noneditableDiv, false);
-    // Check fake caret has been added after
-    assertSelectionIsCaretBlock(editor, 'after');
+    selectBesideContentEditable(editor, noneditableDiv, 'after');
 
     TinyAssertions.assertContent(editor, content);
   });

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -1,10 +1,12 @@
-import { PhantomSkipper } from '@ephox/agar';
+import { Mouse, PhantomSkipper } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyHooks } from '@ephox/wrap-mcagar';
+import { Scroll } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { isCaretContainerBlock } from 'tinymce/core/caret/CaretContainer';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
 import Theme from 'tinymce/themes/silver/Theme';
 
@@ -15,8 +17,31 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
     disable_nodechange: true,
     entities: 'raw',
     indent: false,
+    content_style: 'body { margin: 16px; }',
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme ]);
+
+  const getScrollTop = (editor: Editor) => Scroll.get(TinyDom.document(editor)).top;
+
+  const assertSelectionIsCaretBlock = (editor: Editor, caretValue: 'before' | 'after') => {
+    const selectedNode = editor.selection.getNode();
+    assert.isTrue(isCaretContainerBlock(selectedNode));
+    assert.equal(selectedNode.getAttribute('data-mce-caret'), caretValue);
+  };
+
+  const selectBesideContentEditable = (editor: Editor, contentEditableElm: HTMLElement, clickBefore: boolean) => {
+    editor.selection.scrollIntoView(contentEditableElm);
+
+    const scrollTop = getScrollTop(editor);
+    const bodyPaddingOffset = 8; // Default is 16 so divide by 2
+    const rect = contentEditableElm.getBoundingClientRect();
+    const clientX = clickBefore ? rect.left - bodyPaddingOffset : rect.right + bodyPaddingOffset;
+    const clientY = rect.top + (rect.height / 2);
+
+    Mouse.point('mousedown', 0, TinyDom.documentElement(editor), clientX, clientY);
+    // Check the scoll position has not changed
+    assert.equal(getScrollTop(editor), scrollTop);
+  };
 
   it('click on link in cE=false', () => {
     const editor = hook.editor();
@@ -239,5 +264,37 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
       assert.equal(newRng.endContainer, paraElem, `End container should be before ${elmName}`);
       assert.equal(newRng.endOffset, 0, `End offset should be before ${elmName}`);
     });
+  });
+
+  it('TINY-7062: place cursor in ce=true element, click to left of ce=false parent element', () => {
+    const editor = hook.editor();
+    const content = '<p style="padding-bottom: 2000px;">Normal paragraph with padding</p><div contenteditable="false"><p contenteditable="true">abc</p></div>';
+
+    editor.setContent(content);
+    TinySelections.setCursor(editor, [ 1, 0, 0 ], 1);
+
+    // Click to the left of the ce=false element
+    const noneditableDiv = editor.dom.select('div[contenteditable=false]')[0];
+    selectBesideContentEditable(editor, noneditableDiv, true);
+    // Check fake caret has been added before
+    assertSelectionIsCaretBlock(editor, 'before');
+
+    TinyAssertions.assertContent(editor, content);
+  });
+
+  it('TINY-7062: place cursor in ce=true element, click to right of ce=false parent element', () => {
+    const editor = hook.editor();
+    const content = '<p style="padding-bottom: 2000px;">Normal paragraph with padding</p><div contenteditable="false"><p contenteditable="true">abc</p></div>';
+
+    editor.setContent(content);
+    TinySelections.setCursor(editor, [ 1, 0, 0 ], 1);
+
+    // Click to the right of the ce=false element
+    const noneditableDiv = editor.dom.select('div[contenteditable=false]')[0];
+    selectBesideContentEditable(editor, noneditableDiv, false);
+    // Check fake caret has been added after
+    assertSelectionIsCaretBlock(editor, 'after');
+
+    TinyAssertions.assertContent(editor, content);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -39,7 +39,7 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
     const clientY = rect.top + (rect.height / 2);
 
     Mouse.point('mousedown', 0, TinyDom.documentElement(editor), clientX, clientY);
-    // Check the scoll position has not changed
+    // Check the scroll position has not changed
     assert.equal(getScrollTop(editor), scrollTop);
     // Check fake caret has been added
     assertSelectionIsCaretBlock(editor, clickPoint);


### PR DESCRIPTION
Related Ticket: TINY-7062

Description of Changes:
* Focus body after setting range. Chrome would scroll the editor when calling focus before setting the range when clicking from inside an editable element to beside a non-editable element

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #6456