### PR TITLE
TINY-7842: Check for content editable true root elements when inserting content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Table cells that were both row and column headers would not retain the correct state when converting back to a regular row or column #TINY-7709
 - Clicking beside a non-editable element could cause the editor to incorrectly scroll to the top of the document #TINY-7062
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
+- Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the cursor to an incorrect location #TINY-7842
 
 ## 5.9.2 - 2021-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Table cells that were both row and column headers would not retain the correct state when converting back to a regular row or column #TINY-7709
 - Clicking beside a non-editable element could cause the editor to incorrectly scroll to the top of the document #TINY-7062
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
-- Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the cursor to an incorrect location #TINY-7842
+- Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
 
 ## 5.9.2 - 2021-09-08
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -21,6 +21,7 @@ import Tools from '../api/util/Tools';
 import CaretPosition from '../caret/CaretPosition';
 import { CaretWalker } from '../caret/CaretWalker';
 import * as TableDelete from '../delete/TableDelete';
+import * as CefUtils from '../dom/CefUtils';
 import * as NodeType from '../dom/NodeType';
 import * as PaddingBr from '../dom/PaddingBr';
 import * as RangeNormalizer from '../selection/RangeNormalizer';
@@ -120,18 +121,6 @@ const moveSelectionToMarker = (editor: Editor, marker: HTMLElement | null): void
   const dom = editor.dom;
   const selection = editor.selection;
 
-  const getContentEditableFalseParent = (node: Node): Node | null => {
-    const root = editor.getBody();
-
-    for (; node && node !== root; node = node.parentNode) {
-      if (dom.getContentEditable(node) === 'false') {
-        return node;
-      }
-    }
-
-    return null;
-  };
-
   if (!marker) {
     return;
   }
@@ -139,10 +128,10 @@ const moveSelectionToMarker = (editor: Editor, marker: HTMLElement | null): void
   selection.scrollIntoView(marker);
 
   // If marker is in cE=false then move selection to that element instead
-  const parentEditableFalseElm = getContentEditableFalseParent(marker);
-  if (parentEditableFalseElm) {
+  const parentEditableElm = CefUtils.getContentEditableRoot(editor.getBody(), marker);
+  if (dom.getContentEditable(parentEditableElm) === 'false') {
     dom.remove(marker);
-    selection.select(parentEditableFalseElm);
+    selection.select(parentEditableElm);
     return;
   }
 

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -622,4 +622,30 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       );
     }
   });
+
+  it('TINY-7842: Inserting content into a contenteditable=true block within a contenteditable=false parent', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<p>some content to stop the fake caret rendering before the CEF element</p>' +
+      '<div contenteditable="false">' +
+        '<p>Non editable content</p>' +
+        '<div contenteditable="true">' +
+          '<p>Editablecontent</p>' +
+        '</div>' +
+      '</div>'
+    );
+    TinySelections.setCursor(editor, [ 1, 1, 0, 0 ], 8);
+    InsertContent.insertAtCaret(editor, ' pasted ');
+    TinyAssertions.assertContent(
+      editor,
+      '<p>some content to stop the fake caret rendering before the CEF element</p>' +
+      '<div contenteditable="false">' +
+        '<p>Non editable content</p>' +
+        '<div contenteditable="true">' +
+          '<p>Editable pasted content</p>' +
+        '</div>' +
+      '</div>'
+    );
+    TinyAssertions.assertCursor(editor, [ 1, 1, 0, 0 ], 16);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7842

Description of Changes:
* Check for content editable true root elements when inserting content. Previously we would only look for `ce=false` parents up the tree without taking into account any `ce=true` that were found along the way

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
