### PR TITLE
TINY-3463: Fixed the `image` and `media` toolbar buttons showing the incorrect active state in some cases

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed notifications rendering in the wrong place initially and when the page was scrolled #TINY-7894
 - Fixed an exception getting thrown when the number of `col` elements didn't match the number of columns in a table #TINY-7041 #TINY-8011
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
+- Fixed the `image` toolbar button showing the incorrect active state in some cases #TINY-3463
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
 
 ## 5.9.2 - 2021-09-08

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed notifications rendering in the wrong place initially and when the page was scrolled #TINY-7894
 - Fixed an exception getting thrown when the number of `col` elements didn't match the number of columns in a table #TINY-7041 #TINY-8011
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
-- Fixed the `image` toolbar button showing the incorrect active state in some cases #TINY-3463
+- Fixed the `image` and `media` toolbar buttons showing the incorrect active state in some cases #TINY-3463
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
 
 ## 5.9.2 - 2021-09-08

--- a/modules/tinymce/src/plugins/image/main/ts/core/ImageSelection.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/ImageSelection.ts
@@ -131,6 +131,7 @@ const insertOrUpdateImage = (editor: Editor, partialData: Partial<ImageData>): v
 
 export {
   normalizeCss,
+  getSelectedImage,
   readImageDataFromSelection,
   insertOrUpdateImage
 };

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Buttons.ts
@@ -5,9 +5,12 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Type } from '@ephox/katamari';
+
 import Editor from 'tinymce/core/api/Editor';
 
 import { isFigure, isImage } from '../core/ImageData';
+import * as ImageSelection from '../core/ImageSelection';
 import * as Utils from '../core/Utils';
 import { Dialog } from './Dialog';
 
@@ -16,7 +19,11 @@ const register = (editor: Editor): void => {
     icon: 'image',
     tooltip: 'Insert/edit image',
     onAction: Dialog(editor).open,
-    onSetup: (buttonApi) => editor.selection.selectorChangedWithUnbind('img:not([data-mce-object],[data-mce-placeholder]),figure.image', buttonApi.setActive).unbind
+    onSetup: (buttonApi) => {
+      // Set the initial state and then bind to selection changes to update the state when the selection changes
+      buttonApi.setActive(Type.isNonNullable(ImageSelection.getSelectedImage(editor)));
+      return editor.selection.selectorChangedWithUnbind('img:not([data-mce-object],[data-mce-placeholder]),figure.image', buttonApi.setActive).unbind;
+    }
   });
 
   editor.ui.registry.addMenuItem('image', {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -11,9 +11,16 @@ import { advancedTabSelectors, assertInputValue, fillActiveDialog, ImageDialogDa
 describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'image',
+    toolbar: 'image',
     indent: false,
-    base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (editor) => {
+      editor.ui.registry.addContextToolbar('test-image', {
+        predicate: (node) => node.nodeName.toLowerCase() === 'img',
+        items: 'image'
+      });
+    }
+  }, [ Plugin, Theme ], true);
 
   const pInitAndOpenDialog = async (editor: Editor, content: string, cursorPos: Cursors.CursorSpec | Cursors.RangeSpec) => {
     editor.settings.image_advtab = true;
@@ -218,4 +225,16 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
       }
     )
   );
+
+  it('TINY-3463: Ensure initial toolbar button state shows correctly', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Content</p><p><img src="image.png"></p>');
+
+    TinySelections.setCursor(editor, [ 0, 0 ], 4);
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn:not(.tox-tbtn--enabled)');
+
+    TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -231,10 +231,10 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
     editor.setContent('<p>Content</p><p><img src="image.png"></p>');
 
     TinySelections.setCursor(editor, [ 0, 0 ], 4);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Insert/edit image"]:not(.tox-tbtn--enabled)');
 
     TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[title="Insert/edit image"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[title="Insert/edit image"]');
   });
 });

--- a/modules/tinymce/src/plugins/media/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Selection.ts
@@ -12,6 +12,9 @@ import * as UpdateHtml from './UpdateHtml';
 declare let escape: any;
 declare let unescape: any;
 
+const isMediaElement = (element: Element): boolean =>
+  element.hasAttribute('data-mce-object') || element.hasAttribute('data-ephox-embed-iri');
+
 const setup = (editor: Editor): void => {
   editor.on('click keyup touchend', () => {
     const selectedNode = editor.selection.getNode();
@@ -50,5 +53,6 @@ const setup = (editor: Editor): void => {
 };
 
 export {
-  setup
+  setup,
+  isMediaElement
 };

--- a/modules/tinymce/src/plugins/media/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/ui/Buttons.ts
@@ -6,10 +6,8 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
-import { Toolbar } from 'tinymce/core/api/ui/Ui';
 
-const stateSelectorAdapter = (editor: Editor, selector: string[]) => (buttonApi: Toolbar.ToolbarToggleButtonInstanceApi) =>
-  editor.selection.selectorChangedWithUnbind(selector.join(','), buttonApi.setActive).unbind;
+import { isMediaElement } from '../core/Selection';
 
 const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceMedia');
@@ -18,7 +16,11 @@ const register = (editor: Editor): void => {
     tooltip: 'Insert/edit media',
     icon: 'embed',
     onAction,
-    onSetup: stateSelectorAdapter(editor, [ 'img[data-mce-object]', 'span[data-mce-object]', 'div[data-ephox-embed-iri]' ])
+    onSetup: (buttonApi) => {
+      const selection = editor.selection;
+      buttonApi.setActive(isMediaElement(selection.getNode()));
+      return selection.selectorChangedWithUnbind('img[data-mce-object],span[data-mce-object],div[data-ephox-embed-iri]', buttonApi.setActive).unbind;
+    }
   });
 
   editor.ui.registry.addMenuItem('media', {

--- a/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
@@ -13,6 +13,7 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 import * as Settings from '../api/Settings';
 import { dataToHtml } from '../core/DataToHtml';
 import * as HtmlToData from '../core/HtmlToData';
+import { isMediaElement } from '../core/Selection';
 import * as Service from '../core/Service';
 import { DialogSubData, MediaData, MediaDialogData } from '../core/Types';
 import * as UpdateHtml from '../core/UpdateHtml';
@@ -93,9 +94,6 @@ const handleError = (editor: Editor) => (error?: { msg: string }): void => {
 
 const snippetToData = (editor: Editor, embedSnippet: string): MediaData =>
   HtmlToData.htmlToData(Settings.getScripts(editor), embedSnippet);
-
-const isMediaElement = (element: Element): boolean =>
-  element.hasAttribute('data-mce-object') || element.hasAttribute('data-ephox-embed-iri');
 
 const getEditorData = (editor: Editor): MediaData => {
   const element = editor.selection.getNode();

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
@@ -74,10 +74,10 @@ describe('browser.tinymce.plugins.media.MediaPluginSanityTest', () => {
     editor.setContent('<p>Content</p><p><iframe src="https://www.youtube.com/embed/b3XFjWInBog" width="560" height="314" allowFullscreen="1"></iframe></p>');
 
     TinySelections.setCursor(editor, [ 0, 0 ], 4);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Insert/edit media"]:not(.tox-tbtn--enabled)');
 
     TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[title="Insert/edit media"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[title="Insert/edit media"]');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-3463

Description of Changes:

This ensures the initial active state is set for the `image` and `media` toolbar buttons, as since this wasn't done the button didn't show as active when in a toolbar drawer or context toolbar.

Note: The associated Jira is about auditing and fixing all cases, but for now this just fixes the immediate case identified in TINY-3463.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
