### PR TITLE
Prepare branch for 6.0 work

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-primaryBranch=develop
+primaryBranch=next

--- a/modules/acid/CHANGELOG.md
+++ b/modules/acid/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 4.0.1 - TBD
 
-### Added
-
 ## 4.0.0 - 2021-08-26
 
 ### Added

--- a/modules/acid/CHANGELOG.md
+++ b/modules/acid/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 4.0.1 - TBD
+
+### Added
+
 ## 4.0.0 - 2021-08-26
 
 ### Added

--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 6.0.1 - TBD
+
 ## 6.0.0 - 2021-08-26
 
 ### Added

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 9.0.1 - TBD
+
 ### Fixed
 - Fixed sketcher behaviours augmenting in the wrong order, which prevented behaviours being revoked.
 - Fixed debugging throwing errors.

--- a/modules/boss/CHANGELOG.md
+++ b/modules/boss/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 5.0.1 - TBD
+
 ## 5.0.0 - 2021-08-26
 
 ### Changed

--- a/modules/boulder/CHANGELOG.md
+++ b/modules/boulder/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.0. 1 - TBD
+
 ## 6.0.0 - 2021-08-26
 
 ### Improved

--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 3.0.3 - TBD
+
 ## 3.0.2 - 2021-08-27
 
 ### Fixed

--- a/modules/darwin/CHANGELOG.md
+++ b/modules/darwin/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 7.0.1 - TBD
+
 ## 7.0.0 - 2021-08-26
 
 ## Added

--- a/modules/dragster/CHANGELOG.md
+++ b/modules/dragster/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 6.0.1 - TBD
+
 ## 6.0.0 - 2021-08-26
 
 ### Changed

--- a/modules/imagetools/CHANGELOG.md
+++ b/modules/imagetools/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 5.0.1 - TBD
+
 ## 5.0.0 - 2021-08-26
 
 ### Changed

--- a/modules/jax/CHANGELOG.md
+++ b/modules/jax/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 6.0.1 - TBD
+
 ## 6.0.0 - 2021-08-26
 
 ### Improved

--- a/modules/katamari-assertions/CHANGELOG.md
+++ b/modules/katamari-assertions/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 3.0.1 - TBD
+
 ## 3.0.0 - 2021-08-26
 
 ### Changed

--- a/modules/katamari/CHANGELOG.md
+++ b/modules/katamari/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 8.0.1 - TBD
+
 ## 8.0.0 - 2021-08-26
 
 ### Added

--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 7.0.3 - TBD
+
 ## 7.0.2 - 2021-09-08
 
 ### Fixed

--- a/modules/phoenix/CHANGELOG.md
+++ b/modules/phoenix/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 7.0.1 - TBD
+
 ## 7.0.0 - 2021-08-26
 
 ### Changed

--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 5.0.1 - TBD
+
 ## 5.0.0 - 2021-08-26
 
 ### Changed

--- a/modules/porkbun/CHANGELOG.md
+++ b/modules/porkbun/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 6.0.1 - TBD
+
 ## 6.0.0 - 2021-08-26
 
 ### Changed

--- a/modules/robin/CHANGELOG.md
+++ b/modules/robin/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 9.0.1 - TBD
+
 ## 9.0.0 - 2021-08-26
 
 ### Added

--- a/modules/sand/CHANGELOG.md
+++ b/modules/sand/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 5.0.1 - TBD
+
 ## 5.0.0 - 2021-08-26
 
 ### Improved

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 10.0.0 - TBD
+
 ### Changed
 - The `pixelSize` and `percentSize` functions in `TableSize` no longer require the initial width to be provided.
 - `ColumnSizes` will now use `col` elements to calculate the column width where appropriate.

--- a/modules/sugar/CHANGELOG.md
+++ b/modules/sugar/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 8.1.0 - TBD
+
 ### Added
 - Added new `parentElement` function to the `Traverse` API.
 - Added new `setOptions` function to the `Attribute` API.

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 5.10.0 - TBD
+
 ### Changed
 - The deprecated `scope` attribute is no longer added to `td` cells when converting a row to a header row #TINY-7731
 

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.10.0",
+  "version": "6.0.0",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related Ticket: Get a branch ready for us to have somewhere to put our 6.0 work

Description of Changes:
* Added a placeholder release to each changelog, so we can tell 5.x work apart from 6.0 work and avoid git conflicts
* Update `build.properties` so that Jenkins knows which branch to look at when doing merges and tests
* Updated `modules/tinymce/package.json` to the new version

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
