### PR TITLE
TINY-8087: Mark more things as deprecated

### DIFF
--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -15,10 +15,12 @@ const deprecatedSettings = (
   'boolean_attributes,editor_deselector,editor_selector,elements,file_browser_callback_types,filepicker_validator_handler,' +
   'force_hex_style_colors,force_p_newlines,gecko_spellcheck,images_dataimg_filter,mode,move_caret_before_on_enter_elements,' +
   'non_empty_elements,self_closing_elements,short_ended_elements,special,spellchecker_select_languages,spellchecker_whitelist,' +
-  'tab_focus,table_responsive_width,text_block_elements,text_inline_elements,toolbar_drawer,types,validate,whitespace_elements'
+  'tab_focus,table_responsive_width,text_block_elements,text_inline_elements,toolbar_drawer,types,validate,whitespace_elements' +
+  'paste_word_valid_elements,paste_retain_style_properties,paste_convert_word_fake_lists'
 ).split(',');
 
 const deprecatedPlugins = 'bbcode,colorpicker,contextmenu,fullpage,legacyoutput,spellchecker,textcolor'.split(',');
+const movedToPremiumPlugins = 'imagetools,toc'.split(',');
 
 const getDeprecatedSettings = (settings: RawEditorSettings): string[] => {
   const settingNames = Arr.filter(deprecatedSettings, (setting) => Obj.has(settings, setting));
@@ -32,7 +34,14 @@ const getDeprecatedSettings = (settings: RawEditorSettings): string[] => {
 
 const getDeprecatedPlugins = (settings: EditorSettings): string[] => {
   const plugins = Tools.makeMap(settings.plugins, ' ');
-  return Arr.sort(Arr.filter(deprecatedPlugins, (plugin) => Obj.has(plugins, plugin)));
+  const hasPlugin = (plugin: string) => Obj.has(plugins, plugin);
+  const pluginNames = [
+    ...Arr.filter(deprecatedPlugins, hasPlugin),
+    ...Arr.bind(movedToPremiumPlugins, (plugin) => {
+      return hasPlugin(plugin) ? [ `${plugin} (moving to premium)` ] : [];
+    })
+  ];
+  return Arr.sort(pluginNames);
 };
 
 const logDeprecationsWarning = (rawSettings: RawEditorSettings, finalSettings: EditorSettings): void => {


### PR DESCRIPTION
Related Ticket: TINY-8087

Description of Changes:
* Mark Table of Contents and ImageTools as deprecated since they are being moved to premium.
* Mark various paste word settings as deprecated, since we're removing Word logic from paste in 6.0.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
