### PR TITLE
TINY-8053: Fix 'data-mce-selected' attrs not removed from noneditable cell

### DIFF
--- a/modules/darwin/CHANGELOG.md
+++ b/modules/darwin/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## Fixed
+- Some of the selection annotation attributes were not cleared if the `Ephemera.selectedSelector` attribute was not present.
+
 ## 7.0.0 - 2021-08-26
 
 ## Added

--- a/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
@@ -53,6 +53,11 @@ const keyboard = (win: Window, container: SugarElement, isRoot: (e: SugarElement
     const shiftKey = realEvent.shiftKey === true;
 
     const handler = CellSelection.retrieve(container, annotations.selectedSelector).fold(() => {
+      // Make sure any possible lingering annotations are cleared
+      if (SelectionKeys.isNavigation(keycode) && shiftKey === false) {
+        annotations.clearBeforeUpdate(container);
+      }
+
       // Shift down should predict the movement and set the selection.
       if (SelectionKeys.isDown(keycode) && shiftKey) {
         return Fun.curry(VerticalMovement.select, bridge, container, isRoot, KeyDirection.down, finish, start, annotations.selectRange);

--- a/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
@@ -54,7 +54,7 @@ const keyboard = (win: Window, container: SugarElement, isRoot: (e: SugarElement
 
     const handler = CellSelection.retrieve(container, annotations.selectedSelector).fold(() => {
       // Make sure any possible lingering annotations are cleared
-      if (SelectionKeys.isNavigation(keycode) && shiftKey === false) {
+      if (SelectionKeys.isNavigation(keycode) && !shiftKey) {
         annotations.clearBeforeUpdate(container);
       }
 
@@ -102,7 +102,7 @@ const keyboard = (win: Window, container: SugarElement, isRoot: (e: SugarElement
         return update([ rc(0, -1), rc(-1, 0) ]);
       } else if (direction.isForward(keycode) && shiftKey) {
         return update([ rc(0, +1), rc(+1, 0) ]);
-      } else if (SelectionKeys.isNavigation(keycode) && shiftKey === false) { // Clear the selection on normal arrow keys.
+      } else if (SelectionKeys.isNavigation(keycode) && !shiftKey) { // Clear the selection on normal arrow keys.
         return clearToNavigate;
       } else {
         return Optional.none;
@@ -117,7 +117,7 @@ const keyboard = (win: Window, container: SugarElement, isRoot: (e: SugarElement
       const realEvent = event.raw;
       const keycode = realEvent.which;
       const shiftKey = realEvent.shiftKey === true;
-      if (shiftKey === false) {
+      if (!shiftKey) {
         return Optional.none<Response>();
       }
       if (SelectionKeys.isNavigation(keycode)) {

--- a/modules/darwin/src/main/ts/ephox/darwin/api/SelectionAnnotation.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/SelectionAnnotation.ts
@@ -55,7 +55,7 @@ const byAttr = (ephemera: Ephemera, onSelection: (cells: SugarElement[], start: 
   };
 
   const clearBeforeUpdate = (container: SugarElement) => {
-    const sels = SelectorFilter.descendants(container, ephemera.selectedSelector);
+    const sels = SelectorFilter.descendants(container, `${ephemera.selectedSelector},${ephemera.firstSelectedSelector},${ephemera.lastSelectedSelector}`);
     Arr.each(sels, removeSelectionAttributes);
   };
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split toolbar buttons incorrectly had nested `tabindex="-1"` attributes #TINY-7879
 - Fixed notifications rendering in the wrong place initially and when the page was scrolled #TINY-7894
 - Fixed an exception getting thrown when the number of `col` elements didn't match the number of columns in a table #TINY-7041 #TINY-8011
+- The table selection state could become incorrect after selecting a noneditable table cell #TINY-8053
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
 - Fixed urls not cleaned correctly in some cases in the `link` and `image` plugin #TINY-7998
 - Rounding errors were causing the line height dropdowns and the `LineHeight` query command to be inaccurate on Safari #TINY-7895


### PR DESCRIPTION
Related Ticket: TINY-8053

Description of Changes:
* Update darwin logic to clear firstSelectedAttr and lastSelectedAttr even if the selectedAttr is not present on the table cells. This can occur from SelectionOverrides removing the selectedAttr on the noneditable cell before the darwin annotation clearing logic runs

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
