### PR TITLE
TINY-8238: Exclude more internal selectors from the imported CSS list

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Internal selectors were appearing in the style list when using the `importcss` plugin #TINY-8238
+
 ## 5.10.1 - 2021-11-03
 
 ### Fixed

--- a/modules/tinymce/src/plugins/importcss/demo/css/rules.css
+++ b/modules/tinymce/src/plugins/importcss/demo/css/rules.css
@@ -5,3 +5,88 @@
 h1.blue {
   color: blue;
 }
+
+.ephox-summary-card {
+  border: 1px solid #AAA;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.2), 0 1px 5px 0 rgba(0,0,0,.12);
+  padding: 10px;
+  overflow: hidden;
+  margin-bottom: 1em;
+}
+
+.ephox-summary-card a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.ephox-summary-card a:visited {
+  color: inherit;
+}
+
+.ephox-summary-card-title {
+  font-size: 1.2em;
+  display: block;
+}
+
+.ephox-summary-card-author {
+  color: #999;
+  display: block;
+  margin-top: 0.5em;
+}
+
+.ephox-summary-card-website {
+  color: #999;
+  display: block;
+  margin-top: 0.5em;
+}
+
+.ephox-summary-card-thumbnail {
+  max-width: 180px;
+  max-height: 180px;
+  margin-left: 2em;
+  float: right;
+}
+
+.ephox-summary-card-description {
+  margin-top: 0.5em;
+  display: block;
+}
+
+.tiny-pageembed--21by9,
+.tiny-pageembed--16by9,
+.tiny-pageembed--4by3,
+.tiny-pageembed--1by1 {
+  display: block;
+  overflow: hidden;
+  padding: 0;
+  position: relative;
+  width: 100%;
+}
+
+.tiny-pageembed--21by9 {
+  padding-top: 42.857143%;
+}
+
+.tiny-pageembed--16by9 {
+  padding-top: 56.25%;
+}
+
+.tiny-pageembed--4by3 {
+  padding-top: 75%;
+}
+
+.tiny-pageembed--1by1 {
+  padding-top: 100%;
+}
+
+.tiny-pageembed--21by9 iframe,
+.tiny-pageembed--16by9 iframe,
+.tiny-pageembed--4by3 iframe,
+.tiny-pageembed--1by1 iframe {
+  border: 0;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -33,7 +33,7 @@ interface Group extends UserDefinedGroup {
   readonly filter: Filter | undefined;
 }
 
-const internalEditorStyle = /^\.(?:ephox|tiny|mce)(?:-+\w+)+$/;
+const internalEditorStyle = /^\.(?:ephox|tiny-pageembed|mce)(?:-+\w+)+$/;
 
 const removeCacheSuffix = (url: string): string => {
   const cacheSuffix = Env.cacheSuffix;

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -257,7 +257,7 @@ const setup = (editor: Editor): void => {
     };
 
     Tools.each(getSelectors(editor, editor.getDoc(), compileFilter(Settings.getFileFilter(editor))), (selector) => {
-      if (selector.match(internalEditorStyle) === null) {
+      if (!internalEditorStyle.test(selector)) {
         if (!selectorFilter || selectorFilter(selector)) {
           const selectorGroups = getGroupsBySelector(groups, selector);
 

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -33,6 +33,8 @@ interface Group extends UserDefinedGroup {
   readonly filter: Filter | undefined;
 }
 
+const INTERNAL_EDITOR_STYLE = /^\.(?:ephox|tiny|mce)(?:-+\w+)+$/;
+
 const removeCacheSuffix = (url: string): string => {
   const cacheSuffix = Env.cacheSuffix;
 
@@ -255,7 +257,7 @@ const setup = (editor: Editor): void => {
     };
 
     Tools.each(getSelectors(editor, editor.getDoc(), compileFilter(Settings.getFileFilter(editor))), (selector) => {
-      if (selector.indexOf('.mce-') === -1) {
+      if (selector.match(INTERNAL_EDITOR_STYLE) === null) {
         if (!selectorFilter || selectorFilter(selector)) {
           const selectorGroups = getGroupsBySelector(groups, selector);
 

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -33,7 +33,7 @@ interface Group extends UserDefinedGroup {
   readonly filter: Filter | undefined;
 }
 
-const INTERNAL_EDITOR_STYLE = /^\.(?:ephox|tiny|mce)(?:-+\w+)+$/;
+const internalEditorStyle = /^\.(?:ephox|tiny|mce)(?:-+\w+)+$/;
 
 const removeCacheSuffix = (url: string): string => {
   const cacheSuffix = Env.cacheSuffix;
@@ -257,7 +257,7 @@ const setup = (editor: Editor): void => {
     };
 
     Tools.each(getSelectors(editor, editor.getDoc(), compileFilter(Settings.getFileFilter(editor))), (selector) => {
-      if (selector.match(INTERNAL_EDITOR_STYLE) === null) {
+      if (selector.match(internalEditorStyle) === null) {
         if (!selectorFilter || selectorFilter(selector)) {
           const selectorGroups = getGroupsBySelector(groups, selector);
 

--- a/modules/tinymce/src/plugins/importcss/test/css/internal.css
+++ b/modules/tinymce/src/plugins/importcss/test/css/internal.css
@@ -1,0 +1,15 @@
+/* old style embeds */
+.ephox-summary-card-description {
+  margin-top: 0.5em;
+  display: block;
+}
+
+/* new style embeds */
+.tiny-pageembed--1by1 {
+  padding-top: 100%;
+}
+
+/* very old style definitions */
+.mce-container {
+  display: block
+}

--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
@@ -317,7 +317,7 @@ describe('browser.tinymce.plugins.importcss.ImportCssTest', () => {
     }
   ));
 
-  it('TBA: content_css with two files, basic and internal CSS classes', () => pTestEditorWithSettings(
+  it('TINY-8238: content_css with two files, basic and internal CSS classes', () => pTestEditorWithSettings(
     {
       menuContents: [
         { tag: 'h1', html: 'h1.red', submenu: false },

--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
@@ -316,4 +316,22 @@ describe('browser.tinymce.plugins.importcss.ImportCssTest', () => {
       ]
     }
   ));
+
+  it('TBA: content_css with two files, basic and internal CSS classes', () => pTestEditorWithSettings(
+    {
+      menuContents: [
+        { tag: 'h1', html: 'h1.red', submenu: false },
+        { tag: 'p', html: 'p.other', submenu: false },
+        { tag: 'span', html: 'span.inline', submenu: false }
+      ],
+      choice: Optional.some('h1.red')
+    },
+    {
+      content_css: [
+        '/project/tinymce/src/plugins/importcss/test/css/basic.css',
+        '/project/tinymce/src/plugins/importcss/test/css/internal.css'
+      ],
+      importcss_append: undefined
+    }
+  ));
 });


### PR DESCRIPTION
Related Ticket:TINY-8238

Description of Changes:
* Switch from a simple `.mce-` check to a regex that covers all the ways we phrase our content CSS selectors

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
