### PR TITLE
TINY-8036: Fixed a regression in the format expand range logic when using block formats with a wrapper

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The number of `col` elements is normalised to match the number of columns in a table after a table action #TINY-8011
 
 ### Fixed
+- Fixed a regression that caused block wrapper formats to apply and remove incorrectly when using a collapsed selection with multiple words #TINY-8036
 - Resizing table columns in some scenarios would resize the column to an incorrect position #TINY-7731
 - Image resize backdrop element did not have `data-mce-bogus="all"` set #TINY-7854
 - Resize handles appeared on top of dialogs and menus when using an inline editor #TINY-3263

--- a/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
@@ -121,14 +121,14 @@ const findSelectorEndPoint = (dom: DOMUtils, formatList: Format[], rng: Range, c
 };
 
 const findBlockEndPoint = (editor: Editor, formatList: Format[], container: Node, siblingName: Sibling) => {
-  let node = container;
+  let node: Node | null = container;
   const dom = editor.dom;
   const root = dom.getRoot();
   const format = formatList[0];
 
   // Expand to block of similar type
-  if (FormatUtils.isBlockFormat(format) && !format.wrapper) {
-    node = dom.getParent(container, format.block, root);
+  if (FormatUtils.isBlockFormat(format)) {
+    node = format.wrapper ? null : dom.getParent(container, format.block, root);
   }
 
   // Expand to first wrappable block element or any block element

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
-import { LegacyUnit, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -2527,5 +2527,13 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.formatter.apply('formatA', { value: 'a' });
     editor.formatter.apply('formatA', { value: 'b' });
     assert.equal(getContent(editor), '<p class="a b">test</p>');
+  });
+
+  it('TINY-8036: Apply blockquote with multiple words and collapsed selection', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>test test</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 7);
+    editor.formatter.apply('blockquote');
+    TinyAssertions.assertContent(editor, '<blockquote><p>test test</p></blockquote>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -602,5 +602,13 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
     editor.formatter.remove('formatA', { value: 'a' });
     assert.equal(getContent(editor), '<p class="b">test</p>');
+  });
+
+  it('TINY-8036: Remove blockquote format with multiple words and collapsed selection', () => {
+    const editor = hook.editor();
+    editor.setContent('<blockquote><p>test test</p></blockquote>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 5);
+    editor.formatter.remove('blockquote');
+    TinyAssertions.assertContent(editor, '<p>test test</p>');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8036

Description of Changes:

Fixes a regression introduced in https://github.com/tinymce/tinymce/pull/7002 whereby block wrapper formats didn't expand out to the parent block correctly. This in turn caused blockquotes to fail to apply/remove correctly when there were multiple words.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
