### PR TITLE
TINY-8049: Sort deprecation lists and fix docs URL

### DIFF
--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -27,12 +27,12 @@ const getDeprecatedSettings = (settings: RawEditorSettings): string[] => {
   if (forcedRootBlock === false || forcedRootBlock === '') {
     settingNames.push('forced_root_block (false only)');
   }
-  return settingNames;
+  return Arr.sort(settingNames);
 };
 
 const getDeprecatedPlugins = (settings: EditorSettings): string[] => {
   const plugins = Tools.makeMap(settings.plugins, ' ');
-  return Arr.filter(deprecatedPlugins, (plugin) => Obj.has(plugins, plugin));
+  return Arr.sort(Arr.filter(deprecatedPlugins, (plugin) => Obj.has(plugins, plugin)));
 };
 
 const logDeprecationsWarning = (rawSettings: RawEditorSettings, finalSettings: EditorSettings): void => {
@@ -51,7 +51,7 @@ const logDeprecationsWarning = (rawSettings: RawEditorSettings, finalSettings: E
     // eslint-disable-next-line no-console
     console.warn(
       'The following deprecated features are currently enabled, these will be removed in TinyMCE 6.0. ' +
-      'See https://www.tiny.cloud/docs/release-notes/6.0-upcoming-changes for more information.' +
+      'See https://www.tiny.cloud/docs/release-notes/6.0-upcoming-changes/ for more information.' +
       themesMessage +
       pluginsMessage +
       settingsMessage


### PR DESCRIPTION
Related Ticket: TINY-8049

Description of Changes:
* Sort the deprecation lists to help with readability
* Fixed a missing trailing `/` for the docs URL

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
