### PR TITLE
TINY-3463: Fixed the `selection.selectorChanged` API not firing correctly if the selector matched the current selection when registered

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an exception getting thrown when the number of `col` elements didn't match the number of columns in a table #TINY-7041 #TINY-8011
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
 - Fixed the `image` and `media` toolbar buttons showing the incorrect active state in some cases #TINY-3463
+- Fixed the `selection.selectorChanged` API not firing correctly if the selector matched the current selection when registered #TINY-3463
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
 - The `wordcount` plugin was incorrectly treating soft hyphens (`&shy;` entities) as word breaks #TINY-7908
 

--- a/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
@@ -29,6 +29,12 @@ export default (dom: DOMUtils, editor: Editor) => {
   let selectorChangedData: Record<string, SelectorChangedCallback[]>;
   let currentSelectors: Record<string, SelectorChangedCallback[]>;
 
+  const matches = (selector: string, nodes: Node[]): boolean =>
+    Arr.exists(nodes, (node) => dom.is(node, selector));
+
+  const getParents = (elem: Element): Element[] =>
+    dom.getParents(elem, null, dom.getRoot());
+
   return {
     selectorChangedWithUnbind: (selector: string, callback: SelectorChangedCallback): { unbind: () => void } => {
       if (!selectorChangedData) {
@@ -36,25 +42,24 @@ export default (dom: DOMUtils, editor: Editor) => {
         currentSelectors = {};
 
         editor.on('NodeChange', (e) => {
-          const node = e.element, parents = dom.getParents(node, null, dom.getRoot()), matchedSelectors = {};
+          const node = e.element;
+          const parents = getParents(node);
+          const matchedSelectors = {};
 
           // Check for new matching selectors
           Tools.each(selectorChangedData, (callbacks, selector) => {
-            Tools.each(parents, (node) => {
-              if (dom.is(node, selector)) {
-                if (!currentSelectors[selector]) {
-                  // Execute callbacks
-                  Tools.each(callbacks, (callback) => {
-                    callback(true, { node, selector, parents });
-                  });
+            if (matches(selector, parents)) {
+              if (!currentSelectors[selector]) {
+                // Execute callbacks
+                Arr.each(callbacks, (callback) => {
+                  callback(true, { node, selector, parents });
+                });
 
-                  currentSelectors[selector] = callbacks;
-                }
-
-                matchedSelectors[selector] = callbacks;
-                return false;
+                currentSelectors[selector] = callbacks;
               }
-            });
+
+              matchedSelectors[selector] = callbacks;
+            }
           });
 
           // Check if current selectors still match
@@ -76,6 +81,11 @@ export default (dom: DOMUtils, editor: Editor) => {
       }
 
       selectorChangedData[selector].push(callback);
+
+      // Setup the initial state if selected already
+      if (matches(selector, getParents(editor.selection.getStart()))) {
+        currentSelectors[selector] = selectorChangedData[selector];
+      }
 
       return {
         unbind: () => {

--- a/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj } from '@ephox/katamari';
+import { Arr, Obj, Optional } from '@ephox/katamari';
 
 import Editor from '../Editor';
 import Tools from '../util/Tools';
@@ -29,8 +29,8 @@ export default (dom: DOMUtils, editor: Editor) => {
   let selectorChangedData: Record<string, SelectorChangedCallback[]>;
   let currentSelectors: Record<string, SelectorChangedCallback[]>;
 
-  const matches = (selector: string, nodes: Node[]): boolean =>
-    Arr.exists(nodes, (node) => dom.is(node, selector));
+  const matches = (selector: string, nodes: Node[]): Optional<Node> =>
+    Arr.find(nodes, (node) => dom.is(node, selector));
 
   const getParents = (elem: Element): Element[] =>
     dom.getParents(elem, null, dom.getRoot());
@@ -48,7 +48,7 @@ export default (dom: DOMUtils, editor: Editor) => {
 
           // Check for new matching selectors
           Tools.each(selectorChangedData, (callbacks, selector) => {
-            if (matches(selector, parents)) {
+            matches(selector, parents).each((node) => {
               if (!currentSelectors[selector]) {
                 // Execute callbacks
                 Arr.each(callbacks, (callback) => {
@@ -59,7 +59,7 @@ export default (dom: DOMUtils, editor: Editor) => {
               }
 
               matchedSelectors[selector] = callbacks;
-            }
+            });
           });
 
           // Check if current selectors still match
@@ -83,9 +83,9 @@ export default (dom: DOMUtils, editor: Editor) => {
       selectorChangedData[selector].push(callback);
 
       // Setup the initial state if selected already
-      if (matches(selector, getParents(editor.selection.getStart()))) {
+      matches(selector, getParents(editor.selection.getStart())).each(() => {
         currentSelectors[selector] = selectorChangedData[selector];
-      }
+      });
 
       return {
         unbind: () => {

--- a/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/SelectorChanged.ts
@@ -29,7 +29,7 @@ export default (dom: DOMUtils, editor: Editor) => {
   let selectorChangedData: Record<string, SelectorChangedCallback[]>;
   let currentSelectors: Record<string, SelectorChangedCallback[]>;
 
-  const matches = (selector: string, nodes: Node[]): Optional<Node> =>
+  const findMatchingNode = (selector: string, nodes: Node[]): Optional<Node> =>
     Arr.find(nodes, (node) => dom.is(node, selector));
 
   const getParents = (elem: Element): Element[] =>
@@ -48,7 +48,7 @@ export default (dom: DOMUtils, editor: Editor) => {
 
           // Check for new matching selectors
           Tools.each(selectorChangedData, (callbacks, selector) => {
-            matches(selector, parents).each((node) => {
+            findMatchingNode(selector, parents).each((node) => {
               if (!currentSelectors[selector]) {
                 // Execute callbacks
                 Arr.each(callbacks, (callback) => {
@@ -83,7 +83,7 @@ export default (dom: DOMUtils, editor: Editor) => {
       selectorChangedData[selector].push(callback);
 
       // Setup the initial state if selected already
-      matches(selector, getParents(editor.selection.getStart())).each(() => {
+      findMatchingNode(selector, getParents(editor.selection.getStart())).each(() => {
         currentSelectors[selector] = selectorChangedData[selector];
       });
 


### PR DESCRIPTION
Related Ticket: TINY-3463

Description of Changes:

This is a followup for an issue @ltrouton found when QAing that turned out to be an existing core bug whereby the `selectorChanged` API doesn't setup the state correctly if the selector already matches the current selection.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
