### PR TITLE
TINY-8238: Fixed another case for internal selectors

### DIFF
--- a/modules/tinymce/src/plugins/importcss/demo/css/rules.css
+++ b/modules/tinymce/src/plugins/importcss/demo/css/rules.css
@@ -63,19 +63,19 @@ h1.blue {
   width: 100%;
 }
 
-.tiny-pageembed--21by9 {
+.tiny-pageembed.tiny-pageembed--21by9 {
   padding-top: 42.857143%;
 }
 
-.tiny-pageembed--16by9 {
+.tiny-pageembed.tiny-pageembed--16by9 {
   padding-top: 56.25%;
 }
 
-.tiny-pageembed--4by3 {
+.tiny-pageembed.tiny-pageembed--4by3 {
   padding-top: 75%;
 }
 
-.tiny-pageembed--1by1 {
+.tiny-pageembed.tiny-pageembed--1by1 {
   padding-top: 100%;
 }
 

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -33,7 +33,7 @@ interface Group extends UserDefinedGroup {
   readonly filter: Filter | undefined;
 }
 
-const internalEditorStyle = /^\.(?:ephox|tiny-pageembed|mce)(?:-+\w+)+$/;
+const internalEditorStyle = /^\.(?:ephox|tiny-pageembed|mce)(?:[.-]+\w+)+$/;
 
 const removeCacheSuffix = (url: string): string => {
   const cacheSuffix = Env.cacheSuffix;

--- a/modules/tinymce/src/plugins/importcss/test/css/internal.css
+++ b/modules/tinymce/src/plugins/importcss/test/css/internal.css
@@ -8,6 +8,9 @@
 .tiny-pageembed--1by1 {
   padding-top: 100%;
 }
+.tiny-pageembed.tiny-pageembed--1by1 {
+  padding-top: 100%;
+}
 
 /* very old style definitions */
 .mce-container {


### PR DESCRIPTION
Related Ticket: TINY-8238

Description of Changes:
* Fixes another case that was missed whereby internal selectors/classes could still be picked up by the import css plugin

Pre-checks:
* [x] ~Changelog entry added~ Done in previous PR
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
