### PR TITLE
TINY-7823: Removed deprecated `file_browser_callback_types`, `force_hex_style_colors` and `images_dataimg_filter` settings

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed deprecated `Schema` settings #TINY-7821
+- Removed deprecated `file_browser_callback_types`, `force_hex_style_colors` and `images_dataimg_filter` settings #TINY-7823
 - The legacy `mobile` theme has been removed #TINY-7832
 
 ## 5.10.0 - TBD

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -210,18 +210,8 @@ const EditorUpload = (editor: Editor): EditorUpload => {
     }
   };
 
-  const isValidDataUriImage = (imgElm: HTMLImageElement) => {
-    if (Arr.forall(urlFilters, (filter) => filter(imgElm)) === false) {
-      return false;
-    }
-
-    if (imgElm.getAttribute('src').indexOf('data:') === 0) {
-      const dataImgFilter = Settings.getImagesDataImgFilter(editor);
-      return dataImgFilter(imgElm);
-    }
-
-    return true;
-  };
+  const isValidDataUriImage = (imgElm: HTMLImageElement) =>
+    Arr.forall(urlFilters, (filter) => filter(imgElm));
 
   const addFilter = (filter: (img: HTMLImageElement) => boolean) => {
     urlFilters.push(filter);

--- a/modules/tinymce/src/core/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/core/main/ts/api/Settings.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Obj, Strings, Type } from '@ephox/katamari';
+import { Arr, Obj, Strings, Type } from '@ephox/katamari';
 
 import { UploadHandler } from '../file/Uploader';
 import DOMUtils from './dom/DOMUtils';
@@ -72,8 +72,6 @@ const shouldEndContainerOnEmptyBlock = (editor: Editor): boolean => editor.getPa
 const getFontStyleValues = (editor: Editor): string[] => Tools.explode(editor.getParam('font_size_style_values', 'xx-small,x-small,small,medium,large,x-large,xx-large'));
 
 const getFontSizeClasses = (editor: Editor): string[] => Tools.explode(editor.getParam('font_size_classes', ''));
-
-const getImagesDataImgFilter = (editor: Editor): (imgElm: HTMLImageElement) => boolean => editor.getParam('images_dataimg_filter', Fun.always, 'function');
 
 const isAutomaticUploadsEnabled = (editor: Editor): boolean => editor.getParam('automatic_uploads', true, 'boolean');
 
@@ -226,7 +224,6 @@ export {
   getFontSizeClasses,
   getIconPackName,
   getIconsUrl,
-  getImagesDataImgFilter,
   isAutomaticUploadsEnabled,
   shouldReuseFileName,
   shouldReplaceBlobUris,

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -106,7 +106,6 @@ interface BaseEditorSettings {
   font_size_legacy_values?: string;
   font_size_style_values?: string;
   fontsize_formats?: string;
-  force_hex_style_colors?: boolean;
   forced_root_block?: boolean | string;
   forced_root_block_attrs?: Record<string, string>;
   formats?: Formats;
@@ -117,7 +116,6 @@ interface BaseEditorSettings {
   icons_url?: string;
   id?: string;
   iframe_aria_text?: string;
-  images_dataimg_filter?: (imgElm: HTMLImageElement) => boolean;
   images_file_types?: string;
   images_replace_blob_uris?: boolean;
   images_reuse_filename?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -158,7 +158,6 @@ export interface DOMUtilsSettings {
   url_converter_scope: any;
   ownEvents: boolean;
   keep_values: boolean;
-  hex_colors: boolean;
   update_styles: boolean;
   root_element: HTMLElement;
   collect: Function;

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -71,7 +71,6 @@ export interface DomParserSettings {
   inline_styles?: boolean;
   blob_cache?: BlobCache;
   document?: Document;
-  images_dataimg_filter?: (img: HTMLImageElement) => boolean;
 }
 
 interface DomParser {

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj, Optional, Type, Unicode } from '@ephox/katamari';
+import { Arr, Optional, Type, Unicode } from '@ephox/katamari';
 
 import Env from '../api/Env';
 import DomParser, { DomParserSettings } from '../api/html/DomParser';
@@ -22,22 +22,6 @@ const isBogusImage = (img: AstNode): boolean =>
 const isInternalImageSource = (img: AstNode): boolean =>
   img.attr('src') === Env.transparentSrc || Type.isNonNullable(img.attr('data-mce-placeholder'));
 
-const isValidDataImg = (img: AstNode, settings: DomParserSettings): boolean => {
-  if (settings.images_dataimg_filter) {
-    // Construct an image element
-    const imgElem = new Image();
-    imgElem.src = img.attr('src');
-    Obj.each(img.attributes.map, (value, key) => {
-      imgElem.setAttribute(key, value);
-    });
-
-    // Check if it should be excluded from being converted to a blob
-    return settings.images_dataimg_filter(imgElem);
-  } else {
-    return true;
-  }
-};
-
 const registerBase64ImageFilter = (parser: DomParser, settings: DomParserSettings): void => {
   const { blob_cache: blobCache } = settings;
   const processImage = (img: AstNode): void => {
@@ -47,7 +31,7 @@ const registerBase64ImageFilter = (parser: DomParser, settings: DomParserSetting
       return;
     }
 
-    parseDataUri(inputSrc).filter(() => isValidDataImg(img, settings)).bind(({ type, data }) =>
+    parseDataUri(inputSrc).bind(({ type, data }) =>
       Optional.from(blobCache.getByData(data, type)).orThunk(() =>
         Conversions.buildBlob(type, data).map((blob) => {
           const blobInfo = blobCache.create(uniqueId(), blob, data);

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -88,10 +88,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     root_name: getRootName(editor),
     validate: true,
     blob_cache: blobCache,
-    document: editor.getDoc(),
-
-    // Deprecated
-    images_dataimg_filter: settings.images_dataimg_filter
+    document: editor.getDoc()
   });
 };
 
@@ -422,7 +419,6 @@ const initContentBody = (editor: Editor, skipWrite?: boolean) => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     url_converter: editor.convertURL,
     url_converter_scope: editor,
-    hex_colors: settings.force_hex_style_colors,
     update_styles: true,
     root_element: editor.inline ? editor.getBody() : null,
     collect: () => editor.inline,

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -41,7 +41,6 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
   }
 
   let testBlobDataUri: string;
-  let dataImgFilter: (img: HTMLImageElement) => boolean;
   let changeEvents: Array<EditorEvent<{}>> = [];
 
   const appendEvent = (event: EditorEvent<{}>) => changeEvents.push(event);
@@ -81,7 +80,6 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
-    images_dataimg_filter: (img) => dataImgFilter ? dataImgFilter(img) : true,
     setup: (ed: Editor) => ed.on('change', appendEvent)
   }, [ Theme ]);
 
@@ -90,7 +88,6 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     editor.editorUpload.destroy();
     editor.settings.automatic_uploads = false;
     delete editor.settings.images_replace_blob_uris;
-    dataImgFilter = undefined;
     clearEvents();
   });
 
@@ -419,28 +416,6 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     return editor.uploadImages(uploadDone);
   });
 
-  it(`TBA: Don't upload filtered image`, () => {
-    const editor = hook.editor();
-    let uploadCount = 0;
-
-    assertEventsLength(0);
-    const uploadDone = () => {
-      assertEventsLength(0);
-      assert.equal(uploadCount, 0, 'Should not upload.');
-    };
-
-    dataImgFilter = (img) => !img.hasAttribute('data-skip');
-
-    editor.setContent('<img src="' + testBlobDataUri + '" data-skip="1">');
-
-    editor.settings.images_upload_handler = (_data: BlobInfo, success) => {
-      uploadCount++;
-      success('url');
-    };
-
-    return editor.uploadImages(uploadDone);
-  });
-
   it(`TBA: Don't upload api filtered image`, () => {
     const editor = hook.editor();
     let uploadCount = 0, filterCount = 0;
@@ -452,7 +427,6 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       assert.equal(filterCount, 1, 'Should have filtered one item.');
     };
 
-    dataImgFilter = Fun.always;
     editor.editorUpload.addFilter((img) => {
       filterCount++;
       return !img.hasAttribute('data-skip');

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -15,7 +15,8 @@ describe('browser.tinymce.core.dom.DOMUtils', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
     const dom = DOMUtils(document, {
-      hex_colors: true, keep_values: true, url_converter: (u) => {
+      keep_values: true,
+      url_converter: (u) => {
         return 'X' + u + 'Y';
       }
     });

--- a/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/api/Settings.ts
@@ -71,9 +71,6 @@ const getAllowHtmlDataUrls = (editor: Editor): boolean =>
 const getPasteDataImages = (editor: Editor): boolean =>
   editor.getParam('paste_data_images', false, 'boolean');
 
-const getImagesDataImgFilter = (editor: Editor): ((imgElm: HTMLImageElement) => boolean) | undefined =>
-  editor.getParam('images_dataimg_filter');
-
 const getImagesReuseFilename = (editor: Editor): boolean | undefined =>
   editor.getParam('images_reuse_filename');
 
@@ -109,7 +106,6 @@ export {
   getValidate,
   getAllowHtmlDataUrls,
   getPasteDataImages,
-  getImagesDataImgFilter,
   getImagesReuseFilename,
   getForcedRootBlock,
   getForcedRootBlockAttrs,

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
@@ -155,48 +155,6 @@ describe('browser.tinymce.plugins.paste.ImagePasteTest', () => {
     delete editor.settings.images_file_types;
   });
 
-  it('TBA: dropImages - images_dataimg_filter', async () => {
-    const editor = hook.editor();
-    const clipboard = Clipboard(editor, Cell('html'));
-
-    editor.settings.images_dataimg_filter = (img: HTMLImageElement) => {
-      assert.strictEqual(img.src, 'data:image/gif;base64,' + base64ImgSrc);
-      return false;
-    };
-
-    const event = mockEvent('drop', [
-      base64ToBlob(base64ImgSrc, 'image/gif', 'image.gif')
-    ]);
-    clipboard.pasteImageData(event, editor.selection.getRng());
-
-    await pWaitForSelector(editor, 'img');
-    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '" />a</p>');
-    assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
-
-    delete editor.settings.images_dataimg_filter;
-  });
-
-  it('TBA: pasteImages - images_dataimg_filter', async () => {
-    const editor = hook.editor();
-    const clipboard = Clipboard(editor, Cell('html'));
-
-    editor.settings.images_dataimg_filter = (img: HTMLImageElement) => {
-      assert.strictEqual(img.src, 'data:image/gif;base64,' + base64ImgSrc);
-      return false;
-    };
-
-    const event = mockEvent('paste', [
-      base64ToBlob(base64ImgSrc, 'image/gif', 'image.gif')
-    ]);
-    clipboard.pasteImageData(event, editor.selection.getRng());
-
-    await pWaitForSelector(editor, 'img');
-    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '" />a</p>');
-    assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
-
-    delete editor.settings.images_dataimg_filter;
-  });
-
   it('TINY-8079: Should filter items that are not files when pasting images', async () => {
     const editor = hook.editor();
 

--- a/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Settings.ts
@@ -12,7 +12,7 @@ import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import { AllowedFormat } from 'tinymce/core/api/fmt/StyleFormat';
-import { ContentLanguage } from 'tinymce/core/api/SettingsTypes';
+import { ContentLanguage, FilePickerCallback } from 'tinymce/core/api/SettingsTypes';
 
 export interface ToolbarGroupSetting {
   name?: string;
@@ -162,21 +162,26 @@ const getMenus = (editor: Editor) => {
   }
 };
 
-const getMenubar = (editor: Editor) => editor.getParam('menubar');
+const getMenubar = (editor: Editor): string | boolean | undefined =>
+  editor.getParam('menubar');
 
-const getToolbar = (editor: Editor): Array<string | ToolbarGroupSetting> | string | boolean => editor.getParam('toolbar', true);
+const getToolbar = (editor: Editor): Array<string | ToolbarGroupSetting> | string | boolean =>
+  editor.getParam('toolbar', true);
 
-const getFilePickerCallback = (editor: Editor) => editor.getParam('file_picker_callback');
+const getFilePickerCallback = (editor: Editor): FilePickerCallback | undefined =>
+  editor.getParam('file_picker_callback', undefined, 'function');
 
-const getFilePickerTypes = (editor: Editor) => editor.getParam('file_picker_types');
+const getFilePickerTypes = (editor: Editor): string | undefined =>
+  editor.getParam('file_picker_types', undefined, 'string');
 
-const getFileBrowserCallbackTypes = (editor: Editor) => editor.getParam('file_browser_callback_types');
+const noTypeaheadUrls = (editor: Editor): boolean =>
+  editor.getParam('typeahead_urls') === false;
 
-const noTypeaheadUrls = (editor: Editor) => editor.getParam('typeahead_urls') === false;
+const getAnchorTop = (editor: Editor): string | false =>
+  editor.getParam('anchor_top', '#top');
 
-const getAnchorTop = (editor: Editor): string | false => editor.getParam('anchor_top', '#top');
-
-const getAnchorBottom = (editor: Editor): string | false => editor.getParam('anchor_bottom', '#bottom');
+const getAnchorBottom = (editor: Editor): string | false =>
+  editor.getParam('anchor_bottom', '#bottom');
 
 const getFilePickerValidatorHandler = (editor: Editor) => {
   const handler = editor.getParam('file_picker_validator_handler', undefined, 'function');
@@ -223,7 +228,6 @@ export {
   getToolbar,
   getFilePickerCallback,
   getFilePickerTypes,
-  getFileBrowserCallbackTypes,
   noTypeaheadUrls,
   getAnchorTop,
   getAnchorBottom,

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
@@ -61,17 +61,17 @@ export interface UiFactoryBackstageForUrlInput {
 
 const isTruthy = (value: any) => !!value;
 
-const makeMap = (value: any): Record<string, boolean> => Obj.map(Tools.makeMap(value, /[, ]/), isTruthy);
+const makeMap = (value: string): Record<string, boolean> =>
+  Obj.map(Tools.makeMap(value, /[, ]/), isTruthy);
 
-const getPicker = (editor: Editor): Optional<Picker> => Optional.from(Settings.getFilePickerCallback(editor)).filter(Type.isFunction) as Optional<Picker>;
+const getPicker = (editor: Editor): Optional<Picker> =>
+  Optional.from(Settings.getFilePickerCallback(editor));
 
 const getPickerTypes = (editor: Editor): boolean | Record<string, boolean> => {
-  const optFileTypes = Optional.some(Settings.getFilePickerTypes(editor)).filter(isTruthy);
-  const optLegacyTypes = Optional.some(Settings.getFileBrowserCallbackTypes(editor)).filter(isTruthy);
-  const optTypes = optFileTypes.or(optLegacyTypes).map(makeMap);
+  const optFileTypes = Optional.from(Settings.getFilePickerTypes(editor)).filter(isTruthy).map(makeMap);
   return getPicker(editor).fold(
     Fun.never,
-    (_picker) => optTypes.fold<boolean | Record<string, boolean>>(
+    (_picker) => optFileTypes.fold<boolean | Record<string, boolean>>(
       Fun.always,
       (types) => Obj.keys(types).length > 0 ? types : false)
   );
@@ -106,7 +106,8 @@ const getUrlPicker = (editor: Editor, filetype: string): Optional<UrlPicker> => 
   picker.call(editor, handler, entry.value, meta);
 }));
 
-const getTextSetting = (value: string | boolean): string | undefined => Optional.from(value).filter(Type.isString).getOrUndefined();
+const getTextSetting = (value: string | boolean): string | undefined =>
+  Optional.from(value).filter(Type.isString).getOrUndefined();
 
 export const getLinkInformation = (editor: Editor): Optional<LinkInformation> => {
   if (Settings.noTypeaheadUrls(editor)) {
@@ -119,9 +120,11 @@ export const getLinkInformation = (editor: Editor): Optional<LinkInformation> =>
     anchorBottom: getTextSetting(Settings.getAnchorBottom(editor))
   });
 };
-export const getValidationHandler = (editor: Editor): Optional<UrlValidationHandler> => Optional.from(Settings.getFilePickerValidatorHandler(editor));
+export const getValidationHandler = (editor: Editor): Optional<UrlValidationHandler> =>
+  Optional.from(Settings.getFilePickerValidatorHandler(editor));
 
-export const getUrlPickerTypes = (editor: Editor): boolean | Record<string, boolean> => getPickerTypes(editor);
+export const getUrlPickerTypes = (editor: Editor): boolean | Record<string, boolean> =>
+  getPickerTypes(editor);
 
 export const UrlInputBackstage = (editor: Editor): UiFactoryBackstageForUrlInput => ({
   getHistory,


### PR DESCRIPTION
Related Ticket: TINY-7823

Description of Changes:
* Removed the `file_browser_callback_types` legacy fallback option.
* Removed the unused/undocumented `force_hex_style_colors` setting (and associated DOMUtils setting).
* Removes the deprecated `images_dataimg_filter` setting

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
