### PR TITLE
TINY-8235: Fixed incorrect partial/shared editor types in McAgar

### DIFF
--- a/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
@@ -23,8 +23,8 @@ export interface GetContentArgs {
 
 export interface Editor {
   id: string;
-  settings: Record<string, any>;
-  options: any;
+  settings?: Record<string, any>;
+  options?: any;
   inline: boolean;
 
   dom: any;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/alien/Options.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/alien/Options.ts
@@ -11,7 +11,7 @@ const get = <R>(editor: Editor, name: string): R => {
 const set = <T>(editor: Editor, name: string, value: T): void => {
   if (editor.options) {
     editor.options.set(name, value);
-  } else {
+  } else if (editor.settings) {
     editor.settings[name] = value;
   }
 };
@@ -19,7 +19,7 @@ const set = <T>(editor: Editor, name: string, value: T): void => {
 const unset = (editor: Editor, name: string): void => {
   if (editor.options) {
     editor.options.unset(name);
-  } else {
+  } else if (editor.settings) {
     delete editor.settings[name];
   }
 };

--- a/modules/mcagar/src/test/ts/browser/api/TinySetAndDeleteSettingTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinySetAndDeleteSettingTest.ts
@@ -10,7 +10,7 @@ UnitTest.asynctest('TinySetAndDeleteSettingTest', (success, failure) => {
 
   const sAssertSetting = (editor: Editor, key: string, expected: any) => {
     return Step.sync(() => {
-      const actual = editor.options ? editor.options.get(key) : editor.settings[key];
+      const actual = editor.options ? editor.options.get(key) : editor.settings?.[key];
 
       return Assertions.assertEq('should have expected val at key', expected, actual);
     });
@@ -18,7 +18,7 @@ UnitTest.asynctest('TinySetAndDeleteSettingTest', (success, failure) => {
 
   const sAssertSettingType = (editor: Editor, key: string, expected: any) => {
     return Step.sync(() => {
-      const actual = editor.options ? editor.options.get(key) : editor.settings[key];
+      const actual = editor.options ? editor.options.get(key) : editor.settings?.[key];
 
       return Assertions.assertEq('should have expected type', expected, typeof actual);
     });


### PR DESCRIPTION
Related Ticket: TINY-8235

Description of Changes:

When doing some upgrades I noticed the shared Editor types don't work as `options` is mandatory. So this fixes them so that they work with TinyMCE 5/6 types.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
