### PR TITLE
TINY-8058: Ensure insertdatetime buttons and menus use the editor commands

### DIFF
--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Commands.ts
@@ -11,12 +11,12 @@ import * as Actions from '../core/Actions';
 import * as Settings from './Settings';
 
 const register = (editor: Editor): void => {
-  editor.addCommand('mceInsertDate', () => {
-    Actions.insertDateTime(editor, Settings.getDateFormat(editor));
+  editor.addCommand('mceInsertDate', (_ui, value) => {
+    Actions.insertDateTime(editor, value ?? Settings.getDateFormat(editor));
   });
 
-  editor.addCommand('mceInsertTime', () => {
-    Actions.insertDateTime(editor, Settings.getTimeFormat(editor));
+  editor.addCommand('mceInsertTime', (_ui, value) => {
+    Actions.insertDateTime(editor, value ?? Settings.getTimeFormat(editor));
   });
 };
 

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
@@ -28,17 +28,17 @@ const register = (editor: Editor): void => {
       ));
     },
     onAction: (_api) => {
-      Actions.insertDateTime(editor, defaultFormat.get());
+      editor.execCommand('mceInsertDate', false, defaultFormat.get());
     },
     onItemAction: (_api, value) => {
       defaultFormat.set(value);
-      Actions.insertDateTime(editor, value);
+      editor.execCommand('mceInsertDate', false, value);
     }
   });
 
   const makeMenuItemHandler = (format: string) => (): void => {
     defaultFormat.set(format);
-    Actions.insertDateTime(editor, format);
+    editor.execCommand('mceInsertDate', false, format);
   };
 
   editor.ui.registry.addNestedMenuItem('insertdatetime', {

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
@@ -18,6 +18,8 @@ const register = (editor: Editor): void => {
   const formats = Settings.getFormats(editor);
   const defaultFormat = Cell(Settings.getDefaultDateTime(editor));
 
+  const insertDateTime = (format: string) => editor.execCommand('mceInsertDate', false, format);
+
   editor.ui.registry.addSplitButton('insertdatetime', {
     icon: 'insert-time',
     tooltip: 'Insert date/time',
@@ -28,17 +30,17 @@ const register = (editor: Editor): void => {
       ));
     },
     onAction: (_api) => {
-      editor.execCommand('mceInsertDate', false, defaultFormat.get());
+      insertDateTime(defaultFormat.get());
     },
     onItemAction: (_api, value) => {
       defaultFormat.set(value);
-      editor.execCommand('mceInsertDate', false, value);
+      insertDateTime(value);
     }
   });
 
   const makeMenuItemHandler = (format: string) => (): void => {
     defaultFormat.set(format);
-    editor.execCommand('mceInsertDate', false, format);
+    insertDateTime(format);
   };
 
   editor.ui.registry.addNestedMenuItem('insertdatetime', {


### PR DESCRIPTION
Related Ticket: TINY-8058

Description of Changes:
* Ensure insertdatetime buttons and menus use the editor commands

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
