### PR TITLE
TINY-7894: Fixed a number of notification positioning issues

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Table cells that were both row and column headers would not retain the correct state when converting back to a regular row or column #TINY-7709
 - Clicking beside a non-editable element could cause the editor to incorrectly scroll to the top of the document #TINY-7062
 - Split toolbar buttons incorrectly had nested `tabindex="-1"` attributes #TINY-7879
+- Fixed notifications rendering in the wrong place initially and when the page was scrolled #TINY-7894
 - Fixed an exception getting thrown when the number of `col` elements didn't match the number of columns in a table #TINY-7041 #TINY-8011
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -154,11 +154,15 @@ const NotificationManager = (editor: Editor): NotificationManager => {
           timeout: 0
         }, false);
       }
+
+      // Ensure the notifications are repositioned once the skin has loaded, as otherwise
+      // any notifications rendered before then may have wrapped and been in the wrong place
+      reposition();
     });
 
     // NodeChange is needed for inline mode and autoresize as the positioning is done
     // from the bottom up, which changes when the content in the editor changes.
-    editor.on('ResizeEditor ResizeWindow NodeChange', () => {
+    editor.on('show ResizeEditor ResizeWindow NodeChange', () => {
       Delay.requestAnimationFrame(reposition);
     });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -1,6 +1,8 @@
 import { ApproxStructure, Assertions, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Focus, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { Arr } from '@ephox/katamari';
+import { TinyDom } from '@ephox/mcagar';
+import { Focus, Scroll, SugarBody, SugarElement, SugarLocation, Traverse } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -8,6 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { NotificationApi } from 'tinymce/core/api/NotificationManager';
 import Theme from 'tinymce/themes/silver/Theme';
 
+import * as PageScroll from '../../module/PageScroll';
 import { resizeToPos } from '../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () => {
@@ -151,6 +154,41 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       notification.progressBar.value(100);
       assertStructure('Check notification structure with 100% progress', notification, 'success', 'Message', 100);
       notification.close();
+    });
+
+    it('TINY-7894: Should always render below the top of the header and within the content area', () => {
+      const editor = hook.editor();
+      const cleanup = PageScroll.setup(editor, 2000);
+
+      // Scroll so the editor is below the bottom of the window
+      Scroll.to(0, 0);
+      const notification1 = openNotification(editor, 'success', 'Message');
+      assertPosition('Below window notification', notification1, 226, -2200);
+      notification1.close();
+
+      // Scroll so the header is above the top of the window, but the bottom of the editor is in view
+      const topOfEditor = SugarLocation.absolute(TinyDom.container(editor)).top;
+      Scroll.to(0, topOfEditor + 100);
+      const notification2 = openNotification(editor, 'success', 'Message');
+      assertPosition('Partial editor view notification', notification2, 226, -2100);
+      notification2.close();
+
+      // Scroll so the editor is above the top of the window
+      Scroll.to(0, 4000);
+      const notification3 = openNotification(editor, 'success', 'Message');
+      assertPosition('Above window notification', notification3, 226, -2000);
+      notification3.close();
+
+      cleanup();
+    });
+
+    it('TINY-7894: Opening multiple notifications should be able to expand past the bottom of the content area', () => {
+      const editor = hook.editor();
+
+      const notifications = Arr.range(9, (i) => openNotification(editor, 'success', `Message ${i + 1}`));
+      assertPosition('Last notification is outside the content area', notifications[notifications.length - 1], 220, 185);
+
+      Arr.each(notifications, (notification) => notification.close());
     });
   });
 


### PR DESCRIPTION
Related Ticket: TINY-7894

Description of Changes:
* Fixes an issue where the notifications could be incorrectly positioned on initial render.
* Fixes an issue where notifications were rendered when the editor was not visible in the window.
* Did a little bit of cleanup in the notification manager logic, as it was doing some unnecessary things (stuff that looks to have been required in 4.x, but not in 5.x).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
