### PR TITLE
TINY-7836: Ensure forecolor/backcolor toolbar buttons have an initial color set

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Clicking the `forecolor` or `backcolor` toolbar buttons would do nothing until selecting a color #TINY-7836
 - Fixed an exception thrown on Safari when closing the `searchreplace` plugin dialog #TINY-8166
 
 ## 5.10.0 - 2021-10-11

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
@@ -20,8 +20,8 @@ describe('browser.tinymce.themes.silver.editor.color.GetCurrentColorTest', () =>
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme ], true);
 
-  const assertCurrentColor = (editor: Editor, format: string, label: string, expected: string) => {
-    const actual = ColorSwatch.getCurrentColor(editor, format);
+  const assertCurrentColor = (editor: Editor, format: 'forecolor' | 'hilitecolor', label: string, expected: string) => {
+    const actual = ColorSwatch.getCurrentColor(editor, format).getOrDie('No current color found');
     assert.equal(actual, expected, label);
   };
 
@@ -36,6 +36,6 @@ describe('browser.tinymce.themes.silver.editor.color.GetCurrentColorTest', () =>
     const editor = hook.editor();
     editor.setContent('<p style="background-color: red;">hello <span style="background-color: blue;">world</span></p>');
     TinySelections.setCursor(editor, [ 0, 1, 0 ], 2);
-    assertCurrentColor(editor, 'backcolor', 'should return blue', 'blue');
+    assertCurrentColor(editor, 'hilitecolor', 'should return blue', 'blue');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -19,15 +19,18 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme ], true);
 
-  const forecolorStruct = ApproxStructure.build((s, str) => {
+  const forecolorStruct = (color: string) => ApproxStructure.build((s, str) => {
     return s.element('body', {
       children: [
         s.element('p', {
           children: [
             s.element('span', {
               styles: {
-                color: str.is('rgb(35, 111, 161)')
-              }
+                color: str.is(color)
+              },
+              children: [
+                s.text(str.is('hello'))
+              ]
             }),
             s.text(str.is(' test'))
           ]
@@ -36,46 +39,62 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
     });
   });
 
-  const backcolorStruct = ApproxStructure.build((s, str) => {
+  const backcolorStruct = (color: string) => ApproxStructure.build((s, str) => {
     return s.element('body', {
       children: [
         s.element('p', {
           children: [
             s.element('span', {
               styles: {
-                'background-color': str.is('rgb(35, 111, 161)')
-              }
+                'background-color': str.is(color)
+              },
+              children: [
+                s.text(str.is('hello'))
+              ]
             }),
             s.text(str.is(' test'))
           ]
         })
       ]
     });
+  });
+
+  const setupContent = (editor: Editor) => {
+    editor.setContent('hello test');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 5);
+  };
+
+  it('TINY-7836: Initial color is set to black for both buttons', () => {
+    const editor = hook.editor();
+    setupContent(editor);
+    TinyUiActions.clickOnUi(editor, 'div[title="Text color"] .tox-tbtn');
+    TinyAssertions.assertContentStructure(editor, forecolorStruct('rgb(0, 0, 0)'));
+    setupContent(editor);
+    TinyUiActions.clickOnUi(editor, 'div[title="Background color"] .tox-tbtn');
+    TinyAssertions.assertContentStructure(editor, backcolorStruct('rgb(0, 0, 0)'));
   });
 
   it('TBA: forecolor', async () => {
     const editor = hook.editor();
-    editor.setContent('hello test');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 5);
+    setupContent(editor);
     TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
     TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#2DC26B"]');
     TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
     TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#236FA1"]');
-    TinyAssertions.assertContentStructure(editor, forecolorStruct);
+    TinyAssertions.assertContentStructure(editor, forecolorStruct('rgb(35, 111, 161)'));
   });
 
   it('TBA: backcolor', async () => {
     const editor = hook.editor();
-    editor.setContent('hello test');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 5);
+    setupContent(editor);
     TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
     TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#2DC26B"]');
     TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
     TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#236FA1"]');
-    TinyAssertions.assertContentStructure(editor, backcolorStruct);
+    TinyAssertions.assertContentStructure(editor, backcolorStruct('rgb(35, 111, 161)'));
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-7836

Description of Changes:

The `forecolor` and `backcolor` toolbar buttons never had an initial state which means they didn't work/did nothing until you manually selected a color. As such, this just sets the initial state to black so that the toolbar buttons will work.

Note: I also did a little bit of cleanup here, as I originally was looking at using `getCurrentColor` but then decided against it because of the Jira spec and due to the fact that when setting up the UI we don't have the editor body available yet.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
