### PR TITLE
TINY-4603: Renaming link options to be more consistent

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add-ons such as plugins and themes are no longer constructed using the `new` operator #TINY-8256
 - A number of APIs that were not proper classes, are no longer constructed using the `new` operator #TINY-8322
 - Moved the `print` plugin's functionality to TinyMCE core #TINY-8314
-- The `default_link_target` has been renamed to `link_default_target` for both `link` and `autolink` plugins #TINY-4603
-- The `rel_list` has been renamed to `link_rel_list` for `link` plugins #TINY-4603
-- The `target_list` has been renamed to `link_target_list` for `link` plugins #TINY-4603
+- The `default_link_target` option has been renamed to `link_default_target` for both `link` and `autolink` plugins #TINY-4603
+- The `rel_list` option has been renamed to `link_rel_list` for the `link` plugin #TINY-4603
+- The `target_list` option has been renamed to `link_target_list` for the `link` plugin #TINY-4603
 
 ### Fixed
 - The object returned from the `editor.fire()` API was incorrect if the editor had been removed #TINY-8018

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add-ons such as plugins and themes are no longer constructed using the `new` operator #TINY-8256
 - A number of APIs that were not proper classes, are no longer constructed using the `new` operator #TINY-8322
 - Moved the `print` plugin's functionality to TinyMCE core #TINY-8314
+- The `default_link_target` has been renamed to `link_default_target` for both `link` and `autolink` plugins #TINY-4603
+- The `rel_list` has been renamed to `link_rel_list` for `link` plugins #TINY-4603
+- The `target_list` has been renamed to `link_target_list` for `link` plugins #TINY-4603
 
 ### Fixed
 - The object returned from the `editor.fire()` API was incorrect if the editor had been removed #TINY-8018

--- a/modules/tinymce/src/plugins/autolink/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/api/Options.ts
@@ -25,7 +25,7 @@ const register = (editor: Editor): void => {
     default: new RegExp('^' + Regexes.link().source + '$', 'i')
   });
 
-  registerOption('default_link_target', {
+  registerOption('link_default_target', {
     processor: 'string'
   });
 
@@ -36,7 +36,7 @@ const register = (editor: Editor): void => {
 };
 
 const getAutoLinkPattern = option<RegExp>('autolink_pattern');
-const getDefaultLinkTarget = option<string>('default_link_target');
+const getDefaultLinkTarget = option<string>('link_default_target');
 const getDefaultLinkProtocol = option<string>('link_default_protocol');
 
 export {

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -136,14 +136,14 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     );
   });
 
-  it(`TBA: default_link_target='_self'`, () => {
+  it(`TBA: link_default_target='_self'`, () => {
     const editor = hook.editor();
-    editor.options.set('default_link_target', '_self');
+    editor.options.set('link_default_target', '_self');
     LegacyUnit.equal(
       typeUrl(editor, 'http://www.domain.com'),
       '<p><a href="http://www.domain.com" target="_self">http://www.domain.com</a>&nbsp;</p>'
     );
-    editor.options.unset('default_link_target');
+    editor.options.unset('link_default_target');
   });
 
   it('TBA: link_default_protocol=https', () => {

--- a/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
@@ -51,7 +51,7 @@ const register = (editor: Editor): void => {
     processor: (value) => Type.isString(value) || Type.isFunction(value) || Type.isArrayOf(value, Type.isObject)
   });
 
-  registerOption('default_link_target', {
+  registerOption('link_default_target', {
     processor: 'string'
   });
 
@@ -60,12 +60,12 @@ const register = (editor: Editor): void => {
     default: 'http'
   });
 
-  registerOption('target_list', {
+  registerOption('link_target_list', {
     processor: (value) => Type.isBoolean(value) || Type.isArrayOf(value, Type.isObject),
     default: true
   });
 
-  registerOption('rel_list', {
+  registerOption('link_rel_list', {
     processor: 'object[]',
     default: []
   });
@@ -94,10 +94,10 @@ const register = (editor: Editor): void => {
 const assumeExternalTargets = option<AssumeExternalTargets>('link_assume_external_targets');
 const hasContextToolbar = option<boolean>('link_context_toolbar');
 const getLinkList = option<string | UserListItem[] | UserLinkListCallback>('link_list');
-const getDefaultLinkTarget = option<string>('default_link_target');
+const getDefaultLinkTarget = option<string>('link_default_target');
 const getDefaultLinkProtocol = option<string>('link_default_protocol');
-const getTargetList = option<boolean | UserListItem[]>('target_list');
-const getRelList = option<UserListItem[]>('rel_list');
+const getTargetList = option<boolean | UserListItem[]>('link_target_list');
+const getRelList = option<UserListItem[]>('link_rel_list');
 const getLinkClassList = option<UserListItem[]>('link_class_list');
 const shouldShowLinkTitle = option<boolean>('link_title');
 const allowUnsafeLinkTarget = option<boolean>('allow_unsafe_link_target');

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
@@ -10,7 +10,7 @@ describe('browser.tinymce.plugins.link.AllowUnsafeLinkTargetTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'link',
-    target_list: [
+    link_target_list: [
       { title: 'New page', value: '_blank' }
     ],
     base_url: '/project/tinymce/js/tinymce'
@@ -56,10 +56,10 @@ describe('browser.tinymce.plugins.link.AllowUnsafeLinkTargetTest', () => {
     TinyAssertions.assertContent(editor, '<p><a href="http://www.google.com" target="_blank" rel="alternate nofollow noopener">Google</a></p>');
   });
 
-  it('TBA: allow_unsafe_link_target=false: proper option selected for defined rel_list', async () => {
+  it('TBA: allow_unsafe_link_target=false: proper option selected for defined link_rel_list', async () => {
     const editor = hook.editor();
     editor.options.set('allow_unsafe_link_target', false);
-    editor.options.set('rel_list', [
+    editor.options.set('link_rel_list', [
       { title: 'Lightbox', value: 'lightbox' },
       { title: 'Test rel', value: 'alternate nofollow' },
       { title: 'Table of contents', value: 'toc' }

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkTargetTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DefaultLinkTargetTest.ts
@@ -33,15 +33,15 @@ describe('browser.tinymce.plugins.link.DefaultLinkTargetTest', () => {
 
   it('TBA: adds target if default is set', async () => {
     const editor = hook.editor();
-    editor.options.set('default_link_target', '_blank');
+    editor.options.set('link_default_target', '_blank');
     await TestLinkUi.pInsertLink(editor, 'http://www.google.com');
     await TestLinkUi.pAssertContentPresence(editor, { 'a[target="_blank"]': 1, 'a': 1 });
   });
 
-  it('TBA: adds target if default is set and target_list is enabled', async () => {
+  it('TBA: adds target if default is set and link_target_list is enabled', async () => {
     const editor = hook.editor();
-    editor.options.set('default_link_target', '_blank');
-    editor.options.set('target_list', [
+    editor.options.set('link_default_target', '_blank');
+    editor.options.set('link_target_list', [
       { title: 'None', value: '' },
       { title: 'New', value: '_blank' }
     ]);
@@ -49,18 +49,18 @@ describe('browser.tinymce.plugins.link.DefaultLinkTargetTest', () => {
     await TestLinkUi.pAssertContentPresence(editor, { 'a[target="_blank"]': 1, 'a': 1 });
   });
 
-  it('TBA: adds target if default is set and target_list is disabled', async () => {
+  it('TBA: adds target if default is set and link_target_list is disabled', async () => {
     const editor = hook.editor();
-    editor.options.set('default_link_target', '_blank');
-    editor.options.set('target_list', false);
+    editor.options.set('link_default_target', '_blank');
+    editor.options.set('link_target_list', false);
     await TestLinkUi.pInsertLink(editor, 'http://www.google.com');
     await TestLinkUi.pAssertContentPresence(editor, { 'a[target="_blank"]': 1, 'a': 1 });
-    editor.options.unset('target_list');
+    editor.options.unset('link_target_list');
   });
 
   it(`TBA: changing to current window doesn't apply the default`, async () => {
     const editor = hook.editor();
-    editor.options.set('default_link_target', '_blank');
+    editor.options.set('link_default_target', '_blank');
     await TestLinkUi.pInsertLink(editor, 'http://www.google.com');
     await TestLinkUi.pAssertContentPresence(editor, { 'a[target="_blank"]': 1, 'a': 1 });
     await TestLinkUi.pOpenLinkDialog(editor);
@@ -71,7 +71,7 @@ describe('browser.tinymce.plugins.link.DefaultLinkTargetTest', () => {
 
   it(`TBA: default isn't applied to an existing link`, async () => {
     const editor = hook.editor();
-    editor.options.set('default_link_target', '_blank');
+    editor.options.set('link_default_target', '_blank');
     editor.setContent('<a href="http://www.google.com">https://www.google.com/</a>');
     await TestLinkUi.pAssertContentPresence(editor, { 'a:not([target="_blank"])': 1, 'a': 1 });
     await TestLinkUi.pOpenLinkDialog(editor);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
@@ -75,7 +75,7 @@ describe('browser.tinymce.plugins.link.DialogSectionsTest', () => {
   const checkTargetSection = (exists: boolean, value: Optional<boolean>) => {
     checkSections([
       {
-        option: { key: 'target_list', value },
+        option: { key: 'link_target_list', value },
         selector: 'label:contains("Open link in...")',
         exists
       }
@@ -95,7 +95,7 @@ describe('browser.tinymce.plugins.link.DialogSectionsTest', () => {
   const checkRelSection = (exists: boolean, value: Optional<Array<{ value: string; title: string }>>) => {
     checkSections([
       {
-        option: { key: 'rel_list', value },
+        option: { key: 'link_rel_list', value },
         selector: 'label:contains("Rel")',
         exists
       }

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
@@ -103,7 +103,7 @@ describe('browser.tinymce.plugins.link.ListOptionsTest', () => {
 
   it('TBA: Checking rel generation', () => {
     const editor = hook.editor();
-    editor.options.set('rel_list', [
+    editor.options.set('link_rel_list', [
       { value: '', text: 'None' },
       { value: 'just one', text: 'Just One' }
     ]);
@@ -115,13 +115,13 @@ describe('browser.tinymce.plugins.link.ListOptionsTest', () => {
         { value: '', text: 'None' },
         { value: 'just one', text: 'Just One' }
       ],
-      'Checking rel_list output'
+      'Checking link_rel_list output'
     );
   });
 
   it('TBA: Checking targets generation', () => {
     const editor = hook.editor();
-    editor.options.set('target_list', [
+    editor.options.set('link_target_list', [
       { value: 'target1', text: 'Target1' },
       { value: 'target2', text: 'Target2' }
     ]);
@@ -133,7 +133,7 @@ describe('browser.tinymce.plugins.link.ListOptionsTest', () => {
         { value: 'target1', text: 'Target1' },
         { value: 'target2', text: 'Target2' }
       ],
-      'Checking target_list output'
+      'Checking link_target_list output'
     );
   });
 });


### PR DESCRIPTION
Description of Changes:
Renamed variables to be consistent with other option names.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
