### PR TITLE
TINY-8091: Fixed autolink not activating when the URL is prefixed by a bracket

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an exception thrown on Safari when closing the `searchreplace` plugin dialog #TINY-8166
+- The `autolink` plugin did not convert URLs to links when starting with a bracket #TINY-8091
+- The `autolink` plugin incorrectly created nested links in some cases #TINY-8091
 - Tables could have an incorrect height set on rows when rendered outside of the editor #TINY-7699
 
 ## 5.10.0 - 2021-10-11

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -1,6 +1,6 @@
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Type } from '@ephox/katamari';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 import fc from 'fast-check';
 
@@ -13,7 +13,7 @@ import * as KeyUtils from '../module/test/KeyUtils';
 
 describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
   before(function () {
-    if (Env.browser.isIE() || Env.browser.isEdge()) {
+    if (Env.browser.isIE()) {
       this.skip();
     }
   });
@@ -21,7 +21,8 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'autolink',
     indent: false,
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    inline_boundaries: false
   }, [ Plugin, Theme ], true);
 
   const typeUrl = (editor: Editor, url: string): string => {
@@ -31,13 +32,12 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     return editor.getContent();
   };
 
-  const typeAnEclipsedURL = (editor: Editor, url: string, expectedUrl?: string, withDotAtTheEnd?: boolean): void => {
-    const dot = withDotAtTheEnd ? '.' : '';
-    const modifiedurl = '(' + url + dot;
-    editor.setContent('<p>' + modifiedurl + '</p>');
-    LegacyUnit.setSelection(editor, 'p', modifiedurl.length);
-    KeyUtils.type(editor, ')');
-    assert.equal(editor.getContent(), `<p>(<a href="${expectedUrl || url}">${url + dot}</a>)</p>`, 'Create a link of an eclipsed url');
+  const typeAnEclipsedURL = (editor: Editor, url: string, expectedUrl?: string, startBracket: string = '(', endBracket: string = ')'): void => {
+    const modifiedUrl = startBracket + url;
+    editor.setContent('<p>' + modifiedUrl + '</p>');
+    LegacyUnit.setSelection(editor, 'p', modifiedUrl.length);
+    KeyUtils.type(editor, endBracket);
+    assert.equal(editor.getContent(), `<p>${startBracket}<a href="${expectedUrl || url}">${url}</a>${endBracket}</p>`, 'Create a link of an eclipsed url');
   };
 
   const typeNewlineURL = (editor: Editor, url: string, expectedUrl?: string, withDotAtTheEnd?: boolean): void => {
@@ -73,35 +73,35 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assertIsLink(editor, 'http://user:password@www.domain.com', 'http://user:password@www.domain.com');
   });
 
-  it('TINY-4773: AutoLink: Unexpected urls ended with space', () => {
+  it('TINY-4773: Unexpected urls ended with space', () => {
     const editor = hook.editor();
     assertIsLink(editor, 'first-last@domain', 'mailto:first-last@domain'); // No .com or similar needed.
     assertNoLink(editor, 'first-last@()', 'first-last@()');
     assertNoLink(editor, 'first-last@¶¶KJ', 'first-last@&para;&para;KJ');
   });
 
-  it('TINY-4773: AutoLink: text which should not work', () => {
+  it('TINY-4773: text which should not work', () => {
     const editor = hook.editor();
     assertNoLink(editor, 'first-last@@domain@.@com'); // We only accept one @
     assertNoLink(editor, 'first-last@¶¶KJ@', 'first-last@&para;&para;KJ@'); // Anything goes after the @
     assertNoLink(editor, 'first-last@'); // We only accept one @
   });
 
-  it('TINY-4773: AutoLink: multiple @ characters', () => {
+  it('TINY-4773: multiple @ characters', () => {
     const editor = hook.editor();
     fc.assert(fc.property(fc.hexaString(0, 30), fc.hexaString(0, 30), fc.hexaString(0, 30), (s1, s2, s3) => {
       assertNoLink(editor, `${s1}@@${s2}@.@${s3}`, `${s1}@@${s2}@.@${s3}`);
     }));
   });
 
-  it('TINY-4773: AutoLink: ending in @ character', () => {
+  it('TINY-4773: ending in @ character', () => {
     const editor = hook.editor();
     fc.assert(fc.property(fc.hexaString(0, 100), (s1) => {
       assertNoLink(editor, `${s1}@`, `${s1}@`);
     }));
   });
 
-  it('TBA: Urls ended with )', () => {
+  it('TBA: Urls ended with bracket', () => {
     const editor = hook.editor();
     typeAnEclipsedURL(editor, 'http://www.domain.com');
     typeAnEclipsedURL(editor, 'https://www.domain.com');
@@ -109,6 +109,9 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     typeAnEclipsedURL(editor, 'ftp://www.domain.com');
     typeAnEclipsedURL(editor, 'www.domain.com', 'http://www.domain.com');
     typeAnEclipsedURL(editor, 'www.domain.com', 'http://www.domain.com');
+
+    typeAnEclipsedURL(editor, 'https://www.domain.com', 'https://www.domain.com', '[', ']');
+    typeAnEclipsedURL(editor, 'https://www.domain.com', 'https://www.domain.com', '{', '}');
   });
 
   it('TBA: Urls ended with new line', () => {
@@ -175,5 +178,21 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com', '!');
     assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com', ';');
     assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com', ':');
+  });
+
+  it('TINY-8091: should not create nested links', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="https://www.domain.com/"><strong>https://www.domain.com/</strong></a></p>');
+    TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 23);
+    KeyUtils.type(editor, ' ');
+    TinyAssertions.assertContent(editor, '<p><a href="https://www.domain.com/"><strong>https://www.domain.com/&nbsp;</strong></a></p>');
+  });
+
+  it('TINY-8091: should trigger when typing in the middle of brackets', () => {
+    const editor = hook.editor();
+    assert.equal(typeUrl(editor, '(https://www.domain.com'), '<p>(<a href="https://www.domain.com">https://www.domain.com</a>&nbsp;</p>');
+    assert.equal(typeUrl(editor, '(https://www.domain.com,'), '<p>(<a href="https://www.domain.com">https://www.domain.com</a>,&nbsp;</p>');
+    assert.equal(typeUrl(editor, '[https://www.domain.com,'), '<p>[<a href="https://www.domain.com">https://www.domain.com</a>,&nbsp;</p>');
+    assert.equal(typeUrl(editor, '{https://www.domain.com'), '<p>{<a href="https://www.domain.com">https://www.domain.com</a>&nbsp;</p>');
   });
 });

--- a/modules/tinymce/src/plugins/autolink/test/ts/module/test/KeyUtils.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/module/test/KeyUtils.ts
@@ -1,18 +1,18 @@
-import { Arr, Fun, Unicode } from '@ephox/katamari';
+import { Arr, Fun, Obj, Unicode } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
 const isText = (node: Node): node is Text => node.nodeType === 3;
 
 const charCodeToKeyCode = (charCode: number): number => {
-  const lookup = {
+  const lookup: Record<string, number> = {
     '0': 48, '1': 49, '2': 50, '3': 51, '4': 52, '5': 53, '6': 54, '7': 55, '8': 56, '9': 57, 'a': 65, 'b': 66, 'c': 67,
-    'd': 68, 'e': 69, 'f': 70, 'g': 71, 'h': 72, 'i': 73, 'j': 74, 'k': 75, 'l': 76, 'm': 77, 'n': 78, 'o': 79, 'p': 80, 'q': 81,
-    'r': 82, 's': 83, 't': 84, 'u': 85, 'v': 86, 'w': 87, 'x': 88, 'y': 89, ' ': 32, ',': 188, '-': 189, '.': 190, '/': 191,
-    '\\': 220, '[': 219, ']': 221, '\'': 222, ';': 186, '=': 187, ')': 41
+    'd': 68, 'e': 69, 'f': 70, 'g': 71, 'h': 72, 'i': 73, 'j': 74, 'k': 75, 'l': 76, 'm': 77, 'n': 78, 'o': 79, 'p': 80,
+    'q': 81, 'r': 82, 's': 83, 't': 84, 'u': 85, 'v': 86, 'w': 87, 'x': 88, 'y': 89, 'z': 90, ' ': 32, ',': 188, '-': 189,
+    '.': 190, '/': 191, '\\': 220, '[': 219, ']': 221, '\'': 222, ';': 186, '=': 187, '(': 57, ')': 48
   };
 
-  return lookup[String.fromCharCode(charCode)];
+  return Obj.get(lookup, String.fromCharCode(charCode)).getOr(charCode);
 };
 
 const needsNbsp = (rng: Range, chr: string): boolean => {
@@ -70,7 +70,7 @@ const type = (editor: Editor, chr: string | number | Record<string, number | str
 
   const startElm = editor.selection.getStart();
   fakeEvent(startElm, 'keydown', evt);
-  fakeEvent(startElm, 'keypress', evt);
+  fakeEvent(startElm, 'keypress', { ...evt, keyCode: evt.charCode });
 
   if (!evt.isDefaultPrevented()) {
     if (keyCode === 8) {


### PR DESCRIPTION
Related Ticket: TINY-8091

Description of Changes:
* Fixed URLs not converted when part of a list in brackets. e.g: `(https://www.example.com and https://www.anotherexample.com)`.
  * Note: As discussed at standup, we're limiting this just to brackets atm as it's not entirely clear what should trigger this and doing anything larger may require a much larger rewrite.
* Fixed a separate issue I found while testing that caused nested links to be created if there were other inline elements inside a link already.
* Did some minor code cleanup (e.g extracting out the `isTextNode` and `isElement` functions)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
