### PR TITLE
TINY-8235: Added additional built-in processors and made use of them

### DIFF
--- a/modules/katamari/CHANGELOG.md
+++ b/modules/katamari/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added a new `unique` API to the `Arr` module to remove duplicate elements in an array.
+- Added a new `Type.is` API to check if an object type matches the specified constructor type.
 
 ### Changed
 - Swapped `Optional` to be a class, instead of an object with function fields.
@@ -16,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Optional` objects should now be faster to construct and work with.
 - The `Result` and `Optional` APIs are now thoroughly documented.
 - Added private `.tag` and `.value` properties to `Result`, to make them friendlier to view in the debugger or console.
+
+### Removed
+- Removed support for Microsoft Internet Explorer.
 
 ## 8.1.0 - 2021-10-11
 

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -18,7 +18,7 @@ const typeOf = (x: any): string => {
   const t = typeof x;
   if (x === null) {
     return 'null';
-  } else if (t === 'object' && hasProto(x, Array, (o, proto) => proto.isPrototypeOf(o))) {
+  } else if (t === 'object' && Array.isArray(x)) {
     return 'array';
   } else if (t === 'object' && hasProto(x, String, (o, proto) => proto.isPrototypeOf(o))) {
     return 'string';

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -1,17 +1,16 @@
 const getPrototypeOf = Object.getPrototypeOf;
 
-const hasProto = (v: Object, predicate: (v: Object) => boolean, name: string): boolean => {
-  if (predicate(v)) {
+interface Constructor<T extends Object> {
+  readonly prototype: T;
+  readonly name: string;
+}
+
+const hasProto = <T extends Object>(v: Object, constructor: Constructor<T>, predicate: (v: Object, prototype: T) => boolean): boolean => {
+  if (predicate(v, constructor.prototype)) {
     return true;
   } else {
     // String-based fallback time
-    const constructor = v.constructor;
-    if (isNonNullable(constructor)) {
-      return constructor.name === name;
-    } else {
-      // IE doesn't support the constructor API
-      return getPrototypeOf(v).toString() === `[object ${name}]`;
-    }
+    return v.constructor?.name === constructor.name;
   }
 };
 
@@ -19,9 +18,9 @@ const typeOf = (x: any): string => {
   const t = typeof x;
   if (x === null) {
     return 'null';
-  } else if (t === 'object' && hasProto(x, (v) => Array.prototype.isPrototypeOf(v), 'Array')) {
+  } else if (t === 'object' && hasProto(x, Array, (o, proto) => proto.isPrototypeOf(o))) {
     return 'array';
-  } else if (t === 'object' && hasProto(x, (v) => String.prototype.isPrototypeOf(v), 'String')) {
+  } else if (t === 'object' && hasProto(x, String, (o, proto) => proto.isPrototypeOf(o))) {
     return 'string';
   } else {
     return t;
@@ -37,6 +36,9 @@ const isSimpleType = <Yolo>(type: string) => (value: any): value is Yolo =>
 const eq = <T> (t: T) => (a: any): a is T =>
   t === a;
 
+export const is = <E extends Object>(value: any, constructor: Constructor<E>): value is E =>
+  isObject(value) && hasProto<E>(value, constructor, (o, proto) => getPrototypeOf(o) === proto);
+
 export const isString: (value: any) => value is string =
   isType('string');
 
@@ -44,7 +46,7 @@ export const isObject: (value: any) => value is Object =
   isType('object');
 
 export const isPlainObject = (value: unknown): value is Object =>
-  isObject(value) && hasProto(value, (v) => getPrototypeOf(v) === Object.prototype, 'Object');
+  is(value, Object);
 
 export const isArray: (value: any) => value is Array<unknown> =
   isType('array');

--- a/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
@@ -218,4 +218,22 @@ describe('atomic.katamari.api.struct.TypeTest', () => {
       assert.isFalse(Type.isPlainObject(Optional.some(5)));
     });
   });
+
+  context('Type.is', () => {
+    it('returns false for null or undefined', () => {
+      assert.isFalse(Type.is(null, RegExp));
+      assert.isFalse(Type.is(undefined, RegExp));
+    });
+
+    it('returns false for things that are not even objects', () => {
+      assert.isFalse(Type.is('hello', RegExp));
+      assert.isFalse(Type.is(5, RegExp));
+      assert.isFalse(Type.is([ 1, 2, 4 ], RegExp));
+    });
+
+    it('returns true for items that match the constructor', () => {
+      assert.isTrue(Type.is(/test/, RegExp));
+      assert.isTrue(Type.is(new Set(), Set));
+    });
+  });
 });

--- a/modules/katamari/src/test/ts/browser/TypeBrowserTest.ts
+++ b/modules/katamari/src/test/ts/browser/TypeBrowserTest.ts
@@ -7,10 +7,19 @@ describe('browser.katamari.TypeBrowserTest', () => {
   it('Type cross window test', () => new Promise<void>((success, failure) => {
 
     const runTest = (frameEval: (script: string) => any) => {
-      const check = (expected, method, input) => {
+      const check = (expected: boolean, method: string, input: string) => {
         const frameValue = frameEval(input);
         if (expected !== Type[method](frameValue)) {
           const failMessage = `Type method ${method} did not return ${expected} for frame value '${input}'`;
+          failure(failMessage);
+          throw new Error(failMessage);
+        }
+      };
+
+      const checkIs = (expected: boolean, input: string, constructor: { prototype: any; name: string }) => {
+        const frameValue = frameEval(input);
+        if (expected !== Type.is(frameValue, constructor)) {
+          const failMessage = `Type.is did not return ${expected} for frame value '${input}'`;
           failure(failMessage);
           throw new Error(failMessage);
         }
@@ -23,6 +32,7 @@ describe('browser.katamari.TypeBrowserTest', () => {
       check(false, 'isFunction', '[]');
       check(false, 'isNumber', '[]');
       check(false, 'isPlainObject', '[]');
+      checkIs(false, '[]', RegExp);
 
       check(false, 'isArray', '({})');
       check(true, 'isObject', '({})');
@@ -30,6 +40,7 @@ describe('browser.katamari.TypeBrowserTest', () => {
       check(false, 'isFunction', '({})');
       check(false, 'isNumber', '({})');
       check(true, 'isPlainObject', '({})');
+      checkIs(false, '({})', RegExp);
 
       check(false, 'isArray', '"hi"');
       check(false, 'isObject', '"hi"');
@@ -37,6 +48,7 @@ describe('browser.katamari.TypeBrowserTest', () => {
       check(false, 'isFunction', '"hi"');
       check(false, 'isNumber', '"hi"');
       check(false, 'isPlainObject', '"hi"');
+      checkIs(false, '"hi"', RegExp);
 
       check(false, 'isArray', 'new Function()');
       check(false, 'isObject', 'new Function()');
@@ -44,6 +56,7 @@ describe('browser.katamari.TypeBrowserTest', () => {
       check(true, 'isFunction', 'new Function()');
       check(false, 'isNumber', 'new Function()');
       check(false, 'isPlainObject', 'new Function()');
+      checkIs(false, 'new Function()', RegExp);
 
       check(false, 'isArray', '5');
       check(false, 'isObject', '5');
@@ -51,6 +64,15 @@ describe('browser.katamari.TypeBrowserTest', () => {
       check(false, 'isFunction', '5');
       check(true, 'isNumber', '5');
       check(false, 'isPlainObject', '5');
+      checkIs(false, '5', RegExp);
+
+      check(false, 'isArray', 'new RegExp("test", "g")');
+      check(true, 'isObject', 'new RegExp("test", "g")');
+      check(false, 'isString', 'new RegExp("test", "g")');
+      check(false, 'isFunction', 'new RegExp("test", "g")');
+      check(false, 'isNumber', 'new RegExp("test", "g")');
+      check(false, 'isPlainObject', 'new RegExp("test", "g")');
+      checkIs(true, 'new RegExp("test", "g")', RegExp);
     };
 
     // no sugar, because sugar depends on katamari

--- a/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
@@ -27,10 +27,12 @@ export interface BuiltInOptionTypeMap {
   'string': string;
   'number': number;
   'boolean': boolean;
-  'string[]': string[];
   'array': any[];
   'function': Function;
   'object': any;
+  'string[]': string[];
+  'object[]': any[];
+  'regexp': RegExp;
 }
 
 export type BuiltInOptionType = keyof BuiltInOptionTypeMap;
@@ -146,6 +148,10 @@ const getBuiltInProcessor = <K extends BuiltInOptionType>(type: K): Processor<Bu
         return Type.isString;
       case 'string[]':
         return (val) => Type.isArrayOf(val, Type.isString);
+      case 'object[]':
+        return (val) => Type.isArrayOf(val, Type.isObject);
+      case 'regexp':
+        return (val) => Type.is(val, RegExp);
     }
   })() as (val: unknown) => val is BuiltInOptionTypeMap[K];
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorOptionsTest.ts
@@ -134,7 +134,7 @@ describe('browser.tinymce.core.EditorOptionsTest', () => {
       function: Fun.noop,
       object: obj,
       objectArray: objArray,
-      regexp: regexp
+      regexp
     });
 
     options.register('string', { processor: 'string' });

--- a/modules/tinymce/src/core/test/ts/browser/EditorOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorOptionsTest.ts
@@ -122,6 +122,9 @@ describe('browser.tinymce.core.EditorOptionsTest', () => {
 
   it('TINY-8206: should work with the built-in processors', () => {
     const obj = {};
+    const objArray = [ obj ];
+    const regexp = /test/;
+
     const options = create({
       string: 'a',
       stringArray: [ 'a', 'b' ],
@@ -129,7 +132,9 @@ describe('browser.tinymce.core.EditorOptionsTest', () => {
       boolTrue: true,
       boolFalse: false,
       function: Fun.noop,
-      object: obj
+      object: obj,
+      objectArray: objArray,
+      regexp: regexp
     });
 
     options.register('string', { processor: 'string' });
@@ -139,6 +144,9 @@ describe('browser.tinymce.core.EditorOptionsTest', () => {
     options.register('boolFalse', { processor: 'boolean' });
     options.register('function', { processor: 'function' });
     options.register('object', { processor: 'object' });
+    options.register('objectArray', { processor: 'object[]' });
+    options.register('objectArray', { processor: 'object[]' });
+    options.register('regexp', { processor: 'regexp' });
 
     assert.equal(options.get('string'), 'a');
     assert.deepEqual(options.get('stringArray'), [ 'a', 'b' ]);
@@ -147,6 +155,8 @@ describe('browser.tinymce.core.EditorOptionsTest', () => {
     assert.isFalse(options.get('boolFalse'));
     assert.equal(options.get('function'), Fun.noop);
     assert.equal(options.get('object'), obj);
+    assert.equal(options.get('objectArray'), objArray);
+    assert.equal(options.get('regexp'), regexp);
   });
 
   it('TINY-8206: should work with boolean processors', () => {

--- a/modules/tinymce/src/plugins/advlist/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/api/Options.ts
@@ -5,8 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Type } from '@ephox/katamari';
-
 import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
@@ -19,23 +17,14 @@ const option: {
 const register = (editor: Editor): void => {
   const registerOption = editor.options.register;
 
-  const stringListProcessor = (value: unknown) => {
-    const valid = Type.isString(value);
-    if (valid) {
-      return { value: value.split(/[ ,]/), valid };
-    } else {
-      return { valid: false as const, message: 'Must be a string.' };
-    }
-  };
-
   registerOption('advlist_number_styles', {
-    processor: stringListProcessor,
-    default: 'default,lower-alpha,lower-greek,lower-roman,upper-alpha,upper-roman'
+    processor: 'string[]',
+    default: 'default,lower-alpha,lower-greek,lower-roman,upper-alpha,upper-roman'.split(',')
   });
 
   registerOption('advlist_bullet_styles', {
-    processor: stringListProcessor,
-    default: 'default,circle,square'
+    processor: 'string[]',
+    default: 'default,circle,square'.split(',')
   });
 };
 

--- a/modules/tinymce/src/plugins/autolink/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/api/Options.ts
@@ -5,7 +5,6 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Type } from '@ephox/katamari';
 import { Regexes } from '@ephox/polaris';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -21,7 +20,7 @@ const register = (editor: Editor): void => {
   const registerOption = editor.options.register;
 
   registerOption('autolink_pattern', {
-    processor: Type.isNonNullable,
+    processor: 'regexp',
     // Use the Polaris link detection, however for autolink we need to make it be an exact match
     default: new RegExp('^' + Regexes.link().source + '$', 'i')
   });

--- a/modules/tinymce/src/plugins/codesample/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/api/Options.ts
@@ -20,7 +20,7 @@ const register = (editor: Editor): void => {
   const registerOption = editor.options.register;
 
   registerOption('codesample_languages', {
-    processor: 'array'
+    processor: 'object[]'
   });
 
   registerOption('codesample_global_prismjs', {

--- a/modules/tinymce/src/plugins/help/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/api/Options.ts
@@ -21,7 +21,7 @@ const register = (editor: Editor): void => {
   const registerOption = editor.options.register;
 
   registerOption('help_tabs', {
-    processor: 'object[]'
+    processor: 'array'
   });
 };
 

--- a/modules/tinymce/src/plugins/help/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/api/Options.ts
@@ -21,7 +21,7 @@ const register = (editor: Editor): void => {
   const registerOption = editor.options.register;
 
   registerOption('help_tabs', {
-    processor: 'array'
+    processor: 'object[]'
   });
 };
 

--- a/modules/tinymce/src/plugins/image/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/api/Options.ts
@@ -44,7 +44,7 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('image_class_list', {
-    processor: 'array'
+    processor: 'object[]'
   });
 
   registerOption('image_description', {

--- a/modules/tinymce/src/plugins/importcss/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/api/Options.ts
@@ -52,7 +52,7 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('importcss_groups', {
-    processor: 'array'
+    processor: 'object[]'
   });
 
   registerOption('importcss_append', {

--- a/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
@@ -66,12 +66,12 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('rel_list', {
-    processor: 'array',
+    processor: 'object[]',
     default: []
   });
 
   registerOption('link_class_list', {
-    processor: 'array',
+    processor: 'object[]',
     default: []
   });
 

--- a/modules/tinymce/src/plugins/media/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/api/Options.ts
@@ -22,7 +22,7 @@ const register = (editor: Editor): void => {
   const registerOption = editor.options.register;
 
   registerOption('media_scripts', {
-    processor: 'array'
+    processor: 'object[]'
   });
 
   registerOption('audio_template_callback', {

--- a/modules/tinymce/src/plugins/noneditable/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/noneditable/main/ts/api/Options.ts
@@ -16,6 +16,8 @@ const option: {
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 
+const isRegExp = (x: unknown): x is RegExp => Type.is(x, RegExp);
+
 const register = (editor: Editor): void => {
   const registerOption = editor.options.register;
 
@@ -31,9 +33,9 @@ const register = (editor: Editor): void => {
 
   registerOption('noneditable_regexp', {
     processor: (value) => {
-      if (Type.isArray(value)) {
+      if (Type.isArrayOf(value, isRegExp)) {
         return { value, valid: true };
-      } else if (value?.constructor === RegExp) {
+      } else if (isRegExp(value)) {
         return { value: [ value ], valid: true };
       } else {
         return { valid: false, message: 'Must be a RegExp or an array of RegExp.' };

--- a/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj, Optional, Type } from '@ephox/katamari';
+import { Arr, Obj, Optional } from '@ephox/katamari';
 import { SugarElement, Width } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -171,15 +171,7 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('table_clone_elements', {
-    processor: (value) => {
-      if (Type.isString(value)) {
-        return { value: value.split(/[ ,]/), valid: true };
-      } else if (Type.isArrayOf(value, Type.isString)) {
-        return { value, valid: true };
-      } else {
-        return { valid: false, message: 'Must be a string or an array of strings.' };
-      }
-    }
+    processor: 'string[]'
   });
 
   registerOption('table_background_color_map', {

--- a/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
@@ -69,12 +69,12 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('table_border_widths', {
-    processor: 'array',
+    processor: 'object[]',
     default: defaultCellBorderWidths
   });
 
   registerOption('table_border_styles', {
-    processor: 'array',
+    processor: 'object[]',
     default: defaultCellBorderStyles
   });
 
@@ -130,17 +130,17 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('table_cell_class_list', {
-    processor: 'array',
+    processor: 'object[]',
     default: []
   });
 
   registerOption('table_row_class_list', {
-    processor: 'array',
+    processor: 'object[]',
     default: []
   });
 
   registerOption('table_class_list', {
-    processor: 'array',
+    processor: 'object[]',
     default: []
   });
 
@@ -183,12 +183,12 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('table_background_color_map', {
-    processor: 'array',
+    processor: 'object[]',
     default: []
   });
 
   registerOption('table_border_color_map', {
-    processor: 'array',
+    processor: 'object[]',
     default: []
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -100,6 +100,44 @@ const register = (editor: Editor): void => {
     default: '1 1.1 1.2 1.3 1.4 1.5 2'
   });
 
+  registerOption('font_formats', {
+    processor: 'string',
+    default: 'Andale Mono=andale mono,monospace;' +
+      'Arial=arial,helvetica,sans-serif;' +
+      'Arial Black=arial black,sans-serif;' +
+      'Book Antiqua=book antiqua,palatino,serif;' +
+      'Comic Sans MS=comic sans ms,sans-serif;' +
+      'Courier New=courier new,courier,monospace;' +
+      'Georgia=georgia,palatino,serif;' +
+      'Helvetica=helvetica,arial,sans-serif;' +
+      'Impact=impact,sans-serif;' +
+      'Symbol=symbol;' +
+      'Tahoma=tahoma,arial,helvetica,sans-serif;' +
+      'Terminal=terminal,monaco,monospace;' +
+      'Times New Roman=times new roman,times,serif;' +
+      'Trebuchet MS=trebuchet ms,geneva,sans-serif;' +
+      'Verdana=verdana,geneva,sans-serif;' +
+      'Webdings=webdings;' +
+      'Wingdings=wingdings,zapf dingbats'
+  });
+
+  registerOption('fontsize_formats', {
+    processor: 'string',
+    default: '8pt 10pt 12pt 14pt 18pt 24pt 36pt'
+  });
+
+  registerOption('block_formats', {
+    processor: 'string',
+    default: 'Paragraph=p;' +
+      'Heading 1=h1;' +
+      'Heading 2=h2;' +
+      'Heading 3=h3;' +
+      'Heading 4=h4;' +
+      'Heading 5=h5;' +
+      'Heading 6=h6;' +
+      'Preformatted=pre'
+  });
+
   registerOption('content_langs', {
     processor: 'object[]'
   });

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -82,7 +82,7 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('style_formats', {
-    processor: 'array'
+    processor: 'object[]'
   });
 
   registerOption('style_formats_merge', {
@@ -101,7 +101,7 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('content_langs', {
-    processor: 'array'
+    processor: 'object[]'
   });
 
   registerOption('removed_menuitems', {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -6,7 +6,7 @@
  */
 
 import { Transformations } from '@ephox/acid';
-import { Arr, Type } from '@ephox/katamari';
+import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
@@ -43,13 +43,7 @@ const register = (editor: Editor): void => {
   const registerOption = editor.options.register;
 
   registerOption('color_map', {
-    processor: (value) => {
-      if (Type.isArrayOf(value, Type.isString)) {
-        return { value: mapColors(value), valid: true };
-      } else {
-        return { valid: false, message: 'Must be an array of strings.' };
-      }
-    },
+    processor: 'string[]',
     default: [
       '#BFEDD2', 'Light Green',
       '#FBEEB8', 'Light Yellow',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -6,7 +6,7 @@
  */
 
 import { Transformations } from '@ephox/acid';
-import { Arr } from '@ephox/katamari';
+import { Arr, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
@@ -43,7 +43,13 @@ const register = (editor: Editor): void => {
   const registerOption = editor.options.register;
 
   registerOption('color_map', {
-    processor: 'string[]',
+    processor: (value) => {
+      if (Type.isArrayOf(value, Type.isString)) {
+        return { value: mapColors(value), valid: true };
+      } else {
+        return { valid: false, message: 'Must be an array of strings.' };
+      }
+    },
     default: [
       '#BFEDD2', 'Light Green',
       '#FBEEB8', 'Light Yellow',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSelect.ts
@@ -15,24 +15,6 @@ import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 
-const defaultFontsFormats = 'Andale Mono=andale mono,monospace;' +
-  'Arial=arial,helvetica,sans-serif;' +
-  'Arial Black=arial black,sans-serif;' +
-  'Book Antiqua=book antiqua,palatino,serif;' +
-  'Comic Sans MS=comic sans ms,sans-serif;' +
-  'Courier New=courier new,courier,monospace;' +
-  'Georgia=georgia,palatino,serif;' +
-  'Helvetica=helvetica,arial,sans-serif;' +
-  'Impact=impact,sans-serif;' +
-  'Symbol=symbol;' +
-  'Tahoma=tahoma,arial,helvetica,sans-serif;' +
-  'Terminal=terminal,monaco,monospace;' +
-  'Times New Roman=times new roman,times,serif;' +
-  'Trebuchet MS=trebuchet ms,geneva,sans-serif;' +
-  'Verdana=verdana,geneva,sans-serif;' +
-  'Webdings=webdings;' +
-  'Wingdings=wingdings,zapf dingbats';
-
 // A list of fonts that must be in a font family for the font to be recognised as the system stack
 // Note: Don't include 'BlinkMacSystemFont', as Chrome on Mac converts it to different names
 const systemStackFonts = [ '-apple-system', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'sans-serif' ];
@@ -106,7 +88,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     });
   };
 
-  const dataset = buildBasicSettingsDataset(editor, 'font_formats', defaultFontsFormats, Delimiter.SemiColon);
+  const dataset = buildBasicSettingsDataset(editor, 'font_formats', Delimiter.SemiColon);
 
   return {
     tooltip: 'Fonts',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontsizeSelect.ts
@@ -16,8 +16,6 @@ import { createMenuItems, createSelectButton, FormatterFormatItem, SelectSpec } 
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as FormatRegister from './utils/FormatRegister';
 
-const defaultFontsizeFormats = '8pt 10pt 12pt 14pt 18pt 24pt 36pt';
-
 // See https://websemantics.uk/articles/font-size-conversion/ for conversions
 const legacyFontSizes: Record<string, string> = {
   '8pt': '1',
@@ -99,7 +97,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     });
   };
 
-  const dataset = buildBasicSettingsDataset(editor, 'fontsize_formats', defaultFontsizeFormats, Delimiter.Space);
+  const dataset = buildBasicSettingsDataset(editor, 'fontsize_formats', Delimiter.Space);
 
   return {
     tooltip: 'Font sizes',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FormatSelect.ts
@@ -18,17 +18,6 @@ import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
 
-const defaultBlocks = (
-  'Paragraph=p;' +
-  'Heading 1=h1;' +
-  'Heading 2=h2;' +
-  'Heading 3=h3;' +
-  'Heading 4=h4;' +
-  'Heading 5=h5;' +
-  'Heading 6=h6;' +
-  'Preformatted=pre'
-);
-
 const getSpec = (editor: Editor): SelectSpec => {
   const fallbackFormat = 'Paragraph';
 
@@ -50,7 +39,7 @@ const getSpec = (editor: Editor): SelectSpec => {
     });
   };
 
-  const dataset = buildBasicSettingsDataset(editor, 'block_formats', defaultBlocks, Delimiter.SemiColon);
+  const dataset = buildBasicSettingsDataset(editor, 'block_formats', Delimiter.SemiColon);
 
   return {
     tooltip: 'Blocks',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
@@ -55,8 +55,8 @@ const split = (rawFormats: string, delimiter: Delimiter): string[] => {
   }
 };
 
-const buildBasicSettingsDataset = (editor: Editor, settingName: string, defaults: string, delimiter: Delimiter): BasicSelectDataset => {
-  const rawFormats = editor.getParam(settingName, defaults, 'string');
+const buildBasicSettingsDataset = (editor: Editor, settingName: string, delimiter: Delimiter): BasicSelectDataset => {
+  const rawFormats = editor.options.get(settingName);
   const data = process(split(rawFormats, delimiter));
   return {
     type: 'basic',


### PR DESCRIPTION
Related Ticket: TINY-8235

Description of Changes:
* Adds a `Type.is` function to Katamari to check if an object is a specific class/constructor type
* Swap to using `Array.isArray` instead of the custom proto check
* Adds the `regexp` and `object[]` built-in processors for options
* Changed the `string[]` built-in processor to allow a string array or a comma/space separated string (as discussed at stand up)
* Updated the registered options to make use of them

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
