### PR TITLE
TINY-8063: Mark several more APIs as deprecated

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pressing the Escape key would not cancel a drag action that started on a `contenteditable="false"` element within the editor #TINY-7917
 
 ### Deprecated
-- Several APIs have been deprecated. See the release notes for information #TINY-8023
+- Several APIs have been deprecated. See the release notes for information #TINY-8023 #TINY-8063
 
 ## 5.9.2 - 2021-09-08
 

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -196,6 +196,10 @@ class Editor implements EditorObservable {
   /**
    * Dom query instance with default scope to the editor document and default element is the body of the editor.
    *
+   * <br>
+   * <em><code>DomQuery</code> has been deprecated and marked for removal in TinyMCE 6.0.</em>
+   *
+   * @deprecated
    * @property $
    * @type tinymce.dom.DomQuery
    * @example

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -164,6 +164,10 @@ const EditorManager: EditorManager = {
   /**
    * Dom query instance.
    *
+   * <br>
+   * <em><code>DomQuery</code> has been deprecated and marked for removal in TinyMCE 6.0.</em>
+   *
+   * @deprecated
    * @property $
    * @type tinymce.dom.DomQuery
    */

--- a/modules/tinymce/src/core/main/ts/api/Env.ts
+++ b/modules/tinymce/src/core/main/ts/api/Env.ts
@@ -228,8 +228,11 @@ const Env: Env = {
   /**
    * Constant that is <code>true</code> if the browser has a modern file API.
    *
+   * <br>
+   * <em><code>fileApi</code> has been deprecated and marked for removal in TinyMCE 6.0.</em>
    * @property fileApi
    * @type Boolean
+   * @deprecated
    */
   fileApi,
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1242,7 +1242,23 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     schema,
     events,
     isBlock,
+
+    /**
+     * <em><code>DomQuery</code> has been deprecated and marked for removal in TinyMCE 6.0.</em>
+     *
+     * @deprecated
+     * @property $
+     * @type tinymce.dom.DomQuery
+     */
     $,
+
+    /**
+     * <em><code>DomQuery</code> has been deprecated and marked for removal in TinyMCE 6.0.</em>
+     *
+     * @deprecated
+     * @property $$
+     * @type tinymce.dom.DomQuery
+     */
     $$,
 
     root: null,

--- a/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Sizzle.ts
@@ -21,8 +21,10 @@ import { Arr } from '@ephox/katamari';
  *
  * Date: @DATE
  *
+ * @deprecated
  * @private
  * @class tinymce.dom.sizzle
+ * @summary Sizzle has been deprecated and marked for removal in TinyMCE 6.0.
  */
 
 /* eslint-enable */


### PR DESCRIPTION
Related Ticket: TINY-8063

Description of Changes:
Mark `fileApi`, `Sizzle` and `$` (`DomQuery` alias) as deprecated

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
