### PR TITLE
TINY-7674: Fixed media live embed video and audio elements were unable to be played in some cases

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
 - Dragging and dropping `contenteditable="false"` elements could result in the element being placed in an unexpected location #TINY-7917
 - Pressing the Escape key would not cancel a drag action that started on a `contenteditable="false"` element within the editor #TINY-7917
+- Media live embed `video` and `audio` elements wouldn't play in some cases #TINY-7674
 
 ### Deprecated
 - Several APIs have been deprecated. See the release notes for information #TINY-8023

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842
 - Dragging and dropping `contenteditable="false"` elements could result in the element being placed in an unexpected location #TINY-7917
 - Pressing the Escape key would not cancel a drag action that started on a `contenteditable="false"` element within the editor #TINY-7917
-- Media live embed `video` and `audio` elements wouldn't play in some cases #TINY-7674
+- Media live embed `video` and `audio` elements were unable to be played in some cases #TINY-7674
 
 ### Deprecated
 - Several APIs have been deprecated. See the release notes for information #TINY-8023

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -112,7 +112,7 @@ const createPreviewNode = (editor: Editor, node: AstNode): AstNode => {
     // Recreate the child nodes using the sanitized inner HTML
     const sanitizedHtml = previewWrapper.attr('data-mce-html');
     if (Type.isNonNullable(sanitizedHtml)) {
-      appendNodeContent(editor, name, previewNode, sanitizedHtml);
+      appendNodeContent(editor, name, previewNode, unescape(sanitizedHtml));
     }
   }
 


### PR DESCRIPTION
Related Ticket: TINY-7674

Description of Changes:
* Fixes an issue where media live embeds wouldn't play correctly when they had child `<source>` nodes. This was caused by not unescaping the attribute value that stores the real HTML when trying to process it.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #6673
