### PR TITLE
TINY-8234: Added missing api_key option and ignore mobile when reporting unregistered options

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Obj, Strings, Type } from '@ephox/katamari';
+import { Arr, Obj, Strings, Type } from '@ephox/katamari';
 
 import Editor from './Editor';
 import { EditorOptions, NormalizedEditorOptions } from './OptionTypes';
@@ -209,7 +209,7 @@ const create = (editor: Editor, initialOptions: Record<string, unknown>): Option
   const values: Record<string, any> = {};
 
   editor.on('init', () => {
-    const unregisteredOptions = Arr.filter(Obj.keys(initialOptions), Fun.not(isRegistered));
+    const unregisteredOptions = Arr.filter(Obj.keys(initialOptions), (option) => !isRegistered(option) && option !== 'mobile');
     if (unregisteredOptions.length > 0) {
       // eslint-disable-next-line no-console
       console.warn('The following options were specified but have not been registered:\n - ' + unregisteredOptions.join('\n - '));

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -651,6 +651,10 @@ const register = (editor: Editor) => {
     default: true
   });
 
+  registerOption('api_key', {
+    processor: 'string'
+  });
+
   // These options must be registered later in the init sequence due to their default values
   // TODO: TINY-8234 Should we have a way to lazily load the default values?
   editor.on('ScriptsLoaded', () => {


### PR DESCRIPTION
Related Ticket: TINY-8234

Description of Changes:
* Added the missing `api_key` option which is used with cloud
* Don't report `mobile` as an unregistered option as it'll be flatten when normalised

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
