### PR TITLE
TINY-7894: Fixed docking state being set incorrectly in some edge cases

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fixed sketcher behaviours augmenting in the wrong order, which prevented behaviours being revoked.
 - Fixed debugging throwing errors.
+- `Docking` state could end up incorrect internally, which caused `Docking.refresh()` to not work.
 
 ## 9.0.0 - 2021-08-26
 


### PR DESCRIPTION
Related Ticket: TINY-7894

Description of Changes:
This was a bug found when trying to get docking working with notifications. I'm still not sure exactly what triggers this case, but it makes sense that the docking state can end up in a bad state as there are 3 possible morph modes, but only 2 possible states. So if we happen to end up morphing to between the 2 modes that are undocked, then the state could have ended up in a bad state. So this resolves that by explicitly setting the state based on how we're morphing.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ Tests exist for docking in general and as discussed on slack, since we don't know the cause and are short on time we're going to skip this specific edge case.
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
