### PR TITLE
TINY-7986: Fixed missing quickbars and rtc help url/name mapping

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -7,7 +7,10 @@
 
 import { Arr } from '@ephox/katamari';
 
-type PluginType = 'opensource' | 'premium';
+export const enum PluginType {
+  Premium = 'premium',
+  OpenSource = 'opensource'
+}
 
 interface PartialPluginUrl {
   readonly key: string;
@@ -20,9 +23,6 @@ export interface PluginUrl extends PartialPluginUrl {
   readonly type: PluginType;
   readonly slug: string;
 }
-
-const premiumType: PluginType = 'premium';
-const openSourceType: PluginType = 'opensource';
 
 const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'advlist', name: 'Advanced List' },
@@ -55,6 +55,7 @@ const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'paste', name: 'Paste' },
   { key: 'preview', name: 'Preview' },
   { key: 'print', name: 'Print' },
+  { key: 'quickbars', name: 'Quick Toolbars' },
   { key: 'save', name: 'Save' },
   { key: 'searchreplace', name: 'Search and Replace' },
   { key: 'spellchecker', name: 'Spell Checker' },
@@ -68,27 +69,28 @@ const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'visualchars', name: 'Visual Characters' },
   { key: 'wordcount', name: 'Word Count' },
   // TODO: Add other premium plugins when they are included in the website
-  { key: 'advcode', name: 'Advanced Code Editor*', type: premiumType },
-  { key: 'formatpainter', name: 'Format Painter*', type: premiumType },
-  { key: 'powerpaste', name: 'PowerPaste*', type: premiumType },
-  { key: 'tinydrive', name: 'Tiny Drive*', type: premiumType },
-  { key: 'tinymcespellchecker', name: 'Spell Checker Pro*', type: premiumType },
-  { key: 'a11ychecker', name: 'Accessibility Checker*', type: premiumType },
-  { key: 'linkchecker', name: 'Link Checker*', type: premiumType },
-  { key: 'mentions', name: 'Mentions*', type: premiumType },
-  { key: 'mediaembed', name: 'Enhanced Media Embed*', type: premiumType },
-  { key: 'checklist', name: 'Checklist*', type: premiumType },
-  { key: 'casechange', name: 'Case Change*', type: premiumType },
-  { key: 'permanentpen', name: 'Permanent Pen*', type: premiumType },
-  { key: 'pageembed', name: 'Page Embed*', type: premiumType },
-  { key: 'tinycomments', name: 'Tiny Comments*', type: premiumType, slug: 'comments' },
-  { key: 'advtable', name: 'Advanced Tables*', type: premiumType },
-  { key: 'autocorrect', name: 'Autocorrect*', type: premiumType },
-  { key: 'export', name: 'Export*', type: premiumType }
+  { key: 'a11ychecker', name: 'Accessibility Checker', type: PluginType.Premium },
+  { key: 'advcode', name: 'Advanced Code Editor', type: PluginType.Premium },
+  { key: 'advtable', name: 'Advanced Tables', type: PluginType.Premium },
+  { key: 'autocorrect', name: 'Autocorrect', type: PluginType.Premium },
+  { key: 'casechange', name: 'Case Change', type: PluginType.Premium },
+  { key: 'checklist', name: 'Checklist', type: PluginType.Premium },
+  { key: 'export', name: 'Export', type: PluginType.Premium },
+  { key: 'mediaembed', name: 'Enhanced Media Embed', type: PluginType.Premium },
+  { key: 'formatpainter', name: 'Format Painter', type: PluginType.Premium },
+  { key: 'linkchecker', name: 'Link Checker', type: PluginType.Premium },
+  { key: 'mentions', name: 'Mentions', type: PluginType.Premium },
+  { key: 'pageembed', name: 'Page Embed', type: PluginType.Premium },
+  { key: 'permanentpen', name: 'Permanent Pen', type: PluginType.Premium },
+  { key: 'powerpaste', name: 'PowerPaste', type: PluginType.Premium },
+  { key: 'rtc', name: 'Real-Time Collaboration', type: PluginType.Premium },
+  { key: 'tinymcespellchecker', name: 'Spell Checker Pro', type: PluginType.Premium },
+  { key: 'tinycomments', name: 'Tiny Comments', type: PluginType.Premium, slug: 'comments' },
+  { key: 'tinydrive', name: 'Tiny Drive', type: PluginType.Premium }
 ], (item) => ({
   ...item,
   // Set the defaults/fallbacks for the plugin urls
-  type: item.type || openSourceType,
+  type: item.type || PluginType.OpenSource,
   slug: item.slug || item.key
 }));
 

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -16,29 +16,10 @@ import * as PluginUrls from '../data/PluginUrls';
 
 const tab = (editor: Editor): Dialog.TabSpec => {
   const availablePlugins = () => {
-    const premiumPlugins = [
-      // TODO: Add other premium plugins such as permanent pen when they are included in the website
-      'Accessibility Checker',
-      'Advanced Code Editor',
-      'Advanced Tables',
-      // 'Autocorrect',
-      'Case Change',
-      'Checklist',
-      'Export',
-      'Tiny Comments',
-      'Tiny Drive',
-      'Enhanced Media Embed',
-      'Format Painter',
-      'Link Checker',
-      'Mentions',
-      'MoxieManager',
-      'Page Embed',
-      'Permanent Pen',
-      'PowerPaste',
-      'Spell Checker Pro'
-    ];
-
-    const premiumPluginList = Arr.map(premiumPlugins, (plugin) => '<li>' + I18n.translate(plugin) + '</li>').join('');
+    const premiumPlugins = Arr.filter(PluginUrls.urls, ({ key, type }) => {
+      return key !== 'autocorrect' && type === PluginUrls.PluginType.Premium;
+    });
+    const premiumPluginList = Arr.map(premiumPlugins, (plugin) => '<li>' + I18n.translate(plugin.name) + '</li>').join('');
 
     return '<div data-mce-tabstop="1" tabindex="-1">' +
       '<p><b>' + I18n.translate('Premium plugins:') + '</b></p>' +
@@ -58,7 +39,8 @@ const tab = (editor: Editor): Dialog.TabSpec => {
     const getMetadata = editor.plugins[key].getMetadata;
     return typeof getMetadata === 'function' ? makeLink(getMetadata()) : key;
   }, (x) => {
-    return makeLink({ name: x.name, url: `https://www.tiny.cloud/docs/plugins/${x.type}/${x.slug}` });
+    const name = x.type === PluginUrls.PluginType.Premium ? `${x.name}*` : x.name;
+    return makeLink({ name, url: `https://www.tiny.cloud/docs/plugins/${x.type}/${x.slug}` });
   });
 
   const getPluginKeys = (editor: Editor) => {


### PR DESCRIPTION
Related Ticket: TINY-7986

Description of Changes:
* Fixed missing RTC and Quickbars metadata causing plain text to be shown.
* Cleaned up the Premium Plugins list as it was duplicated and easy to miss updating both.

Pre-checks:
* [x] ~Changelog entry added~ We don't normally include changelog entries for this.
* [x] ~Tests have been added (if applicable)~
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
