### PR TITLE
TINY-4520: Remove all DomQuery $ helper functions

### DIFF
--- a/modules/tinymce/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
@@ -8,8 +8,8 @@ export default () => {
 
   const paintClientRect = (rect, color, id) => {
     const editor: Editor = tinymce.activeEditor;
-    const $ = editor.$;
-    let rectDiv;
+    const dom = editor.dom;
+    let rectDiv: HTMLElement;
     const viewPort = editor.dom.getViewPort();
 
     if (!rect) {
@@ -18,13 +18,14 @@ export default () => {
 
     color = color || 'red';
     id = id || color;
-    rectDiv = $('#' + id);
+    rectDiv = dom.get(id);
 
-    if (!rectDiv[0]) {
-      rectDiv = $('<div></div>').appendTo(editor.getBody());
+    if (!rectDiv) {
+      rectDiv = dom.add(editor.getBody(), 'div');
     }
 
-    rectDiv.attr('id', id).css({
+    dom.setAttrib(rectDiv, 'id', id);
+    dom.setStyles(rectDiv, {
       position: 'absolute',
       left: (rect.left + viewPort.x) + 'px',
       top: (rect.top + viewPort.y) + 'px',

--- a/modules/tinymce/src/core/main/ts/NodeChange.ts
+++ b/modules/tinymce/src/core/main/ts/NodeChange.ts
@@ -5,7 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import DomQuery from './api/dom/DomQuery';
+import { Arr, Fun } from '@ephox/katamari';
+
 import Editor from './api/Editor';
 import Env from './api/Env';
 import * as Settings from './api/Settings';
@@ -22,7 +23,7 @@ import { hasAnyRanges } from './selection/SelectionUtils';
 
 class NodeChange {
   private readonly editor: Editor;
-  private lastPath: DomQuery | [] = [];
+  private lastPath: Node[] = [];
 
   public constructor(editor: Editor) {
     this.editor = editor;
@@ -136,10 +137,11 @@ class NodeChange {
    * @private
    * @return {Boolean} True if the element path is the same false if it's not.
    */
-  private isSameElementPath(startElm) {
+  private isSameElementPath(startElm: Node) {
     let i;
+    const editor = this.editor;
 
-    const currentPath = this.editor.$(startElm).parentsUntil(this.editor.getBody()).add(startElm);
+    const currentPath = Arr.reverse(editor.dom.getParents(startElm, Fun.always, editor.getBody()));
     if (currentPath.length === this.lastPath.length) {
       for (i = currentPath.length; i >= 0; i--) {
         if (currentPath[i] !== this.lastPath[i]) {

--- a/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
@@ -7,7 +7,6 @@
 
 import { Arr, Obj } from '@ephox/katamari';
 
-import { DomQueryConstructor } from './dom/DomQuery';
 import ScriptLoader from './dom/ScriptLoader';
 import Editor from './Editor';
 import I18n from './util/I18n';
@@ -104,8 +103,8 @@ type WaitState = 'added' | 'loaded';
 
 // This is a work around as constructors will only work with classes,
 // but our plugins are all functions.
-type AddOnCallback<T> = (editor: Editor, url: string, $?: DomQueryConstructor) => void | T;
-export type AddOnConstructor<T> = new (editor: Editor, url: string, $?: DomQueryConstructor) => T;
+type AddOnCallback<T> = (editor: Editor, url: string) => void | T;
+export type AddOnConstructor<T> = new (editor: Editor, url: string) => T;
 
 interface AddOnManager<T> {
   items: AddOnConstructor<T>[];

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -21,7 +21,6 @@ import Quirks from '../util/Quirks';
 import * as VisualAids from '../view/VisualAids';
 import AddOnManager from './AddOnManager';
 import Annotator from './Annotator';
-import DomQuery, { DomQueryConstructor } from './dom/DomQuery';
 import DOMUtils from './dom/DOMUtils';
 import ScriptLoader from './dom/ScriptLoader';
 import EditorSelection from './dom/Selection';
@@ -193,20 +192,6 @@ class Editor implements EditorObservable {
    */
   public setMode: (mode: string) => void;
 
-  /**
-   * Dom query instance with default scope to the editor document and default element is the body of the editor.
-   * <br>
-   * <em>Deprecated in TinyMCE 5.10 and has been marked for removal in TinyMCE 6.0.</em>
-   *
-   * @deprecated
-   * @property $
-   * @type tinymce.dom.DomQuery
-   * @example
-   * tinymce.activeEditor.$('p').css('color', 'red');
-   * tinymce.activeEditor.$().append('<p>new</p>');
-   */
-  public $: DomQueryConstructor;
-
   public shortcuts: Shortcuts;
   public loadedCSS: Record<string, any> = {};
   public editorCommands: EditorCommands;
@@ -347,11 +332,6 @@ class Editor implements EditorObservable {
     // Call setup
     editorManager.fire('SetupEditor', { editor: this });
     this.execCallback('setup', this);
-
-    this.$ = DomQuery.overrideDefaults(() => ({
-      context: this.inline ? this.getBody() : this.getDoc(),
-      element: this.getBody()
-    }));
   }
 
   /**

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -10,7 +10,7 @@ import { Arr, Obj, Type } from '@ephox/katamari';
 import * as ErrorReporter from '../ErrorReporter';
 import * as FocusController from '../focus/FocusController';
 import AddOnManager from './AddOnManager';
-import DomQuery, { DomQueryConstructor } from './dom/DomQuery';
+import DomQuery from './dom/DomQuery';
 import DOMUtils from './dom/DOMUtils';
 import Editor from './Editor';
 import Env from './Env';
@@ -64,12 +64,15 @@ const globalEventDelegate = (e) => {
   });
 };
 
-const toggleGlobalEvents = (state) => {
+const toggleGlobalEvents = (state: boolean) => {
   if (state !== boundGlobalEvents) {
+    const DOM = DOMUtils.DOM;
     if (state) {
-      DomQuery(window).on('resize scroll', globalEventDelegate);
+      DOM.bind(window, 'resize', globalEventDelegate);
+      DOM.bind(window, 'scroll', globalEventDelegate);
     } else {
-      DomQuery(window).off('resize scroll', globalEventDelegate);
+      DOM.unbind(window, 'resize', globalEventDelegate);
+      DOM.unbind(window, 'scroll', globalEventDelegate);
     }
 
     boundGlobalEvents = state;
@@ -118,7 +121,6 @@ const purgeDestroyedEditor = (editor) => {
 };
 
 interface EditorManager extends Observable<EditorManagerEventMap> {
-  $: DomQueryConstructor;
   defaultSettings: RawEditorSettings;
   majorVersion: string;
   minorVersion: string;
@@ -160,17 +162,6 @@ const EditorManager: EditorManager = {
   defaultSettings: {},
   documentBaseURL: null,
   suffix: null,
-
-  /**
-   * Dom query instance.
-   * <br>
-   * <em>Deprecated in TinyMCE 5.10 and has been marked for removal in TinyMCE 6.0.</em>
-   *
-   * @deprecated
-   * @property $
-   * @type tinymce.dom.DomQuery
-   */
-  $: DomQuery,
 
   /**
    * Major version of TinyMCE build.

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -6,6 +6,7 @@
  */
 
 import { Arr, Cell, Type } from '@ephox/katamari';
+import { Attribute, SugarElement } from '@ephox/sugar';
 
 import * as ErrorReporter from '../ErrorReporter';
 import { BlobInfoImagePair, ImageScanner } from '../file/ImageScanner';
@@ -132,7 +133,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
 
     replaceUrlInUndoStack(image.src, resultUri);
 
-    editor.$(image).attr({
+    Attribute.setAll(SugarElement.fromDom(image), {
       'src': Settings.shouldReuseFileName(editor) ? cacheInvalidator(resultUri) : resultUri,
       'data-mce-src': src
     });

--- a/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/ThemeManager.ts
@@ -6,7 +6,6 @@
  */
 
 import AddOnManager from './AddOnManager';
-import { DomQueryConstructor } from './dom/DomQuery';
 import Editor from './Editor';
 import { NotificationManagerImpl } from './NotificationManager';
 import { EditorUiApi } from './ui/Ui';
@@ -17,7 +16,7 @@ export interface Theme {
   inline?: any;
   execCommand?: (command: string, ui?: boolean, value?: any) => boolean;
   destroy?: () => void;
-  init?: (editor: Editor, url: string, $: DomQueryConstructor) => void;
+  init?: (editor: Editor, url: string) => void;
   renderUI?: () => {
     iframeContainer?: HTMLIFrameElement;
     editorContainer: HTMLElement;

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -6,7 +6,7 @@
  */
 
 import { Arr, Obj, Type } from '@ephox/katamari';
-import { Selectors, SugarElement } from '@ephox/sugar';
+import { SelectorFind, Selectors, SugarElement } from '@ephox/sugar';
 
 import * as CefUtils from '../../dom/CefUtils';
 import * as NodeType from '../../dom/NodeType';
@@ -450,7 +450,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
     });
 
     controlElm = e.type === 'mousedown' ? e.target : selection.getNode();
-    controlElm = dom.$(controlElm).closest('table,img,figure.image,hr,video,span.mce-preview-object')[0];
+    controlElm = SelectorFind.closest(SugarElement.fromDom(controlElm), 'table,img,figure.image,hr,video,span.mce-preview-object').getOrUndefined()?.dom;
 
     if (isChildOrEqual(controlElm, rootElement)) {
       disableGeckoResize();

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -23,7 +23,6 @@ import Styles, { StyleMap } from '../html/Styles';
 import { URLConverter } from '../SettingsTypes';
 import { MappedEvent } from '../util/EventDispatcher';
 import Tools from '../util/Tools';
-import DomQuery, { DomQueryConstructor } from './DomQuery';
 import EventUtils, { EventUtilsCallback } from './EventUtils';
 import StyleSheetLoader from './StyleSheetLoader';
 import DomTreeWalker from './TreeWalker';
@@ -192,12 +191,7 @@ interface DOMUtils {
   schema: Schema;
   events: EventUtils;
   root: Node;
-  $: DomQueryConstructor;
 
-  $$: {
-    <T extends Node>(elm: T | T[] | DomQuery<T>): DomQuery<T>;
-    (elm: string): DomQuery<Node>;
-  };
   isBlock: (node: string | Node) => boolean;
   clone: (node: Node, deep: boolean) => Node;
   getRoot: () => HTMLElement;
@@ -338,13 +332,6 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
   const events = settings.ownEvents ? new EventUtils() : EventUtils.Event;
   const blockElementsMap = schema.getBlockElements();
 
-  const $ = DomQuery.overrideDefaults(() => {
-    return {
-      context: doc,
-      element: self.getRoot()
-    };
-  });
-
   /**
    * Returns true/false if the specified element is a block element or not.
    *
@@ -364,8 +351,6 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     elm && doc && Type.isString(elm)
       ? doc.getElementById(elm)
       : elm as HTMLElement;
-
-  const $$ = <T extends Node>(elm: string | T | T[] | DomQuery<T>): DomQuery<T | Node> => $(Type.isString(elm) ? get(elm) : elm);
 
   const _get = (elm: string | Node): SugarElement<HTMLElement> | null => {
     const value = get(elm);
@@ -1242,24 +1227,6 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     schema,
     events,
     isBlock,
-
-    /**
-     * <em>Deprecated in TinyMCE 5.10 and has been marked for removal in TinyMCE 6.0.</em>
-     *
-     * @deprecated
-     * @property $
-     * @type tinymce.dom.DomQuery
-     */
-    $,
-
-    /**
-     * <em>Deprecated in TinyMCE 5.10 and has been marked for removal in TinyMCE 6.0.</em>
-     *
-     * @deprecated
-     * @property $$
-     * @type tinymce.dom.DomQuery
-     */
-    $$,
 
     root: null,
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -6,7 +6,7 @@
  */
 
 import { Optional, Type } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Remove, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import ElementUtils from '../api/dom/ElementUtils';
@@ -173,7 +173,7 @@ const moveSelectionToMarker = (editor: Editor, marker: HTMLElement | null): void
   dom.remove(marker);
 
   if (parentBlock && dom.isEmpty(parentBlock)) {
-    editor.$(parentBlock).empty();
+    Remove.empty(SugarElement.fromDom(parentBlock));
 
     rng.setStart(parentBlock, 0);
     rng.setEnd(parentBlock, 0);

--- a/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
+++ b/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
@@ -96,7 +96,7 @@ const focusEditor = (editor: Editor) => {
 
   // Move focus to contentEditable=true child if needed
   const contentEditableHost = getContentEditableHost(editor, selection.getNode());
-  if (editor.$.contains(body, contentEditableHost)) {
+  if (editor.dom.isChildOf(contentEditableHost, body)) {
     focusBody(contentEditableHost);
     normalizeSelection(editor, rng);
     activateEditor(editor);

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -38,7 +38,7 @@ const initPlugin = (editor: Editor, initializedPlugins: string[], plugin: string
     }
 
     try {
-      const pluginInstance = new Plugin(editor, pluginUrl, editor.$);
+      const pluginInstance = new Plugin(editor, pluginUrl);
 
       editor.plugins[plugin] = pluginInstance;
 
@@ -92,7 +92,7 @@ const initTheme = (editor: Editor) => {
     editor.theme = new Theme(editor, ThemeManager.urls[theme]);
 
     if (editor.theme.init) {
-      editor.theme.init(editor, ThemeManager.urls[theme] || editor.documentBaseUrl.replace(/\/$/, ''), editor.$);
+      editor.theme.init(editor, ThemeManager.urls[theme] || editor.documentBaseUrl.replace(/\/$/, ''));
     }
   } else {
     // Theme set to false or null doesn't produce a theme api

--- a/modules/tinymce/src/core/main/ts/keyboard/CefNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/CefNavigation.ts
@@ -6,6 +6,7 @@
  */
 
 import { Fun, Optional } from '@ephox/katamari';
+import { Insert, SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import Env from '../api/Env';
@@ -51,15 +52,15 @@ const exitPreBlock = (editor: Editor, direction: HDirection, range: Range): void
 
     const caretPos = getVisualCaretPosition(CaretPosition.fromRangeStart(range));
     if (!caretPos) {
-      const newBlock = createTextBlock(editor);
+      const newBlock = SugarElement.fromDom(createTextBlock(editor));
 
       if (direction === 1) {
-        editor.$(pre).after(newBlock);
+        Insert.after(SugarElement.fromDom(pre), newBlock);
       } else {
-        editor.$(pre).before(newBlock);
+        Insert.before(SugarElement.fromDom(pre), newBlock);
       }
 
-      editor.selection.select(newBlock, true);
+      editor.selection.select(newBlock.dom, true);
       editor.selection.collapse();
     }
   }

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -124,7 +124,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       assertEventsLength(0);
       return editor.uploadImages(() => {
         editor.setContent(imageHtml(blobUri));
-        assert.isFalse(hasBlobAsSource(editor.$<HTMLImageElement>('img')[0]), 'replace uploaded blob uri with result uri (copy/paste of an uploaded blob uri)');
+        assert.isFalse(hasBlobAsSource(editor.dom.select('img')[0]), 'replace uploaded blob uri with result uri (copy/paste of an uploaded blob uri)');
         assert.equal(editor.getContent(), '<p><img src="file.png" /></p>', 'replace uploaded blob uri with result uri (copy/paste of an uploaded blob uri)');
         assertEventsLength(1);
       });
@@ -147,7 +147,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       return editor.uploadImages(() => {
         assertEventsLength(0);
         editor.setContent(imageHtml(blobUri));
-        assert.isTrue(hasBlobAsSource(editor.$<HTMLImageElement>('img')[0]), 'Has blob');
+        assert.isTrue(hasBlobAsSource(editor.dom.select('img')[0]), 'Has blob');
         assert.equal(editor.getContent(), '<p><img src="file.png" /></p>', 'contains image');
       });
     });
@@ -257,7 +257,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       assertResultReusesFilename(editor, uploadedBlobInfo, result);
 
       editor.uploadImages((_result) => {
-        const img = editor.$<HTMLImageElement>('img')[0];
+        const img = editor.dom.select('img')[0];
         assertEventsLength(1);
         assert.isFalse(hasBlobAsSource(img), 'uploadImages reuse filename');
         assert.include(img.src, 'custom.png?size=small&', 'Check the cache invalidation string was added');
@@ -280,7 +280,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       }
 
       assert.equal(editor.getContent(), '<p><img src="myimage.png" /></p>', 'uploadConcurrentImages');
-      LegacyUnit.equalDom(result[0].element, editor.$('img')[0]);
+      LegacyUnit.equalDom(result[0].element, editor.dom.select('img')[0]);
       assert.isTrue(result[0].status, 'uploadConcurrentImages');
     };
 
@@ -314,7 +314,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
         assert.isAtLeast(uploadCount, 1, 'Should at least be one.');
       }
 
-      LegacyUnit.equalDom(result[0].element, editor.$<HTMLImageElement>('img')[0]);
+      LegacyUnit.equalDom(result[0].element, editor.dom.select('img')[0]);
       assert.isFalse(result[0].status, 'uploadConcurrentImages (fail)');
       assert.isEmpty(result[0].uploadUri, 'uploadConcurrentImages (fail)');
     };
@@ -352,7 +352,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
         assert.isAtLeast(uploadCount, 1, 'Should at least be one.');
       }
 
-      assert.isUndefined(editor.$('img')[0], 'No element in the editor');
+      assert.isUndefined(editor.dom.select('img')[0], 'No element in the editor');
       assert.isFalse(result[0].status, 'Status is false');
       assert.isEmpty(result[0].uploadUri, 'Uri is empty');
       assert.equal(editor.undoManager.data[0].content, '<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" data-mce-placeholder="1"></p>', 'content is correct');

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -1851,7 +1851,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
       }
     });
 
-    editor.formatter.apply('format', {}, editor.$('td td')[0]);
+    editor.formatter.apply('format', {}, editor.dom.select('td td')[0]);
 
     assert.equal(
       getContent(editor),

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -340,7 +340,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     const editor = hook.editor();
     editor.setContent('<table><tbody><tr><td>A</td></tr><tr><td>B</td></tr></tbody></table>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.$('td')[1].firstChild, 0);
+    rng.setStart(editor.dom.select('td')[1].firstChild, 0);
     rng.setEnd(editor.getBody(), 1);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertLink', false, { href: 'x' });

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -48,7 +48,7 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
   it('click on link in cE=false', () => {
     const editor = hook.editor();
     editor.setContent('<p contentEditable="false"><a href="#"><strong>link</strong></a></p>');
-    const evt = editor.fire('click', { target: editor.$('strong')[0] } as any);
+    const evt = editor.fire('click', { target: editor.dom.select('strong')[0] } as any);
 
     assert.equal(evt.isDefaultPrevented(), true);
   });

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -518,39 +518,39 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
   it('getBookmark/setBookmark on cE=false', () => {
     const editor = hook.editor();
     editor.setContent('text<span contentEditable="false">1</span>');
-    editor.selection.select(editor.$('span')[0]);
+    editor.selection.select(editor.dom.select('span')[0]);
     const bookmark = editor.selection.getBookmark(2);
     editor.setContent('text<span contentEditable="false">1</span>');
     editor.selection.moveToBookmark(bookmark);
-    LegacyUnit.equalDom(editor.selection.getNode(), editor.$('span')[0]);
+    LegacyUnit.equalDom(editor.selection.getNode(), editor.dom.select('span')[0]);
   });
 
   it('getBookmark/setBookmark before cE=false', () => {
     const editor = hook.editor();
     editor.setContent('<p><input><span contentEditable="false">1</span></p>');
-    CaretContainer.insertInline(editor.$('span')[0], true);
+    CaretContainer.insertInline(editor.dom.select('span')[0], true);
     const rng = editor.dom.createRng();
-    rng.setStart(editor.$('span')[0].previousSibling, 0);
-    rng.setEnd(editor.$('span')[0].previousSibling, 0);
+    rng.setStart(editor.dom.select('span')[0].previousSibling, 0);
+    rng.setEnd(editor.dom.select('span')[0].previousSibling, 0);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2);
     editor.setContent('<p><input><span contentEditable="false">1</span></p>');
     editor.selection.moveToBookmark(bookmark);
-    LegacyUnit.equalDom(editor.selection.getNode(), editor.$('span')[0]);
+    LegacyUnit.equalDom(editor.selection.getNode(), editor.dom.select('span')[0]);
   });
 
   it('getBookmark/setBookmark before cE=false block', () => {
     const editor = hook.editor();
     editor.setContent('<p contentEditable="false">1</p>');
-    CaretContainer.insertBlock('p', editor.$('p')[0], true);
+    CaretContainer.insertBlock('p', editor.dom.select('p')[0], true);
     const rng = editor.dom.createRng();
-    rng.setStart(editor.$('p')[0], 0);
-    rng.setEnd(editor.$('p')[0], 0);
+    rng.setStart(editor.dom.select('p')[0], 0);
+    rng.setEnd(editor.dom.select('p')[0], 0);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2);
     editor.setContent('<p contentEditable="false">1</p>');
     editor.selection.moveToBookmark(bookmark);
-    LegacyUnit.equalDom(editor.selection.getNode(), editor.$('p')[0]);
+    LegacyUnit.equalDom(editor.selection.getNode(), editor.dom.select('p')[0]);
   });
 
   it('select empty TD', () => {
@@ -1200,8 +1200,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p>x</p>');
-    rng.setStart(editor.$('p')[0].firstChild, 0);
-    rng.setEnd(editor.$('p')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild, 1);
 
     editor.selection.setRng(rng);
     editor.selection.setRng(null);
@@ -1219,8 +1219,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
     editor.setContent('<p>x</p>');
 
-    rng.setStart(editor.$('p')[0].firstChild, 0);
-    rng.setEnd(editor.$('p')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild, 1);
     editor.selection.setRng(rng);
 
     const tmpNode = document.createTextNode('y');
@@ -1240,7 +1240,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
   it('setRng invalid range removed parent context', () => {
     const editor = hook.editor();
     editor.setContent('<p><strong><em>x</em></strong></p>');
-    const textNode = editor.$('em')[0].firstChild;
+    const textNode = editor.dom.select('em')[0].firstChild;
 
     editor.setContent('');
 
@@ -1264,8 +1264,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
     editor.setContent('<p>x</p>');
 
-    rng.setStart(editor.$('p')[0].firstChild, 0);
-    rng.setEnd(editor.$('p')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild, 1);
 
     editor.selection.setRng(rng);
     editor.selection.setRng(null);

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
@@ -168,8 +168,8 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a<br>b</h1><p>c</p>';
 
     const rng = editor.selection.getRng();
-    rng.setStart(editor.$('h1')[0].lastChild, 1);
-    rng.setEnd(editor.$('h1')[0].lastChild, 1);
+    rng.setStart(editor.dom.select('h1')[0].lastChild, 1);
+    rng.setEnd(editor.dom.select('h1')[0].lastChild, 1);
     editor.selection.setRng(rng);
 
     editor.execCommand('ForwardDelete');

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -10,7 +10,7 @@ import { Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 const isChildOfBody = (editor: Editor, elm: Node): boolean => {
-  return editor.$.contains(editor.getBody(), elm);
+  return editor.dom.isChildOf(elm, editor.getBody());
 };
 
 const isTableCellNode = (node: Node | null): boolean => {

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -99,7 +99,8 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
     editor.setContent('<div style="min-height: 35px;"><img src="#" /></div><div style="height: 5500px;"></div>');
     await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5585), 10, 3000);
     // Update the img element to load an image
-    editor.$('img').attr('src', 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png');
+    const image = editor.dom.select('img')[0];
+    editor.dom.setAttrib(image, 'src', 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png');
     // Content height + div image height (84px) + bottom margin = 5634
     await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5634), 10, 3000);
     await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5634), 10, 3000);

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/CodeSample.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/CodeSample.ts
@@ -19,6 +19,7 @@ const getSelectedCodeSample = (editor: Editor): Optional<Element> => {
 };
 
 const insertCodeSample = (editor: Editor, language: string, code: string): void => {
+  const dom = editor.dom;
   editor.undoManager.transact(() => {
     const node = getSelectedCodeSample(editor);
 
@@ -26,9 +27,11 @@ const insertCodeSample = (editor: Editor, language: string, code: string): void 
 
     return node.fold(() => {
       editor.insertContent('<pre id="__new" class="language-' + language + '">' + code + '</pre>');
-      editor.selection.select(editor.$('#__new').removeAttr('id')[0]);
+      const newPre = dom.select('#__new')[0];
+      dom.setAttrib(newPre, 'id', null);
+      editor.selection.select(newPre);
     }, (n) => {
-      editor.dom.setAttrib(n, 'class', 'language-' + language);
+      dom.setAttrib(n, 'class', 'language-' + language);
       n.innerHTML = code;
       Prism.get(editor).highlightElement(n);
       editor.selection.select(n);

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
@@ -5,46 +5,53 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Strings } from '@ephox/katamari';
+
 import Editor from 'tinymce/core/api/Editor';
+import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Utils from '../util/Utils';
 import * as Prism from './Prism';
 
 const setup = (editor: Editor): void => {
-  const $ = editor.$;
-
   editor.on('PreProcess', (e) => {
-    $('pre[contenteditable=false]', e.node)
-      .filter(Utils.trimArg(Utils.isCodeSample))
-      .each((idx, elm) => {
-        const $elm = $(elm), code = elm.textContent;
+    const dom = editor.dom;
+    const pres = dom.select('pre[contenteditable=false]', e.node);
+    Tools.each(Tools.grep<HTMLElement>(pres, Utils.isCodeSample), (elm) => {
+      const code = elm.textContent;
 
-        $elm.attr('class', $.trim($elm.attr('class')));
-        $elm.removeAttr('contentEditable');
+      dom.setAttrib(elm, 'class', Strings.trim(dom.getAttrib(elm, 'class')));
+      dom.setAttrib(elm, 'contentEditable', null);
 
-        $elm.empty().append($('<code></code>').each(function () {
-          // Needs to be textContent since innerText produces BR:s
-          this.textContent = code;
-        }));
-      });
+      // Empty the pre element
+      let child: Node;
+      while ((child = elm.firstChild)) {
+        elm.removeChild(child);
+      }
+
+      const codeElm = dom.add(elm, 'code');
+      // Needs to be textContent since innerText produces BR:s
+      codeElm.textContent = code;
+    });
   });
 
   editor.on('SetContent', () => {
-    const unprocessedCodeSamples = $('pre').filter(Utils.trimArg(Utils.isCodeSample)).filter((idx, elm) => {
-      return elm.contentEditable !== 'false';
+    const dom = editor.dom;
+    const unprocessedCodeSamples = Tools.grep(dom.select('pre'), (elm) => {
+      return Utils.isCodeSample(elm) && elm.contentEditable !== 'false';
     });
 
     if (unprocessedCodeSamples.length) {
       editor.undoManager.transact(() => {
-        unprocessedCodeSamples.each((idx, elm: HTMLElement) => {
-          $(elm).find('br').each((idx, elm) => {
+        Tools.each(unprocessedCodeSamples, (elm) => {
+          Tools.each(dom.select('br', elm), (elm) => {
             elm.parentNode.replaceChild(editor.getDoc().createTextNode('\n'), elm);
           });
 
           elm.contentEditable = 'false';
-          elm.innerHTML = editor.dom.encode(elm.textContent);
+          elm.innerHTML = dom.encode(elm.textContent);
           Prism.get(editor).highlightElement(elm);
-          elm.className = $.trim(elm.className);
+          elm.className = Strings.trim(elm.className);
         });
       });
     }

--- a/modules/tinymce/src/plugins/imagetools/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/imagetools/main/ts/core/Actions.ts
@@ -165,7 +165,7 @@ const updateSelectedImage = (editor: Editor, origBlob: Blob, ir: ImageResult, up
 
     editor.undoManager.transact(() => {
       const imageLoadedHandler = () => {
-        editor.$(selectedImage).off('load', imageLoadedHandler);
+        editor.dom.unbind(selectedImage, 'load', imageLoadedHandler);
         editor.nodeChanged();
 
         if (uploadImmediately) {
@@ -176,17 +176,18 @@ const updateSelectedImage = (editor: Editor, origBlob: Blob, ir: ImageResult, up
         }
       };
 
-      editor.$(selectedImage).on('load', imageLoadedHandler);
+      editor.dom.bind(selectedImage, 'load', imageLoadedHandler);
       if (size) {
-        editor.$(selectedImage).attr({
+        editor.dom.setAttribs(selectedImage, {
           width: size.w,
           height: size.h
         });
       }
 
-      editor.$(selectedImage).attr({
+      editor.dom.setAttribs(selectedImage, {
         src: blobInfo.blobUri()
-      }).removeAttr('data-mce-src');
+      });
+      selectedImage.removeAttribute('data-mce-src');
     });
 
     return blobInfo;

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -28,7 +28,7 @@ const gotoLink = (editor: Editor, a: HTMLAnchorElement | null): void => {
   if (a) {
     const href = Utils.getHref(a);
     if (/^#/.test(href)) {
-      const targetEl = editor.$<HTMLElement>(href);
+      const targetEl = editor.dom.select(href);
       if (targetEl.length) {
         editor.selection.scrollIntoView(targetEl[0], true);
       }

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -6,7 +6,7 @@
  */
 
 import { Arr } from '@ephox/katamari';
-import { Compare, SugarElement } from '@ephox/sugar';
+import { Compare, Remove, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import RangeUtils from 'tinymce/core/api/dom/RangeUtils';
@@ -107,7 +107,7 @@ const mergeLiElements = (dom: DOMUtils, fromElm: Element, toElm: Element): void 
   }
 
   if (NodeType.isEmpty(dom, toElm, true)) {
-    dom.$(toElm).empty();
+    Remove.empty(SugarElement.fromDom(toElm));
   }
 
   moveChildren(dom, fromElm, toElm);
@@ -130,7 +130,7 @@ const mergeLiElements = (dom: DOMUtils, fromElm: Element, toElm: Element): void 
 };
 
 const mergeIntoEmptyLi = (editor: Editor, fromLi: HTMLLIElement, toLi: HTMLLIElement): void => {
-  editor.dom.$(toLi).empty();
+  Remove.empty(SugarElement.fromDom(toLi));
   mergeLiElements(editor.dom, fromLi, toLi);
   editor.selection.setCursorLocation(toLi, 0);
 };

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
@@ -606,7 +606,7 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteTest', () => {
     );
 
     editor.focus();
-    editor.selection.setCursorLocation(editor.$('ul ul li')[0], 0);
+    editor.selection.setCursorLocation(editor.dom.select('ul ul li')[0], 0);
     editor.plugins.lists.backspaceDelete(true);
 
     TinyAssertions.assertContent(editor, '<ul><li>1<ul><li>2</li></ul></li><li>3</li></ul>');
@@ -624,7 +624,7 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteTest', () => {
     );
 
     editor.focus();
-    editor.selection.setCursorLocation(editor.$('li')[1], 1);
+    editor.selection.setCursorLocation(editor.dom.select('li')[1], 1);
     editor.plugins.lists.backspaceDelete(false);
 
     TinyAssertions.assertContent(editor, '<ul><li>1</li><li>2</li><li>3</li></ul>');

--- a/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
@@ -5,6 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Arr } from '@ephox/katamari';
+
 import Editor from 'tinymce/core/api/Editor';
 import AstNode from 'tinymce/core/api/html/Node';
 import Tools from 'tinymce/core/api/util/Tools';
@@ -110,11 +112,9 @@ const setup = (editor: Editor): void => {
   editor.on('SetContent', () => {
     // TODO: This shouldn't be needed there should be a way to mark bogus
     // elements so they are never removed except external save
-    editor.$('span.mce-preview-object').each((index, elm) => {
-      const $elm = editor.$(elm);
-
-      if ($elm.find('span.mce-shim').length === 0) {
-        $elm.append('<span class="mce-shim"></span>');
+    Arr.each(editor.dom.select('span.mce-preview-object'), (elm) => {
+      if (editor.dom.select('span.mce-shim', elm).length === 0) {
+        editor.dom.add(elm, 'span', { class: 'mce-shim' });
       }
     });
   });

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Quirks.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Quirks.ts
@@ -5,6 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Arr } from '@ephox/katamari';
+
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Tools from 'tinymce/core/api/util/Tools';
@@ -153,8 +155,10 @@ const removeWebKitStyles = (editor: Editor, content: string, internal: boolean, 
 };
 
 const removeUnderlineAndFontInAnchor = (editor: Editor, root: Element): void => {
-  editor.$('a', root).find('font,u').each((i, node) => {
-    editor.dom.remove(node, true);
+  Arr.each(editor.dom.select('a', root), (anchor) => {
+    Arr.each(editor.dom.select('font,u', anchor), (node) => {
+      editor.dom.remove(node, true);
+    });
   });
 };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -23,7 +23,7 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
   const cleanTableHtml = (html: string) => html.replace(/<p>(&nbsp;|<br[^>]+>)<\/p>$/, '');
 
   const selectOne = (editor: Editor, start: string) => {
-    const startElm = editor.$(start)[0];
+    const startElm = editor.dom.select(start)[0];
 
     editor.fire('mousedown', { target: startElm, button: 0 } as unknown as MouseEvent);
     editor.fire('mouseup', { target: startElm, button: 0 } as unknown as MouseEvent);
@@ -32,8 +32,8 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
   };
 
   const selectRangeXY = (editor: Editor, start: string, end: string) => {
-    const startElm = editor.$(start)[0];
-    const endElm = editor.$(end)[0];
+    const startElm = editor.dom.select(start)[0];
+    const endElm = editor.dom.select(end)[0];
 
     editor.fire('mousedown', { target: startElm, button: 0 } as unknown as MouseEvent);
     editor.fire('mouseover', { target: endElm, button: 0 } as unknown as MouseEvent);

--- a/modules/tinymce/src/plugins/toc/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/core/FilterContent.ts
@@ -6,25 +6,30 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
+import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Settings from '../api/Settings';
 
 const setup = (editor: Editor): void => {
-  const $ = editor.$, tocClass = Settings.getTocClass(editor);
+  const tocClass = Settings.getTocClass(editor);
 
   editor.on('PreProcess', (e) => {
-    const $tocElm = $('.' + tocClass, e.node);
-    if ($tocElm.length) {
-      $tocElm.removeAttr('contentEditable');
-      $tocElm.find('[contenteditable]').removeAttr('contentEditable');
+    const dom = editor.dom;
+    const tocElm = dom.select('.' + tocClass, e.node)[0];
+    if (tocElm) {
+      const ceElems = [ tocElm ].concat(dom.select('[contenteditable]', tocElm));
+      Tools.each(ceElems, (ceElem) => {
+        dom.setAttrib(ceElem, 'contentEditable', null);
+      });
     }
   });
 
   editor.on('SetContent', () => {
-    const $tocElm = $('.' + tocClass);
-    if ($tocElm.length) {
-      $tocElm.attr('contentEditable', false);
-      $tocElm.children(':first-child').attr('contentEditable', true);
+    const dom = editor.dom;
+    const tocElm = dom.select('.' + tocClass)[0];
+    if (tocElm) {
+      dom.setAttrib(tocElm, 'contentEditable', false);
+      dom.setAttrib(tocElm.firstElementChild, 'contentEditable', true);
     }
   });
 };

--- a/modules/tinymce/src/plugins/toc/main/ts/core/Toc.ts
+++ b/modules/tinymce/src/plugins/toc/main/ts/core/Toc.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import DomQuery from 'tinymce/core/api/dom/DomQuery';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
@@ -39,11 +38,11 @@ const readHeaders = (editor: Editor): Header[] => {
   const tocClass = Settings.getTocClass(editor);
   const headerTag = Settings.getTocHeader(editor);
   const selector = generateSelector(Settings.getTocDepth(editor));
-  let headers = editor.$<HTMLHeadingElement>(selector);
+  let headers = editor.dom.select<HTMLHeadingElement>(selector);
 
   // if headerTag is one of h1-9, we need to filter it out from the set
   if (headers.length && /^h[1-9]$/i.test(headerTag)) {
-    headers = headers.filter((i, el) => {
+    headers = Tools.grep(headers, (el) => {
       return !editor.dom.hasClass(el.parentNode, tocClass);
     });
   }
@@ -53,7 +52,7 @@ const readHeaders = (editor: Editor): Header[] => {
     return {
       id: id ? id : tocId(),
       level: parseInt(h.nodeName.replace(/^H/i, ''), 10),
-      title: editor.$.text(h),
+      title: h.innerText,
       element: h
     };
   });
@@ -130,15 +129,15 @@ const generateTocContentHtml = (editor: Editor): string => {
   return html;
 };
 
-const isEmptyOrOffscreen = (editor: Editor, nodes: DomQuery<Node>): boolean => {
+const isEmptyOrOffscreen = (editor: Editor, nodes: Node[]): boolean => {
   return !nodes.length || editor.dom.getParents(nodes[0], '.mce-offscreen-selection').length > 0;
 };
 
 const insertToc = (editor: Editor): void => {
   const tocClass = Settings.getTocClass(editor);
-  const $tocElm = editor.$('.' + tocClass);
+  const tocElms = editor.dom.select('.' + tocClass);
 
-  if (isEmptyOrOffscreen(editor, $tocElm)) {
+  if (isEmptyOrOffscreen(editor, tocElms)) {
     editor.insertContent(generateTocHtml(editor));
   } else {
     updateToc(editor);
@@ -147,11 +146,11 @@ const insertToc = (editor: Editor): void => {
 
 const updateToc = (editor: Editor): void => {
   const tocClass = Settings.getTocClass(editor);
-  const $tocElm = editor.$('.' + tocClass);
+  const tocElms = editor.dom.select('.' + tocClass);
 
-  if ($tocElm.length) {
+  if (tocElms.length) {
     editor.undoManager.transact(() => {
-      $tocElm.html(generateTocContentHtml(editor));
+      editor.dom.setHTML(tocElms, generateTocContentHtml(editor));
     });
   }
 };

--- a/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
+++ b/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
@@ -1,8 +1,8 @@
 import { describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import DomQuery from 'tinymce/core/api/dom/DomQuery';
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import Plugin from 'tinymce/plugins/toc/Plugin';
@@ -22,16 +22,18 @@ describe('browser.tinymce.plugins.toc.TocPluginTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin, Theme ]);
 
-  const stripAttribs = ($el: DomQuery, attr: string[] | string): void => {
+  const stripAttribs = (el: Element, attr: string[] | string): void => {
     if (Tools.isArray(attr)) {
       Tools.each(attr, (attr) => {
-        stripAttribs($el, attr);
+        stripAttribs(el, attr);
       });
       return;
     }
 
-    $el.removeAttr(attr);
-    $el.find('[' + attr + ']').removeAttr(attr);
+    el.removeAttribute(attr);
+    Tools.each(el.querySelectorAll('[' + attr + ']'), (child) => {
+      child.removeAttribute(attr);
+    });
   };
 
   const trimBr = (html: string): string =>
@@ -52,16 +54,18 @@ describe('browser.tinymce.plugins.toc.TocPluginTest', () => {
     LegacyUnit.setSelection(editor, 'h1', 0);
     editor.execCommand('mceInsertToc');
 
-    const $toc = editor.$<Element>('.tst-toc');
+    const tocs = editor.dom.select('.tst-toc');
 
-    assert.lengthOf($toc, 2, 'ToC inserted');
-    assert.equal($toc.attr('contentEditable'), 'false', 'cE=false');
+    assert.lengthOf(tocs, 2, 'ToC inserted');
+    Arr.each(tocs, (toc) => {
+      assert.equal(toc.getAttribute('contentEditable'), 'false', 'cE=false');
 
-    assert.lengthOf($toc.find('ul ul ul'), 0, 'no levels beyond 2 are included');
+      assert.lengthOf(editor.dom.select('ul ul ul', toc), 0, 'no levels beyond 2 are included');
 
-    stripAttribs($toc, [ 'data-mce-href', 'data-mce-selected' ]);
+      stripAttribs(toc, [ 'data-mce-href', 'data-mce-selected' ]);
+    });
 
-    assert.equal(trimBr(HtmlUtils.normalizeHtml($toc[0].outerHTML)),
+    assert.equal(trimBr(HtmlUtils.normalizeHtml(tocs[0].outerHTML)),
       '<div class="tst-toc" contenteditable="false">' +
       '<h3 contenteditable="true">Table of Contents</h3>' +
       '<ul>' +
@@ -95,11 +99,11 @@ describe('browser.tinymce.plugins.toc.TocPluginTest', () => {
     LegacyUnit.setSelection(editor, 'h1', 0);
     editor.execCommand('mceInsertToc');
 
-    const $toc = editor.$<Element>('.tst-toc');
+    const toc = editor.dom.select('.tst-toc')[0];
 
-    stripAttribs($toc, [ 'data-mce-href', 'data-mce-selected' ]);
+    stripAttribs(toc, [ 'data-mce-href', 'data-mce-selected' ]);
 
-    LegacyUnit.equal(trimBr(HtmlUtils.normalizeHtml($toc[0].innerHTML)),
+    LegacyUnit.equal(trimBr(HtmlUtils.normalizeHtml(toc.innerHTML)),
       '<h3 contenteditable="true">Table of Contents</h3>' +
       '<ul>' +
       '<li>' +
@@ -135,12 +139,13 @@ describe('browser.tinymce.plugins.toc.TocPluginTest', () => {
     editor.execCommand('mceInsertToc');
 
     // add one more heading
-    editor.$().append('<h1 id="h5">H1</h1><p>This is some text.</p>');
+    editor.dom.add(editor.getBody(), 'h1', { id: 'h5' }, 'H1');
+    editor.dom.add(editor.getBody(), 'p', {}, 'This is some text.');
 
     LegacyUnit.setSelection(editor, 'li', 0);
     editor.execCommand('mceUpdateToc');
 
-    assert.lengthOf(editor.$('.tst-toc > ul a[href="#h5"]'), 1, 'ToC has been successfully updated');
+    assert.lengthOf(editor.dom.select('.tst-toc > ul a[href="#h5"]'), 1, 'ToC has been successfully updated');
   });
 
   it('Misc', () => {
@@ -161,13 +166,14 @@ describe('browser.tinymce.plugins.toc.TocPluginTest', () => {
 
     editor.setContent(contents);
 
-    const $toc = editor.$<Element>('.tst-toc');
-    assert.equal($toc.attr('contentEditable'), 'false', 'cE added back after setContent()');
-    assert.equal($toc.find(':first-child').attr('contentEditable'), 'true', 'cE added back to title after setContent()');
+    const toc = editor.dom.select('.tst-toc')[0];
+    assert.equal(toc.getAttribute('contentEditable'), 'false', 'cE added back after setContent()');
+    const tocChild = toc.firstElementChild;
+    assert.equal(tocChild.getAttribute('contentEditable'), 'true', 'cE added back to title after setContent()');
 
-    stripAttribs($toc, [ 'data-mce-href', 'data-mce-selected' ]);
+    stripAttribs(toc, [ 'data-mce-href', 'data-mce-selected' ]);
 
-    assert.equal(trimBr(HtmlUtils.normalizeHtml($toc[0].innerHTML)),
+    assert.equal(trimBr(HtmlUtils.normalizeHtml(toc.innerHTML)),
       '<h3 contenteditable="true">Table of Contents</h3>' +
       '<ul>' +
       '<li>' +


### PR DESCRIPTION
Related Ticket: TINY-4520

Description of Changes:

The second PR in the series of removing `DomQuery` and `Sizzle`... This removes all uses of the `$` variable declared on `EditorManager`, `Editor`, `AddOnManager` and `DOMUtils`.

Pre-checks:
* [x] ~Changelog entry added~ (will be added on the last PR that actually removes everything)
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):