### PR TITLE
TINY-8256: Don't use the new operator when constructing addons

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `editor.setContent()` API can now be prevented using the `BeforeSetContent` event. This makes it consistent with the `editor.selection.setContent()` API #TINY-8018
 - Aligning a table to the left or right will now use margin styling instead of float styling #TINY-6558
 - The `tinymce.settings` global property is no longer set upon initialization #TINY-7359
+- Addons such as plugins and themes are no longer constructed using the `new` operator #TINY-8256
 
 ### Fixed
 - The object returned from the `editor.fire()` API was incorrect if the editor had been removed #TINY-8018

--- a/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
@@ -24,7 +24,7 @@ import I18n from './util/I18n';
  *
  * @class tinymce.Theme
  * @example
- * tinymce.ThemeManager.add('MyTheme', function(editor) {
+ * tinymce.ThemeManager.add('MyTheme', (editor) => {
  *     // Setup up custom UI elements in the dom
  *     var div = document.createElement('div');
  *     var iframe = document.createElement('iframe');
@@ -63,7 +63,7 @@ import I18n from './util/I18n';
  *
  * @class tinymce.Plugin
  * @example
- * tinymce.PluginManager.add('MyPlugin', function(editor, url) {
+ * tinymce.PluginManager.add('MyPlugin', (editor, url) => {
  *     // Register a toolbar button that triggers an alert when clicked
  *     // To show this button in the editor, include it in the toolbar setting
  *     editor.ui.registry.addButton('myCustomToolbarButton', {
@@ -101,10 +101,7 @@ export interface UrlObject { prefix: string; resource: string; suffix: string }
 
 type WaitState = 'added' | 'loaded';
 
-// This is a work around as constructors will only work with classes,
-// but our plugins are all functions.
-type AddOnCallback<T> = (editor: Editor, url: string) => void | T;
-export type AddOnConstructor<T> = new (editor: Editor, url: string) => T;
+export type AddOnConstructor<T> = (editor: Editor, url: string) => void | T;
 
 interface AddOnManager<T> {
   items: AddOnConstructor<T>[];
@@ -113,7 +110,7 @@ interface AddOnManager<T> {
   _listeners: { name: string; state: WaitState; callback: () => void }[];
   get: (name: string) => AddOnConstructor<T>;
   requireLangPack: (name: string, languages: string) => void;
-  add: (id: string, addOn: AddOnCallback<T>) => AddOnConstructor<T>;
+  add: (id: string, addOn: AddOnConstructor<T>) => AddOnConstructor<T>;
   remove: (name: string) => void;
   createUrl: (baseUrl: UrlObject, dep: string | UrlObject) => UrlObject;
   load: (name: string, addOnUrl: string | UrlObject, success?: () => void, scope?: any, failure?: () => void) => void;
@@ -154,14 +151,13 @@ const AddOnManager = <T>(): AddOnManager<T> => {
     }
   };
 
-  const add = (id: string, addOn: AddOnCallback<T>) => {
-    const addOnConstructor = addOn as unknown as AddOnConstructor<T>;
-    items.push(addOnConstructor);
-    lookup[id] = { instance: addOnConstructor };
+  const add = (id: string, addOn: AddOnConstructor<T>) => {
+    items.push(addOn);
+    lookup[id] = { instance: addOn };
 
     runListeners(id, 'added');
 
-    return addOnConstructor;
+    return addOn;
   };
 
   const remove = (name: string) => {

--- a/modules/tinymce/src/core/main/ts/api/PluginManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/PluginManager.ts
@@ -6,9 +6,11 @@
  */
 
 import AddOnManager from './AddOnManager';
+import Editor from './Editor';
 
 export interface Plugin {
   getMetadata?: () => { name: string; url: string };
+  init?: (editor: Editor, url: string) => void;
 
   // Allow custom apis
   [key: string]: any;

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -34,11 +34,11 @@ const initPlugin = (editor: Editor, initializedPlugins: string[], plugin: string
     }
 
     try {
-      const pluginInstance = new Plugin(editor, pluginUrl);
+      const pluginInstance = Plugin(editor, pluginUrl) || {};
 
       editor.plugins[plugin] = pluginInstance;
 
-      if (pluginInstance.init) {
+      if (Type.isFunction(pluginInstance.init)) {
         pluginInstance.init(editor, pluginUrl);
         initializedPlugins.push(plugin);
       }
@@ -83,9 +83,9 @@ const initTheme = (editor: Editor) => {
 
   if (Type.isString(theme)) {
     const Theme = ThemeManager.get(theme);
-    editor.theme = new Theme(editor, ThemeManager.urls[theme]);
+    editor.theme = Theme(editor, ThemeManager.urls[theme]) || {};
 
-    if (editor.theme.init) {
+    if (Type.isFunction(editor.theme.init)) {
       editor.theme.init(editor, ThemeManager.urls[theme] || editor.documentBaseUrl.replace(/\/$/, ''));
     }
   } else {


### PR DESCRIPTION
Related Ticket: TINY-8256

Description of Changes:

Updated how plugins and themes are initialised so that they don't use the `new` operator. This means that plugins/themes can be defined using arrow functions, etc...

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
