### PR TITLE
TINY-8160: Fixed test failure on Chrome 95

### DIFF
--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
@@ -44,11 +44,11 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsErrorTest', () => {
   };
 
   it('TBA: Incorrect service url no api key', () =>
-    pTestImageToolsError('http://0.0.0.0.0.0/', undefined, 'ImageProxy HTTP error: Incorrect Image Proxy URL')
+    pTestImageToolsError('http://nonexistant.tiny.cloud/', undefined, 'ImageProxy HTTP error: Incorrect Image Proxy URL')
   );
 
   it('TBA: Incorrect service url with api key', () =>
-    pTestImageToolsError('http://0.0.0.0.0.0/', 'fake_key', 'ImageProxy HTTP error: Incorrect Image Proxy URL')
+    pTestImageToolsError('http://nonexistant.tiny.cloud/', 'fake_key', 'ImageProxy HTTP error: Incorrect Image Proxy URL')
   );
 
   it('TBA: 403 no api key', () =>


### PR DESCRIPTION
Related Ticket: TINY-8160

Description of Changes:

This test used `0.0.0.0.0.0` as the domain so that it would not be able to resolve the host. However, as of Chrome 95 they throw an error for this because of https://www.chromestatus.com/feature/5679790780579840. As such, I've just changed the URL to something else that won't resolve.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] ~Milestone set~ (Not tied to a release)
* [x] Review comments resolved

GitHub issues (if applicable):
