### PR TITLE
TINY-8207: Added theme registration our mcagar wrapper file. Removed all manual theme registration in tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ runs `tsc -b -w` for those times when you don't need to iterate in the browser.
 an alias to `tsc -b` just in case you forget
 
 `yarn eslint`
-runs `eslint` in _all_ projects, with a rule set that is far more strict than most projects were previously subject to. This is a good source of things to improve when bored.
+runs `eslint` across the entire repository with the rule set that is required to pass in CI. Use `yarn eslint --fix` to automatically fix minor problems. The [ESLint vscode plugin](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) can be used to apply lint fixes on save.
 
 `yarn tinymce-grunt`
 easy access to the TinyMCE grunt commands from the root folder.

--- a/modules/tinymce/src/core/test/ts/browser/ClickContentEditableFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ClickContentEditableFalseTest.ts
@@ -3,7 +3,6 @@ import { Hierarchy } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const clickMiddleOf = (editor: Editor, elementPath: number[]) => {
   const element = Hierarchy.follow(TinyDom.body(editor), elementPath).getOrDie().dom as HTMLElement;
@@ -21,7 +20,7 @@ describe('browser.tinymce.core.ClickContentEditableFalseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
 
   it('Click on content editable false', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -6,7 +6,6 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.DragDropOverridesTest', () => {
   const fired = Cell(false);
@@ -14,7 +13,7 @@ describe('browser.tinymce.core.DragDropOverridesTest', () => {
     indent: false,
     menubar: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   before(() => {
     hook.editor().on('dragend', () => {

--- a/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import VisualBlocksPlugin from 'tinymce/plugins/visualblocks/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const assertPageLinkPresence = (url: string, exists: boolean): void => {
   const links = document.head.querySelectorAll(`link[href="${url}"]`);
@@ -33,7 +32,6 @@ const testCleanup = (comment: string, settings: RawEditorSettings, html: string 
 
 describe('browser.tinymce.core.EditorCleanupTest', () => {
   before(() => {
-    Theme();
     VisualBlocksPlugin();
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorForcedSettingsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorForcedSettingsTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.EditorForcedSettingsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -12,7 +11,7 @@ describe('browser.tinymce.core.EditorForcedSettingsTest', () => {
     inline: true,
     // Settings that are to be forced
     validate: false
-  }, [ Theme ]);
+  }, []);
 
   it('Validate forced settings', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/EditorManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorManagerTest.ts
@@ -7,7 +7,6 @@ import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import PluginManager from 'tinymce/core/api/PluginManager';
 import Tools from 'tinymce/core/api/util/Tools';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as ViewBlock from '../module/test/ViewBlock';
 
@@ -15,7 +14,6 @@ describe('browser.tinymce.core.EditorManagerTest', () => {
   const viewBlock = ViewBlock.bddSetup();
 
   before(() => {
-    Theme();
     EditorManager._setBaseUrl('/project/tinymce/js/tinymce');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorPaddEmptyWithBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorPaddEmptyWithBrTest.ts
@@ -3,7 +3,6 @@ import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.EditorPaddEmptyWithBrTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -15,7 +14,7 @@ describe('browser.tinymce.core.EditorPaddEmptyWithBrTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     padd_empty_with_br: true
-  }, [ Theme ]);
+  }, []);
 
   it('Padd empty elements with br', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -1,17 +1,13 @@
 import { Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.EditorRemoveTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const settings = {
     base_url: '/project/tinymce/js/tinymce'

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
@@ -4,13 +4,12 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.EditorRemovedApiTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     test_callback: Fun.noop
-  }, [ Theme ]);
+  }, []);
 
   const tryAccess = (name: string, expectedValue: any) => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/EditorRtlTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRtlTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import EditorManager from 'tinymce/core/api/EditorManager';
 import I18n from 'tinymce/core/api/util/I18n';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.EditorRtlTest', () => {
   before(() => {
@@ -24,7 +23,7 @@ describe('browser.tinymce.core.EditorRtlTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('I18n.isRtl', () => {
     assert.isTrue(I18n.isRtl(), 'Should be in rtl mode after creating an editor in arabic');

--- a/modules/tinymce/src/core/test/ts/browser/EditorSettingsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorSettingsTest.ts
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import * as EditorSettings from 'tinymce/core/EditorSettings';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.EditorSettingsTest', () => {
   const detection = PlatformDetection.detect();
@@ -17,7 +16,7 @@ describe('browser.tinymce.core.EditorSettingsTest', () => {
 
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const expectedDefaultSettings: RawEditorSettings = {
     toolbar_mode: 'floating'

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -10,7 +10,6 @@ import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import PluginManager from 'tinymce/core/api/PluginManager';
 import URI from 'tinymce/core/api/util/URI';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
 
@@ -25,7 +24,7 @@ describe('browser.tinymce.core.EditorTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('TBA: Event: change', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -11,7 +11,6 @@ import { BlobInfo } from 'tinymce/core/api/file/BlobCache';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Promise from 'tinymce/core/api/util/Promise';
 import * as Conversions from 'tinymce/core/file/Conversions';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const assertResult = (editor: Editor, title: string, uploadUri: string, uploadedBlobInfo: BlobInfo, result: UploadResult[]) => {
   const firstResult = result[0];
@@ -90,7 +89,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     setup: (ed: Editor) => ed.on('change', appendEvent)
-  }, [ Theme ]);
+  }, []);
 
   afterEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/EditorViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorViewTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as EditorView from 'tinymce/core/EditorView';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.EditorViewTest', () => {
   PhantomSkipper.bddSetup();
@@ -63,7 +62,7 @@ describe('browser.tinymce.core.EditorViewTest', () => {
       const hook = tester.setup<Editor>({
         base_url: '/project/tinymce/js/tinymce',
         ...tester.settings
-      }, [ Theme ]);
+      }, []);
 
       before(() => {
         const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.FontSelectCustomTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -19,7 +18,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     ].join(''),
     font_formats: 'Arial=arial; Arial Black=arial black; Arial Narrow=arial narrow; Bauhaus 93="bauhaus 93"; Bookman Old Style=bookman old style; Bookshelf Symbol 7=bookshelf symbol 7; Times New Roman=times new roman, times;',
     fontsize_formats: '8pt=1 12pt 12.75pt 13pt 24pt 32pt'
-  }, [ Theme ]);
+  }, []);
 
   const assertSelectBoxDisplayValue = (editor, title, expectedValue) => {
     const selectBox = UiFinder.findIn(SugarBody.body(), '*[title="' + title + '"]').getOrDie();

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.FontSelectTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -18,7 +17,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       '.mce-content-body h1 { font-family: Arial; font-size: 32px; }'
     ].join(''),
     fontsize_formats: '8pt=1 12pt 12.75pt 13pt 24pt 32pt'
-  }, [ Theme ]);
+  }, []);
 
   const systemFontStackVariants = [
     `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;`, // Oxide

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -3,7 +3,6 @@ import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const pressArrowKey = (editor: Editor) => {
     const dom = editor.dom, target = editor.selection.getNode();

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -5,7 +5,6 @@ import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wr
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
 import * as KeyUtils from '../module/test/KeyUtils';
@@ -22,7 +21,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
         'margin,margin-top,margin-right,margin-bottom,margin-left,display,text-align'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const getContent = (editor: Editor) => {
     return editor.getContent().toLowerCase().replace(/[\r]+/g, '');

--- a/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
@@ -3,7 +3,6 @@ import { LegacyUnit, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.FormatterCheckTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -17,7 +16,7 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
         'margin,margin-top,margin-right,margin-bottom,margin-left,display,text-align,vertical-align'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Selected style element text', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
@@ -3,12 +3,11 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.FormatterClosestTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const assertClosest = (names: string[], expectedName: string) => {
     const actualName = hook.editor().formatter.closest(names);

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
@@ -3,7 +3,6 @@ import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.FormatterRemoveForcedRootBlockFalseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -16,7 +15,7 @@ describe('browser.tinymce.core.FormatterRemoveForcedRootBlockFalseTest', () => {
     },
     base_url: '/project/tinymce/js/tinymce',
     forced_root_block: false
-  }, [ Theme ]);
+  }, []);
 
   const getContent = (editor: Editor) => editor.getContent().toLowerCase().replace(/[\r]+/g, '');
 

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -4,7 +4,6 @@ import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wr
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
 import * as KeyUtils from '../module/test/KeyUtils';
@@ -20,7 +19,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
         'margin,margin-top,margin-right,margin-bottom,margin-left,display,text-align'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const getContent = (editor: Editor) => {
     return editor.getContent().toLowerCase().replace(/[\r]+/g, '');

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -3,7 +3,6 @@ import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.FormattingCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -17,7 +16,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
         'float,margin,margin-top,margin-right,margin-bottom,margin-left,padding-left,text-align,display'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Justify - multiple block elements selected - queryCommandState', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/InlineEditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/InlineEditorRemoveTest.ts
@@ -1,15 +1,11 @@
 import { UiFinder } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.InlineEditorRemoveTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const settings = {
     inline: true,

--- a/modules/tinymce/src/core/test/ts/browser/InlineEditorSaveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/InlineEditorSaveTest.ts
@@ -5,13 +5,12 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.InlineEditorSaveTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     inline: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const assertBogusNotExist = () => {
     UiFinder.findIn(SugarBody.body(), '[data-mce-bogus]').fold(() => {

--- a/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
@@ -5,7 +5,6 @@ import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
 
@@ -21,7 +20,7 @@ describe('browser.tinymce.core.MiscCommandsTest', () => {
         'float,margin,margin-top,margin-right,margin-bottom,margin-left,padding-left,text-align,display'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const normalizeRng = (rng: Range) => {
     if (rng.startContainer.nodeType === 3) {

--- a/modules/tinymce/src/core/test/ts/browser/ModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ModeTest.ts
@@ -5,13 +5,12 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.ModeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     readonly: true
-  }, [ Theme ]);
+  }, []);
 
   const assertBodyClass = (editor: Editor, cls: string, state: boolean) => {
     assert.equal(Class.has(TinyDom.body(editor), cls), state, 'Should be the expected class state');

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { NotificationSpec } from 'tinymce/core/api/NotificationManager';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.NotificationManagerTest', () => {
   Arr.each([
@@ -27,7 +26,7 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
           editor.on('BeforeOpenNotification', (event) => beforeOpenEvents.push(event));
           editor.on('OpenNotification', (event) => openEvents.push(event));
         }
-      }, [ Theme ]);
+      }, []);
 
       afterEach(() => {
         const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -8,7 +8,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as Readonly from 'tinymce/core/mode/Readonly';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const tOptional = OptionalInstances.tOptional;
 
@@ -18,7 +17,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
     toolbar: 'bold',
     plugins: 'table',
     statusbar: false
-  }, [ Theme, TablePlugin ]);
+  }, [ TablePlugin ]);
 
   const setMode = (editor: Editor, mode: string) => {
     editor.mode.set(mode);

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -8,7 +8,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { isCaretContainerBlock } from 'tinymce/core/caret/CaretContainer';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.SelectionOverridesTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -19,7 +18,7 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
     indent: false,
     content_style: 'body { margin: 16px; }',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const getScrollTop = (editor: Editor) => Scroll.get(TinyDom.document(editor)).top;
 

--- a/modules/tinymce/src/core/test/ts/browser/ShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ShortcutsTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.ShortcutsTest', () => {
   const os = PlatformDetection.detect().os;
@@ -15,7 +14,7 @@ describe('browser.tinymce.core.ShortcutsTest', () => {
     indent: false,
     entities: 'raw',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Shortcuts formats', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -8,7 +8,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { AddUndoEvent } from 'tinymce/core/api/EventTypes';
 import { UndoLevel } from 'tinymce/core/undo/UndoManagerTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
 import * as KeyUtils from '../module/test/KeyUtils';
@@ -22,7 +21,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     indent: false,
     entities: 'raw',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Initial states', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.WindowManagerTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -12,7 +11,7 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
     indent: false,
     entities: 'raw',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('OpenWindow/CloseWindow events', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotateTest.ts
@@ -3,7 +3,6 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { annotate, assertHtmlContent } from '../../module/test/AnnotationAsserts';
 
@@ -22,7 +21,7 @@ describe('browser.tinymce.core.annotate.AnnotateTest', () => {
         });
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   // TODO: Consider testing collapse sections.
   it('should word grab with a collapsed selection', () => {

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { annotate, assertHtmlContent, assertMarker } from '../../module/test/AnnotationAsserts';
 
@@ -79,7 +78,7 @@ describe('browser.tinymce.core.annotate.AnnotationChangedTest', () => {
         ed.annotator.annotationChanged('delta', listener);
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   const changes: Cell<Array<{state: boolean; name: string; uid: string}>> = Cell([ ]);
 

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationPersistenceTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationPersistenceTest.ts
@@ -1,17 +1,13 @@
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { McEditor, TinyAssertions, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import { AnnotatorSettings } from 'tinymce/core/api/Annotator';
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { annotate } from '../../module/test/AnnotationAsserts';
 
 describe('browser.tinymce.core.annotate.AnnotationPersistenceTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const runTinyWithSettings = async (annotation: AnnotatorSettings, runTests: (editor: Editor) => void) => {
     const settings = {

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
@@ -3,7 +3,6 @@ import { before, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { annotate, assertGetAll, assertHtmlContent } from '../../module/test/AnnotationAsserts';
 
@@ -31,7 +30,7 @@ describe('browser.tinymce.core.annotate.AnnotationRemovedTest', () => {
         });
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   before(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -1,5 +1,5 @@
 import { Assertions } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Hierarchy, Html, Remove, Replication, SelectorFilter, SugarElement } from '@ephox/sugar';
 import { McEditor, TinyAssertions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
@@ -12,12 +12,8 @@ import {
 } from 'tinymce/core/bookmark/BookmarkTypes';
 import * as GetBookmark from 'tinymce/core/bookmark/GetBookmark';
 import * as ResolveBookmark from 'tinymce/core/bookmark/ResolveBookmark';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const bookmarkTest = (runTests: (editor: Editor) => void) => async () => {
     const editor = await McEditor.pFromSettings<Editor>({

--- a/modules/tinymce/src/core/test/ts/browser/caret/FirefoxFakeCaretBeforeTableTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FirefoxFakeCaretBeforeTableTypeTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as KeyUtils from '../../module/test/KeyUtils';
 
@@ -23,7 +22,7 @@ describe('browser.tinymce.core.FirefoxFakeCaretBeforeTableTypeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     plugins: 'table'
-  }, [ Theme, TablePlugin ]);
+  }, [ TablePlugin ]);
 
   it('cursor before table type', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/commands/ContentLangTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/ContentLangTest.ts
@@ -2,12 +2,11 @@ import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.ContentLangTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   context('lang format plays nicely with other formats', () => {
     beforeEach(() => {

--- a/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
@@ -4,13 +4,12 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.commands.LineHeightTest', () => {
   const platform = PlatformDetection.detect();
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const assertHeight = (editor: Editor, value: string) => {
     const current = editor.queryCommandValue('LineHeight');

--- a/modules/tinymce/src/core/test/ts/browser/commands/OutdentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/OutdentCommandTest.ts
@@ -3,13 +3,12 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.commands.OutdentCommandTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
 
   const assertOutdentCommandState = (editor: Editor, expectedState: boolean) => {
     assert.equal(editor.queryCommandState('outdent'), expectedState);

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ContentFormat } from 'tinymce/core/content/ContentTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.EditorContentEventsTest', () => {
   const initialContent = '<p>Some initial content</p>';
@@ -19,7 +18,7 @@ describe('browser.tinymce.core.content.EditorContentEventsTest', () => {
         events.push(e.type);
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentForcedRootBlockTest.ts
@@ -2,14 +2,13 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.EditorContentForcedRootBlockTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     inline: true,
     forced_root_block: 'div'
-  }, [ Theme ]);
+  }, []);
 
   it('getContent empty editor depending on forced_root_block setting', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
@@ -1,16 +1,12 @@
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import AstNode from 'tinymce/core/api/html/Node';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.EditorContentNotInitializedTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const settings = {
     menubar: false,

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import AstNode from 'tinymce/core/api/html/Node';
 import HtmlSerializer from 'tinymce/core/api/html/Serializer';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const defaultExpectedEvents = [
   'beforesetcontent',
@@ -25,7 +24,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         events.push(e.type);
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   const getFontTree = (): AstNode => {
     const body = new AstNode('body', 1);

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentWsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentWsTest.ts
@@ -1,13 +1,9 @@
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { McEditor, TinyAssertions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.EditorContentWsTest', () => {
-  before(() => {
-    Theme();
-  });
 
   it('Editor initialized on pre element should retain whitespace on get/set content', async () => {
     const editor = await McEditor.pFromHtml<Editor>('<pre>  a  </pre>', {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTextFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTextFormatTest.ts
@@ -4,12 +4,11 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.EditorGetContentTextFormatTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('get text format content should trim zwsp', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTreeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTreeTest.ts
@@ -5,13 +5,12 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import AstNode from 'tinymce/core/api/html/Node';
 import HtmlSerializer from 'tinymce/core/api/html/Serializer';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.EditorGetContentTreeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     inline: true
-  }, [ Theme ]);
+  }, []);
 
   const toHtml = (node: AstNode): string => {
     const htmlSerializer = HtmlSerializer({});

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorResetContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorResetContentTest.ts
@@ -4,12 +4,11 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.EditorResetContentTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const assertEditorState = (editor: Editor, content: string) => {
     const html = editor.getContent();

--- a/modules/tinymce/src/core/test/ts/browser/content/HTMLDataURLsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/HTMLDataURLsTest.ts
@@ -1,13 +1,8 @@
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Theme from 'tinymce/themes/silver/Theme';
-
 describe('browser.tinymce.core.content.HTMLDataURLsTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const initialContent = '<p><a href="data:text/plain;base64,SGVsbG8sIHdvcmxkCg==">Click me</a></p>';
 

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
@@ -3,7 +3,6 @@ import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -17,7 +16,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
         'float,margin,margin-top,margin-right,margin-bottom,margin-left,padding-left,text-align,display'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const normalizeRng = (rng: Range) => {
     if (rng.startContainer.nodeType === 3) {

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentForcedRootFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentForcedRootFalseTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as InsertContent from 'tinymce/core/content/InsertContent';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.InsertContentForcedRootBlockFalseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.core.content.InsertContentForcedRootBlockFalseTest', (
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const trimBrs = (string: string) => {
     return string.replace(/<br>/g, '');

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -7,7 +7,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { SetContentEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as InsertContent from 'tinymce/core/content/InsertContent';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.InsertContentTest', () => {
   const browser = PlatformDetection.detect().browser;
@@ -18,7 +17,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('TBA: insertAtCaret - i inside text, converts to em', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentWebKitBugs.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentWebKitBugs.ts
@@ -2,14 +2,13 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.InsertContentTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     content_style: 'blockquote { font-size: 12px }' // Needed to produce spans with runtime styles
-  }, [ Theme ]);
+  }, []);
 
   it('Insert contents on a triple click selection should not produce odd spans', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/content/PlaceholderVisuallyEmptyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/PlaceholderVisuallyEmptyTest.ts
@@ -5,13 +5,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { isVisuallyEmpty } from 'tinymce/core/content/Placeholder';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.content.PlaceholderVisuallyEmptyTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     forced_root_block: false
-  }, [ Theme ]);
+  }, []);
 
   const assertEmpty = (label: string, editor: Editor, expected: boolean, forcedRootBlockFalse: boolean) => {
     const body = editor.getBody();

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
@@ -6,13 +6,12 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as BlockBoundaryDelete from 'tinymce/core/delete/BlockBoundaryDelete';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.BlockBoundaryDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
 
   const doDelete = (editor: Editor) => {
     const returnVal = BlockBoundaryDelete.backspaceDelete(editor, true);

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockRangeDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockRangeDeleteTest.ts
@@ -5,13 +5,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as BlockRangeDelete from 'tinymce/core/delete/BlockRangeDelete';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.BlockRangeDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
 
   const doDelete = (editor: Editor) => {
     const returnVal = BlockRangeDelete.backspaceDelete(editor, true);

--- a/modules/tinymce/src/core/test/ts/browser/delete/CaretBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CaretBoundaryDeleteTest.ts
@@ -5,14 +5,13 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as KeyUtils from '../../module/test/KeyUtils';
 
 describe('browser.tinymce.core.delete.CaretBoundaryDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const cefStruct = (text: string) => ApproxStructure.build((s, str) => s.element('span', {
     attrs: {

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteNoneditableTest.ts
@@ -6,13 +6,12 @@ import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import NoneditablePlugin from 'tinymce/plugins/noneditable/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.CefDeleteNoneditableTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     plugins: 'noneditable'
-  }, [ Theme, NoneditablePlugin ], true);
+  }, [ NoneditablePlugin ], true);
 
   it('TINY-3868: Should not backspace cef inside cef with ranged selection', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -3,12 +3,11 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.CefDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const fakeBackspaceKeyOnRange = (editor: Editor) => {
     editor.getDoc().execCommand('Delete', false, null);

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
@@ -4,14 +4,13 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as DeleteCommands from 'tinymce/core/delete/DeleteCommands';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.DeleteCommandsTest', () => {
   const caret = Cell<Text>(null);
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
 
   it('Delete should merge blocks', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteElementTest.ts
@@ -5,14 +5,13 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as DeleteElement from 'tinymce/core/delete/DeleteElement';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.DeleteElementTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const deleteElementPath = (editor: Editor, forward: boolean, path: number[]) => {
     const element = Hierarchy.follow(TinyDom.body(editor), path).getOrDie();

--- a/modules/tinymce/src/core/test/ts/browser/delete/ImageBlockDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/ImageBlockDeleteTest.ts
@@ -3,13 +3,12 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.ImageBlockDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     content_style: 'img.block { display: block }',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   context('Delete keys for image block element', () => {
     it('Should place the selection on the image block element on delete before (inline)', () => {

--- a/modules/tinymce/src/core/test/ts/browser/delete/InlineBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/InlineBoundaryDeleteTest.ts
@@ -8,12 +8,11 @@ import Editor from 'tinymce/core/api/Editor';
 import CaretPosition from 'tinymce/core/caret/CaretPosition';
 import * as BoundaryLocation from 'tinymce/core/keyboard/BoundaryLocation';
 import * as InlineUtils from 'tinymce/core/keyboard/InlineUtils';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.InlineBoundaryDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const locationName = (location: BoundaryLocation.LocationAdt) => {
     return location.fold(

--- a/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
@@ -6,13 +6,12 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as InlineFormatDelete from 'tinymce/core/delete/InlineFormatDelete';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.InlineFormatDelete', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
 
   const doDelete = (editor: Editor) => {
     const returnVal = InlineFormatDelete.backspaceDelete(editor, true);

--- a/modules/tinymce/src/core/test/ts/browser/delete/MediaDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/MediaDeleteTest.ts
@@ -5,12 +5,11 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.MediaDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const assertEmptyEditorStructure = (editor: Editor) => TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) =>
     s.element('body', {

--- a/modules/tinymce/src/core/test/ts/browser/delete/OutdentForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/OutdentForcedRootBlockFalseTest.ts
@@ -3,13 +3,12 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.OutdentForcedRootBlockFalseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     forced_root_block: false
-  }, [ Theme ], true);
+  }, [], true);
 
   const testDeleteOrBackspaceKey = (key: number) => (
     setupHtml: string,

--- a/modules/tinymce/src/core/test/ts/browser/delete/OutdentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/OutdentTest.ts
@@ -3,12 +3,11 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.OutdentTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const testDeleteOrBackspaceKey = (key: number) => (
     setupHtml: string,

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -7,13 +7,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as TableDelete from 'tinymce/core/delete/TableDelete';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.delete.TableDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const assertRawNormalizedContent = (editor: Editor, expectedContent: string) => {
     const element = Replication.deep(TinyDom.body(editor));

--- a/modules/tinymce/src/core/test/ts/browser/dom/ContentCssCorsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ContentCssCorsTest.ts
@@ -4,7 +4,6 @@ import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.dom.ContentCssCorsTest', () => {
   before(function () {
@@ -12,7 +11,6 @@ describe('browser.tinymce.core.dom.ContentCssCorsTest', () => {
     if (PlatformDetection.detect().browser.isIE()) {
       this.skip();
     }
-    Theme();
   });
 
   const settings = {

--- a/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
   const eventCounter = Cell<Record<string, number>>({ });
@@ -22,7 +21,7 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
         counter[e.type] = (counter[e.type] || 0) + 1;
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   const contextMenuClickInMiddleOf = (editor: Editor, elementPath: number[]) => {
     const element = Hierarchy.follow(TinyDom.body(editor), elementPath).getOrDie().dom as HTMLElement;

--- a/modules/tinymce/src/core/test/ts/browser/dom/RangePointTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/RangePointTest.ts
@@ -5,13 +5,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as RangePoint from 'tinymce/core/dom/RangePoint';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.dom.RangePointsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     content_style: 'body.mce-content-body, p { margin: 0 }'
-  }, [ Theme ]);
+  }, []);
 
   const pAssertXYWithinRange = (editor: Editor, x: number, y: number) => Waiter.pTryUntil('Assert XY position is within selection range', () => {
     const actual = RangePoint.isXYWithinRange(x, y, editor.selection.getRng());

--- a/modules/tinymce/src/core/test/ts/browser/dom/ReferrerPolicyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ReferrerPolicyTest.ts
@@ -7,15 +7,11 @@ import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
-import Theme from 'tinymce/themes/silver/Theme';
 
 // TODO Find a way to test the referrerpolicy with ScriptLoader, as it removes the dom reference as soon as it's finished loading so we can't check
 // via dom elements. For now we're just loading a script to make sure it doesn't completely die when loading.
 describe('browser.tinymce.core.dom.ReferrerPolicyTest', () => {
   const platform = PlatformDetection.detect();
-  before(() => {
-    Theme();
-  });
 
   const settings = {
     base_url: '/project/tinymce/js/tinymce',

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
@@ -9,7 +9,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { ScrollIntoViewEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as ScrollIntoView from 'tinymce/core/dom/ScrollIntoView';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface State {
   readonly elm: HTMLElement;
@@ -29,7 +28,7 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
     height: 500,
     base_url: '/project/tinymce/js/tinymce',
     content_style: 'body.mce-content-body  { margin: 0 }'
-  }, [ Theme ], true);
+  }, [], true);
 
   const scrollReset = (editor: Editor) => {
     editor.getWin().scrollTo(0, 0);

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionEventsTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface HandlerAndArgs {
   readonly eventArgs: Cell<EditorEvent<any>>;
@@ -17,7 +16,7 @@ interface HandlerAndArgs {
 describe('browser.tinymce.core.dom.SelectionEventsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const bindEventMutator = (editor: Editor, eventName: string, mutator: (editor: Editor, e: EditorEvent<any>) => void): HandlerAndArgs => {
     const eventArgs = Cell(null);

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionQuirksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionQuirksTest.ts
@@ -4,12 +4,11 @@ import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections 
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.dom.SelectionQuirksTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
   let normalizeMonitor: Monitor<Range>;
 
   before(() => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -6,7 +6,6 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import * as CaretContainer from 'tinymce/core/caret/CaretContainer';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.dom.SelectionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -20,7 +19,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     custom_elements: 'custom1,~custom2',
     extended_valid_elements: 'custom1,custom2',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('getContent', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerEventsTest.ts
@@ -4,14 +4,13 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.dom.SerializerEventsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     inline: true,
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Pre/post process events', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/fmt/BlockFormatsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/BlockFormatsTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.BlockFormatsTest', () => {
   context('Testing that the selection is still collapsed after a formatting operation', () => {
@@ -13,7 +12,7 @@ describe('browser.tinymce.core.fmt.BlockFormatsTest', () => {
       statusbar: false,
       menubar: false,
       base_url: '/project/tinymce/js/tinymce'
-    }, [ Theme ]);
+    }, []);
 
     it('apply heading format at the end of paragraph should not expand selection', () => {
       const editor = hook.editor();
@@ -58,7 +57,7 @@ describe('browser.tinymce.core.fmt.BlockFormatsTest', () => {
         { title: 'Div', block: 'div' },
         { title: 'Pre', block: 'pre' }
       ]
-    }, [ Theme ]);
+    }, []);
 
     it('Using default style formats config, the Block formatting dropdown should show the correct format selection ', async () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
@@ -9,7 +9,6 @@ import * as CaretFormat from 'tinymce/core/fmt/CaretFormat';
 import { getParentCaretContainer, isCaretNode } from 'tinymce/core/fmt/FormatContainer';
 import { FormatVars } from 'tinymce/core/fmt/FormatTypes';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.CaretFormatTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -24,7 +23,7 @@ describe('browser.tinymce.core.fmt.CaretFormatTest', () => {
         { selector: '*:not(tr,td,th,table)', attributes: [ 'style', 'class' ], split: false, expand: false, deep: true }
       ]
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   const applyCaretFormat = (editor: Editor, name: string, vars: FormatVars) => {
     CaretFormat.applyCaretFormat(editor, name, vars);

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import * as ExpandRange from 'tinymce/core/fmt/ExpandRange';
 import { RangeLikeObject } from 'tinymce/core/selection/RangeTypes';
 import { ZWSP } from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
   const inlineFormat = [{ inline: 'b' }];
@@ -17,7 +16,7 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
   const selectorFormatCollapsed = [{ selector: 'div', classes: 'b', collapsed: true }];
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const expandRng = (editor: Editor, startPath: number[], startOffset: number, endPath: number[], endOffset: number, format, excludeTrailingSpaces: boolean = false) => {
     const startContainer = Hierarchy.follow(TinyDom.body(editor), startPath).getOrDie();

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FontsizeFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FontsizeFormatTest.ts
@@ -3,14 +3,13 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.FontsizeFormatTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     toolbar: 'fontsizeselect',
     fontsize_formats: '1em',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const assertMenuItemCount = (expected: number) => {
     const actual = document.querySelectorAll('.tox-collection__item').length;

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
@@ -2,12 +2,11 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.FormatChangeSelectionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Check selection after removing part of an inline format', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeVarsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeVarsTest.ts
@@ -6,14 +6,13 @@ import { PlatformDetection } from '@ephox/sand';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.FormatChangeVarsTest', () => {
   const browser = PlatformDetection.detect().browser;
 
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const events = {
     general: [] as boolean[],

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -2,7 +2,6 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface TestConfig {
   readonly selector: string;
@@ -20,7 +19,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
     toolbar: 'forecolor backcolor | bold italic underline strikethrough | alignleft',
     format_empty_lines: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const tagHTML = (tag: string) => `<${tag}>a</${tag}><${tag}>&nbsp;</${tag}><${tag}>b</${tag}>`;
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/HooksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/HooksTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Hooks from 'tinymce/core/fmt/Hooks';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.HooksTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -13,7 +12,7 @@ describe('browser.tinymce.core.fmt.HooksTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('pre - postProcessHook', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
@@ -4,14 +4,13 @@ import { Arr } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 type Alignment = 'left' | 'center' | 'right' | 'justify';
 
 describe('browser.tinymce.core.fmt.MediaAlignTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const mediaApproxStructure = (tag: string, alignment: Alignment) => {
     const alignStyles = (str: ApproxStructure.StringApi) => {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/PreviewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/PreviewTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Preview from 'tinymce/core/fmt/Preview';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../../module/test/HtmlUtils';
 
@@ -182,7 +181,7 @@ describe('browser.tinymce.core.fmt.PreviewTest', () => {
         '}'
       ),
       base_url: '/project/tinymce/js/tinymce'
-    }, [ Theme ], true);
+    }, [], true);
 
     it('Check initial styles were loaded', () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -4,13 +4,12 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import { Format } from 'tinymce/core/fmt/FormatTypes';
 import * as RemoveFormat from 'tinymce/core/fmt/RemoveFormat';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const removeFormat: Format[] = [{
     selector: 'strong, em',

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveHighlightFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveHighlightFormatTest.ts
@@ -2,12 +2,11 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.RemoveHighlightFormatTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   context('We remove a block', () => {
     it('Which starts in the color, but ends outside of it', () => {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveTrailingWhitespaceFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveTrailingWhitespaceFormatTest.ts
@@ -3,7 +3,6 @@ import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.fmt.RemoveTrailingWhitespaceFormatTest', () => {
   const browser = PlatformDetection.detect().browser;
@@ -11,7 +10,7 @@ describe('browser.tinymce.core.fmt.RemoveTrailingWhitespaceFormatTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     toolbar: 'bold'
-  }, [ Theme ], true);
+  }, [], true);
 
   // TODO: This function was needed to make tests pass on IE, so investigate why it's needed
   const legacySetContent = (editor: Editor, content: string) => {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -5,7 +5,6 @@ import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface Selection {
   readonly startPath: number[];
@@ -27,7 +26,7 @@ describe('browser.tinymce.core.fmt.TextDecorationColorTest', () => {
       custom_format: { inline: 'span', classes: 'abc', styles: { textDecoration: 'underline' }}
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const pApplyForecolor = async (editor: Editor) => {
     TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');

--- a/modules/tinymce/src/core/test/ts/browser/focus/CefFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/CefFocusTest.ts
@@ -1,15 +1,11 @@
 import { Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { McEditor, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.focus.CefFocusTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const pCreateInlineEditor = (html: string) => McEditor.pFromHtml<Editor>(html, {
     menubar: false,

--- a/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
@@ -1,17 +1,13 @@
 import { Assertions } from '@ephox/agar';
-import { before, context, describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Focus, Hierarchy, SugarBody, SugarNode } from '@ephox/sugar';
 import { McEditor, TinyAssertions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as EditorFocus from 'tinymce/core/focus/EditorFocus';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.focus.EditorFocusTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const pCreateInlineEditor = (html: string) => McEditor.pFromHtml<Editor>(html, {
     menubar: false,

--- a/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
@@ -7,7 +7,6 @@ import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import FocusManager from 'tinymce/core/api/FocusManager';
 import * as FocusController from 'tinymce/core/focus/FocusController';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.focus.FocusControllerTest', () => {
   Arr.each([
@@ -22,7 +21,7 @@ describe('browser.tinymce.core.focus.FocusControllerTest', () => {
         entities: 'raw',
         indent: false,
         base_url: '/project/tinymce/js/tinymce'
-      }, [ Theme ]);
+      }, []);
 
       it('isEditorUIElement on valid element', () => {
         const uiElm = DOMUtils.DOM.create('div', { class: 'mce-abc' }, null);

--- a/modules/tinymce/src/core/test/ts/browser/focus/MediaFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/MediaFocusTest.ts
@@ -3,12 +3,11 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.focus.MediaFocusTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('TINY-4211: Focus media will select the object', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/init/ContentStylePositionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ContentStylePositionTest.ts
@@ -5,14 +5,13 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.ContentStylePositionTest', () => {
   const contentStyle = '.class {color: blue;}';
   const hook = TinyHooks.bddSetupLight<Editor>({
     content_style: contentStyle,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('content styles should be after content css', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/init/EditorInitializationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/EditorInitializationTest.ts
@@ -8,7 +8,6 @@ import 'tinymce';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import Env from 'tinymce/core/api/Env';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as ViewBlock from '../../module/test/ViewBlock';
 
@@ -16,7 +15,6 @@ describe('browser.tinymce.core.init.EditorInitializationTest', () => {
   const viewBlock = ViewBlock.bddSetup();
 
   before(() => {
-    Theme();
     EditorManager._setBaseUrl('/project/tinymce/js/tinymce');
 
     let htmlReset = '';

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyDirectionalityTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyDirectionalityTest.ts
@@ -5,11 +5,9 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.InitContentBodyDirectionalityTest', () => {
   before(() => {
-    Theme();
     EditorManager.addI18n('ar', {
       Bold: 'Bold test',
       _dir: 'rtl'

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyFiltersTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodyFiltersTest.ts
@@ -3,7 +3,6 @@ import { Arr } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.InitContentBodyFiltersTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -19,7 +18,7 @@ describe('browser.tinymce.core.init.InitContentBodyFiltersTest', () => {
         });
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   it('TINY-4742: Insert content to activate node filters, check content is in editor', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodySelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodySelectionTest.ts
@@ -1,16 +1,12 @@
-import { before, context, describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
 import { McEditor, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.InitContentBodySelectionTest', () => {
   const isIE = PlatformDetection.detect().browser.isIE();
-  before(() => {
-    Theme();
-  });
 
   const initAndAssertContent = (label: string, html: string, path: number[], offset = 0, extraSettings = {}) => {
     it(label, async () => {

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorIconTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorIconTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import IconManager from 'tinymce/core/api/IconManager';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.InitEditorIconTest', () => {
   const overrideIcon = '<svg>override-icon</svg>';
@@ -18,7 +17,7 @@ describe('browser.tinymce.core.init.InitEditorIconTest', () => {
     setup: (editor) => {
       editor.ui.registry.addIcon('custom-icon', overrideIcon);
     }
-  }, [ Theme ]);
+  }, []);
 
   // Copy of '/src/core/test/assets/icons/custom''. For assertion in test.
   const customIconPack = {

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorOnHiddenElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorOnHiddenElementTest.ts
@@ -1,13 +1,9 @@
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.InitEditorOnHiddenElementTest', () => {
-  before(() => {
-    Theme();
-  });
 
   // Firefox specific test, errors were thrown when the editor was initialised on hidden element.
   it('editor initializes successfully', async () => {

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorPluginInitErrorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorPluginInitErrorTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import PluginManager from 'tinymce/core/api/PluginManager';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import ErrorHelper from '../../module/test/ErrorHelpers';
 
@@ -22,7 +21,7 @@ describe('browser.tinymce.core.init.InitEditorPluginInitErrorTest', () => {
     setup: (editor: Editor) => {
       errorHelper.trackErrors(editor, 'PluginLoadError');
     }
-  }, [ Theme ]);
+  }, []);
 
   it('TBA: Editor is responsive after using a plugin that throws an error during init', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEventsOrderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEventsOrderTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('Init events order test', () => {
   const events: string[] = [];
@@ -23,7 +22,7 @@ describe('Init events order test', () => {
     setup: (editor) => {
       editor.on('preinit addeditor scriptsloaded init visualaid loadcontent beforesetcontent setcontent postrender', addEvent);
     }
-  }, [ Theme ]);
+  }, []);
 
   after(() => {
     EditorManager.off('setupeditor addeditor', addEvent);

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorWithCustomAttrsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorWithCustomAttrsTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.InitIframeEditorWithCustomAttrsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.core.init.InitIframeEditorWithCustomAttrsTest', () => 
       'data-custom1': 'a',
       'data-custom2': 'b'
     }
-  }, [ Theme ]);
+  }, []);
 
   it('Check if iframe element has the right custom attributes', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/init/RegisterFormatsBeforeSetContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/RegisterFormatsBeforeSetContentTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.RegisterFormatsBeforeSetContentTest', () => {
   const customFormatNames = Singleton.value<string[]>();
@@ -21,7 +20,7 @@ describe('browser.tinymce.core.init.RegisterFormatsBeforeSetContentTest', () => 
         customFormatNames.set(names);
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   it('Register formats before setContent test', () => {
     const formats = customFormatNames.get().getOrDie('Should be format names');

--- a/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
@@ -6,14 +6,12 @@ import { McEditor, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.init.ShadowDomEditorTest', () => {
   before(function () {
     if (!SugarShadowDom.isSupported()) {
       this.skip();
     }
-    Theme();
   });
 
   const isSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.min.css');

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysAnchorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysAnchorTest.ts
@@ -6,13 +6,12 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.ArrowKeysAnchorTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
   const BEFORE = true;
   const AFTER = false;
   const START = true;

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
@@ -7,7 +7,6 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import * as CaretContainer from 'tinymce/core/caret/CaretContainer';
 import * as NodeType from 'tinymce/core/dom/NodeType';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as KeyUtils from '../../module/test/KeyUtils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.core.keyboard.ArrowKeysCefTest', () => {
       editor.on('ScrollIntoView', () => scrollIntoViewCount++);
       editor.on('keydown', () => keydownCount++);
     }
-  }, [ Theme ], true);
+  }, [], true);
   let scrollIntoViewCount = 0;
   let keydownCount = 0;
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointBrModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointBrModeTest.ts
@@ -3,7 +3,6 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointBrModeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -11,7 +10,7 @@ describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointBrModeTest', () 
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
 
   context('Arrow keys in figcaption', () => {
     it('Arrow up from start of figcaption to paragraph before figure', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
@@ -3,14 +3,13 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
 
   context('Arrow keys in figcaption', () => {
     it('Arrow up from start of figcaption to paragraph before figure', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysInlineBoundariesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysInlineBoundariesTest.ts
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import * as NodeType from 'tinymce/core/dom/NodeType';
 import * as WordSelection from 'tinymce/core/selection/WordSelection';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.ArrowKeysInlineBoundariesTest', () => {
   const detect = PlatformDetection.detect();
@@ -17,7 +16,7 @@ describe('browser.tinymce.core.keyboard.ArrowKeysInlineBoundariesTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const assertCaretAtZwsp = (editor: Editor) => {
     const rng = editor.selection.getRng();

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysTableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysTableTest.ts
@@ -5,13 +5,12 @@ import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.ArrowKeysTableTest', () => {
   const browser = PlatformDetection.detect().browser;
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const table = (html: string) => ApproxStructure.fromHtml('<table><tbody><tr><td>' + html + '</td></tr></tbody></table>');
   const block = ApproxStructure.fromHtml('<p><br></p>');

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyAnchorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyAnchorTest.ts
@@ -5,12 +5,11 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.EnterKeyAnchorTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const setup = (editor: Editor, html: string, elementPath: number[], offset: number) => {
     editor.setContent(html);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../../module/test/HtmlUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const pressEnter = (editor: Editor, evt?: any) => {
     const dom = editor.dom;

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
@@ -3,13 +3,12 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   it('Enter before HR in the beginning of content', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyInlineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyInlineTest.ts
@@ -1,14 +1,10 @@
 import { Keys } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { McEditor, TinyAssertions, TinyContentActions, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.EnterKeyInlineTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const settings = {
     base_url: '/project/tinymce/js/tinymce',

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -16,7 +15,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const pressEnter = (editor: Editor, evt?: any) => {
     const dom = editor.dom;

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../../module/test/HtmlUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const pressEnter = (editor: Editor, evt?: any) => {
     const dom = editor.dom;

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
@@ -3,14 +3,13 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
 
   context('Home key', () => {
     it('Home key should move caret before cef within the same block', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysBrModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysBrModeTest.ts
@@ -2,14 +2,13 @@ import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.InsertKeysBrModeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     forced_root_block: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const fireInsert = (editor: Editor) => {
     editor.fire('input', { isComposing: false } as InputEvent);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysTest.ts
@@ -6,14 +6,13 @@ import { Hierarchy, Insert, SugarElement } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.InsertKeysTest', () => {
   const browser = PlatformDetection.detect().browser;
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const fireInsert = (editor: Editor) => {
     editor.fire('input', { isComposing: false } as InputEvent);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/MediaNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/MediaNavigationTest.ts
@@ -8,14 +8,13 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import * as CaretContainer from 'tinymce/core/caret/CaretContainer';
 import * as NodeType from 'tinymce/core/dom/NodeType';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.MediaNavigationTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     height: 400,
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const assertStartContainer = (editor: Editor, f: (node: Node) => boolean) => {
     const startContainer = editor.selection.getRng().startContainer;

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
@@ -3,13 +3,12 @@ import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.SpaceKeyTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   beforeEach(() => {
     hook.editor().focus();

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/TableNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/TableNavigationTest.ts
@@ -3,13 +3,12 @@ import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.TableNavigationTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   beforeEach(() => {
     hook.editor().focus();

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/TypeTextAtCefTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/TypeTextAtCefTest.ts
@@ -3,13 +3,12 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.keyboard.TypeTextAtCef', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   it('Type text before cef inline element', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/ForcedRootBlockTest.ts
@@ -4,7 +4,6 @@ import { Obj } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.newline.ForcedRootBlockTest', () => {
   const forcedRootBlock = 'p';
@@ -14,7 +13,7 @@ describe('browser.tinymce.core.newline.ForcedRootBlockTest', () => {
     forced_root_block_attrs: forcedRootBlockAttrs,
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const bookmarkSpan = '<span data-mce-type="bookmark" id="mce_2_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px"></span>';
   const baseExpectedHTML = (innerHTML: string) => `<p class="${forcedRootBlockAttrs.class}" style="${forcedRootBlockAttrs.style}">${innerHTML}</p>`;

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
@@ -7,13 +7,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as InsertBr from 'tinymce/core/newline/InsertBr';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.newline.InsertBrTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   beforeEach(() => {
     hook.editor().focus();

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -5,13 +5,12 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as InsertNewLine from 'tinymce/core/newline/InsertNewLine';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.newline.InsertNewLine', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const bookmarkSpan = '<span data-mce-type="bookmark" id="mce_2_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px"></span>';
 

--- a/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
@@ -3,13 +3,12 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.selection.DetailsElementTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Should should retain open attribute if it is not opened', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
@@ -8,14 +8,13 @@ import { GetContentEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { GetSelectionContentArgs } from 'tinymce/core/content/ContentTypes';
 import { getContent } from 'tinymce/core/selection/GetSelectionContent';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.selection.GetSelectionContentTest', () => {
   const browser = PlatformDetection.detect().browser;
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
   const testDivId = 'testDiv1';
 
   const focusDiv = () => {

--- a/modules/tinymce/src/core/test/ts/browser/selection/MultiClickSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/MultiClickSelectionTest.ts
@@ -2,12 +2,11 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.selection.MultiClickSelectionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const fakeMultiClick = (editor: Editor, clickCount) => {
     editor.fire('click', { detail: clickCount } as MouseEvent);

--- a/modules/tinymce/src/core/test/ts/browser/selection/RangeInsertNodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/RangeInsertNodeTest.ts
@@ -5,13 +5,12 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { rangeInsertNode } from 'tinymce/core/selection/RangeInsertNode';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.selection.RangeInsertNode', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const insertNode = (editor: Editor, node: Node | DocumentFragment) => {
     rangeInsertNode(editor.dom, editor.selection.getRng(), node);

--- a/modules/tinymce/src/core/test/ts/browser/selection/RangeWalkTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/RangeWalkTest.ts
@@ -5,13 +5,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as RangeWalk from 'tinymce/core/selection/RangeWalk';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.selection.RangeWalkTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const complexList = '<ul>' +
     '<li>Test 1</li>' +

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectBeforeBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectBeforeBlockTest.ts
@@ -1,17 +1,13 @@
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { McEditor, TinyAssertions, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as InsertNewline from 'tinymce/core/newline/InsertNewLine';
-import Theme from 'tinymce/themes/silver/Theme';
 
 // With a few exceptions, it is considered invalid for the cursor to be immediately before a block level element. These tests address
 // known cases where it was possible to position the cursor in one of those locations.
 describe('browser.tinymce.core.selection.SelectBeforeBlock', () => {
-  before(() => {
-    Theme();
-  });
 
   const settings = {
     base_url: '/project/tinymce/js/tinymce'

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkIframeEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkIframeEditorTest.ts
@@ -3,13 +3,12 @@ import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.selection.SelectionBookmarkIframeEditorTest', () => {
   const browser = PlatformDetection.detect().browser;
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
   const testDivId = 'testDiv1234';
 
   const removeTestDiv = () => {

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
@@ -7,7 +7,6 @@ import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.selection.SelectionBookmarkInlineEditorTest', () => {
   const browser = PlatformDetection.detect().browser;
@@ -15,7 +14,7 @@ describe('browser.tinymce.core.selection.SelectionBookmarkInlineEditorTest', () 
     inline: true,
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
   const testDivId = 'testDiv1234';
 
   const removeTestDiv = () => {

--- a/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
@@ -8,13 +8,12 @@ import { SetContentEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { SetSelectionContentArgs } from 'tinymce/core/content/ContentTypes';
 import * as SetSelectionContent from 'tinymce/core/selection/SetSelectionContent';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.selection.SetSelectionContentTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const setContentOverride = (editor: Editor, content: string, overrideContent: string, args: Partial<SetSelectionContentArgs>) => {
     const handler = (e: EditorEvent<SetContentEvent>) => {

--- a/modules/tinymce/src/core/test/ts/browser/undo/ForcedRootBlockTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/ForcedRootBlockTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as Levels from 'tinymce/core/undo/Levels';
 import { UndoLevelType } from 'tinymce/core/undo/UndoManagerTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.undo.ForcedRootBlockTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.core.undo.ForcedRootBlockTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   it('createFromEditor', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/undo/LevelsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/LevelsTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as Levels from 'tinymce/core/undo/Levels';
 import { UndoLevelType } from 'tinymce/core/undo/UndoManagerTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.undo.LevelsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.core.undo.LevelsTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const getBookmark = (editor: Editor) => {
     return editor.selection.getBookmark(2, true);

--- a/modules/tinymce/src/core/test/ts/browser/util/ImageUploaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ImageUploaderTest.ts
@@ -6,12 +6,11 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { BlobCache, BlobInfo } from 'tinymce/core/api/file/BlobCache';
 import ImageUploader, { UploadResult } from 'tinymce/core/api/util/ImageUploader';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.util.ImageUploaderTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
   let image1: BlobInfo;
   let image2: BlobInfo;
 

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../../module/test/HtmlUtils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     indent: false,
     disable_nodechange: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   it('Delete from beginning of P into H1', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/module/McAgar.ts
+++ b/modules/tinymce/src/core/test/ts/module/McAgar.ts
@@ -1,7 +1,9 @@
+/* eslint-disable @tinymce/no-main-module-imports */
 /*
   This is a helper module that allows us to ensure that TinyMCE core is included/compiled
   before mcagar loads. This ensures that the core of the editor isn't loaded from pre-built
   files in node_modules and is always the latest version.
  */
 import 'tinymce';
+import 'tinymce/themes/silver/Main';
 export * from '@ephox/mcagar';

--- a/modules/tinymce/src/core/test/ts/webdriver/PageUpDownKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/PageUpDownKeysTest.ts
@@ -4,14 +4,13 @@ import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('webdriver.tinymce.core.keyboard.PageUpDownKeyTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Theme ], true);
+  }, [], true);
   const platform = PlatformDetection.detect();
   const supportsPageUpDown = !(platform.os.isOSX() || platform.os.isWindows() && platform.browser.isFirefox());
 

--- a/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
   const togglePlaceholderCount = Cell(0);
@@ -20,7 +19,7 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
         togglePlaceholderCount.set(togglePlaceholderCount.get() + 1);
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   before(() => hook.editor().focus());
 

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface Definition {
   readonly inputContent: string;
@@ -28,7 +27,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistPluginTest', () => {
     },
     disable_nodechange: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ AdvListPlugin, ListsPlugin, Theme ]);
+  }, [ AdvListPlugin, ListsPlugin ]);
 
   const listStyleTest = (title: string, definition: Definition) => {
     it(title, () => {

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/ChangeListStyleTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/ChangeListStyleTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.advlist.ChangeListStyleTest', () => {
   Arr.each([
@@ -20,7 +19,7 @@ describe('browser.tinymce.plugins.advlist.ChangeListStyleTest', () => {
         menubar: false,
         statusbar: false,
         base_url: '/project/tinymce/js/tinymce'
-      }, [ AdvListPlugin, ListsPlugin, Theme ]);
+      }, [ AdvListPlugin, ListsPlugin ]);
 
       const pWaitForMenu = (editor: Editor) => TinyUiActions.pWaitForUi(editor, '.tox-menu.tox-selected-menu');
 

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
     advlist_number_styles: 'default,circle,square',
     toolbar: 'numlist bullist',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ AdvListPlugin, ListsPlugin, Theme ]);
+  }, [ AdvListPlugin, ListsPlugin ]);
 
   const pClickOnSplitBtnFor = async (editor: Editor, label: string) => {
     TinyUiActions.clickOnToolbar(editor, '[aria-label="' + label + '"] > .tox-tbtn + .tox-split-button__chevron');

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/ToolbarButtonStructureTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/ToolbarButtonStructureTest.ts
@@ -7,13 +7,11 @@ import { McEditor } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.advlist.ToolbarButtonStructureTest', () => {
   before(() => {
     AdvListPlugin();
     ListsPlugin();
-    Theme();
   });
 
   Arr.each([

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAlertTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/anchor/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAddAnchor } from '../module/Helpers';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.anchor.AnchorAlertTest', () => {
     plugins: 'anchor',
     toolbar: 'anchor',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
   const dialogSelector = 'div[role="dialog"].tox-dialog';
   const alertDialogSelector = 'div[role="dialog"].tox-dialog.tox-alert-dialog';
 

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAllowHtmlTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorAllowHtmlTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/anchor/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAddAnchor, pAssertAnchorPresence } from '../module/Helpers';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.anchor.AnchorAllowHtmlTest', () => {
     toolbar: 'anchor',
     allow_html_in_named_anchor: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const assertContentStructure = (editor: Editor, id: string, isContentEditable: boolean, innerContent: string) =>
     TinyAssertions.assertContentStructure(editor,

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorEditTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorEditTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/anchor/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAddAnchor, pAssertAnchorPresence } from '../module/Helpers';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.anchor.AnchorEditTest', () => {
     plugins: 'anchor',
     toolbar: 'anchor',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Add anchor, change anchor, undo anchor change then the anchor should be there as first entered', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorFormatsTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorFormatsTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/anchor/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.anchor.AnchorFormatsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.anchor.AnchorFormatsTest', () => {
     toolbar: 'anchor',
     allow_html_in_named_anchor: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const testMatchFormat = (editor: Editor, expected: boolean) => {
     const match = editor.formatter.match('namedAnchor');

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorInlineTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorInlineTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/anchor/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAddAnchor } from '../module/Helpers';
 
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.anchor.AnchorInlineTest', () => {
     plugins: 'anchor',
     toolbar: 'anchor',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   // Note: HTML should not be contained in the anchor because of the allow_html_in_named_anchor setting which is false by default
   it('TBA: Add anchor by selecting text content, then check that anchor is inserted correctly', async () => {

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/AnchorSanityTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/anchor/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAddAnchor, pAssertAnchorPresence } from '../module/Helpers';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.anchor.AnchorSanityTest', () => {
     plugins: 'anchor',
     toolbar: 'anchor',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Add text and anchor, then check if that anchor is present in the editor', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -7,7 +7,6 @@ import fc from 'fast-check';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/autolink/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as KeyUtils from '../module/test/KeyUtils';
 
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     inline_boundaries: false
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const typeUrl = (editor: Editor, url: string): string => {
     editor.setContent('<p>' + url + '</p>');

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/ConsecutiveLinkTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/ConsecutiveLinkTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/autolink/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as KeyUtils from '../module/test/KeyUtils';
 
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.autolink.ConsecutiveLinkTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'autolink',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Chrome adds a nbsp between link and text', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/EnterKeyTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/EnterKeyTest.ts
@@ -5,13 +5,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/autolink/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.autolink.EnterKeyTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'autolink',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TINY-1202: Focus on editor, set content, set cursor at end of content, assert enter/return keystroke and keydown event', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import AutoresizePlugin from 'tinymce/plugins/autoresize/Plugin';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
   PhantomSkipper.bddSetup();
@@ -26,7 +25,7 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
         resizeEventsCount.set(resizeEventsCount.get() + 1);
       });
     }
-  }, [ AutoresizePlugin, FullscreenPlugin, Theme ], true);
+  }, [ AutoresizePlugin, FullscreenPlugin ], true);
 
   const assertEditorHeightAbove = (editor: Editor, minHeight: number) => {
     const editorHeight = editor.getContainer().offsetHeight;

--- a/modules/tinymce/src/plugins/autosave/test/ts/browser/AutoSavePluginTest.ts
+++ b/modules/tinymce/src/plugins/autosave/test/ts/browser/AutoSavePluginTest.ts
@@ -4,14 +4,13 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/autosave/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.autosave.AutoSavePluginTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'autosave',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const checkIfEmpty = (editor: Editor, html: string, isEmpty: boolean): void => {
     const result = isEmpty ? 'empty.' : 'not empty.';

--- a/modules/tinymce/src/plugins/autosave/test/ts/browser/ShouldRestoreWhenEmptyTest.ts
+++ b/modules/tinymce/src/plugins/autosave/test/ts/browser/ShouldRestoreWhenEmptyTest.ts
@@ -4,12 +4,10 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/autosave/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.autosave.ShouldRestoreWhenEmptyTest', () => {
   before(() => {
     Plugin();
-    Theme();
   });
 
   const testingPrefix = Math.random().toString(36).substring(7);

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapAutocompletionTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapAutocompletionTest.ts
@@ -4,14 +4,13 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiAc
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/charmap/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.charmap.AutocompletionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'charmap',
     toolbar: 'charmap',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Autocomplete, trigger an autocomplete and check it appears', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/charmap/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { fakeEvent } from '../module/Helpers';
 
@@ -21,7 +20,7 @@ describe('browser.tinymce.plugins.charmap.DialogHeightTest', () => {
         plugins: 'charmap',
         toolbar: 'charmap',
         base_url: '/project/tinymce/js/tinymce'
-      }, [ Plugin, Theme ], true);
+      }, [ Plugin ], true);
 
       before(() => {
         // Make the shadow host focusable

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
@@ -5,14 +5,13 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Plugin from 'tinymce/plugins/charmap/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.charmap.CharMapPluginTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'charmap',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Replace characters by array', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/charmap/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { fakeEvent } from '../module/Helpers';
 
@@ -24,7 +23,7 @@ describe('browser.tinymce.plugins.charmap.SearchTest', () => {
     plugins: 'charmap',
     toolbar: 'charmap',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   // TODO: Replicate this test with only one category of characters.
   it('TBA: Open dialog, Search for "euro", Euro should be first option', async () => {

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapUserDefinedTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapUserDefinedTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/charmap/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { fakeEvent } from '../module/Helpers';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.charmap.CharmapUserDefinedTest', () => {
     toolbar: 'charmap',
     charmap: [[ 'A'.charCodeAt(0), 'A' ]],
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: User defined charmap', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/InsertQuotationMarkTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/InsertQuotationMarkTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/charmap/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.charmap.InsertQuotationMarkTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.charmap.InsertQuotationMarkTest', () => {
     charmap_append: [[ 34, 'quotation mark' ]],
     toolbar: 'charmap',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Open dialog, click on the All tab and click on Quotation Mark and then assert Quotation Mark is inserted', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
+++ b/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
@@ -4,14 +4,13 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/code/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.code.CodeSanityTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'code',
     toolbar: 'code',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const toolbarButtonSelector = '[role="toolbar"] button[aria-label="Source code"]';
 

--- a/modules/tinymce/src/plugins/code/test/ts/browser/CodeTextareaTest.ts
+++ b/modules/tinymce/src/plugins/code/test/ts/browser/CodeTextareaTest.ts
@@ -4,14 +4,13 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/code/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.code.CodeTextareaTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'code',
     toolbar: 'code',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pOpenDialog = async (editor: Editor) => {
     editor.execCommand('mceCodeEditor');

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/ChangeCodeSampleTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/ChangeCodeSampleTest.ts
@@ -3,7 +3,6 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/codesample/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TestUtils from '../module/CodeSampleTestUtils';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.codesample.ChangeLanguageCodeSampleTest', () =
     plugins: 'codesample',
     toolbar: 'codesample',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const jsContent = 'var foo = "bar";';
 

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/codesample/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TestUtils from '../module/CodeSampleTestUtils';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.codesample.CodeSampleSanityTest', () => {
     plugins: 'codesample',
     toolbar: 'codesample',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const markupContent = '<p>hello world</p>';
   const newContent = 'editor content should not change to this';

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSelectionTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSelectionTest.ts
@@ -5,7 +5,6 @@ import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-m
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/codesample/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TestUtils from '../module/CodeSampleTestUtils';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.codesample.CodeSampleSelectionTest', () => {
     plugins: 'codesample',
     toolbar: 'codesample',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const dialogSelector = 'div.tox-dialog';
   const markupContent = '<p>hello world</p>';

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -2,7 +2,6 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Plugin from 'tinymce/plugins/directionality/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () => {
   const hook = TinyHooks.bddSetupLight({
@@ -10,7 +9,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     toolbar: 'ltr rtl',
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Set and select content, click on the Right to left toolbar button and assert direction is right to left', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/DifferentEmojiDatabaseTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/DifferentEmojiDatabaseTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/emoticons/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const getFilename = (url: string) => {
   const m = /([^\/\\]+)$/.exec(url);
@@ -20,7 +19,6 @@ const getFilename = (url: string) => {
 describe('browser.tinymce.plugins.emoticons.DifferentEmojiDatabaseTest', () => {
   before(() => {
     Plugin();
-    Theme();
   });
 
   const pTestEditorWithSettings = async (categories: string[], databaseUrl: string) => {

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAppendTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAppendTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/emoticons/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { fakeEvent } from '../module/test/Utils';
 
@@ -27,7 +26,7 @@ describe('browser.tinymce.plugins.emoticons.AppendTest', () => {
         char: '🤯'
       }
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const tabElement = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi, arr: ApproxStructure.ArrayApi) =>
     (name: string): StructAssert => s.element('div', {

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAutocompletionTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAutocompletionTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiAc
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/emoticons/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.emoticons.AutocompletionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.emoticons.AutocompletionTest', () => {
     base_url: '/project/tinymce/js/tinymce',
     emoticons_database_url: '/project/tinymce/src/plugins/emoticons/test/js/test-emojis.js',
     emoticons_database_id: 'tinymce.plugins.emoticons.test-emojis.js'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   // NOTE: This is almost identical to charmap
   it('TBA: Autocomplete, trigger an autocomplete and check it appears', async () => {

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonSearchTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonSearchTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/emoticons/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { fakeEvent } from '../module/test/Utils';
 
@@ -25,7 +24,7 @@ describe('browser.tinymce.plugins.emoticons.SearchTest', () => {
     toolbar: 'emoticons',
     base_url: '/project/tinymce/js/tinymce',
     emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojis.js'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Open dialog, Search for "rainbow", Rainbow should be first option', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmoticonTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmoticonTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/emoticons/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { fakeEvent } from '../module/test/Utils';
 
@@ -16,7 +15,7 @@ describe('browser.tinymce.plugins.emoticons.ImageEmoticonTest', () => {
     toolbar: 'emoticons',
     base_url: '/project/tinymce/js/tinymce',
     emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojiimages.js'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Open dialog, Search for "dog", Dog should be first option', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -8,7 +8,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
   const lastEventArgs = Cell(null);
@@ -88,7 +87,7 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
             lastEventArgs.set(e);
           });
         }
-      }, [ FullscreenPlugin, LinkPlugin, Theme ]);
+      }, [ FullscreenPlugin, LinkPlugin ]);
 
       it('TBA: Toggle fullscreen on, open link dialog, insert link, close dialog and toggle fullscreen off', async () => {
         const editor = hook.editor();

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullscreenPluginInlineEditorTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullscreenPluginInlineEditorTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.fullscreen.FullScreenPluginInlineEditorTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginInlineEditorTest', 
     plugins: 'fullscreen link',
     toolbar: 'fullscreen link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ FullscreenPlugin, LinkPlugin, Theme ]);
+  }, [ FullscreenPlugin, LinkPlugin ]);
 
   it('TBA: Assert isFullscreen api function is present and fullscreen button is absent', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import { getFullscreenElement } from 'tinymce/plugins/fullscreen/core/NativeFullscreen';
 import Plugin from 'tinymce/plugins/fullscreen/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('webdriver.tinymce.plugins.fullscreen.FullScreenPluginNativeModeTest', () => {
   before(function () {
@@ -19,7 +18,7 @@ describe('webdriver.tinymce.plugins.fullscreen.FullScreenPluginNativeModeTest', 
     toolbar: 'fullscreen',
     base_url: '/project/tinymce/js/tinymce',
     fullscreen_native: true
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pIsFullscreen = (fullscreen: boolean) => Waiter.pTryUntilPredicate('Waiting for fullscreen mode to ' + (fullscreen ? 'start' : 'end'), () => {
     if (fullscreen) {

--- a/modules/tinymce/src/plugins/help/test/ts/browser/CustomTabsTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/CustomTabsTest.ts
@@ -8,12 +8,10 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import Plugin from 'tinymce/plugins/help/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.help.CustomTabsTest', () => {
   before(() => {
     Plugin();
-    Theme();
   });
 
   const compareTabNames = (editor: Editor, expectedNames: string[]) => {

--- a/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
@@ -5,14 +5,13 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/help/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'help',
     toolbar: 'help',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   // Tab key press
   const pressTabKey = (editor: Editor) => TinyUiActions.keydown(editor, Keys.tab());

--- a/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import HelpPlugin from 'tinymce/plugins/help/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as PluginAssert from '../module/PluginAssert';
 import { selectors } from '../module/Selectors';
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.help.IgnoreForcedPluginsTest', () => {
     toolbar: 'help',
     forced_plugins: [ 'link' ],
     base_url: '/project/tinymce/js/tinymce'
-  }, [ HelpPlugin, LinkPlugin, Theme ]);
+  }, [ HelpPlugin, LinkPlugin ]);
 
   it('TBA: Hide forced plugins from Help plugin list', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/help/test/ts/browser/MetadataTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/MetadataTest.ts
@@ -2,7 +2,6 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import HelpPlugin from 'tinymce/plugins/help/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as PluginAssert from '../module/PluginAssert';
 import { selectors } from '../module/Selectors';
@@ -14,7 +13,7 @@ describe('Browser Test: .MetadataTest', () => {
     plugins: 'help fake nometafake',
     toolbar: 'help',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ HelpPlugin, FakePlugin, NoMetaFakePlugin, Theme ]);
+  }, [ HelpPlugin, FakePlugin, NoMetaFakePlugin ]);
 
   it('TBA: Assert Help Plugin list contains getMetadata functionality', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/help/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/PluginTest.ts
@@ -2,7 +2,6 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Plugin from 'tinymce/plugins/help/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as PluginAssert from '../module/PluginAssert';
 import { selectors } from '../module/Selectors';
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.help.PluginTest', () => {
     plugins: 'help',
     toolbar: 'help',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Assert Help Plugin list contains Help', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/hr/test/ts/browser/HrSanityTest.ts
+++ b/modules/tinymce/src/plugins/hr/test/ts/browser/HrSanityTest.ts
@@ -4,14 +4,13 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/hr/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.hr.HrSanitytest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'hr',
     toolbar: 'hr',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Click on the horizontal rule toolbar button and assert hr is added to the editor', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { fillActiveDialog, generalTabSelectors, ImageDialogData } from '../module/Helpers';
 
@@ -16,7 +15,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     a11y_advanced_options: true
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pInitAndOpenDialog = async (editor: Editor, content: string, cursorPos: Cursors.RangeSpec | Cursors.CursorSpec) => {
     editor.settings.image_advtab = true;

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ContextMenuTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.image.ContextMenuTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.image.ContextMenuTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_caption: true
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const pOpenContextMenu = async (editor: Editor, target: string) => {
     // Not sure why this is needed, but without the browser deselects the contextmenu target

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertCleanHtml, assertInputCheckbox, assertInputValue, fillActiveDialog, generalTabSelectors } from '../module/Helpers';
 
@@ -16,7 +15,7 @@ describe('browser.tinymce.plugins.image.DescriptiveImageDialogTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     a11y_advanced_options: true
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pressTab = (editor: Editor) => TinyUiActions.keydown(editor, Keys.tab());
   const pressEsc = (editor: Editor) => TinyUiActions.keydown(editor, Keys.escape());

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.image.DialogTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.image.DialogTest', () => {
     toolbar: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pressTab = (editor: Editor) => TinyUiActions.keydown(editor, Keys.tab());
   const pressEsc = (editor: Editor) => TinyUiActions.keydown(editor, Keys.escape());

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertCleanHtml, assertInputValue, fakeEvent, fillActiveDialog, generalTabSelectors, setInputValue } from '../module/Helpers';
 
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     file_picker_callback: (callback, _value, _meta) => {
       callback('https://www.google.com/logos/google.jpg', { width: '200' });
     }
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Update an image by setting title to empty should remove the existing title attribute', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { generalTabSelectors, setInputValue } from '../module/Helpers';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.image.FigureDeleteTest', () => {
     toolbar: 'image',
     image_caption: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: removing src in dialog should remove figure element', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { fillActiveDialog } from '../module/Helpers';
 
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.image.FigureResizeTest', () => {
     image_caption: true,
     height: 400,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const getElementSize = (elm: SugarElement<HTMLImageElement>) => {
     const width = Css.get(elm, 'width');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageListTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageListTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertInputValue, generalTabSelectors, pSetListBoxItem, setInputValue } from '../module/Helpers';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.image.ImageListTest', () => {
     plugins: 'image',
     toolbar: 'image',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: click image list, check that source changes, change source and check that image list changes', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { advancedTabSelectors, assertInputValue, fillActiveDialog, ImageDialogData, setInputValue } from '../module/Helpers';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
         items: 'image'
       });
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const pInitAndOpenDialog = async (editor: Editor, content: string, cursorPos: Cursors.CursorSpec | Cursors.RangeSpec) => {
     editor.settings.image_advtab = true;

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertCleanHtml, assertInputValue, generalTabSelectors, setInputValue } from '../module/Helpers';
 
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.image.ImageResizeTest', () => {
       console.log('file picker pressed');
       callback('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
     }
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: image proportion constrains should work directly', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -8,7 +8,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as Conversions from 'tinymce/core/file/Conversions';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
   const src = 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png';
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
     toolbar: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const closeDialog = (editor: Editor) =>
     TinyUiActions.cancelDialog(editor);

--- a/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import { ImageData } from 'tinymce/plugins/image/core/ImageData';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.image.api.CommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.image.api.CommandsTest', () => {
     toolbar: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const updateImage = (editor: Editor, data: Partial<ImageData>) => editor.execCommand('mceUpdateImage', false, data);
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
@@ -6,7 +6,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 type Alignment = 'left' | 'center' | 'right' | 'justify';
 
@@ -72,7 +71,7 @@ describe('browser.tinymce.plugins.image.ImageAlignTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_caption: true
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const pCheckToolbarHighlighting = async (editor: Editor, alignment: Alignment, isFigure: boolean) => {
     const ariaLabels = {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageSelectionTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageSelectionTest.ts
@@ -6,7 +6,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { ImageData } from 'tinymce/plugins/image/core/ImageData';
 import { insertOrUpdateImage } from 'tinymce/plugins/image/core/ImageSelection';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.image.core.ImageSelectionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.image.core.ImageSelectionTest', () => {
     indent: false,
     inline: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const updateImageOrFigure = (editor: Editor, data: Partial<ImageData>) => {
     insertOrUpdateImage(editor, {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertCleanHtml, assertInputValue, fillActiveDialog, generalTabSelectors } from '../../module/Helpers';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.image.plugin.DefaultEmptyTest', () => {
     plugins: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: default image dialog on empty data', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DimensionsFalseTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DimensionsFalseTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertCleanHtml, fillActiveDialog } from '../../module/Helpers';
 
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.image.plugin.DimensionsFalseTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_dimensions: false
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: image dialog image_dimensions: false', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertCleanHtml, fillActiveDialog } from '../../module/Helpers';
 
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
       { title: 'class1', value: 'class1' },
       { title: 'class2', value: 'class2' }
     ]
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: all image dialog ui options on empty editor', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertCleanHtml, fakeEvent, fillActiveDialog, generalTabSelectors } from '../../module/Helpers';
 
@@ -16,7 +15,7 @@ describe('browser.tinymce.plugins.image.plugin.PrependAbsoluteTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_prepend_url: prependUrl
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: image recognizes relative src url and prepends absolute image_prepend_url setting.', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertCleanHtml, fakeEvent, fillActiveDialog, generalTabSelectors } from '../../module/Helpers';
 
@@ -16,7 +15,7 @@ describe('browser.tinymce.plugins.image.plugin.PrependRelativeTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_prepend_url: prependUrl
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: image recognizes relative src url and prepends relative image_prepend_url setting.', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ContextToolbarTest.ts
@@ -6,7 +6,6 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiAc
 import Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';
 import ImageToolsPlugin from 'tinymce/plugins/imagetools/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { ImageOps } from '../module/test/ImageOps';
 import * as ImageUtils from '../module/test/ImageUtils';
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.imagetools.ContextToolbarTest', () => {
     plugins: 'image imagetools',
     base_url: '/project/tinymce/js/tinymce',
     height: 900
-  }, [ ImagePlugin, ImageToolsPlugin, Theme ], true);
+  }, [ ImagePlugin, ImageToolsPlugin ], true);
 
   const pOpenContextToolbar = async (editor: Editor, source: string) => {
     await ImageUtils.pLoadImage(editor, source, { width: 460, height: 598 });

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCropTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCropTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/imagetools/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { ImageOps } from '../module/test/ImageOps';
 import * as ImageUtils from '../module/test/ImageUtils';
@@ -25,7 +24,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsCropTest', () => {
         automatic_uploads: false,
         images_upload_handler: uploadHandlerState.handler(srcUrl),
         base_url: '/project/tinymce/js/tinymce'
-      }, [ Plugin, Theme ]);
+      }, [ Plugin ]);
 
       beforeEach(() => uploadHandlerState.resetState());
 

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCustomFetchTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsCustomFetchTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
 import Plugin from 'tinymce/plugins/imagetools/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as ImageUtils from '../module/test/ImageUtils';
 
@@ -22,7 +21,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsCustomFetchTest', () => {
     images_upload_handler: uploadHandlerState.handler(srcUrl),
     imagetools_cors_hosts: [ 'localhost' ],
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: flip image with custom fetch image', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsDisabledButtonsTest.ts
@@ -5,7 +5,6 @@ import { McEditor, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';
 import ImageToolsPlugin from 'tinymce/plugins/imagetools/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () => {
 
@@ -23,7 +22,6 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsDisabledButtonsTest', () 
   const rotateClockwiseImageButtonSelector = '[role="toolbar"] button[title="Rotate clockwise"]';
 
   before(() => {
-    Theme();
     ImageToolsPlugin();
     ImagePlugin();
   });

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsErrorTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/imagetools/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as ImageUtils from '../module/test/ImageUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsErrorTest', () => {
     plugins: 'imagetools',
     automatic_uploads: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pAssertErrorMessage = async (html: string) => {
     const content = await UiFinder.pWaitFor('Find notification', SugarBody.body(), '.tox-notification__body > p') as SugarElement<HTMLElement>;

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsPluginTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/ImageToolsPluginTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import URI from 'tinymce/core/api/util/URI';
 import Plugin from 'tinymce/plugins/imagetools/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as ImageUtils from '../module/test/ImageUtils';
 
@@ -21,7 +20,7 @@ describe('browser.tinymce.plugins.imagetools.ImageToolsPluginTest', () => {
     automatic_uploads: false,
     images_upload_handler: uploadHandlerState.handler(srcUrl),
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   // Some browsers can transform BMP images on the canvas, others can't. When that happens the image is converted to a PNG.
   // See https://html.spec.whatwg.org/multipage/canvas.html#serialising-bitmaps-to-a-file

--- a/modules/tinymce/src/plugins/imagetools/test/ts/browser/SequenceTest.ts
+++ b/modules/tinymce/src/plugins/imagetools/test/ts/browser/SequenceTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/imagetools/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { ImageOps } from '../module/test/ImageOps';
 import * as ImageUtils from '../module/test/ImageUtils';
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.imagetools.SequenceTest', () => {
     imagetools_cors_hosts: [ 'moxiecode.cachefly.net' ],
     base_url: '/project/tinymce/js/tinymce',
     toolbar: 'editimage'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Test image operations on an image from the same domain', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssGroupsPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssGroupsPluginTest.ts
@@ -7,7 +7,6 @@ import { McEditor, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import Plugin from 'tinymce/plugins/importcss/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { Navigation, pProcessNavigation } from '../module/MenuNavigationTestUtils';
 
@@ -22,7 +21,6 @@ interface Assertion {
 describe('browser.tinymce.plugins.importcss.ImportCssGroupsTest', () => {
   before(() => {
     Plugin();
-    Theme();
   });
 
   const pTestEditorWithSettings = async (assertion: Assertion, pluginSettings: RawEditorSettings) => {

--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
@@ -7,7 +7,6 @@ import { McEditor, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import Plugin from 'tinymce/plugins/importcss/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface MenuDetails {
   readonly tag?: string;
@@ -24,7 +23,6 @@ interface Assertion {
 describe('browser.tinymce.plugins.importcss.ImportCssTest', () => {
   before(() => {
     Plugin();
-    Theme();
   });
 
   const pAssertMenu = async (label: string, expected: MenuDetails[]) => {

--- a/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/InsertDatetimeSanityTest.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/InsertDatetimeSanityTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/insertdatetime/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.insertdatetime.InsertDatetimeSanityTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.insertdatetime.InsertDatetimeSanityTest', () =
     insertdatetime_element: true,
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Click on Insertdatetime button and select the first item from the drop down menu. Assert date time is inserted', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.link.AllowUnsafeLinkTargetTest', () => {
       { title: 'New page', value: '_blank' }
     ],
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   before(() => {
     TestLinkUi.clearHistory();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AnchorFalseTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AnchorFalseTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.link.AnchorFalseTest', () => {
     anchor_top: false,
     anchor_bottom: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   before(() => {
     LocalStorage.setItem('tinymce-url-history', JSON.stringify({

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   context('Default setting', () => {
     it('TBA: www-urls are prompted to add http:// prefix, accept', async () => {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
@@ -5,7 +5,6 @@ import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   before(() => {
     TestLinkUi.clearHistory();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkProtocolTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.link.DefaultLinkProtocolTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   context('link_default_protocol: "http"', () => {
     before(() => {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkTargetTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkTargetTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.link.DefaultLinkTargetTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   before(() => {
     TestLinkUi.clearHistory();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.link.DialogFlowTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   before(() => {
     TestLinkUi.clearHistory();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -21,7 +20,7 @@ describe('browser.tinymce.plugins.link.DialogSectionsTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   before(() => {
     TestLinkUi.clearHistory();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ImageFigureLinkTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import * as LinkPluginUtils from 'tinymce/plugins/link/core/Utils';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.link.ImageFigureLinkTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   before(() => {
     TestLinkUi.clearHistory();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import Plugin from 'tinymce/plugins/link/Plugin';
 import { LinkDialogData } from 'tinymce/plugins/link/ui/DialogTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.link.LinkDialogOverrideTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -47,7 +46,7 @@ describe('browser.tinymce.plugins.link.LinkDialogOverrideTest', () => {
         });
       });
     }
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   it('TINY-7738: Regression test for supported dialog validation workaround', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkJustFirstFieldTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkJustFirstFieldTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.link.JustFirstFieldTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const doc = SugarDocument.getDocument();
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
@@ -10,7 +10,6 @@ import { ClassListOptions } from 'tinymce/plugins/link/ui/sections/ClassListOpti
 import { LinkListOptions } from 'tinymce/plugins/link/ui/sections/LinkListOptions';
 import { RelOptions } from 'tinymce/plugins/link/ui/sections/RelOptions';
 import { TargetOptions } from 'tinymce/plugins/link/ui/sections/TargetOptions';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.link.ListOptionsTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   before(() => {
     TestLinkUi.clearHistory();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
     toolbar: 'link',
     link_quicklink: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const doc = SugarDocument.getDocument();
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -3,14 +3,13 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'unlink',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Removing a link with a collapsed selection', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageLinkTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.link.SelectedImageTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const doc = SugarDocument.getDocument();
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     plugins: 'link',
     toolbar: 'link openlink unlink',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: should not get anchor info if not selected node', async () => {
     TestLinkUi.clearHistory();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -22,7 +21,7 @@ describe('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
       });
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const doc = SugarDocument.getDocument();
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.link.UpdateLinkTest', () => {
     plugins: 'link',
     toolbar: '',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   before(() => {
     TestLinkUi.clearHistory();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlInputTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlInputTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.link.UrlInputTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: insert url by typing', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.link.UrlProtocolTest', () => {
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pTestProtocolConfirm = async (editor: Editor, url: string, expectedProtocol: string) => {
     const presence = {};

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyDlTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyDlTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.ApplyDlTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -22,7 +21,7 @@ describe('browser.tinymce.plugins.lists.ApplyDlTest', () => {
         'margin-bottom,margin-left,display,position,top,left,list-style-type'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Apply DL list to multiple Ps', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnParagraphWithStylesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnParagraphWithStylesTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.ApplyListOnParagraphWithStylesTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -11,7 +10,7 @@ describe('browser.tinymce.plugins.lists.ApplyListOnParagraphWithStylesTest', () 
     plugins: 'lists',
     toolbar: 'numlist bullist',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: remove margin from p when applying list on it, but leave other styles', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.ApplyTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -22,7 +21,7 @@ describe('browser.tinymce.plugins.lists.ApplyTest', () => {
         'margin-bottom,margin-left,display,position,top,left,list-style-type'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Apply UL list to single P', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('Browser Test: .RemoveTrailingBlockquoteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -12,7 +11,7 @@ describe('Browser Test: .RemoveTrailingBlockquoteTest', () => {
     plugins: 'lists',
     toolbar: '',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: backspace from p inside div into li', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.BackspaceDeleteInlineTest', () => {
   const setupElement = () => {
@@ -38,7 +37,7 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteInlineTest', () => {
       '*': 'color,font-size,font-family,background-color,font-weight,font-style,text-decoration,float,' +
       'margin,margin-top,margin-right,margin-bottom,margin-left,display,position,top,left,list-style-type'
     }
-  }, setupElement, [ Plugin, Theme ], true);
+  }, setupElement, [ Plugin ], true);
 
   it('TBA: Backspace at beginning of LI on body UL', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver//Theme';
 
 describe('browser.tinymce.plugins.lists.BackspaceDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteTest', () => {
     },
     content_style: '.mce-content-body { line-height: normal; }', // Breaks tests in phantomjs unless we have this
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Backspace at beginning of single LI in UL', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ChangeListStyleTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ChangeListStyleTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.ChangeListStyleTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -11,7 +10,7 @@ describe('browser.tinymce.plugins.lists.ChangeListStyleTest', () => {
     plugins: 'lists',
     toolbar: 'numlist bullist',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: ul to ol, cursor only in parent', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.IndentTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -22,7 +21,7 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
         'margin-bottom,margin-left,display,position,top,left,list-style-type'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   beforeEach(() => {
     hook.editor().focus();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/InlineTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/InlineTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.InlineTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -22,7 +21,7 @@ describe('browser.tinymce.plugins.lists.InlineTest', () => {
         'margin-bottom,margin-left,display,position,top,left,list-style-type'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Remove UL in inline body element contained in LI', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { ExecCommandEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/PublicApi';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -21,7 +20,7 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
     toolbar: false,
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const contentMenuSelector = '.tox-tinymce-aux .tox-menu .tox-collection__item:contains("List properties...")';
   const inputSelector = 'label:contains(Start list at number) + input.tox-textfield';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.OutdentTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -22,7 +21,7 @@ describe('browser.tinymce.plugins.lists.OutdentTest', () => {
         'margin-bottom,margin-left,display,position,top,left,list-style-type'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Outdent inside LI in beginning of OL in LI', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockAttrsTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockAttrsTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.RemoveForcedRootBlockAttrsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -25,7 +24,7 @@ describe('browser.tinymce.plugins.lists.RemoveForcedRootBlockAttrsTest', () => {
     forced_root_block_attrs: {
       'data-editor': '1'
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Remove UL with forced_root_block_attrs', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.RemoveForcedRootBlockFalseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.lists.RemoveForcedRootBlockFalseTest', () => {
     },
     base_url: '/project/tinymce/js/tinymce',
     forced_root_block: false
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Remove UL with single LI in BR mode', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.RemoveTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -22,7 +21,7 @@ describe('browser.tinymce.plugins.lists.RemoveTest', () => {
         'margin-bottom,margin-left,display,position,top,left,list-style-type'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Remove UL at single LI', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } fro
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.TableInListTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.lists.TableInListTest', () => {
     toolbar: 'bullist numlist indent outdent',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: unlist table in list then add list inside table', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListWithEmptyLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListWithEmptyLiTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -11,7 +10,7 @@ describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
     plugins: 'lists',
     toolbar: 'bullist',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: toggle bullet list on list with two empty LIs', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
       { filter: 'http://media1.tinymce.com' },
       { filter: 'http://media2.tinymce.com', width: 100, height: 200 }
     ]
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Object retained as is', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.media.DataAttributeTest', () => {
       resolve({ html: '<div data-ephox-embed-iri="' + data.url + '" style="max-width: 300px; max-height: 150px"></div>' });
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pTestEmbedContentFromUrlWithAttribute = async (editor: Editor, url: string, content: string) => {
     editor.setContent('');

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
@@ -7,14 +7,13 @@ import Editor from 'tinymce/core/api/Editor';
 import * as DataToHtml from 'tinymce/plugins/media/core/DataToHtml';
 import { MediaData } from 'tinymce/plugins/media/core/Types';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.media.core.DataToHtmlTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: [ 'media' ],
     toolbar: 'media',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pTestDataToHtml = async (editor: Editor, data: MediaData, expected: StructAssert) => {
     const actual = SugarElement.fromHtml(DataToHtml.dataToHtml(editor, data));

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataUnwrapTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataUnwrapTest.ts
@@ -6,14 +6,13 @@ import Editor from 'tinymce/core/api/Editor';
 import { MediaData, MediaDialogData } from 'tinymce/plugins/media/core/Types';
 import Plugin from 'tinymce/plugins/media/Plugin';
 import * as Dialog from 'tinymce/plugins/media/ui/Dialog';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.media.core.DataUnwrapTest', () => {
   TinyHooks.bddSetupLight<Editor>({
     plugins: [ 'media' ],
     toolbar: 'media',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const inputData: MediaDialogData = {
     source: {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DimensionsFalseEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DimensionsFalseEmbedTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.media.DimensionsFalseEmbedTest', () => {
     toolbar: 'media',
     media_dimensions: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const struct = ApproxStructure.build((s, str, arr) => {
     return s.element('body', {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.plugins.media.core.EphoxEmbedTest', () => {
       });
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const ephoxEmbedStructure = ApproxStructure.build((s, str/* , arr*/) => {
     return s.element('div', {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -22,7 +21,7 @@ describe('browser.tinymce.plugins.media.IsCachedResponseTest', () => {
       }
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const pWaitForAndAssertNotification = async (expected: string) => {
     const notification = await UiFinder.pWaitFor('Could not find notification', SugarBody.body(), 'div.tox-notification__body') as SugarElement<HTMLElement>;

--- a/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
@@ -5,14 +5,13 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.media.core.LiveEmbedNodeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: [ 'media' ],
     toolbar: 'media',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const assertStructure = (
     editor: Editor,

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.media.core.MediaEmbedTest', () => {
       });
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Embed content, open dialog, set size and assert custom media_url_resolver formatting', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.media.MediaPluginSanityTest', () => {
         items: 'media'
       });
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Embed content, open dialog, set size and assert constrained and unconstrained size recalculation', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/media/test/ts/browser/NoAdvancedTabTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/NoAdvancedTabTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.media.NoAdvancedTabTest', () => {
     plugins: [ 'media' ],
     toolbar: 'media',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: if alt source and poster set to false, do not show advanced tab', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.media.core.PlaceholderTest', () => {
       { filter: 'http://media2.tinymce.com', width: 100, height: 200 }
     ],
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pTestPlaceholder = async (editor: Editor, url: string, expected: string, struct: StructAssert) => {
     await Utils.pOpenDialog(editor);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ReopenResizeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ReopenResizeTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.media.ReopenResizeTest', () => {
     forced_root_block: false,
     media_live_embeds: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pWaitForResizeHandles = (editor: Editor) =>
     Waiter.pTryUntil('Wait for new width value', () => {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.media.core.SubmitTest', () => {
     plugins: [ 'media' ],
     toolbar: 'media',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const mediaUrlResolver = (data: { url: string }, resolve: (data: { html: string }) => void) => {
     setTimeout(() => {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/UpdateMediaPosterAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/UpdateMediaPosterAttributeTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.media.UpdateMediaPosterAttributeTest', () => {
     plugins: [ 'media' ],
     toolbar: 'media',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const source = 'http://test.se';
   const poster1 = 'https://www.google.com/logos/google.jpg';

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingForceTabTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingForceTabTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import VK from 'tinymce/core/api/util/VK';
 import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.nonbreaking.NonbreakingForceTabTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.nonbreaking.NonbreakingForceTabTest', () => {
     nonbreaking_force_tab: 5,
     theme: 'silver',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Undo level on insert tab', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSanityTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingSanityTest.ts
@@ -5,14 +5,13 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.nonbreaking.NonbreakingSanityTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'nonbreaking',
     toolbar: 'nonbreaking',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   it('TBA: Click on the nbsp button and assert nonbreaking space is inserted', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingVisualCharsTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NonbreakingVisualCharsTest.ts
@@ -6,14 +6,13 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';
 import VisualCharsPlugin from 'tinymce/plugins/visualchars/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.nonbreaking.NonbreakingVisualCharsTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'nonbreaking visualchars',
     toolbar: 'nonbreaking visualchars',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, NonbreakingPlugin, VisualCharsPlugin ]);
+  }, [ NonbreakingPlugin, VisualCharsPlugin ]);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingTypingTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingTypingTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('webdriver.tinymce.plugins.nonbreaking.NonbreakingTypingTest', () => {
   // Note: Uses RealKeys, so needs a browser. Headless won't work.
@@ -14,7 +13,7 @@ describe('webdriver.tinymce.plugins.nonbreaking.NonbreakingTypingTest', () => {
     toolbar: 'nonbreaking',
     nonbreaking_wrap: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const isGecko = Env.browser.isFirefox();
   const isGeckoOrIE = isGecko || Env.browser.isIE();

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingVisualCharsTypingTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingVisualCharsTypingTest.ts
@@ -7,7 +7,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 import Editor from 'tinymce/core/api/Editor';
 import NonbreakingPlugin from 'tinymce/plugins/nonbreaking/Plugin';
 import VisualCharsPlugin from 'tinymce/plugins/visualchars/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('webdriver.tinymce.plugins.nonbreaking.NonbreakingVisualCharsTypingTest', () => {
   // Note: Uses RealKeys, so needs a browser. Headless won't work.
@@ -16,7 +15,7 @@ describe('webdriver.tinymce.plugins.nonbreaking.NonbreakingVisualCharsTypingTest
     toolbar: 'nonbreaking visualchars',
     visualchars_default_state: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, NonbreakingPlugin, VisualCharsPlugin ]);
+  }, [ NonbreakingPlugin, VisualCharsPlugin ]);
 
   const detection = PlatformDetection.detect();
 

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingWrapTypingTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/webdriver/NonbreakingWrapTypingTest.ts
@@ -6,7 +6,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('webdriver.tinymce.plugins.nonbreaking.NonbreakingWrapTypingTest', () => {
   // Note: Uses RealKeys, so needs a browser. Headless won't work.
@@ -15,7 +14,7 @@ describe('webdriver.tinymce.plugins.nonbreaking.NonbreakingWrapTypingTest', () =
     toolbar: 'nonbreaking',
     nonbreaking_wrap: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   const isGecko = Env.browser.isFirefox();
   const isGeckoOrIE = isGecko || Env.browser.isIE();

--- a/modules/tinymce/src/plugins/noneditable/test/ts/browser/NonEditablePluginTest.ts
+++ b/modules/tinymce/src/plugins/noneditable/test/ts/browser/NonEditablePluginTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/noneditable/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.noneditable.NonEditablePluginTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.noneditable.NonEditablePluginTest', () => {
     plugins: 'noneditable',
     entities: 'raw',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   it('TBA: noneditable class', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSanityTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSanityTest.ts
@@ -4,14 +4,13 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/pagebreak/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.pagebreak.PageBreakSanityTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'pagebreak',
     toolbar: 'pagebreak',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   it('TBA: Click on the pagebreak toolbar button and assert pagebreak is inserted', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/pagebreak/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
     toolbar: 'pagebreak',
     pagebreak_split_block: false, // default
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   const clickPageBreak = (editor: Editor) => TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Page break"]');
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ImagePasteTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { Clipboard } from 'tinymce/plugins/paste/api/Clipboard';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.paste.ImagePasteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.paste.ImagePasteTest', () => {
     paste_data_images: true,
     plugins: 'paste',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/InternalClipboardTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/InternalClipboardTest.ts
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import * as InternalHtml from 'tinymce/plugins/paste/core/InternalHtml';
 import PastePlugin from 'tinymce/plugins/paste/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.paste.InternalClipboardTest', () => {
   const browser = PlatformDetection.detect().browser;
@@ -30,7 +29,7 @@ describe('browser.tinymce.plugins.paste.InternalClipboardTest', () => {
       });
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ PastePlugin, TablePlugin, Theme ]);
+  }, [ PastePlugin, TablePlugin ]);
 
   const resetProcessEvents = () => {
     lastPreProcessEvent = null;

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteBinTest.ts
@@ -7,7 +7,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import { getPasteBinParent, PasteBin } from 'tinymce/plugins/paste/core/PasteBin';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface TestCase {
   readonly label: string;
@@ -17,7 +16,6 @@ interface TestCase {
 
 describe('browser.tinymce.plugins.paste.PasteBin', () => {
   before(() => {
-    Theme();
     Plugin();
   });
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteFormatToggleTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteFormatToggleTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.paste.PasteFormatToggleTest', () => {
   before(function () {
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.paste.PasteFormatToggleTest', () => {
     plugins: 'paste',
     valid_styles: 'font-family,color',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: paste plain text', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteSettingsTest.ts
@@ -5,11 +5,9 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.paste.PasteSettingsTest', () => {
   before(() => {
-    Theme();
     Plugin();
   });
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteStylesTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteStylesTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.paste.PasteStylesTest', () => {
   before(function () {
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.paste.PasteStylesTest', () => {
     plugins: 'paste',
     valid_styles: 'font-family,color',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Paste span with encoded style attribute, paste_webkit_styles: font-family', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as Utils from 'tinymce/plugins/paste/core/Utils';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Strings from '../module/test/Strings';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.paste.PasteTest', () => {
     indent: false,
     plugins: 'paste',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PlainTextPasteTest.ts
@@ -7,11 +7,9 @@ import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.paste.PlainTextPaste', () => {
   before(() => {
-    Theme();
     Plugin();
   });
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/ProcessFiltersTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/ProcessFiltersTest.ts
@@ -7,7 +7,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as ProcessFilters from 'tinymce/plugins/paste/core/ProcessFilters';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 type PreProcessHandler = (e: EditorEvent<{ content: string; internal: boolean; wordContent: boolean }>) => void;
 type PostProcessHandler = (e: EditorEvent<{ node: HTMLElement; internal: boolean; wordContent: boolean }>) => void;
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.paste.ProcessFiltersTest', () => {
     plugins: 'paste',
     base_url: '/project/tinymce/js/tinymce',
     extended_valid_elements: 'b[*]'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const processPre = (editor: Editor, html: string, internal: boolean, preProcess: PreProcessHandler) => {
     editor.on('PastePreProcess', preProcess);

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as SmartPaste from 'tinymce/plugins/paste/core/SmartPaste';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 // Test cases for TINY-4523 - image url/anchor link paste smartpaste/pasteAsText interactions
 // Pasting an image anchor link (<a href=”….jpg”>):
@@ -25,7 +24,7 @@ describe('browser.tinymce.plugins.paste.SmartPasteTest', () => {
     indent: false,
     plugins: 'paste',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/paste/test/ts/webdriver/CutTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/webdriver/CutTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/paste/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('webdriver.tinymce.plugins.paste.CutTest', () => {
   before(function () {
@@ -20,7 +19,7 @@ describe('webdriver.tinymce.plugins.paste.CutTest', () => {
     base_url: '/project/tinymce/js/tinymce',
     toolbar: false,
     statusbar: false
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Set and select content, cut using edit menu and assert cut content', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
@@ -5,14 +5,13 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as IframeContent from 'tinymce/plugins/preview/core/IframeContent';
 import Plugin from 'tinymce/plugins/preview/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.preview.PreviewContentCssTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'preview',
     base_url: '/project/tinymce/js/tinymce',
     content_css: '/project/tinymce/js/tinymce/skins/content/default/content.css'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   const assertIframeHtmlContains = (editor: Editor, text: string) => {
     const actual = IframeContent.getPreviewHtml(editor);

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentStyleTest.ts
@@ -5,13 +5,12 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as IframeContent from 'tinymce/plugins/preview/core/IframeContent';
 import Plugin from 'tinymce/plugins/preview/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.preview.PreviewContentStyleTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'preview',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   const assertIframeContains = (editor: Editor, text: string, shouldMatch: boolean) => {
     const actual = IframeContent.getPreviewHtml(editor);

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewSanityTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewSanityTest.ts
@@ -5,14 +5,13 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/preview/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.preview.PreviewSanityTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'preview',
     toolbar: 'preview',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   const dialogSelector = 'div[role="dialog"]';
   const docBody = SugarBody.body();

--- a/modules/tinymce/src/plugins/print/test/ts/browser/PrintSanityTest.ts
+++ b/modules/tinymce/src/plugins/print/test/ts/browser/PrintSanityTest.ts
@@ -3,14 +3,13 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/print/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.print.PrintSanityTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'print',
     toolbar: 'print',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   it('TBA: Assert print button exists', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/quickbars/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.quickbars.ContentEditableTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.quickbars.ContentEditableTest', () => {
     toolbar: false,
     menubar: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ], true);
+  }, [ Plugin ], true);
 
   const pAssertToolbarVisible = () => Waiter.pTryUntil('toolbar should exist', () => UiFinder.exists(SugarBody.body(), '.tox-toolbar'));
 

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import QuickbarsPlugin from 'tinymce/plugins/quickbars/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 enum Alignment {
   Left = 'left',
@@ -21,7 +20,7 @@ describe('browser.tinymce.plugins.quickbars.SelectionToolbarTest', () => {
     toolbar: false,
     menubar: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, LinkPlugin, QuickbarsPlugin ], true);
+  }, [ LinkPlugin, QuickbarsPlugin ], true);
 
   const imgSrc = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarFalseTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarFalseTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/quickbars/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.quickbars.ToolbarFalseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.quickbars.ToolbarFalseTest', () => {
     quickbars_selection_toolbar: false,
     quickbars_image_toolbar: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   const pAssertToolbarNotVisible = async () => {
     // We can't wait for something to happen, as nothing will change. So instead, just wait some time for when the toolbar would have normally shown

--- a/modules/tinymce/src/plugins/save/test/ts/browser/SaveSanityTest.ts
+++ b/modules/tinymce/src/plugins/save/test/ts/browser/SaveSanityTest.ts
@@ -4,14 +4,13 @@ import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@e
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/save/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.save.SaveSanityTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'save',
     toolbar: 'save',
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   it('TBA: Assert Save button is disabled when editor is opened.', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogCyclingTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogCyclingTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogCyclingTest',
     plugins: 'searchreplace',
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   const assertMatchFound = (editor: Editor, index: number) => {
     const matches = SelectorFilter.descendants(TinyDom.body(editor), '.mce-match-marker');

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogTest', () => 
     menubar: false,
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   const browser = PlatformDetection.detect().browser;
 

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceInSelectionTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceInSelectionTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface FindScenario {
   readonly content: string;
@@ -34,7 +33,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceInSelectionTest', (
     plugins: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
     extended_valid_elements: 'b,i'
-  }, [ Theme, Plugin ], true);
+  }, [ Plugin ], true);
 
   const isReplaceScenario = (scenario: FindScenario | ReplaceScenario): scenario is ReplaceScenario => Obj.has(scenario as Record<string, any>, 'replace');
 

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
@@ -5,7 +5,6 @@ import { TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
       edit: { title: 'Edit', items: 'selectall searchreplace' }
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const doc = SugarDocument.getDocument();
 

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePluginTest', () => 
     valid_elements: 'p,b,i,br,span[contenteditable]',
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: SearchReplace: Find no match', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', () =
     plugins: 'searchreplace',
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   const body = SugarBody.body();
 

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.searchreplace.UndoReplaceSpanTest', () => {
     plugins: 'searchreplace',
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme, Plugin ]);
+  }, [ Plugin ]);
 
   it('TBA: replace one of three found, undo and redo and assert there is no matcher spans in editor', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
+++ b/modules/tinymce/src/plugins/tabfocus/test/ts/browser/TabfocusSanityTest.ts
@@ -5,14 +5,13 @@ import { TinyContentActions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/tabfocus/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.tabfocus.TabfocusSanityTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'tabfocus',
     tabfocus_elements: 'tempinput1',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme, Plugin ], true);
+  }, [ Plugin ], true);
 
   before(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/AlignedCellRowStyleChangeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/AlignedCellRowStyleChangeTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../module/test/TableTestUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.table.AlignedCellRowStyleChangeTest', () => {
       '*': 'width,height,vertical-align,text-align,float,border-color,background-color,border,padding,border-spacing,border-collapse'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: Set background color on selected table row with text-align: center', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -8,7 +8,6 @@ import Tools from 'tinymce/core/api/util/Tools';
 import PastePlugin from 'tinymce/plugins/paste/Plugin';
 import { TableEventData } from 'tinymce/plugins/table/api/Events';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.ClipboardTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
       '*': 'width,height,vertical-align,text-align,float,border-color,background-color,border,padding,border-spacing,border-collapse'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ PastePlugin, TablePlugin, Theme ], true);
+  }, [ PastePlugin, TablePlugin ], true);
 
   const cleanTableHtml = (html: string) => html.replace(/<p>(&nbsp;|<br[^>]+>)<\/p>$/, '');
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/DragResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/DragResizeTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.DragResizeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -16,7 +15,7 @@ describe('browser.tinymce.plugins.table.DragResizeTest', () => {
     height: 400,
     base_url: '/project/tinymce/js/tinymce',
     table_sizing_mode: 'fixed'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const dragDrop = (container: SugarElement<HTMLElement>, selector: string, dx: number, dy: number) => {
     const elem = UiFinder.findIn(container, selector).getOrDie();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/DragSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/DragSelectionTest.ts
@@ -4,14 +4,13 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.DragSelectionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     plugins: 'table',
     height: 300
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TINY-5950: Drag and drop should not select', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/EmptyRowTableTest.ts
@@ -3,13 +3,12 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.EmptyRowTableTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     plugins: 'table'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TINY-4679: Empty tr elements should not be removed', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
@@ -6,7 +6,6 @@ import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks } from '@ephox/w
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertSelectedCells, selectWithMouse } from '../module/test/TableTestUtils';
 
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
       '*': 'width,height,vertical-align,text-align,float,border-color,background-color,border,padding,border-spacing,border-collapse'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const simpleTable =
   '<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
@@ -7,14 +7,13 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 import * as Helpers from 'tinymce/plugins/table/ui/Helpers';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.HelpersTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: extractDataFromCellElement 1', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/IndentListsInTableTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.IndentListsInTableTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.table.IndentListsInTableTest', () => {
     toolbar: 'table numlist',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ ListsPlugin, TablePlugin, Theme ], true);
+  }, [ ListsPlugin, TablePlugin ], true);
 
   const assertTableInnerHTML = (editor: Editor, expected: string) => {
     const table = editor.getBody().firstChild as HTMLTableElement;

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InlineEditorInsideTableTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const findAll = (selector: string) => UiFinder.findAllIn(SugarBody.body(), selector);
 
@@ -40,7 +39,7 @@ describe('browser.tinymce.plugins.table.InlineEditorInsideTableTest', () => {
     plugins: 'table',
     menubar: 'table',
     statusbar: false
-  }, setupElement, [ Plugin, Theme ]);
+  }, setupElement, [ Plugin ]);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableSizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableSizeTest.ts
@@ -5,7 +5,6 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../module/test/TableTestUtils';
 
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.table.InsertColumnTableSizeTest', () => {
     plugins: 'table',
     width: 400,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const emptyTable = {
     html: '<table style = "width: 100%;">' +

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertRowTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertRowTableResizeTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../module/test/TableTestUtils';
 
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.table.InsertRowTableResizeTest', () => {
     setup: (editor) => {
       editor.on('ObjectResized', () => objectResizedCounter++);
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const emptyTable = {
     html: '<table style = "width: 100%;">' +

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { insertTableTest } from '../module/test/TableTestUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.table.InsertTableTest', () => {
     },
     base_url: '/project/tinymce/js/tinymce',
     statusbar: false
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: insert 2x2 table', () =>
     insertTableTest(hook.editor(), 2, 2, [

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableWidthsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableWidthsTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { insertTable, getWidths } from '../module/test/TableTestUtils';
 
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.table.InsertTableWidthsTest', () => {
         width: 800,
         height: 400,
         base_url: '/project/tinymce/js/tinymce'
-      }, [ Plugin, Theme ]);
+      }, [ Plugin ]);
 
       beforeEach(() => {
         hook.editor().setContent('');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableWithColGroupsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertTableWithColGroupsTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { insertTableTest } from '../module/test/TableTestUtils';
 
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.table.InsertTableWithColGroupsTest', () => {
     base_url: '/project/tinymce/js/tinymce',
     statusbar: false,
     table_use_colgroups: true
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TINY-6050: insert 2x2 table', () =>
     insertTableTest(hook.editor(), 2, 2, [

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InvalidColCountTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InvalidColCountTest.ts
@@ -6,13 +6,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.InvalidColCountTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const assertBasicTablePresence = (editor: Editor, tdCount: number, colCountOpt: Optional<number>) => {
     TinyAssertions.assertContentPresence(editor, {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/KeyboardCellNavigationTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/KeyboardCellNavigationTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.quirks.KeyboardCellNavigationTest', () => {
   before(function () {
@@ -21,7 +20,7 @@ describe('browser.tinymce.plugins.table.quirks.KeyboardCellNavigationTest', () =
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce',
     height: 300
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const selectionChangeState = Cell(false);
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ModifyColumnsTableResizeTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface TableCommandMap {
   readonly mceTableInsertColBefore: number;
@@ -59,7 +58,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         ...baseSettings,
         table_sizing_mode: 'responsive',
         table_column_resizing: 'preservetable',
-      }, [ Plugin, Theme ]);
+      }, [ Plugin ]);
 
       it('TINY-6711: will resize table because responsive tables cannot honour this setting', () => {
         const editor = hook.editor();
@@ -162,7 +161,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         ...baseSettings,
         table_sizing_mode: 'responsive',
         table_column_resizing: 'resizetable',
-      }, [ Plugin, Theme ]);
+      }, [ Plugin ]);
 
       it('TINY-6711: should resize table when inserting a column', () => {
         const editor = hook.editor();
@@ -271,7 +270,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         ...baseSettings,
         table_sizing_mode: 'fixed',
         table_column_resizing: 'preservetable',
-      }, [ Plugin, Theme ]);
+      }, [ Plugin ]);
 
       it('TINY-6711: should preserve table width when inserting a column', () => {
         const editor = hook.editor();
@@ -374,7 +373,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         ...baseSettings,
         table_sizing_mode: 'fixed',
         table_column_resizing: 'resizetable',
-      }, [ Plugin, Theme ]);
+      }, [ Plugin ]);
 
       it('TINY-6711: should resize table when inserting a column', () => {
         const editor = hook.editor();
@@ -480,7 +479,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         ...baseSettings,
         table_sizing_mode: 'relative',
         table_column_resizing: 'preservetable',
-      }, [ Plugin, Theme ]);
+      }, [ Plugin ]);
 
       it('TINY-6711: should preserve table width when inserting a column', () => {
         const editor = hook.editor();
@@ -583,7 +582,7 @@ describe('browser.tinymce.plugins.table.ModifyColumnsTableResizeTest', () => {
         ...baseSettings,
         table_sizing_mode: 'relative',
         table_column_resizing: 'resizetable',
-      }, [ Plugin, Theme ]);
+      }, [ Plugin ]);
 
       it('TINY-6711: should resize table when inserting a column', () => {
         const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NestedFakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NestedFakeSelectionTest.ts
@@ -5,7 +5,6 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertSelectedCells, selectWithKeyboard, selectWithMouse } from '../module/test/TableTestUtils';
 
@@ -24,7 +23,7 @@ describe('browser.tinymce.plugins.table.NestedFakeSelectionTest', () => {
       '*': 'width,height,vertical-align,text-align,float,border-color,background-color,border,padding,border-spacing,border-collapse'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const basicNestedTable =
   '<table>' +

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NewCellRowEventsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NewCellRowEventsTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.NewCellRowEventsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.table.NewCellRowEventsTest', () => {
       '*': 'width,height,vertical-align,text-align,float,border-color,background-color,border,padding,border-spacing,border-collapse'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Table newcell/newrow events', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ResizeTableTest.ts
@@ -12,7 +12,6 @@ import { ObjectResizeEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../module/test/TableTestUtils';
 
@@ -154,7 +153,7 @@ describe('browser.tinymce.plugins.table.ResizeTableTest', () => {
   });
 
   context('table_sizing_mode=unset (default config)', () => {
-    const hook = TinyHooks.bddSetup<Editor>(defaultSettings, [ Plugin, Theme ]);
+    const hook = TinyHooks.bddSetup<Editor>(defaultSettings, [ Plugin ]);
 
     it('TBA: resize should detect current unit for % table', async () => {
       const editor = hook.editor();
@@ -200,7 +199,7 @@ describe('browser.tinymce.plugins.table.ResizeTableTest', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       ...defaultSettings,
       table_sizing_mode: 'relative'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TBA: new tables should default to % and resize should force %', async () => {
       const editor = hook.editor();
@@ -236,7 +235,7 @@ describe('browser.tinymce.plugins.table.ResizeTableTest', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       ...defaultSettings,
       table_sizing_mode: 'fixed'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TBA: new tables should default to px and resize should force px', async () => {
       const editor = hook.editor();
@@ -271,7 +270,7 @@ describe('browser.tinymce.plugins.table.ResizeTableTest', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       ...defaultSettings,
       table_sizing_mode: 'responsive'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6051: new tables should default to no widths and resize should force %', async () => {
       const editor = hook.editor();
@@ -308,7 +307,7 @@ describe('browser.tinymce.plugins.table.ResizeTableTest', () => {
       ...defaultSettings,
       table_column_resizing: 'preservetable',
       table_sizing_mode: 'fixed'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6001: adjusting an inner column should not change the table width', async () => {
       const editor = hook.editor();
@@ -347,7 +346,7 @@ describe('browser.tinymce.plugins.table.ResizeTableTest', () => {
       ...defaultSettings,
       table_column_resizing: 'resizetable',
       table_sizing_mode: 'fixed'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6001: adjusting an inner column should change the table width', async () => {
       const editor = hook.editor();
@@ -388,7 +387,7 @@ describe('browser.tinymce.plugins.table.ResizeTableTest', () => {
       ...defaultSettings,
       table_column_resizing: 'resizetable',
       table_sizing_mode: 'relative'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6242: adjusting the entire table should not resize more than the last column width', async () => {
       const editor = hook.editor();
@@ -415,7 +414,7 @@ describe('browser.tinymce.plugins.table.ResizeTableTest', () => {
       table_column_resizing: 'resizetable',
       table_use_colgroups: true,
       table_sizing_mode: 'responsive'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6601: adjusting the entire table should not resize more than the last column width', async () => {
       const editor = hook.editor();
@@ -436,7 +435,7 @@ describe('browser.tinymce.plugins.table.ResizeTableTest', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       ...defaultSettings,
       table_column_resizing: 'resizetable'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6646: with responsive colgroup table, adjusting an inner column with content', async () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/SwitchTableSectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/SwitchTableSectionTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
   const basicContent = `<table>
@@ -202,7 +201,7 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
       plugins: 'table',
       base_url: '/project/tinymce/js/tinymce',
       table_header_type: 'section'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6007: Switch from body to header', () =>
       switchToHeader(hook.editor(), basicContent, theadExpected)
@@ -238,7 +237,7 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
       plugins: 'table',
       base_url: '/project/tinymce/js/tinymce',
       table_header_type: 'cells'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6007: Switch from body to header', () =>
       switchToHeader(hook.editor(), basicContent, thsExpected)
@@ -274,7 +273,7 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
       plugins: 'table',
       base_url: '/project/tinymce/js/tinymce',
       table_header_type: 'sectionCells'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6007: Switch from body to header', () =>
       switchToHeader(hook.editor(), basicContent, bothExpected)
@@ -314,7 +313,7 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
       plugins: 'table',
       base_url: '/project/tinymce/js/tinymce',
       table_header_type: 'auto'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6007: switch to a header when one already exists using detection (section)', () =>
       switchExistingHeader(hook.editor(), theadExpected, existingTheadExpected)
@@ -350,7 +349,7 @@ describe('browser.tinymce.plugins.table.SwitchTableSectionTest', () => {
       plugins: 'table',
       base_url: '/project/tinymce/js/tinymce',
       table_header_type: 'foo'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6007: Setting an invalid option defaults to section when switching header', () =>
       switchToHeader(hook.editor(), basicContent, theadExpected)

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TabKeyNavigationTest.ts
@@ -7,7 +7,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.TabKeyNavigationTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.table.TabKeyNavigationTest', () => {
       '*': 'width,height,vertical-align,text-align,float,border-color,background-color,border,padding,border-spacing,border-collapse'
     },
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
   const logEvent = (event: EditorEvent<TableModifiedEvent>) => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableCellPropsStyleTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableCellPropsStyleTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../module/test/TableTestUtils';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.table.TableCellPropsStyleTest', () => {
     plugins: 'table',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TBA: change background color on selected table cells', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableFormatsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableFormatsTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../module/test/TableTestUtils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.plugins.table.TableFormatsTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const beforeTable = (selectedCells: SelectedCells = {}) => {
     const { cell1, cell2, cell3, cell4 } = selectedCells;

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableNoWidthTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableNoWidthTest.ts
@@ -3,14 +3,13 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.TableNoWidthTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'table',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TINY-6051: Removing and adding a column doesn\'t add sizes', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSectionApiTest.ts
@@ -9,7 +9,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
   const bodyContent = `<table>
@@ -246,7 +245,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       ...defaultSettings,
       table_header_type: 'section'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6150: Switch from body to header row', () =>
       switchType(hook.editor(), bodyContent, theadContent, 'mceTableRowType', 'header')
@@ -261,7 +260,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       ...defaultSettings,
       table_header_type: 'cells'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6150: Switch from body to header row', () =>
       switchType(hook.editor(), bodyContent, thsContent, 'mceTableRowType', 'header', [ 'newcell', 'tablemodified' ])
@@ -276,7 +275,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       ...defaultSettings,
       table_header_type: 'sectionCells'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6150: Switch from body to header row', () =>
       switchType(hook.editor(), bodyContent, theadThsContent, 'mceTableRowType', 'header', [ 'newcell', 'tablemodified' ])
@@ -291,7 +290,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       ...defaultSettings,
       table_header_type: 'foo'
-    }, [ Plugin, Theme ]);
+    }, [ Plugin ]);
 
     it('TINY-6150: Switch from body to header row', () =>
       switchType(hook.editor(), bodyContent, theadContent, 'mceTableRowType', 'header')
@@ -299,7 +298,7 @@ describe('browser.tinymce.plugins.table.TableSectionApiTest', () => {
   });
 
   context('Basic tests', () => {
-    const hook = TinyHooks.bddSetupLight<Editor>(defaultSettings, [ Plugin, Theme ]);
+    const hook = TinyHooks.bddSetupLight<Editor>(defaultSettings, [ Plugin ]);
 
     context('Switch row types', () => {
       it('TINY-6150: Switch header row to body row', () =>

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableSizingModeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableSizingModeTest.ts
@@ -6,14 +6,13 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.TableSizingModeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     width: 800,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const test = (editor: Editor, assertion: ApproxStructure.Builder<StructAssert>, defaultStyles?: Record<string, string>) => {
     editor.setContent('');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const enum Direction {
   Row,
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.table.TwoCellsSelectionTest', () => {
     plugins: 'table',
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const setup = (editor: Editor, colgroup: boolean, direction: Direction) => {
     editor.setContent(

--- a/modules/tinymce/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
@@ -6,7 +6,6 @@ import { TinyContentActions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../module/test/TableTestUtils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.plugins.table.UnmergeCellTableResizeTest', () => {
     plugins: 'table',
     width: 400,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const emptyTable: Scenario = {
     html: '<table style = "width: 100%;">' +

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/ApplyCellStyleCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/ApplyCellStyleCommandTest.ts
@@ -9,7 +9,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.plugins.table.command.ApplyCellStyleCommandTest', () =
     setup: (editor: Editor) => {
       editor.on('tablemodified', logEvent);
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
   const logEvent = (event: EditorEvent<TableModifiedEvent>) => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/CommandsOnLockedColumnsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/CommandsOnLockedColumnsTest.ts
@@ -9,7 +9,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -28,7 +27,7 @@ describe('browser.tinymce.plugins.table.command.CommandsOnLockedColumnsTest', ()
     setup: (editor: Editor) => {
       editor.on('tablemodified', logEvent);
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
   const logEvent = (event: EditorEvent<TableModifiedEvent>) => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertCommandsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertCommandsTest.ts
@@ -6,7 +6,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.command.InsertCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.table.command.InsertCommandsTest', () => {
     setup: (editor: Editor) => {
       editor.on('tablemodified', logEvent);
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const cleanTableHtml = (html: string) =>
     html.replace(/<p>(&nbsp;|<br[^>]+>)<\/p>$/, '');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertTableStructureWithSizes, insertTable } from '../../module/test/TableTestUtils';
 
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.table.command.InsertTableCommandTest', () => {
     base_url: '/project/tinymce/js/tinymce',
     statusbar: false,
     table_header_type: 'cells'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const assertNumNewUndoLevels = (editor: Editor, expected: number) => {
     // Add one to expected to account for the initial undo level

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandWithColGroupsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/InsertTableCommandWithColGroupsTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertTableStructureWithSizes, insertTable } from '../../module/test/TableTestUtils';
 
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.table.command.InsertTableCommandWithColGroupsT
     statusbar: false,
     table_header_type: 'cells',
     table_use_colgroups: true
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   beforeEach(() => {
     hook.editor().setContent('');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableEventData } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 type TableModifiedEvent = EditorEvent<TableEventData>;
 
@@ -24,7 +23,7 @@ describe('browser.tinymce.plugins.table.command.MergeCellCommandTest', () => {
     base_url: '/project/tinymce/js/tinymce',
     indent: false,
     setup: (ed: Editor) => ed.on('TableModified', logModifiedEvent),
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   let modifiedEvents = [];
   const logModifiedEvent = (event: TableModifiedEvent) => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/ModifyClassesCommandsTest.ts
@@ -6,7 +6,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.table.command.ModifyClassesCommandsTest', () =
     setup: (editor: Editor) => {
       editor.on('tablemodified', logEvent);
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
   const logEvent = (event: EditorEvent<TableModifiedEvent>) => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/TableDeleteColumnTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/TableDeleteColumnTest.ts
@@ -7,7 +7,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.command.TableDeleteColumnTest', () => {
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
@@ -18,7 +17,7 @@ describe('browser.tinymce.plugins.table.command.TableDeleteColumnTest', () => {
     setup: (editor: Editor) => {
       editor.on('tablemodified', logEvent);
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   afterEach(() => {
     events = [];

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { tableSizingModeScenarioTest } from '../../module/test/TableSizingModeCommandUtil';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.table.command.TableSizingModeCommandTest', () 
     content_css: false,
     content_style: 'body { margin: 10px; max-width: 800px }',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TINY-6000: Percent (relative) to pixel (fixed) sizing', () => tableSizingModeScenarioTest(hook.editor(), false, {
     mode: 'relative',

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandWithColGroupsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/TableSizingModeCommandWithColGroupsTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { tableSizingModeScenarioTest } from '../../module/test/TableSizingModeCommandUtil';
 
@@ -16,7 +15,7 @@ describe('browser.tinymce.plugins.table.command.TableSizingModeCommandWithColGro
     content_style: 'body { margin: 10px; max-width: 800px }',
     base_url: '/project/tinymce/js/tinymce',
     table_use_colgroups: true
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TINY-6000, TINY-6050: Percent (relative) to pixel (fixed) sizing', () => tableSizingModeScenarioTest(hook.editor(), true, {
     mode: 'relative',

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/CustomTableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/CustomTableToolbarTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.table.CustomTableToolbarTest', () => {
     plugins: 'table',
     table_toolbar: 'tableprops tabledelete',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('test custom count of toolbar buttons', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/DefaultTableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/DefaultTableToolbarTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.table.DefaultTableToolbarTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('test default count of toolbar buttons', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableAppearanceOptionsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableAppearanceOptionsTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.table.TableAppearanceTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const tableHtml = '<table><tbody><tr><td>x</td></tr></tbody></table>';
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableCellClassListTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableCellClassListTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -11,7 +10,7 @@ describe('browser.tinymce.plugins.table.TableCellClassListTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const tableHtml = '<table><tbody><tr><td>x</td></tr></tbody></table>';
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableClassListTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableClassListTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -11,7 +10,7 @@ describe('browser.tinymce.plugins.table.TableClassListTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const tableHtml = '<table><tbody><tr><td>x</td></tr></tbody></table>';
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.table.TableDefaultAttributesTest', () => {
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce',
     statusbar: false
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   beforeEach(() => {
     hook.editor().setContent('');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesWithColGroupsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultAttributesWithColGroupsTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.table.TableDefaultAttributesWithColGroupsTest'
     base_url: '/project/tinymce/js/tinymce',
     statusbar: false,
     table_use_colgroups: true
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   beforeEach(() => {
     hook.editor().setContent('');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultStylesTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableDefaultStylesTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.table.TableDefaultStylesTest', () => {
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce',
     statusbar: false
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('no styles without setting', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
@@ -4,14 +4,13 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.TableGridFalse', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'table',
     table_grid: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('test table grid disabled', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableRowClassListTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableRowClassListTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -11,7 +10,7 @@ describe('browser.tinymce.plugins.table.TableRowClassListTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const tableHtml = '<table><tbody><tr><td>x</td></tr></tbody></table>';
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableTabNavigationDisabledTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableTabNavigationDisabledTest.ts
@@ -4,14 +4,13 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.TableTableNavigationDisabledTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     table_tab_navigation: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const tableHtml = '<table><tbody><tr><td>a</td></tr><tr><td>a</td></tr></tbody></table>';
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
@@ -5,12 +5,10 @@ import { McEditor, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
   before(() => {
     Plugin();
-    Theme();
   });
 
   const tableHtml = '<table><tbody><tr><td>x</td></tr></tbody></table>';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
@@ -3,14 +3,13 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.ToolbarButtonDisplayTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     toolbar: 'tablecaption',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const pDisplayTest = async (startPath: number[], startOffset: number, endPath: number[], endOffset: number, shouldBeEnabled: boolean) => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextMenuTest.ts
@@ -6,7 +6,6 @@ import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.ContextMenuTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.table.ContextMenuTest', () => {
     toolbar: 'table',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const pOpenContextMenu = async (editor: Editor, target: string) => {
     await TinyUiActions.pTriggerContextMenu(editor, target, '.tox-silver-sink [role="menuitem"]');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextToolbarTest.ts
@@ -6,13 +6,12 @@ import { TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions }
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.ContextToolbarTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const tableHtml = '<table style = "width: 5%;">' +
   '<tbody>' +

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/LockedColumnDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/LockedColumnDisabledButtonsTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface ButtonDetails {
   readonly name: string;
@@ -70,7 +69,7 @@ describe('browser.tinymce.plugins.table.LockedColumnDisabledButtonsTest', () => 
     plugins: 'table',
     toolbar,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const table = (lockedColumns: number[] = [ 0 ]) =>
     `<table data-snooker-locked-cols="${lockedColumns.join(',')}">` +

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderStyleTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderStyleTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAssertStyleCanBeToggledOnAndOff, setEditorContentTableAndSelection } from '../../module/test/TableModifiersTestUtils';
 import * as TableTestUtils from '../../module/test/TableTestUtils';
@@ -28,7 +27,7 @@ describe('browser.tinymce.plugins.table.ui.TableBorderStyleTest', () => {
         value: ''
       },
     ]
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TINY-7478: Ensure the table border style adds and removes it as expected for a single cell', async () =>
     await pAssertStyleCanBeToggledOnAndOff(hook.editor(), {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderWidthTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableBorderWidthTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAssertStyleCanBeToggledOnAndOff } from '../../module/test/TableModifiersTestUtils';
 
@@ -27,7 +26,7 @@ describe('browser.tinymce.plugins.table.ui.TableBorderWidthTest', () => {
         value: ''
       },
     ]
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TINY-7478: Ensure the table border width adds and removes it as expected with a single cell', async () =>
     await pAssertStyleCanBeToggledOnAndOff(hook.editor(), {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
@@ -6,7 +6,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertStructureIsRestoredToDefault, clickOnButton, pClickOnMenuItem, setEditorContentTableAndSelection } from '../../module/test/TableModifiersTestUtils';
 
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.table.ui.TableCaptionTest', () => {
       table: { title: 'Table', items: 'tablecaption' },
     },
     menubar: 'table',
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
   const logEvent = (event: EditorEvent<TableModifiedEvent>) => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellBackgroundColorTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellBackgroundColorTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAssertStyleCanBeToggledOnAndOffWithoutCheckmarks } from '../../module/test/TableModifiersTestUtils';
 
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.table.ui.TableCellBackgroundColorTest', () => 
         value: '#51a951',
       }
     ],
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TINY-7476: The color should be changed for a single cell', async () => {
     await pAssertStyleCanBeToggledOnAndOffWithoutCheckmarks(hook.editor(), {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellBorderColorTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellBorderColorTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAssertStyleCanBeToggledOnAndOffWithoutCheckmarks } from '../../module/test/TableModifiersTestUtils';
 
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.table.ui.TableCellBorderColorTest', () => {
         value: '#159a15',
       }
     ],
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   it('TINY-7476: The color should be changed for a single cell', async () => {
     await pAssertStyleCanBeToggledOnAndOffWithoutCheckmarks(hook.editor(), {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -7,7 +7,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableEventData, TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -27,7 +26,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
       });
       editor.on('newcell', logEventTypes);
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const generalSelectors = {
     width: 'label.tox-label:contains(Width) + input.tox-textfield',

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableClassListButtonsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableClassListButtonsTest.ts
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAssertMenuPresence, pAssertNoCheckmarksInMenu, setEditorContentTableAndSelection } from '../../module/test/TableModifiersTestUtils';
 
@@ -63,7 +62,7 @@ describe('browser.tinymce.plugins.table.ui.TableClassListButtonsTest', () => {
     setup: (editor: Editor) => {
       editor.on('tablemodified', logEvent);
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
   const logEvent = (event: EditorEvent<TableModifiedEvent>) => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableColumnHeaderUiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableColumnHeaderUiTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { clickOnButton, makeCell, pClickOnMenuItem } from '../../module/test/TableModifiersTestUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.table.ui.TableColumnHeaderUiTest', () => {
     menubar: 'table',
     toolbar: 'tablecolheader',
     indent: false,
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const setEditorAndSelectionForOn = (editor: Editor, type: 'th' | 'td') => {
     editor.setContent(

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     toolbar: 'tableprops',
     base_url: '/project/tinymce/js/tinymce',
     table_advtab: true
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   // Table html structure
   const htmlEmptyTable = '<table><tr><td>X</td></tr></table>';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogStyleWithCssTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogStyleWithCssTest.ts
@@ -6,7 +6,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -98,7 +97,7 @@ describe('browser.tinymce.plugins.table.ui.TableCellDialogStyleWithCssTest', () 
         base_url: '/project/tinymce/js/tinymce',
         toolbar: 'tableprops',
         table_style_by_css: spec.style_by_css
-      }, [ Plugin, Theme ]);
+      }, [ Plugin ]);
 
       it('TINY-4926: falls back to cellpadding attribute if no CSS is defined', async () => {
         const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     },
     table_advtab: false,
     statusbar: false
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const generalSelectors = {
     width: 'label.tox-label:contains(Width) + input.tox-textfield',

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { TableModifiedEvent } from 'tinymce/plugins/table/api/Events';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as TableTestUtils from '../../module/test/TableTestUtils';
 
@@ -24,7 +23,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     setup: (editor: Editor) => {
       editor.on('tablemodified', logEvent);
     }
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const generalSelectors = {
     type: 'label.tox-label:contains(Row type) + div.tox-listboxfield > .tox-listbox',

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowHeaderUiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowHeaderUiTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { clickOnButton, makeCell, pClickOnMenuItem } from '../../module/test/TableModifiersTestUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.table.ui.TableRowHeaderUiTest', () => {
     menubar: 'table',
     toolbar: 'tablerowheader',
     indent: false,
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const setEditorContentAndSelection = (editor: Editor, tableSection: 'thead' | 'tbody') => {
     editor.setContent(

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableValignButtonsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableValignButtonsTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAssertStyleCanBeToggledOnAndOff } from '../../module/test/TableModifiersTestUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.table.ui.TableValignButtonsTest', () => {
     },
     menubar: 'table',
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   context('Test for a single cell selection', () => {
     it('TINY-7477: Check that valign works for Top value', async () =>

--- a/modules/tinymce/src/plugins/template/test/ts/browser/DatesTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/DatesTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pInsertTemplate } from '../module/InsertTemplate';
 import { Settings } from '../module/Settings';
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.template.DatesTest', () => {
     plugins: 'template',
     toolbar: 'template',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const { addSettings, cleanupSettings } = Settings(hook);
 

--- a/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
@@ -6,7 +6,6 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 import Plugin from 'tinymce/plugins/template/Plugin';
 import { getPreviewContent } from 'tinymce/plugins/template/ui/Dialog';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { Settings } from '../module/Settings';
 
@@ -64,7 +63,7 @@ describe('browser.tinymce.plugins.template.Dialog.getPreviewContent', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'template',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const checkPreview = (expected: string, html: string = '') => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/template/test/ts/browser/InvalidUrlTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/InvalidUrlTest.ts
@@ -5,7 +5,6 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const dialogSelector = 'div.tox-dialog';
 const alertDialogSelector = 'div.tox-dialog.tox-alert-dialog';
@@ -16,7 +15,7 @@ describe('browser.tinymce.plugins.template.InvalidUrlTest', () => {
     plugins: 'template',
     toolbar: 'template',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Test loading in snippet from file that does not exist', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/template/test/ts/browser/SelectedContentTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/SelectedContentTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pInsertTemplate } from '../module/InsertTemplate';
 import { Settings } from '../module/Settings';
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.template.SelectedContentTest', () => {
     plugins: 'template',
     toolbar: 'template',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const { addSettings, cleanupSettings } = Settings(hook);
 

--- a/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pInsertTemplate } from '../module/InsertTemplate';
 import { Settings } from '../module/Settings';
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.template.TemplateSanityTest', () => {
     plugins: 'template',
     toolbar: 'template',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const { addSettings, cleanupSettings } = Settings(hook);
 

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/FindInlinePatternTest.ts
@@ -10,7 +10,6 @@ import { findPatterns } from 'tinymce/plugins/textpattern/core/InlinePattern';
 import { InlinePattern, InlinePatternMatch } from 'tinymce/plugins/textpattern/core/PatternTypes';
 import TextPatternPlugin from 'tinymce/plugins/textpattern/Plugin';
 import { PathRange } from 'tinymce/plugins/textpattern/utils/PathRange';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface ExpectedPatternMatch {
   readonly pattern: Partial<InlinePattern>;
@@ -23,7 +22,7 @@ describe('browser.tinymce.plugins.textpattern.FindInlinePatternTest', () => {
     forced_root_block: false,
     plugins: 'textpattern lists',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ ListsPlugin, TextPatternPlugin, Theme ]);
+  }, [ ListsPlugin, TextPatternPlugin ]);
 
   const mockEditor = {
     getParam: () =>

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/ReplacementTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/ReplacementTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/textpattern/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.plugins.textpattern.ReplacementTest', () => {
     indent: false,
     plugins: 'textpattern',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginForcedRootBlockFalseTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import TextPatternPlugin from 'tinymce/plugins/textpattern/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -13,7 +12,7 @@ describe('browser.tinymce.plugins.textpattern.TextPatternPluginForcedRootBlockFa
     plugins: 'textpattern lists',
     base_url: '/project/tinymce/js/tinymce',
     forced_root_block: false
-  }, [ ListsPlugin, TextPatternPlugin, Theme ]);
+  }, [ ListsPlugin, TextPatternPlugin ]);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextPatternPluginTest.ts
@@ -8,7 +8,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import TextPatternPlugin from 'tinymce/plugins/textpattern/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.plugins.textpattern.TextPatternPluginTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'textpattern lists',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ ListsPlugin, TextPatternPlugin, Theme ]);
+  }, [ ListsPlugin, TextPatternPlugin ]);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextSearchTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TextSearchTest.ts
@@ -9,14 +9,13 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/textpattern/Plugin';
 import * as TextSearch from 'tinymce/plugins/textpattern/text/TextSearch';
 import { SpotPoint } from 'tinymce/plugins/textpattern/utils/Spot';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.textpattern.TextSearchTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'textpattern',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TrailingPunctuationTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TrailingPunctuationTest.ts
@@ -4,13 +4,12 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/textpattern/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.textpattern.TrailingPunctuationTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'textpattern',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   const pTypeAndTriggerTest = (patternText: string, trigger: string, tag: string, rawText: string) => async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/TriggerInlinePatternBeginningTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/TriggerInlinePatternBeginningTest.ts
@@ -4,14 +4,13 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/textpattern/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.textpattern.TriggerInlinePatternBeginningTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'textpattern',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ], true);
+  }, [ Plugin ], true);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/textpattern/test/ts/browser/UndoTextPatternTest.ts
+++ b/modules/tinymce/src/plugins/textpattern/test/ts/browser/UndoTextPatternTest.ts
@@ -3,7 +3,6 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/textpattern/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as Utils from '../module/test/Utils';
 
@@ -11,7 +10,7 @@ describe('browser.tinymce.plugins.textpattern.UndoTextPatternTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'textpattern',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   beforeEach(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
+++ b/modules/tinymce/src/plugins/toc/test/ts/browser/TocPluginTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 import Plugin from 'tinymce/plugins/toc/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.plugins.toc.TocPluginTest', () => {
     toc_depth: 2,
     toc_header: 'h3',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const stripAttribs = (el: Element, attr: string[] | string): void => {
     if (Tools.isArray(attr)) {

--- a/modules/tinymce/src/plugins/visualblocks/test/ts/browser/PreviewFormatTest.ts
+++ b/modules/tinymce/src/plugins/visualblocks/test/ts/browser/PreviewFormatTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/visualblocks/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.visualblocks.PreviewFormatsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -21,7 +20,7 @@ describe('browser.tinymce.plugins.visualblocks.PreviewFormatsTest', () => {
         border: 13px solid black;
       }
     `
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const pWaitForVisualBlocks = (editor: Editor, waitUntilEnabled: boolean = true) =>
     Waiter.pTryUntil('Wait for background css to be applied to first element', () => {

--- a/modules/tinymce/src/plugins/visualblocks/test/ts/browser/VisualBlocksSanityTest.ts
+++ b/modules/tinymce/src/plugins/visualblocks/test/ts/browser/VisualBlocksSanityTest.ts
@@ -4,14 +4,13 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/visualblocks/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.visualblocks.VisualBlocksSanityTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'visualblocks',
     toolbar: 'visualblocks',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Assert visual blocks are not present, click on the visual blocks button and assert they are present, click on the button again and assert they are not present', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/DefaultStateTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/DefaultStateTest.ts
@@ -4,7 +4,6 @@ import { TinyAssertions, TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-m
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/visualchars/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertNbspStruct, assertSpanStruct } from '../module/test/Utils';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.plugins.visualchars.DefaultStateTest', () => {
     toolbar: 'visualchars',
     base_url: '/project/tinymce/js/tinymce',
     visualchars_default_state: true
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('tests the default visualchars state', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/InlinePluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/InlinePluginTest.ts
@@ -4,7 +4,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/visualchars/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.visualchars.InlinePluginTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -12,7 +11,7 @@ describe('browser.tinymce.plugins.visualchars.InlinePluginTest', () => {
     plugins: 'visualchars',
     toolbar: 'visualchars',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TINY-6282: Editor should not steal focus when loaded inline with visualchars', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/visualchars/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertSpanStruct, assertNbspStruct, assertStruct } from '../module/test/Utils';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.plugins.visualchars.PluginTest', () => {
     plugins: 'visualchars',
     toolbar: 'visualchars',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   it('TBA: Set content, click visual chars button and assert span char is present in whitespaces, click the button again and assert no span is present in the whitespace', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/PluginTest.ts
@@ -6,13 +6,12 @@ import { assert } from 'chai';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/wordcount/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.wordcount.PluginTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'wordcount',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ () => Plugin(2), Theme ], true);
+  }, [ () => Plugin(2) ], true);
 
   beforeEach(() => {
     hook.editor().setContent('');

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/api/ApiTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/api/ApiTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { WordCountApi } from 'tinymce/plugins/wordcount/api/Api';
 import Plugin from 'tinymce/plugins/wordcount/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface Sel {
   readonly startPath: number[];
@@ -19,7 +18,7 @@ describe('browser.tinymce.plugins.wordcount.ApiTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'wordcount',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const createTest = (getCount: (api: WordCountApi) => number) => (content: string, expectedLength: number, sel?: Sel) => () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/wordcount/test/ts/browser/core/GetTextTest.ts
+++ b/modules/tinymce/src/plugins/wordcount/test/ts/browser/core/GetTextTest.ts
@@ -5,13 +5,12 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { getText } from 'tinymce/plugins/wordcount/core/GetText';
 import Plugin from 'tinymce/plugins/wordcount/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.plugins.wordcount.GetTextTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'wordcount',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin, Theme ]);
+  }, [ Plugin ]);
 
   const assertGetText = (node: Node, expected: string[]) => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
@@ -7,7 +7,6 @@ import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
   const platform = PlatformDetection.detect();
@@ -95,7 +94,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
         items: 'form:test-form'
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   const openToolbar = (editor: Editor, toolbarKey: string) => {
     editor.fire('contexttoolbar-show', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/DisableTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/DisableTest.ts
@@ -5,12 +5,11 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.DisableTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const pAssertUiDisabled = async (editor: Editor, disabled: boolean) => {
     const overlord = UiFinder.findIn(SugarBody.body(), '.tox-toolbar-overlord').getOrDie();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/EventsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/EventsTest.ts
@@ -5,7 +5,6 @@ import { McEditor, TinyContentActions, TinyDom, TinyUiActions } from '@ephox/wra
 
 import Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.EventsTest', () => {
   const settings = {
@@ -21,7 +20,6 @@ describe('browser.tinymce.themes.silver.editor.EventsTest', () => {
   const editMenuButtonSelector = 'button:contains("Edit")';
 
   before(() => {
-    Theme();
     LinkPlugin();
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
@@ -3,7 +3,6 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.MenuGroupHeadingTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +13,7 @@ describe('browser.tinymce.themes.silver.editor.MenuGroupHeadingTest', () => {
       { title: 'Table styles' },
       { title: 'Table row 1', selector: 'tr', classes: 'tablerow1' }
     ]
-  }, [ Theme ]);
+  }, []);
 
   it('TINY-2226: Menu should contain a group heading with the correct classes and text', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -8,7 +8,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { NotificationApi } from 'tinymce/core/api/NotificationManager';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as PageScroll from '../../module/PageScroll';
 import { resizeToPos } from '../../module/UiUtils';
@@ -36,7 +35,7 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
     const hook = TinyHooks.bddSetupLight<Editor>({
       base_url: '/project/tinymce/js/tinymce',
       width: 600
-    }, [ Theme ]);
+    }, []);
 
     const assertStructure = (label: string, notification: NotificationApi, type: string, message: string, progress?: number) => {
       Assertions.assertStructure(label, ApproxStructure.build((s, str, arr) => s.element('div', {
@@ -198,7 +197,7 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       toolbar_location: 'bottom',
       width: 600,
       height: 400
-    }, [ Theme ]);
+    }, []);
 
     it('Check notification stacking and structure', async () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShadowDomInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShadowDomInlineTest.ts
@@ -4,13 +4,12 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Settings from 'tinymce/themes/silver/api/Settings';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.ShadowDomInlineTest', () => {
   const hook = TinyHooks.bddSetupInShadowRoot<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     inline: true
-  }, [ Theme ]);
+  }, []);
 
   it('UI container should be inside the shadow root', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
@@ -1,19 +1,14 @@
 import { UiFinder } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as UiUtils from '../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.ShowHideTest', () => {
   const base_url = '/project/tinymce/js/tinymce';
-
-  before(() => {
-    Theme();
-  });
 
   const pWaitForVisible = (label: string, selector: string) => UiFinder.pWaitForVisible(label, SugarBody.body(), selector);
   const pWaitForHidden = (label: string, selector: string) => UiFinder.pWaitForHidden(label, SugarBody.body(), selector);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCancelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCancelTest.ts
@@ -2,7 +2,6 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.SilverDialogCancelTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -25,7 +24,7 @@ describe('browser.tinymce.themes.silver.editor.SilverDialogCancelTest', () => {
         });
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   it('Dialog closes without error using cancel button', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCloseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCloseTest.ts
@@ -2,7 +2,6 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.SilverDialogCloseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -25,7 +24,7 @@ describe('browser.tinymce.themes.silver.editor.SilverDialogCloseTest', () => {
         });
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   it('Dialog closes without error using close button', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogPopupsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogPopupsTest.ts
@@ -6,7 +6,6 @@ import { SelectorExists, SugarBody, SugarDocument, SugarElement, WindowSelection
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.DialogPopupsTest', () => {
   before(function () {
@@ -64,7 +63,7 @@ describe('browser.tinymce.themes.silver.editor.DialogPopupsTest', () => {
         })
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   const pWaitForDialogClosed = () => Waiter.pTryUntil(
     'Waiting for dialog to close',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorDirectionalityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorDirectionalityTest.ts
@@ -5,11 +5,9 @@ import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.SilverEditorDirectionalityTest', () => {
   before(() => {
-    Theme();
     EditorManager.addI18n('ar', {
       Bold: 'Bold test',
       _dir: 'rtl'

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -8,7 +8,6 @@ import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.SilverEditorTest', () => {
   const os = PlatformDetection.detect().os;
@@ -130,7 +129,7 @@ describe('browser.tinymce.themes.silver.editor.SilverEditorTest', () => {
         }
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   it('Check basic structure and actions', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerPriorityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerPriorityTest.ts
@@ -4,7 +4,6 @@ import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerPriorityTest', () => {
   const toolbar: SugarElement<HTMLDivElement> = SugarElement.fromHtml('<div style="margin: 50px 0;"></div>');
@@ -26,7 +25,7 @@ describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerPriori
     menubar: 'file',
     toolbar: 'undo bold',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Check priority of fixed_toolbar_container(_target) setting', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetNotInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetNotInlineTest.ts
@@ -4,7 +4,6 @@ import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTargetNotInlineTest', () => {
   const toolbar: SugarElement<HTMLDivElement> = SugarElement.fromHtml('<div style="margin: 50px 0;"></div>');
@@ -22,7 +21,7 @@ describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTarget
     menubar: 'file',
     toolbar: 'undo bold',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Check fixed_toolbar_container_target setting is ignored when not an inline editor', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetTest.ts
@@ -4,7 +4,6 @@ import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTargetTest', () => {
   const toolbar: SugarElement<HTMLDivElement> = SugarElement.fromHtml('<div style="margin: 50px 0;"></div>');
@@ -22,7 +21,7 @@ describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTarget
     menubar: 'file',
     toolbar: 'undo bold',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Check fixed_toolbar_container_target setting for inline editor', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
@@ -4,7 +4,6 @@ import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as UiUtils from '../../module/UiUtils';
 
@@ -25,7 +24,7 @@ describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTest',
     menubar: 'file',
     toolbar: 'undo bold',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Check basic structure', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -8,7 +8,6 @@ import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as UiUtils from '../../module/UiUtils';
 
@@ -133,7 +132,7 @@ describe('browser.tinymce.themes.silver.editor.SilverInlineEditorTest', () => {
         }
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   beforeEach(async () => {
     hook.editor().focus();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun, Type } from '@ephox/katamari';
 import { Css, Scroll, SugarBody, SugarElement } from '@ephox/sugar';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
@@ -7,14 +7,10 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ToolbarMode } from 'tinymce/themes/silver/api/Settings';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pOpenMore } from '../../module/MenuUtils';
 
 describe('browser.tinymce.themes.silver.editor.SilverInlineEditorWidthTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const structureTest = (editor: Editor, container: SugarElement<Node>, maxWidth: number) =>
     Assertions.assertStructure(

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -1,6 +1,6 @@
 import { Mouse, UiFinder } from '@ephox/agar';
 import { Boxes } from '@ephox/alloy';
-import { before, context, describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
@@ -9,7 +9,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface Scenario {
   readonly settings: RawEditorSettings;
@@ -19,9 +18,6 @@ interface Scenario {
 }
 
 describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const getBounds = (selector: string) => {
     const elem = UiFinder.findIn(SugarBody.body(), selector).getOrDie();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
@@ -4,14 +4,13 @@ import { Focus, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.ToolbarPersistTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     inline: true,
     base_url: '/project/tinymce/js/tinymce',
     toolbar_persist: true
-  }, [ Theme ]);
+  }, []);
 
   const unfocusEditor = () => {
     const div = SugarElement.fromTag('input');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
@@ -4,13 +4,12 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.ToxWrappingTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     menubar: true,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('Check editor container has tox-tinymce wrapper', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteCancelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteCancelTest.ts
@@ -6,7 +6,6 @@ import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections,
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pWaitForAutocompleteToClose } from '../../../module/AutocompleterUtils';
 
@@ -43,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteCancelTe
         }
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   const expectedSimplePara = (content: string) => (s, str): StructAssert => s.element('p', {
     children: [ s.text(str.is(content), true) ]

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteReloadTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteReloadTest.ts
@@ -5,7 +5,6 @@ import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@e
 import Editor from 'tinymce/core/api/Editor';
 import { InlineContent } from 'tinymce/core/api/ui/Ui';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAssertAutocompleterStructure, pWaitForAutocompleteToOpen } from '../../../module/AutocompleterUtils';
 
@@ -58,7 +57,7 @@ describe('Editor Autocompleter Reload test', () => {
         }
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   const pAssertInitialMenu = () => pAssertAutocompleterStructure({
     type: 'list',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
@@ -7,7 +7,6 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiAc
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { getGreenImageDataUrl } from '../../../module/Assets';
 import {
@@ -255,7 +254,7 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteTest', (
         }
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   beforeEach(() => {
     store.clear();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as MenuUtils from '../../../module/MenuUtils';
 
@@ -15,7 +14,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
     toolbar: 'align fontselect fontsizeselect formatselect styleselect',
     base_url: '/project/tinymce/js/tinymce',
     content_css: '/project/tinymce/src/themes/silver/test/css/content.css'
-  }, [ Theme ]);
+  }, []);
 
   const pAssertFocusOnItem = (itemText: string) => FocusTools.pTryOnSelector(
     `Focus should be on ${itemText}`,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as MenuUtils from '../../../module/MenuUtils';
 
@@ -54,7 +53,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.StyleSelectFormatNamesTes
         classes: [ 'my-selector' ]
       }
     ]
-  }, [ Theme ]);
+  }, []);
 
   const assertStyleSelectMenuItems = (label: string, expectedItems: StyleSelectMenuItem[]) => {
     const group = UiFinder.findIn(SugarBody.body(), '.tox-selected-menu .tox-collection__group').getOrDie();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -1,18 +1,14 @@
 import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { extractOnlyOne } from '../../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const defaultToolbarGroupSettings = {
     toolbar: 'formatting',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -6,7 +6,6 @@ import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 import * as ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
 
 describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () => {
@@ -17,7 +16,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
     context(tester.label, () => {
       const hook = tester.setup<Editor>({
         base_url: '/project/tinymce/js/tinymce'
-      }, [ Theme ]);
+      }, []);
       const dialogSelector = 'div[role="dialog"]';
       let currentColor = '';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
-import Theme from 'tinymce/themes/silver/Theme';
 import * as ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
 import * as Settings from 'tinymce/themes/silver/ui/core/color/Settings';
 
@@ -29,7 +28,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorSettingsTest', () => {
     toolbar: 'forecolor backcolor',
     base_url: '/project/tinymce/js/tinymce',
     color_map: colorSettings
-  }, [ Theme ]);
+  }, []);
 
   const resetLocalStorage = () => {
     LocalStorage.removeItem('tinymce-custom-colors');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
@@ -4,7 +4,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 import * as ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
 
 describe('browser.tinymce.themes.silver.editor.color.GetCurrentColorTest', () => {
@@ -18,7 +17,7 @@ describe('browser.tinymce.themes.silver.editor.color.GetCurrentColorTest', () =>
   const hook = TinyHooks.bddSetupLight<Editor>({
     toolbar: 'forecolor backcolor',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const assertCurrentColor = (editor: Editor, format: 'forecolor' | 'hilitecolor', label: string, expected: string) => {
     const actual = ColorSwatch.getCurrentColor(editor, format).getOrDie('No current color found');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorCommandsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorCommandsTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorCommandsTest', () => {
   before(function () {
@@ -19,7 +18,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorCommandsTest', () 
   const hook = TinyHooks.bddSetupLight<Editor>({
     toolbar: 'forecolor backcolor',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   before(() => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
@@ -5,7 +5,6 @@ import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', () => {
   before(function () {
@@ -18,7 +17,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
   const hook = TinyHooks.bddSetupLight<Editor>({
     toolbar: 'forecolor backcolor',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const backcolorTitleStruct = ApproxStructure.build((s, str) =>
     s.element('body', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -4,7 +4,6 @@ import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () => {
   before(function () {
@@ -17,7 +16,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
   const hook = TinyHooks.bddSetupLight<Editor>({
     toolbar: 'forecolor backcolor fontsizeselect',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   const forecolorStruct = (color: string) => ApproxStructure.build((s, str) => {
     return s.element('body', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuPositionTest.ts
@@ -3,7 +3,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { assertContentMenuPosition, pOpenContextMenu } from '../../../module/ContextMenuUtils';
 
@@ -14,7 +13,7 @@ describe('browser.tinymce.themes.silver.editor.contextmenu.ContextMenuPositionTe
     height: 200,
     base_url: '/project/tinymce/js/tinymce',
     contextmenu_avoid_overlap: '.mce-spellchecker-word'
-  }, [ LinkPlugin, Theme ], true);
+  }, [ LinkPlugin ], true);
 
   it('TINY-6036: Context menu opened on node should open at right click position', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
@@ -5,12 +5,11 @@ import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.contextmenu.CustomContextMenuTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme ], true);
+  }, [], true);
 
   const pOpenContextMenu = async (editor: Editor, selector: string) =>
     await TinyUiActions.pTriggerContextMenu(editor, selector, '.tox-silver-sink .tox-menu.tox-collection [role="menuitem"]');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/DesktopContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/DesktopContextMenuTest.ts
@@ -9,7 +9,6 @@ import ImagePlugin from 'tinymce/plugins/image/Plugin';
 import ImageToolsPlugin from 'tinymce/plugins/imagetools/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pOpenContextMenu, pWaitForAndCloseDialog } from '../../../module/ContextMenuUtils';
 
@@ -20,7 +19,7 @@ describe('browser.tinymce.themes.silver.editor.contextmenu.DesktopContextMenuTes
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_caption: true
-  }, [ ImagePlugin, ImageToolsPlugin, LinkPlugin, TablePlugin, Theme ], true);
+  }, [ ImagePlugin, ImageToolsPlugin, LinkPlugin, TablePlugin ], true);
 
   // Assert focus is on the expected menu item
   const pAssertFocusOnItem = (label: string, selector: string) =>

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/MobileContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/MobileContextMenuTest.ts
@@ -10,7 +10,6 @@ import ImagePlugin from 'tinymce/plugins/image/Plugin';
 import ImageToolsPlugin from 'tinymce/plugins/imagetools/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pWaitForAndCloseDialog } from '../../../module/ContextMenuUtils';
 
@@ -43,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.contextmenu.MobileContextMenuTest
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_caption: true
-  }, [ ImagePlugin, ImageToolsPlugin, LinkPlugin, TablePlugin, Theme ], true);
+  }, [ ImagePlugin, ImageToolsPlugin, LinkPlugin, TablePlugin ], true);
 
   const pOpenContextMenu = async (editor: Editor, target: string) => {
     const targetElem = UiFinder.findIn(TinyDom.body(editor), target).getOrDie();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -6,7 +6,6 @@ import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 import { getContextToolbarBounds } from 'tinymce/themes/silver/ui/context/ContextToolbarBounds';
 
 import TestBackstage from '../../../module/TestBackstage';
@@ -39,7 +38,6 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
   const expectedMargin = 1;
 
   before(() => {
-    Theme();
     const body = SugarBody.body();
     Css.set(body, 'margin-left', '10px');
     Css.set(body, 'margin-right', '10px');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
@@ -6,7 +6,6 @@ import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface Scenario {
   readonly content: string;
@@ -38,7 +37,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarDist
         items: 'alpha'
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   before(() => {
     Css.setAll(TinyDom.contentAreaContainer(hook.editor()), {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -8,7 +8,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { getGreenImageDataUrl } from '../../../module/Assets';
 
@@ -70,7 +69,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
         position: 'node'
       });
     }
-  }, [ FullscreenPlugin, Theme ], true);
+  }, [ FullscreenPlugin ], true);
 
   beforeEach(() => {
     // Reset scroll position for each test

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
@@ -6,7 +6,6 @@ import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface Scenario {
   readonly content: string;
@@ -43,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarInli
         position: 'node'
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   before(() => {
     Css.setAll(TinyDom.contentAreaContainer(hook.editor()), {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLookupTest', () => {
   const predicateNodeNames = Cell<Record<string, string[]>>({ });
@@ -72,7 +71,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
         scope: 'editor'
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   const recordNode = (type: string, node: Node) => {
     const nodeName = node.nodeName.toLowerCase();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -5,7 +5,6 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest', () => {
   const store = TestHelpers.TestStore();
@@ -21,7 +20,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
         items: 'alpha'
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   it('TBA: Moving selection away from the context toolbar predicate should make it disappear', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
@@ -5,12 +5,10 @@ import { Focus, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { McEditor, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.RemoveContextToolbarOnFocusoutTest', () => {
   let inputElm: SugarElement<HTMLInputElement>;
   before(() => {
-    Theme();
 
     inputElm = SugarElement.fromTag('input');
     Insert.append(SugarBody.body(), inputElm);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
@@ -4,7 +4,6 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { extractOnlyOne } from '../../../module/UiUtils';
 
@@ -13,7 +12,7 @@ describe('browser.tinymce.themes.silver.editor.core.AlignmentButtonsTest', () =>
     toolbar: 'alignleft aligncenter alignright alignjustify alignnone',
     toolbar_mode: 'wrap',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('TBA: Toolbar alignment buttons structure', () => {
     const toolbar = extractOnlyOne(SugarBody.body(), '.tox-toolbar');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -1,5 +1,5 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute } from '@ephox/sugar';
@@ -7,7 +7,6 @@ import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyUiActions } fr
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface ToolbarOrMenuSpec {
   readonly name: string;
@@ -70,7 +69,7 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
     context('Default settings', () => {
       const hook = TinyHooks.bddSetup<Editor>({
         ...baseSettings
-      }, [ Theme ]);
+      }, []);
 
       Arr.each([ menuSpec, toolbarSpec ], (spec) => {
         it(`TINY-4843: ${spec.name} lists correct line heights`, async () => {
@@ -151,7 +150,7 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
       const hook = TinyHooks.bddSetup<Editor>({
         ...baseSettings,
         lineheight_formats: '1 1.1 1.11 1.111'
-      }, [ Theme ]);
+      }, []);
 
       Arr.each([ menuSpec, toolbarSpec ], (spec) => {
         it(`TINY-4843: ${spec.name} lists specified line heights`, async () => {
@@ -167,7 +166,7 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
       const hook = TinyHooks.bddSetup<Editor>({
         ...baseSettings,
         lineheight_formats: '1.000 20px 22.0px 1.5e2%'
-      }, [ Theme ]);
+      }, []);
 
       beforeEach(() => {
         hook.editor().setContent('');
@@ -210,7 +209,7 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
           { title: 'Portuguese', code: 'pt' },
           { title: 'Chinese', code: 'zh' }
         ]
-      }, [ Theme ]);
+      }, []);
 
       const defaultLanguages = [ 'English', 'Spanish', 'French', 'German', 'Portuguese', 'Chinese' ];
 
@@ -290,10 +289,6 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
     });
 
     context('Advanced settings', () => {
-      before(() => {
-        Theme();
-      });
-
       Arr.each([ menuSpec, toolbarSpec ], (spec) => {
         it(`TINY-6149: ${spec.name} applies custom language attributes`, async () => {
           const editor = await McEditor.pFromSettings<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ContentLanguageHiddenTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ContentLanguageHiddenTest.ts
@@ -3,13 +3,12 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.core.ContentLanguageHiddenTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     toolbar: 'language | bold italic'
-  }, [ Theme ]);
+  }, []);
 
   it('TINY-7570: Does not show the toolbar button if content_langs is not defined', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
@@ -4,13 +4,12 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     toolbar: 'bold italic underline strikethrough',
-  }, [ Theme ]);
+  }, []);
 
   const assertToolbarButtonPressed = (title: string) =>
     UiFinder.exists(SugarBody.body(), `button[title="${title}"][aria-pressed="true"]`);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
@@ -3,13 +3,12 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.header.HeaderLocationTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     toolbar_location: 'bottom'
-  }, [ Theme ]);
+  }, []);
 
   it('Header should be located at the bottom in the editor container', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderInitialPlacementTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderInitialPlacementTest.ts
@@ -1,17 +1,13 @@
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ToolbarLocation } from 'tinymce/themes/silver/api/Settings';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as StickyUtils from '../../../module/StickyHeaderUtils';
 
 describe('browser.tinymce.themes.silver.editor.header.StickyHeaderInitialPlacementTest ', () => {
-  before(() => {
-    Theme();
-  });
 
   Arr.each([
     { location: ToolbarLocation.top, height: 2000, expectDocked: false },

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderScrollIntoViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderScrollIntoViewTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as ScrollIntoView from 'tinymce/core/dom/ScrollIntoView';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.header.StickyHeaderScrollIntoViewTest', () => {
   PhantomSkipper.bddSetup();
@@ -16,7 +15,7 @@ describe('browser.tinymce.themes.silver.editor.header.StickyHeaderScrollIntoView
     inline: true,
     base_url: '/project/tinymce/js/tinymce',
     content_style: 'body.mce-content-body, .mce-content-body p { margin: 0 }'
-  }, [ Theme ], true);
+  }, [], true);
 
   const scrollReset = (editor: Editor) => {
     editor.getWin().scrollTo(0, 0);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarSettingsTest.ts
@@ -1,19 +1,15 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { countNumber, extractOnlyOne } from '../../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarSettingsTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const pCreateEditorWithMenubar = (menubar: boolean | string | undefined) => McEditor.pFromSettings<Editor>({
     menubar,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.sizing.GridSinkSizingTest', () => {
   let style: SugarElement<HTMLStyleElement>;
@@ -26,7 +25,7 @@ body {
 
   TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   it('TINY-6783:  Sink width matches body width when in display grid', () => {
     const bodyWidth = Width.get(SugarBody.body());

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeNotInRootTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeNotInRootTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.sizing.ResizeNotInRootTest', () => {
   const expectedWidth = 300;
@@ -23,7 +22,7 @@ describe('browser.tinymce.themes.silver.editor.sizing.ResizeNotInRootTest', () =
     base_url: '/project/tinymce/js/tinymce',
     fixed_toolbar_container: '#toolbar',
     inline: true,
-  }, [ Theme ]);
+  }, []);
 
   it('TINY-6683: Should not resize the sink to the body width', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
@@ -5,7 +5,6 @@ import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { resizeToPos } from '../../../module/UiUtils';
 
@@ -19,7 +18,7 @@ describe('browser.tinymce.themes.silver.editor.sizing.ResizeTTest', () => {
     width: 400,
     max_height: 500,
     max_width: 500
-  }, [ Theme ]);
+  }, []);
 
   const assertEditorSize = (container: SugarElement<HTMLElement>, expectedWidth: number, expectedHeight: number) => {
     assert.equal(container.dom.offsetHeight, expectedHeight, `Editor should be ${expectedHeight}px high`);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarSettingsTest.ts
@@ -1,19 +1,15 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { countNumber, extractOnlyOne } from '../../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.EditorToolbarSettingsTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const pCreateEditorWithToolbar = (
     toolbarVal: boolean | string | string[] | Record<string, any> | undefined,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -1,5 +1,5 @@
 import { Keys, UiFinder, Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Cell } from '@ephox/katamari';
 import { Css, SugarBody, SugarLocation } from '@ephox/sugar';
 import { McEditor, TinyContentActions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
@@ -7,17 +7,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAssertFloatingToolbarPosition, pOpenFloatingToolbarAndAssertPosition } from '../../../module/ToolbarUtils';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloatingPositionTest', () => {
   const toolbarHeight = 39;
   const lineHeight = 30;
-
-  before(() => {
-    Theme();
-  });
 
   const getUiContainerTop = (editor: Editor) => {
     const uiContainer = TinyDom.container(editor);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarPositionTest.ts
@@ -7,7 +7,6 @@ import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as PageScroll from '../../../module/PageScroll';
 
@@ -207,7 +206,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarPositionTest
     const hook = TinyHooks.bddSetup<Editor>({
       ...settings,
       toolbar_location: 'top'
-    }, [ Theme ]);
+    }, []);
 
     setupInitialContent(hook);
     getTopPositionTests(hook);
@@ -217,7 +216,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarPositionTest
     const hook = TinyHooks.bddSetup<Editor>({
       ...settings,
       toolbar_location: 'bottom'
-    }, [ Theme ]);
+    }, []);
 
     setupInitialContent(hook);
     getBottomPositionTests(hook);
@@ -229,7 +228,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarPositionTest
     const hook = TinyHooks.bddSetup<Editor>({
       ...settings,
       toolbar_location: 'auto'
-    }, [ Theme ]);
+    }, []);
 
     setupInitialContent(hook);
     getTopPositionTests(hook);
@@ -269,7 +268,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarPositionTest
     const hook = TinyHooks.bddSetup<Editor>({
       ...settings,
       fixed_toolbar_container: '#toolbar'
-    }, [ Theme ]);
+    }, []);
 
     setupInitialContent(hook);
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -7,7 +7,6 @@ import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import { ToolbarMode } from 'tinymce/themes/silver/api/Settings';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pOpenMore } from '../../../module/MenuUtils';
 import { resizeToPos } from '../../../module/UiUtils';
@@ -23,7 +22,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
     height: 400,
     readonly: true,
     resize: 'both'
-  }, [ AdvListPlugin, ListsPlugin, Theme ]);
+  }, [ AdvListPlugin, ListsPlugin ]);
 
   const resizeTo = (sx: number, sy: number, dx: number, dy: number) => {
     const resizeHandle = UiFinder.findIn(SugarBody.body(), '.tox-statusbar__resize-handle').getOrDie();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerFloatingPositionTest.ts
@@ -5,7 +5,6 @@ import { Css, Insert, Remove, Scroll, SugarBody, SugarElement, SugarLocation } f
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { pAssertFloatingToolbarHeight, pOpenFloatingToolbarAndAssertPosition } from '../../../module/ToolbarUtils';
 
@@ -34,7 +33,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerFloatingPosi
     base_url: '/project/tinymce/js/tinymce',
     toolbar: 'undo redo | styleselect | bold italic underline | strikethrough superscript subscript | alignleft aligncenter alignright aligncenter | outdent indent | cut copy paste | selectall remove',
     toolbar_mode: 'floating'
-  }, setupElement, [ Theme ]);
+  }, setupElement, []);
 
   before(async () => {
     // Firefox requires a small wait, otherwise the initial toolbar position is incorrect

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -1,18 +1,14 @@
-import { before, context, describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings, ToolbarMode } from 'tinymce/core/api/SettingsTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as UiUtils from '../../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const assertToolbarToggleState = (editor: Editor, expected: boolean) => {
     const state = editor.queryCommandState('ToggleToolbarDrawer');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarFocusTest.ts
@@ -1,16 +1,12 @@
 import { FocusTools, Keys } from '@ephox/agar';
-import { before, context, describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarDocument } from '@ephox/sugar';
 import { McEditor, TinyContentActions, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarFocusTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const pTestFocus = async (settings: RawEditorSettings) => {
     const editor = await McEditor.pFromSettings<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/icons/IconsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/icons/IconsTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
-import Theme from 'tinymce/themes/silver/Theme';
 import * as Icons from 'tinymce/themes/silver/ui/icons/Icons';
 
 type IconProvider = Icons.IconProvider;
@@ -18,7 +17,7 @@ describe('browser.tinymce.themes.silver.icons.IconsTest', () => {
     setup: () => {
       I18n.add('rtllang', { _dir: 'rtl' });
     }
-  }, [ Theme ]);
+  }, []);
 
   const iconIndent = getAllOxide().indent;
   const iconDefault = getAllOxide()['temporary-placeholder'];

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -7,7 +7,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Sidebar } from 'tinymce/core/api/ui/Ui';
-import Theme from 'tinymce/themes/silver/Theme';
 
 interface EventLog {
   readonly name: string;
@@ -54,7 +53,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarTest', () => {
         onHide: logEvent('mysidebar3:hide')
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   const pClickAndAssertEvents = async (editor: Editor, tooltip: string, expected: EventLog[]) => {
     store.clear();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
@@ -5,7 +5,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.skin.OxideBlockedDialogTest', () => {
   let testDialogApi: Dialog.DialogInstanceApi<{}>;
@@ -39,7 +38,7 @@ describe('browser.tinymce.themes.silver.skin.OxideBlockedDialogTest', () => {
         }
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   it('Check structure of font format', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
@@ -6,7 +6,6 @@ import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar'
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.skin.OxideCollectionComponentTest', () => {
   before(function () {
@@ -74,7 +73,7 @@ describe('browser.tinymce.themes.silver.skin.OxideCollectionComponentTest', () =
         }
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   const structureItem = (optText: Optional<string>, optIcon: Optional<string>): ApproxStructure.Builder<StructAssert> =>
     (s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -7,7 +7,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
   const store = TestHelpers.TestStore();
@@ -46,7 +45,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
         onItemAction: store.adder('onItemAction')
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   const structColor = (value: string): ApproxStructure.Builder<StructAssert> =>
     (s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
@@ -6,7 +6,6 @@ import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.skin.OxideFontFormatMenuTest', () => {
   const isIE = PlatformDetection.detect().browser.isIE();
@@ -31,7 +30,7 @@ describe('browser.tinymce.themes.silver.skin.OxideFontFormatMenuTest', () => {
       { title: 'Red paragraph', block: 'p', styles: { color: 'rgb(255, 0, 0)' }},
       { title: 'Table row 1', selector: 'tr', classes: 'tablerow1' }
     ]
-  }, [ Theme ]);
+  }, []);
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     ':focus { background-color: rgb(222, 224, 226); }',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
@@ -7,7 +7,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.skin.OxideGridCollectionMenuTest', () => {
   const store = TestHelpers.TestStore();
@@ -32,7 +31,7 @@ describe('browser.tinymce.themes.silver.skin.OxideGridCollectionMenuTest', () =>
         onItemAction: store.adder('onItemAction')
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     ':focus { background-color: rgb(222, 224, 226); }'

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
@@ -5,7 +5,6 @@ import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.skin.OxideListCollectionMenuTest', () => {
   const store = TestHelpers.TestStore();
@@ -46,7 +45,7 @@ describe('browser.tinymce.themes.silver.skin.OxideListCollectionMenuTest', () =>
         }
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     ':focus { background-color: rgb(222, 224, 226); }'

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -6,7 +6,6 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
-import Theme from 'tinymce/themes/silver/Theme';
 
 const tableCellsApprox = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi, arr: ApproxStructure.ArrayApi, selectedRows: number, selectedCols: number) => {
   const cells: StructAssert[] = [];
@@ -72,7 +71,7 @@ describe('browser.tinymce.themes.silver.skin.OxideTablePickerMenuTest', () => {
         getSubmenuItems: () => [ tableMenuItem ]
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   it('TBA: Check structure of table picker', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
@@ -6,7 +6,6 @@ import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', () => {
   const store = TestHelpers.TestStore();
@@ -33,7 +32,7 @@ describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', ()
         onItemAction: store.adder('onItemAction')
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   it('Check structure of toolbar collection', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -5,11 +5,9 @@ import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorSettings } from 'tinymce/core/api/SettingsTypes';
 import WordcountPlugin from 'tinymce/plugins/wordcount/Plugin';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
   before(() => {
-    Theme();
     WordcountPlugin(5);
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberEditorTest.ts
@@ -6,12 +6,11 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.throbber.ThrobberEditorTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme ]);
+  }, []);
 
   const pToggleThrobber = async (editor: Editor, action: () => void = Fun.noop) => {
     editor.setProgressState(true);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberFocusTest.ts
@@ -5,12 +5,11 @@ import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.throbber.ThrobberFocusTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ], true);
+  }, [], true);
 
   before(() => {
     const input = SugarElement.fromHtml('<input id="tempInput" />');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -5,7 +5,6 @@ import { Class, Focus, Insert, Remove, SugarBody, SugarElement, SugarNode } from
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -30,7 +29,7 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
       });
     },
     contextmenu: 'test'
-  }, [ Theme ], true);
+  }, [], true);
 
   const pWaitForThrobber = () =>
     UiFinder.pWaitForVisible('waiting for throbber to open', SugarBody.body(), '.tox-throbber');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberTest.ts
@@ -4,12 +4,11 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.throbber.ThrobberTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme ]);
+  }, []);
 
   const assertThrobberHiddenStructure = () => {
     const throbber = UiFinder.findIn(SugarBody.body(), '.tox-throbber').getOrDie();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
@@ -8,7 +8,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as DialogUtils from '../../module/DialogUtils';
 
@@ -16,7 +15,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogApiAccessTest', () =>
   const store = TestHelpers.TestStore();
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const dialogSpec: Dialog.DialogSpec<{ fieldA: string }> = {
     title: 'Silver Test Access Dialog',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
@@ -7,14 +7,13 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as DialogUtils from '../../module/DialogUtils';
 
 describe('browser.tinymce.themes.silver.window.SilverDialogAriaLabelTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     '.tox-dialog { background: white; border: 2px solid black; padding: 1em; margin: 1em; }'

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -9,7 +9,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 import I18n from 'tinymce/core/api/util/I18n';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as DialogUtils from '../../module/DialogUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
   const store = TestHelpers.TestStore();
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   const dialogSpec: Dialog.DialogSpec<{ fred: string }> = {
     title: 'Test dialog',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as DialogUtils from '../../module/DialogUtils';
 import * as PageScroll from '../../module/PageScroll';
@@ -54,7 +53,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
       width: 600,
       toolbar_sticky: false,
       toolbar_mode: 'wrap'
-    }, [ Theme ]);
+    }, []);
 
     it('Test position when resizing', async () => {
       const editor = hook.editor();
@@ -127,7 +126,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
       width: 600,
       toolbar_sticky: true,
       toolbar_location: 'bottom'
-    }, [ Theme ]);
+    }, []);
 
     PageScroll.bddSetup(hook.editor, 1000);
 
@@ -179,7 +178,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
         element: div,
         teardown: () => Remove.remove(div)
       };
-    }, [ Theme ]);
+    }, []);
 
     PageScroll.bddSetup(hook.editor, 1000);
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
@@ -9,7 +9,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 import { WindowParams } from 'tinymce/core/api/WindowManager';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as DialogUtils from '../../module/DialogUtils';
 
@@ -17,7 +16,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
   const store = TestHelpers.TestStore();
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     '.tox-dialog { background: white; border: 2px solid black; padding: 1em; margin: 1em; }'

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import { ToolbarLocation, ToolbarMode } from 'tinymce/themes/silver/api/Settings';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as MenuUtils from './MenuUtils';
 import * as PageScroll from './PageScroll';
@@ -31,7 +30,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
       toolbar_mode: toolbarMode,
       toolbar_location: toolbarLocation,
       toolbar_sticky: true,
-    }, [ FullscreenPlugin, Theme ], true);
+    }, [ FullscreenPlugin ], true);
 
     PageScroll.bddSetup(hook.editor, 5000);
 

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/AutocompleteDelayedResponseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/AutocompleteDelayedResponseTest.ts
@@ -7,7 +7,6 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinyUiActions } from '@e
 
 import Editor from 'tinymce/core/api/Editor';
 import PromisePolyfill from 'tinymce/core/api/util/Promise';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import { AutocompleterStructure, pAssertAutocompleterStructure, pWaitForAutocompleteToClose } from '../../module/AutocompleterUtils';
 
@@ -59,7 +58,7 @@ describe('webdriver.tinymce.themes.silver.editor.AutocompleteDelayedResponseTest
         }
       });
     }
-  }, [ Theme ], true);
+  }, [], true);
 
   const pTestAutocompleter = async (scenario: Scenario) => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
@@ -4,7 +4,6 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import { Editor } from 'tinymce/core/api/PublicApi';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('webdriver.tinymce.themes.silver.editor.menubar.DisabledNestedMenuItemTest', () => {
 
@@ -47,7 +46,7 @@ describe('webdriver.tinymce.themes.silver.editor.menubar.DisabledNestedMenuItemT
         }]
       });
     }
-  }, [ Theme ]);
+  }, []);
 
   const pOpenCodeMenu = () => {
     TinyUiActions.clickOnMenu(hook.editor(), codeMenuItemSelector);

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
@@ -1,15 +1,11 @@
 import { RealMouse, UiFinder, Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.themes.silver.editor.core.SimpleControlsInlineTest', () => {
-  before(() => {
-    Theme();
-  });
 
   const settings = {
     inline: true,

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/TabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/TabbingTest.ts
@@ -5,12 +5,11 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import Theme from 'tinymce/themes/silver/Theme';
 
 describe('webdriver.tinymce.themes.silver.editor.TabbingTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-  }, [ Theme ]);
+  }, []);
 
   it('TINY-3707: Should focus on text editor when tabbing into it', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
@@ -7,14 +7,13 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import Theme from 'tinymce/themes/silver/Theme';
 
 import * as UiUtils from '../../module/UiUtils';
 
 describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Theme ]);
+  }, []);
 
   before(() => {
     const editor = hook.editor();


### PR DESCRIPTION
Added theme registration our `mcagar` wrapper file.
Removed all manual theme registration in tests.

Related Ticket: TINY-8207

Description of Changes:
* Deleted a lot of code. Feels good.
* search/replace + `eslint --fix` = winning
* Only two significant files to review:
  * `modules/tinymce/src/core/test/ts/module/McAgar.ts`
  * `package.json` where I added an `eslint-fix` script, it's quite handy

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] ~Milestone set~
* [x] Review comments resolved

GitHub issues (if applicable):
