### PR TITLE
TINY-8049: Rework deprecation messaging to use a single console warning and to include settings

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a new `URI.isDomSafe(uri)` API to be able to check if a URI is considered safe to be inserted into the DOM #TINY-7998
 - Added the `ESC` key code constant to the `VK` API #TINY-7917
+- Added a new `deprecation_warnings` setting to be able to turn off deprecation console warning messages #TINY-8049
 
 ### Improved
 - The `element` argument of the `editor.selection.scrollIntoView()` API is now optional, and if it is not provided the current selection will be scrolled into view #TINY-7291

--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Arr, Obj } from '@ephox/katamari';
+
+import { EditorSettings, RawEditorSettings } from './api/SettingsTypes';
+import Tools from './api/util/Tools';
+
+const deprecatedSettings = (
+  'autoresize_on_init,content_editable_state,convert_fonts_to_spans,inline_styles,padd_empty_with_br,block_elements,' +
+  'boolean_attributes,editor_deselector,editor_selector,elements,file_browser_callback_types,filepicker_validator_handler,' +
+  'force_hex_style_colors,force_p_newlines,gecko_spellcheck,images_dataimg_filter,mode,move_caret_before_on_enter_elements,' +
+  'non_empty_elements,self_closing_elements,short_ended_elements,special,spellchecker_select_languages,spellchecker_whitelist,' +
+  'tab_focus,table_responsive_width,text_block_elements,text_inline_elements,toolbar_drawer,types,validate,whitespace_elements'
+).split(',');
+
+const deprecatedPlugins = 'bbcode,colorpicker,contextmenu,fullpage,legacyoutput,spellchecker,textcolor'.split(',');
+
+const getDeprecatedSettings = (settings: RawEditorSettings): string[] => {
+  const settingNames = Arr.filter(deprecatedSettings, (setting) => Obj.has(settings, setting));
+  // Forced root block is a special case whereby only the empty/false value is deprecated
+  const forcedRootBlock = settings.forced_root_block;
+  if (forcedRootBlock === false || forcedRootBlock === '') {
+    settingNames.push('forced_root_block (false only)');
+  }
+  return settingNames;
+};
+
+const getDeprecatedPlugins = (settings: EditorSettings): string[] => {
+  const plugins = Tools.makeMap(settings.plugins, ' ');
+  return Arr.filter(deprecatedPlugins, (plugin) => Obj.has(plugins, plugin));
+};
+
+const logDeprecationsWarning = (rawSettings: RawEditorSettings, finalSettings: EditorSettings): void => {
+  // Note: Ensure we use the original user settings, not the final when logging
+  const deprecatedSettings = getDeprecatedSettings(rawSettings);
+  const deprecatedPlugins = getDeprecatedPlugins(finalSettings);
+
+  const hasDeprecatedPlugins = deprecatedPlugins.length > 0;
+  const hasDeprecatedSettings = deprecatedSettings.length > 0;
+  const isLegacyMobileTheme = finalSettings.theme === 'mobile';
+  if (hasDeprecatedPlugins || hasDeprecatedSettings || isLegacyMobileTheme) {
+    const listJoiner = '\n- ';
+    const themesMessage = isLegacyMobileTheme ? `\n\nThemes:${listJoiner}mobile` : '';
+    const pluginsMessage = hasDeprecatedPlugins ? `\n\nPlugins:${listJoiner}${deprecatedPlugins.join(listJoiner)}` : '';
+    const settingsMessage = hasDeprecatedSettings ? `\n\nSettings:${listJoiner}${deprecatedSettings.join(listJoiner)}` : '';
+    // eslint-disable-next-line no-console
+    console.warn(
+      'The following deprecated features are currently enabled, these will be removed in TinyMCE 6.0. ' +
+      'See https://www.tiny.cloud/docs/release-notes/6.0-upcoming-changes for more information.' +
+      themesMessage +
+      pluginsMessage +
+      settingsMessage
+    );
+  }
+};
+
+export {
+  logDeprecationsWarning
+};

--- a/modules/tinymce/src/core/main/ts/EditorSettings.ts
+++ b/modules/tinymce/src/core/main/ts/EditorSettings.ts
@@ -12,6 +12,7 @@ import Editor from './api/Editor';
 import Env from './api/Env';
 import { EditorSettings, RawEditorSettings, ToolbarMode } from './api/SettingsTypes';
 import Tools from './api/util/Tools';
+import { logDeprecationsWarning } from './Deprecations';
 
 export interface ParamTypeMap {
   'hash': Record<string, string>;
@@ -228,7 +229,11 @@ const combineSettings = (isMobileDevice: boolean, isPhone: boolean, defaultSetti
 
 const getEditorSettings = (editor: Editor, id: string, documentBaseUrl: string, defaultOverrideSettings: RawEditorSettings, settings: RawEditorSettings): EditorSettings => {
   const defaultSettings = getDefaultSettings(settings, id, documentBaseUrl, isTouch, editor);
-  return combineSettings(isPhone || isTablet, isPhone, defaultSettings, defaultOverrideSettings, settings);
+  const finalSettings = combineSettings(isPhone || isTablet, isPhone, defaultSettings, defaultOverrideSettings, settings);
+  if (finalSettings.deprecation_warnings !== false) {
+    logDeprecationsWarning(settings, finalSettings);
+  }
+  return finalSettings;
 };
 
 const getFiltered = <K extends keyof EditorSettings> (predicate: (x: any) => boolean, editor: Editor, name: K): Optional<EditorSettings[K]> => Optional.from(editor.settings[name]).filter(predicate);

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -73,6 +73,7 @@ interface BaseEditorSettings {
   content_css_cors?: boolean;
   content_security_policy?: string;
   content_style?: string;
+  deprecation_warnings?: boolean;
   font_css?: string | string[];
   content_langs?: ContentLanguage[];
   contextmenu?: string | false;

--- a/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/bbcode/main/ts/Plugin.ts
@@ -11,8 +11,6 @@ import * as Convert from './core/Convert';
 
 export default (): void => {
   PluginManager.add('bbcode', (editor) => {
-    // eslint-disable-next-line no-console
-    console.warn('The bbcode plugin has been deprecated and marked for removal in TinyMCE 6.0');
     editor.on('BeforeSetContent', (e) => {
       e.content = Convert.bbcode2html(e.content);
     });

--- a/modules/tinymce/src/plugins/colorpicker/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/colorpicker/main/ts/Plugin.ts
@@ -8,8 +8,6 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 
 export default () => {
-  PluginManager.add('colorpicker', () => {
-    // eslint-disable-next-line no-console
-    console.warn('Color picker plugin is now built in to the core editor, please remove it from your editor configuration');
-  });
+  // eslint-disable-next-line @tinymce/prefer-fun
+  PluginManager.add('colorpicker', () => {});
 };

--- a/modules/tinymce/src/plugins/contextmenu/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/contextmenu/main/ts/Plugin.ts
@@ -8,8 +8,6 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 
 export default () => {
-  PluginManager.add('contextmenu', () => {
-    // eslint-disable-next-line no-console
-    console.warn('Context menu plugin is now built in to the core editor, please remove it from your editor configuration');
-  });
+  // eslint-disable-next-line @tinymce/prefer-fun
+  PluginManager.add('contextmenu', () => {});
 };

--- a/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullpage/main/ts/Plugin.ts
@@ -15,8 +15,6 @@ import * as Buttons from './ui/Buttons';
 
 export default (): void => {
   PluginManager.add('fullpage', (editor) => {
-    // eslint-disable-next-line no-console
-    console.warn('The fullpage plugin has been deprecated and marked for removal in TinyMCE 6.0');
     const headState = Cell(''), footState = Cell('');
 
     Commands.register(editor, headState);

--- a/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/legacyoutput/main/ts/Plugin.ts
@@ -18,8 +18,6 @@ import * as Formats from './core/Formats';
 
 export default (): void => {
   PluginManager.add('legacyoutput', (editor) => {
-    // eslint-disable-next-line no-console
-    console.warn('The legacyoutput plugin has been deprecated and marked for removal in TinyMCE 6.0');
     Formats.setup(editor);
   });
 };

--- a/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/spellchecker/main/ts/Plugin.ts
@@ -20,8 +20,6 @@ import * as SuggestionsMenu from './ui/SuggestionsMenu';
 export default (): void => {
   PluginManager.add('spellchecker', (editor, pluginUrl) => {
     if (DetectProPlugin.hasProPlugin(editor) === false) {
-      // eslint-disable-next-line no-console
-      console.warn('The spellchecker plugin has been deprecated and marked for removal in TinyMCE 6.0');
       const startedState = Cell(false);
       const currentLanguageState = Cell<string>(Settings.getLanguage(editor));
       const textMatcherState = Cell(null);

--- a/modules/tinymce/src/plugins/textcolor/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/textcolor/main/ts/Plugin.ts
@@ -8,8 +8,6 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 
 export default () => {
-  PluginManager.add('textcolor', () => {
-    // eslint-disable-next-line no-console
-    console.warn('Text color plugin is now built in to the core editor, please remove it from your editor configuration');
-  });
+  // eslint-disable-next-line @tinymce/prefer-fun
+  PluginManager.add('textcolor', () => {});
 };


### PR DESCRIPTION
Related Ticket:  TINY-8049

Description of Changes:

This reworks the deprecation messaging to be a little less intrusive by logging a single console warning with the various plugins/settings being used that have been deprecated and that will be removed.

Note: The "placeholder" plugins don't use `Fun.noop` as it needs to be a separate function since it's used as a class constructor.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
