### PR TITLE
TINY-7895: Revert previous commit, as it introduced regressions

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Transitions.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Transitions.ts
@@ -31,7 +31,7 @@ const shouldApplyTransitionCss = (transition: Transition, decision: RepositionDe
 
 const hasChanges = (position: PositionCss, intermediate: Record<TransitionProp, Optional<string>>): boolean => {
   // Round to 3 decimal points
-  const round = (value: string) => parseFloat(value).toFixed(3);
+  const round = (value: string) => parseFloat(value).toPrecision(3);
 
   return Obj.find(intermediate, (value, key) => {
     const newValue = position[key as TransitionProp].map(round);

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The table selection state could become incorrect after selecting a noneditable table cell #TINY-8053
 - As of Mozilla Firefox 91, toggling fullscreen mode with `toolbar_sticky` enabled would cause the toolbar to disappear #TINY-7873
 - Fixed urls not cleaned correctly in some cases in the `link` and `image` plugin #TINY-7998
-- Rounding errors were causing the line height dropdowns and the `LineHeight` query command to be inaccurate on Safari #TINY-7895
 - Fixed the `image` and `media` toolbar buttons showing the incorrect active state in some cases #TINY-3463
 - Fixed the `selection.selectorChanged` API not firing correctly if the selector matched the current selection when registered #TINY-3463
 - Inserting content into a `contenteditable="true"` element that was contained within a `contenteditable="false"` element would move the selection to an incorrect location #TINY-7842

--- a/modules/tinymce/src/core/main/ts/commands/LineHeight.ts
+++ b/modules/tinymce/src/core/main/ts/commands/LineHeight.ts
@@ -17,9 +17,7 @@ export const lineHeightQuery = (editor: Editor): string => mapRange(editor, (elm
   const specifiedStyle = TransformFind.closest(elm, (elm) => Css.getRaw(elm, 'line-height'), Fun.curry(Compare.eq, root));
   const computedStyle = () => {
     // Css.get returns computed values (in px), and parseFloat will strip any non-number suffix
-    const lineHeightRaw = parseFloat(Css.get(elm, 'line-height'));
-    // TINY-7895: Safari sometimes gives us 22.39999999999 and things like that
-    const lineHeight = parseFloat(lineHeightRaw.toFixed(3));
+    const lineHeight = parseFloat(Css.get(elm, 'line-height'));
     const fontSize = parseFloat(Css.get(elm, 'font-size'));
     return String(lineHeight / fontSize);
   };

--- a/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
@@ -25,7 +25,8 @@ describe('browser.tinymce.core.commands.LineHeightTest', () => {
   });
 
   it('TINY-4843: Unspecified line-height can be read from element', function () {
-    if (platform.browser.isSafari() && platform.browser.version.major < 15) {
+    // TODO: TINY-7895
+    if (platform.browser.isSafari()) {
       this.skip();
     }
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -18,6 +18,7 @@ interface ToolbarOrMenuSpec {
 
 describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
   const platform = PlatformDetection.detect();
+
   const toolbarSpec: ToolbarOrMenuSpec = {
     name: 'Toolbar',
     pOpen: async (editor, title) => {
@@ -111,7 +112,8 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
         });
 
         it(`TINY-7713: ${spec.name} updates if computed line height changes`, async function () {
-          if (platform.browser.isSafari() && platform.browser.version.major < 15) {
+          // TODO: TINY-7895
+          if (platform.browser.isSafari()) {
             this.skip();
           }
           const editor = hook.editor();


### PR DESCRIPTION
This reverts commit 23ae2279804bdc111d471a3bb2a44fca59da510c.

Related Ticket: TINY-7895

Description of Changes:
* What it says on the label — we're gonna have to try this again in a later release

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable): N/A