### PR TITLE
TINY-6870: Switch wordcount plugin to use BDD style tests

### DIFF
--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/api/ApiTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/api/ApiTest.ts
@@ -1,95 +1,89 @@
-import { Assertions, GeneralSteps, Log, Logger, Pipeline, Step } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { TinyApis, TinyLoader } from '@ephox/wrap-mcagar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Type } from '@ephox/katamari';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import { CountGetter, WordCountApi } from 'tinymce/plugins/wordcount/api/Api';
+import { WordCountApi } from 'tinymce/plugins/wordcount/api/Api';
 import Plugin from 'tinymce/plugins/wordcount/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
 interface Sel {
-  startPath: number[];
-  soffset: number;
-  finishPath: number[];
-  foffset: number;
+  readonly startPath: number[];
+  readonly soffset: number;
+  readonly finishPath: number[];
+  readonly foffset: number;
 }
 
-UnitTest.asynctest('browser.tinymce.plugins.wordcount.ApiTest', (success, failure) => {
-  Plugin();
-  Theme();
-
-  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
-    const tinyApis = TinyApis(editor);
-
-    const createAssertionStep = (getCount: CountGetter) => (label: string, content: string, assertedLength: number, sel?: Sel) => GeneralSteps.sequence([
-      tinyApis.sSetContent(content),
-      ...(sel ? [ tinyApis.sSetSelection(sel.startPath, sel.soffset, sel.finishPath, sel.foffset) ] : []),
-      Step.sync(() => Assertions.assertEq(label, getCount(), assertedLength))
-    ]);
-
-    const api: WordCountApi = editor.plugins.wordcount as WordCountApi;
-
-    const bodyWordCount = createAssertionStep(api.body.getWordCount);
-    const bodyCharacterCount = createAssertionStep(api.body.getCharacterCount);
-    const bodyCharacterCountWithoutSpaces = createAssertionStep(api.body.getCharacterCountWithoutSpaces);
-
-    const selectionWordCount = createAssertionStep(api.selection.getWordCount);
-    const selectionCharacterCount = createAssertionStep(api.selection.getCharacterCount);
-    const selectionCharacterCountWithoutSpaces = createAssertionStep(api.selection.getCharacterCountWithoutSpaces);
-
-    Pipeline.async({}, Log.steps('TBA', 'WordCount', [
-      Logger.t('Body word count', GeneralSteps.sequence([
-        bodyWordCount('Simple word count', '<p>My sentence is this.</p>', 4),
-        bodyWordCount('Simple word count', '<p>My sentence is this.</p>', 4),
-        bodyWordCount('Does not count dashes', '<p>Something -- ok</p>', 2),
-        bodyWordCount('Does not count asterisks, non-word characters', '<p>* something\n\u00b7 something else</p>', 3),
-        bodyWordCount('Does count numbers', '<p>Something 123 ok</p>', 3),
-        bodyWordCount('Does not count htmlentities', `<p>It&rsquo;s my life &ndash; &#8211; &#x2013; don't you forget.</p>`, 6),
-        bodyWordCount('Counts hyphenated words as one word', '<p>Hello some-word here.</p>', 3),
-        bodyWordCount('Counts words between blocks as two words', '<p>Hello</p><p>world</p>', 2)
-      ])),
-
-      Logger.t('Body character count', GeneralSteps.sequence([
-        bodyCharacterCount('Simple character count', '<p>My sentence is this.</p>', 20),
-        bodyCharacterCount('Does not count newline', '<p>a<br>b</p>', 2),
-        bodyCharacterCount('Counts surrogate pairs as single character', '<p>𩸽</p>', 1)
-      ])),
-
-      Logger.t('Body character count without spaces', GeneralSteps.sequence([
-        bodyCharacterCountWithoutSpaces('Simple character count', '<p>My sentence is this.</p>', 17),
-        bodyCharacterCountWithoutSpaces('Counts surrogate pairs as single character', '<p>𩸽</p>', 1)
-      ])),
-
-      Logger.t('Selection word count', GeneralSteps.sequence([
-        selectionWordCount('Simple word count', '<p>My sentence is this.</p>', 2, {
-          startPath: [ 0, 0 ],
-          soffset: 2,
-          finishPath: [ 0, 0 ],
-          foffset: 15
-        })
-      ])),
-
-      Logger.t('Selection character count', GeneralSteps.sequence([
-        selectionCharacterCount('Simple word count', '<p>My sentence is this.</p>', 13, {
-          startPath: [ 0, 0 ],
-          soffset: 2,
-          finishPath: [ 0, 0 ],
-          foffset: 15
-        })
-      ])),
-
-      Logger.t('Selection character count without spaces', GeneralSteps.sequence([
-        selectionCharacterCountWithoutSpaces('Simple word count', '<p>My sentence is this.</p>', 10, {
-          startPath: [ 0, 0 ],
-          soffset: 2,
-          finishPath: [ 0, 0 ],
-          foffset: 15
-        })
-      ]))
-    ]), onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.wordcount.ApiTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'wordcount',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const createTest = (getCount: (api: WordCountApi) => number) => (content: string, expectedLength: number, sel?: Sel) => () => {
+    const editor = hook.editor();
+    const api: WordCountApi = editor.plugins.wordcount as WordCountApi;
+    editor.setContent(content);
+    if (Type.isNonNullable(sel)) {
+      TinySelections.setSelection(editor, sel.startPath, sel.soffset, sel.finishPath, sel.foffset);
+    }
+    assert.equal(getCount(api), expectedLength);
+  };
+
+  const bodyWordCount = createTest((api) => api.body.getWordCount());
+  const bodyCharacterCount = createTest((api) => api.body.getCharacterCount());
+  const bodyCharacterCountWithoutSpaces = createTest((api) => api.body.getCharacterCountWithoutSpaces());
+
+  const selectionWordCount = createTest((api) => api.selection.getWordCount());
+  const selectionCharacterCount = createTest((api) => api.selection.getCharacterCount());
+  const selectionCharacterCountWithoutSpaces = createTest((api) => api.selection.getCharacterCountWithoutSpaces());
+
+  context('Body word count', () => {
+    it('Simple word count', bodyWordCount('<p>My sentence is this.</p>', 4));
+    it('Does not count dashes', bodyWordCount('<p>Something -- ok</p>', 2));
+    it('Does not count asterisks, non-word characters', bodyWordCount('<p>* something\n\u00b7 something else</p>', 3));
+    it('Does count numbers', bodyWordCount('<p>Something 123 ok</p>', 3));
+    it('Does not count htmlentities', bodyWordCount(`<p>It&rsquo;s my life &ndash; &#8211; &#x2013; don't you forget.</p>`, 6));
+    it('Counts hyphenated words as one word', bodyWordCount('<p>Hello some-word here.</p>', 3));
+    it('Counts words between blocks as two words', bodyWordCount('<p>Hello</p><p>world</p>', 2));
+  });
+
+  context('Body character count', () => {
+    it('Simple character count', bodyCharacterCount('<p>My sentence is this.</p>', 20));
+    it('Does not count newline', bodyCharacterCount('<p>a<br>b</p>', 2));
+    it('Counts surrogate pairs as single character', bodyCharacterCount('<p>𩸽</p>', 1));
+  });
+
+  context('Body character count without spaces', () => {
+    it('Simple character count', bodyCharacterCountWithoutSpaces('<p>My sentence is this.</p>', 17));
+    it('Counts surrogate pairs as single character', bodyCharacterCountWithoutSpaces('<p>𩸽</p>', 1));
+  });
+
+  context('Selection word count', () => {
+    it('Simple word count', selectionWordCount('<p>My sentence is this.</p>', 2, {
+      startPath: [ 0, 0 ],
+      soffset: 2,
+      finishPath: [ 0, 0 ],
+      foffset: 15
+    }));
+  });
+
+  context('Selection character count', () => {
+    it('Simple word count', selectionCharacterCount('<p>My sentence is this.</p>', 13, {
+      startPath: [ 0, 0 ],
+      soffset: 2,
+      finishPath: [ 0, 0 ],
+      foffset: 15
+    }));
+  });
+
+  context('Selection character count without spaces', () => {
+    it('Simple word count', selectionCharacterCountWithoutSpaces('<p>My sentence is this.</p>', 10, {
+      startPath: [ 0, 0 ],
+      soffset: 2,
+      finishPath: [ 0, 0 ],
+      foffset: 15
+    }));
+  });
 });

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/core/GetTextTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/core/GetTextTest.ts
@@ -1,37 +1,34 @@
-import { Pipeline, Step } from '@ephox/agar';
-import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { TinyLoader } from '@ephox/wrap-mcagar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { getText } from 'tinymce/plugins/wordcount/core/GetText';
 import Plugin from 'tinymce/plugins/wordcount/Plugin';
 import Theme from 'tinymce/themes/silver/Theme';
 
-UnitTest.asynctest('browser.tinymce.plugins.wordcount.GetTextTest', (success, failure) => {
-  Plugin();
-  Theme();
-
-  TinyLoader.setupLight((editor: Editor, onSuccess, onFailure) => {
-    const sAssertGetText = (node: Node, expected) => Step.sync(() => {
-      const actual = getText(node, editor.schema);
-
-      Assert.eq('should be the same', expected, actual);
-    });
-
-    const c = (html) => editor.dom.create('div', {}, html);
-
-    Pipeline.async({}, [
-      sAssertGetText(c('<p></p>'), []),
-      sAssertGetText(c('<p>a b</p>'), [ 'a b' ]),
-      sAssertGetText(c('<p>a&nbsp;b</p>'), [ 'a\u00a0b' ]),
-      sAssertGetText(c('<p>a\uFEFFb</p>'), [ 'ab' ]),
-      sAssertGetText(c('<p><span>a</span> b</p>'), [ 'a b' ]),
-      sAssertGetText(c('<p>a</p><p>b</p>'), [ 'a', 'b' ]),
-      sAssertGetText(c('<p>a<br>b</p>'), [ 'a', 'b' ])
-    ], onSuccess, onFailure);
-  }, {
+describe('browser.tinymce.plugins.wordcount.GetTextTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'wordcount',
-    theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, success, failure);
+  }, [ Plugin, Theme ]);
+
+  const assertGetText = (node: Node, expected: string[]) => {
+    const editor = hook.editor();
+    const actual = getText(node, editor.schema);
+    assert.deepEqual(actual, expected, 'should be the same');
+  };
+
+  it('getText', () => {
+    const editor = hook.editor();
+    const c = (html: string) => editor.dom.create('div', {}, html);
+
+    assertGetText(c('<p></p>'), []);
+    assertGetText(c('<p>a b</p>'), [ 'a b' ]);
+    assertGetText(c('<p>a&nbsp;b</p>'), [ 'a\u00a0b' ]);
+    assertGetText(c('<p>a\uFEFFb</p>'), [ 'ab' ]);
+    assertGetText(c('<p><span>a</span> b</p>'), [ 'a b' ]);
+    assertGetText(c('<p>a</p><p>b</p>'), [ 'a', 'b' ]);
+    assertGetText(c('<p>a<br>b</p>'), [ 'a', 'b' ]);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-6970

Description of Changes:
* Converts the `wordcount` plugin to use BDD style tests

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
