### PR TITLE
TINY-8166: Fixed an exception thrown on Safari when closing the `searchreplace` plugin dialog

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed an exception thrown on Safari when closing the `searchreplace` plugin dialog #TINY-8166
+
 ## 5.10.0 - 2021-10-11
 
 ### Added


### PR DESCRIPTION
Related Ticket: TINY-8166

Description of Changes:

Added a mitigation for Safari invalid selections when finding words in the Search & Replace plugin. This works around https://bugs.webkit.org/show_bug.cgi?id=230594 specifically for Search & Replace, as we know it's safe to reset the selection here. This doesn't solve the issue fully, as that can only be done within Safari, but it will at least prevent the exception getting thrown and will therefore prevent our tests from failing in CI.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ No tests needed, as they already fail once Safari has been upgraded
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
