### PR TITLE
TINY-7821: Removed deprecated `Schema` settings

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+- Removed deprecated `Schema` settings #TINY-7821
+
 ## 5.10.0 - TBD
 
 ### Added

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -258,7 +258,6 @@ class Editor implements EditorObservable {
   public targetElm: HTMLElement;
   public theme: Theme;
   public undoManager: UndoManager;
-  public validate: boolean;
   public windowManager: WindowManager;
   public _beforeUnload: () => void;
   public _eventDispatcher: EventDispatcher<NativeEventMap>;

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -213,27 +213,11 @@ interface BaseEditorSettings {
   mode?: 'exact' | 'textareas' | 'specific_textareas';
   types?: Record<string, any>[];
 
-  // Considered for deprecation (Schema settings)
-  block_elements?: string;
-  boolean_attributes?: string;
-  move_caret_before_on_enter_elements?: string;
-  non_empty_elements?: string;
-  self_closing_elements?: string;
-  short_ended_elements?: string;
-  text_block_elements?: string;
-  text_inline_elements?: string;
-  whitespace_elements?: string;
-  special?: string;
-
   // Internal settings (used by cloud or tests)
   disable_nodechange?: boolean;
   forced_plugins?: string | string[];
   plugin_base_urls?: Record<string, string>;
   service_message?: string;
-
-  // Special always forced on setting
-  // TODO: Get rid of this one
-  validate?: boolean;
 
   // Allow additional dynamic settings
   [key: string]: any;

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -12,26 +12,16 @@ import Tools from '../util/Tools';
 export type SchemaType = 'html4' | 'html5' | 'html5-strict';
 
 export interface SchemaSettings {
-  block_elements?: string;
-  boolean_attributes?: string;
   custom_elements?: string;
   extended_valid_elements?: string;
   invalid_elements?: string;
   invalid_styles?: string | Record<string, string>;
-  move_caret_before_on_enter_elements?: string;
-  non_empty_elements?: string;
   schema?: SchemaType;
-  self_closing_elements?: string;
-  short_ended_elements?: string;
-  special?: string;
-  text_block_elements?: string;
-  text_inline_elements?: string;
   valid_children?: string;
   valid_classes?: string | Record<string, string>;
   valid_elements?: string;
   valid_styles?: string | Record<string, string>;
   verify_html?: boolean;
-  whitespace_elements?: string;
 }
 
 export interface Attribute {
@@ -491,12 +481,12 @@ const Schema = (settings?: SchemaSettings): Schema => {
   const textInlineElementsMap = createLookupTable('text_inline_elements', 'span strong b em i font strike u var cite ' +
     'dfn code mark q sup sub samp');
 
-  each((settings.special || 'script noscript iframe noframes noembed title style textarea xmp').split(' '), (name) => {
+  each(('script noscript iframe noframes noembed title style textarea xmp').split(' '), (name) => {
     specialElements[name] = new RegExp('<\/' + name + '[^>]*>', 'gi');
   });
 
   // Converts a wildcard expression string to a regexp for example *a will become /.*a/.
-  const patternToRegExp = (str) => new RegExp('^' + str.replace(/([?+*])/g, '.$1') + '$');
+  const patternToRegExp = (str: string) => new RegExp('^' + str.replace(/([?+*])/g, '.$1') + '$');
 
   // Parses the specified valid_elements string and adds to the current rules
   // This function is a bit hard to read since it's heavily optimized for speed

--- a/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
@@ -72,9 +72,7 @@ const setContentString = (editor: Editor, body: HTMLElement, content: string, ar
     editor.fire('SetContent', args);
   } else {
     if (args.format !== 'raw') {
-      content = HtmlSerializer({
-        validate: editor.validate
-      }, editor.schema).serialize(
+      content = HtmlSerializer({ validate: false }, editor.schema).serialize(
         editor.parser.parse(content, { isRootContent: true, insert: true })
       );
     }
@@ -93,7 +91,7 @@ const setContentString = (editor: Editor, body: HTMLElement, content: string, ar
 const setContentTree = (editor: Editor, body: HTMLElement, content: AstNode, args: SetContentArgs): AstNode => {
   FilterNode.filter(editor.parser.getNodeFilters(), editor.parser.getAttributeFilters(), content);
 
-  const html = HtmlSerializer({ validate: editor.validate }, editor.schema).serialize(content);
+  const html = HtmlSerializer({ validate: false }, editor.schema).serialize(content);
 
   args.content = isWsPreserveElement(SugarElement.fromDom(body)) ? html : Tools.trim(html);
   setEditorHtml(editor, args.content, args.no_selection);

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -114,26 +114,16 @@ const mkSerializerSettings = (editor: Editor): DomSerializerSettings => {
       indent_before: settings.indent_before,
 
       // Schema settings
-      block_elements: settings.block_elements,
-      boolean_attributes: settings.boolean_attributes,
       custom_elements: settings.custom_elements,
       extended_valid_elements: settings.extended_valid_elements,
       invalid_elements: settings.invalid_elements,
       invalid_styles: settings.invalid_styles,
-      move_caret_before_on_enter_elements: settings.move_caret_before_on_enter_elements,
-      non_empty_elements: settings.non_empty_elements,
       schema: settings.schema,
-      self_closing_elements: settings.self_closing_elements,
-      short_ended_elements: settings.short_ended_elements,
-      special: settings.special,
-      text_block_elements: settings.text_block_elements,
-      text_inline_elements: settings.text_inline_elements,
       valid_children: settings.valid_children,
       valid_classes: settings.valid_classes,
       valid_elements: settings.valid_elements,
       valid_styles: settings.valid_styles,
-      verify_html: settings.verify_html,
-      whitespace_elements: settings.whitespace_elements
+      verify_html: settings.verify_html
     })
   };
 };

--- a/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
@@ -106,7 +106,7 @@ const cleanContent = (editor: Editor, args: SelectionSetContentArgs) => {
     const contextArgs = contextBlock ? { context: contextBlock.nodeName.toLowerCase() } : { };
 
     const node = editor.parser.parse(args.content, { isRootContent: true, forced_root_block: false, ...contextArgs, ...args });
-    return HtmlSerializer({ validate: editor.validate }, editor.schema).serialize(node);
+    return HtmlSerializer({ validate: false }, editor.schema).serialize(node);
   } else {
     return args.content;
   }

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -345,50 +345,6 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     assert.isString(schema.getCustomElements().block);
   });
 
-  it('whitespaceElements', () => {
-    let schema = Schema({ whitespace_elements: 'pre,p' });
-    assert.isObject(schema.getWhiteSpaceElements().pre);
-    assert.isUndefined(schema.getWhiteSpaceElements().span);
-
-    schema = Schema({ whitespace_elements: 'code' });
-    assert.isObject(schema.getWhiteSpaceElements().code);
-  });
-
-  it('selfClosingElements', () => {
-    const schema = Schema({ self_closing_elements: 'pre,p' });
-    assert.isObject(schema.getSelfClosingElements().pre);
-    assert.isObject(schema.getSelfClosingElements().p);
-    assert.isUndefined(schema.getSelfClosingElements().li);
-  });
-
-  it('shortEndedElements', () => {
-    const schema = Schema({ short_ended_elements: 'pre,p' });
-    assert.isObject(schema.getShortEndedElements().pre);
-    assert.isObject(schema.getShortEndedElements().p);
-    assert.isUndefined(schema.getShortEndedElements().img);
-  });
-
-  it('booleanAttributes', () => {
-    const schema = Schema({ boolean_attributes: 'href,alt' });
-    assert.isObject(schema.getBoolAttrs().href);
-    assert.isObject(schema.getBoolAttrs().alt);
-    assert.isUndefined(schema.getBoolAttrs().checked);
-  });
-
-  it('nonEmptyElements', () => {
-    const schema = Schema({ non_empty_elements: 'pre,p' });
-    assert.isObject(schema.getNonEmptyElements().pre);
-    assert.isObject(schema.getNonEmptyElements().p);
-    assert.isUndefined(schema.getNonEmptyElements().img);
-  });
-
-  it('blockElements', () => {
-    const schema = Schema({ block_elements: 'pre,p' });
-    assert.isObject(schema.getBlockElements().pre);
-    assert.isObject(schema.getBlockElements().p);
-    assert.isUndefined(schema.getBlockElements().h1);
-  });
-
   it('isValid', () => {
     const schema = Schema({ valid_elements: 'a[href],i[*]' });
 


### PR DESCRIPTION
Related Ticket: TINY-7821

Description of Changes:
* Removed the various dangerous schema settings that were deprecated
* Removed the `editor.validate` property and replaced the usages with `false` (it would have passed `undefined` previously, so `false` is the equivalent in this case)

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
