### PR TITLE
TINY-7879: Fixed sketcher behaviours augmenting in the wrong order

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Fixed sketcher behaviours augmenting in the wrong order, which prevented behaviours being revoked.
+
 ## 9.0.0 - 2021-08-26
 
 ### Added

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/CompBehaviours.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/CompBehaviours.ts
@@ -1,19 +1,16 @@
-import { Arr, Obj } from '@ephox/katamari';
+import { Arr, Obj, Type } from '@ephox/katamari';
 
 import * as BehaviourBlob from '../../behaviour/common/BehaviourBlob';
 import { AlloyBehaviour, AlloyBehaviourRecord } from '../behaviour/Behaviour';
-
-type BehaviourName = string;
 
 // This goes through the list of behaviours defined for a particular spec (removing anything
 // that has been revoked), and returns the BehaviourType (e.g. Sliding)
 const getBehaviours = (spec: { behaviours?: AlloyBehaviourRecord }): Array<AlloyBehaviour<any, any, any>> => {
   const behaviours: AlloyBehaviourRecord = Obj.get(spec, 'behaviours').getOr({ });
-  const keys = Arr.filter(
-    Obj.keys(behaviours),
-    (k: BehaviourName) => behaviours[k] !== undefined
-  );
-  return Arr.map(keys, (k) => behaviours[k].me);
+  return Arr.bind(Obj.keys(behaviours), (name) => {
+    const behaviour = behaviours[name];
+    return Type.isNonNullable(behaviour) ? [ behaviour.me ] : [];
+  });
 };
 
 const generateFrom = (spec: { behaviours?: AlloyBehaviourRecord }, all: Array<AlloyBehaviour<any, any, any>>): BehaviourBlob.BehaviourData<any, any, any> => BehaviourBlob.generateFrom(spec, all);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/SketchBehaviours.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/SketchBehaviours.ts
@@ -18,8 +18,8 @@ const field = (name: string, forbidden: Array<{ name: () => string }>): FieldPro
 const get = (data: SketchBehaviours): AlloyBehaviourRecord => data.dump;
 
 const augment = (data: SketchBehaviours, original: Array<NamedConfiguredBehaviour<any, any, any>>): AlloyBehaviourRecord => ({
-  ...data.dump,
-  ...derive(original)
+  ...derive(original),
+  ...data.dump
 });
 
 // Is this used?

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/Behaviour.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/Behaviour.ts
@@ -11,7 +11,7 @@ import { BehaviourConfigAndState } from './BehaviourBlob';
 import { BehaviourState, BehaviourStateInitialiser } from './BehaviourState';
 import {
   AlloyBehaviour, BehaviourActiveSpec, BehaviourApiFunc, BehaviourApisRecord, BehaviourConfigDetail, BehaviourConfigSpec, BehaviourExtraRecord,
-  BehaviourInfo, ConfiguredBehaviour, NamedConfiguredBehaviour
+  BehaviourInfo, NamedConfiguredBehaviour
 } from './BehaviourTypes';
 
 export type WrappedApiFunc<T extends (comp: AlloyComponent, config: any, state: any, ...args: any[]) => any> = T extends (comp: AlloyComponent, config: any, state: any, ...args: infer P) => infer R ? (comp: AlloyComponent, ...args: P) => R : never;
@@ -82,7 +82,7 @@ const wrapApi = <D extends BehaviourConfigDetail, S extends BehaviourState>(bNam
 // I think the "revoke" idea is fragile at best.
 const revokeBehaviour = (name: string): NamedConfiguredBehaviour<any, any, any> => ({
   key: name,
-  value: undefined as unknown as ConfiguredBehaviour<any, any, any>
+  value: undefined
 });
 
 const doCreate = <

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourTypes.ts
@@ -10,7 +10,7 @@ import { BehaviourState, BehaviourStateInitialiser } from './BehaviourState';
 
 export type BehaviourApiFunc<D extends BehaviourConfigDetail, S extends BehaviourState> = (component: AlloyComponent, bConfig: D, bState: S, ...rest: any[]) => any;
 
-export type BehaviourRecord = Record<string, ConfiguredBehaviour<any, any, any>>;
+export type BehaviourRecord = Record<string, ConfiguredBehaviour<any, any, any> | undefined>;
 export interface BehaviourApisRecord<D extends BehaviourConfigDetail, S extends BehaviourState> { [key: string]: BehaviourApiFunc<D, S> }
 export type BehaviourExtraRecord<E> = { [K in keyof E]: Function };
 
@@ -25,7 +25,7 @@ export interface BehaviourActiveSpec<D extends BehaviourConfigDetail, S extends 
 }
 export interface NamedConfiguredBehaviour<C extends BehaviourConfigSpec, D extends BehaviourConfigDetail, S extends BehaviourState> {
   key: string;
-  value: ConfiguredBehaviour<C, D, S>;
+  value: ConfiguredBehaviour<C, D, S> | undefined;
 }
 
 export interface AlloyBehaviour<C extends BehaviourConfigSpec, D extends BehaviourConfigDetail, S extends BehaviourState> {

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/SplitDropdownTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/SplitDropdownTest.ts
@@ -132,18 +132,21 @@ UnitTest.asynctest('SplitDropdown List', (success, failure) => {
           attrs: {
             'role': str.is('button'),
             'aria-expanded': str.is('false'),
-            'aria-haspopup': str.is('true')
+            'aria-haspopup': str.is('true'),
+            'tabindex': str.is('-1')
           },
 
           children: [
             s.element('span', {
               attrs: {
-                role: str.is('presentation')
+                role: str.is('presentation'),
+                tabindex: str.none()
               }
             }),
             s.element('span', {
               attrs: {
-                role: str.is('presentation')
+                role: str.is('presentation'),
+                tabindex: str.none()
               }
             })
           ]

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Image resize backdrop element did not have `data-mce-bogus="all"` set #TINY-7854
 - Table cells that were both row and column headers would not retain the correct state when converting back to a regular row or column #TINY-7709
 - Clicking beside a non-editable element could cause the editor to incorrectly scroll to the top of the document #TINY-7062
+- Split toolbar buttons incorrectly had nested `tabindex="-1"` attributes #TINY-7879
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
 


### PR DESCRIPTION
Related Ticket: TINY-7879

Description of Changes:
* Fixed an issue whereby the sketcher behaviours were merged in the incorrect order (this was introduced in 1dff21202ff097180445084a8fccdf831828ae7f when converting from `Merger.merge`). This caused nested focusable/`tabindex="-1"` elements in split toolbar buttons.
* Fixed some incorrect types and did some simplification.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
