### PR TITLE
Prevent error when DataTransferItem.getAsFile() returns null

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an exception getting thrown when there were more `col` elements than columns in a table #TINY-7041
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
+- Unable to paste a screenshot taken from gnome-software on Chrome
 
 ## 5.9.2 - 2021-09-08
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Clipboard.ts
@@ -209,7 +209,8 @@ const isImage = (editor: Editor) => {
 };
 
 const getImagesFromDataTransfer = (editor: Editor, dataTransfer: DataTransfer): File[] => {
-  const items = dataTransfer.items ? Arr.map(Arr.from(dataTransfer.items), (item) => item.getAsFile()) : [];
+  let items = dataTransfer.items ? Arr.map(Arr.from(dataTransfer.items), (item) => item.getAsFile()) : [];
+  items = items.filter((item) => item !== null);
   const files = dataTransfer.files ? Arr.from(dataTransfer.files) : [];
   return Arr.filter(items.length > 0 ? items : files, isImage(editor));
 };


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
`DataTransferItem.getAsFile()` may return null. This change will filter entries to only handle `File` entries and prevent the error mentionned in #7213 .

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable): #7213 
