### PR TITLE
TINY-8194: Remove IE11 from tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,6 @@ node("primary") {
       [ name: "win10Chrome", os: "windows-10", browser: "chrome", buckets: 1 ],
       [ name: "win10FF", os: "windows-10", browser: "firefox", buckets: 1 ],
       [ name: "win10Edge", os: "windows-10", browser: "MicrosoftEdge", buckets: 1 ],
-      [ name: "win10IE", os: "windows-10", browser: "ie", buckets: 3 ],
       [ name: "macSafari", os: "macos", browser: "safari", buckets: 1 ],
       [ name: "macChrome", os: "macos", browser: "chrome", buckets: 1 ],
       [ name: "macFirefox", os: "macos", browser: "firefox", buckets: 1 ]

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the deprecated `filepicker_validator_handler`, `force_p_newlines`, `gecko_spellcheck`, `tab_focus`, `table_responsive_width` and `toolbar_drawer` settings #TINY-7820
 - Removed the deprecated `editor_deselector`, `editor_selector`, `elements`, `mode` and `types` legacy TinyMCE init settings #TINY-7822
 - The legacy `mobile` theme has been removed #TINY-7832
+- Removed Internet Explorer 11 from the automated test suite #TINY-8194
 
 ## 5.10.1 - TBD
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the deprecated `filepicker_validator_handler`, `force_p_newlines`, `gecko_spellcheck`, `tab_focus`, `table_responsive_width` and `toolbar_drawer` settings #TINY-7820
 - Removed the deprecated `editor_deselector`, `editor_selector`, `elements`, `mode` and `types` legacy TinyMCE init settings #TINY-7822
 - The legacy `mobile` theme has been removed #TINY-7832
-- Removed Internet Explorer 11 from the automated test suite #TINY-8194
+- Removed support for Microsoft Internet Explorer 11 #TINY-8194
 
 ## 5.10.1 - TBD
 


### PR DESCRIPTION
Related Ticket: TINY-8194

Description of Changes:
- Remove IE11 from browser test suite

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
