### PR TITLE
TINY-7709: Fixed row/column header operations incorrectly converting `th` to `td`

### DIFF
--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `pixelSize` and `percentSize` functions in `TableSize` no longer require the initial width to be provided.
 - `ColumnSizes` will now use `col` elements to calculate the column width where appropriate.
 - `Sizes.redistribute` no longer requires a `TableSize` instance to be provided.
-- `TableOperations.makeRowHeader` and `TableOperations.makeRowsHeader` no longer adds the deprecated `scope` attribute to `td` elements.
+- `TableOperations.makeRowHeader` and `TableOperations.makeRowsHeader` no longer add the deprecated `scope` attribute to `td` elements.
 - `Generators.transform` no longer accepts a scope, as `TransformOperations` now calculates the appropriate scope.
 
 ### Fixed

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `pixelSize` and `percentSize` functions in `TableSize` no longer require the initial width to be provided.
 - `ColumnSizes` will now use `col` elements to calculate the column width where appropriate.
 - `Sizes.redistribute` no longer requires a `TableSize` instance to be provided.
+- `TableOperations.makeRowHeader` and `TableOperations.makeRowsHeader` no longer adds the deprecated `scope` attribute to `td` elements.
+- `Generators.transform` no longer accepts a scope, as `TransformOperations` now calculates the appropriate scope.
 
 ### Fixed
 - Resizing table cells caused incorrect widths in cases where those cells had grown to fit extra content.
 - Resizing percent tables caused widths to be offset by a few pixels due to an incorrect pixel -> percent conversion.
+- Converting rows or columns to regular cells would in some cases incorrectly convert a cell that was still part of a header.
 
 ## 9.0.0 - 2021-08-26
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Optional, Optionals, Type } from '@ephox/katamari';
+import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { getAttrValue } from '../util/CellUtils';
@@ -105,7 +105,7 @@ const modification = (generators: Generators, toData = elementToData): Generator
   };
 };
 
-const transform = <K extends keyof HTMLElementTagNameMap> (tag: K, scope?: string | null) => {
+const transform = <K extends keyof HTMLElementTagNameMap> (tag: K) => {
   return (generators: Generators): GeneratorsTransform => {
     const list: Item[] = [];
 
@@ -116,7 +116,8 @@ const transform = <K extends keyof HTMLElementTagNameMap> (tag: K, scope?: strin
     };
 
     const makeNew = (element: SugarElement) => {
-      const attrs: Record<string, string | number | null> = Type.isUndefined(scope) ? {} : { scope };
+      // Ensure scope is never set on a td element as it's a deprecated attribute
+      const attrs: Record<string, string | number | null> = tag === 'td' ? { scope: null } : {};
       const cell = generators.replace(element, tag, attrs);
       list.push({
         item: element,
@@ -145,9 +146,9 @@ const transform = <K extends keyof HTMLElementTagNameMap> (tag: K, scope?: strin
 
 const getScopeAttribute = (cell: SugarElement) =>
   Attribute.getOpt(cell, 'scope').map(
-    (attribute) => attribute.substr(0, 3)
     // Attribute can be col, colgroup, row, and rowgroup.
     // As col and colgroup are to be treated as if they are the same, lob off everything after the first three characters and there is no difference.
+    (attribute) => attribute.substr(0, 3)
   );
 
 const merging = (generators: Generators): GeneratorsMerging => {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -165,81 +165,69 @@ const opInsertColumnsAfter = (grid: Structs.RowCells[], extractDetail: ExtractCo
 };
 
 const opMakeColumnHeader = (initialGrid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsTransform) => {
-  const newGrid = TransformOperations.replaceColumn(initialGrid, detail.column, comparator, genWrappers.replaceOrInit);
+  const newGrid = TransformOperations.replaceColumn(initialGrid, detail.column, true, comparator, genWrappers.replaceOrInit);
   return bundle(newGrid, detail.row, detail.column);
 };
 
 const opMakeColumnsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
-  const replacer = (currentGrid: Structs.RowCells[], column: Structs.DetailExt) =>
-    TransformOperations.replaceColumn(currentGrid, column.column, comparator, genWrappers.replaceOrInit);
-
   const columns = ColUtils.uniqueColumns(details);
-  const newGrid = Arr.foldl(columns, replacer, initialGrid);
+  const columnIndexes = Arr.map(columns, (detail) => detail.column);
+  const newGrid = TransformOperations.replaceColumns(initialGrid, columnIndexes, true, comparator, genWrappers.replaceOrInit);
   return bundle(newGrid, details[0].row, details[0].column);
 };
 
 const opMakeCellHeader = (initialGrid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsTransform) => {
-  const newGrid = TransformOperations.replaceCell(initialGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
+  const newGrid = TransformOperations.replaceCell(initialGrid, detail, comparator, genWrappers.replaceOrInit);
   return bundle(newGrid, detail.row, detail.column);
 };
 
 const opMakeCellsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
-  const replacer = (currentGrid: Structs.RowCells[], detail: Structs.DetailExt) =>
-    TransformOperations.replaceCell(currentGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
-
-  const newGrid = Arr.foldl(details, replacer, initialGrid);
+  const newGrid = TransformOperations.replaceCells(initialGrid, details, comparator, genWrappers.replaceOrInit);
   return bundle(newGrid, details[0].row, details[0].column);
 };
 
 const opUnmakeColumnHeader = (initialGrid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsTransform) => {
-  const newGrid = TransformOperations.replaceColumn(initialGrid, detail.column, comparator, genWrappers.replaceOrInit);
+  const newGrid = TransformOperations.replaceColumn(initialGrid, detail.column, false, comparator, genWrappers.replaceOrInit);
   return bundle(newGrid, detail.row, detail.column);
 };
 
 const opUnmakeColumnsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
-  const replacer = (currentGrid: Structs.RowCells[], column: Structs.DetailExt) =>
-    TransformOperations.replaceColumn(currentGrid, column.column, comparator, genWrappers.replaceOrInit);
-
   const columns = ColUtils.uniqueColumns(details);
-  const newGrid = Arr.foldl(columns, replacer, initialGrid);
+  const columnIndexes = Arr.map(columns, (detail) => detail.column);
+  const newGrid = TransformOperations.replaceColumns(initialGrid, columnIndexes, false, comparator, genWrappers.replaceOrInit);
   return bundle(newGrid, details[0].row, details[0].column);
 };
 
 const opUnmakeCellHeader = (initialGrid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsTransform) => {
-  const newGrid = TransformOperations.replaceCell(initialGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
+  const newGrid = TransformOperations.replaceCell(initialGrid, detail, comparator, genWrappers.replaceOrInit);
   return bundle(newGrid, detail.row, detail.column);
 };
 
 const opUnmakeCellsHeader = (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform) => {
-  const replacer = (currentGrid: Structs.RowCells[], detail: Structs.DetailExt) =>
-    TransformOperations.replaceCell(currentGrid, detail.row, detail.column, comparator, genWrappers.replaceOrInit);
-
-  const newGrid = Arr.foldl(details, replacer, initialGrid);
+  const newGrid = TransformOperations.replaceCells(initialGrid, details, comparator, genWrappers.replaceOrInit);
   return bundle(newGrid, details[0].row, details[0].column);
 };
 
-const makeRowSection = (section: Structs.Section) =>
+const makeRowSection = (section: Structs.Section, applyScope: boolean) =>
   (grid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsTransform, tableSection: TableSection) => {
-    const newGrid = TransformOperations.replaceRow(grid, detail.row, section, comparator, genWrappers.replaceOrInit, tableSection);
+    const newGrid = TransformOperations.replaceRow(grid, detail.row, section, applyScope, comparator, genWrappers.replaceOrInit, tableSection);
     return bundle(newGrid, detail.row, detail.column);
   };
 
-const makeRowsSection = (section: Structs.Section) =>
+const makeRowsSection = (section: Structs.Section, applyScope: boolean) =>
   (initialGrid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, genWrappers: GeneratorsTransform, tableSection: TableSection) => {
-    const replacer = (currentGrid: Structs.RowCells[], detail: Structs.DetailExt) =>
-      TransformOperations.replaceRow(currentGrid, detail.row, section, comparator, genWrappers.replaceOrInit, tableSection);
-
     const rows = uniqueRows(details);
-    const newGrid = Arr.foldl(rows, replacer, initialGrid);
+    const rowIndexes = Arr.map(rows, (detail) => detail.row);
+    const newGrid = TransformOperations.replaceRows(initialGrid, rowIndexes, section, applyScope, comparator, genWrappers.replaceOrInit, tableSection);
     return bundle(newGrid, details[0].row, details[0].column);
   };
 
-const opMakeRowHeader = makeRowSection('thead');
-const opMakeRowsHeader = makeRowsSection('thead');
-const opMakeRowBody = makeRowSection('tbody');
-const opMakeRowsBody = makeRowsSection('tbody');
-const opMakeRowFooter = makeRowSection('tfoot');
-const opMakeRowsFooter = makeRowsSection('tfoot');
+const opMakeRowHeader = makeRowSection('thead', true);
+const opMakeRowsHeader = makeRowsSection('thead', true);
+const opMakeRowBody = makeRowSection('tbody', false);
+const opMakeRowsBody = makeRowsSection('tbody', false);
+const opMakeRowFooter = makeRowSection('tfoot', false);
+const opMakeRowsFooter = makeRowsSection('tfoot', false);
 
 const opSplitCellIntoColumns = (grid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, genWrappers: GeneratorsModification) => {
   const newGrid = ModificationOperations.splitCellIntoColumns(grid, detail.row, detail.column, comparator, genWrappers.getOrInit);
@@ -429,6 +417,9 @@ const pasteColumnsExtractor = (before: boolean) => (warehouse: Warehouse, target
     return !checkLocked(warehouse, details.cells);
   });
 
+const headerCellGenerator = Generators.transform('th');
+const bodyCellGenerator = Generators.transform('td');
+
 export const insertRowBefore = RunOperation.run(opInsertRowBefore, RunOperation.onCell, Fun.noop, Fun.noop, Generators.modification);
 export const insertRowsBefore = RunOperation.run(opInsertRowsBefore, RunOperation.onCells, Fun.noop, Fun.noop, Generators.modification);
 export const insertRowAfter = RunOperation.run(opInsertRowAfter, RunOperation.onCell, Fun.noop, Fun.noop, Generators.modification);
@@ -441,20 +432,20 @@ export const splitCellIntoColumns = RunOperation.run(opSplitCellIntoColumns, Run
 export const splitCellIntoRows = RunOperation.run(opSplitCellIntoRows, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.modification);
 export const eraseColumns = RunOperation.run(opEraseColumns, eraseColumnsExtractor, adjustAndRedistributeWidths, prune, Generators.modification);
 export const eraseRows = RunOperation.run(opEraseRows, RunOperation.onCells, Fun.noop, prune, Generators.modification);
-export const makeColumnHeader = RunOperation.run(opMakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('th', 'row'));
-export const makeColumnsHeader = RunOperation.run(opMakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('th', 'row'));
-export const unmakeColumnHeader = RunOperation.run(opUnmakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('td', null));
-export const unmakeColumnsHeader = RunOperation.run(opUnmakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('td', null));
-export const makeRowHeader = RunOperation.run(opMakeRowHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('th', 'col'));
-export const makeRowsHeader = RunOperation.run(opMakeRowsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('th', 'col'));
-export const makeRowBody = RunOperation.run(opMakeRowBody, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('td', null));
-export const makeRowsBody = RunOperation.run(opMakeRowsBody, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('td', null));
-export const makeRowFooter = RunOperation.run(opMakeRowFooter, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('td', null));
-export const makeRowsFooter = RunOperation.run(opMakeRowsFooter, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('td', null));
-export const makeCellHeader = RunOperation.run(opMakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('th'));
-export const makeCellsHeader = RunOperation.run(opMakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('th'));
-export const unmakeCellHeader = RunOperation.run(opUnmakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.transform('td'));
-export const unmakeCellsHeader = RunOperation.run(opUnmakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, Generators.transform('td'));
+export const makeColumnHeader = RunOperation.run(opMakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, headerCellGenerator);
+export const makeColumnsHeader = RunOperation.run(opMakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, headerCellGenerator);
+export const unmakeColumnHeader = RunOperation.run(opUnmakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, bodyCellGenerator);
+export const unmakeColumnsHeader = RunOperation.run(opUnmakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, bodyCellGenerator);
+export const makeRowHeader = RunOperation.run(opMakeRowHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, headerCellGenerator);
+export const makeRowsHeader = RunOperation.run(opMakeRowsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, headerCellGenerator);
+export const makeRowBody = RunOperation.run(opMakeRowBody, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, bodyCellGenerator);
+export const makeRowsBody = RunOperation.run(opMakeRowsBody, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, bodyCellGenerator);
+export const makeRowFooter = RunOperation.run(opMakeRowFooter, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, bodyCellGenerator);
+export const makeRowsFooter = RunOperation.run(opMakeRowsFooter, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, bodyCellGenerator);
+export const makeCellHeader = RunOperation.run(opMakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, headerCellGenerator);
+export const makeCellsHeader = RunOperation.run(opMakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, headerCellGenerator);
+export const unmakeCellHeader = RunOperation.run(opUnmakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, bodyCellGenerator);
+export const unmakeCellsHeader = RunOperation.run(opUnmakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, bodyCellGenerator);
 export const mergeCells = RunOperation.run(opMergeCells, RunOperation.onUnlockedMergable, resize, Fun.noop, Generators.merging);
 export const unmergeCells = RunOperation.run(opUnmergeCells, RunOperation.onUnlockedUnmergable, resize, Fun.noop, Generators.merging);
 export const pasteCells = RunOperation.run(opPasteCells, RunOperation.onPaste, resize, Fun.noop, Generators.modification);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableSection.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableSection.ts
@@ -24,7 +24,6 @@ const section = (): TableSection => ({
   transformCell: (cell: Structs.ElementNew, comparator: CompElm, substitution: Subst) => {
     const newCell = substitution(cell.element, comparator);
     // Convert the cell to a td element as "section" should always use td element
-    // TODO: TINY-7709: This should actually preserve the th element when the cell is in a header column
     const fixedCell = SugarNode.name(newCell) !== 'td' ? Replication.mutate(newCell, 'td') : newCell;
     return Structs.elementnew(fixedCell, cell.isNew, cell.isLocked);
   }

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/TransformOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/TransformOperations.ts
@@ -24,7 +24,7 @@ const alreadyProcessed = (grid: Structs.RowCells[], rowIndex: number, colIndex: 
 
 const rowReplacerPredicate = (targetRow: Structs.RowCells, columnHeaders: boolean[]): ReplacePredicate => {
   const entireTableIsHeader = Arr.forall(columnHeaders, Fun.identity) && isHeaderCells(targetRow.cells);
-  return entireTableIsHeader ? Fun.always : (cell, rowIndex, colIndex) => {
+  return entireTableIsHeader ? Fun.always : (cell, _rowIndex, colIndex) => {
     const type = SugarNode.name(cell.element);
     return !(type === 'th' && columnHeaders[colIndex]);
   };
@@ -43,7 +43,6 @@ const determineScope = (applyScope: boolean, element: SugarElement<HTMLTableCell
   const getScope = (scope: string) => hasSpan(scope) ? `${scope}group` : scope;
 
   if (applyScope) {
-    // Add the scope depending on if there is a merged cell
     return isHeaderCell(element) ? getScope(newScope) : null;
   } else if (isInHeader && isHeaderCell(element)) {
     // The cell is still in a header row/column so ensure the right scope is reverted to

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/TransformOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/TransformOperations.ts
@@ -1,79 +1,166 @@
-import { Arr } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, Fun, Optional } from '@ephox/katamari';
+import { Attribute, SugarElement, SugarNode } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
 import { TableSection } from '../api/TableSection';
+import { isHeaderCell, isHeaderCells } from '../lookup/Type';
 import * as GridRow from '../model/GridRow';
+import * as CellUtils from '../util/CellUtils';
 
 type CompElm = (e1: SugarElement, e2: SugarElement) => boolean;
 type Subst = (element: SugarElement, comparator: CompElm) => SugarElement;
 type CellReplacer = (cell: Structs.ElementNew, comparator: CompElm, substitute: Subst) => Structs.ElementNew;
+type ScopeGenerator = (cell: Structs.ElementNew, rowIndex: number, colIndex: number) => Optional<null | string>;
+type ReplacePredicate = (cell: Structs.ElementNew, rowIndex: number, colIndex: number) => boolean;
+
+const notStartRow = (grid: Structs.RowCells[], rowIndex: number, colIndex: number, comparator: CompElm): boolean =>
+  GridRow.getCellElement(grid[rowIndex], colIndex) !== undefined && (rowIndex > 0 && comparator(GridRow.getCellElement(grid[rowIndex - 1], colIndex), GridRow.getCellElement(grid[rowIndex], colIndex)));
+
+const notStartColumn = (row: Structs.RowCells, index: number, comparator: CompElm): boolean =>
+  index > 0 && comparator(GridRow.getCellElement(row, index - 1), GridRow.getCellElement(row, index));
+
+const alreadyProcessed = (grid: Structs.RowCells[], rowIndex: number, colIndex: number, comparator: CompElm): boolean =>
+  notStartRow(grid, rowIndex, colIndex, comparator) || notStartColumn(grid[rowIndex], colIndex, comparator);
+
+const rowReplacerPredicate = (targetRow: Structs.RowCells, columnHeaders: boolean[]): ReplacePredicate => {
+  const entireTableIsHeader = Arr.forall(columnHeaders, Fun.identity) && isHeaderCells(targetRow.cells);
+  return entireTableIsHeader ? Fun.always : (cell, rowIndex, colIndex) => {
+    const type = SugarNode.name(cell.element);
+    return !(type === 'th' && columnHeaders[colIndex]);
+  };
+};
+
+const columnReplacePredicate = (targetColumn: Structs.ElementNew[], rowHeaders: boolean[]): ReplacePredicate => {
+  const entireTableIsHeader = Arr.forall(rowHeaders, Fun.identity) && isHeaderCells(targetColumn);
+  return entireTableIsHeader ? Fun.always : (cell, rowIndex, _colIndex) => {
+    const type = SugarNode.name(cell.element);
+    return !(type === 'th' && rowHeaders[rowIndex]);
+  };
+};
+
+const determineScope = (applyScope: boolean, element: SugarElement<HTMLTableCellElement>, newScope: 'row' | 'col', isInHeader: boolean) => {
+  const hasSpan = (scope: string) => scope === 'row' ? CellUtils.hasRowspan(element) : CellUtils.hasColspan(element);
+  const getScope = (scope: string) => hasSpan(scope) ? `${scope}group` : scope;
+
+  if (applyScope) {
+    // Add the scope depending on if there is a merged cell
+    return isHeaderCell(element) ? getScope(newScope) : null;
+  } else if (isInHeader && isHeaderCell(element)) {
+    // The cell is still in a header row/column so ensure the right scope is reverted to
+    const oppositeScope = newScope === 'row' ? 'col' : 'row';
+    return getScope(oppositeScope);
+  } else {
+    // No longer a header so ensure the scope is removed
+    return null;
+  }
+};
+
+const rowScopeGenerator = (applyScope: boolean, columnHeaders: boolean[]) => (cell: Structs.ElementNew, rowIndex: number, columnIndex: number) =>
+  Optional.some(determineScope(applyScope, cell.element, 'col', columnHeaders[columnIndex]));
+
+const columnScopeGenerator = (applyScope: boolean, rowHeaders: boolean[]) => (cell: Structs.ElementNew, rowIndex: number) =>
+  Optional.some(determineScope(applyScope, cell.element, 'row', rowHeaders[rowIndex]));
 
 const replace = (cell: Structs.ElementNew, comparator: CompElm, substitute: Subst) =>
   Structs.elementnew(substitute(cell.element, comparator), true, cell.isLocked);
 
-// substitution :: (item, comparator) -> item
-const replaceIn = (grid: Structs.RowCells[], targets: Structs.ElementNew[], comparator: CompElm, substitute: Subst, replacer: CellReplacer): Structs.RowCells[] => {
+const replaceIn = (
+  grid: Structs.RowCells[],
+  targets: Structs.ElementNew[],
+  comparator: CompElm,
+  substitute: Subst,
+  replacer: CellReplacer,
+  genScope: ScopeGenerator,
+  shouldReplace: ReplacePredicate
+): Structs.RowCells[] => {
   const isTarget = (cell: Structs.ElementNew) => {
     return Arr.exists(targets, (target) => {
       return comparator(cell.element, target.element);
     });
   };
 
-  return Arr.map(grid, (row) => {
-    return GridRow.mapCells(row, (cell) => {
-      return isTarget(cell) ? replacer(cell, comparator, substitute) : cell;
+  return Arr.map(grid, (row, rowIndex) => {
+    return GridRow.mapCells(row, (cell, colIndex) => {
+      if (isTarget(cell)) {
+        const newCell = shouldReplace(cell, rowIndex, colIndex) ? replacer(cell, comparator, substitute) : cell;
+        // Update the scope
+        genScope(newCell, rowIndex, colIndex).each((scope) => {
+          Attribute.setOptions(newCell.element, { scope: Optional.from(scope) });
+        });
+        return newCell;
+      } else {
+        return cell;
+      }
     });
   });
 };
 
-const notStartRow = (grid: Structs.RowCells[], rowIndex: number, colIndex: number, comparator: CompElm): boolean => {
-  return GridRow.getCellElement(grid[rowIndex], colIndex) !== undefined && (rowIndex > 0 && comparator(GridRow.getCellElement(grid[rowIndex - 1], colIndex), GridRow.getCellElement(grid[rowIndex], colIndex)));
+const getColumnCells = (rows: Structs.RowCells[], columnIndex: number, comparator: CompElm) =>
+  Arr.bind(rows, (row, i) => {
+    // check if already added.
+    return alreadyProcessed(rows, i, columnIndex, comparator) ? [] : [ GridRow.getCell(row, columnIndex) ];
+  });
+
+const getRowCells = (rows: Structs.RowCells[], rowIndex: number, comparator: CompElm) => {
+  const targetRow = rows[rowIndex];
+  return Arr.bind(targetRow.cells, (item, i) => {
+    // Check that we haven't already added this one.
+    return alreadyProcessed(rows, rowIndex, i, comparator) ? [] : [ item ];
+  });
 };
 
-const notStartColumn = (row: Structs.RowCells, index: number, comparator: CompElm): boolean => {
-  return index > 0 && comparator(GridRow.getCellElement(row, index - 1), GridRow.getCellElement(row, index));
-};
+const replaceColumn = (grid: Structs.RowCells[], index: number, applyScope: boolean, comparator: CompElm, substitution: Subst): Structs.RowCells[] =>
+  replaceColumns(grid, [ index ], applyScope, comparator, substitution);
 
-// substitution :: (item, comparator) -> item
-const replaceColumn = (grid: Structs.RowCells[], index: number, comparator: CompElm, substitution: Subst): Structs.RowCells[] => {
+const replaceColumns = (grid: Structs.RowCells[], indexes: number[], applyScope: boolean, comparator: CompElm, substitution: Subst): Structs.RowCells[] => {
   // Make this efficient later.
   const rows = GridRow.extractGridDetails(grid).rows;
-  const targets = Arr.bind(rows, (row, i) => {
-    // check if already added.
-    const alreadyAdded = notStartRow(rows, i, index, comparator) || notStartColumn(row, index, comparator);
-    return alreadyAdded ? [] : [ GridRow.getCell(row, index) ];
-  });
+  const targets = Arr.bind(indexes, (index) => getColumnCells(rows, index, comparator));
+  const rowHeaders = Arr.map(grid, (row) => isHeaderCells(row.cells));
 
-  return replaceIn(grid, targets, comparator, substitution, replace);
+  const shouldReplaceCell = columnReplacePredicate(targets, rowHeaders);
+  const scopeGenerator = columnScopeGenerator(applyScope, rowHeaders);
+
+  return replaceIn(grid, targets, comparator, substitution, replace, scopeGenerator, shouldReplaceCell);
 };
 
-// substitution :: (item, comparator) -> item
-const replaceRow = (grid: Structs.RowCells[], index: number, section: Structs.Section, comparator: CompElm, substitution: Subst, tableSection: TableSection): Structs.RowCells[] => {
+const replaceRow = (grid: Structs.RowCells[], index: number, section: Structs.Section, applyScope: boolean, comparator: CompElm, substitution: Subst, tableSection: TableSection): Structs.RowCells[] =>
+  replaceRows(grid, [ index ], section, applyScope, comparator, substitution, tableSection);
+
+const replaceRows = (grid: Structs.RowCells[], indexes: number[], section: Structs.Section, applyScope: boolean, comparator: CompElm, substitution: Subst, tableSection: TableSection): Structs.RowCells[] => {
   const { cols, rows } = GridRow.extractGridDetails(grid);
-  const targetRow = rows[index];
-  const targets = Arr.bind(targetRow.cells, (item, i) => {
-    // Check that we haven't already added this one.
-    const alreadyAdded = notStartRow(rows, index, i, comparator) || notStartColumn(targetRow, i, comparator);
-    return alreadyAdded ? [] : [ item ];
-  });
+  const targetRow = rows[indexes[0]];
+  const targets = Arr.bind(indexes, (index) => getRowCells(rows, index, comparator));
+  const columnHeaders = Arr.map(targetRow.cells, (_cell, index) => isHeaderCells(getColumnCells(rows, index, comparator)));
 
   // Transform and replace the target row
   // TODO: TINY-7776: This doesn't deal with rowspans which can break the layout when moving to a new section
   const newRows = [ ...rows ];
-  newRows[index] = tableSection.transformRow(targetRow, section);
-  return replaceIn(cols.concat(newRows), targets, comparator, substitution, tableSection.transformCell);
+  Arr.each(indexes, (index) => {
+    newRows[index] = tableSection.transformRow(rows[index], section);
+  });
+  const newGrid = cols.concat(newRows);
+
+  const shouldReplaceCell = rowReplacerPredicate(targetRow, columnHeaders);
+  const scopeGenerator = rowScopeGenerator(applyScope, columnHeaders);
+
+  return replaceIn(newGrid, targets, comparator, substitution, tableSection.transformCell, scopeGenerator, shouldReplaceCell);
 };
 
-const replaceCell = (grid: Structs.RowCells[], rowIndex: number, columnIndex: number, comparator: CompElm, substitution: Subst): Structs.RowCells[] => {
+const replaceCell = (grid: Structs.RowCells[], detail: Structs.DetailExt, comparator: CompElm, substitution: Subst): Structs.RowCells[] =>
+  replaceCells(grid, [ detail ], comparator, substitution);
+
+const replaceCells = (grid: Structs.RowCells[], details: Structs.DetailExt[], comparator: CompElm, substitution: Subst): Structs.RowCells[] => {
   const rows = GridRow.extractGridDetails(grid).rows;
-  const targetRow = rows[rowIndex];
-  const targetCell = GridRow.getCell(targetRow, columnIndex);
-  return replaceIn(grid, [ targetCell ], comparator, substitution, replace);
+  const targetCells = Arr.map(details, (detail) => GridRow.getCell(rows[detail.row], detail.column));
+  return replaceIn(grid, targetCells, comparator, substitution, replace, Optional.none, Fun.always);
 };
 
 export {
   replaceColumn,
+  replaceColumns,
   replaceRow,
-  replaceCell
+  replaceRows,
+  replaceCell,
+  replaceCells
 };

--- a/modules/snooker/src/test/ts/browser/HeaderOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/HeaderOperationsTest.ts
@@ -205,6 +205,22 @@ UnitTest.test('HeaderOperationsTest', () => {
     );
 
     Assertions.checkOld(
+      'TINY-6666: Convert body to header (section)',
+      Optional.some({ section: 0, row: 0, column: 0 }),
+      '<table>' +
+      '<thead><tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr></thead>' +
+      '<tbody><tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr></tbody>' +
+      '</table>',
+
+      '<table><tbody>' +
+      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeRowHeader, 0, 0, 0, TableSection.section()
+    );
+
+    Assertions.checkOld(
       'TINY-6666: Convert body to footer (section)',
       Optional.some({ section: 1, row: 0, column: 1 }),
       '<table>' +
@@ -234,6 +250,22 @@ UnitTest.test('HeaderOperationsTest', () => {
       '</table>',
 
       TableOperations.makeRowFooter, 0, 0, 1, TableSection.sectionCells()
+    );
+
+    Assertions.checkOld(
+      'TINY-7709: Convert single row with colspan to header',
+      Optional.some({ section: 0, row: 0, column: 1 }),
+      '<table><tbody>' +
+      '<tr><th colspan="2" scope="colgroup">A1</th><th scope="col">C1</th><th scope="col">D1</th></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><td colspan="2">A1</td><td>C1</td><td>D1</td></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeRowHeader, 0, 0, 1
     );
   };
 
@@ -534,7 +566,7 @@ UnitTest.test('HeaderOperationsTest', () => {
             '<td>D1</td>' +
           '</tr>' +
           '<tr>' +
-            '<td rowspan="2">A2</td>' +
+            '<td>A2</td>' +
             '<td>B2</td>' +
             '<td>C2</td>' +
             '<td>D2</td>' +
@@ -810,6 +842,24 @@ UnitTest.test('HeaderOperationsTest', () => {
 
       TableOperations.unmakeColumnHeader, 0, 0, 0
     );
+
+    Assertions.checkOld(
+      'TINY-7709: Convert single column with rowspan to header',
+      Optional.some({ section: 0, row: 2, column: 0 }),
+      '<table><tbody>' +
+      '<tr><th rowspan="2" scope="rowgroup">A1</th><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '<tr><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><th scope="row">A3</th><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><td rowspan="2">A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '<tr><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeColumnHeader, 0, 2, 0
+    );
   };
 
   const testMultipleColumnHeader = () => {
@@ -1072,7 +1122,7 @@ UnitTest.test('HeaderOperationsTest', () => {
     );
 
     Assertions.checkOldMultiple(
-      'TINY-6765: Check that locked columns in the selection are not coverted to header columns',
+      'TINY-6765: Check that locked columns in the selection are not converted to header columns',
       Optional.some({ section: 0, row: 1, column: 0 }),
 
       generateTestTable(
@@ -1194,7 +1244,7 @@ UnitTest.test('HeaderOperationsTest', () => {
       '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
       '</thead>' +
       '<tbody>' +
-      '<tr><th scope="col">A2</th><td scope="col">B2</td><th scope="col">C2</th><th scope="col">D2</th></tr>' +
+      '<tr><th scope="col">A2</th><td>B2</td><th scope="col">C2</th><th scope="col">D2</th></tr>' +
       '</tbody></table>',
 
       '<table><thead>' +
@@ -1259,7 +1309,7 @@ UnitTest.test('HeaderOperationsTest', () => {
       '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr>' +
       '</thead>' +
       '<tbody>' +
-      '<tr><td scope="col">A2</td><td scope="col">B2</td><th scope="col">C2</th><th scope="col">D2</th></tr>' +
+      '<tr><td>A2</td><td>B2</td><th scope="col">C2</th><th scope="col">D2</th></tr>' +
       '</tbody></table>',
 
       '<table><thead>' +
@@ -1276,10 +1326,150 @@ UnitTest.test('HeaderOperationsTest', () => {
     );
   };
 
+  const testMixedHeaders = () => {
+    Assertions.checkOldMultiple(
+      'TINY-7709: Convert regular column to header column with an existing header row',
+      Optional.some({ section: 0, row: 0, column: 0 }),
+      '<table><tbody>' +
+      '<tr><th scope="row">A1</th><th scope="col">B1</th><th scope="col">C1</th><th scope="col">D1</th></tr>' +
+      '<tr><th scope="row">A2</th><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><th scope="row">A3</th><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><th scope="col">A1</th><th scope="col">B1</th><th scope="col">C1</th><th scope="col">D1</th></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeColumnsHeader, [
+        { section: 0, row: 0, column: 0 },
+        { section: 0, row: 1, column: 0 },
+        { section: 0, row: 2, column: 0 }
+      ]
+    );
+
+    Assertions.checkOldMultiple(
+      'TINY-7709: Convert header column to regular column with an existing header row',
+      Optional.some({ section: 0, row: 0, column: 0 }),
+      '<table><tbody>' +
+      '<tr><th scope="col">A1</th><th scope="col">B1</th><th scope="col">C1</th><th scope="col">D1</th></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><th scope="row">A1</th><th scope="col">B1</th><th scope="col">C1</th><th scope="col">D1</th></tr>' +
+      '<tr><th scope="row">A2</th><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><th scope="row">A3</th><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.unmakeColumnsHeader, [
+        { section: 0, row: 0, column: 0 },
+        { section: 0, row: 1, column: 0 },
+        { section: 0, row: 2, column: 0 }
+      ]
+    );
+
+    Assertions.checkOldMultiple(
+      'TINY-7709: Convert header column to regular column with an existing thead section header row',
+      Optional.some({ section: 0, row: 0, column: 0 }),
+      '<table><thead>' +
+      '<tr><td>A1</td><td>B1</td><th>C1</th><th>D1</th></tr>' +
+      '</thead><tbody>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><td>A3</td><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      '<table><thead>' +
+      '<tr><th scope="row">A1</th><td>B1</td><th>C1</th><th>D1</th></tr>' +
+      '</thead><tbody>' +
+      '<tr><th scope="row">A2</th><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><th scope="row">A3</th><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.unmakeColumnsHeader, [
+        { section: 0, row: 0, column: 0 },
+        { section: 1, row: 0, column: 0 },
+        { section: 1, row: 1, column: 0 }
+      ]
+    );
+
+    Assertions.checkOldMultiple(
+      'TINY-7709: Convert regular row to header row with an existing header column',
+      Optional.some({ section: 0, row: 0, column: 0 }),
+      '<table><tbody>' +
+      '<tr><th scope="col">A1</th><th scope="col">B1</th><th scope="col">C1</th><th scope="col">D1</th></tr>' +
+      '<tr><td>A2</td><th scope="row">B2</th><td>C2</td><td>D2</td></tr>' +
+      '<tr><td>A3</td><th scope="row">B3</th><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><td>A1</th><th scope="row">B1</th><td>C1</td><td>D1</th></tr>' +
+      '<tr><td>A2</td><th scope="row">B2</th><td>C2</td><td>D2</td></tr>' +
+      '<tr><td>A3</td><th scope="row">B3</th><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeRowsHeader, [
+        { section: 0, row: 0, column: 0 },
+        { section: 0, row: 0, column: 1 },
+        { section: 0, row: 0, column: 2 },
+        { section: 0, row: 0, column: 3 }
+      ]
+    );
+
+    Assertions.checkOldMultiple(
+      'TINY-7709: Convert header row to regular row with an existing header column',
+      Optional.some({ section: 0, row: 0, column: 0 }),
+      '<table><tbody>' +
+      '<tr><td>A1</td><th scope="row">B1</th><td>C1</td><td>D1</td></tr>' +
+      '<tr><td>A2</td><th scope="row">B2</th><td>C2</td><td>D2</td></tr>' +
+      '<tr><td>A3</td><th scope="row">B3</th><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><th scope="col">A1</th><th scope="col">B1</th><th scope="col">C1</th><th scope="col">D1</th></tr>' +
+      '<tr><td>A2</td><th scope="row">B2</th><td>C2</td><td>D2</td></tr>' +
+      '<tr><td>A3</td><th scope="row">B3</th><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeRowsBody, [
+        { section: 0, row: 0, column: 0 },
+        { section: 0, row: 0, column: 1 },
+        { section: 0, row: 0, column: 2 },
+        { section: 0, row: 0, column: 3 }
+      ]
+    );
+
+    Assertions.checkOldMultiple(
+      'TINY-7709: Convert header row with rowspan to regular row with an existing header column',
+      Optional.some({ section: 0, row: 0, column: 0 }),
+      '<table><tbody>' +
+      '<tr><th rowspan="2" scope="rowgroup">A1</th><td>B1</td><td>C1</td><td>D1</td></tr>' +
+      '<tr><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><th scope="row">A3</th><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      '<table><tbody>' +
+      '<tr><th rowspan="2" scope="col">A1</th><th scope="col">B1</th><th scope="col">C1</th><th scope="col">D1</th></tr>' +
+      '<tr><td>B2</td><td>C2</td><td>D2</td></tr>' +
+      '<tr><th scope="row">A3</th><td>B3</td><td>C3</td><td>D3</td></tr>' +
+      '</tbody></table>',
+
+      TableOperations.makeRowsBody, [
+        { section: 0, row: 0, column: 0 },
+        { section: 0, row: 0, column: 1 },
+        { section: 0, row: 0, column: 2 },
+        { section: 0, row: 0, column: 3 }
+      ]
+    );
+  };
+
   testSingleRowSection();
   testMultipleRowSection();
   testSingleColumnHeader();
   testMultipleColumnHeader();
   testSingleCellHeader();
   testMultipleCellHeader();
+  testMixedHeaders();
 });

--- a/modules/snooker/src/test/ts/browser/MergeOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/MergeOperationsTest.ts
@@ -87,7 +87,7 @@ UnitTest.test('MergeOperationsTest', () => {
     '<table style="border-collapse: collapse;">' +
       '<tbody>' +
         '<tr>' +
-          '<td scope="rowgroup" rowspan="2">A1<br>A2<br></td>' +
+          '<th scope="rowgroup" rowspan="2">A1<br>A2<br></th>' +
           '<td>B1</td>' +
           '<td>C1</td>' +
         '</tr>' +
@@ -101,7 +101,7 @@ UnitTest.test('MergeOperationsTest', () => {
     '<table border="1" style="border-collapse: collapse;">' +
       '<tbody>' +
         '<tr>' +
-          '<td scope="row">A1</td>' +
+          '<th scope="row">A1</th>' +
           '<td>B1</td>' +
           '<td>C1</td>' +
         '</tr>' +
@@ -125,7 +125,7 @@ UnitTest.test('MergeOperationsTest', () => {
     '<table style="border-collapse: collapse;">' +
       '<tbody>' +
         '<tr>' +
-          '<td scope="colgroup" colspan="2">A1<br>B1<br></td>' +
+          '<th scope="colgroup" colspan="2">A1<br>B1<br></th>' +
           '<td>C1</td>' +
         '</tr>' +
         '<tr>' +
@@ -139,7 +139,7 @@ UnitTest.test('MergeOperationsTest', () => {
     '<table border="1" style="border-collapse: collapse;">' +
       '<tbody>' +
         '<tr>' +
-          '<td scope="col">A1</td>' +
+          '<th scope="col">A1</th>' +
           '<td>B1</td>' +
           '<td>C1</td>' +
         '</tr>' +
@@ -163,7 +163,7 @@ UnitTest.test('MergeOperationsTest', () => {
     '<table style="border-collapse: collapse;">' +
       '<tbody>' +
         '<tr>' +
-          '<td rowspan="2">A1<br>A2<br></td>' +
+          '<th rowspan="2">A1<br>A2<br></th>' +
           '<td>B1</td>' +
           '<td>C1</td>' +
         '</tr>' +
@@ -177,12 +177,12 @@ UnitTest.test('MergeOperationsTest', () => {
     '<table border="1" style="border-collapse: collapse;">' +
       '<tbody>' +
         '<tr>' +
-          '<td scope="row">A1</td>' +
+          '<th scope="row">A1</th>' +
           '<td>B1</td>' +
           '<td>C1</td>' +
         '</tr>' +
         '<tr>' +
-          '<td scope="col">A2</td>' +
+          '<th scope="col">A2</th>' +
           '<td>B2</td>' +
           '<td>C2</td>' +
         '</tr>' +
@@ -201,7 +201,7 @@ UnitTest.test('MergeOperationsTest', () => {
     '<table style="border-collapse: collapse;">' +
       '<tbody>' +
         '<tr>' +
-          '<td rowspan="2">A1<br>A2<br></td>' +
+          '<th rowspan="2">A1<br>A2<br></th>' +
           '<td>B1</td>' +
           '<td>C1</td>' +
         '</tr>' +
@@ -215,12 +215,12 @@ UnitTest.test('MergeOperationsTest', () => {
     '<table border="1" style="border-collapse: collapse;">' +
       '<tbody>' +
         '<tr>' +
-          '<td scope="col">A1</td>' +
+          '<th scope="col">A1</th>' +
           '<td>B1</td>' +
           '<td>C1</td>' +
         '</tr>' +
         '<tr>' +
-          '<td scope="row">A2</td>' +
+          '<th scope="row">A2</th>' +
           '<td>B2</td>' +
           '<td>C2</td>' +
         '</tr>' +

--- a/modules/snooker/src/test/ts/browser/operate/TransformOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/operate/TransformOperationsTest.ts
@@ -33,7 +33,7 @@ UnitTest.test('TransformOperationsTest', () => {
   const mapToStructGrid = (grid: Structs.ElementNew[][]) => {
     return Arr.map(grid, (row) => {
       const hasCol = Arr.exists(row, (elementNew) => SugarNode.isTag('col')(elementNew.element));
-      return Structs.rowcells('tr' as any, row, hasCol ? 'colgroup' : 'tbody', false);
+      return Structs.rowcells(SugarElement.fromTag('tr'), row, hasCol ? 'colgroup' : 'tbody', false);
     });
   };
 
@@ -56,7 +56,8 @@ UnitTest.test('TransformOperationsTest', () => {
     const check = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      const actual = TransformOperations.replaceColumn(structGrid, index, comparator, Generators.transform('td', 'scope')(TestGenerator()).replaceOrInit);
+      const substitution = Generators.transform('td')(TestGenerator()).replaceOrInit;
+      const actual = TransformOperations.replaceColumn(structGrid, index, true, comparator, substitution);
       assertGrids(actual, structExpected);
       clearElements();
     };
@@ -117,6 +118,16 @@ UnitTest.test('TransformOperationsTest', () => {
       [ enO('b', false), enO('c', false), enO('d', false) ],
       [ enO('f', false), enO('f', false), enO('f', false) ]
     ], 0);
+
+    check([
+      [ enE('a', false, 'th'), enE('a', false, 'th'), enE('b', false, 'th') ],
+      [ enE('h(c)_0', true), enE('d', false), enE('e', false) ],
+      [ enE('h(f)_1', true), enE('h(f)_1', true), enE('h(f)_1', true) ]
+    ], [
+      [ enO('a', false, 'th'), enO('a', false, 'th'), enO('b', false, 'th') ],
+      [ enO('c', false), enO('d', false), enO('e', false) ],
+      [ enO('f', false), enO('f', false), enO('f', false) ]
+    ], 0);
   })();
 
   // Test basic changing to header (row)
@@ -124,8 +135,8 @@ UnitTest.test('TransformOperationsTest', () => {
     const check = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      const substitution = Generators.transform('td', 'scope')(TestGenerator()).replaceOrInit;
-      const actual = TransformOperations.replaceRow(structGrid, index, 'tbody', comparator, substitution, TableSection.fallback());
+      const substitution = Generators.transform('td')(TestGenerator()).replaceOrInit;
+      const actual = TransformOperations.replaceRow(structGrid, index, 'tbody', true, comparator, substitution, TableSection.fallback());
       assertGrids(actual, structExpected);
       clearElements();
     };
@@ -177,6 +188,16 @@ UnitTest.test('TransformOperationsTest', () => {
       [ enO('a', false), enO('a', false), enO('c', false), enO('f', false) ],
       [ enO('a', false), enO('a', false), enO('d', false), enO('f', false) ]
     ], 0);
+
+    check([
+      [ enE('h(a)_0', true), enE('h(a)_0', true), enE('h(b)_1', true), enE('f', false, 'th') ],
+      [ enE('h(a)_0', true), enE('h(a)_0', true), enE('c', false), enE('f', false, 'th') ],
+      [ enE('h(a)_0', true), enE('h(a)_0', true), enE('d', false), enE('f', false, 'th') ]
+    ], [
+      [ enO('a', false), enO('a', false), enO('b', false), enO('f', false, 'th') ],
+      [ enO('a', false), enO('a', false), enO('c', false), enO('f', false, 'th') ],
+      [ enO('a', false), enO('a', false), enO('d', false), enO('f', false, 'th') ]
+    ], 0);
   })();
 
   // Test basic changing to header (cell)
@@ -184,7 +205,8 @@ UnitTest.test('TransformOperationsTest', () => {
     const check = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], rowIndex: number, colIndex: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
-      const actual = TransformOperations.replaceCell(structGrid, rowIndex, colIndex, comparator, Generators.transform('td')(TestGenerator()).replaceOrInit);
+      const detail = { row: rowIndex, column: colIndex } as Structs.DetailExt;
+      const actual = TransformOperations.replaceCell(structGrid, detail, comparator, Generators.transform('td')(TestGenerator()).replaceOrInit);
       assertGrids(actual, structExpected);
       clearElements();
     };

--- a/modules/sugar/CHANGELOG.md
+++ b/modules/sugar/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added new `parentElement` function to the `Traverse` API.
+- Added new `setOptions` function to the `Attribute` API.
 
 ## 8.0.0 - 2021-08-26
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attribute.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attribute.ts
@@ -29,6 +29,16 @@ const setAll = (element: SugarElement<Element>, attrs: Record<string, string | b
   });
 };
 
+const setOptions = (element: SugarElement<Element>, attrs: Record<string, Optional<string | boolean | number>>): void => {
+  Obj.each(attrs, (v, k) => {
+    v.fold(() => {
+      remove(element, k);
+    }, (value) => {
+      rawSet(element.dom, k, value);
+    });
+  });
+};
+
 const get = (element: SugarElement<Element>, key: string): undefined | string => {
   const v = element.dom.getAttribute(key);
 
@@ -78,4 +88,4 @@ const transfer = (source: SugarElement<Element>, destination: SugarElement<Eleme
   });
 };
 
-export { clone, set, setAll, get, getOpt, has, remove, hasNone, transfer };
+export { clone, set, setAll, setOptions, get, getOpt, has, remove, hasNone, transfer };

--- a/modules/sugar/src/test/ts/browser/AttributeTest.ts
+++ b/modules/sugar/src/test/ts/browser/AttributeTest.ts
@@ -1,4 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
 import { KAssert } from '@ephox/katamari-assertions';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
@@ -81,4 +82,11 @@ UnitTest.test('AttributeTest', () => {
 
   Attribute.set(c, 'tabindex', -1);
   Assert.eq('get', '-1', Attribute.get(c, 'tabindex'));
+
+  Attribute.setOptions(c, {
+    tabindex: Optional.none(),
+    src: Optional.some('custom')
+  });
+  Assert.eq('setOptions - none', false, Attribute.has(c, 'tabindex'));
+  Assert.eq('setOptions - some', 'custom', Attribute.get(c, 'src'));
 });

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- The deprecated `scope` attribute is no longer added to `td` cells when converting a row to a header row #TINY-7731
+
 ### Fixed
 - Resizing table columns in some scenarios would resize the column to an incorrect position #TINY-7731
 - Image resize backdrop element did not have `data-mce-bogus="all"` set #TINY-7854
+- Table cells that were both row and column headers would not retain the correct state when converting back to a regular row or column #TINY-7709
 - Clicking beside a non-editable element could cause the editor to incorrectly scroll to the top of the document #TINY-7062
 
 ## 5.9.2 - 2021-09-08

--- a/modules/tinymce/src/plugins/table/test/ts/browser/SwitchTableSectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/SwitchTableSectionTest.ts
@@ -21,7 +21,7 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
   const theadExpected = `<table>
 <thead>
 <tr id="one">
-<td scope="col">text</td>
+<td>text</td>
 </tr>
 </thead>
 <tbody>
@@ -69,10 +69,10 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
   const existingTheadExpected = `<table>
 <thead>
 <tr id="one">
-<td scope="col">text</td>
+<td>text</td>
 </tr>
 <tr id="two">
-<td scope="col">text</td>
+<td>text</td>
 </tr>
 </thead>
 </table>`;
@@ -102,7 +102,7 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
   const thsAndTheadExpected = `<table>
 <thead>
 <tr id="two">
-<td scope="col">text</td>
+<td>text</td>
 </tr>
 </thead>
 <tbody>
@@ -115,7 +115,7 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
   const theadAndThsExpected = `<table>
 <thead>
 <tr id="one">
-<td scope="col">text</td>
+<td>text</td>
 </tr>
 </thead>
 <tbody>
@@ -141,7 +141,7 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
   const theadAndBothExpected = `<table>
 <thead>
 <tr id="one">
-<td scope="col">text</td>
+<td>text</td>
 </tr>
 <tr id="two">
 <th scope="col">text</th>

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
   const theadContent = `<table>
 <thead>
 <tr id="one">
-<td scope="col">text</td>
+<td>text</td>
 </tr>
 </thead>
 <tbody>

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
@@ -92,7 +92,7 @@ describe('browser.tinymce.plugins.table.TwoCellsSelectionTest', () => {
     TinyAssertions.assertContent(editor,
       '<table>' +
       '<thead>' +
-      '<tr><td scope="col">A2</td><td scope="col">B2</td><td scope="col">C2</td></tr>' +
+      '<tr><td>A2</td><td>B2</td><td>C2</td></tr>' +
       '</thead>' +
       '<tbody>' +
       '<tr><td>A1</td><td>B1</td><td>C1</td></tr>' +

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -102,7 +102,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       type: 'header'
     }, false, generalSelectors);
     await TableTestUtils.pClickDialogButton(editor, true);
-    TinyAssertions.assertContent(editor, '<table style="border: 1px solid black; border-collapse: collapse;" border="1"><thead><tr style="height: 10px; text-align: right;"><td scope="col">X</td></tr></thead></table>');
+    TinyAssertions.assertContent(editor, '<table style="border: 1px solid black; border-collapse: collapse;" border="1"><thead><tr style="height: 10px; text-align: right;"><td>X</td></tr></thead></table>');
     assertEvents([{ type: 'tablemodified', structure: true, style: true }]);
   });
 
@@ -118,7 +118,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       type: 'header'
     }, false, generalSelectors);
     await TableTestUtils.pClickDialogButton(editor, true);
-    TinyAssertions.assertContent(editor, '<table><caption>CAPTION</caption><thead><tr><td scope="col">X</td></tr></thead><tbody><tr><td>Y</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table><caption>CAPTION</caption><thead><tr><td>X</td></tr></thead><tbody><tr><td>Y</td></tr></tbody></table>');
     assertEvents([{ type: 'tablemodified', structure: true, style: false }]);
   });
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowHeaderUiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowHeaderUiTest.ts
@@ -42,12 +42,12 @@ describe('browser.tinymce.plugins.table.ui.TableRowHeaderUiTest', () => {
     '<table>' +
       '<thead>' +
         '<tr>' +
-          makeCell('td', '0-0', 'col') +
-          makeCell('td', '0-1', 'col') +
+          makeCell('td', '0-0', 'none') +
+          makeCell('td', '0-1', 'none') +
         '</tr>' +
         '<tr>' +
-          makeCell('td', '1-0', 'col') +
-          makeCell('td', '1-1', 'col') +
+          makeCell('td', '1-0', 'none') +
+          makeCell('td', '1-1', 'none') +
         '</tr>' +
       '</thead>' +
     '</table>'


### PR DESCRIPTION
Related Ticket: TINY-7709

Description of Changes:
* Added new `setOptions` function to `Attribute` to mirror the `Css.setOptions` function.
* Updated the `TransformOperations` logic to fix issues where the cell may still have been a header when making a column/row a normal column/row.
* Reworked how scopes are created, as they needed more complex logic than what could be done via a generator. It also needed updating when not generating a new cell with these changes.
* Ensure `scope` is never set on `td` elements as it's deprecated/no longer recommended.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
