### PR TITLE
TINY-8162: Fixed types that weren't cleaned up when the deprecated Env properties were removed

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Tinymce.ts
+++ b/modules/tinymce/src/core/main/ts/api/Tinymce.ts
@@ -177,13 +177,6 @@ interface TinyMCE extends EditorManager {
   resolve: Tools['resolve'];
   explode: Tools['explode'];
   _addCacheSuffix: Tools['_addCacheSuffix'];
-
-  // Legacy browser detection
-  isOpera: boolean;
-  isWebKit: boolean;
-  isIE: false | number;
-  isGecko: boolean;
-  isMac: boolean;
 }
 
 /**


### PR DESCRIPTION
Related Ticket: TINY-8162

Description of Changes:

This is something I missed in https://github.com/tinymce/tinymce/pull/7314. Unfortunately because of the way `Tools.extend` work TypeScript couldn't tell these weren't implemented.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
