### PR TITLE
TINY-3263: Fixed resize handles rendering above dialogs/menus in inline mode

### DIFF
--- a/modules/oxide/src/less/theme/content/resize-handles/resize-handle.less
+++ b/modules/oxide/src/less/theme/content/resize-handles/resize-handle.less
@@ -11,6 +11,7 @@
 
 @resize-handle-color: #4099ff;
 @resize-handle-size: 10px;
+@resize-clone-z-index: 10000;
 
 .mce-content-body {
   div.mce-resizehandle {
@@ -24,7 +25,7 @@
     height: @resize-handle-size;
     position: absolute;
     width: @resize-handle-size;
-    z-index: 10000;
+    z-index: @z-index-resize-handle;
 
     &:hover {
       background-color: @resize-handle-color;
@@ -48,7 +49,7 @@
   }
 
   .mce-resize-backdrop {
-    z-index: 10000;
+    z-index: @resize-clone-z-index;
   }
 
   .mce-clonedresizable {
@@ -56,7 +57,7 @@
     opacity: .5;
     outline: 1px dashed black;
     position: absolute;
-    z-index: 10001;
+    z-index: @resize-clone-z-index + 1;
 
     // Hide table borders when using table_column_resizing: 'resizetable'
     &.mce-resizetable-columns th,
@@ -79,6 +80,6 @@
     padding: 5px;
     position: absolute;
     white-space: nowrap;
-    z-index: 10002;
+    z-index: @resize-clone-z-index + 2;
   }
 }

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -57,12 +57,16 @@
 @pad-xl: @base-value * 2;
 
 // z-index stack (reserved range 1000-10000)
+@z-index-fullscreen: 1200;
+@z-index-resize-handle: 1298;
+@z-index-throbber: 1299;
+@z-index-sink: 1300;
+
+// sink z-index stack
+// Note: these are rendered inside the sink so aren't affected by the other global z-index variables
 @z-index-loading: 1000;
 @z-index-dialogs: 1100;
 @z-index-menu: 1150;
-@z-index-fullscreen: 1200;
-@z-index-throbber: 1299;
-@z-index-sink: 1300;
 
 // Responsive breakpoints
 @breakpoint-md: ~"only screen and (min-width:1000px)";

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Resizing table columns in some scenarios would resize the column to an incorrect position #TINY-7731
 - Image resize backdrop element did not have `data-mce-bogus="all"` set #TINY-7854
+- Resize handles appeared on top of dialogs and menus when using an inline editor #TINY-3263
 - Table cells that were both row and column headers would not retain the correct state when converting back to a regular row or column #TINY-7709
 - Clicking beside a non-editable element could cause the editor to incorrectly scroll to the top of the document #TINY-7062
 - Fixed an exception getting thrown when there were more `col` elements than columns in a table #TINY-7041


### PR DESCRIPTION
Related Ticket: TINY-3263

Description of Changes:
* Fixes the resize handle z-index as it was much higher than the sink z-index which meant it rendered above anything in the sink  (e.g. dialogs and menus) in inline mode

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
