### PR TITLE
TINY-7873: Disable window.visualViewport in Firefox to fix sticky toolbar bug in fullscreen mode

### DIFF
--- a/modules/oxide/src/less/theme/components/fullscreen/fullscreen.less
+++ b/modules/oxide/src/less/theme/components/fullscreen/fullscreen.less
@@ -14,14 +14,11 @@
 .tox-fullscreen {
   border: 0;
   height: 100%;
-  left: 0;
   margin: 0;
   overflow: hidden;
   // Android disable pull to reload in fullscreen
   overscroll-behavior: none;
   padding: 0;
-  position: fixed;
-  top: 0;
   touch-action: pinch-zoom;
   width: 100%;
 }
@@ -32,6 +29,9 @@
 
 .tox.tox-tinymce.tox-fullscreen {
   background-color: @fullscreen-container-background-color;
+  left: 0;
+  position: fixed;
+  top: 0;
   z-index: @z-index-fullscreen;
 }
 

--- a/modules/sugar/CHANGELOG.md
+++ b/modules/sugar/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added new `parentElement` function to the `Traverse` API.
 
+### Fixed
+- Disabled `window.visualViewport` in Mozilla Firefox as it was returning an incorrect value for `pageTop` when using `position: 'fixed'`.
+
 ## 8.0.0 - 2021-08-26
 
 ### Added

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/WindowVisualViewport.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/WindowVisualViewport.ts
@@ -1,4 +1,5 @@
 import { Fun, Optional } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 
 import { fromRawEvent } from '../../impl/FilteredEvent';
 import { EventHandler, EventUnbinder } from '../events/Types';
@@ -31,8 +32,13 @@ interface WindowVisualViewport {
 
 const get = (_win?: Window): Optional<WindowVisualViewport> => {
   const win = _win === undefined ? window : _win;
-  // eslint-disable-next-line dot-notation
-  return Optional.from((win as any)['visualViewport']);
+  if (PlatformDetection.detect().browser.isFirefox()) {
+    // TINY-7984: Firefox 91 is returning incorrect values for visualViewport.pageTop, so disable it for now
+    return Optional.none();
+  } else {
+    // eslint-disable-next-line dot-notation
+    return Optional.from((win as any)['visualViewport']);
+  }
 };
 
 const bounds = (x: number, y: number, width: number, height: number): Bounds => ({

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Resizing table columns in some scenarios would resize the column to an incorrect position #TINY-7731
 - Image resize backdrop element did not have `data-mce-bogus="all"` set #TINY-7854
+- Disabled `window.visualViewport` in Mozilla Firefox which caused a bug preventing the sticky toolbar from appearing in fullscreen mode #TINY-7873
 
 ## 5.9.2 - 2021-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resizing table columns in some scenarios would resize the column to an incorrect position #TINY-7731
 - Image resize backdrop element did not have `data-mce-bogus="all"` set #TINY-7854
 - Clicking beside a non-editable element could cause the editor to incorrectly scroll to the top of the document #TINY-7062
-- Disabled `window.visualViewport` in Mozilla Firefox which caused a bug preventing the sticky toolbar from appearing in fullscreen mode #TINY-7873
+- As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
 
 ## 5.9.2 - 2021-09-08
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -1,6 +1,5 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { after, before, context, it } from '@ephox/bedrock-client';
-import { PlatformDetection } from '@ephox/sand';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -18,7 +17,6 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
   const isToolbarTop = toolbarLocation === ToolbarLocation.top;
 
   context('Test editor with toolbar_mode: ' + toolbarMode, () => {
-    const browser = PlatformDetection.detect().browser;
     const hook = TinyHooks.bddSetup<Editor>({
       plugins: 'fullscreen',
       base_url: '/project/tinymce/js/tinymce',
@@ -140,11 +138,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
       });
     });
 
-    it('Toggle fullscreen mode and ensure header moves from docked -> undocked -> docked', async function () {
-      // TINY-7873: On Firefox 91 the header/toolbar isn't showing when toggling fullscreen mode, so we need to investigate
-      if (browser.isFirefox() && browser.version.major >= 91) {
-        this.skip();
-      }
+    it('Toggle fullscreen mode and ensure header moves from docked -> undocked -> docked', async () => {
       const editor = hook.editor();
       await StickyUtils.pScrollAndAssertStructure(isToolbarTop, 200, StickyUtils.expectedHalfView);
       editor.execCommand('mceFullscreen');


### PR DESCRIPTION
Related Ticket: TINY-7873

Description of Changes:
* Also rearranges some CSS after a discussion with @lnewson 

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
