### PR TITLE
TINY-7991: Fixed issues with table sizing when the parent element had padding

### DIFF
--- a/modules/katamari/CHANGELOG.md
+++ b/modules/katamari/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added new `Strings.toInt` and `Strings.toFloat` APIs to be able to parse a string and convert it to a number.
+
 ## 8.0.0 - 2021-08-26
 
 ### Added

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
@@ -1,4 +1,5 @@
 import * as StrAppend from '../str/StrAppend';
+import { Optional } from './Optional';
 
 const nativeFromCodePoint = String.fromCodePoint;
 
@@ -120,4 +121,14 @@ export const fromCodePoint = (...codePoints: number[]): string => {
     }
     return result + String.fromCharCode.apply(null, codeUnits);
   }
+};
+
+export const toInt = (value: string, radix: number = 10): Optional<number> => {
+  const num = parseInt(value, radix);
+  return isNaN(num) ? Optional.none() : Optional.some(num);
+};
+
+export const toFloat = (value: string): Optional<number> => {
+  const num = parseFloat(value);
+  return isNaN(num) ? Optional.none() : Optional.some(num);
 };

--- a/modules/katamari/src/test/ts/atomic/api/str/ToFloatTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/str/ToFloatTest.ts
@@ -1,0 +1,35 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+import * as fc from 'fast-check';
+
+import * as Strings from 'ephox/katamari/api/Strings';
+
+describe('atomic.katamari.api.str.ToFloatTest', () => {
+  it('convert valid string to float', () => {
+    const check = (value: string, expected: number) => {
+      const num = Strings.toFloat(value).getOrDie();
+      assert.equal(num, expected);
+    };
+
+    check('123', 123);
+    check('456.123', 456.123);
+    check('0.0314E+2', 3.14);
+
+    fc.assert(fc.property(fc.float(), (num) => {
+      check('' + num, num);
+    }));
+  });
+
+  it('convert invalid string to float', () => {
+    const checkNone = (value: string) => {
+      const numOpt = Strings.toFloat(value);
+      assert.isFalse(numOpt.isSome());
+    };
+
+    checkNone('abc');
+
+    fc.assert(fc.property(fc.string(), (str) => {
+      checkNone('a' + str);
+    }));
+  });
+});

--- a/modules/katamari/src/test/ts/atomic/api/str/ToIntTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/str/ToIntTest.ts
@@ -1,0 +1,35 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+import * as fc from 'fast-check';
+
+import * as Strings from 'ephox/katamari/api/Strings';
+
+describe('atomic.katamari.api.str.ToIntTest', () => {
+  it('convert valid string to integer', () => {
+    const check = (value: string, expected: number) => {
+      const num = Strings.toInt(value).getOrDie();
+      assert.equal(num, expected);
+    };
+
+    check('123', 123);
+    check('456.123', 456);
+    check('0.0314E+2', 0);
+
+    fc.assert(fc.property(fc.integer(), (num) => {
+      check('' + num, num);
+    }));
+  });
+
+  it('convert invalid string to integer', () => {
+    const checkNone = (value: string) => {
+      const numOpt = Strings.toInt(value);
+      assert.isFalse(numOpt.isSome());
+    };
+
+    checkNone('abc');
+
+    fc.assert(fc.property(fc.string(), (str) => {
+      checkNone('a' + str);
+    }));
+  });
+});

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Resizing percent tables caused widths to be offset by a few pixels due to an incorrect pixel -> percent conversion.
 - Converting rows or columns to regular cells would in some cases incorrectly convert a cell that was still part of a header.
 - An exception was thrown in `TableGrid` when there were more `col` elements than columns in a table.
+- Table percent sizes were incorrectly calculated when the parent element had padding.
 
 ## 9.0.0 - 2021-08-26
 

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
@@ -26,7 +26,8 @@ const justCols = (warehouse: Warehouse): Optional<SugarElement<HTMLTableColEleme
 // Col elements don't have valid computed widths/positions in all browsers, so treat them as invalid in that case
 const isValidColumn = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): boolean => {
   const browser = PlatformDetection.detect().browser;
-  return !isCol(cell) || !(browser.isIE() || browser.isEdge());
+  const supportsColWidths = browser.isChrome() || browser.isFirefox();
+  return isCol(cell) ? supportsColWidths : true;
 };
 
 const getDimension = <T extends HTMLElement, U>(

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/RuntimeSize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/RuntimeSize.ts
@@ -11,48 +11,46 @@ const toNumber = (px: string, fallback: number): number => {
   return isNaN(num) ? fallback : num;
 };
 
-const getProp = (elm: SugarElement, name: string, fallback: number): number =>
-  toNumber(Css.get(elm, name), fallback);
+const getProp = (element: SugarElement<HTMLElement>, name: string, fallback: number): number =>
+  toNumber(Css.get(element, name), fallback);
 
-const getCalculatedHeight = (cell: SugarElement<HTMLElement>): number => {
-  const height = cell.dom.getBoundingClientRect().height;
-  const boxSizing = Css.get(cell, 'box-sizing');
-  if (boxSizing === 'border-box') {
-    return height;
-  } else {
-    const paddingTop = getProp(cell, 'padding-top', 0);
-    const paddingBottom = getProp(cell, 'padding-bottom', 0);
-    const borderTop = getProp(cell, 'border-top-width', 0);
-    const borderBottom = getProp(cell, 'border-bottom-width', 0);
-    const borders = borderTop + borderBottom;
+const getBoxSizing = (element: SugarElement<HTMLElement>): string =>
+  Css.get(element, 'box-sizing');
 
-    return height - paddingTop - paddingBottom - borders;
-  }
+const calcContentBoxSize = (element: SugarElement<HTMLElement>, size: number, upper: 'top' | 'left', lower: 'bottom' | 'right') => {
+  const paddingUpper = getProp(element, `padding-${upper}`, 0);
+  const paddingLower = getProp(element, `padding-${lower}`, 0);
+  const borderUpper = getProp(element, `border-${upper}-width`, 0);
+  const borderLower = getProp(element, `border-${lower}-width`, 0);
+
+  return size - paddingUpper - paddingLower - borderUpper - borderLower;
 };
 
-const getCalculatedWidth = (cell: SugarElement<HTMLElement>): number => {
-  const width = cell.dom.getBoundingClientRect().width;
-  const boxSizing = Css.get(cell, 'box-sizing');
-  if (boxSizing === 'border-box') {
-    return width;
-  } else {
-    const paddingLeft = getProp(cell, 'padding-left', 0);
-    const paddingRight = getProp(cell, 'padding-right', 0);
-    const borderLeft = getProp(cell, 'border-left-width', 0);
-    const borderRight = getProp(cell, 'border-right-width', 0);
-    const borders = borderLeft + borderRight;
-
-    return width - paddingLeft - paddingRight - borders;
-  }
+const getCalculatedHeight = (element: SugarElement<HTMLElement>, boxSizing: string): number => {
+  const height = element.dom.getBoundingClientRect().height;
+  return boxSizing === 'border-box' ? height : calcContentBoxSize(element, height, 'top', 'bottom');
 };
 
-const getHeight = (cell: SugarElement<HTMLElement>): number =>
-  needManualCalc() ? getCalculatedHeight(cell) : getProp(cell, 'height', Height.get(cell));
+const getCalculatedWidth = (element: SugarElement<HTMLElement>, boxSizing: string): number => {
+  const width = element.dom.getBoundingClientRect().width;
+  return boxSizing === 'border-box' ? width : calcContentBoxSize(element, width, 'left', 'right');
+};
 
-const getWidth = (cell: SugarElement<HTMLElement>): number =>
-  needManualCalc() ? getCalculatedWidth(cell) : getProp(cell, 'width', Width.get(cell));
+const getHeight = (element: SugarElement<HTMLElement>): number =>
+  needManualCalc() ? getCalculatedHeight(element, getBoxSizing(element)) : getProp(element, 'height', Height.get(element));
+
+const getWidth = (element: SugarElement<HTMLElement>): number =>
+  needManualCalc() ? getCalculatedWidth(element, getBoxSizing(element)) : getProp(element, 'width', Width.get(element));
+
+const getInnerHeight = (element: SugarElement<HTMLElement>): number =>
+  getCalculatedHeight(element, 'content-box');
+
+const getInnerWidth = (element: SugarElement<HTMLElement>): number =>
+  getCalculatedWidth(element, 'content-box');
 
 export {
+  getInnerHeight,
+  getInnerWidth,
   getHeight,
   getWidth
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -3,7 +3,6 @@ import { Attribute, Css, Dimension, Height, SugarBody, SugarElement, SugarNode, 
 
 import * as TableLookup from '../api/TableLookup';
 import { getSpan } from '../util/CellUtils';
-import * as RuntimeSize from './RuntimeSize';
 
 type SizeGetter = (e: SugarElement<HTMLElement>) => number;
 type SizeSetter = (e: SugarElement<HTMLElement>, value: number) => void;
@@ -30,7 +29,7 @@ export const setHeight = (cell: SugarElement<HTMLElement>, amount: number): void
 };
 
 const getHeightValue = (cell: SugarElement<HTMLElement>): string =>
-  RuntimeSize.getHeight(cell) + 'px';
+  Height.getRuntime(cell) + 'px';
 
 const convert = (cell: SugarElement<HTMLTableCellElement>, number: number, getter: SizeGetter, setter: SizeSetter): number => {
   const newSize = TableLookup.table(cell).map((table) => {
@@ -75,11 +74,11 @@ export const getRawHeight = (element: SugarElement<HTMLElement>): Optional<strin
 
 // Get a percentage size for a percentage parent table
 export const getPercentageWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
-  getPercentSize(cell, Width.get, RuntimeSize.getInnerWidth);
+  getPercentSize(cell, Width.get, Width.getInner);
 
 export const getPixelWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
   // For col elements use the computed width as col elements aren't affected by borders, padding, etc...
-  isCol(cell) ? Width.get(cell) : RuntimeSize.getWidth(cell);
+  isCol(cell) ? Width.get(cell) : Width.getRuntime(cell);
 
 export const getHeight = (cell: SugarElement<HTMLTableCellElement>): number => {
   return get(cell, 'rowspan', getTotalHeight);
@@ -97,8 +96,8 @@ export const setGenericWidth = (cell: SugarElement<HTMLElement>, amount: number,
 export const getPixelTableWidth = (table: SugarElement<HTMLTableElement>): string => Width.get(table) + 'px';
 export const getPixelTableHeight = (table: SugarElement<HTMLTableElement>): string => Height.get(table) + 'px';
 
-export const getPercentTableWidth = (table: SugarElement<HTMLTableElement>): string => getPercentSize(table, Width.get, RuntimeSize.getInnerWidth) + '%';
-export const getPercentTableHeight = (table: SugarElement<HTMLTableElement>): string => getPercentSize(table, Height.get, RuntimeSize.getInnerHeight) + '%';
+export const getPercentTableWidth = (table: SugarElement<HTMLTableElement>): string => getPercentSize(table, Width.get, Width.getInner) + '%';
+export const getPercentTableHeight = (table: SugarElement<HTMLTableElement>): string => getPercentSize(table, Height.get, Height.getInner) + '%';
 
 export const isPercentSizing = (table: SugarElement<HTMLTableElement>): boolean => getRawWidth(table).exists((size) => rPercentageBasedSizeRegex.test(size));
 export const isPixelSizing = (table: SugarElement<HTMLTableElement>): boolean => getRawWidth(table).exists((size) => rPixelBasedSizeRegex.test(size));

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -12,9 +12,9 @@ const rPercentageBasedSizeRegex = /(\d+(\.\d+)?)%/;
 const rPixelBasedSizeRegex = /(\d+(\.\d+)?)px|em/;
 const isCol = SugarNode.isTag('col');
 
-const getPercentSize = (elm: SugarElement<HTMLElement>, getter: SizeGetter): number => {
+const getPercentSize = (elm: SugarElement<HTMLElement>, outerGetter: SizeGetter, innerGetter: SizeGetter): number => {
   const relativeParent = Traverse.parentElement(elm).getOrThunk(() => SugarBody.getBody(Traverse.owner(elm)));
-  return getter(elm) / getter(relativeParent) * 100;
+  return outerGetter(elm) / innerGetter(relativeParent) * 100;
 };
 
 export const setPixelWidth = (cell: SugarElement<HTMLElement>, amount: number): void => {
@@ -75,7 +75,7 @@ export const getRawHeight = (element: SugarElement<HTMLElement>): Optional<strin
 
 // Get a percentage size for a percentage parent table
 export const getPercentageWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
-  getPercentSize(cell, Width.get);
+  getPercentSize(cell, Width.get, RuntimeSize.getInnerWidth);
 
 export const getPixelWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
   // For col elements use the computed width as col elements aren't affected by borders, padding, etc...
@@ -97,8 +97,8 @@ export const setGenericWidth = (cell: SugarElement<HTMLElement>, amount: number,
 export const getPixelTableWidth = (table: SugarElement<HTMLTableElement>): string => Width.get(table) + 'px';
 export const getPixelTableHeight = (table: SugarElement<HTMLTableElement>): string => Height.get(table) + 'px';
 
-export const getPercentTableWidth = (table: SugarElement<HTMLTableElement>): string => getPercentSize(table, Width.get) + '%';
-export const getPercentTableHeight = (table: SugarElement<HTMLTableElement>): string => getPercentSize(table, Height.get) + '%';
+export const getPercentTableWidth = (table: SugarElement<HTMLTableElement>): string => getPercentSize(table, Width.get, RuntimeSize.getInnerWidth) + '%';
+export const getPercentTableHeight = (table: SugarElement<HTMLTableElement>): string => getPercentSize(table, Height.get, RuntimeSize.getInnerHeight) + '%';
 
 export const isPercentSizing = (table: SugarElement<HTMLTableElement>): boolean => getRawWidth(table).exists((size) => rPercentageBasedSizeRegex.test(size));
 export const isPixelSizing = (table: SugarElement<HTMLTableElement>): boolean => getRawWidth(table).exists((size) => rPixelBasedSizeRegex.test(size));

--- a/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
+++ b/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
@@ -36,7 +36,7 @@ UnitTest.test('ColumnSizes.getPixelWidths', () => {
     const roundedPixelWidths = Arr.map(pixelWidths, Math.round);
     Assert.eq(label, getExpectedWidths(cellWidth), roundedPixelWidths);
 
-    Remove.remove(table);
+    Remove.remove(container);
   };
 
   sTest('Pixel Table - Column widths should be the raw size of the cell', pixelTableHtml, () => [ 198, 198 ]);
@@ -60,7 +60,7 @@ UnitTest.test('ColumnSizes.getPercentageWidths', () => {
     const roundedPercentWidths = Arr.map(percentWidths, (width) => parseFloat(width.toFixed(1)));
     Assert.eq(label, expectedWidths, roundedPercentWidths);
 
-    Remove.remove(table);
+    Remove.remove(container);
   };
 
   sTest('Pixel Table - Column widths should be the raw size of the cell', pixelTableHtml, [ 50, 50 ]);

--- a/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
+++ b/modules/snooker/src/test/ts/browser/resize/ColumnSizesTest.ts
@@ -9,6 +9,7 @@ import * as ColumnSizes from 'ephox/snooker/resize/ColumnSizes';
 
 const noneTableHtml = '<table><tbody><tr><td>A</td><td>A</td></tr></tbody></table>';
 const pixelTableHtml = '<table style="width: 400px; border-collapse: collapse"><tbody><tr><td style="width: 200px;">A</td><td style="width: 200px;">A</td></tr></tbody></table>';
+const percentTableHtml = '<table style="width: 80%; border-collapse: collapse"><tbody><tr><td style="width: 50%;">A</td><td style="width: 50%;">A</td></tr></tbody></table>';
 const pixelTableMissingWidthsHtml = `<table style="width: 400px; border-collapse: collapse">
   <tbody>
     <tr><td>A</td><td style="width: 200px;">B</td></tr>
@@ -20,8 +21,10 @@ const noneTableWithColsHtml = '<table><colgroup><col><col></colgroup><tbody><tr>
 
 UnitTest.test('ColumnSizes.getPixelWidths', () => {
   const sTest = (label: string, html: string, getExpectedWidths: (cellWidth: number) => number[]) => {
+    const container = SugarElement.fromHtml<HTMLDivElement>('<div style="width: 500px;"></div>');
     const table = SugarElement.fromHtml<HTMLTableElement>(html);
-    Insert.append(SugarBody.body(), table);
+    Insert.append(container, table);
+    Insert.append(SugarBody.body(), container);
 
     const cellWidth = SelectorFind.descendant<HTMLTableCellElement>(table, 'td')
       .map((cell) => Math.round(parseFloat(Css.get(cell, 'width'))))
@@ -37,10 +40,33 @@ UnitTest.test('ColumnSizes.getPixelWidths', () => {
   };
 
   sTest('Pixel Table - Column widths should be the raw size of the cell', pixelTableHtml, () => [ 198, 198 ]);
+  sTest('Percent Table - Column widths should be the raw size of the cell', percentTableHtml, () => [ 198, 198 ]);
   sTest('Pixel Table - Column widths with missing widths on some cells should be the raw size of the cell', pixelTableMissingWidthsHtml, () => [ 198, 198 ]);
   sTest('Pixel Table - Column width should be the size of the table when using colspans', tableWithSpansHtml, () => [ 0, 400 ]);
   sTest('None Table - Column widths should be the computed size of the cell', noneTableHtml, (width) => [ width, width ]);
   sTest('None Table - Column widths for cols should be the computed size of the cell', noneTableWithColsHtml, (width) => [ width + 2, width + 2 ]); // Add 2 to account for the borders
+});
+
+UnitTest.test('ColumnSizes.getPercentageWidths', () => {
+  const sTest = (label: string, html: string, expectedWidths: number[]) => {
+    const container = SugarElement.fromHtml<HTMLDivElement>('<div style="width: 500px;"></div>');
+    const table = SugarElement.fromHtml<HTMLTableElement>(html);
+    Insert.append(container, table);
+    Insert.append(SugarBody.body(), container);
+
+    const percentWidths = ColumnSizes.getPercentageWidths(Warehouse.fromTable(table), table, TableSize.getTableSize(table));
+
+    // Round to account for precision issues
+    const roundedPercentWidths = Arr.map(percentWidths, (width) => parseFloat(width.toFixed(1)));
+    Assert.eq(label, expectedWidths, roundedPercentWidths);
+
+    Remove.remove(table);
+  };
+
+  sTest('Pixel Table - Column widths should be the raw size of the cell', pixelTableHtml, [ 50, 50 ]);
+  sTest('Percent Table - Column widths should be the raw size of the cell', percentTableHtml, [ 50, 50 ]);
+  sTest('Pixel Table - Column widths with missing widths on some cells should be the raw size of the cell', pixelTableMissingWidthsHtml, [ 50, 50 ]);
+  sTest('Pixel Table - Column width should be the size of the table when using colspans', tableWithSpansHtml, [ 0, 100 ]);
 });
 
 UnitTest.test('ColumnSizes.getPixelHeights', () => {

--- a/modules/sugar/CHANGELOG.md
+++ b/modules/sugar/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added new `parentElement` function to the `Traverse` API.
 - Added new `setOptions` function to the `Attribute` API.
+- Added new `getInner` and `getRuntime` functions to the `Height` API.
+- Added new `getInner` and `getRuntime` functions to the `Width` API.
 
 ### Fixed
 - Disabled `window.visualViewport` in Mozilla Firefox as it was returning an incorrect value for `pageTop` when using `position: 'fixed'`.

--- a/modules/sugar/CHANGELOG.md
+++ b/modules/sugar/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added new `parentElement` function to the `Traverse` API.
 - Added new `setOptions` function to the `Attribute` API.
-- Added new `getInner` and `getRuntime` functions to the `Height` API.
-- Added new `getInner` and `getRuntime` functions to the `Width` API.
+- Added new `getInner` and `getRuntime` functions to the `Width` and `Height` APIs.
 
 ### Fixed
 - Disabled `window.visualViewport` in Mozilla Firefox as it was returning an incorrect value for `pageTop` when using `position: 'fixed'`.

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Height.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Height.ts
@@ -1,4 +1,5 @@
 import { Dimension } from '../../impl/Dimension';
+import * as RuntimeSize from '../../impl/RuntimeSize';
 import * as SugarBody from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
 import * as Css from '../properties/Css';
@@ -15,6 +16,10 @@ const get = (element: SugarElement<HTMLElement>): number => api.get(element);
 
 const getOuter = (element: SugarElement<HTMLElement>): number => api.getOuter(element);
 
+const getInner = RuntimeSize.getInnerHeight;
+
+const getRuntime = RuntimeSize.getHeight;
+
 const setMax = (element: SugarElement<HTMLElement>, value: number): void => {
   // These properties affect the absolute max-height, they are not counted natively, we want to include these properties.
   const inclusions = [ 'margin-top', 'border-top-width', 'padding-top', 'padding-bottom', 'border-bottom-width', 'margin-bottom' ];
@@ -25,6 +30,8 @@ const setMax = (element: SugarElement<HTMLElement>, value: number): void => {
 export {
   set,
   get,
+  getInner,
   getOuter,
+  getRuntime,
   setMax
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
@@ -1,4 +1,5 @@
 import { Dimension } from '../../impl/Dimension';
+import * as RuntimeSize from '../../impl/RuntimeSize';
 import { SugarElement } from '../node/SugarElement';
 import * as Css from '../properties/Css';
 
@@ -13,6 +14,10 @@ const get = (element: SugarElement<HTMLElement>): number => api.get(element);
 
 const getOuter = (element: SugarElement<HTMLElement>): number => api.getOuter(element);
 
+const getInner = RuntimeSize.getInnerWidth;
+
+const getRuntime = RuntimeSize.getWidth;
+
 const setMax = (element: SugarElement<HTMLElement>, value: number): void => {
   // These properties affect the absolute max-height, they are not counted natively, we want to include these properties.
   const inclusions = [ 'margin-left', 'border-left-width', 'padding-left', 'padding-right', 'border-right-width', 'margin-right' ];
@@ -23,6 +28,8 @@ const setMax = (element: SugarElement<HTMLElement>, value: number): void => {
 export {
   set,
   get,
+  getInner,
   getOuter,
+  getRuntime,
   setMax
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/RuntimeSize.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/RuntimeSize.ts
@@ -1,15 +1,16 @@
+import { Strings } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Css, Height, SugarElement, Width } from '@ephox/sugar';
+
+import { SugarElement } from '../api/node/SugarElement';
+import * as Css from '../api/properties/Css';
 
 const needManualCalc = (): boolean => {
   const browser = PlatformDetection.detect().browser;
   return browser.isIE() || browser.isEdge();
 };
 
-const toNumber = (px: string, fallback: number): number => {
-  const num = parseFloat(px); // parseFloat removes suffixes like px
-  return isNaN(num) ? fallback : num;
-};
+const toNumber = (px: string, fallback: number): number =>
+  Strings.toFloat(px).getOr(fallback);
 
 const getProp = (element: SugarElement<HTMLElement>, name: string, fallback: number): number =>
   toNumber(Css.get(element, name), fallback);
@@ -27,20 +28,22 @@ const calcContentBoxSize = (element: SugarElement<HTMLElement>, size: number, up
 };
 
 const getCalculatedHeight = (element: SugarElement<HTMLElement>, boxSizing: string): number => {
-  const height = element.dom.getBoundingClientRect().height;
+  const dom = element.dom;
+  const height = dom.getBoundingClientRect().height || dom.offsetHeight;
   return boxSizing === 'border-box' ? height : calcContentBoxSize(element, height, 'top', 'bottom');
 };
 
 const getCalculatedWidth = (element: SugarElement<HTMLElement>, boxSizing: string): number => {
-  const width = element.dom.getBoundingClientRect().width;
+  const dom = element.dom;
+  const width = dom.getBoundingClientRect().width || dom.offsetWidth;
   return boxSizing === 'border-box' ? width : calcContentBoxSize(element, width, 'left', 'right');
 };
 
 const getHeight = (element: SugarElement<HTMLElement>): number =>
-  needManualCalc() ? getCalculatedHeight(element, getBoxSizing(element)) : getProp(element, 'height', Height.get(element));
+  needManualCalc() ? getCalculatedHeight(element, getBoxSizing(element)) : getProp(element, 'height', element.dom.offsetHeight);
 
 const getWidth = (element: SugarElement<HTMLElement>): number =>
-  needManualCalc() ? getCalculatedWidth(element, getBoxSizing(element)) : getProp(element, 'width', Width.get(element));
+  needManualCalc() ? getCalculatedWidth(element, getBoxSizing(element)) : getProp(element, 'width', element.dom.offsetWidth);
 
 const getInnerHeight = (element: SugarElement<HTMLElement>): number =>
   getCalculatedHeight(element, 'content-box');

--- a/modules/sugar/src/test/ts/browser/DimensionTest.ts
+++ b/modules/sugar/src/test/ts/browser/DimensionTest.ts
@@ -16,6 +16,7 @@ import MathElement from 'ephox/sugar/test/MathElement';
 interface DimensionApi {
   get: (element: SugarElement<HTMLElement>) => number;
   getOuter: (element: SugarElement<HTMLElement>) => number;
+  getInner: (element: SugarElement<HTMLElement>) => number;
   set: (element: SugarElement<HTMLElement>, value: number | string) => void;
 }
 
@@ -35,6 +36,7 @@ UnitTest.test('DimensionTest', () => {
     // disconnected tests
     assert.eq(0, dimension.get(c));
     assert.eq(0, dimension.getOuter(c));
+    assert.eq(0, dimension.getInner(c));
 
     Insert.append(SugarBody.body(), c);
     Insert.append(SugarBody.body(), m);
@@ -45,6 +47,7 @@ UnitTest.test('DimensionTest', () => {
 
     assert.eq(true, dimension.get(c) > 0);
     assert.eq(true, dimension.getOuter(c) > 0);
+    assert.eq(true, dimension.getInner(c) > 0);
 
     dimension.set(c, 0);
 
@@ -54,16 +57,19 @@ UnitTest.test('DimensionTest', () => {
     // padding only
     assert.eq(40, dimension.get(c));        // jQuery === 0
     assert.eq(40, dimension.getOuter(c));
+    assert.eq(0, dimension.getInner(c));
 
     Css.set(c, 'border', '2px solid #fff');
     // border + padding
     assert.eq(44, dimension.get(c));        // jQuery === 0
     assert.eq(44, dimension.getOuter(c));
+    assert.eq(0, dimension.getInner(c));
 
     Css.set(c, 'margin', '3px');
     // border + padding + margin
     assert.eq(44, dimension.get(c));        // jQuery === 0
     assert.eq(44, dimension.getOuter(c));
+    assert.eq(0, dimension.getInner(c));
 
     // COMPLETE MADNESS: With border-sizing: border-box JQuery does WEIRD SHIT when you set width.
     // This is all so that when you request a width, it gives the same value.
@@ -71,35 +77,42 @@ UnitTest.test('DimensionTest', () => {
     dimension.set(c, 20);
     // border + padding + width + margin
     const bpwm = borderBox ? 44 : 64;
+    const innerBpwm = borderBox ? 0 : 20;
     assert.eq(bpwm, dimension.get(c));      // jQuery === 20 in both cases
     assert.eq(bpwm, dimension.getOuter(c)); // jQuery === 64 in both cases
+    assert.eq(innerBpwm, dimension.getInner(c));
 
     Css.remove(c, 'padding');
     // border + mad JQuery width + margin
     const bwmSize = borderBox ? 16 : 20;
     assert.eq(bwmSize + 4, dimension.get(c)); // jQuery === +0
     assert.eq(bwmSize + 4, dimension.getOuter(c));
+    assert.eq(bwmSize, dimension.getInner(c));
 
     dimension.set(c, 20);
     // border + width + margin
     assert.eq(bwmSize + 4, dimension.get(c));          // jQuery === 20
     assert.eq(bwmSize + 4, dimension.getOuter(c));
+    assert.eq(bwmSize, dimension.getInner(c));
 
     Css.remove(c, 'border');
     // width + margin
     assert.eq(20, dimension.get(c));            // jQuery === 24 in border-box mode
     assert.eq(20, dimension.getOuter(c));       // jQuery === 24 in border-box mode
+    assert.eq(20, dimension.getInner(c));
 
     dimension.set(c, 20);
     // width + margin
     assert.eq(20, dimension.get(c));
     assert.eq(20, dimension.getOuter(c));
+    assert.eq(20, dimension.getInner(c));
 
     Css.remove(c, 'margin');
 
     // just width
     assert.eq(20, dimension.get(c));
     assert.eq(20, dimension.getOuter(c));
+    assert.eq(20, dimension.getInner(c));
 
     // generally dupe with above, but replicates a JQuery test
     Css.setAll(c, {
@@ -110,12 +123,16 @@ UnitTest.test('DimensionTest', () => {
     });
 
     const allSize = borderBox ? 30 : 34;        // jQuery === 26 : 30
+    const innerAllSize = borderBox ? 26 : 30;
     assert.eq(allSize, dimension.get(c));
     assert.eq(allSize, dimension.getOuter(c));
+    assert.eq(innerAllSize, dimension.getInner(c));
     Css.set(c, 'padding', '20px');
     const allSizePlusPadding = borderBox ? 44 : 74; // jQuery === 40 : 70
+    const innerAllSizePlusPadding = borderBox ? 0 : 30;
     assert.eq(allSizePlusPadding, dimension.get(c));
     assert.eq(allSizePlusPadding, dimension.getOuter(c));
+    assert.eq(innerAllSizePlusPadding, dimension.getInner(c));
 
     // TODO: Far more extensive tests involving combinations of border, margin and padding.
 
@@ -126,11 +143,14 @@ UnitTest.test('DimensionTest', () => {
     Css.set(c, 'visibility', 'hidden');
     assert.eq(50, dimension.get(c));
     assert.eq(50, dimension.getOuter(c));
+    assert.eq(50, dimension.getInner(c));
 
     Css.set(c, 'border', '5px solid black');
     assert.eq(60, dimension.get(c));
     assert.eq(60, dimension.getOuter(c)); // 5 + 50 + 5
+    assert.eq(50, dimension.getInner(c));
     Remove.remove(c);
+    Remove.remove(m);
   };
 
   runChecks(Width, false); // content-box

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a regression that caused block wrapper formats to apply and remove incorrectly when using a collapsed selection with multiple words #TINY-8036
 - Resizing table columns in some scenarios would resize the column to an incorrect position #TINY-7731
+- Inserting a table where the parent element had padding would cause the table width to be incorrect #TINY-7991
 - Image resize backdrop element did not have `data-mce-bogus="all"` set #TINY-7854
 - Resize handles appeared on top of dialogs and menus when using an inline editor #TINY-3263
 - Fixed the `autoresize` plugin incorrectly scrolling to the top of the editor in some cases when changing content #TINY-7291

--- a/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
@@ -6,6 +6,7 @@
  */
 
 import { Arr, Obj, Optional, Type } from '@ephox/katamari';
+import { Css, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -35,8 +36,8 @@ const defaultCellBorderStyles = Arr.map([ 'Solid', 'Dotted', 'Dashed', 'Double',
 
 const determineDefaultStyles = (editor: Editor): Record<string, string> => {
   if (isPixelsForced(editor)) {
-    const editorWidth = editor.getBody().offsetWidth;
-    return { ...defaultStyles, width: editorWidth + 'px' };
+    const editorWidth = Css.get(SugarElement.fromDom(editor.getBody()), 'width');
+    return { ...defaultStyles, width: editorWidth };
   } else if (isResponsiveForced(editor)) {
     return Obj.filter(defaultStyles, (_value, key) => key !== 'width');
   } else {

--- a/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Settings.ts
@@ -6,7 +6,7 @@
  */
 
 import { Arr, Obj, Optional, Type } from '@ephox/katamari';
-import { Css, SugarElement } from '@ephox/sugar';
+import { SugarElement, Width } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -36,8 +36,11 @@ const defaultCellBorderStyles = Arr.map([ 'Solid', 'Dotted', 'Dashed', 'Double',
 
 const determineDefaultStyles = (editor: Editor): Record<string, string> => {
   if (isPixelsForced(editor)) {
-    const editorWidth = Css.get(SugarElement.fromDom(editor.getBody()), 'width');
-    return { ...defaultStyles, width: editorWidth };
+    // Determine the inner size of the parent block element where the table will be inserted
+    const dom = editor.dom;
+    const parentBlock = dom.getParent<HTMLElement>(editor.selection.getStart(), dom.isBlock) ?? editor.getBody();
+    const contentWidth = Width.getInner(SugarElement.fromDom(parentBlock));
+    return { ...defaultStyles, width: contentWidth + 'px' };
   } else if (isResponsiveForced(editor)) {
     return Obj.filter(defaultStyles, (_value, key) => key !== 'width');
   } else {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableWidthsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableWidthsTest.ts
@@ -1,0 +1,61 @@
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Obj } from '@ephox/katamari';
+import { Css } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/table/Plugin';
+import Theme from 'tinymce/themes/silver/Theme';
+
+import { insertTable, getWidths } from '../module/test/TableTestUtils';
+
+describe('browser.tinymce.plugins.table.InsertTableWidthsTest', () => {
+  Arr.each([ 'fixed', 'relative' ], (mode) => {
+    context(`table_sizing_mode: ${mode}`, () => {
+      const hook = TinyHooks.bddSetupLight<Editor>({
+        plugins: 'table',
+        table_sizing_mode: mode,
+        width: 800,
+        height: 400,
+        base_url: '/project/tinymce/js/tinymce'
+      }, [ Plugin, Theme ]);
+
+      beforeEach(() => {
+        hook.editor().setContent('');
+      });
+
+      const assertTableWidth = (label: string, editor: Editor, table: HTMLTableElement, expectedWidth: number, diff: number = 1) => {
+        const widths = getWidths(editor, table);
+        assert.approximately(widths.px, expectedWidth, diff, label);
+      };
+
+      const testTableSize = (mode: string, expectedWidth: number, styles: Record<string, string> = {}) => () => {
+        const editor = hook.editor();
+        Css.setAll(TinyDom.body(editor), styles);
+
+        // Insert into the body
+        insertTable(editor, { rows: 3, columns: 3 });
+        // Insert into the first cell of the table
+        insertTable(editor, { rows: 2, columns: 2 });
+
+        const tables = editor.dom.select('table');
+        assertTableWidth('Outer table', editor, tables[0], expectedWidth);
+        assertTableWidth('Inner table', editor, tables[1], expectedWidth / 3 - 12, 5); // 12px is the cell padding
+
+        Obj.each(styles, (_, name) => Css.remove(TinyDom.body(editor), name));
+      };
+
+      it('TINY-7991: with default styles', testTableSize(mode, 766));
+
+      Arr.each([ 'border-box', 'content-box' ], (boxSizing) => {
+        context(`box-sizing: ${boxSizing}`, () => {
+          it('TINY-7991: with only box-sizing', testTableSize(mode, 766, { 'box-sizing': boxSizing }));
+          it('TINY-7991: with margins', testTableSize(mode, 738, { 'box-sizing': boxSizing, 'margin': '30px' }));
+          it('TINY-7991: with padding', testTableSize(mode, 726, { 'box-sizing': boxSizing, 'padding': '20px' }));
+          it('TINY-7991: with borders', testTableSize(mode, 756, { 'box-sizing': boxSizing, 'border': '5px black solid' }));
+        });
+      });
+    });
+  });
+});

--- a/versions.txt
+++ b/versions.txt
@@ -2,5 +2,6 @@
 # Format: [package_name]@[new_version]
 
 imagetools@5.1.0
+katamari@8.1.0
 snooker@10.0.0
 sugar@8.1.0


### PR DESCRIPTION
Related Ticket: TINY-7991

Description of Changes:

Katamari:
* Added new helper functions to convert a string to an integer or float.

Sugar:
* Moved `RuntimeSize` logic from Snooker to Sugar (this was done as I needed the "inner" size to fix the fixed width table size).
* Added new `getInner()` and `getRuntime()` functions to `Width` and `Height` (this just exposes the `RuntimeSize` logic).

Snooker:
* Updated the sizing logic in `Sizes` to use the inner/content width for the parent element when calculating the percentage widths.
* Changed the is `col` safe logic to use an allow list and removed Safari as it can return 0px for the col element in some cases.

Note: The snooker fix to `Sizes.ts` it the core of this fix, the rest were largely side-effects to be able to get the inner/content width of an element.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
