### PR TITLE
TINY-7735: Add 'removed' flag to UploadResult

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `URI.isDomSafe(uri)` API to check if a URI is considered safe to be inserted into the DOM #TINY-7998
 - Added the `ESC` key code constant to the `VK` API #TINY-7917
 - Added a new `deprecation_warnings` setting for turning off deprecation console warning messages #TINY-8049
-- Extended returned result of the `editor.uploadImages` function with the `removed` flag, reflecting the image has been removed after failed upload #TINY-7735
+- The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload #TINY-7735
 
 ### Improved
 - The `element` argument of the `editor.selection.scrollIntoView()` API is now optional, and if it is not provided the current selection will be scrolled into view #TINY-7291

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload #TINY-7735
+
 ### Changed
 - The `editor.getContent()` API can provide custom content by preventing and overriding `content` in the `BeforeGetContent` event. This makes it consistent with the `editor.selection.getContent()` API #TINY-8018
 - The `editor.setContent()` API can now be prevented using the `BeforeSetContent` event. This makes it consistent with the `editor.selection.setContent()` API #TINY-8018
@@ -49,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `URI.isDomSafe(uri)` API to check if a URI is considered safe to be inserted into the DOM #TINY-7998
 - Added the `ESC` key code constant to the `VK` API #TINY-7917
 - Added a new `deprecation_warnings` setting for turning off deprecation console warning messages #TINY-8049
-- The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload #TINY-7735
 
 ### Improved
 - The `element` argument of the `editor.selection.scrollIntoView()` API is now optional, and if it is not provided the current selection will be scrolled into view #TINY-7291

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `URI.isDomSafe(uri)` API to check if a URI is considered safe to be inserted into the DOM #TINY-7998
 - Added the `ESC` key code constant to the `VK` API #TINY-7917
 - Added a new `deprecation_warnings` setting for turning off deprecation console warning messages #TINY-8049
+- Extended returned result of the `editor.uploadImages` function with the `removed` flag, reflecting the image has been removed after failed upload #TINY-7735
 
 ### Improved
 - The `element` argument of the `editor.selection.scrollIntoView()` API is now optional, and if it is not provided the current selection will be scrolled into view #TINY-7291

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -153,6 +153,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
         const filteredResult: UploadResult[] = Arr.map(result, (uploadInfo, index) => {
           const blobInfo = imageInfos[index].blobInfo;
           const image = imageInfos[index].image;
+          let removed = false;
 
           if (uploadInfo.status && Settings.shouldReplaceBlobUris(editor)) {
             blobCache.removeByUri(image.src);
@@ -165,6 +166,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
             if (uploadInfo.error.options.remove) {
               replaceUrlInUndoStack(image.getAttribute('src'), Env.transparentSrc);
               imagesToRemove.push(image);
+              removed = true;
             }
 
             ErrorReporter.uploadError(editor, uploadInfo.error.message);
@@ -174,7 +176,8 @@ const EditorUpload = (editor: Editor): EditorUpload => {
             element: image,
             status: uploadInfo.status,
             uploadUri: uploadInfo.url,
-            blobInfo
+            blobInfo,
+            removed
           };
         });
 
@@ -182,18 +185,13 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           changeHandler.fireIfChanged();
         }
 
-        if (imagesToRemove.length > 0) {
-          if (Rtc.isRtc(editor)) {
-            // TODO TINY-7735 replace with RTC API to remove images
-            console.error('Removing images on failed uploads is currently unsupported for RTC'); // eslint-disable-line no-console
-          } else {
-            editor.undoManager.transact(() => {
-              Arr.each(imagesToRemove, (element) => {
-                editor.dom.remove(element);
-                blobCache.removeByUri(element.src);
-              });
+        if (imagesToRemove.length > 0 && !Rtc.isRtc(editor)) {
+          editor.undoManager.transact(() => {
+            Arr.each(imagesToRemove, (element) => {
+              editor.dom.remove(element);
+              blobCache.removeByUri(element.src);
             });
-          }
+          });
         }
 
         if (callback) {

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -33,6 +33,7 @@ export interface UploadResult {
   status: boolean;
   blobInfo: BlobInfo;
   uploadUri: string;
+  removed: boolean;
 }
 
 export type UploadCallback = (results: UploadResult[]) => void;

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -484,13 +484,11 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
         Delay.setTimeout(() => {
           success('file.png');
         }, 0);
-      }
-      if (uploadCount === 2 ) {
+      } else if (uploadCount === 2 ) {
         Delay.setTimeout(() => {
           failure('Error');
         }, 0);
-      }
-      if (uploadCount === 3 ) {
+      } else if (uploadCount === 3 ) {
         Delay.setTimeout(() => {
           failure('Error', { remove: true });
         }, 0);

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, before, describe, it } from '@ephox/bedrock-client';
-import { Fun } from '@ephox/katamari';
+import { Fun, Arr } from '@ephox/katamari';
 import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -38,9 +38,10 @@ const randBlobDataUri = (width: number, height: number) => {
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
-  const imageData = new window.ImageData(width, height);
-  imageData.data.set(imageData.data.map(() => random(0, 255)));
-  canvas.getContext('2d').putImageData(imageData, 0, 0);
+  const ctx = canvas.getContext('2d');
+  const imageData = ctx.createImageData(width, height);
+  imageData.data.set(Arr.range(imageData.data.length, () => random(0, 255)));
+  ctx.putImageData(imageData, 0, 0);
   return canvas.toDataURL();
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -34,7 +34,7 @@ const assertResult = (editor: Editor, title: string, uploadUri: string, uploaded
 const random = (min: number, max: number) =>
   Math.round(Math.random() * (max - min) + min);
 
-const randBlobDataUri = (width, height) => {
+const randBlobDataUri = (width: number, height: number) => {
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -482,15 +482,15 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       uploadCount++;
 
       if (uploadCount === 1 ) {
-        Delay.setTimeout(() => {
+        setTimeout(() => {
           success('file.png');
         }, 0);
       } else if (uploadCount === 2 ) {
-        Delay.setTimeout(() => {
+        setTimeout(() => {
           failure('Error');
         }, 0);
       } else if (uploadCount === 3 ) {
-        Delay.setTimeout(() => {
+        setTimeout(() => {
           failure('Error', { remove: true });
         }, 0);
       }

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -31,7 +31,8 @@ const assertResult = (editor: Editor, title: string, uploadUri: string, uploaded
   return result;
 };
 
-const random = (min: number, max: number) => Math.round(Math.random() * (max - min) + min);
+const random = (min: number, max: number) =>
+  Math.round(Math.random() * (max - min) + min);
 
 const randBlobDataUri = (width, height) => {
   const canvas = document.createElement('canvas');

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -457,7 +457,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     assert.equal(editor.getContent(), '<p><img src="blob:http%3A//host/f8d1e462-8646-485f-87c5-f9bcee5873c6" /></p>', 'Retain blobs not in blob cache');
   });
 
-  it('TINY-7735: UploadResult should contain removed flag if {remove: true} option passed to failure callback', () => {
+  it('TINY-7735: UploadResult should contain the removed flag if the {remove: true} option was passed to the failure callback', () => {
     const editor = hook.editor();
     let uploadCount = 0;
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -497,6 +497,6 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       }
     };
 
-    editor.uploadImages(uploadDone);
+    return editor.uploadImages(uploadDone);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-7735

Description of Changes:
* Add `removed` boolean flag to UploadResult. If some image failed to upload this flag signals to the RTC plugin to remove it from alt-model.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
