### PR TITLE
TINY-8278: Added a lock for headless tests to prevent them running simultaneously

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,11 +118,14 @@ node("headless-macos") {
 
     processes["headless-and-archive"] = {
       stage ("headless tests") {
-        // chrome-headless tests run on the same node as the pipeline
-        // we are re-using the state prepared by `ci-all` below
-        // if we ever change these tests to run on a different node, rollup is required in addition to the normal CI command
-        echo "Platform: chrome-headless tests on node: $NODE_NAME"
-        runHeadlessTests(runAllTests)
+        // Prevent multiple headless tests running at once
+        lock("headless tests") {
+          // chrome-headless tests run on the same node as the pipeline
+          // we are re-using the state prepared by `ci-all` below
+          // if we ever change these tests to run on a different node, rollup is required in addition to the normal CI command
+          echo "Platform: chrome-headless tests on node: $NODE_NAME"
+          runHeadlessTests(runAllTests)
+        }
       }
 
       if (BRANCH_NAME != primaryBranch) {


### PR DESCRIPTION
Related Ticket: TINY-8278

Description of Changes:

This just attempts to fix an issue we found where tests seemed to be locking up when running multiple headless browsers in parallel.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
