### PR TITLE
TINY-7908: SHY entities should not be treated as word-breaks

### DIFF
--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Fixed
-- `Pattern.chars` and `Pattern.wordbreak` now accept soft hyphen (SHY) entities #TINY-7908
+- `Pattern.chars` and `Pattern.wordbreak` now treat soft hyphen characters (`&shy;` entities) as part of a word #TINY-7908
 
 ## 5.0.0 - 2021-08-26
 

--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- `Pattern.chars` and `Pattern.wordbreak` now accept soft hyphen (SHY) entities #TINY-7908
+
 ## 5.0.0 - 2021-08-26
 
 ### Changed

--- a/modules/polaris/src/main/ts/ephox/polaris/pattern/Chars.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/pattern/Chars.ts
@@ -5,12 +5,14 @@ import { punctuationStr } from '../words/UnicodeData';
 // \w is a word character
 // "'" is an apostrophe
 // '-' is a hyphen
+// \u00AD is a soft hyphen
 
 // (https://en.wikipedia.org/wiki/List_of_Unicode_characters#Latin_Extended-A)
 // \u00C0 - \u00FF are various language characters (Latin-1)
 // \u0100 - \u017F are various language characters (Latin Extended-A)
 // \u2018 and \u2019 are the smart quote characters
-const charsStr = '\\w' + `'` + '\\-' + '\\u0100-\\u017F\\u00C0-\\u00FF' + Unicode.zeroWidth + '\\u2018\\u2019';
+// \u00AD is a soft hyphen (SHY) character
+const charsStr = '\\w' + `'` + '\\-' + Unicode.softHyphen + '\\u0100-\\u017F\\u00C0-\\u00FF' + Unicode.zeroWidth + '\\u2018\\u2019';
 const wordbreakStr = '[^' + charsStr + ']';
 const wordcharStr = '[' + charsStr + ']';
 

--- a/modules/polaris/src/test/ts/atomic/pattern/CharsTest.ts
+++ b/modules/polaris/src/test/ts/atomic/pattern/CharsTest.ts
@@ -53,7 +53,8 @@ UnitTest.test('CharsTest', () => {
     de: {
       label: 'German',
       html: 'http://character-code.com/german-html-codes.php',
-      chars: 'ÄäÉéÖöÜüß'
+      // TINY-7908: Including \u00AD (soft hyphens) because they appear to be more common in German text
+      chars: 'ÄäÉéÖöÜüß\u00AD'
     },
     nb: {
       label: 'Norwegian',

--- a/modules/robin/CHANGELOG.md
+++ b/modules/robin/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- `TextZone` functions no longer treat soft hyphens (`&shy;` entities) as word breaks #TINY-7908
+
 ## 9.0.0 - 2021-08-26
 
 ### Added

--- a/modules/robin/src/main/ts/ephox/robin/api/general/TextSearch.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/TextSearch.ts
@@ -82,7 +82,6 @@ const expandRight = <E, D>(universe: Universe<E, D>, item: E, offset: number, ra
 // through until the offset left is 0. This is designed to find text node positions that
 // have been fragmented.
 const scanRight = <E, D>(universe: Universe<E, D>, item: E, originalOffset: number): Optional<SpotPoint<E>> => {
-  // MAKE THIS A LOOP
   const isRoot = Fun.never;
   if (!universe.property().isText(item)) {
     return Optional.none();

--- a/modules/robin/src/main/ts/ephox/robin/api/general/TextSearch.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/TextSearch.ts
@@ -82,6 +82,7 @@ const expandRight = <E, D>(universe: Universe<E, D>, item: E, offset: number, ra
 // through until the offset left is 0. This is designed to find text node positions that
 // have been fragmented.
 const scanRight = <E, D>(universe: Universe<E, D>, item: E, originalOffset: number): Optional<SpotPoint<E>> => {
+  // MAKE THIS A LOOP
   const isRoot = Fun.never;
   if (!universe.property().isText(item)) {
     return Optional.none();

--- a/modules/robin/src/test/ts/browser/zone/EntityTest.ts
+++ b/modules/robin/src/test/ts/browser/zone/EntityTest.ts
@@ -1,0 +1,36 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Unicode } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import * as DomTextZones from 'ephox/robin/api/dom/DomTextZones';
+import { ZoneViewports } from 'ephox/robin/api/general/ZoneViewports';
+
+describe('browser.robin.zone.EntityTest', () => {
+  it('TINY-7908: Soft hyphens are not treated as a word boundary', () => {
+    const content = SugarElement.fromHtml('<div>some plain words and a hy&shy;phenated word</div>');
+    const zones = DomTextZones.single(content, 'en-US', ZoneViewports.anything());
+    const rawZones = zones.zones.map((z) => ({ lang: z.lang, words: z.words.map((w) => w.word) }));
+    assert.deepEqual(rawZones, [
+      { lang: 'en-US', words: [ 'some', 'plain', 'words', 'and', 'a', `hy${Unicode.softHyphen}phenated`, 'word' ] }
+    ]);
+  });
+
+  it('Zero width spaces are not treated as a word boundary', () => {
+    const content = SugarElement.fromHtml(`<div>some plain words with some&#xFEFF;space</div>`);
+    const zones = DomTextZones.single(content, 'en-US', ZoneViewports.anything());
+    const rawZones = zones.zones.map((z) => ({ lang: z.lang, words: z.words.map((w) => w.word) }));
+    assert.deepEqual(rawZones, [
+      { lang: 'en-US', words: [ 'some', 'plain', 'words', 'with', `some${Unicode.zeroWidth}space` ] }
+    ]);
+  });
+
+  it('Non breaking spaces are treated as a word boundary', () => {
+    const content = SugarElement.fromHtml(`<div>some plain words with some&nbsp;space</div>`);
+    const zones = DomTextZones.single(content, 'en-US', ZoneViewports.anything());
+    const rawZones = zones.zones.map((z) => ({ lang: z.lang, words: z.words.map((w) => w.word) }));
+    assert.deepEqual(rawZones, [
+      { lang: 'en-US', words: [ 'some', 'plain', 'words', 'with', 'some', 'space' ] }
+    ]);
+  });
+});

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an exception getting thrown when the number of `col` elements didn't match the number of columns in a table #TINY-7041 #TINY-8011
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
+- The `wordcount` plugin no longer treats soft hyphens (`&shy;` entities) as a word break #TINY-7908
 
 ## 5.9.2 - 2021-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an exception getting thrown when the number of `col` elements didn't match the number of columns in a table #TINY-7041 #TINY-8011
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
-- The `wordcount` plugin no longer treats soft hyphens (`&shy;` entities) as a word break #TINY-7908
+- The `wordcount` plugin was incorrectly treating soft hyphens (`&shy;` entities) as word breaks #TINY-7908
 
 ## 5.9.2 - 2021-09-08
 

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
@@ -56,4 +56,11 @@ describe('browser.tinymce.plugins.wordcount.PluginTest', () => {
     editor.execCommand('mceAddUndoLevel');
     await pWaitForWordcount(2);
   });
+
+  it('TINY-7908: Does not treat soft hyphens as a word break', async () => {
+    const editor = hook.editor();
+    await pWaitForWordcount(0);
+    editor.setContent('<p>Soft hy&shy;phen</p>');
+    await pWaitForWordcount(2);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7908 (take 2)

Description of Changes:
* Add soft-hyphens to the list of accepted word characters in Polaris
  * This affects Robin's zone-walker related APIs
  * This also affects the word count plugin

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): N/A