### PR TITLE
TINY-8282: bind default events last so they can be prevented by themes/plugins

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -27,6 +27,9 @@ import { addVisualInternal } from './view/VisualAidsImpl';
 
 /** API implemented by the RTC plugin */
 interface RtcRuntimeApi {
+  init: {
+    bindEvents: () => void;
+  };
   undoManager: {
     beforeChange: () => void;
     add: () => UndoLevel;
@@ -70,6 +73,9 @@ interface RtcRuntimeApi {
 
 /** A copy of the TinyMCE api definitions that the plugin overrides  */
 interface RtcAdaptor {
+  init: {
+    bindEvents: () => void;
+  };
   undoManager: {
     beforeChange: (locks: Locks, beforeBookmark: UndoBookmark) => void;
     add: (
@@ -125,6 +131,9 @@ interface RtcEditor extends Editor {
 }
 
 const makePlainAdaptor = (editor: Editor): RtcAdaptor => ({
+  init: {
+    bindEvents: Fun.noop
+  },
   undoManager: {
     beforeChange: (locks, beforeBookmark) => Operations.beforeChange(editor, locks, beforeBookmark),
     add: (undoManager, index, locks, beforeBookmark, level, event) =>
@@ -167,9 +176,12 @@ const makePlainAdaptor = (editor: Editor): RtcAdaptor => ({
 
 const makeRtcAdaptor = (rtcEditor: RtcRuntimeApi): RtcAdaptor => {
   const defaultVars = (vars: Record<string, string>) => Type.isObject(vars) ? vars : {};
-  const { undoManager, formatter, editor, selection, raw } = rtcEditor;
+  const { init, undoManager, formatter, editor, selection, raw } = rtcEditor;
 
   return {
+    init: {
+      bindEvents: init.bindEvents
+    },
     undoManager: {
       beforeChange: undoManager.beforeChange,
       add: undoManager.add,
@@ -214,6 +226,9 @@ const makeNoopAdaptor = (): RtcAdaptor => {
   const empty = Fun.constant('');
 
   return {
+    init: {
+      bindEvents: Fun.noop
+    },
     undoManager: {
       beforeChange: Fun.noop,
       add: nul,
@@ -410,3 +425,6 @@ export const getSelectedContent = (editor: Editor, format: ContentFormat, args: 
 
 export const addVisual = (editor: Editor, elm: HTMLElement): void =>
   getRtcInstanceWithError(editor).editor.addVisual(elm);
+
+export const bindEvents = (editor: Editor): void =>
+  getRtcInstanceWithError(editor).init.bindEvents();

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -474,9 +474,11 @@ const initContentBody = (editor: Editor, skipWrite?: boolean) => {
       setupRtc().then((_rtcMode) => {
         editor.setProgressState(false);
         initEditorWithInitialContent(editor);
+        Rtc.bindEvents(editor);
       }, (err) => {
         editor.notificationManager.open({ type: 'error', text: String(err) });
         initEditorWithInitialContent(editor);
+        Rtc.bindEvents(editor);
       });
     });
   });


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This is part of a change on both the RTC side and the tinymce core side.

- [x] Notify me when merged since the rtc plugin in the 6-dev channel will be broken unless we also publish a new rtc plugin

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
