### PR TITLE
TINY-8171: Moved the iframe title to the body as VoiceOver and Chrome Vox wouldn't read it when on the iframe directly

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- The iframe aria help text was not read by some screen readers #TINY-8171
 - Clicking the `forecolor` or `backcolor` toolbar buttons would do nothing until selecting a color #TINY-7836
 - Crop functionality did not work in the `imagetools` plugin when the editor was rendered in a shadow root #TINY-6387
 - Fixed an exception thrown on Safari when closing the `searchreplace` plugin dialog #TINY-8166

--- a/modules/tinymce/src/core/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/core/main/ts/api/Settings.ts
@@ -206,7 +206,7 @@ const getVisualAidsTableClass = (editor: Editor) => editor.getParam('visual_tabl
 
 const getVisualAidsAnchorClass = (editor: Editor) => editor.getParam('visual_anchor_class', 'mce-item-anchor', 'string');
 
-const getIframeTitle = (editor: Editor) => editor.getParam('iframe_aria_text', 'Rich Text Area. Press ALT-0 for help.', 'string');
+const getIframeAriaText = (editor: Editor) => editor.getParam('iframe_aria_text', 'Rich Text Area. Press ALT-0 for help.', 'string');
 
 export {
   getIframeAttrs,
@@ -274,5 +274,5 @@ export {
   getVisualAidsTableClass,
   getFontCss,
   getVisualAidsAnchorClass,
-  getIframeTitle
+  getIframeAriaText
 };

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -77,7 +77,7 @@ const getIframeHtml = (editor: Editor) => {
   }
 
   iframeHTML += '</head>' +
-    `<body id=${bodyId}" class="mce-content-body ${bodyClass}" data-id="${editor.id}" aria-label="${translatedAriaText}">` +
+    `<body id="${bodyId}" class="mce-content-body ${bodyClass}" data-id="${editor.id}" aria-label="${translatedAriaText}">` +
     '<br>' +
     '</body></html>';
 

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -70,21 +70,23 @@ const getIframeHtml = (editor: Editor) => {
 
   const bodyId = Settings.getBodyId(editor);
   const bodyClass = Settings.getBodyClass(editor);
+  const translatedAriaText = editor.translate(Settings.getIframeAriaText(editor));
 
   if (Settings.getContentSecurityPolicy(editor)) {
     iframeHTML += '<meta http-equiv="Content-Security-Policy" content="' + Settings.getContentSecurityPolicy(editor) + '" />';
   }
 
-  iframeHTML += '</head><body id="' + bodyId +
-    '" class="mce-content-body ' + bodyClass +
-    '" data-id="' + editor.id + '"><br></body></html>';
+  iframeHTML += '</head>' +
+    `<body id=${bodyId}" class="mce-content-body ${bodyClass}" data-id="${editor.id}" aria-label="${translatedAriaText}">` +
+    '<br>' +
+    '</body></html>';
 
   return iframeHTML;
 };
 
 const createIframe = (editor: Editor, o) => {
-  const iframeTranslatedTitle = editor.translate(Settings.getIframeTitle(editor));
-  const ifr = createIframeElement(editor.id, iframeTranslatedTitle, o.height, Settings.getIframeAttrs(editor)).dom;
+  const iframeTitle = editor.translate('Rich Text Area');
+  const ifr = createIframeElement(editor.id, iframeTitle, o.height, Settings.getIframeAttrs(editor)).dom;
 
   ifr.onload = () => {
     ifr.onload = null;

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Attribute, SugarElement } from '@ephox/sugar';
-import { McEditor } from '@ephox/wrap-mcagar';
+import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -14,7 +14,9 @@ describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
       base_url: '/project/tinymce/js/tinymce'
     });
     const iframe = SugarElement.fromDom(editor.iframeElement);
-    assert.equal(Attribute.get(iframe, 'title'), defaultIframeTitle);
+    const iframeBody = TinyDom.body(editor);
+    assert.equal(Attribute.get(iframe, 'title'), 'Rich Text Area');
+    assert.equal(Attribute.get(iframeBody, 'aria-label'), defaultIframeTitle);
     McEditor.remove(editor);
   });
 
@@ -24,7 +26,9 @@ describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
       iframe_aria_text: customIframeTitle
     });
     const iframe = SugarElement.fromDom(editor.iframeElement);
-    assert.equal(Attribute.get(iframe, 'title'), customIframeTitle);
+    const iframeBody = TinyDom.body(editor);
+    assert.equal(Attribute.get(iframe, 'title'), 'Rich Text Area');
+    assert.equal(Attribute.get(iframeBody, 'aria-label'), customIframeTitle);
     McEditor.remove(editor);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8171

Description of Changes:

As discussed at stand up, this moves the iframe aria text to the body since a number of screen readers don't read the iframe title anymore. However, the iframe itself still must have a title, so we're leaving that as `Rich Text Area`. This means `Rich Text Area` won't have translations, but it's the lesser of two bad situations so we're pushing ahead.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
