### PR TITLE
TINY-8284: Fixed not parsing the grunt options to numbers and updated chunking value

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,9 +126,9 @@ module.exports = function (grunt) {
   const runAllTests = grunt.option('ignore-lerna-changed') || false;
   const changes = fetchLernaProjects(grunt.log, runAllTests);
 
-  const bucket = grunt.option('bucket') || 1;
-  const buckets = grunt.option('buckets') || 1;
-  const chunk = grunt.option('chunk') || 100;
+  const bucket = parseInt(grunt.option('bucket'), 10) || 1;
+  const buckets = parseInt(grunt.option('buckets'), 10) || 1;
+  const chunk = parseInt(grunt.option('chunk'), 10) || 100;
 
   const phantomTests = filterChanges(changes, runsInPhantom);
   const browserTests = filterChangesNot(changes, runsInPhantom);

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ def runTests(name, bedrockCommand, runAll) {
 def runBrowserTests(name, browser, os, bucket, buckets, runAll) {
   def bedrockCommand =
     "yarn grunt browser-auto" +
-      " --chunk=200" +
+      " --chunk=400" +
       " --bedrock-os=" + os +
       " --bedrock-browser=" + browser +
       " --bucket=" + bucket +


### PR DESCRIPTION
Related Ticket: TINY-8284

Description of Changes:

@TheSpyder noticed today that the `--chunk` argument wasn't working and this turned out to be the cause (since it uses the bedrock API directly). That means that for quite a while now the tests have been running pretty much all of them without reloading which might explain some of the IE flakes we've had.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] ~Milestone set~
* [x] Review comments resolved

GitHub issues (if applicable):
