### PR TITLE
Fix vimeo private video links

### DIFF
--- a/modules/tinymce/src/plugins/media/main/ts/core/UrlPatterns.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/UrlPatterns.ts
@@ -36,6 +36,12 @@ const urlPatterns: UrlPattern[] = [
     allowFullscreen: true
   },
   {
+    regex: /vimeo\.com\/([0-9]+)\/([a-z0-9]+)/,
+    type: 'iframe', w: 425, h: 350,
+    url: 'player.vimeo.com/video/$1?h=$2&title=0&byline=0',
+    allowFullscreen: true
+  },
+  {
     regex: /vimeo\.com\/([0-9]+)/,
     type: 'iframe', w: 425, h: 350,
     url: 'player.vimeo.com/video/$1?title=0&byline=0&portrait=0&color=8dc7dc',


### PR DESCRIPTION
Fix bad link for private access vimeo video. Link should have hash parameter (h=)

Related Ticket:

Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
