### PR TITLE
TINY-8331: Added SugarElement types for Sugar, Dragster, ImageTools, Agar and McAgar

### DIFF
--- a/modules/agar/src/demo/ts/ephox/agar/demo/DemoContainer.ts
+++ b/modules/agar/src/demo/ts/ephox/agar/demo/DemoContainer.ts
@@ -1,6 +1,6 @@
 import { Class, Html, Insert, InsertAll, Remove, SugarElement, SugarElements } from '@ephox/sugar';
 
-export const init = (name: string, f: (success: () => void, failure: (err: any) => void) => SugarElement[]): void => {
+export const init = (name: string, f: (success: () => void, failure: (err: any) => void) => SugarElement<Node>[]): void => {
   const container = SugarElement.fromTag('div');
   Class.add(container, 'demo-container');
   Html.set(container, '<p>' + name + '</p>');

--- a/modules/agar/src/main/ts/ephox/agar/alien/SizzleFind.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SizzleFind.ts
@@ -1,34 +1,36 @@
 import { Arr, Optional } from '@ephox/katamari';
-import { SugarElement, Traverse } from '@ephox/sugar';
+import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import * as Sizzle from 'sizzle';
 
-const toOptionEl = (output: Element[]): Optional<SugarElement<Element>> =>
+type SizzleContext = Element | Document | DocumentFragment;
+
+const toOptionEl = <T extends Element>(output: T[]): Optional<SugarElement<T>> =>
   output.length === 0 ? Optional.none() : Optional.from(output[0]).map(SugarElement.fromDom);
 
 /* Petrie makes extensive use of :visible, :has() and :contains() which are sizzle extensions */
-const descendant = (sugarElement: SugarElement<any>, selector: string): Optional<SugarElement<Element>> => {
-  const siz: Element[] = Sizzle(selector, sugarElement.dom);
+const descendant = <T extends Element>(sugarElement: SugarElement<SizzleContext>, selector: string): Optional<SugarElement<T>> => {
+  const siz = Sizzle(selector, sugarElement.dom) as T[];
   return toOptionEl(siz);
 };
 
-const toArrayEl = (elements: (Node | Window)[]): SugarElement<Node | Window>[] =>
+const toArrayEl = <T extends Node | Window>(elements: T[]): SugarElement<T>[] =>
   Arr.map(elements, SugarElement.fromDom);
 
 /* Petrie makes extensive use of :visible, :has() and :contains() which are sizzle extensions */
-const descendants = (sugarElement: SugarElement<any>, selector: string): SugarElement<any>[] =>
-  toArrayEl(Sizzle(selector, sugarElement.dom));
+const descendants = <T extends Element>(sugarElement: SugarElement<SizzleContext>, selector: string): SugarElement<T>[] =>
+  toArrayEl(Sizzle(selector, sugarElement.dom) as T[]);
 
-const matches = (sugarElement: SugarElement<any>, selector: string): boolean =>
-  Sizzle.matchesSelector(sugarElement.dom, selector);
+const matches = <T extends Element>(sugarElement: SugarElement<Node>, selector: string): sugarElement is SugarElement<T> =>
+  SugarNode.isElement(sugarElement) && Sizzle.matchesSelector(sugarElement.dom, selector);
 
-const child = (sugarElement: SugarElement<any>, selector: string): Optional<SugarElement<any>> => {
+const child = <T extends Element>(sugarElement: SugarElement<Node>, selector: string): Optional<SugarElement<T>> => {
   const children = Traverse.children(sugarElement);
-  return Arr.find(children, (child) => matches(child, selector));
+  return Arr.find(children, (child): child is SugarElement<T> => matches(child, selector));
 };
 
-const children = (sugarElement: SugarElement<any>, selector: string): SugarElement<any>[] => {
+const children = <T extends Element>(sugarElement: SugarElement<Node>, selector: string): SugarElement<T>[] => {
   const children = Traverse.children(sugarElement);
-  return Arr.filter(children, (child) => matches(child, selector));
+  return Arr.filter(children, (child): child is SugarElement<T> => matches(child, selector));
 };
 
 export {

--- a/modules/agar/src/main/ts/ephox/agar/api/ApproxStructure.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/ApproxStructure.ts
@@ -44,7 +44,7 @@ const arrApi = {
 const build = <T>(f: Builder<T>): T =>
   f(structApi, strApi, arrApi);
 
-const getAttrsExcept = (node: SugarElement<any>, exclude: string[]): Record<string, string> =>
+const getAttrsExcept = (node: SugarElement<Element>, exclude: string[]): Record<string, string> =>
   Obj.bifilter(Attribute.clone(node), (value, key) => !Arr.contains(exclude, key)).t;
 
 const toAssertableObj = (obj: Record<string, string>): Record<string, CombinedAssert> =>
@@ -53,7 +53,7 @@ const toAssertableObj = (obj: Record<string, string>): Record<string, CombinedAs
 const toAssertableArr = (arr: string[]): (StringAssert & ArrayAssert)[] =>
   Arr.map(arr, ApproxComparisons.has);
 
-const fromElement = (node: SugarElement<any>): StructAssert => {
+const fromElement = (node: SugarElement<Node>): StructAssert => {
   if (SugarNode.isElement(node)) {
     return ApproxStructures.element(SugarNode.name(node), {
       children: Arr.map(Traverse.children(node), fromElement),

--- a/modules/agar/src/main/ts/ephox/agar/api/Assertions.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Assertions.ts
@@ -40,7 +40,7 @@ const assertHtml = (label: TestLabel, expected: string, actual: string): void =>
   }
 };
 
-const assertStructure = (label: TestLabel, expected: StructAssert, container: SugarElement<any>): void => {
+const assertStructure = (label: TestLabel, expected: StructAssert, container: SugarElement<Node>): void => {
   Logger.sync(label, () => {
     if (expected.type === 'advanced') {
       expected.doAssert(elementQueue([ container ], Optional.none()));
@@ -54,11 +54,11 @@ const assertHtmlStructure = (label: TestLabel, expected: string, actual: string)
   assertStructure(label, ApproxStructure.fromHtml(expected), SugarElement.fromHtml(actual));
 };
 
-const assertHtmlStructure2 = (label: TestLabel, expected: string, actual: SugarElement<any>): void => {
+const assertHtmlStructure2 = (label: TestLabel, expected: string, actual: SugarElement<Node>): void => {
   assertStructure(label, ApproxStructure.fromHtml(expected), actual);
 };
 
-const assertPresence = (label: TestLabel, expected: Record<string, number>, container: SugarElement<any>): void => {
+const assertPresence = (label: TestLabel, expected: Record<string, number>, container: SugarElement<Node>): void => {
   Obj.each(expected, (num: number, selector: string) => {
     const actual = UiFinder.findAllIn(container, selector).length;
     Assert.eq(TestLabel.concat('Did not find ' + num + ' of ' + selector + ', found: ' + actual + '. Test: ', label), num, actual);
@@ -67,7 +67,7 @@ const assertPresence = (label: TestLabel, expected: Record<string, number>, cont
 
 const assertEq = Assert.eq;
 
-const assertDomEq = (label: TestLabel, expected: SugarElement<any>, actual: SugarElement<any>): void => {
+const assertDomEq = (label: TestLabel, expected: SugarElement<Node>, actual: SugarElement<Node>): void => {
   Assert.eq(
     TestLabel.concat(label, () => '\nExpected : ' + Truncate.getHtml(expected) + '\nActual: ' + Truncate.getHtml(actual)),
     true,

--- a/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
@@ -33,13 +33,13 @@ const pasteFiles = (target: SugarElement<Element>, files: File[]): void =>
     });
   });
 
-const cPasteDataTransfer = (mutator: (dataTransfer: DataTransfer) => void): Chain<SugarElement<any>, SugarElement<any>> =>
+const cPasteDataTransfer = <T extends Element>(mutator: (dataTransfer: DataTransfer) => void): Chain<SugarElement<T>, SugarElement<T>> =>
   Chain.op((target) => pasteDataTransfer(target, mutator));
 
-const cPasteItems = (items: Record<string, string>): Chain<SugarElement<any>, SugarElement<any>> =>
+const cPasteItems = <T extends Element>(items: Record<string, string>): Chain<SugarElement<T>, SugarElement<T>> =>
   Chain.op((target) => pasteItems(target, items));
 
-const cPasteFiles = (files: File[]): Chain<SugarElement<any>, SugarElement<any>> =>
+const cPasteFiles = <T extends Element>(files: File[]): Chain<SugarElement<T>, SugarElement<T>> =>
   Chain.op((target) => pasteFiles(target, files));
 
 const sPasteDataTransfer = <T>(mutator: (dataTransfer: DataTransfer) => void, selector: string): Step<T, T> =>
@@ -83,10 +83,10 @@ const copy = (target: SugarElement<Element>): DataTransfer => {
   return dataTransfer;
 };
 
-const cCut: Chain<SugarElement<any>, DataTransfer> =
+const cCut: Chain<SugarElement<Element>, DataTransfer> =
   Chain.mapper(cut);
 
-const cCopy: Chain<SugarElement<any>, DataTransfer> =
+const cCopy: Chain<SugarElement<Element>, DataTransfer> =
   Chain.mapper(copy);
 
 export {

--- a/modules/agar/src/main/ts/ephox/agar/api/Cursors.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Cursors.ts
@@ -4,9 +4,9 @@ import { Hierarchy, SugarElement } from '@ephox/sugar';
 import { Chain } from './Chain';
 
 export interface CursorRange {
-  readonly start: SugarElement<any>;
+  readonly start: SugarElement<Node>;
   readonly soffset: number;
-  readonly finish: SugarElement<any>;
+  readonly finish: SugarElement<Node>;
   readonly foffset: number;
 }
 
@@ -17,7 +17,7 @@ export interface CursorPath {
   readonly foffset: number;
 }
 
-const range = (obj: { start: SugarElement<any>; soffset: number; finish: SugarElement<any>; foffset: number }): CursorRange => ({
+const range = (obj: { start: SugarElement<Node>; soffset: number; finish: SugarElement<Node>; foffset: number }): CursorRange => ({
   start: obj.start,
   soffset: obj.soffset,
   finish: obj.finish,
@@ -65,13 +65,13 @@ const isCursorSpec = (spec: CursorSpec | RangeSpec): spec is CursorSpec =>
 const pathFrom = (spec: CursorSpec | RangeSpec): CursorPath =>
   isCursorSpec(spec) ? pathFromCollapsed(spec) : pathFromRange(spec);
 
-const follow = (container: SugarElement<any>, calcPath: number[]): Result<SugarElement<any>, string> =>
+const follow = (container: SugarElement<Node>, calcPath: number[]): Result<SugarElement<Node>, string> =>
   Hierarchy.follow(container, calcPath).fold(() =>
     Result.error('Could not follow path: ' + calcPath.join(',')),
   Result.value
   );
 
-const followPath = (container: SugarElement<any>, calcPath: CursorPath): Result<CursorRange, string> =>
+const followPath = (container: SugarElement<Node>, calcPath: CursorPath): Result<CursorRange, string> =>
   follow(container, calcPath.startPath).bind((start) =>
     follow(container, calcPath.finishPath).map((finish) =>
       range({
@@ -81,11 +81,11 @@ const followPath = (container: SugarElement<any>, calcPath: CursorPath): Result<
         foffset: calcPath.foffset
       })));
 
-const cFollowPath = (calcPath: CursorPath): Chain<SugarElement<any>, CursorRange> =>
-  Chain.binder((container: SugarElement<any>) => followPath(container, calcPath));
+const cFollowPath = (calcPath: CursorPath): Chain<SugarElement<Node>, CursorRange> =>
+  Chain.binder((container) => followPath(container, calcPath));
 
-const cFollowCursor = (elementPath: number[], offset: number): Chain<SugarElement<any>, CursorRange> =>
-  Chain.binder((container: SugarElement<any>) =>
+const cFollowCursor = (elementPath: number[], offset: number): Chain<SugarElement<Node>, CursorRange> =>
+  Chain.binder((container) =>
     follow(container, elementPath).map((element) =>
       range({
         start: element,
@@ -96,16 +96,16 @@ const cFollowCursor = (elementPath: number[], offset: number): Chain<SugarElemen
     )
   );
 
-const cFollow = (elementPath: number[]): Chain<SugarElement<any>, SugarElement<any>> =>
-  Chain.binder((container: SugarElement<any>) => follow(container, elementPath));
+const cFollow = (elementPath: number[]): Chain<SugarElement<Node>, SugarElement<Node>> =>
+  Chain.binder((container) => follow(container, elementPath));
 
 const cToRange = Chain.mapper(range);
 const cToPath = Chain.mapper(path);
 
-const calculate = (container: SugarElement<any>, calcPath: CursorPath): CursorRange =>
+const calculate = (container: SugarElement<Node>, calcPath: CursorPath): CursorRange =>
   followPath(container, calcPath).getOrDie();
 
-const calculateOne = (container: SugarElement<any>, calcPath: number[]): SugarElement<any> =>
+const calculateOne = (container: SugarElement<Node>, calcPath: number[]): SugarElement<Node> =>
   follow(container, calcPath).getOrDie();
 
 export {

--- a/modules/agar/src/main/ts/ephox/agar/api/DragnDrop.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/DragnDrop.ts
@@ -16,7 +16,7 @@ interface Item {
   type: string;
 }
 
-const isDraggable = (element: SugarElement<any>): boolean => {
+const isDraggable = (element: SugarElement<Element>): boolean => {
   const name = SugarNode.name(element);
   return (
     name === 'img' ||
@@ -37,7 +37,7 @@ const checkNotDefaultPrevented = (evt: DragEvent): void => {
   }
 };
 
-const dragnDrop = (from: SugarElement<any>, to: SugarElement<any>, prevented: boolean = true): void => {
+const dragnDrop = (from: SugarElement<Element>, to: SugarElement<Element>, prevented: boolean = true): void => {
   const fromWin = getWindowFromElement(from);
   const toWin = getWindowFromElement(to);
   const fromRect = from.dom.getBoundingClientRect();
@@ -98,8 +98,8 @@ const cDragnDrop = <T extends Element> (fromSelector: string, toSelector: string
 const sDragnDrop = <T>(fromSelector: string, toSelector: string, prevented?: boolean): Step<T, T> =>
   Chain.asStep(SugarBody.body(), [ cDragnDrop(fromSelector, toSelector, prevented) ]);
 
-const pDragnDrop = (fromSelector: string, toSelector: string, prevented?: boolean): Promise<SugarElement<Element>> =>
-  Chain.toPromise(cDragnDrop(fromSelector, toSelector, prevented))(SugarBody.body());
+const pDragnDrop = (fromSelector: string, toSelector: string, prevented?: boolean): Promise<SugarElement<HTMLElement>> =>
+  Chain.toPromise(cDragnDrop<HTMLElement>(fromSelector, toSelector, prevented))(SugarBody.body());
 
 const sDropFiles = <T>(files: File[], toSelector: string, prevented?: boolean): Step<T, T> => Chain.asStep(SugarBody.body(), [
   UiFinder.cFindIn(toSelector),

--- a/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
@@ -17,14 +17,14 @@ const getFocused = <T extends HTMLElement>(doc: SugarElement<Document | ShadowRo
   );
 };
 
-const getActiveValue = (element: SugarElement<Node>): string => {
+const getActiveValue = (element: SugarElement<Node>): string | undefined => {
   const doc = SugarShadowDom.getRootNode(element);
   const focused = getFocused(doc).getOrDie();
   return UiControls.getValue(focused as SugarElement<any>);
 };
 
-const setFocus = <T extends Element>(container: SugarElement<Node>, selector: string): SugarElement<T> => {
-  const elem = UiFinder.findIn(container, selector).getOrDie();
+const setFocus = <T extends HTMLElement>(container: SugarElement<Node>, selector: string): SugarElement<T> => {
+  const elem = UiFinder.findIn<T>(container, selector).getOrDie();
   Focus.focus(elem);
   return elem;
 };
@@ -92,7 +92,7 @@ const sTryOnSelector = <T>(label: string, doc: SugarElement<Document | ShadowRoo
 const pTryOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, selector: string): Promise<SugarElement<HTMLElement>> =>
   Waiter.pTryUntil(label + '. Focus did not match: ' + selector, () => isOnSelector(label, doc, selector));
 
-const cSetFocus = <T extends Node, U extends Element>(label: string, selector: string): Chain<SugarElement<T>, SugarElement<U>> =>
+const cSetFocus = <T extends Node, U extends HTMLElement>(label: string, selector: string): Chain<SugarElement<T>, SugarElement<U>> =>
   // Input: container
   Chain.control(
     Chain.mapper((container) => setFocus<U>(container, selector)),

--- a/modules/agar/src/main/ts/ephox/agar/api/Keyboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Keyboard.ts
@@ -12,7 +12,7 @@ export type KeyModifiers = MixedKeyModifiers;
   modifiers - { shift: BOOL, alt: BOOL }
   dispatcher - dispatch event from some element
 */
-const fakeKeys = (types: string[]) => (value: number, modifiers: KeyModifiers = {}, dispatcher: SugarElement<any>) => {
+const fakeKeys = (types: string[]) => (value: number, modifiers: KeyModifiers = {}, dispatcher: SugarElement<Node>) => {
   const doc = Traverse.owner(dispatcher);
   Arr.each(types, (type) => {
     keyevent(type, doc, value, modifiers, dispatcher);

--- a/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
@@ -58,7 +58,7 @@ const cMouseMove = cMouseMoveWith({ });
 const cMouseOut = cMouseOutWith({ });
 
 const triggerOn = <T extends Element>(container: SugarElement<Node>, selector: string, action: (ele: SugarElement<T>) => void): SugarElement<T> => {
-  const ele = UiFinder.findIn(container, selector).getOrDie();
+  const ele = UiFinder.findIn<T>(container, selector).getOrDie();
   action(ele);
   return ele;
 };

--- a/modules/agar/src/main/ts/ephox/agar/api/Touch.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Touch.ts
@@ -6,56 +6,58 @@ import { Step } from './Step';
 import * as UiFinder from './UiFinder';
 
 const touchStart = Touches.touchstart;
-const touchStartAt = (element: SugarElement<any>, dx: number, dy: number): void => Touches.touchstartAt(dx, dy)(element);
+const touchStartAt = (element: SugarElement<Node>, dx: number, dy: number): void => Touches.touchstartAt(dx, dy)(element);
 const touchEnd = Touches.touchend;
-const touchEndAt = (element: SugarElement<any>, dx: number, dy: number): void => Touches.touchendAt(dx, dy)(element);
+const touchEndAt = (element: SugarElement<Node>, dx: number, dy: number): void => Touches.touchendAt(dx, dy)(element);
 const touchMove = Touches.touchmove;
-const touchMoveTo = (element: SugarElement<any>, dx: number, dy: number): void => Touches.touchmoveTo(dx, dy)(element);
+const touchMoveTo = (element: SugarElement<Node>, dx: number, dy: number): void => Touches.touchmoveTo(dx, dy)(element);
 
-const cTrigger = (selector: string, action: (ele: SugarElement<any>) => void) => Chain.async<SugarElement, SugarElement>((container, next, die) => {
-  UiFinder.findIn(container, selector).fold(
-    () => die('Could not find element: ' + selector),
-    (ele) => {
-      action(ele);
-      next(container);
-    }
-  );
-});
+const cTrigger = <T extends Node, U extends Element>(selector: string, action: (ele: SugarElement<U>) => void) =>
+  Chain.async<SugarElement<T>, SugarElement<T>>((container, next, die) => {
+    UiFinder.findIn<U>(container, selector).fold(
+      () => die('Could not find element: ' + selector),
+      (ele) => {
+        action(ele);
+        next(container);
+      }
+    );
+  });
 
-const sTriggerWith = <T>(container: SugarElement<any>, selector: string, action: (ele: SugarElement<any>) => void) => Chain.asStep<T, SugarElement>(container, [ cTrigger(selector, action) ]);
+const sTriggerWith = <T, U extends Element>(container: SugarElement<Node>, selector: string, action: (ele: SugarElement<U>) => void) =>
+  Chain.asStep<T, SugarElement<Node>>(container, [ cTrigger<Node, U>(selector, action) ]);
 
-const trueTap = (elem: SugarElement<any>): void => {
+const trueTap = (elem: SugarElement<HTMLElement>): void => {
   // The closest event queue to a true tap event
   Focus.focus(elem);
   Touches.touchstart(elem);
   Touches.touchend(elem);
 };
 
-const tap = (elem: SugarElement<any>): void => {
+const tap = (elem: SugarElement<Node>): void => {
   Touches.touchstart(elem);
   Touches.touchend(elem);
 };
 
-const sTap = <T>(element: SugarElement<any>): Step<T, T> =>
+const sTap = <T>(element: SugarElement<Node>): Step<T, T> =>
   Step.sync<T>(() => tap(element));
 
-const sTrueTapOn = <T>(container: SugarElement<any>, selector: string): Step<T, T> =>
-  sTriggerWith<T>(container, selector, trueTap);
+const sTrueTapOn = <T>(container: SugarElement<Node>, selector: string): Step<T, T> =>
+  sTriggerWith<T, HTMLElement>(container, selector, trueTap);
 
-const sTapOn = <T>(container: SugarElement<any>, selector: string): Step<T, T> =>
-  sTriggerWith<T>(container, selector, tap);
+const sTapOn = <T>(container: SugarElement<Node>, selector: string): Step<T, T> =>
+  sTriggerWith<T, Element>(container, selector, tap);
 
-const cTapOn = (selector: string): Chain<SugarElement, SugarElement> =>
+const cTapOn = <T extends Node>(selector: string): Chain<SugarElement<T>, SugarElement<T>> =>
   cTrigger(selector, tap);
 
-const cTouchStartAt = (dx: number, dy: number): Chain<SugarElement, SugarElement> =>
-  Chain.op(Touches.touchstartAt(dx, dy));
+const cTouchStartAt = <T extends Node>(dx: number, dy: number): Chain<SugarElement<T>, SugarElement<T>> =>
+  Chain.op<SugarElement<T>>(Touches.touchstartAt(dx, dy));
 
-const cTouchEndAt = (dx: number, dy: number): Chain<SugarElement, SugarElement> =>
-  Chain.op(Touches.touchendAt(dx, dy));
+const cTouchEndAt = <T extends Node>(dx: number, dy: number): Chain<SugarElement<T>, SugarElement<T>> =>
+  Chain.op<SugarElement<T>>(Touches.touchendAt(dx, dy));
 
-const cTouchMoveTo = (dx: number, dy: number): Chain<SugarElement, SugarElement> =>
-  Chain.op(Touches.touchmoveTo(dx, dy));
+const cTouchMoveTo = <T extends Node>(dx: number, dy: number): Chain<SugarElement<T>, SugarElement<T>> =>
+  Chain.op<SugarElement<T>>(Touches.touchmoveTo(dx, dy));
 
 const point = Touches.point;
 

--- a/modules/agar/src/main/ts/ephox/agar/api/UiControls.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/UiControls.ts
@@ -7,7 +7,7 @@ import * as UiFinder from './UiFinder';
 
 type TogglableElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | HTMLOptionElement | HTMLButtonElement;
 
-const fireEvent = (elem: SugarElement, event: string) => {
+const fireEvent = (elem: SugarElement<Node>, event: string) => {
   const evt = new Event(event, {
     bubbles: true,
     cancelable: true
@@ -23,7 +23,7 @@ const setValue = (element: SugarElement<TogglableElement>, newValue: string, eve
 };
 
 const setValueOn = (container: SugarElement<Node>, selector: string, newValue: string, eventName?: string): void => {
-  const element = UiFinder.findIn(container, selector).getOrDie();
+  const element = UiFinder.findIn<TogglableElement>(container, selector).getOrDie();
   setValue(element, newValue, eventName);
 };
 

--- a/modules/agar/src/main/ts/ephox/agar/api/UiFinder.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/UiFinder.ts
@@ -1,4 +1,3 @@
-import { TestLabel } from '@ephox/bedrock-client';
 import { Fun, Result } from '@ephox/katamari';
 import { SugarElement, Truncate, Visibility } from '@ephox/sugar';
 
@@ -7,11 +6,8 @@ import { Chain } from './Chain';
 import * as Guard from './Guard';
 import { Step } from './Step';
 
-const findIn = (container: SugarElement<any>, selector: string): Result<SugarElement<any>, TestLabel> =>
-  UiSearcher.findIn(container, selector);
-
-const findAllIn = (container: SugarElement<any>, selector: string): SugarElement<any>[] =>
-  UiSearcher.findAllIn(container, selector);
+const findIn = UiSearcher.findIn;
+const findAllIn = UiSearcher.findAllIn;
 
 const exists = (container: SugarElement<Node>, selector: string): void => {
   findIn(container, selector).fold(
@@ -31,74 +27,74 @@ const notExists = (container: SugarElement<Node>, selector: string): void => {
   );
 };
 
-const cWaitFor = (message: string, selector: string): Chain<SugarElement<any>, SugarElement<any>> =>
+const cWaitFor = <T extends Element>(message: string, selector: string): Chain<SugarElement<Node>, SugarElement<T>> =>
   cWaitForState(message, selector, Fun.always);
 
-const sWaitFor = <T>(message: string, container: SugarElement<any>, selector: string): Step<T, T> =>
-  Chain.asStep<T, SugarElement>(container, [ cWaitFor(message, selector) ]);
+const sWaitFor = <T>(message: string, container: SugarElement<Node>, selector: string): Step<T, T> =>
+  Chain.asStep<T, SugarElement<Node>>(container, [ cWaitFor(message, selector) ]);
 
-const cWaitForVisible = (message: string, selector: string): Chain<SugarElement<any>, SugarElement<any>> =>
-  cWaitForState(message, selector, Visibility.isVisible);
+const cWaitForVisible = <T extends HTMLElement>(message: string, selector: string): Chain<SugarElement<Node>, SugarElement<T>> =>
+  cWaitForState<T>(message, selector, Visibility.isVisible);
 
 // TODO: Perhaps create cWaitForNoState rather than Fun.not here?
-const cWaitForHidden = (message: string, selector: string): Chain<SugarElement<any>, SugarElement<any>> =>
-  cWaitForState(message, selector, Fun.not(Visibility.isVisible));
+const cWaitForHidden = <T extends HTMLElement>(message: string, selector: string): Chain<SugarElement<Node>, SugarElement<T>> =>
+  cWaitForState<T>(message, selector, Fun.not(Visibility.isVisible));
 
-const sWaitForVisible = <T>(message: string, container: SugarElement<any>, selector: string): Step<T, T> =>
-  Chain.asStep<T, SugarElement>(container, [ cWaitForVisible(message, selector) ]);
+const sWaitForVisible = <T>(message: string, container: SugarElement<Node>, selector: string): Step<T, T> =>
+  Chain.asStep<T, SugarElement<Node>>(container, [ cWaitForVisible(message, selector) ]);
 
-const sWaitForHidden = <T>(message: string, container: SugarElement<any>, selector: string): Step<T, T> =>
-  Chain.asStep<T, SugarElement>(container, [ cWaitForHidden(message, selector) ]);
+const sWaitForHidden = <T>(message: string, container: SugarElement<Node>, selector: string): Step<T, T> =>
+  Chain.asStep<T, SugarElement<Node>>(container, [ cWaitForHidden(message, selector) ]);
 
-const cHasState = <T> (predicate: (element: SugarElement<T>) => boolean): Chain<SugarElement<T>, SugarElement<T>> =>
+const cHasState = <T extends Node> (predicate: (element: SugarElement<T>) => boolean): Chain<SugarElement<T>, SugarElement<T>> =>
   Chain.binder((element) => predicate(element) ? Result.value(element) :
     Result.error(Truncate.getHtml(element) + ' did not match predicate: ' + predicate.toString()));
 
-const cFindWithState = (selector: string, predicate: (element: SugarElement<any>) => boolean): Chain<SugarElement<any>, SugarElement<any>> =>
+const cFindWithState = <T extends Element>(selector: string, predicate: (element: SugarElement<T>) => boolean): Chain<SugarElement<Node>, SugarElement<T>> =>
   Chain.fromChains([
     cFindIn(selector),
     cHasState(predicate)
   ]);
 
 // Wait for a selector to have state. Max wait time: 10 seconds.
-const cWaitForState = (message: string, selector: string, predicate: (element: SugarElement<any>) => boolean): Chain<SugarElement<any>, SugarElement<any>> =>
+const cWaitForState = <T extends Element>(message: string, selector: string, predicate: (element: SugarElement<T>) => boolean): Chain<SugarElement<Node>, SugarElement<T>> =>
   Chain.control(
     cFindWithState(selector, predicate),
     Guard.tryUntil(message, 10, 10000)
   );
 
-const sExists = <T>(container: SugarElement<any>, selector: string): Step<T, T> =>
+const sExists = <T>(container: SugarElement<Node>, selector: string): Step<T, T> =>
   Step.sync<T>(() => exists(container, selector));
 
-const sNotExists = <T>(container: SugarElement<any>, selector: string): Step<T, T> =>
+const sNotExists = <T>(container: SugarElement<Node>, selector: string): Step<T, T> =>
   Step.sync<T>(() => notExists(container, selector));
 
-const cExists = (selector: string): Chain<SugarElement<any>, SugarElement<any>> =>
-  Chain.op((container: SugarElement<any>) => exists(container, selector));
+const cExists = <T extends Node>(selector: string): Chain<SugarElement<T>, SugarElement<T>> =>
+  Chain.op((container) => exists(container, selector));
 
-const cNotExists = (selector: string): Chain<SugarElement<any>, SugarElement<any>> =>
-  Chain.op((container: SugarElement<any>) => notExists(container, selector));
+const cNotExists = <T extends Node>(selector: string): Chain<SugarElement<T>, SugarElement<T>> =>
+  Chain.op((container) => notExists(container, selector));
 
-const cFindIn = (selector: string): Chain<SugarElement<any>, SugarElement<any>> =>
-  Chain.binder((container: SugarElement<any>) =>
+const cFindIn = (selector: string): Chain<SugarElement<Node>, SugarElement<Element>> =>
+  Chain.binder((container) =>
     findIn(container, selector)
   );
 
-const cFindAllIn = (selector: string): Chain<SugarElement<any>, SugarElement<any>[]> =>
-  Chain.mapper((container: SugarElement<any>) =>
+const cFindAllIn = <T extends Element>(selector: string): Chain<SugarElement<Node>, SugarElement<T>[]> =>
+  Chain.mapper((container) =>
     findAllIn(container, selector)
   );
 
-const pWaitFor = (message: string, container: SugarElement<Node>, selector: string): Promise<SugarElement<Element>> =>
-  Chain.toPromise(cWaitFor(message, selector))(container);
+const pWaitFor = <T extends Element>(message: string, container: SugarElement<Node>, selector: string): Promise<SugarElement<T>> =>
+  Chain.toPromise(cWaitFor<T>(message, selector))(container);
 
-const pWaitForVisible = (message: string, container: SugarElement<Node>, selector: string): Promise<SugarElement<Element>> =>
-  Chain.toPromise(cWaitForVisible(message, selector))(container);
+const pWaitForVisible = <T extends HTMLElement>(message: string, container: SugarElement<Node>, selector: string): Promise<SugarElement<T>> =>
+  Chain.toPromise(cWaitForVisible<T>(message, selector))(container);
 
-const pWaitForHidden = (message: string, container: SugarElement<Node>, selector: string): Promise<SugarElement<Element>> =>
-  Chain.toPromise(cWaitForHidden(message, selector))(container);
+const pWaitForHidden = <T extends HTMLElement>(message: string, container: SugarElement<Node>, selector: string): Promise<SugarElement<T>> =>
+  Chain.toPromise(cWaitForHidden<T>(message, selector))(container);
 
-const pWaitForState = (message: string, container: SugarElement<Node>, selector: string, predicate: (element: SugarElement<any>) => boolean): Promise<SugarElement<Element>> =>
+const pWaitForState = <T extends Element>(message: string, container: SugarElement<Node>, selector: string, predicate: (element: SugarElement<T>) => boolean): Promise<SugarElement<T>> =>
   Chain.toPromise(cWaitForState(message, selector, predicate))(container);
 
 export {

--- a/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
@@ -6,29 +6,29 @@ import * as SizzleFind from '../alien/SizzleFind';
 
 interface TargetAdt {
   fold: <T> (
-    self: (element: SugarElement<any>, selector: string) => T,
-    children: (element: SugarElement<any>, selector: string) => T,
-    descendants: (element: SugarElement<any>, selector: string) => T
+    self: (element: SugarElement<Node>, selector: string) => T,
+    children: (element: SugarElement<Node>, selector: string) => T,
+    descendants: (element: SugarElement<Node>, selector: string) => T
   ) => T;
   match: <T>(branches: {
-    self: (element: SugarElement<any>, selector: string) => T;
-    children: (element: SugarElement<any>, selector: string) => T;
-    descendants: (element: SugarElement<any>, selector: string) => T;
+    self: (element: SugarElement<Node>, selector: string) => T;
+    children: (element: SugarElement<Node>, selector: string) => T;
+    descendants: (element: SugarElement<Node>, selector: string) => T;
   }) => T;
   log: (label: string) => void;
 }
 
 const targets: {
-  self: (element: SugarElement<any>, selector: string) => TargetAdt;
-  children: (element: SugarElement<any>, selector: string) => TargetAdt;
-  descendants: (element: SugarElement<any>, selector: string) => TargetAdt;
+  self: (element: SugarElement<Node>, selector: string) => TargetAdt;
+  children: (element: SugarElement<Node>, selector: string) => TargetAdt;
+  descendants: (element: SugarElement<Node>, selector: string) => TargetAdt;
 } = Adt.generate([
   { self: [ 'element', 'selector' ] },
   { children: [ 'element', 'selector' ] },
   { descendants: [ 'element', 'selector' ] }
 ]);
 
-const derive = (element: SugarElement<any>, selector: string) => {
+const derive = (element: SugarElement<Node>, selector: string) => {
   // Not sure if error is what I want here.
   if (selector === undefined) {
     throw new Error('No selector passed through');
@@ -41,19 +41,19 @@ const derive = (element: SugarElement<any>, selector: string) => {
   }
 };
 
-const matchesSelf = (element: SugarElement<any>, selector: string): Optional<SugarElement<any>> =>
-  SizzleFind.matches(element, selector) ? Optional.some(element) : Optional.none();
+const matchesSelf = <T extends Element>(element: SugarElement<Node>, selector: string): Optional<SugarElement<T>> =>
+  SizzleFind.matches<T>(element, selector) ? Optional.some(element) : Optional.none();
 
-const select = (element: SugarElement<any>, selector: string): Optional<SugarElement<any>> =>
-  derive(element, selector).fold(
+const select = <T extends Element>(element: SugarElement<Node>, selector: string): Optional<SugarElement<T>> =>
+  derive(element, selector).fold<Optional<SugarElement<T>>>(
     matchesSelf,
     SizzleFind.child,
     SizzleFind.descendant
   );
 
-const selectAll = (element: SugarElement<any>, selector: string): Array<SugarElement<any>> =>
-  derive(element, selector).fold(
-    (element, selector) => matchesSelf(element, selector).toArray(),
+const selectAll = <T extends Element>(element: SugarElement<Node>, selector: string): Array<SugarElement<T>> =>
+  derive(element, selector).fold<Array<SugarElement<T>>>(
+    (element, selector) => matchesSelf<T>(element, selector).toArray(),
     SizzleFind.children,
     SizzleFind.descendants
   );
@@ -64,13 +64,13 @@ const toResult = <T>(message: TestLabel, option: Optional<T>): Result<T, TestLab
     Result.value
   );
 
-const findIn = (container: SugarElement<any>, selector: string): Result<SugarElement<any>, TestLabel> =>
+const findIn = <T extends Element>(container: SugarElement<Node>, selector: string): Result<SugarElement<T>, TestLabel> =>
   toResult(
     () => 'Could not find selector: ' + selector + ' in ' + Truncate.getHtml(container),
     select(container, selector)
   );
 
-const findAllIn = (container: SugarElement<any>, selector: string): Array<SugarElement<any>> =>
+const findAllIn = <T extends Element>(container: SugarElement<Node>, selector: string): Array<SugarElement<T>> =>
   selectAll(container, selector);
 
 export {

--- a/modules/agar/src/main/ts/ephox/agar/touch/Touches.ts
+++ b/modules/agar/src/main/ts/ephox/agar/touch/Touches.ts
@@ -1,6 +1,6 @@
 import { SugarElement, SugarLocation, SugarNode, Traverse } from '@ephox/sugar';
 
-const point = (type: string, element: SugarElement<any>, x: number, y: number): void => {
+const point = (type: string, element: SugarElement<Node>, x: number, y: number): void => {
   const touch = {
     identifier: Date.now(),
     target: element.dom,
@@ -41,13 +41,16 @@ const point = (type: string, element: SugarElement<any>, x: number, y: number): 
   }
 };
 
-const touch = (eventType: string) => (element: SugarElement<any>): void => {
-  const position = SugarLocation.absolute(SugarNode.isText(element) ? Traverse.parent(element).getOrDie() : element);
+const findElement = (element: SugarElement<Node>): SugarElement<Element> =>
+  (SugarNode.isText(element) ? Traverse.parent(element).getOrDie() : element) as SugarElement<Element>;
+
+const touch = (eventType: string) => (element: SugarElement<Node>): void => {
+  const position = SugarLocation.absolute(findElement(element));
   point(eventType, element, position.left, position.top);
 };
 
-const touchAt = (eventType: string) => (dx: number, dy: number) => (element: SugarElement<any>): void => {
-  const position = SugarLocation.absolute(SugarNode.isText(element) ? Traverse.parent(element).getOrDie() : element);
+const touchAt = (eventType: string) => (dx: number, dy: number) => (element: SugarElement<Node>): void => {
+  const position = SugarLocation.absolute(findElement(element));
   point(eventType, element, position.left + dx, position.top + dy);
 };
 

--- a/modules/agar/src/test/ts/browser/FocusToolsTest.ts
+++ b/modules/agar/src/test/ts/browser/FocusToolsTest.ts
@@ -13,7 +13,7 @@ import * as DomContainers from 'ephox/agar/test/DomContainers';
 
 UnitTest.asynctest('FocusToolsTest', (success, failure) => {
 
-  const sTestFocusTools = (doc: SugarElement, docNode: SugarElement) =>
+  const sTestFocusTools = (doc: SugarElement<Document>, docNode: SugarElement<HTMLElement>) =>
     GeneralSteps.sequence([
       FocusTools.sSetFocus('Focusing div', docNode, 'div[test-id]'),
       FocusTools.sIsOnSelector('Should be on div[test-id]', doc, 'div[test-id]'),

--- a/modules/agar/src/test/ts/browser/file/PatchFileInputTest.ts
+++ b/modules/agar/src/test/ts/browser/file/PatchFileInputTest.ts
@@ -14,7 +14,7 @@ UnitTest.asynctest('PatchFileInputTest', (success, failure) => {
   const files = [ createFile('a.txt', 0, new Blob([ 'x' ])) ];
   const filesState = Singleton.value<FileList>();
 
-  const pickFiles = (body: SugarElement<any>, next: (files: FileList) => void) => {
+  const pickFiles = (body: SugarElement<Node>, next: (files: FileList) => void) => {
     const elm = SugarElement.fromHtml<HTMLInputElement>('<input type="file">');
     elm.dom.onchange = () => {
       Remove.remove(elm);
@@ -24,7 +24,7 @@ UnitTest.asynctest('PatchFileInputTest', (success, failure) => {
     elm.dom.click();
   };
 
-  const cPickFiles = Chain.async<SugarElement, FileList>((input, next, _die) => pickFiles(input, next));
+  const cPickFiles = Chain.async<SugarElement<Node>, FileList>((input, next, _die) => pickFiles(input, next));
   const sPickFiles = Step.async((next, _die) => pickFiles(SugarBody.body(), (files) => {
     filesState.set(files);
     next();

--- a/modules/agar/src/test/ts/module/ephox/agar/test/DomContainers.ts
+++ b/modules/agar/src/test/ts/module/ephox/agar/test/DomContainers.ts
@@ -41,7 +41,7 @@ const mSetupShadowRoot = Step.stateful((state, next, _die) => {
 });
 
 interface TeardownState {
-  container: SugarElement<any>;
+  container: SugarElement<HTMLElement>;
 }
 
 const mTeardown = Step.stateful<TeardownState, TeardownState>((state, next, _die) => {

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/InlinesDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/InlinesDemo.ts
@@ -166,7 +166,7 @@ export default (): void => {
         }
       },
       events: AlloyEvents.derive([
-        AlloyEvents.run<EventArgs>(NativeEvents.contextmenu(), (component, simulatedEvent) => {
+        AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.contextmenu(), (component, simulatedEvent) => {
           simulatedEvent.event.kill();
           InlineView.showAt(inlineComp, inlineMenu, {
             anchor: {

--- a/modules/alloy/src/test/ts/browser/events/GuiEventsTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/GuiEventsTest.ts
@@ -37,7 +37,7 @@ UnitTest.asynctest('GuiEventsTest', (success, failure) => {
 
   const triggerEvent = (eventName: string, event: EventArgs) => {
     const target = event.target;
-    const targetValue = SugarNode.isText(target) ? 'text(' + SugarText.get(target) + ')' : Attribute.get(target, 'class');
+    const targetValue = SugarNode.isText(target) ? 'text(' + SugarText.get(target) + ')' : Attribute.get(target as SugarElement<Element>, 'class');
     store.adder({ eventName, target: targetValue })();
     return false;
   };

--- a/modules/alloy/src/test/ts/browser/position/SelectionInDocPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/SelectionInDocPositionTest.ts
@@ -132,7 +132,7 @@ UnitTest.asynctest('SelectionInDocPositionTest', (success, failure) => {
                 const root = data.inline.element;
                 const path = data.path;
                 const range = Cursors.calculate(root, path);
-                range.start.dom.scrollIntoView();
+                (range.start as SugarElement<Element>).dom.scrollIntoView();
                 return Result.value(data);
               }),
 
@@ -168,7 +168,7 @@ UnitTest.asynctest('SelectionInDocPositionTest', (success, failure) => {
                   finishPath: [ 7 ],
                   foffset: 1
                 }));
-                Scroll.intoView(range.start, true);
+                Scroll.intoView(range.start as SugarElement<Element>, true);
                 return Result.value(data);
               }),
 

--- a/modules/dragster/src/demo/ts/ephox/dragster/demo/Sizers.ts
+++ b/modules/dragster/src/demo/ts/ephox/dragster/demo/Sizers.ts
@@ -14,7 +14,7 @@ export interface Sizers {
   readonly southeast: () => Box;
   readonly hide: () => void;
   readonly show: () => void;
-  readonly update: (target: SugarElement) => void;
+  readonly update: (target: SugarElement<HTMLElement>) => void;
   readonly destroy: () => void;
 }
 
@@ -53,7 +53,7 @@ export const Sizers = (): Sizers => {
   const southeast = box();
   Css.set(southeast.element(), 'cursor', 'se-resize');
 
-  const update = (target: SugarElement) => {
+  const update = (target: SugarElement<HTMLElement>) => {
     const loc = SugarLocation.viewport(target);
     const w = Width.get(target);
     const h = Height.get(target);

--- a/modules/dragster/src/main/ts/ephox/dragster/api/DragApis.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/DragApis.ts
@@ -7,11 +7,11 @@ export interface DragMutation {
   mutate: (x: number, y: number) => void;
 }
 
-export interface DragMode {
+export interface DragMode<T> {
   compare: (old: SugarPosition, nu: SugarPosition) => SugarPosition;
-  extract: (event: EventArgs) => Optional<SugarPosition>;
+  extract: (event: EventArgs<T>) => Optional<SugarPosition>;
   mutate: (mutation: DragMutation, info: SugarPosition) => void;
-  sink: (dragApi: DragApi, settings: Partial<BlockerOptions>) => DragSink;
+  sink: (dragApi: DragApi<T>, settings: Partial<BlockerOptions>) => DragSink;
 }
 
 export interface DragSink {
@@ -21,14 +21,14 @@ export interface DragSink {
   destroy: () => void;
 }
 
-export interface DragApi {
-  forceDrop: (evt?: EventArgs) => void;
-  drop: (evt?: EventArgs) => void;
-  move: (evt: EventArgs) => void;
-  delayDrop: (evt?: EventArgs) => void;
+export interface DragApi<T> {
+  forceDrop: (evt?: EventArgs<T>) => void;
+  drop: (evt?: EventArgs<T>) => void;
+  move: (evt: EventArgs<T>) => void;
+  delayDrop: (evt?: EventArgs<T>) => void;
 }
 
-export const DragMode: (value: DragMode) => DragMode = Contracts.exactly([
+export const DragMode: <T>(value: DragMode<T>) => DragMode<T> = Contracts.exactly([
   'compare',
   'extract',
   'mutate',
@@ -42,7 +42,7 @@ export const DragSink: (value: DragSink) => DragSink = Contracts.exactly([
   'destroy'
 ]);
 
-export const DragApi: (value: DragApi) => DragApi = Contracts.exactly([
+export const DragApi: <T>(value: DragApi<T>) => DragApi<T> = Contracts.exactly([
   'forceDrop',
   'drop',
   'move',

--- a/modules/dragster/src/main/ts/ephox/dragster/api/Dragger.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/Dragger.ts
@@ -4,11 +4,11 @@ import { DragMode, DragMutation } from './DragApis';
 import MouseDrag from './MouseDrag';
 
 export interface DraggerOptions extends BlockerOptions {
-  readonly mode: DragMode;
+  readonly mode: DragMode<MouseEvent>;
 }
 
 const transform = (mutation: DragMutation, settings: Partial<DraggerOptions> = {}): Dragging.Dragging => {
-  const mode: DragMode = settings.mode !== undefined ? settings.mode : MouseDrag;
+  const mode = settings.mode ?? MouseDrag;
   return Dragging.setup(mutation, mode, settings);
 };
 

--- a/modules/dragster/src/main/ts/ephox/dragster/api/MouseDrag.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/MouseDrag.ts
@@ -34,7 +34,7 @@ const sink = (dragApi: DragApi<MouseEvent>, settings: Partial<BlockerOptions>) =
     mdown.unbind();
   };
 
-  const start = (parent: SugarElement) => {
+  const start = (parent: SugarElement<Node>) => {
     Insert.append(parent, blocker.element());
   };
 

--- a/modules/dragster/src/main/ts/ephox/dragster/api/MouseDrag.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/MouseDrag.ts
@@ -8,7 +8,7 @@ const compare = (old: SugarPosition, nu: SugarPosition) => {
   return SugarPosition(nu.left - old.left, nu.top - old.top);
 };
 
-const extract = (event: EventArgs) => {
+const extract = (event: EventArgs<MouseEvent>) => {
   return Optional.some(SugarPosition(event.x, event.y));
 };
 
@@ -16,7 +16,7 @@ const mutate = (mutation: DragMutation, info: SugarPosition) => {
   mutation.mutate(info.left, info.top);
 };
 
-const sink = (dragApi: DragApi, settings: Partial<BlockerOptions>) => {
+const sink = (dragApi: DragApi<MouseEvent>, settings: Partial<BlockerOptions>) => {
   const blocker = Blocker(settings);
 
   // Included for safety. If the blocker has stayed on the screen, get rid of it on a click.
@@ -50,7 +50,7 @@ const sink = (dragApi: DragApi, settings: Partial<BlockerOptions>) => {
   });
 };
 
-export default DragMode({
+export default DragMode<MouseEvent>({
   compare,
   extract,
   sink,

--- a/modules/dragster/src/main/ts/ephox/dragster/core/Dragging.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/core/Dragging.ts
@@ -26,7 +26,7 @@ export interface Dragging {
   readonly events: DragActionEvents['registry'];
 }
 
-const setup = (mutation: DragMutation, mode: DragMode, settings: Partial<BlockerOptions>): Dragging => {
+const setup = <T>(mutation: DragMutation, mode: DragMode<T>, settings: Partial<BlockerOptions>): Dragging => {
   let active = false;
 
   const events: DragActionEvents = Events.create({
@@ -52,7 +52,7 @@ const setup = (mutation: DragMutation, mode: DragMode, settings: Partial<Blocker
     events.trigger.start();
   };
 
-  const mousemove = (event: EventArgs) => {
+  const mousemove = (event: EventArgs<T>) => {
     throttledDrop.cancel();
     movement.onEvent(event, mode);
   };

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/DragTypes.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/DragTypes.ts
@@ -17,7 +17,7 @@ export interface DragEvents {
 }
 
 export interface DragState {
-  readonly onEvent: (event: EventArgs, mode: DragMode) => void;
+  readonly onEvent: <T>(event: EventArgs<T>, mode: DragMode<T>) => void;
   readonly reset: () => void;
   readonly events: DragEvents['registry'];
 }

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/InDrag.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/InDrag.ts
@@ -15,7 +15,7 @@ export const InDrag = (): DragState => {
 
   // Return position delta between previous position and nu position,
   // or None if this is the first. Set the previous position to nu.
-  const update = (mode: DragMode, nu: SugarPosition) => {
+  const update = <T>(mode: DragMode<T>, nu: SugarPosition) => {
     const result = previous.map((old) => {
       return mode.compare(old, nu);
     });
@@ -24,7 +24,7 @@ export const InDrag = (): DragState => {
     return result;
   };
 
-  const onEvent = (event: EventArgs, mode: DragMode) => {
+  const onEvent = <T>(event: EventArgs<T>, mode: DragMode<T>) => {
     const dataOption = mode.extract(event);
 
     // Dragster move events require a position delta. The moveevent is only triggered

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/Movement.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/Movement.ts
@@ -9,7 +9,7 @@ export interface Movement {
   readonly on: () => void;
   readonly off: () => void;
   readonly isOn: () => boolean;
-  readonly onEvent: (event: EventArgs, mode: DragMode) => void;
+  readonly onEvent: <T>(event: EventArgs<T>, mode: DragMode<T>) => void;
   readonly events: DragEvents['registry'];
 }
 
@@ -28,7 +28,7 @@ export const Movement = (): Movement => {
     dragState = noDragState;
   };
 
-  const onEvent = (event: EventArgs, mode: DragMode) => {
+  const onEvent = <T>(event: EventArgs<T>, mode: DragMode<T>) => {
     dragState.onEvent(event, mode);
   };
 

--- a/modules/dragster/src/main/ts/ephox/dragster/transform/Grow.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/transform/Grow.ts
@@ -23,7 +23,7 @@ interface Growth {
 type GrowthFn = (x: number, y: number) => Growth;
 
 const grower = (f: GrowthFn) => {
-  return (element: SugarElement) => {
+  return (element: SugarElement<HTMLElement>) => {
     const events: GrowEvents = Events.create({
       grow: Event([ 'x', 'y' ])
     });

--- a/modules/dragster/src/main/ts/ephox/dragster/transform/Relocate.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/transform/Relocate.ts
@@ -20,7 +20,7 @@ interface Relocate {
   readonly events: RelocateEvents['registry'];
 }
 
-const both = (element: SugarElement): Relocate => {
+const both = (element: SugarElement<HTMLElement>): Relocate => {
   const mutate = (x: number, y: number) => {
     const location = SugarLocation.absolute(element);
     Css.setAll(element, {

--- a/modules/dragster/src/test/ts/atomic/DraggerTest.ts
+++ b/modules/dragster/src/test/ts/atomic/DraggerTest.ts
@@ -23,7 +23,7 @@ UnitTest.test('DraggerTest', () => {
     sink: (dragApi, _settings) => {
       optApi = Optional.some(dragApi);
       return DragSink({
-        element: () => 'element' as unknown as SugarElement, // fake element
+        element: () => 'element' as unknown as SugarElement<HTMLElement>, // fake element
         start: (v) => {
           assert.eq(argumentToStart, v);
         },

--- a/modules/dragster/src/test/ts/atomic/DraggerTest.ts
+++ b/modules/dragster/src/test/ts/atomic/DraggerTest.ts
@@ -6,7 +6,7 @@ import { DragApi, DragMode, DragSink } from 'ephox/dragster/api/DragApis';
 import * as Dragging from 'ephox/dragster/core/Dragging';
 
 UnitTest.test('DraggerTest', () => {
-  let optApi: Optional<DragApi> = Optional.none();
+  let optApi: Optional<DragApi<any>> = Optional.none();
 
   const argumentToStart: any = 'start';
   const argumentToMutate: any = 'mutate';

--- a/modules/imagetools/src/main/ts/ephox/imagetools/assets/ImageAssetTypes.ts
+++ b/modules/imagetools/src/main/ts/ephox/imagetools/assets/ImageAssetTypes.ts
@@ -11,11 +11,11 @@ export interface BlobImageAsset {
 export interface UrlImageAsset {
   id: () => string;
   url: () => string;
-  raw: () => SugarElement;
+  raw: () => SugarElement<HTMLImageElement>;
 }
 
 export type BlobCallback<T> = (id: string, imageresult: ImageResult, objurl: string) => T;
-export type UrlCallback<T> = (id: string, url: string, raw: SugarElement) => T;
+export type UrlCallback<T> = (id: string, url: string, raw: SugarElement<HTMLImageElement>) => T;
 
 export interface ImageAssetAdt {
   fold: <T> (

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/McEditor.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/McEditor.ts
@@ -8,7 +8,7 @@ import { detectTinymceBaseUrl, setupTinymceBaseUrl } from '../loader/Urls';
 
 const errorMessageEditorRemoved = 'Editor Removed';
 
-const pFromElement = <T extends EditorType = EditorType>(element: SugarElement, settings: Record<string, any>): Promise<T> => {
+const pFromElement = <T extends EditorType = EditorType>(element: SugarElement<Element>, settings: Record<string, any>): Promise<T> => {
   return new Promise((resolve, reject) => {
     const nuSettings: Record<string, any> = {
       toolbar_mode: 'wrap',
@@ -68,7 +68,7 @@ const pFromElement = <T extends EditorType = EditorType>(element: SugarElement, 
 };
 
 const pFromHtml = <T extends EditorType = EditorType>(html: string | null, settings: Record<string, any>): Promise<T> => {
-  const element = html ? SugarElement.fromHtml(html) : SugarElement.fromTag(settings.inline ? 'div' : 'textarea');
+  const element = html ? SugarElement.fromHtml<Element>(html) : SugarElement.fromTag(settings.inline ? 'div' : 'textarea');
   return pFromElement(element, settings);
 };
 
@@ -76,7 +76,7 @@ const pFromSettings = <T extends EditorType = EditorType>(settings: Record<strin
   return pFromHtml<T>(null, settings);
 };
 
-const cFromElement = <T extends EditorType = EditorType>(element: SugarElement, settings: Record<string, any>): Chain<unknown, T> => {
+const cFromElement = <T extends EditorType = EditorType>(element: SugarElement<Element>, settings: Record<string, any>): Chain<unknown, T> => {
   return Chain.fromPromise(() => pFromElement(element, settings));
 };
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyDom.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyDom.ts
@@ -3,7 +3,7 @@ import { SimRange, SugarElement } from '@ephox/sugar';
 import { Editor } from '../alien/EditorTypes';
 
 export interface TinyDom {
-  readonly fromDom: (elm: Node) => SugarElement;
+  readonly fromDom: <T extends Node | Window>(elm: T) => SugarElement<T>;
   readonly fromRange: (rng: Range) => SimRange;
   readonly body: (editor: Editor) => SugarElement<HTMLElement>;
   readonly document: (editor: Editor) => SugarElement<HTMLDocument>;
@@ -16,7 +16,7 @@ export interface TinyDom {
 /**
  * @deprecated Use SugarElement.fromDom instead.
  */
-const fromDom = (elm: Node): SugarElement<Node> =>
+const fromDom = <T extends Node | Window>(elm: T): SugarElement<T> =>
   SugarElement.fromDom(elm);
 
 const fromRange = (rng: Range): SimRange =>

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyAssertions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyAssertions.ts
@@ -6,7 +6,7 @@ import { Editor, GetContentArgs } from '../../alien/EditorTypes';
 import { Presence } from '../pipeline/TinyApis';
 import { TinyDom } from '../TinyDom';
 
-const assertPath = (label: string, root: SugarElement, expPath: number[], expOffset: number, actElement: Node, actOffset: number) => {
+const assertPath = (label: string, root: SugarElement<Node>, expPath: number[], expOffset: number, actElement: Node, actOffset: number) => {
   const expected = Cursors.calculateOne(root, expPath);
   const message = () => {
     const actual = SugarElement.fromDom(actElement);

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
@@ -68,10 +68,10 @@ const closeDialog = (editor: Editor, selector?: string): void => {
 const pWaitForUi = (editor: Editor, selector: string): Promise<SugarElement<Element>> =>
   UiFinder.pWaitFor(`Waiting for a UI element matching '${selector}' to exist`, getUiRoot(editor), selector);
 
-const pWaitForPopup = (editor: Editor, selector: string): Promise<SugarElement<Element>> =>
+const pWaitForPopup = (editor: Editor, selector: string): Promise<SugarElement<HTMLElement>> =>
   UiFinder.pWaitForVisible(`Waiting for a popup matching '${selector}' to be visible`, getUiRoot(editor), selector);
 
-const pWaitForDialog = (editor: Editor, selector?: string): Promise<SugarElement> => {
+const pWaitForDialog = (editor: Editor, selector?: string): Promise<SugarElement<Element>> => {
   const dialogSelector = Type.isUndefined(selector) ? getThemeSelectors().dialogSelector : selector;
   return UiFinder.pWaitForVisible(`Waiting for a dialog matching '${dialogSelector}' to be visible`, getUiRoot(editor), dialogSelector);
 };

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
@@ -26,20 +26,20 @@ const getMenuRoot = (editor: Editor) => {
 
 const clickOnToolbar = <T extends Element>(editor: Editor, selector: string): SugarElement<T> => {
   const container = getToolbarRoot(editor);
-  const elem = UiFinder.findIn(container, selector).getOrDie();
+  const elem = UiFinder.findIn<T>(container, selector).getOrDie();
   Mouse.click(elem);
   return elem;
 };
 
 const clickOnMenu = <T extends Element>(editor: Editor, selector: string): SugarElement<T> => {
   const container = getMenuRoot(editor);
-  const elem = UiFinder.findIn(container, selector).getOrDie();
+  const elem = UiFinder.findIn<T>(container, selector).getOrDie();
   Mouse.click(elem);
   return elem;
 };
 
 const clickOnUi = <T extends Element>(editor: Editor, selector: string): SugarElement<T> => {
-  const elem = UiFinder.findIn(getUiRoot(editor), selector).getOrDie();
+  const elem = UiFinder.findIn<T>(getUiRoot(editor), selector).getOrDie();
   Mouse.click(elem);
   return elem;
 };

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/ActionChains.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/ActionChains.ts
@@ -20,7 +20,7 @@ const cUiDoc = Chain.injectThunked(() => {
   return SugarElement.fromDom(document);
 });
 
-const cTriggerKeyEvent = <T>(cTarget: Chain<T, SugarElement>, evtType: 'keydown' | 'keyup' | 'keypress' | 'keystroke', code: number, modifiers = {}) => {
+const cTriggerKeyEvent = <T>(cTarget: Chain<T, SugarElement<Document>>, evtType: 'keydown' | 'keyup' | 'keypress' | 'keystroke', code: number, modifiers = {}) => {
   return NamedChain.asChain([
     NamedChain.direct(NamedChain.inputName(), cTarget, 'doc'),
     NamedChain.direct('doc', FocusTools.cGetFocused, 'activeElement'),

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/RemoteTinyLoader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/RemoteTinyLoader.ts
@@ -30,7 +30,14 @@ const setup = (callback: Loader.RunCallback, urls: string[], settings: Record<st
   }, failure);
 };
 
-const setupFromElement = (callback: Loader.RunCallback, urls: string[], settings: Record<string, any>, element: SugarElement, success: Loader.SuccessCallback, failure: Loader.FailureCallback): void => {
+const setupFromElement = (
+  callback: Loader.RunCallback,
+  urls: string[],
+  settings: Record<string, any>,
+  element: SugarElement<Element>,
+  success: Loader.SuccessCallback,
+  failure: Loader.FailureCallback
+): void => {
   loadScripts(urls, () => {
     Loader.setup({
       preInit: setupBaseUrl,

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyLoader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyLoader.ts
@@ -33,7 +33,13 @@ const setup = (callback: Loader.RunCallback, settings: Record<string, any>, succ
   }, settings, Optional.none());
 };
 
-const setupFromElement = (callback: Loader.RunCallback, settings: Record<string, any>, element: SugarElement, success: Loader.SuccessCallback, failure: Loader.FailureCallback): void => {
+const setupFromElement = (
+  callback: Loader.RunCallback,
+  settings: Record<string, any>,
+  element: SugarElement<Element>,
+  success: Loader.SuccessCallback,
+  failure: Loader.FailureCallback
+): void => {
   Loader.setup({
     preInit: setupTinymceBaseUrl,
     run: callback,
@@ -42,7 +48,12 @@ const setupFromElement = (callback: Loader.RunCallback, settings: Record<string,
   }, settings, Optional.some(element));
 };
 
-const setupInShadowRoot = (callback: (editor: any, shadowRoot: SugarElement<ShadowRoot>, success: SuccessCallback, failure: FailureCallback) => void, settings: Record<string, any>, success: Loader.SuccessCallback, failure: Loader.FailureCallback): void => {
+const setupInShadowRoot = (
+  callback: (editor: any, shadowRoot: SugarElement<ShadowRoot>, success: SuccessCallback, failure: FailureCallback) => void,
+  settings: Record<string, any>,
+  success: Loader.SuccessCallback,
+  failure: Loader.FailureCallback
+): void => {
   if (!SugarShadowDom.isSupported()) {
     return success();
   }

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/UiChains.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/UiChains.ts
@@ -12,7 +12,7 @@ export interface UiChains {
 
   cWaitForPopup: <T> (label: string, selector: string) => Chain<T, T>;
   cWaitForUi: <T> (label: string, selector: string) => Chain<T, T>;
-  cWaitForState: <T> (hasState: (element: SugarElement) => boolean) => (label: string, selector: string) => Chain<T, T>;
+  cWaitForState: <T, U extends Element> (hasState: (element: SugarElement<U>) => boolean) => (label: string, selector: string) => Chain<T, T>;
 
   cCloseDialog: <T> (selector: string) => Chain<T, T>;
   cSubmitDialog: <T> (selector?: string) => Chain<T, T>;
@@ -30,7 +30,7 @@ const cEditorRoot = Chain.mapper((editor: Editor) => {
 
 const cDialogRoot = Chain.injectThunked(SugarBody.body);
 
-const cGetToolbarRoot: Chain<Editor, SugarElement> = NamedChain.asChain([
+const cGetToolbarRoot: Chain<Editor, SugarElement<HTMLElement>> = NamedChain.asChain([
   NamedChain.direct(NamedChain.inputName(), Chain.identity, 'editor'),
   NamedChain.direct('editor', cToolstripRoot, 'container'),
   NamedChain.merge([ 'editor', 'container' ], 'data'),
@@ -38,12 +38,12 @@ const cGetToolbarRoot: Chain<Editor, SugarElement> = NamedChain.asChain([
   NamedChain.output('toolbar')
 ]);
 
-const cGetMenuRoot = Chain.fromChains<Editor, SugarElement>([
+const cGetMenuRoot = Chain.fromChains<Editor, SugarElement<HTMLElement>>([
   cToolstripRoot,
-  Chain.binder((container: SugarElement) => UiFinder.findIn(container, getThemeSelectors().menuBarSelector))
+  Chain.binder((container: SugarElement<HTMLElement>) => UiFinder.findIn(container, getThemeSelectors().menuBarSelector))
 ]);
 
-const cClickOnWithin = <T>(label: string, selector: string, cContext: Chain<T, SugarElement>): Chain<T, T> => {
+const cClickOnWithin = <T>(label: string, selector: string, cContext: Chain<T, SugarElement<Node>>): Chain<T, T> => {
   return Chain.control(
     NamedChain.asChain([
       NamedChain.direct(NamedChain.inputName(), cContext, 'context'),
@@ -67,7 +67,7 @@ const cClickOnMenu = <T extends Editor>(label: string, selector: string): Chain<
   return cClickOnWithin<T>(label, selector, cGetMenuRoot);
 };
 
-const cWaitForState = <T>(hasState: (element: SugarElement) => boolean) => {
+const cWaitForState = <T, U extends Element>(hasState: (element: SugarElement<U>) => boolean) => {
   return (label: string, selector: string): Chain<T, T> => {
     return NamedChain.asChain([
       NamedChain.write('element', Chain.fromChains([
@@ -87,11 +87,11 @@ const cWaitForVisible = <T>(label: string, selector: string): Chain<T, T> => {
 };
 
 const cWaitForPopup = <T>(label: string, selector: string): Chain<T, T> => {
-  return cWaitForState<T>(Visibility.isVisible)(label, selector);
+  return cWaitForState<T, HTMLElement>(Visibility.isVisible)(label, selector);
 };
 
 const cWaitForUi = <T>(label: string, selector: string): Chain<T, T> => {
-  return cWaitForState<T>(Fun.always)(label, selector);
+  return cWaitForState<T, Element>(Fun.always)(label, selector);
 };
 
 const cTriggerContextMenu = <T>(label: string, target: string, menu: string): Chain<T, T> => {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
@@ -49,7 +49,7 @@ const loadScript = (url: string): FutureResult<string, Error> => FutureResult.nu
   Insert.append(SugarBody.body(), script);
 });
 
-const setup = (callbacks: Callbacks, settings: Record<string, any>, elementOpt: Optional<SugarElement>): void => {
+const setup = (callbacks: Callbacks, settings: Record<string, any>, elementOpt: Optional<SugarElement<Element>>): void => {
   const target = elementOpt.getOrThunk(() => createTarget(settings.inline));
   const randomId = Id.generate('tiny-loader');
   Attribute.set(target, 'id', randomId);

--- a/modules/mcagar/src/main/ts/ephox/mcagar/selection/SelectionTools.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/selection/SelectionTools.ts
@@ -9,7 +9,7 @@ const toDomRange = (range: SimRange): Range => {
   return rng;
 };
 
-const createDomSelection = (container: SugarElement, sPath: number[], soffset: number, fPath: number[], foffset: number): Range => {
+const createDomSelection = (container: SugarElement<Node>, sPath: number[], soffset: number, fPath: number[], foffset: number): Range => {
   const path = Cursors.path({
     startPath: sPath,
     soffset,
@@ -19,7 +19,7 @@ const createDomSelection = (container: SugarElement, sPath: number[], soffset: n
   return toDomRange(Cursors.calculate(container, path));
 };
 
-const createDomCursor = (container: SugarElement, elementPath: number[], offset: number): Range => {
+const createDomCursor = (container: SugarElement<Node>, elementPath: number[], offset: number): Range => {
   const elm = Cursors.calculateOne(container, elementPath);
   return toDomRange(Cursors.range({
     start: elm,
@@ -29,7 +29,7 @@ const createDomCursor = (container: SugarElement, elementPath: number[], offset:
   }));
 };
 
-const createDomSelectionOf = (container: SugarElement, start: SugarElement, soffset: number, finish: SugarElement, foffset: number): Range => {
+const createDomSelectionOf = (container: SugarElement<Node>, start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number): Range => {
   return toDomRange(Cursors.range({
     start,
     soffset,
@@ -38,19 +38,19 @@ const createDomSelectionOf = (container: SugarElement, start: SugarElement, soff
   }));
 };
 
-const cCreateDomSelection = (sPath: number[], soffset: number, fPath: number[], foffset: number): Chain<SugarElement, Range> => {
+const cCreateDomSelection = (sPath: number[], soffset: number, fPath: number[], foffset: number): Chain<SugarElement<Node>, Range> => {
   return Chain.mapper((container) => {
     return createDomSelection(container, sPath, soffset, fPath, foffset);
   });
 };
 
-const cCreateDomCursor = (elementPath: number[], offset: number): Chain<SugarElement, Range> => {
+const cCreateDomCursor = (elementPath: number[], offset: number): Chain<SugarElement<Node>, Range> => {
   return Chain.mapper((container) => {
     return createDomCursor(container, elementPath, offset);
   });
 };
 
-const cCreateDomSelectionOf = (start: SugarElement, soffset: number, finish: SugarElement, foffset: number): Chain<SugarElement, Range> => {
+const cCreateDomSelectionOf = (start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number): Chain<SugarElement<Node>, Range> => {
   return Chain.mapper((container) => {
     return createDomSelectionOf(container, start, soffset, finish, foffset);
   });

--- a/modules/mcagar/src/test/ts/browser/doc/ScenarioTutorialTest.ts
+++ b/modules/mcagar/src/test/ts/browser/doc/ScenarioTutorialTest.ts
@@ -11,7 +11,7 @@ import { TinyDom } from 'ephox/mcagar/api/TinyDom';
 
 UnitTest.asynctest('Tutorial: Property Testing with TinyMCE', (success, failure) => {
 
-  const sAssertion = (editor: Editor, body: SugarElement) => Step.sync(() => {
+  const sAssertion = (editor: Editor, body: SugarElement<Node>) => Step.sync(() => {
     const strongs = UiFinder.findAllIn(body, 'strong');
     Assertions.assertEq('There should be no strong tags', 0, strongs.length);
     const editorContent1 = editor.getContent();

--- a/modules/snooker/src/test/ts/browser/lookup/TypeTest.ts
+++ b/modules/snooker/src/test/ts/browser/lookup/TypeTest.ts
@@ -11,7 +11,7 @@ describe('browser.snooker.lookup.TypeTest', () => {
   const container = SugarElement.fromTag('div');
 
   const assertWithWarehouse = (assertions: (warehouse: Warehouse, table: SugarElement<HTMLTableElement>) => void) => {
-    const table = UiFinder.findIn(container, 'table').getOrDie();
+    const table = UiFinder.findIn<HTMLTableElement>(container, 'table').getOrDie();
     const warehouse = Warehouse.fromTable(table);
     assertions(warehouse, table);
   };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Compare.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Compare.ts
@@ -9,7 +9,7 @@ const eq = (e1: SugarElement<unknown>, e2: SugarElement<unknown>): boolean =>
 const isEqualNode = (e1: SugarElement<Node>, e2: SugarElement<Node>): boolean =>
   e1.dom.isEqualNode(e2.dom);
 
-const member = (element: SugarElement, elements: SugarElement[]): boolean =>
+const member = (element: SugarElement<unknown>, elements: SugarElement<unknown>[]): boolean =>
   Arr.exists(elements, Fun.curry(eq, element));
 
 // Returns: true if node e1 contains e2, otherwise false.

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/DomFuture.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/DomFuture.ts
@@ -8,7 +8,7 @@ type WorkDone = (res: Result<EventArgs, string>) => void;
 type Worker = (callback: WorkDone) => void;
 type TaskConstructor<T> = (worker: Worker) => T;
 
-const w = <T> (fType: TaskConstructor<T>, element: SugarElement, eventType: string, timeout: number) => fType((callback) => {
+const w = <T> (fType: TaskConstructor<T>, element: SugarElement<EventTarget>, eventType: string, timeout: number) => fType((callback) => {
   const listener = DomEvent.bind(element, eventType, (event) => {
     clearTimeout(time);
     listener.unbind();
@@ -21,10 +21,10 @@ const w = <T> (fType: TaskConstructor<T>, element: SugarElement, eventType: stri
   }, timeout);
 });
 
-const cWaitFor = (element: SugarElement, eventType: string, timeout: number): LazyValue<Result<EventArgs, string>> =>
+const cWaitFor = (element: SugarElement<EventTarget>, eventType: string, timeout: number): LazyValue<Result<EventArgs, string>> =>
   w(LazyValue.nu, element, eventType, timeout);
 
-const waitFor = (element: SugarElement, eventType: string, timeout: number): Future<Result<EventArgs, string>> =>
+const waitFor = (element: SugarElement<EventTarget>, eventType: string, timeout: number): Future<Result<EventArgs, string>> =>
   w<Future<Result<EventArgs, string>>>(Future.nu, element, eventType, timeout);
 
 export { cWaitFor, waitFor };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Truncate.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Truncate.ts
@@ -3,7 +3,7 @@ import * as SugarShadowDom from '../node/SugarShadowDom';
 import * as Html from '../properties/Html';
 import * as Replication from './Replication';
 
-const getHtml = (element: SugarElement<any>): string => {
+const getHtml = (element: SugarElement<Node>): string => {
   if (SugarShadowDom.isShadowRoot(element)) {
     return '#shadow-root';
   } else {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/DomEvent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/DomEvent.ts
@@ -7,16 +7,16 @@ import { EventHandler, EventUnbinder } from './Types';
 const filter = Fun.always; // no filter on plain DomEvents
 
 const bind: {
-  <K extends keyof HTMLElementEventMap> (element: SugarElement, event: K, handler: EventHandler<HTMLElementEventMap[K]>): EventUnbinder;
-  <T extends Event>(element: SugarElement, event: string, handler: EventHandler<T>): EventUnbinder;
-} = <T extends Event>(element: SugarElement, event: string, handler: EventHandler<T>): EventUnbinder =>
-  FilteredEvent.bind<T>(element, event, filter, handler);
+  <K extends keyof HTMLElementEventMap, T extends Node | Window = Node> (element: SugarElement<EventTarget>, event: K, handler: EventHandler<HTMLElementEventMap[K], T>): EventUnbinder;
+  <E extends Event, T extends Node | Window = Node>(element: SugarElement<EventTarget>, event: string, handler: EventHandler<E, T>): EventUnbinder;
+} = <E extends Event, T extends Node | Window = Node>(element: SugarElement<EventTarget>, event: string, handler: EventHandler<E, T>): EventUnbinder =>
+  FilteredEvent.bind<E, T>(element, event, filter, handler);
 
 const capture: {
-  <K extends keyof HTMLElementEventMap> (element: SugarElement, event: K, handler: EventHandler<HTMLElementEventMap[K]>): EventUnbinder;
-  <T extends Event>(element: SugarElement, event: string, handler: EventHandler<T>): EventUnbinder;
-} = <T extends Event>(element: SugarElement, event: string, handler: EventHandler<T>): EventUnbinder =>
-  FilteredEvent.capture<T>(element, event, filter, handler);
+  <K extends keyof HTMLElementEventMap, T extends Node | Window = Node> (element: SugarElement<EventTarget>, event: K, handler: EventHandler<HTMLElementEventMap[K], T>): EventUnbinder;
+  <E extends Event, T extends Node | Window = Node>(element: SugarElement<EventTarget>, event: string, handler: EventHandler<E, T>): EventUnbinder;
+} = <E extends Event, T extends Node | Window = Node>(element: SugarElement<EventTarget>, event: string, handler: EventHandler<E, T>): EventUnbinder =>
+  FilteredEvent.capture<E, T>(element, event, filter, handler);
 
 const fromRawEvent = FilteredEvent.fromRawEvent;
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvents.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvents.ts
@@ -19,18 +19,19 @@ const isLeftButtonPressed = (raw: MouseEvent) => {
 };
 
 // Not 100% sure whether this works, so use with caution
-const isRealClick = (raw: any): boolean => {
+const isRealClick = (raw: MouseEvent): boolean => {
   // standards, only gecko/webkit as of Sept 2015
   // https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted
   // fallback to yes because there's no other way to really know
   const isTrusted = raw.isTrusted !== undefined && raw.isTrusted !== true ? false : true;
   // Firefox non-standard property
   // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent#mozInputSource
-  return (raw.mozInputSource === 6 || raw.mozInputSource === 0) ? false : isTrusted;
+  const firefoxRaw = raw as any;
+  return (firefoxRaw.mozInputSource === 6 || firefoxRaw.mozInputSource === 0) ? false : isTrusted;
 };
 
 const filtered = (event: string, filter: EventFilter<MouseEvent>) => ({
-  bind: (element: SugarElement, f: EventHandler<MouseEvent>) => {
+  bind: (element: SugarElement<EventTarget>, f: EventHandler<MouseEvent>) => {
     return FilteredEvent.bind(element, event, filter, f);
   }
 });

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Types.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Types.ts
@@ -1,18 +1,18 @@
 import { SugarElement } from '../node/SugarElement';
 
-export interface EventArgs<T = Event> {
-  readonly target: SugarElement;
-  readonly x: number;
-  readonly y: number;
+export interface EventArgs<E = Event, T extends Node | Window = Node> {
+  readonly target: SugarElement<T>;
+  readonly x: E extends { clientX: number } ? number : undefined;
+  readonly y: E extends { clientY: number } ? number : undefined;
   readonly stop: () => void;
   readonly prevent: () => void;
   readonly kill: () => void;
-  readonly raw: T;
+  readonly raw: E;
 }
 
 export interface EventUnbinder {
   unbind: () => void;
 }
 
-export type EventHandler<T = Event> = (evt: EventArgs<T>) => void;
-export type EventFilter<T = Event> = (evt: T) => boolean;
+export type EventHandler<E = Event, T extends Node | Window = Node> = (evt: EventArgs<E, T>) => void;
+export type EventFilter<E = Event> = (evt: E) => boolean;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElement.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElement.ts
@@ -9,9 +9,10 @@ const fromHtml = <E extends Node = Node & ChildNode> (html: string, scope?: Docu
   const div = doc.createElement('div');
   div.innerHTML = html;
   if (!div.hasChildNodes() || div.childNodes.length > 1) {
+    const message = 'HTML does not have a single root node';
     // eslint-disable-next-line no-console
-    console.error('HTML does not have a single root node', html);
-    throw new Error('HTML must have a single root node');
+    console.error(message, html);
+    throw new Error(message);
   }
   return fromDom(div.childNodes[0] as unknown as E);
 };
@@ -19,7 +20,7 @@ const fromHtml = <E extends Node = Node & ChildNode> (html: string, scope?: Docu
 const fromTag: {
   <K extends keyof HTMLElementTagNameMap>(tag: K, scope?: Document | null): SugarElement<HTMLElementTagNameMap[K]>;
   (tag: string, scope?: Document | null): SugarElement<HTMLElement>;
-} = (tag: string, scope?: Document | null): SugarElement => {
+} = (tag: string, scope?: Document | null): SugarElement<HTMLElement> => {
   const doc = scope || document;
   const node = doc.createElement(tag);
   return fromDom(node);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
@@ -13,7 +13,7 @@ export type RootNode = SugarElement<Document | ShadowRoot>;
  * Note: this is insufficient to test if any element is a shadow root, but it is sufficient to differentiate between
  * a Document and a ShadowRoot.
  */
-export const isShadowRoot = (dos: RootNode): dos is SugarElement<ShadowRoot> =>
+export const isShadowRoot = (dos: SugarElement<Node>): dos is SugarElement<ShadowRoot> =>
   SugarNode.isDocumentFragment(dos) && Type.isNonNullable((dos.dom as ShadowRoot).host);
 
 /* eslint-disable @tinymce/no-implicit-dom-globals, @typescript-eslint/unbound-method */

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/ContentEditable.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/ContentEditable.ts
@@ -4,7 +4,7 @@ import * as SugarBody from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
 import * as SelectorFind from '../search/SelectorFind';
 
-const closest = (target: SugarElement<HTMLElement>): Optional<SugarElement<HTMLElement>> =>
+const closest = (target: SugarElement<Node>): Optional<SugarElement<HTMLElement>> =>
   SelectorFind.closest(target, '[contenteditable]');
 
 const isEditable = (element: SugarElement<HTMLElement>, assumeEditable: boolean = false): boolean => {

--- a/modules/sugar/src/test/ts/browser/AttributeTest.ts
+++ b/modules/sugar/src/test/ts/browser/AttributeTest.ts
@@ -6,15 +6,15 @@ import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Attribute from 'ephox/sugar/api/properties/Attribute';
 import Div from 'ephox/sugar/test/Div';
 
-type AttrFn<K, V> = (element: SugarElement<any>, k: K, v: V) => void;
+type AttrFn<K, V> = (element: SugarElement<HTMLElement>, k: K, v: V) => void;
 type InvalidValue<V> = V | null | undefined | {};
 
 UnitTest.test('AttributeTest', () => {
   const c = Div();
 
-  const checkErr = <K, V>(f: AttrFn<K, V>, element: SugarElement, k: K, v?: InvalidValue<V>) => {
+  const checkErr = <K, V>(f: AttrFn<K, V>, element: SugarElement<Node>, k: K, v?: InvalidValue<V>) => {
     try {
-      f(element, k, v as V);
+      f(element as SugarElement<HTMLElement>, k, v as V);
     } catch (e) {
       // expected
       return;

--- a/modules/sugar/src/test/ts/browser/ElementFromPointTest.ts
+++ b/modules/sugar/src/test/ts/browser/ElementFromPointTest.ts
@@ -25,7 +25,7 @@ UnitTest.test('ElementFromPointTest', () => {
     });
   };
 
-  const getAt = (elm: SugarElement, placeX: number, placeY: number, testX: number, testY: number) => {
+  const getAt = (elm: SugarElement<Node>, placeX: number, placeY: number, testX: number, testY: number) => {
     placeElm(elm, placeX, placeY, 100, 50);
     return SugarElement.fromPoint(SugarElement.fromDom(document), testX, testY);
   };

--- a/modules/sugar/src/test/ts/browser/impl/RuntimeSizeTest.ts
+++ b/modules/sugar/src/test/ts/browser/impl/RuntimeSizeTest.ts
@@ -23,27 +23,28 @@ interface TableModel {
 UnitTest.test('Runtime Size Test', () => {
   const random = (min: number, max: number) => Math.round(Math.random() * (max - min) + min);
 
-  const getOuterHeight = (elm: SugarElement) => Math.round(elm.dom.getBoundingClientRect().height);
-  const getOuterWidth = (elm: SugarElement) => Math.round(elm.dom.getBoundingClientRect().width);
+  const getOuterHeight = (elm: SugarElement<HTMLElement>) => Math.round(elm.dom.getBoundingClientRect().height);
+  const getOuterWidth = (elm: SugarElement<HTMLElement>) => Math.round(elm.dom.getBoundingClientRect().width);
 
-  const measureCells = (getSize: (e: SugarElement) => number, table: SugarElement) => Arr.map(SelectorFilter.descendants(table, 'td'), getSize);
+  const measureCells = (getSize: (e: SugarElement<HTMLElement>) => number, table: SugarElement<HTMLElement>) =>
+    Arr.map(SelectorFilter.descendants<HTMLTableCellElement>(table, 'td'), getSize);
 
-  const measureTable = (table: SugarElement, getSize: (e: SugarElement) => number) => ({
+  const measureTable = (table: SugarElement<HTMLElement>, getSize: (e: SugarElement<HTMLElement>) => number) => ({
     total: getSize(table),
     cells: measureCells(getSize, table)
   });
 
-  const setHeight = (table: SugarElement, value: string) => Css.set(table, 'height', value);
-  const setWidth = (table: SugarElement, value: string) => Css.set(table, 'width', value);
+  const setHeight = (table: SugarElement<Node>, value: string) => Css.set(table, 'height', value);
+  const setWidth = (table: SugarElement<Node>, value: string) => Css.set(table, 'width', value);
 
-  const resizeTableBy = (table: SugarElement, setSize: (e: SugarElement, v: string) => void, tableInfo: { total: number; cells: number[] }, delta: number) => {
+  const resizeTableBy = (table: SugarElement<HTMLElement>, setSize: (e: SugarElement<HTMLElement>, v: string) => void, tableInfo: { total: number; cells: number[] }, delta: number) => {
     setSize(table, '');
-    Arr.map(SelectorFilter.descendants(table, 'td'), (cell, i) => {
+    Arr.map(SelectorFilter.descendants<HTMLTableCellElement>(table, 'td'), (cell, i) => {
       setSize(cell, (tableInfo.cells[i] + delta) + 'px');
     });
   };
 
-  const assertSize = (s1: { total: number; cells: number[] }, table: SugarElement, getOuterSize: (e: SugarElement) => number, message: string) => {
+  const assertSize = (s1: { total: number; cells: number[] }, table: SugarElement<HTMLElement>, getOuterSize: (e: SugarElement<HTMLElement>) => number, message: string) => {
     const s2 = measureTable(table, getOuterSize);
     const tableHtml = Html.getOuter(table);
 
@@ -142,8 +143,13 @@ UnitTest.test('Runtime Size Test', () => {
   const getHeightDelta = (model: TableModel, delta: number) => model.rows * delta;
   const getWidthDelta = (model: TableModel, delta: number) => model.cols * delta;
 
-  const testTableSize = (createTable: (rows: number, cols: number) => SugarElement, getOuterSize: (e: SugarElement) => number, getSize: (e: SugarElement) => number,
-                         setSize: (e: SugarElement, v: string) => void, getTotalDelta: (model: TableModel, delta: number) => number) => () => {
+  const testTableSize = (
+    createTable: (rows: number, cols: number) => SugarElement<HTMLElement>,
+    getOuterSize: (e: SugarElement<HTMLElement>) => number,
+    getSize: (e: SugarElement<HTMLElement>) => number,
+    setSize: (e: SugarElement<HTMLElement>, v: string) => void,
+    getTotalDelta: (model: TableModel, delta: number) => number
+  ) => () => {
     const rows = random(1, 5);
     const cols = random(1, 5);
 

--- a/modules/tinymce/src/plugins/help/test/ts/browser/CustomTabsTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/CustomTabsTest.ts
@@ -16,7 +16,7 @@ describe('browser.tinymce.plugins.help.CustomTabsTest', () => {
 
   const compareTabNames = (editor: Editor, expectedNames: string[]) => {
     editor.execCommand('mceHelp');
-    const actualTabs = UiFinder.findAllIn(SugarDocument.getDocument(), 'div.tox-dialog__body-nav-item.tox-tab');
+    const actualTabs = UiFinder.findAllIn<HTMLDivElement>(SugarDocument.getDocument(), 'div.tox-dialog__body-nav-item.tox-tab');
     const actualNames = Arr.map(actualTabs, (tab) => Html.get(tab));
     Arr.map(expectedNames, (x, i) => {
       assert.equal(actualNames[i], x, 'Tab names did not match');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
@@ -47,7 +47,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
   const pTestUiStateEnabled = async (editor: Editor, alt: string) => {
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    const altElem = UiFinder.findIn(SugarBody.body(), generalTabSelectors.alt).getOrDie();
+    const altElem = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), generalTabSelectors.alt).getOrDie();
     const value = Value.get(altElem);
     assert.equal(value, alt, 'Assert input value');
     TinyUiActions.submitDialog(editor);

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureResizeTest.ts
@@ -53,7 +53,7 @@ describe('browser.tinymce.plugins.image.FigureResizeTest', () => {
     TinyUiActions.submitDialog(editor);
 
     const body = TinyDom.body(editor);
-    const img = UiFinder.findIn(body, 'figure > img').getOrDie();
+    const img = UiFinder.findIn<HTMLImageElement>(body, 'figure > img').getOrDie();
     Mouse.trueClick(img);
     TinyAssertions.assertSelection(editor, [], 0, [], 1);
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -42,12 +42,12 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
   };
 
   const pAssertSrcTextValue = (expectedValue: string) => Waiter.pTryUntil('Waited for input to change to expected value', () => {
-    const input = UiFinder.findIn(SugarBody.body(), 'label.tox-label:contains("Source") + div > div > input.tox-textfield').getOrDie();
+    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), 'label.tox-label:contains("Source") + div > div > input.tox-textfield').getOrDie();
     assert.equal(Value.get(input), expectedValue, 'Assert field source value ');
   }, 10, 10000);
 
   const pAssertSrcTextValueStartsWith = (expectedValue: string) => Waiter.pTryUntil('Waited for input to change to start with expected value', () => {
-    const input = UiFinder.findIn(SugarBody.body(), 'label.tox-label:contains("Source") + div > div > input.tox-textfield').getOrDie();
+    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), 'label.tox-label:contains("Source") + div > div > input.tox-textfield').getOrDie();
     assert.isTrue(Strings.startsWith(Value.get(input), expectedValue), 'Assert field source value');
   }, 10, 10000);
 

--- a/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
@@ -54,7 +54,7 @@ const gotoAdvancedTab = (): void => {
 };
 
 const setFieldValue = (selector: string, value: string | boolean): SugarElement<HTMLElement> => {
-  const element = UiFinder.findIn(SugarBody.body(), selector).getOrDie();
+  const element = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), selector).getOrDie();
   Focus.focus(element);
   if (element.dom.type === 'checkbox' && Type.isBoolean(value)) {
     Checked.set(element, value);
@@ -111,13 +111,13 @@ const assertCleanHtml = (label: string, editor: Editor, expected: string): void 
   Assertions.assertHtml(label, expected, cleanHtml(editor.getContent()));
 
 const assertInputValue = (selector: string, expected: string): void => {
-  const element = UiFinder.findIn(SugarBody.body(), selector).getOrDie();
+  const element = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), selector).getOrDie();
   const value = Value.get(element);
   assert.equal(value, expected, `input value should be ${expected}`);
 };
 
 const assertInputCheckbox = (selector: string, expectedState: boolean): void => {
-  const element = UiFinder.findIn(SugarBody.body(), selector).getOrDie();
+  const element = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), selector).getOrDie();
   const value = Checked.get(element);
   assert.equal(value, expectedState, `input value should be ${expectedState}`);
 };

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
@@ -40,7 +40,7 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Link"]');
     await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Remove link"]');
     await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Open link"]');
-    await UiFinder.pWaitForState('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com');
+    await UiFinder.pWaitForState<HTMLInputElement>('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com');
   });
 
   it('TBA: shows relative link urls', async () => {
@@ -49,7 +49,7 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     editor.setContent('<a href="#heading-1">heading</a>');
     Mouse.trueClickOn(TinyDom.body(editor), 'a');
     await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Link"]');
-    await UiFinder.pWaitForState('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === '#heading-1');
+    await UiFinder.pWaitForState<HTMLInputElement>('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === '#heading-1');
   });
 
   it('TBA: works with non text elements (e.g. images)', async () => {
@@ -58,6 +58,6 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     editor.setContent('<a href="http://www.google.com/"><img src="image.jpg"></a>');
     Mouse.trueClickOn(TinyDom.body(editor), 'a');
     await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Link"]');
-    await UiFinder.pWaitForState('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com/');
+    await UiFinder.pWaitForState<HTMLInputElement>('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com/');
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
@@ -25,7 +25,7 @@ describe('browser.tinymce.plugins.link.DialogFlowTest', () => {
   });
 
   const pAssertInputValue = async (editor: Editor, expected: string, group: string) => {
-    const input = await TestLinkUi.pFindInDialog(editor, 'label:contains("' + group + '") + input');
+    const input = await TestLinkUi.pFindInDialog<HTMLInputElement>(editor, 'label:contains("' + group + '") + input');
     const value = UiControls.getValue(input);
     assert.equal(value, expected, 'Checking input value');
   };

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
@@ -56,7 +56,7 @@ describe('browser.tinymce.plugins.link.LinkDialogOverrideTest', () => {
 
     // Assert save button disabled
     UiFinder.exists(sugarBody, 'button[title="Save"][disabled="disabled"]');
-    const input = UiFinder.findIn(sugarBody, 'input[type="url"]').getOrDie();
+    const input = UiFinder.findIn<HTMLInputElement>(sugarBody, 'input[type="url"]').getOrDie();
 
     // Set value and fire 'input' event
     UiControls.setValue(input, 'https://www.google.com', 'input');

--- a/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
@@ -34,7 +34,7 @@ const fireEvent = (elem: SugarElement, event: string) => {
 };
 
 const getInput = (selector: string) =>
-  UiFinder.findIn(SugarBody.body(), selector).getOrDie();
+  UiFinder.findIn<HTMLInputElement>(SugarBody.body(), selector).getOrDie();
 
 const assertInputValue = (label: string, selector: string, expected: string | boolean): void => {
   const input = getInput(selector);
@@ -94,9 +94,9 @@ const pClickConfirmNo = async (editor: Editor) => {
   await pWaitForConfirmClose();
 };
 
-const pFindInDialog = async (editor: Editor, selector: string) => {
+const pFindInDialog = async <T extends Element>(editor: Editor, selector: string) => {
   const dialog = await TinyUiActions.pWaitForDialog(editor);
-  return UiFinder.findIn(dialog, selector).getOrDie();
+  return UiFinder.findIn<T>(dialog, selector).getOrDie();
 };
 
 const clearHistory = () => {
@@ -113,7 +113,7 @@ const pSetListBoxItem = async (editor: Editor, group: string, itemText: string) 
 };
 
 const pSetInputFieldValue = async (editor: Editor, group: string, newValue: string) => {
-  const element = await pFindInDialog(editor, 'label:contains("' + group + '") + input');
+  const element = await pFindInDialog<HTMLInputElement>(editor, 'label:contains("' + group + '") + input');
   UiControls.setValue(element, newValue);
   fireEvent(element, 'input');
 };

--- a/modules/tinymce/src/plugins/media/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/module/test/Utils.ts
@@ -21,7 +21,7 @@ const pOpenDialog = async (editor: Editor) => {
   return await TinyUiActions.pWaitForDialog(editor);
 };
 
-const findInDialog = <T extends HTMLElement>(dialog: SugarElement<HTMLElement>, selector: string) =>
+const findInDialog = <T extends HTMLElement>(dialog: SugarElement<Element>, selector: string) =>
   UiFinder.findIn<T>(dialog, selector).getOrDie();
 
 const pFindInDialog = <T extends HTMLElement>(selector: string) => async (editor: Editor) => {
@@ -29,12 +29,12 @@ const pFindInDialog = <T extends HTMLElement>(selector: string) => async (editor
   return findInDialog<T>(dialog, selector);
 };
 
-const getValueOn = (dialog: SugarElement<HTMLElement>, selector: string) => {
+const getValueOn = (dialog: SugarElement<Element>, selector: string) => {
   const elem = findInDialog<HTMLInputElement>(dialog, selector);
   return UiControls.getValue(elem);
 };
 
-const setValueOn = (dialog: SugarElement<HTMLElement>, selector: string, newValue: string) => {
+const setValueOn = (dialog: SugarElement<Element>, selector: string, newValue: string) => {
   const elem = findInDialog<HTMLInputElement>(dialog, selector);
   UiControls.setValue(elem, newValue);
 };

--- a/modules/tinymce/src/plugins/media/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/module/test/Utils.ts
@@ -21,21 +21,21 @@ const pOpenDialog = async (editor: Editor) => {
   return await TinyUiActions.pWaitForDialog(editor);
 };
 
-const findInDialog = (dialog: SugarElement<HTMLElement>, selector: string) =>
-  UiFinder.findIn(dialog, selector).getOrDie();
+const findInDialog = <T extends HTMLElement>(dialog: SugarElement<HTMLElement>, selector: string) =>
+  UiFinder.findIn<T>(dialog, selector).getOrDie();
 
-const pFindInDialog = (selector: string) => async (editor: Editor) => {
+const pFindInDialog = <T extends HTMLElement>(selector: string) => async (editor: Editor) => {
   const dialog = await TinyUiActions.pWaitForDialog(editor);
-  return findInDialog(dialog, selector);
+  return findInDialog<T>(dialog, selector);
 };
 
 const getValueOn = (dialog: SugarElement<HTMLElement>, selector: string) => {
-  const elem = findInDialog(dialog, selector);
+  const elem = findInDialog<HTMLInputElement>(dialog, selector);
   return UiControls.getValue(elem);
 };
 
 const setValueOn = (dialog: SugarElement<HTMLElement>, selector: string, newValue: string) => {
-  const elem = findInDialog(dialog, selector);
+  const elem = findInDialog<HTMLInputElement>(dialog, selector);
   UiControls.setValue(elem, newValue);
 };
 
@@ -122,8 +122,8 @@ const fakeEvent = (elem: SugarElement<HTMLElement>, name: string) => {
   element.dispatchEvent(event);
 };
 
-const pFindFilepickerInput = pFindInDialog(selectors.source);
-const pFindTextarea = pFindInDialog(selectors.embed);
+const pFindFilepickerInput = pFindInDialog<HTMLInputElement>(selectors.source);
+const pFindTextarea = pFindInDialog<HTMLTextAreaElement>(selectors.embed);
 
 const pSetSourceInput = async (editor: Editor, value: string) => {
   const input = await pFindFilepickerInput(editor);
@@ -134,7 +134,7 @@ const pSetSourceInput = async (editor: Editor, value: string) => {
 const pPasteTextareaValue = async (editor: Editor, value: string) => {
   const button = await pFindInDialog(selectors.embedButton)(editor);
   Mouse.click(button);
-  const embed = await pFindInDialog(selectors.embed)(editor);
+  const embed = await pFindTextarea(editor);
   UiControls.setValue(embed, value);
   fakeEvent(embed, 'paste');
   // Need to wait for the post paste event to fire
@@ -146,7 +146,7 @@ const pAssertEmbedData = async (editor: Editor, content: string) => {
   const dialog = await TinyUiActions.pWaitForDialog(editor);
   await Waiter.pTryUntil('Textarea should have a proper value',
     () => {
-      const elem = findInDialog(dialog, selectors.embed);
+      const elem = findInDialog<HTMLTextAreaElement>(dialog, selectors.embed);
       const value = UiControls.getValue(elem);
       assert.equal(value, content, 'embed content');
     }

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
@@ -11,22 +11,22 @@ const fakeEvent = (elm: SugarElement<HTMLElement>, name: string) => {
   elm.dom.dispatchEvent(evt);
 };
 
-const pFindInDialog = async (editor: Editor, selector: string) => {
+const pFindInDialog = async <T extends HTMLElement>(editor: Editor, selector: string) => {
   const dialog = await TinyUiActions.pWaitForDialog(editor);
-  return UiFinder.findIn(dialog, selector).getOrDie();
+  return UiFinder.findIn<T>(dialog, selector).getOrDie();
 };
 
 const pAssertFieldValue = async (editor: Editor, selector: string, value: string) => {
   const dialog = await TinyUiActions.pWaitForDialog(editor);
   await Waiter.pTryUntilPredicate(`Wait for new ${selector} value`, () => {
-    const result = UiFinder.findIn(dialog, selector);
+    const result = UiFinder.findIn<HTMLInputElement>(dialog, selector);
     const actualValue = UiControls.getValue(result.getOrDie());
     return actualValue === value;
   });
 };
 
 const pSetFieldValue = async (editor: Editor, selector: string, value: string) => {
-  const elm = await pFindInDialog(editor, selector);
+  const elm = await pFindInDialog<HTMLInputElement>(editor, selector);
   UiControls.setValue(elm, value);
   fakeEvent(elm, 'input');
 };

--- a/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
@@ -1,6 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -27,7 +28,7 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
       '</tr></tbody>' +
       '</table>'
     );
-    const td = UiFinder.findIn(TinyDom.body(editor), 'td.foo').getOrDie();
+    const td = UiFinder.findIn<HTMLTableCellElement>(TinyDom.body(editor), 'td.foo').getOrDie();
     const cellData = Helpers.extractDataFromCellElement(editor, td.dom, true, Optional.none());
     assert.equal(cellData.class, 'foo', 'Extracts class');
     assert.equal(cellData.scope, 'row', 'Extracts scope');
@@ -56,7 +57,7 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
       '</tbody>' +
       '</table>'
     );
-    const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo');
+    const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo') as [ SugarElement<HTMLTableColElement>, SugarElement<HTMLTableCellElement> ];
     const cellData = Helpers.extractDataFromCellElement(editor, elements[1].dom, true, Optional.some(elements[0].dom));
     assert.equal(cellData.class, 'foo', 'Extracts class');
     assert.equal(cellData.scope, 'row', 'Extracts scope');
@@ -82,7 +83,7 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
       '</tr></tbody>' +
       '</table>'
     );
-    const td = UiFinder.findIn(TinyDom.body(editor), 'td.foo').getOrDie();
+    const td = UiFinder.findIn<HTMLTableCellElement>(TinyDom.body(editor), 'td.foo').getOrDie();
     const cellData = Helpers.extractDataFromCellElement(editor, td.dom, true, Optional.none());
     assert.equal(cellData.width, '20px', 'Extracts width from style');
     assert.equal(cellData.height, '30px', 'Extracts height from style');
@@ -104,7 +105,7 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
       '</tbody>' +
       '</table>'
     );
-    const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo');
+    const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo') as [ SugarElement<HTMLTableColElement>, SugarElement<HTMLTableCellElement> ];
     const cellData = Helpers.extractDataFromCellElement(editor, elements[1].dom, true, Optional.some(elements[0].dom));
     assert.equal(cellData.width, '20px', 'Extracts width from style');
     assert.equal(cellData.height, '30px', 'Extracts height from style');
@@ -122,7 +123,7 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
       '</tr></tbody>' +
       '</table>'
     );
-    const td = UiFinder.findIn(TinyDom.body(editor), 'td.foo').getOrDie();
+    const td = UiFinder.findIn<HTMLTableCellElement>(TinyDom.body(editor), 'td.foo').getOrDie();
     const cellData = Helpers.extractDataFromCellElement(editor, td.dom, true, Optional.none());
     assert.equal(cellData.bordercolor, '#008000', 'Extracts border-color from shorthand');
     assert.equal(cellData.borderstyle, 'dashed', 'Extracts border-style from shorthand');
@@ -142,7 +143,7 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
       '</tbody>' +
       '</table>'
     );
-    const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo');
+    const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo') as [ SugarElement<HTMLTableColElement>, SugarElement<HTMLTableCellElement> ];
     const cellData = Helpers.extractDataFromCellElement(editor, elements[1].dom, true, Optional.some(elements[0].dom));
     assert.equal(cellData.bordercolor, '#008000', 'Extracts border-color from shorthand');
     assert.equal(cellData.borderstyle, 'dashed', 'Extracts border-style from shorthand');
@@ -157,7 +158,7 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
       'border-style: dashed; border-color: #d91111"><td>a</td></tr>' +
       '</tbody></table>'
     );
-    const tr = UiFinder.findIn(TinyDom.body(editor), 'tr.foo').getOrDie();
+    const tr = UiFinder.findIn<HTMLTableRowElement>(TinyDom.body(editor), 'tr.foo').getOrDie();
     const rowData = Helpers.extractDataFromRowElement(editor, tr.dom, true);
     assert.equal(rowData.height, '30px', 'Extracts height');
     assert.equal(rowData.class, 'foo', 'Extracts class');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableSizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertColumnTableSizeTest.ts
@@ -134,7 +134,7 @@ describe('browser.tinymce.plugins.table.InsertColumnTableSizeTest', () => {
   const insertTable = (editor: Editor, table: string) => {
     editor.setContent(table);
     const bodyElem = TinyDom.body(editor);
-    const tableElem = UiFinder.findIn(bodyElem, 'table').getOr(bodyElem);
+    const tableElem = UiFinder.findIn<HTMLTableElement>(bodyElem, 'table').getOrDie();
     SelectorFind.descendant(tableElem, 'td,th').each((cell) => {
       editor.selection.select(cell.dom, true);
       editor.selection.collapse(true);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/InsertRowTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/InsertRowTableResizeTest.ts
@@ -139,7 +139,7 @@ describe('browser.tinymce.plugins.table.InsertRowTableResizeTest', () => {
   const insertTable = (editor: Editor, table: string) => {
     editor.setContent(table);
     const bodyElem = TinyDom.fromDom(editor.getBody());
-    const tableElem = UiFinder.findIn(bodyElem, 'table').getOr(bodyElem);
+    const tableElem = UiFinder.findIn<HTMLTableElement>(bodyElem, 'table').getOrDie();
     SelectorFind.descendant(tableElem, 'td,th').each((cell) => {
       editor.selection.select(cell.dom, true);
       editor.selection.collapse(true);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/UnmergeCellTableResizeTest.ts
@@ -236,7 +236,7 @@ describe('browser.tinymce.plugins.table.UnmergeCellTableResizeTest', () => {
   const insertTable = (editor: Editor, table: string) => {
     editor.setContent(table);
     const bodyElem = TinyDom.body(editor);
-    const tableElem = UiFinder.findIn(bodyElem, 'table').getOr(bodyElem);
+    const tableElem = UiFinder.findIn<HTMLTableElement>(bodyElem, 'table').getOrDie();
     SelectorFind.descendant(tableElem, 'td,th').each((cell) => {
       editor.selection.select(cell.dom, true);
       editor.selection.collapse(true);

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -183,7 +183,7 @@ const pDragResizeBar = async (editor: Editor, rowOrCol: 'row' | 'column', index:
 };
 
 // The critical part is the target element as this is what Darwin (MouseSelection.ts) uses to determine the fake selection
-const selectWithMouse = (start: SugarElement<Element>, end: SugarElement<Element>): void => {
+const selectWithMouse = (start: SugarElement<Node>, end: SugarElement<Node>): void => {
   Mouse.mouseDown(start, { button: 0 });
   Mouse.mouseOver(end, { button: 0 });
   Mouse.mouseUp(end, { button: 0 });
@@ -211,7 +211,7 @@ const getCellWidth = (editor: Editor, table: SugarElement<HTMLTableElement>, row
 };
 
 const getInput = (selector: string) =>
-  UiFinder.findIn(SugarBody.body(), selector).getOrDie();
+  UiFinder.findIn<HTMLInputElement>(SugarBody.body(), selector).getOrDie();
 
 const assertInputValue = (label: string, selector: string, expected: string | boolean): void => {
   const input = getInput(selector);

--- a/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
@@ -51,7 +51,7 @@ describe('browser.tinymce.plugins.template.TemplateSanityTest', () => {
       templates: [{ title: 'a', description: '<strong>b</strong>', url: '/project/tinymce/src/plugins/template/test/html/test_template.html' }]
     });
     await pInsertTemplate(editor, async (dialogEl) => {
-      await UiFinder.pWaitForState('iframe is loaded', dialogEl, 'iframe', (elm) => {
+      await UiFinder.pWaitForState<HTMLIFrameElement>('iframe is loaded', dialogEl, 'iframe', (elm) => {
         const iframeDoc = elm.dom.contentDocument || elm.dom.contentWindow.document;
         return iframeDoc.body.firstChild !== null;
       });

--- a/modules/tinymce/src/plugins/visualblocks/test/ts/browser/PreviewFormatTest.ts
+++ b/modules/tinymce/src/plugins/visualblocks/test/ts/browser/PreviewFormatTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.plugins.visualblocks.PreviewFormatsTest', () => {
 
   const pWaitForVisualBlocks = (editor: Editor, waitUntilEnabled: boolean = true) =>
     Waiter.pTryUntil('Wait for background css to be applied to first element', () => {
-      const p = TinyDom.fromDom(editor.getBody().firstChild);
+      const p = SugarElement.fromDom(editor.getBody().firstElementChild);
       const background = Css.get(p, 'background-image');
       if (waitUntilEnabled) {
         assert.include(background, 'url(', 'Paragraph should have a url background');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/CropRect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/imagetools/CropRect.ts
@@ -147,11 +147,11 @@ const create = (currentRect: GeomRect, viewPortRect: GeomRect, clampRect: GeomRe
 
     repaint(currentRect);
 
-    const handleFocus = (e: EventArgs<FocusEvent>) => {
+    const handleFocus = (e: EventArgs<FocusEvent, Element>) => {
       Attribute.set(e.target, 'aria-grabbed', e.raw.type === 'focus' ? 'true' : 'false');
     };
 
-    const handleKeydown = (e: EventArgs<KeyboardEvent>) => {
+    const handleKeydown = (e: EventArgs<KeyboardEvent, Element>) => {
       let activeHandle: Handle;
 
       Arr.each(handles, (handle) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -19,7 +19,7 @@ interface Scenario {
 describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
 
   const getBounds = (selector: string) => {
-    const elem = UiFinder.findIn(SugarBody.body(), selector).getOrDie();
+    const elem = UiFinder.findIn<HTMLElement>(SugarBody.body(), selector).getOrDie();
     return Boxes.box(elem);
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
@@ -29,7 +29,7 @@ body {
 
   it('TINY-6783:  Sink width matches body width when in display grid', () => {
     const bodyWidth = Width.get(SugarBody.body());
-    const sink = UiFinder.findIn(SugarBody.body(), '.tox-silver-sink').getOrDie();
+    const sink = UiFinder.findIn<HTMLDivElement>(SugarBody.body(), '.tox-silver-sink').getOrDie();
     const sinkWidth = Width.get(sink);
     assert.equal(sinkWidth, bodyWidth, `Sink should be ${bodyWidth}px wide`);
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -201,7 +201,7 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
       editorContainer
     ));
 
-    const button = UiFinder.findIn(editorContainer, 'button[aria-label="Bold"]').getOrDie();
+    const button = UiFinder.findIn<HTMLButtonElement>(editorContainer, 'button[aria-label="Bold"]').getOrDie();
     Mouse.trueClick(button);
     await Waiter.pTryUntil('', () => Assertions.assertStructure(
       'Check p element path',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
@@ -40,7 +40,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogAriaLabelTest', () =>
   };
 
   const assertDialogLabelledBy = () => {
-    const dialog = UiFinder.findIn(SugarBody.body(), '[role="dialog"]').getOrDie();
+    const dialog = UiFinder.findIn<HTMLElement>(SugarBody.body(), '[role="dialog"]').getOrDie();
     const labelId = getDialogLabelId(dialog);
     UiFinder.exists(dialog, `#${labelId}`);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
@@ -30,27 +30,27 @@ describe('headless.tinymce.themes.silver.components.colorpicker.ColorPickerTest'
     Waiter.pTryUntil(
       'Waiting until hex updates the other fields',
       () => {
-        const input = UiFinder.findIn(component.element, `label:contains("${labelText}") + input`).getOrDie();
+        const input = UiFinder.findIn<HTMLInputElement>(component.element, `label:contains("${labelText}") + input`).getOrDie();
         const value = UiControls.getValue(input);
         assert.equal(value, expected, 'Checking value in input');
       }
     );
 
   const setRgbValue = (component: AlloyComponent, value: string, colour: 'R' | 'G' | 'B') => {
-    const input = UiFinder.findIn(component.element, `label:contains("${colour}") + input`).getOrDie();
+    const input = UiFinder.findIn<HTMLInputElement>(component.element, `label:contains("${colour}") + input`).getOrDie();
     UiControls.setValue(input, value);
     fireEvent(input, 'input');
   };
 
   const setHexValue = (component: AlloyComponent, value: string) => {
-    const input = UiFinder.findIn(component.element, `label:contains("#") + input`).getOrDie();
+    const input = UiFinder.findIn<HTMLInputElement>(component.element, `label:contains("#") + input`).getOrDie();
     UiControls.setValue(input, value);
     fireEvent(input, 'input');
   };
 
   const pAssertPaletteHue = (component: AlloyComponent, expected: number) => {
     return Waiter.pTryUntil('Assert hue of palette matches expected', () => {
-      const canvas = UiFinder.findIn(component.element, 'canvas').getOrDie();
+      const canvas = UiFinder.findIn<HTMLCanvasElement>(component.element, 'canvas').getOrDie();
       // get 1px square from top right of palette canvas
       const imageData = canvas.dom.getContext('2d').getImageData(100, 0, 1, 1).data;
       const rgb = { red: imageData[0], green: imageData[1], blue: imageData[2], alpha: (imageData[3] / 255) * 100 };

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/TabbedDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/TabbedDialogTest.ts
@@ -102,7 +102,7 @@ describe('headless.tinymce.themes.silver.window.TabbedDialogTest', () => {
     const dialog = UiFinder.findIn(SugarBody.body(), '[role="dialog"]').getOrDie();
     UiFinder.findIn(dialog, '[role="tab"]:contains("Basic")').getOrDie();
     UiFinder.findIn(dialog, '[role="tab"]:contains("Advanced")').getOrDie();
-    const tabview = UiFinder.findIn(dialog, '[role="tabpanel"]').getOrDie();
+    const tabview = UiFinder.findIn<HTMLElement>(dialog, '[role="tabpanel"]').getOrDie();
 
     Mouse.clickOn(dialog, 'button:contains("-> Basic")');
     assertFormContents('Clicking Basic button', tabview, (s, str, _arr) => s.element('input', {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
@@ -160,7 +160,7 @@ describe('headless.tinymce.themes.silver.window.WindowManagerRedialTest', () => 
     Mouse.clickOn(SugarBody.body(), 'button:contains("Destination: DialogB")');
 
     Mouse.clickOn(SugarBody.body(), 'button:contains("Destination: DialogC")');
-    const input = UiFinder.findIn(SugarBody.body(), 'input').getOrDie();
+    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), 'input').getOrDie();
     assert.equal(Value.get(input), 'C.Alpha', 'Checking input value');
 
     dialogApi.disable('tab.switch.two');

--- a/modules/tinymce/src/themes/silver/test/ts/module/DomUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/DomUtils.ts
@@ -4,7 +4,7 @@ import { Traverse, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 
 const assertValue = (label: string, component: AlloyComponent, selector: string, expected: string) => {
-  const elem = UiFinder.findIn(component.element, selector).getOrDie();
+  const elem = UiFinder.findIn<HTMLSelectElement>(component.element, selector).getOrDie();
   assert.equal(Value.get(elem), expected, label + ' - checking value of ' + selector);
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -53,7 +53,7 @@ const pOpenNestedMenus = (menus: OpenNestedMenus[]) =>
   }), Promise.resolve());
 
 const assertMoreDrawerInViewport = (type: ToolbarMode) => {
-  const toolbar = UiFinder.findIn(SugarBody.body(), getToolbarSelector(type, true)).getOrDie();
+  const toolbar = UiFinder.findIn<HTMLDivElement>(SugarBody.body(), getToolbarSelector(type, true)).getOrDie();
   const winBox = Boxes.win();
   const drawerBox = Boxes.box(toolbar);
   // -1 from the bottom to account for the negative margin

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
@@ -128,7 +128,7 @@ const pAssertMenuStructure = (label: string, container: SugarElement<HTMLElement
 
 // Assume editor height 400
 const pTestMenuScroll = async (top: boolean) => {
-  const menu = UiFinder.findIn(SugarBody.body(), '[role="menu"]').getOrDie();
+  const menu = UiFinder.findIn<HTMLElement>(SugarBody.body(), '[role="menu"]').getOrDie();
   await pAssertMenuStructure('Checking the opened menus default positioning', menu, 'absolute');
   scrollRelativeEditor(200, top);
   await pAssertMenuStructure('When the top of the editor scrolls off screen, menus should become sticky', menu, 'fixed');

--- a/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
@@ -11,7 +11,7 @@ const countNumber = (container: SugarElement<Node>, selector: string) => {
 };
 
 const extractOnlyOne = (container: SugarElement<Node>, selector: string) => {
-  const ts = UiFinder.findAllIn(container, selector);
+  const ts = UiFinder.findAllIn<HTMLElement>(container, selector);
   if (ts.length === 1) {
     return ts[0];
   } else {


### PR DESCRIPTION
Related Ticket: TINY-8331

Description of Changes:

This is a first PR to start cleaning up some of the `any` types we have for `SugarElement` in the hopes that we maybe able to remove the `any` default we currently have.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
