### PR TITLE
TINY-7484: Remove zero width space before counting words

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tables could have an incorrect height set on rows when rendered outside of the editor #TINY-7699
 - In certain circumstances, the table of contents plugin would incorrectly add an extra empty list item #TINY-4636
 - The insert table grid menu displayed an incorrect size when re-opening the grid #TINY-6532
+- The word count plugin was treating the zero width space character (`&#8203;`) as a word #TINY-7484
 
 ## 5.10.0 - 2021-10-11
 

--- a/modules/tinymce/src/plugins/wordcount/main/ts/core/Count.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/core/Count.ts
@@ -14,11 +14,14 @@ import { getText } from './GetText';
 
 export type Counter = (node: Node, schema: Schema) => number;
 
+const removeZwsp = (text: string) =>
+  text.replace('\u200B', '');
+
 const strLen = (str: string): number =>
   str.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length;
 
 const countWords: Counter = (node: Node, schema: Schema): number => {
-  const text = getText(node, schema).join('\n');
+  const text = removeZwsp(getText(node, schema).join('\n'));
   return Words.getWords(text.split(''), Fun.identity).length;
 };
 

--- a/modules/tinymce/src/plugins/wordcount/main/ts/core/Count.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/core/Count.ts
@@ -15,12 +15,14 @@ import { getText } from './GetText';
 export type Counter = (node: Node, schema: Schema) => number;
 
 const removeZwsp = (text: string) =>
-  text.replace('\u200B', '');
+  text.replace(/\u200B/g, '');
 
 const strLen = (str: string): number =>
   str.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length;
 
 const countWords: Counter = (node: Node, schema: Schema): number => {
+  // TINY-7484: The grapheme word boundary logic used by Polaris states a ZWSP (\u200B) should be treated as
+  // a word boundary, however word counting normally does not consider it as anything so we strip it out. 
   const text = removeZwsp(getText(node, schema).join('\n'));
   return Words.getWords(text.split(''), Fun.identity).length;
 };

--- a/modules/tinymce/src/plugins/wordcount/main/ts/core/Count.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/core/Count.ts
@@ -22,7 +22,7 @@ const strLen = (str: string): number =>
 
 const countWords: Counter = (node: Node, schema: Schema): number => {
   // TINY-7484: The grapheme word boundary logic used by Polaris states a ZWSP (\u200B) should be treated as
-  // a word boundary, however word counting normally does not consider it as anything so we strip it out. 
+  // a word boundary, however word counting normally does not consider it as anything so we strip it out.
   const text = removeZwsp(getText(node, schema).join('\n'));
   return Words.getWords(text.split(''), Fun.identity).length;
 };

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
@@ -63,4 +63,19 @@ describe('browser.tinymce.plugins.wordcount.PluginTest', () => {
     editor.setContent('<p>Soft hy&shy;phen</p>');
     await pWaitForWordcount(2);
   });
+
+  it('TINY-7484: Does not treat zwsp character as splitting a word', async () => {
+    const editor = hook.editor();
+    await pWaitForWordcount(0);
+    editor.setContent('<p><span>wo&#8203;rd</span></p>');
+    await pWaitForWordcount(1);
+  });
+
+  it('TINY-7484: Does not treat zwsp character as a word', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><span>word&#8203;</span></p>');
+    await pWaitForWordcount(1);
+    editor.setContent('<p><span>&#8203;</span></p>');
+    await pWaitForWordcount(0);
+  });
 });

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
@@ -78,4 +78,11 @@ describe('browser.tinymce.plugins.wordcount.PluginTest', () => {
     editor.setContent('<p><span>&#8203;</span></p>');
     await pWaitForWordcount(0);
   });
+
+  it('TINY-7484: Multiple zwsp characters', async () => {
+    const editor = hook.editor();
+    await pWaitForWordcount(0);
+    editor.setContent('<p><span>&#8203;&#8203;&#8203;wo&#8203;rd&#8203;&#8203;&#8203;</span></p>');
+    await pWaitForWordcount(1);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7484

Description of Changes:
Removes the `&#8203;`/`\u200B` character before counting words

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
