### PR TITLE
TINY-7596: Fix entire nodes within cells being cleaned when they still contain content

### DIFF
--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -154,7 +154,7 @@ const emptyMultiTableCells = (
   return true;
 };
 
-// Delete the contents of a range inside a cell. Runs on tables that are a single cell as well as partial selections that need to be cleaned up.
+// Delete the contents of a range inside a cell. Runs on tables that are a single cell or partial selections that need to be cleaned up.
 const deleteCellContents = (editor: Editor, rng: Range, cell: SugarElement<HTMLTableCellElement>, moveSelection: boolean = true): boolean => {
   rng.deleteContents();
   // Pad the last block node
@@ -170,12 +170,8 @@ const deleteCellContents = (editor: Editor, rng: Range, cell: SugarElement<HTMLT
   if (!Compare.eq(cell, lastBlock)) {
     const additionalCleanupNodes = Optionals.is(Traverse.parent(lastBlock), cell) ? [] : Traverse.siblings(lastBlock);
     Arr.each(additionalCleanupNodes.concat(Traverse.children(cell)), (node) => {
-      if (!Compare.eq(node, lastBlock) && !Compare.contains(node, lastBlock)) {
-        // Don't clear any nodes that still have content in their descendants
-        const hasNonEmptyDescendant = PredicateExists.descendant(node, Fun.not(Empty.isEmpty));
-        if (!hasNonEmptyDescendant) {
-          Remove.remove(node);
-        }
+      if (!Compare.eq(node, lastBlock) && !Compare.contains(node, lastBlock) && !Empty.isEmpty(node)) { // Don't clear any nodes that still have content
+        Remove.remove(node);
       }
     });
   }

--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -6,7 +6,7 @@
  */
 
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
-import { Attribute, Compare, PredicateExists, Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import { Attribute, Compare, Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -170,7 +170,7 @@ const deleteCellContents = (editor: Editor, rng: Range, cell: SugarElement<HTMLT
   if (!Compare.eq(cell, lastBlock)) {
     const additionalCleanupNodes = Optionals.is(Traverse.parent(lastBlock), cell) ? [] : Traverse.siblings(lastBlock);
     Arr.each(additionalCleanupNodes.concat(Traverse.children(cell)), (node) => {
-      if (!Compare.eq(node, lastBlock) && !Compare.contains(node, lastBlock) && !Empty.isEmpty(node)) { // Don't clear any nodes that still have content
+      if (!Compare.eq(node, lastBlock) && !Compare.contains(node, lastBlock) && Empty.isEmpty(node)) {
         Remove.remove(node);
       }
     });

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -413,6 +413,15 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       TinyAssertions.assertContent(editor, '<p>a1</p><table><tbody><tr><td><p>56</p></td><td>b</td></tr></tbody></table>');
     });
 
+    it('TINY-7596: Partially select and delete from before table into table multiple paragraphs within cell', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>a123</p><table><tbody><tr><td><p>456</p><p>789</p></td><td>b</td></tr></tbody></table>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0, 0, 0, 0, 0 ], 2);
+      doDelete(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
+      TinyAssertions.assertContent(editor, '<p>a1</p><table><tbody><tr><td><p>6</p><p>789</p></td><td>b</td></tr></tbody></table>');
+    });
+
     it('TINY-6044: Partially select and delete from after table into table', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table><p>abcd</p>');


### PR DESCRIPTION
Related Ticket: TINY-7596 (Part 2)

Description of Changes:
Ensures we don't clean out nodes that aren't empty

Pre-checks:
* [x] ~Changelog entry added~ Already exists
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
