### PR TITLE
TINY-8100: Deprecate Schema.getSpecialElements()

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -963,8 +963,11 @@ const Schema = (settings?: SchemaSettings): Schema => {
    * Returns a map with special elements. These are elements that needs to be parsed
    * in a special way such as script, style, textarea etc. The map object values
    * are regexps used to find the end of the element.
+   * <br>
+   * <em>Deprecated in TinyMCE 5.10 and has been marked for removal in TinyMCE 6.0</em>.
    *
    * @method getSpecialElements
+   * @deprecated
    * @return {Object} Name/value lookup map for special elements.
    */
   const getSpecialElements = Fun.constant(specialElements);


### PR DESCRIPTION
Related Ticket: TINY-8100

Description of Changes:
* Deprecated another method

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): N/A