### PR TITLE
TINY-8206: Added the isSet function to the editor options API

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/EditorOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorOptionsTest.ts
@@ -199,4 +199,19 @@ describe('browser.tinymce.core.EditorOptionsTest', () => {
     options.register('string', { processor: 'number', default: 5 });
     assert.equal(options.get('string'), 5);
   });
+
+  it('TINY-8206: isSet should return true when set or an initial value exists', () => {
+    const options = create({ string: 'value' });
+    assert.isFalse(options.isSet('nonexistant'));
+
+    options.register('string', { processor: 'string' });
+    options.register('number', { processor: 'number', default: 10 });
+    assert.isTrue(options.isSet('string'));
+    assert.isFalse(options.isSet('number'));
+
+    options.set('string', 'test');
+    options.set('number', 1);
+    assert.isTrue(options.isSet('string'));
+    assert.isTrue(options.isSet('number'));
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-8206/TINY-8235

Description of Changes:
* Adds an `isSet` API to see if a custom value has been set for an option

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
