### PR TITLE
TINY-7908: SHY entities should not be treated as word-breaks

### DIFF
--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- `Pattern.chars` and `Pattern.wordbreak` now accept soft hyphen (SHY) entities
+
 ## 5.0.0 - 2021-08-26
 
 ### Changed

--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 5.0.1 - 2021-09-24
+
 ### Fixed
-- `Pattern.chars` and `Pattern.wordbreak` now accept soft hyphen (SHY) entities
+- `Pattern.chars` and `Pattern.wordbreak` now accept soft hyphen (SHY) entities #TINY-7908
 
 ## 5.0.0 - 2021-08-26
 

--- a/modules/polaris/src/main/ts/ephox/polaris/pattern/Chars.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/pattern/Chars.ts
@@ -5,12 +5,14 @@ import { punctuationStr } from '../words/UnicodeData';
 // \w is a word character
 // "'" is an apostrophe
 // '-' is a hyphen
+// \u00AD is a soft hyphen
 
 // (https://en.wikipedia.org/wiki/List_of_Unicode_characters#Latin_Extended-A)
 // \u00C0 - \u00FF are various language characters (Latin-1)
 // \u0100 - \u017F are various language characters (Latin Extended-A)
 // \u2018 and \u2019 are the smart quote characters
-const charsStr = '\\w' + `'` + '\\-' + '\\u0100-\\u017F\\u00C0-\\u00FF' + Unicode.zeroWidth + '\\u2018\\u2019';
+// \u00AD is a soft hyphen (SHY) entity
+const charsStr = '\\w' + `'` + '\\-\\u00AD' + '\\u0100-\\u017F\\u00C0-\\u00FF' + Unicode.zeroWidth + '\\u2018\\u2019';
 const wordbreakStr = '[^' + charsStr + ']';
 const wordcharStr = '[' + charsStr + ']';
 

--- a/modules/polaris/src/test/ts/atomic/pattern/CharsTest.ts
+++ b/modules/polaris/src/test/ts/atomic/pattern/CharsTest.ts
@@ -53,7 +53,8 @@ UnitTest.test('CharsTest', () => {
     de: {
       label: 'German',
       html: 'http://character-code.com/german-html-codes.php',
-      chars: 'ÄäÉéÖöÜüß'
+      // TINY-7908: Including \u00AD (soft hyphens) because they appear to be more common in German text
+      chars: 'ÄäÉéÖöÜüß\u00AD'
     },
     nb: {
       label: 'Norwegian',

--- a/modules/robin/CHANGELOG.md
+++ b/modules/robin/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 9.0.1 - 2021-09-24
+
+### Fixed
+- TextZone methods no longer treat soft hyphens (shy entities) as word breaks #TINY-7908
+
 ## 9.0.0 - 2021-08-26
 
 ### Added

--- a/modules/robin/src/test/ts/browser/zone/EntityTest.ts
+++ b/modules/robin/src/test/ts/browser/zone/EntityTest.ts
@@ -1,0 +1,36 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Unicode } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import * as DomTextZones from 'ephox/robin/api/dom/DomTextZones';
+import { ZoneViewports } from 'ephox/robin/api/general/ZoneViewports';
+
+describe('browser.robin.zone.EntityTest', () => {
+  it('TINY-7908: Soft hyphens are not treated as a word boundary', () => {
+    const content = SugarElement.fromHtml('<div>some plain words and a hy&shy;phenated word</div>');
+    const zones = DomTextZones.single(content, 'en-US', ZoneViewports.anything());
+    const rawZones = zones.zones.map((z) => ({ lang: z.lang, words: z.words.map((w) => w.word) }));
+    assert.deepEqual(rawZones, [
+      { lang: 'en-US', words: [ 'some', 'plain', 'words', 'and', 'a', `hy${Unicode.softHyphen}phenated`, 'word' ] }
+    ]);
+  });
+
+  it('Zero width spaces are not treated as a word boundary', () => {
+    const content = SugarElement.fromHtml(`<div>some plain words with some&#xFEFF;space</div>`);
+    const zones = DomTextZones.single(content, 'en-US', ZoneViewports.anything());
+    const rawZones = zones.zones.map((z) => ({ lang: z.lang, words: z.words.map((w) => w.word) }));
+    assert.deepEqual(rawZones, [
+      { lang: 'en-US', words: [ 'some', 'plain', 'words', 'with', `some${Unicode.zeroWidth}space` ] }
+    ]);
+  });
+
+  it('Non breaking spaces are treated as a word boundary', () => {
+    const content = SugarElement.fromHtml(`<div>some plain words with some&nbsp;space</div>`);
+    const zones = DomTextZones.single(content, 'en-US', ZoneViewports.anything());
+    const rawZones = zones.zones.map((z) => ({ lang: z.lang, words: z.words.map((w) => w.word) }));
+    assert.deepEqual(rawZones, [
+      { lang: 'en-US', words: [ 'some', 'plain', 'words', 'with', 'some', 'space' ] }
+    ]);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-7908

Description of Changes:
* Add soft hyphens to the list of accepted word characters in Polaris (with follow-ons to robin also)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable): N/A