### PR TITLE
TINY-8070: More deprecation fixes

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -389,7 +389,7 @@ class Editor implements EditorObservable {
    * Executes a legacy callback. This method is useful to call old 2.x option callbacks.
    * There new event model is a better way to add callback so this method might be removed in the future.
    * <br>
-   * <em>Deprecated in TinyMCE 5.10 and has been marked for removal in TinyMCE 6.0</em>
+   * <em>Deprecated in TinyMCE 5.10 and has been marked for removal in TinyMCE 6.0.</em>
    *
    * @deprecated
    * @method execCallback

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -197,10 +197,13 @@ const EditorManager: EditorManager = {
   releaseDate: '@@releaseDate@@',
 
   /**
-   * Collection of editor instances. Deprecated use tinymce.get() instead.
+   * Collection of editor instances.
+   * <br>
+   * <em>Deprecated in TinyMCE 4.7 and has been marked for removal in TinyMCE 6.0</em> - Use tinymce.get() instead.
    *
    * @property editors
    * @type Object
+   * @deprecated
    */
   editors: legacyEditors,
 


### PR DESCRIPTION
Related Ticket: TINY-8070

Description of Changes:
* Fixed incorrect deprecation style for the `EditorManager` editors property.
* Fixed missing fullstop.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
