### PR TITLE
TINY-8162: Removed old v4 deprecated toolbar button/menu APIs

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -1085,34 +1085,6 @@ class Editor implements EditorObservable {
   public _scanForImages(): Promise<BlobInfoImagePair[]> {
     return this.editorUpload.scanForImages();
   }
-
-  /**
-   * No longer supported, use editor.ui.registry.addButton instead
-   */
-  public addButton() {
-    throw new Error('editor.addButton has been removed in tinymce 5x, use editor.ui.registry.addButton or editor.ui.registry.addToggleButton or editor.ui.registry.addSplitButton instead');
-  }
-
-  /**
-   * No longer supported, use editor.ui.registry.addSidebar instead
-   */
-  public addSidebar() {
-    throw new Error('editor.addSidebar has been removed in tinymce 5x, use editor.ui.registry.addSidebar instead');
-  }
-
-  /**
-   * No longer supported, use editor.ui.registry.addMenuItem instead
-   */
-  public addMenuItem() {
-    throw new Error('editor.addMenuItem has been removed in tinymce 5x, use editor.ui.registry.addMenuItem instead');
-  }
-
-  /**
-   * No longer supported, use editor.ui.registry.addContextMenu instead
-   */
-  public addContextToolbar() {
-    throw new Error('editor.addContextToolbar has been removed in tinymce 5x, use editor.ui.registry.addContextToolbar instead');
-  }
 }
 
 export default Editor;


### PR DESCRIPTION
Related Ticket: TINY-8162

Description of Changes:
* Just cleans up some more deprecated APIs that we'd missed

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
