### PR TITLE
TINY-7736: Fixed issues when clicking into a table cell when another cell had a cef element

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize handles appeared on top of dialogs and menus when using an inline editor #TINY-3263
 - Table cells that were both row and column headers would not retain the correct state when converting back to a regular row or column #TINY-7709
 - Clicking beside a non-editable element could cause the editor to incorrectly scroll to the top of the document #TINY-7062
+- Clicking in a table cell, with a non-editable element in an adjacent cell, incorrectly caused the non-editable element to be selected #TINY-7736
 - Split toolbar buttons incorrectly had nested `tabindex="-1"` attributes #TINY-7879
 - Fixed notifications rendering in the wrong place initially and when the page was scrolled #TINY-7894
 - Fixed an exception getting thrown when the number of `col` elements didn't match the number of columns in a table #TINY-7041 #TINY-8011

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -1,7 +1,7 @@
 import { Mouse, PhantomSkipper } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { Scroll } from '@ephox/sugar';
+import { Scroll, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -25,20 +25,20 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
 
   const assertSelectionIsCaretBlock = (editor: Editor, caretValue: 'before' | 'after') => {
     const selectedNode = editor.selection.getNode();
-    assert.isTrue(isCaretContainerBlock(selectedNode));
+    assert.isTrue(isCaretContainerBlock(selectedNode), 'Selected node should be a fake caret node');
     assert.equal(selectedNode.getAttribute('data-mce-caret'), caretValue);
   };
 
-  const selectBesideContentEditable = (editor: Editor, contentEditableElm: HTMLElement, clickPoint: 'before' | 'after') => {
+  const selectBesideContentEditable = (editor: Editor, contentEditableElm: HTMLElement, clickPoint: 'before' | 'after', offset: number = 8) => {
     editor.selection.scrollIntoView(contentEditableElm);
 
     const scrollTop = getScrollTop(editor);
-    const bodyMarginOffset = 8; // Default is 16 so divide by 2
     const rect = contentEditableElm.getBoundingClientRect();
-    const clientX = clickPoint === 'before' ? rect.left - bodyMarginOffset : rect.right + bodyMarginOffset;
+    const clientX = clickPoint === 'before' ? rect.left - offset : rect.right + offset;
     const clientY = rect.top + (rect.height / 2);
 
-    Mouse.point('mousedown', 0, TinyDom.documentElement(editor), clientX, clientY);
+    const target = Traverse.parentElement(SugarElement.fromDom(contentEditableElm)).getOrThunk(() => TinyDom.documentElement(editor));
+    Mouse.point('mousedown', 0, target, clientX, clientY);
     // Check the scroll position has not changed
     assert.equal(getScrollTop(editor), scrollTop);
     // Check fake caret has been added
@@ -53,7 +53,7 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
     assert.equal(evt.isDefaultPrevented(), true);
   });
 
-  it('click next to cE=false block', () => {
+  it('click in non-empty cell next to cell with cE=false block', () => {
     const editor = hook.editor();
     editor.setContent(
       '<table style="width: 100%">' +
@@ -65,16 +65,45 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
     );
 
     const firstTd = editor.dom.select('td')[0];
-    const rect = editor.dom.getRect(firstTd);
+    const rect = firstTd.getBoundingClientRect();
+    Mouse.mouseDown(SugarElement.fromDom(firstTd), { dx: 10, dy: rect.height / 2 });
 
-    editor.fire('mousedown', {
-      target: firstTd as EventTarget,
-      clientX: rect.x + rect.w,
-      clientY: rect.y + 10
-    } as MouseEvent);
+    const selectedNode = editor.selection.getNode();
+    assert.isFalse(isCaretContainerBlock(selectedNode));
+  });
 
-    // Since we can't do a real click we need to check if it gets sucked in towards the cE=false block
-    assert.equal(editor.selection.getNode().nodeName !== 'P', true);
+  it('TINY-7736: click in empty cell next to cell with cE=false block', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table style="width: 100%">' +
+      '<tr><th>Header 1</th><th>Header 2</th></tr>' +
+      '<tr>' +
+      '<td><div contentEditable="false" style="height: 100px">1</div><p>&nbsp;</p></td>' +
+      '<td>&nbsp;</td>' +
+      '</tr>' +
+      '</table>'
+    );
+
+    const secondTd = editor.dom.select('td')[1];
+    const rect = secondTd.getBoundingClientRect();
+    Mouse.mouseDown(SugarElement.fromDom(secondTd), { dx: 10, dy: rect.height / 2 });
+
+    const selectedNode = editor.selection.getNode();
+    assert.isFalse(isCaretContainerBlock(selectedNode));
+  });
+
+  it('TINY-7736: click next to cE=false block in table cell', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table style="width: 100%">' +
+      '<tr>' +
+      '<td><p>&nbsp;</p><div contentEditable="false" style="width: 100px; height: 100px">2</div><p>&nbsp;</p></td>' +
+      '</tr>' +
+      '</table>'
+    );
+
+    const noneditableDiv = editor.dom.select('div')[0];
+    selectBesideContentEditable(editor, noneditableDiv, 'before', 2);
   });
 
   it('offscreen copy of cE=false block remains offscreen', function () {


### PR DESCRIPTION
Related Ticket: TINY-7736

Description of Changes:
Fixes an issue where the "better mouse target" logic didn't handle clicking into an empty block element, which resulted in the selection being placed next to a cef element on the same "line" as the target.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
Fixes #6350
Fixes #6547
