### PR TITLE
TINY-8331: Added SugarElement types for Snooker and Darwin

### DIFF
--- a/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
@@ -17,7 +17,7 @@ interface RC {
 }
 
 export type MouseHandler = MouseSelection;
-export type ExternalHandler = (start: SugarElement<Node>, finish: SugarElement<Node>) => void;
+export type ExternalHandler = (start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => void;
 
 export interface KeyboardHandler {
   readonly keydown: (event: EventArgs<KeyboardEvent>, start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number, direction: typeof SelectionKeys.ltr) => Optional<Response>;
@@ -26,7 +26,7 @@ export interface KeyboardHandler {
 
 const rc = (rows: number, cols: number): RC => ({ rows, cols });
 
-const mouse = (win: Window, container: SugarElement, isRoot: (e: SugarElement) => boolean, annotations: SelectionAnnotation): MouseHandler => {
+const mouse = (win: Window, container: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean, annotations: SelectionAnnotation): MouseHandler => {
   const bridge = WindowBridge(win);
 
   const handlers = MouseSelection(bridge, container, isRoot, annotations);
@@ -39,7 +39,7 @@ const mouse = (win: Window, container: SugarElement, isRoot: (e: SugarElement) =
   };
 };
 
-const keyboard = (win: Window, container: SugarElement, isRoot: (e: SugarElement) => boolean, annotations: SelectionAnnotation): KeyboardHandler => {
+const keyboard = (win: Window, container: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean, annotations: SelectionAnnotation): KeyboardHandler => {
   const bridge = WindowBridge(win);
 
   const clearToNavigate = () => {
@@ -47,12 +47,12 @@ const keyboard = (win: Window, container: SugarElement, isRoot: (e: SugarElement
     return Optional.none<Response>();
   };
 
-  const keydown = (event: EventArgs<KeyboardEvent>, start: SugarElement, soffset: number, finish: SugarElement, foffset: number, direction: typeof SelectionKeys.ltr) => {
+  const keydown = (event: EventArgs<KeyboardEvent>, start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number, direction: typeof SelectionKeys.ltr) => {
     const realEvent = event.raw;
     const keycode = realEvent.which;
     const shiftKey = realEvent.shiftKey === true;
 
-    const handler = CellSelection.retrieve(container, annotations.selectedSelector).fold(() => {
+    const handler = CellSelection.retrieve<HTMLTableCellElement>(container, annotations.selectedSelector).fold(() => {
       // Make sure any possible lingering annotations are cleared
       if (SelectionKeys.isNavigation(keycode) && !shiftKey) {
         annotations.clearBeforeUpdate(container);
@@ -112,7 +112,7 @@ const keyboard = (win: Window, container: SugarElement, isRoot: (e: SugarElement
     return handler();
   };
 
-  const keyup = (event: EventArgs<KeyboardEvent>, start: SugarElement, soffset: number, finish: SugarElement, foffset: number) => {
+  const keyup = (event: EventArgs<KeyboardEvent>, start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number) => {
     return CellSelection.retrieve(container, annotations.selectedSelector).fold<Optional<Response>>(() => {
       const realEvent = event.raw;
       const keycode = realEvent.which;
@@ -134,10 +134,10 @@ const keyboard = (win: Window, container: SugarElement, isRoot: (e: SugarElement
   };
 };
 
-const external = (win: Window, container: SugarElement, isRoot: (e: SugarElement) => boolean, annotations: SelectionAnnotation): ExternalHandler => {
+const external = (win: Window, container: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean, annotations: SelectionAnnotation): ExternalHandler => {
   const bridge = WindowBridge(win);
 
-  return (start: SugarElement, finish: SugarElement) => {
+  return (start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => {
     annotations.clearBeforeUpdate(container);
     CellSelection.identify(start, finish, isRoot).each((cellSel) => {
       const boxes = cellSel.boxes.getOr([]);

--- a/modules/darwin/src/main/ts/ephox/darwin/api/SelectionAnnotation.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/SelectionAnnotation.ts
@@ -4,9 +4,9 @@ import { Attribute, Class, OnNode, SelectorFilter, SugarElement } from '@ephox/s
 import { Ephemera } from './Ephemera';
 
 export interface SelectionAnnotation {
-  clearBeforeUpdate: (container: SugarElement) => void;
-  clear: (container: SugarElement) => void;
-  selectRange: (container: SugarElement, cells: SugarElement[], start: SugarElement, finish: SugarElement) => void;
+  clearBeforeUpdate: (container: SugarElement<Node>) => void;
+  clear: (container: SugarElement<Node>) => void;
+  selectRange: (container: SugarElement<Node>, cells: SugarElement<HTMLTableCellElement>[], start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => void;
   selectedSelector: string;
   firstSelectedSelector: string;
   lastSelectedSelector: string;
@@ -16,12 +16,12 @@ const byClass = (ephemera: Ephemera): SelectionAnnotation => {
   const addSelectionClass = OnNode.addClass(ephemera.selected);
   const removeSelectionClasses = OnNode.removeClasses([ ephemera.selected, ephemera.lastSelected, ephemera.firstSelected ]);
 
-  const clear = (container: SugarElement) => {
+  const clear = (container: SugarElement<Node>) => {
     const sels = SelectorFilter.descendants(container, ephemera.selectedSelector);
     Arr.each(sels, removeSelectionClasses);
   };
 
-  const selectRange = (container: SugarElement, cells: SugarElement[], start: SugarElement, finish: SugarElement) => {
+  const selectRange = (container: SugarElement<Node>, cells: SugarElement<HTMLTableCellElement>[], start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => {
     clear(container);
     Arr.each(cells, addSelectionClass);
     Class.add(start, ephemera.firstSelected);
@@ -38,28 +38,28 @@ const byClass = (ephemera: Ephemera): SelectionAnnotation => {
   };
 };
 
-const byAttr = (ephemera: Ephemera, onSelection: (cells: SugarElement[], start: SugarElement, finish: SugarElement) => void, onClear: () => void): SelectionAnnotation => {
-  const removeSelectionAttributes = (element: SugarElement) => {
+const byAttr = (ephemera: Ephemera, onSelection: (cells: SugarElement<HTMLTableCellElement>[], start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => void, onClear: () => void): SelectionAnnotation => {
+  const removeSelectionAttributes = (element: SugarElement<HTMLTableCellElement>) => {
     Attribute.remove(element, ephemera.selected);
     Attribute.remove(element, ephemera.firstSelected);
     Attribute.remove(element, ephemera.lastSelected);
   };
 
-  const addSelectionAttribute = (element: SugarElement) => {
+  const addSelectionAttribute = (element: SugarElement<HTMLTableCellElement>) => {
     Attribute.set(element, ephemera.selected, '1');
   };
 
-  const clear = (container: SugarElement) => {
+  const clear = (container: SugarElement<Node>) => {
     clearBeforeUpdate(container);
     onClear();
   };
 
-  const clearBeforeUpdate = (container: SugarElement) => {
-    const sels = SelectorFilter.descendants(container, `${ephemera.selectedSelector},${ephemera.firstSelectedSelector},${ephemera.lastSelectedSelector}`);
+  const clearBeforeUpdate = (container: SugarElement<Node>) => {
+    const sels = SelectorFilter.descendants<HTMLTableCellElement>(container, `${ephemera.selectedSelector},${ephemera.firstSelectedSelector},${ephemera.lastSelectedSelector}`);
     Arr.each(sels, removeSelectionAttributes);
   };
 
-  const selectRange = (container: SugarElement, cells: SugarElement[], start: SugarElement, finish: SugarElement) => {
+  const selectRange = (container: SugarElement<Node>, cells: SugarElement<HTMLTableCellElement>[], start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => {
     clear(container);
     Arr.each(cells, addSelectionAttribute);
     Attribute.set(start, ephemera.firstSelected, '1');

--- a/modules/darwin/src/main/ts/ephox/darwin/api/TableSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/TableSelection.ts
@@ -5,13 +5,13 @@ import { Compare, SelectorFind, SugarElement } from '@ephox/sugar';
 import * as CellSelection from '../selection/CellSelection';
 
 // Explicitly calling CellSelection.retrieve so that we can see the API signature.
-const retrieve = <T extends Element> (container: SugarElement, selector: string): Optional<SugarElement<T>[]> => {
+const retrieve = <T extends Element> (container: SugarElement<Node>, selector: string): Optional<SugarElement<T>[]> => {
   return CellSelection.retrieve<T>(container, selector);
 };
 
-const retrieveBox = (container: SugarElement, firstSelectedSelector: string, lastSelectedSelector: string): Optional<Structs.Bounds> => {
+const retrieveBox = (container: SugarElement<Node>, firstSelectedSelector: string, lastSelectedSelector: string): Optional<Structs.Bounds> => {
   return CellSelection.getEdges(container, firstSelectedSelector, lastSelectedSelector).bind((edges) => {
-    const isRoot = (ancestor: SugarElement) => {
+    const isRoot = (ancestor: SugarElement<Node>) => {
       return Compare.eq(container, ancestor);
     };
     const sectionSelector = 'thead,tfoot,tbody,table';

--- a/modules/darwin/src/main/ts/ephox/darwin/api/WindowBridge.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/WindowBridge.ts
@@ -5,9 +5,9 @@ import { Situs } from '../selection/Situs';
 import * as Util from '../selection/Util';
 
 export interface WindowBridge {
-  elementFromPoint: (x: number, y: number) => Optional<SugarElement>;
-  getRect: (element: SugarElement) => ClientRect | DOMRect;
-  getRangedRect: (start: SugarElement, soffset: number, finish: SugarElement, foffset: number) => Optional<RawRect>;
+  elementFromPoint: (x: number, y: number) => Optional<SugarElement<Element>>;
+  getRect: (element: SugarElement<Element>) => ClientRect | DOMRect;
+  getRangedRect: (start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number) => Optional<RawRect>;
   getSelection: () => Optional<SimRange>;
   fromSitus: (situs: Situs) => SimRange;
   situsFromPoint: (x: number, y: number) => Optional<Situs>;
@@ -31,7 +31,7 @@ export const WindowBridge = (win: Window): WindowBridge => {
     return element.dom.getBoundingClientRect();
   };
 
-  const getRangedRect = (start: SugarElement, soffset: number, finish: SugarElement, foffset: number): Optional<RawRect> => {
+  const getRangedRect = (start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number): Optional<RawRect> => {
     const sel = SimSelection.exact(start, soffset, finish, foffset);
     return WindowSelection.getFirstRect(win, sel);
   };

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
@@ -8,11 +8,18 @@ import { Response } from '../selection/Response';
 import * as Util from '../selection/Util';
 
 // Based on a start and finish, select the appropriate box of cells
-const sync = (container: SugarElement, isRoot: (element: SugarElement) => boolean, start: SugarElement, soffset: number, finish: SugarElement,
-              foffset: number, selectRange: (container: SugarElement, boxes: SugarElement[], start: SugarElement, finish: SugarElement) => void): Optional<Response> => {
+const sync = (
+  container: SugarElement<Node>,
+  isRoot: (element: SugarElement<Node>) => boolean,
+  start: SugarElement<Node>,
+  soffset: number,
+  finish: SugarElement<Node>,
+  foffset: number,
+  selectRange: (container: SugarElement<Node>, boxes: SugarElement<HTMLTableCellElement>[], start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => void
+): Optional<Response> => {
   if (!(Compare.eq(start, finish) && soffset === foffset)) {
-    return SelectorFind.closest(start, 'td,th', isRoot).bind((s) => {
-      return SelectorFind.closest(finish, 'td,th', isRoot).bind((f) => {
+    return SelectorFind.closest<HTMLTableCellElement>(start, 'td,th', isRoot).bind((s) => {
+      return SelectorFind.closest<HTMLTableCellElement>(finish, 'td,th', isRoot).bind((f) => {
         return detect(container, isRoot, s, f, selectRange);
       });
     });
@@ -22,8 +29,13 @@ const sync = (container: SugarElement, isRoot: (element: SugarElement) => boolea
 };
 
 // If the cells are different, and there is a rectangle to connect them, select the cells.
-const detect = (container: SugarElement, isRoot: (element: SugarElement) => boolean, start: SugarElement, finish: SugarElement,
-                selectRange: (container: SugarElement, boxes: SugarElement[], start: SugarElement, finish: SugarElement) => void): Optional<Response> => {
+const detect = (
+  container: SugarElement<Node>,
+  isRoot: (element: SugarElement<Node>) => boolean,
+  start: SugarElement<HTMLTableCellElement>,
+  finish: SugarElement<HTMLTableCellElement>,
+  selectRange: (container: SugarElement<Node>, boxes: SugarElement<HTMLTableCellElement>[], start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => void
+): Optional<Response> => {
   if (!Compare.eq(start, finish)) {
     return CellSelection.identify(start, finish, isRoot).bind((cellSel) => {
       const boxes = cellSel.boxes.getOr([]);
@@ -42,7 +54,13 @@ const detect = (container: SugarElement, isRoot: (element: SugarElement) => bool
   }
 };
 
-const update = (rows: number, columns: number, container: SugarElement, selected: SugarElement[], annotations: SelectionAnnotation): Optional<SugarElement[]> => {
+const update = (
+  rows: number,
+  columns: number,
+  container: SugarElement<Node>,
+  selected: SugarElement<HTMLTableCellElement>[],
+  annotations: SelectionAnnotation
+): Optional<SugarElement<HTMLTableCellElement>[]> => {
   const updateSelection = (newSels: IdentifiedExt) => {
     annotations.clearBeforeUpdate(container);
     annotations.selectRange(container, newSels.boxes, newSels.start, newSels.finish);

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Rectangles.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Rectangles.ts
@@ -6,7 +6,7 @@ import * as Carets from './Carets';
 
 type Carets = Carets.Carets;
 
-const getPartialBox = (bridge: WindowBridge, element: SugarElement, offset: number) => {
+const getPartialBox = (bridge: WindowBridge, element: SugarElement<Node>, offset: number) => {
   if (offset >= 0 && offset < Awareness.getEnd(element)) {
     return bridge.getRangedRect(element, offset, element, offset + 1);
   } else if (offset > 0) {
@@ -22,11 +22,11 @@ const toCaret = (rect: RawRect): Carets => ({
   bottom: rect.bottom
 });
 
-const getElemBox = (bridge: WindowBridge, element: SugarElement) => {
+const getElemBox = (bridge: WindowBridge, element: SugarElement<Element>) => {
   return Optional.some(bridge.getRect(element));
 };
 
-const getBoxAt = (bridge: WindowBridge, element: SugarElement, offset: number): Optional<Carets> => {
+const getBoxAt = (bridge: WindowBridge, element: SugarElement<Node>, offset: number): Optional<Carets> => {
   // Note, we might need to consider this offset and descend.
   if (SugarNode.isElement(element)) {
     return getElemBox(bridge, element).map(toCaret);
@@ -37,7 +37,7 @@ const getBoxAt = (bridge: WindowBridge, element: SugarElement, offset: number): 
   }
 };
 
-const getEntireBox = (bridge: WindowBridge, element: SugarElement): Optional<Carets> => {
+const getEntireBox = (bridge: WindowBridge, element: SugarElement<Node>): Optional<Carets> => {
   if (SugarNode.isElement(element)) {
     return getElemBox(bridge, element).map(toCaret);
   } else if (SugarNode.isText(element)) {

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
@@ -27,9 +27,9 @@ export interface Retries {
 
 export interface CaretMovement {
   point: (caret: Carets) => number;
-  adjuster: (bridge: WindowBridge, element: SugarElement, guessBox: Carets, original: Carets, caret: Carets) => Retries;
+  adjuster: (bridge: WindowBridge, element: SugarElement<Node>, guessBox: Carets, original: Carets, caret: Carets) => Retries;
   move: (caret: Carets, amount: number) => Carets;
-  gather: (element: SugarElement, isRoot: (e: SugarElement) => boolean) => Optional<SugarElement>;
+  gather: (element: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean) => Optional<SugarElement<Node>>;
 }
 
 const JUMP_SIZE = 5;
@@ -48,7 +48,7 @@ const isOutside = (caret: Carets, box: Carets): boolean => {
 };
 
 // Find the block and determine whether or not that block is outside. If it is outside, move up/down and right.
-const inOutsideBlock = (bridge: WindowBridge, element: SugarElement, caret: Carets) => {
+const inOutsideBlock = (bridge: WindowBridge, element: SugarElement<Node>, caret: Carets) => {
   return PredicateFind.closest(element, DomStructure.isBlock).fold(Fun.never, (cell) => {
     return Rectangles.getEntireBox(bridge, cell).exists((box) => {
       return isOutside(caret, box);
@@ -76,7 +76,7 @@ const inOutsideBlock = (bridge: WindowBridge, element: SugarElement, caret: Care
  *    because the guess is GOOD.
  */
 
-const adjustDown = (bridge: WindowBridge, element: SugarElement, guessBox: Carets, original: Carets, caret: Carets): Retries => {
+const adjustDown = (bridge: WindowBridge, element: SugarElement<Node>, guessBox: Carets, original: Carets, caret: Carets): Retries => {
   const lowerCaret = Carets.moveDown(caret, JUMP_SIZE);
   if (Math.abs(guessBox.bottom - original.bottom) < 1) {
     return adt.retry(lowerCaret);
@@ -89,7 +89,7 @@ const adjustDown = (bridge: WindowBridge, element: SugarElement, guessBox: Caret
   }
 };
 
-const adjustUp = (bridge: WindowBridge, element: SugarElement, guessBox: Carets, original: Carets, caret: Carets): Retries => {
+const adjustUp = (bridge: WindowBridge, element: SugarElement<Node>, guessBox: Carets, original: Carets, caret: Carets): Retries => {
   const higherCaret = Carets.moveUp(caret, JUMP_SIZE);
   if (Math.abs(guessBox.top - original.top) < 1) {
     return adt.retry(higherCaret);

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
@@ -16,7 +16,7 @@ type Carets = Carets.Carets;
 
 const MAX_RETRIES = 20;
 
-const findSpot = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, direction: KeyDirection): Optional<SpotPoint<SugarElement<Node>>> => {
+const findSpot = (bridge: WindowBridge, isRoot: (e: SugarElement<Node>) => boolean, direction: KeyDirection): Optional<SpotPoint<SugarElement<Node>>> => {
   return bridge.getSelection().bind((sel) => {
     return BrTags.tryBr(isRoot, sel.finish, sel.foffset, direction).fold(() => {
       return Optional.some(Spot.point(sel.finish, sel.foffset));
@@ -28,7 +28,7 @@ const findSpot = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, di
   });
 };
 
-const scan = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, element: SugarElement, offset: number, direction: KeyDirection, numRetries: number): Optional<Situs> => {
+const scan = (bridge: WindowBridge, isRoot: (e: SugarElement<Node>) => boolean, element: SugarElement<Node>, offset: number, direction: KeyDirection, numRetries: number): Optional<Situs> => {
   if (numRetries === 0) {
     return Optional.none();
   }
@@ -59,7 +59,7 @@ const scan = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, elemen
   });
 };
 
-const tryAgain = (bridge: WindowBridge, element: SugarElement, offset: number, move: (carets: Carets, jump: number) => Carets, direction: KeyDirection): Optional<Situs> => {
+const tryAgain = (bridge: WindowBridge, element: SugarElement<Node>, offset: number, move: (carets: Carets, jump: number) => Carets, direction: KeyDirection): Optional<Situs> => {
   return Rectangles.getBoxAt(bridge, element, offset).bind((box) => {
     return tryAt(bridge, direction, move(box, Retries.getJumpSize()));
   });
@@ -75,13 +75,13 @@ const tryAt = (bridge: WindowBridge, direction: KeyDirection, box: Carets): Opti
   }
 };
 
-const tryCursor = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, element: SugarElement, offset: number, direction: KeyDirection): Optional<Situs> => {
+const tryCursor = (bridge: WindowBridge, isRoot: (e: SugarElement<Node>) => boolean, element: SugarElement<Node>, offset: number, direction: KeyDirection): Optional<Situs> => {
   return Rectangles.getBoxAt(bridge, element, offset).bind((box) => {
     return tryAt(bridge, direction, box);
   });
 };
 
-const handle = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, direction: KeyDirection): Optional<SimRange> => {
+const handle = (bridge: WindowBridge, isRoot: (e: SugarElement<Node>) => boolean, direction: KeyDirection): Optional<SimRange> => {
   return findSpot(bridge, isRoot, direction).bind((spot) => {
     // There is a point to start doing box-hitting from
     return scan(bridge, isRoot, spot.element, spot.offset, direction, MAX_RETRIES).map(bridge.fromSitus);

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/VerticalMovement.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/VerticalMovement.ts
@@ -10,12 +10,12 @@ import * as KeySelection from './KeySelection';
 import * as TableKeys from './TableKeys';
 
 interface Simulated {
-  readonly start: SugarElement;
-  readonly finish: SugarElement;
+  readonly start: SugarElement<HTMLTableCellElement>;
+  readonly finish: SugarElement<HTMLTableCellElement>;
   readonly range: SimRange;
 }
 
-const inSameTable = (elem: SugarElement, table: SugarElement): boolean => {
+const inSameTable = (elem: SugarElement<Node>, table: SugarElement<HTMLTableElement>): boolean => {
   return PredicateExists.ancestor(elem, (e) => {
     return Traverse.parent(e).exists((p) => {
       return Compare.eq(p, table);
@@ -25,14 +25,14 @@ const inSameTable = (elem: SugarElement, table: SugarElement): boolean => {
 
 // Note: initial is the finishing element, because that's where the cursor starts from
 // Anchor is the starting element, and is only used to work out if we are in the same table
-const simulate = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, direction: KeyDirection, initial: SugarElement, anchor: SugarElement): Optional<Simulated> => {
-  return SelectorFind.closest(initial, 'td,th', isRoot).bind((start) => {
-    return SelectorFind.closest(start, 'table', isRoot).bind((table) => {
+const simulate = (bridge: WindowBridge, isRoot: (e: SugarElement<Node>) => boolean, direction: KeyDirection, initial: SugarElement<Node>, anchor: SugarElement<Node>): Optional<Simulated> => {
+  return SelectorFind.closest<HTMLTableCellElement>(initial, 'td,th', isRoot).bind((start) => {
+    return SelectorFind.closest<HTMLTableElement>(start, 'table', isRoot).bind((table) => {
       if (!inSameTable(anchor, table)) {
         return Optional.none<Simulated>();
       }
       return TableKeys.handle(bridge, isRoot, direction).bind((range) => {
-        return SelectorFind.closest(range.finish, 'td,th', isRoot).map<Simulated>((finish) => {
+        return SelectorFind.closest<HTMLTableCellElement>(range.finish, 'td,th', isRoot).map<Simulated>((finish) => {
           return {
             start,
             finish,
@@ -44,8 +44,14 @@ const simulate = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, di
   });
 };
 
-const navigate = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, direction: KeyDirection, initial: SugarElement,
-                  anchor: SugarElement, precheck: (initial: SugarElement, isRoot: (e: SugarElement) => boolean) => Optional<Response>): Optional<Response> => {
+const navigate = (
+  bridge: WindowBridge,
+  isRoot: (e: SugarElement<Node>) => boolean,
+  direction: KeyDirection,
+  initial: SugarElement<Node>,
+  anchor: SugarElement<Node>,
+  precheck: (initial: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean) => Optional<Response>
+): Optional<Response> => {
   return precheck(initial, isRoot).orThunk(() => {
     return simulate(bridge, isRoot, direction, initial, anchor).map((info) => {
       const range = info.range;
@@ -57,9 +63,9 @@ const navigate = (bridge: WindowBridge, isRoot: (e: SugarElement) => boolean, di
   });
 };
 
-const firstUpCheck = (initial: SugarElement, isRoot: (e: SugarElement) => boolean): Optional<Response> => {
-  return SelectorFind.closest(initial, 'tr', isRoot).bind((startRow) => {
-    return SelectorFind.closest(startRow, 'table', isRoot).bind((table) => {
+const firstUpCheck = (initial: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean): Optional<Response> => {
+  return SelectorFind.closest<HTMLTableRowElement>(initial, 'tr', isRoot).bind((startRow) => {
+    return SelectorFind.closest<HTMLTableElement>(startRow, 'table', isRoot).bind((table) => {
       const rows = SelectorFilter.descendants(table, 'tr');
       if (Compare.eq(startRow, rows[0])) {
         return DomGather.seekLeft(table, (element) => {
@@ -78,9 +84,9 @@ const firstUpCheck = (initial: SugarElement, isRoot: (e: SugarElement) => boolea
   });
 };
 
-const lastDownCheck = (initial: SugarElement, isRoot: (e: SugarElement) => boolean): Optional<Response> => {
-  return SelectorFind.closest(initial, 'tr', isRoot).bind((startRow) => {
-    return SelectorFind.closest(startRow, 'table', isRoot).bind((table) => {
+const lastDownCheck = (initial: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean): Optional<Response> => {
+  return SelectorFind.closest<HTMLTableRowElement>(initial, 'tr', isRoot).bind((startRow) => {
+    return SelectorFind.closest<HTMLTableElement>(startRow, 'table', isRoot).bind((table) => {
       const rows = SelectorFilter.descendants(table, 'tr');
       if (Compare.eq(startRow, rows[rows.length - 1])) {
         return DomGather.seekRight(table, (element) => {
@@ -98,8 +104,15 @@ const lastDownCheck = (initial: SugarElement, isRoot: (e: SugarElement) => boole
   });
 };
 
-const select = (bridge: WindowBridge, container: SugarElement, isRoot: (e: SugarElement) => boolean, direction: KeyDirection, initial: SugarElement,
-                anchor: SugarElement, selectRange: (container: SugarElement, boxes: SugarElement[], start: SugarElement, finish: SugarElement) => void): Optional<Response> => {
+const select = (
+  bridge: WindowBridge,
+  container: SugarElement<Node>,
+  isRoot: (e: SugarElement<Node>) => boolean,
+  direction: KeyDirection,
+  initial: SugarElement<Node>,
+  anchor: SugarElement<Node>,
+  selectRange: (container: SugarElement<Node>, boxes: SugarElement<HTMLTableCellElement>[], start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>) => void
+): Optional<Response> => {
   return simulate(bridge, isRoot, direction, initial, anchor).bind((info) => {
     return KeySelection.detect(container, isRoot, info.start, info.finish, selectRange);
   });

--- a/modules/darwin/src/main/ts/ephox/darwin/navigation/BrTags.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/navigation/BrTags.ts
@@ -6,17 +6,15 @@ import { Situs } from '../selection/Situs';
 import { BeforeAfter } from './BeforeAfter';
 import { KeyDirection } from './KeyDirection';
 
-const isBr = (elem: SugarElement) => {
-  return SugarNode.name(elem) === 'br';
-};
+const isBr = SugarNode.isTag('br');
 
-const gatherer = (cand: SugarElement, gather: KeyDirection['gather'], isRoot: (e: SugarElement) => boolean): Optional<SugarElement> => {
+const gatherer = (cand: SugarElement<Node>, gather: KeyDirection['gather'], isRoot: (e: SugarElement<Node>) => boolean): Optional<SugarElement<Node>> => {
   return gather(cand, isRoot).bind((target) => {
     return SugarNode.isText(target) && SugarText.get(target).trim().length === 0 ? gatherer(target, gather, isRoot) : Optional.some(target);
   });
 };
 
-const handleBr = (isRoot: (e: SugarElement) => boolean, element: SugarElement, direction: KeyDirection) => {
+const handleBr = (isRoot: (e: SugarElement<Node>) => boolean, element: SugarElement<Node>, direction: KeyDirection) => {
   // 1. Has a neighbouring sibling ... position relative to neighbouring element
   // 2. Has no neighbouring sibling ... position relative to gathered element
   return direction.traverse(element).orThunk(() => {
@@ -24,14 +22,14 @@ const handleBr = (isRoot: (e: SugarElement) => boolean, element: SugarElement, d
   }).map(direction.relative);
 };
 
-const findBr = (element: SugarElement, offset: number) => {
+const findBr = (element: SugarElement<Node>, offset: number) => {
   return Traverse.child(element, offset).filter(isBr).orThunk(() => {
     // Can be either side of the br, and still be a br.
     return Traverse.child(element, offset - 1).filter(isBr);
   });
 };
 
-const handleParent = (isRoot: (e: SugarElement) => boolean, element: SugarElement, offset: number, direction: KeyDirection) => {
+const handleParent = (isRoot: (e: SugarElement<Node>) => boolean, element: SugarElement<Node>, offset: number, direction: KeyDirection) => {
   // 1. Has no neighbouring sibling, position relative to gathered element
   // 2. Has a neighbouring sibling, position at the neighbouring sibling with respect to parent
   return findBr(element, offset).bind((br) => {
@@ -45,7 +43,7 @@ const handleParent = (isRoot: (e: SugarElement) => boolean, element: SugarElemen
   });
 };
 
-const tryBr = (isRoot: (e: SugarElement) => boolean, element: SugarElement, offset: number, direction: KeyDirection): Optional<Situs> => {
+const tryBr = (isRoot: (e: SugarElement<Node>) => boolean, element: SugarElement<Node>, offset: number, direction: KeyDirection): Optional<Situs> => {
   // Three different situations
   // 1. the br is the child, and it has a previous sibling. Use parent, index-1)
   // 2. the br is the child and it has no previous sibling, set to before the previous gather result
@@ -61,7 +59,7 @@ const tryBr = (isRoot: (e: SugarElement) => boolean, element: SugarElement, offs
   });
 };
 
-const process = (analysis: BeforeAfter): Optional<SpotPoint<SugarElement>> => {
+const process = (analysis: BeforeAfter): Optional<SpotPoint<SugarElement<HTMLTableCellElement>>> => {
   return BeforeAfter.cata(analysis,
     (_message) => {
       return Optional.none();

--- a/modules/darwin/src/main/ts/ephox/darwin/navigation/KeyDirection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/navigation/KeyDirection.ts
@@ -9,9 +9,9 @@ import { Situs } from '../selection/Situs';
 import { BeforeAfter, BeforeAfterFailureConstructor } from './BeforeAfter';
 
 export interface KeyDirection {
-  traverse: (element: SugarElement) => Optional<SugarElement>;
-  gather: (element: SugarElement, isRoot: (e: SugarElement) => boolean) => Optional<SugarElement>;
-  relative: (element: SugarElement) => Situ;
+  traverse: (element: SugarElement<Node>) => Optional<SugarElement<Node & ChildNode>>;
+  gather: (element: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean) => Optional<SugarElement<Node>>;
+  relative: (element: SugarElement<Node>) => Situ;
   retry: (bridge: WindowBridge, caret: Carets) => Optional<Situs>;
   failure: BeforeAfterFailureConstructor;
 }

--- a/modules/darwin/src/main/ts/ephox/darwin/queries/CellOpSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/queries/CellOpSelection.ts
@@ -15,7 +15,7 @@ const selection = (selections: Selections): SugarElement<HTMLTableCellElement>[]
     Arr.pure
   );
 
-const unmergable = (selections: Selections): Optional<SugarElement[]> => {
+const unmergable = (selections: Selections): Optional<SugarElement<HTMLTableCellElement>[]> => {
   const hasSpan = (elem: SugarElement<Element>, type: 'colspan' | 'rowspan') => Attribute.getOpt(elem, type).exists((span) => parseInt(span, 10) > 1);
   const hasRowOrColSpan = (elem: SugarElement<Element>) => hasSpan(elem, 'rowspan') || hasSpan(elem, 'colspan');
 

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/CellSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/CellSelection.ts
@@ -6,8 +6,8 @@ import { Compare, SelectorFilter, SelectorFind, Selectors, SugarElement } from '
 import { Identified, IdentifiedExt } from './Identified';
 
 interface Edges {
-  readonly first: SugarElement;
-  readonly last: SugarElement;
+  readonly first: SugarElement<HTMLTableCellElement>;
+  readonly last: SugarElement<HTMLTableCellElement>;
   readonly table: SugarElement<HTMLTableElement>;
 }
 
@@ -15,9 +15,9 @@ const lookupTable = (container: SugarElement<Node>) => {
   return SelectorFind.ancestor<HTMLTableElement>(container, 'table');
 };
 
-const identify = (start: SugarElement, finish: SugarElement, isRoot?: (element: SugarElement) => boolean): Optional<Identified> => {
-  const getIsRoot = (rootTable: SugarElement) => {
-    return (element: SugarElement) => {
+const identify = (start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>, isRoot?: (element: SugarElement<Node>) => boolean): Optional<Identified> => {
+  const getIsRoot = (rootTable: SugarElement<HTMLTableElement>) => {
+    return (element: SugarElement<Node>) => {
       return (isRoot !== undefined && isRoot(element)) || Compare.eq(element, rootTable);
     };
   };
@@ -39,7 +39,7 @@ const identify = (start: SugarElement, finish: SugarElement, isRoot?: (element: 
             finish
           });
         } else if (Compare.contains(startTable, finishTable)) { // Selecting from the parent table to the nested table.
-          const ancestorCells = SelectorFilter.ancestors(finish, 'td,th', getIsRoot(startTable));
+          const ancestorCells = SelectorFilter.ancestors<HTMLTableCellElement>(finish, 'td,th', getIsRoot(startTable));
           const finishCell = ancestorCells.length > 0 ? ancestorCells[ancestorCells.length - 1] : finish;
           return Optional.some({
             boxes: TablePositions.nestedIntercepts(startTable, start, startTable, finish, finishTable),
@@ -47,7 +47,7 @@ const identify = (start: SugarElement, finish: SugarElement, isRoot?: (element: 
             finish: finishCell
           });
         } else if (Compare.contains(finishTable, startTable)) { // Selecting from the nested table to the parent table.
-          const ancestorCells = SelectorFilter.ancestors(start, 'td,th', getIsRoot(finishTable));
+          const ancestorCells = SelectorFilter.ancestors<HTMLTableCellElement>(start, 'td,th', getIsRoot(finishTable));
           const startCell = ancestorCells.length > 0 ? ancestorCells[ancestorCells.length - 1] : start;
           return Optional.some({
             boxes: TablePositions.nestedIntercepts(finishTable, start, startTable, finish, finishTable),
@@ -57,9 +57,9 @@ const identify = (start: SugarElement, finish: SugarElement, isRoot?: (element: 
         } else { // Selecting from a nested table to a different nested table.
           return DomParent.ancestors(start, finish).shared.bind((lca) => {
             return SelectorFind.closest<HTMLTableElement>(lca, 'table', isRoot).bind((lcaTable) => {
-              const finishAncestorCells = SelectorFilter.ancestors(finish, 'td,th', getIsRoot(lcaTable));
+              const finishAncestorCells = SelectorFilter.ancestors<HTMLTableCellElement>(finish, 'td,th', getIsRoot(lcaTable));
               const finishCell = finishAncestorCells.length > 0 ? finishAncestorCells[finishAncestorCells.length - 1] : finish;
-              const startAncestorCells = SelectorFilter.ancestors(start, 'td,th', getIsRoot(lcaTable));
+              const startAncestorCells = SelectorFilter.ancestors<HTMLTableCellElement>(start, 'td,th', getIsRoot(lcaTable));
               const startCell = startAncestorCells.length > 0 ? startAncestorCells[startAncestorCells.length - 1] : start;
               return Optional.some({
                 boxes: TablePositions.nestedIntercepts(lcaTable, start, startTable, finish, finishTable),
@@ -85,9 +85,9 @@ const getLast = (boxes: SugarElement<HTMLTableCellElement>[], lastSelectedSelect
   });
 };
 
-const getEdges = (container: SugarElement, firstSelectedSelector: string, lastSelectedSelector: string): Optional<Edges> => {
-  return SelectorFind.descendant(container, firstSelectedSelector).bind((first) => {
-    return SelectorFind.descendant(container, lastSelectedSelector).bind((last) => {
+const getEdges = (container: SugarElement<Node>, firstSelectedSelector: string, lastSelectedSelector: string): Optional<Edges> => {
+  return SelectorFind.descendant<HTMLTableCellElement>(container, firstSelectedSelector).bind((first) => {
+    return SelectorFind.descendant<HTMLTableCellElement>(container, lastSelectedSelector).bind((last) => {
       return DomParent.sharedOne(lookupTable, [ first, last ]).map((table) => {
         return {
           first,
@@ -99,9 +99,9 @@ const getEdges = (container: SugarElement, firstSelectedSelector: string, lastSe
   });
 };
 
-const expandTo = (finish: SugarElement, firstSelectedSelector: string): Optional<IdentifiedExt> => {
-  return SelectorFind.ancestor(finish, 'table').bind((table) => {
-    return SelectorFind.descendant(table, firstSelectedSelector).bind((start) => {
+const expandTo = (finish: SugarElement<HTMLTableCellElement>, firstSelectedSelector: string): Optional<IdentifiedExt> => {
+  return SelectorFind.ancestor<HTMLTableElement>(finish, 'table').bind((table) => {
+    return SelectorFind.descendant<HTMLTableCellElement>(table, firstSelectedSelector).bind((start) => {
       return identify(start, finish).bind((identified) => {
         return identified.boxes.map<IdentifiedExt>((boxes) => {
           return {

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/CellSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/CellSelection.ts
@@ -11,8 +11,8 @@ interface Edges {
   readonly table: SugarElement<HTMLTableElement>;
 }
 
-const lookupTable = (container: SugarElement) => {
-  return SelectorFind.ancestor(container, 'table');
+const lookupTable = (container: SugarElement<Node>) => {
+  return SelectorFind.ancestor<HTMLTableElement>(container, 'table');
 };
 
 const identify = (start: SugarElement, finish: SugarElement, isRoot?: (element: SugarElement) => boolean): Optional<Identified> => {
@@ -56,7 +56,7 @@ const identify = (start: SugarElement, finish: SugarElement, isRoot?: (element: 
           });
         } else { // Selecting from a nested table to a different nested table.
           return DomParent.ancestors(start, finish).shared.bind((lca) => {
-            return SelectorFind.closest(lca, 'table', isRoot).bind((lcaTable) => {
+            return SelectorFind.closest<HTMLTableElement>(lca, 'table', isRoot).bind((lcaTable) => {
               const finishAncestorCells = SelectorFilter.ancestors(finish, 'td,th', getIsRoot(lcaTable));
               const finishCell = finishAncestorCells.length > 0 ? finishAncestorCells[finishAncestorCells.length - 1] : finish;
               const startAncestorCells = SelectorFilter.ancestors(start, 'td,th', getIsRoot(lcaTable));
@@ -79,9 +79,9 @@ const retrieve = <T extends Element> (container: SugarElement<Node>, selector: s
   return sels.length > 0 ? Optional.some(sels) : Optional.none<SugarElement<T>[]>();
 };
 
-const getLast = (boxes: SugarElement<Element>[], lastSelectedSelector: string): Optional<SugarElement<Element>> => {
+const getLast = (boxes: SugarElement<HTMLTableCellElement>[], lastSelectedSelector: string): Optional<SugarElement<HTMLTableCellElement>> => {
   return Arr.find(boxes, (box) => {
-    return Selectors.is(box, lastSelectedSelector);
+    return Selectors.is<HTMLTableCellElement>(box, lastSelectedSelector);
   });
 };
 
@@ -115,7 +115,7 @@ const expandTo = (finish: SugarElement, firstSelectedSelector: string): Optional
   });
 };
 
-const shiftSelection = (boxes: SugarElement[], deltaRow: number, deltaColumn: number,
+const shiftSelection = (boxes: SugarElement<HTMLTableCellElement>[], deltaRow: number, deltaColumn: number,
                         firstSelectedSelector: string, lastSelectedSelector: string): Optional<IdentifiedExt> => {
   return getLast(boxes, lastSelectedSelector).bind((last) => {
     return TablePositions.moveBy(last, deltaRow, deltaColumn).bind((finish) => {

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Identified.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Identified.ts
@@ -2,13 +2,13 @@ import { Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 export interface Identified {
-  readonly boxes: Optional<SugarElement[]>;
-  readonly start: SugarElement;
-  readonly finish: SugarElement;
+  readonly boxes: Optional<SugarElement<HTMLTableCellElement>[]>;
+  readonly start: SugarElement<HTMLTableCellElement>;
+  readonly finish: SugarElement<HTMLTableCellElement>;
 }
 
 export interface IdentifiedExt {
-  readonly boxes: SugarElement[];
-  readonly start: SugarElement;
-  readonly finish: SugarElement;
+  readonly boxes: SugarElement<HTMLTableCellElement>[];
+  readonly start: SugarElement<HTMLTableCellElement>;
+  readonly finish: SugarElement<HTMLTableCellElement>;
 }

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Situs.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Situs.ts
@@ -5,7 +5,7 @@ export interface Situs {
   readonly finish: Situ;
 }
 
-const create = (start: SugarElement, soffset: number, finish: SugarElement, foffset: number): Situs => {
+const create = (start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number): Situs => {
   return {
     start: Situ.on(start, soffset),
     finish: Situ.on(finish, foffset)

--- a/modules/snooker/src/demo/ts/ephox/snooker/demo/DetectDemo.ts
+++ b/modules/snooker/src/demo/ts/ephox/snooker/demo/DetectDemo.ts
@@ -123,9 +123,9 @@ Ready.execute(() => {
     '</table>');
 
   const ephoxUi = SelectorFind.first('#ephox-ui').getOrDie();
-  const ltrs = SugarElement.fromHtml('<div class="ltrs"></div>');
+  const ltrs = SugarElement.fromHtml<HTMLDivElement>('<div class="ltrs"></div>');
   InsertAll.append(ltrs, [ SugarElement.fromHtml('<p>Left to Right tables</p>'), tester, SugarElement.fromTag('p'), subject2 ]);
-  const rtls = SugarElement.fromHtml('<div dir="rtl"></div>');
+  const rtls = SugarElement.fromHtml<HTMLDivElement>('<div dir="rtl"></div>');
   InsertAll.append(rtls, [ SugarElement.fromHtml('<p>Right to Left table</p>'), subject3 ]);
   InsertAll.append(ephoxUi, [ ltrs, rtls ]);
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CellLocation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CellLocation.ts
@@ -7,10 +7,10 @@ import { SugarElement } from '@ephox/sugar';
  * when navigating past the last cell (e.g. create a new row).
  */
 
-type NoneHandler<T> = (current: SugarElement | undefined) => T;
-type FirstHandler<T> = (current: SugarElement) => T;
-type MiddleHandler<T> = (current: SugarElement, target: any) => T;
-type LastHandler<T> = (current: SugarElement) => T;
+type NoneHandler<T> = (current: SugarElement<HTMLTableCellElement> | undefined) => T;
+type FirstHandler<T> = (current: SugarElement<HTMLTableCellElement>) => T;
+type MiddleHandler<T> = (current: SugarElement<HTMLTableCellElement>, target: SugarElement<HTMLTableCellElement>) => T;
+type LastHandler<T> = (current: SugarElement<HTMLTableCellElement>) => T;
 
 export interface CellLocation {
   fold: <T> (
@@ -29,10 +29,10 @@ export interface CellLocation {
 }
 
 const adt: {
-  none: (current: SugarElement | undefined) => CellLocation;
-  first: (current: SugarElement) => CellLocation;
-  middle: (current: SugarElement, target: SugarElement) => CellLocation;
-  last: (current: SugarElement) => CellLocation;
+  none: (current: SugarElement<HTMLTableCellElement> | undefined) => CellLocation;
+  first: (current: SugarElement<HTMLTableCellElement>) => CellLocation;
+  middle: (current: SugarElement<HTMLTableCellElement>, target: SugarElement<HTMLTableCellElement>) => CellLocation;
+  last: (current: SugarElement<HTMLTableCellElement>) => CellLocation;
 } = Adt.generate([
   { none: [ 'current' ] },
   { first: [ 'current' ] },
@@ -40,7 +40,7 @@ const adt: {
   { last: [ 'current' ] }
 ]);
 
-const none = (current: SugarElement | undefined = undefined): CellLocation => adt.none(current);
+const none = (current?: SugarElement<HTMLTableCellElement>): CellLocation => adt.none(current);
 
 export const CellLocation = {
   ...adt,

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CellMutations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CellMutations.ts
@@ -2,13 +2,13 @@ import { SugarElement } from '@ephox/sugar';
 
 import * as Sizes from '../resize/Sizes';
 import * as CellUtils from '../util/CellUtils';
+import { CellElement } from '../util/TableTypes';
 
-const halve = (main: SugarElement, other: SugarElement): void => {
-  const colspan = CellUtils.getSpan(main, 'colspan');
+const halve = (main: SugarElement<CellElement>, other: SugarElement<CellElement>): void => {
   // Only set width on the new cell if we have a colspan of 1 (or no colspan) as we can only safely do that for cells
   // that are a single column, since we don't know the individual column widths for a cell with a colspan.
   // Instead, we'll rely on the adjustments/postAction logic to set the widths based on other cells in the column
-  if (colspan === 1) {
+  if (!CellUtils.hasColspan(main)) {
     const width = Sizes.getGenericWidth(main);
     width.each((w) => {
       const newWidth = w.value / 2;

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
@@ -3,9 +3,10 @@ import { Attribute, InsertAll, Replication, SugarElement } from '@ephox/sugar';
 
 import { onUnlockedCells, TargetSelection } from '../model/RunOperation';
 import * as CellUtils from '../util/CellUtils';
+import { CellElement } from '../util/TableTypes';
 import { Warehouse } from './Warehouse';
 
-const constrainSpan = (element: SugarElement, property: 'colspan' | 'rowspan' | 'span', value: number) => {
+const constrainSpan = (element: SugarElement<CellElement>, property: 'colspan' | 'rowspan' | 'span', value: number) => {
   const currentColspan = CellUtils.getAttrValue(element, property, 1);
   if (value === 1 || currentColspan <= 1) {
     Attribute.remove(element, property);
@@ -43,7 +44,7 @@ const generateRows = (house: Warehouse, minColRange: number, maxColRange: number
     return fakeTR;
   });
 
-const copyCols = (table: SugarElement, target: TargetSelection): Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]> => {
+const copyCols = (table: SugarElement<HTMLTableElement>, target: TargetSelection): Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]> => {
   const house = Warehouse.fromTable(table);
   const details = onUnlockedCells(house, target);
   return details.map((selectedCells): SugarElement<HTMLTableRowElement | HTMLTableColElement>[] => {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
@@ -139,7 +139,7 @@ const getTableWidthDelta = (table: SugarElement<HTMLTableElement>, warehouse: Wa
   return tableSize.getCellDelta(delta);
 };
 
-const extract = (table: SugarElement, selectedSelector: string): SugarElement => {
+const extract = (table: SugarElement<HTMLTableElement>, selectedSelector: string): SugarElement<HTMLTableElement> => {
   const isSelected = (detail: DetailExt) => Selectors.is(detail.element, selectedSelector);
 
   const replica = Replication.deep(table);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
@@ -2,13 +2,14 @@ import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { getAttrValue } from '../util/CellUtils';
+import { CellElement, CompElm, RowElement } from '../util/TableTypes';
 
 export interface RowData {
-  readonly element: SugarElement<HTMLTableRowElement | HTMLTableColElement>;
+  readonly element: SugarElement<RowElement>;
 }
 
 export interface CellData {
-  readonly element: SugarElement<HTMLTableCellElement | HTMLTableColElement>;
+  readonly element: SugarElement<CellElement>;
   readonly colspan: number;
   readonly rowspan: number;
 }
@@ -16,7 +17,7 @@ export interface CellData {
 export interface Generators {
   readonly cell: (cellData: CellData) => SugarElement<HTMLTableCellElement>;
   readonly row: (rowData: RowData) => SugarElement<HTMLTableRowElement>;
-  readonly replace: <K extends keyof HTMLElementTagNameMap>(cell: SugarElement<HTMLTableCellElement>, tag: K, attrs: Record<string, string | number | boolean | null>) => SugarElement<HTMLElementTagNameMap[K]>;
+  readonly replace: (cell: SugarElement<HTMLTableCellElement>, tag: 'td' | 'th', attrs: Record<string, string | number | boolean | null>) => SugarElement<HTMLTableCellElement>;
   readonly gap: () => SugarElement<HTMLTableCellElement>;
   readonly colGap: () => SugarElement<HTMLTableColElement>;
   readonly col: (prev: CellData) => SugarElement<HTMLTableColElement>;
@@ -26,7 +27,7 @@ export interface Generators {
 export interface SimpleGenerators extends Generators {
   readonly cell: () => SugarElement<HTMLTableCellElement>;
   readonly row: () => SugarElement<HTMLTableRowElement>;
-  readonly replace: <T extends HTMLElement>(cell: SugarElement<HTMLTableCellElement>) => SugarElement<T>;
+  readonly replace: (cell: SugarElement<HTMLTableCellElement>) => SugarElement<HTMLTableCellElement>;
   readonly gap: () => SugarElement<HTMLTableCellElement>;
   readonly col: () => SugarElement<HTMLTableColElement>;
   readonly colgroup: () => SugarElement<HTMLTableColElement>;
@@ -35,35 +36,35 @@ export interface SimpleGenerators extends Generators {
 export interface GeneratorsWrapper {}
 
 export interface GeneratorsModification extends GeneratorsWrapper {
-  readonly getOrInit: (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) => SugarElement;
+  readonly getOrInit: <T extends RowElement | CellElement>(element: SugarElement<T>, comparator: CompElm) => SugarElement<T>;
 }
 
 export interface GeneratorsTransform extends GeneratorsWrapper {
-  readonly replaceOrInit: (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) => SugarElement;
+  readonly replaceOrInit: <T extends RowElement | CellElement>(element: SugarElement<T>, comparator: CompElm) => SugarElement<T>;
 }
 
 export interface GeneratorsMerging extends GeneratorsWrapper {
-  readonly unmerge: (cell: SugarElement) => () => SugarElement;
-  readonly merge: (cells: SugarElement[]) => () => SugarElement;
+  readonly unmerge: (cell: SugarElement<HTMLTableCellElement>) => () => SugarElement<HTMLTableCellElement>;
+  readonly merge: (cells: SugarElement<HTMLTableCellElement>[]) => () => SugarElement<HTMLTableCellElement>;
 }
 
 interface Recent {
-  readonly item: SugarElement;
-  readonly replacement: SugarElement;
+  readonly item: SugarElement<CellElement>;
+  readonly replacement: SugarElement<CellElement>;
 }
 
 interface Item {
-  readonly item: SugarElement;
-  readonly sub: SugarElement;
+  readonly item: SugarElement<HTMLTableCellElement>;
+  readonly sub: SugarElement<HTMLTableCellElement>;
 }
 
 const isCol = SugarNode.isTag('col');
 const isColgroup = SugarNode.isTag('colgroup');
 
-const isRow = (element: SugarElement): element is SugarElement<HTMLTableRowElement | HTMLTableColElement> =>
+const isRow = (element: SugarElement<RowElement | CellElement>): element is SugarElement<RowElement> =>
   SugarNode.name(element) === 'tr' || isColgroup(element);
 
-const elementToData = (element: SugarElement): CellData => {
+const elementToData = (element: SugarElement<CellElement>): CellData => {
   const colspan = getAttrValue(element, 'colspan', 1);
   const rowspan = getAttrValue(element, 'rowspan', 1);
   return {
@@ -82,23 +83,24 @@ const modification = (generators: Generators, toData = elementToData): Generator
   const nuRow = (data: RowData) =>
     isColgroup(data.element) ? generators.colgroup(data) : generators.row(data);
 
-  const add = (element: SugarElement) => {
+  const add = (element: SugarElement<RowElement | CellElement>) => {
     if (isRow(element)) {
       return nuRow({ element });
     } else {
-      const replacement = nuCell(toData(element));
-      recent = Optional.some({ item: element, replacement });
+      const cell = element as SugarElement<CellElement>;
+      const replacement = nuCell(toData(cell));
+      recent = Optional.some({ item: cell, replacement });
       return replacement;
     }
   };
 
   let recent = Optional.none<Recent>();
-  const getOrInit = (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) => {
+  const getOrInit = <T extends RowElement | CellElement>(element: SugarElement<T>, comparator: CompElm): SugarElement<T> => {
     return recent.fold(() => {
       return add(element);
     }, (p) => {
       return comparator(element, p.item) ? p.replacement : add(element);
-    });
+    }) as SugarElement<T>;
   };
 
   return {
@@ -106,17 +108,17 @@ const modification = (generators: Generators, toData = elementToData): Generator
   };
 };
 
-const transform = <K extends keyof HTMLElementTagNameMap> (tag: K) => {
+const transform = (tag: 'td' | 'th') => {
   return (generators: Generators): GeneratorsTransform => {
     const list: Item[] = [];
 
-    const find = (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) => {
+    const find = (element: SugarElement<RowElement | CellElement>, comparator: CompElm) => {
       return Arr.find(list, (x) => {
         return comparator(x.item, element);
       });
     };
 
-    const makeNew = (element: SugarElement) => {
+    const makeNew = (element: SugarElement<HTMLTableCellElement>) => {
       // Ensure scope is never set on a td element as it's a deprecated attribute
       const attrs: Record<string, string | number | null> = tag === 'td' ? { scope: null } : {};
       const cell = generators.replace(element, tag, attrs);
@@ -127,15 +129,16 @@ const transform = <K extends keyof HTMLElementTagNameMap> (tag: K) => {
       return cell;
     };
 
-    const replaceOrInit = (element: SugarElement, comparator: (a: SugarElement, b: SugarElement) => boolean) => {
+    const replaceOrInit = <T extends RowElement | CellElement>(element: SugarElement<T>, comparator: CompElm): SugarElement<T> => {
       if (isRow(element) || isCol(element)) {
         return element;
       } else {
-        return find(element, comparator).fold(() => {
-          return makeNew(element);
+        const cell = element as SugarElement<HTMLTableCellElement>;
+        return find(cell, comparator).fold(() => {
+          return makeNew(cell);
         }, (p) => {
-          return comparator(element, p.item) ? p.sub : makeNew(element);
-        });
+          return comparator(element, p.item) ? p.sub : makeNew(cell);
+        }) as SugarElement<T>;
       }
     };
 
@@ -145,7 +148,7 @@ const transform = <K extends keyof HTMLElementTagNameMap> (tag: K) => {
   };
 };
 
-const getScopeAttribute = (cell: SugarElement) =>
+const getScopeAttribute = (cell: SugarElement<HTMLElement>) =>
   Attribute.getOpt(cell, 'scope').map(
     // Attribute can be col, colgroup, row, and rowgroup.
     // As col and colgroup are to be treated as if they are the same, lob off everything after the first three characters and there is no difference.
@@ -153,7 +156,7 @@ const getScopeAttribute = (cell: SugarElement) =>
   );
 
 const merging = (generators: Generators): GeneratorsMerging => {
-  const unmerge = (cell: SugarElement) => {
+  const unmerge = (cell: SugarElement<HTMLTableCellElement>) => {
     const scope = getScopeAttribute(cell);
 
     scope.each((attribute) => Attribute.set(cell, 'scope', attribute));
@@ -174,7 +177,7 @@ const merging = (generators: Generators): GeneratorsMerging => {
     };
   };
 
-  const merge = (cells: SugarElement[]) => {
+  const merge = (cells: SugarElement<HTMLTableCellElement>[]) => {
     const getScopeProperty = () => {
 
       const stringAttributes = Optionals.cat(

--- a/modules/snooker/src/main/ts/ephox/snooker/api/OtherCells.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/OtherCells.ts
@@ -3,16 +3,17 @@ import { SugarElement } from '@ephox/sugar';
 
 import { onCells, TargetSelection, toDetailList } from '../model/RunOperation';
 import * as Transitions from '../model/Transitions';
+import { CellElement } from '../util/TableTypes';
 import { Generators } from './Generators';
 import { DetailExt, RowCells } from './Structs';
 import { Warehouse } from './Warehouse';
 
 export interface OtherCells {
-  readonly upOrLeftCells: SugarElement<HTMLTableCellElement>[];
-  readonly downOrRightCells: SugarElement<HTMLTableCellElement>[];
+  readonly upOrLeftCells: SugarElement<CellElement>[];
+  readonly downOrRightCells: SugarElement<CellElement>[];
 }
 
-const getUpOrLeftCells = (grid: RowCells[], selectedCells: DetailExt[]): SugarElement[] => {
+const getUpOrLeftCells = (grid: RowCells[], selectedCells: DetailExt[]): SugarElement<CellElement>[] => {
   // Get rows up or at the row of the bottom right cell
   const upGrid = grid.slice(0, selectedCells[selectedCells.length - 1].row + 1);
   const upDetails = toDetailList(upGrid);
@@ -23,7 +24,7 @@ const getUpOrLeftCells = (grid: RowCells[], selectedCells: DetailExt[]): SugarEl
   });
 };
 
-const getDownOrRightCells = (grid: RowCells[], selectedCells: DetailExt[]): SugarElement[] => {
+const getDownOrRightCells = (grid: RowCells[], selectedCells: DetailExt[]): SugarElement<CellElement>[] => {
   // Get rows down or at the row of the top left cell (including rowspans)
   const downGrid = grid.slice(selectedCells[0].row + selectedCells[0].rowspan - 1, grid.length);
   const downDetails = toDetailList(downGrid);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/ResizeWire.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/ResizeWire.ts
@@ -1,5 +1,5 @@
-import { Fun, Optional } from '@ephox/katamari';
-import { SugarElement, SugarLocation, SugarPosition } from '@ephox/sugar';
+import { Fun } from '@ephox/katamari';
+import { SugarElement, SugarLocation, SugarNode, SugarPosition, Traverse } from '@ephox/sugar';
 
 // parent: the container where the resize bars are appended
 //         this gets mouse event handlers only if it is not a child of 'view' (eg, detached/inline mode)
@@ -12,15 +12,15 @@ import { SugarElement, SugarLocation, SugarPosition } from '@ephox/sugar';
 type ResizeCallback = (elm: SugarElement<Element>) => boolean;
 
 export interface ResizeWire {
-  parent: () => SugarElement;
-  view: () => SugarElement;
+  parent: () => SugarElement<Node>;
+  view: () => SugarElement<Node>;
   origin: () => SugarPosition;
   isResizable: ResizeCallback;
 }
 
-const only = (element: SugarElement, isResizable: ResizeCallback): ResizeWire => {
+const only = (element: SugarElement<Document | Element>, isResizable: ResizeCallback): ResizeWire => {
   // If element is a 'document', use the document element ('HTML' tag) for appending.
-  const parent = Optional.from(element.dom.documentElement).map(SugarElement.fromDom).getOr(element);
+  const parent = SugarNode.isDocument(element) ? Traverse.documentElement(element) : element;
   return {
     parent: Fun.constant(parent),
     view: Fun.constant(element),
@@ -29,7 +29,7 @@ const only = (element: SugarElement, isResizable: ResizeCallback): ResizeWire =>
   };
 };
 
-const detached = (editable: SugarElement, chrome: SugarElement, isResizable: ResizeCallback): ResizeWire => {
+const detached = (editable: SugarElement<Element>, chrome: SugarElement<Element>, isResizable: ResizeCallback): ResizeWire => {
   const origin = () => SugarLocation.absolute(chrome);
   return {
     parent: Fun.constant(chrome),
@@ -39,7 +39,7 @@ const detached = (editable: SugarElement, chrome: SugarElement, isResizable: Res
   };
 };
 
-const body = (editable: SugarElement, chrome: SugarElement, isResizable: ResizeCallback): ResizeWire => {
+const body = (editable: SugarElement<Element>, chrome: SugarElement<Element>, isResizable: ResizeCallback): ResizeWire => {
   return {
     parent: Fun.constant(chrome),
     view: Fun.constant(editable),

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
@@ -1,6 +1,8 @@
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
+import { CellElement, RowElement, RowCell } from '../util/TableTypes';
+
 export interface Dimension {
   readonly width: number;
   readonly height: number;
@@ -26,17 +28,17 @@ export interface Coords {
   readonly y: number;
 }
 
-export interface Detail {
-  readonly element: SugarElement;
+export interface Detail<T extends CellElement = CellElement> {
+  readonly element: SugarElement<T>;
   readonly rowspan: number;
   readonly colspan: number;
 }
 
-export interface DetailNew extends Detail {
+export interface DetailNew<T extends CellElement = CellElement> extends Detail<T> {
   readonly isNew: boolean;
 }
 
-export interface DetailExt extends Detail {
+export interface DetailExt extends Detail<HTMLTableCellElement> {
   readonly row: number;
   readonly column: number;
   readonly isLocked: boolean;
@@ -45,25 +47,25 @@ export interface DetailExt extends Detail {
 export type Section = 'tfoot' | 'thead' | 'tbody' | 'colgroup';
 const validSectionList: Section[] = [ 'tfoot', 'thead', 'tbody', 'colgroup' ];
 
-export interface RowDetail<T extends Detail> {
-  readonly element: SugarElement<HTMLTableRowElement | HTMLTableColElement>;
+export interface RowDetail<T extends Detail<RowCell<R>>, R extends RowElement = RowElement> {
+  readonly element: SugarElement<R>;
   readonly cells: T[];
   readonly section: Section;
 }
 
-export interface RowDetailNew<T extends Detail> extends RowDetail<T> {
+export interface RowDetailNew<T extends Detail<RowCell<R>>, R extends RowElement = RowElement> extends RowDetail<T, R> {
   readonly isNew: boolean;
 }
 
-export interface RowCells {
-  readonly element: SugarElement<HTMLTableRowElement | HTMLTableColElement>;
-  readonly cells: ElementNew[];
+export interface RowCells<R extends RowElement = RowElement> {
+  readonly element: SugarElement<R>;
+  readonly cells: ElementNew<RowCell<R>>[];
   readonly section: Section;
   readonly isNew: boolean;
 }
 
-export interface ElementNew {
-  readonly element: SugarElement;
+export interface ElementNew<T extends CellElement = CellElement> {
+  readonly element: SugarElement<T>;
   readonly isNew: boolean;
   readonly isLocked: boolean;
 }
@@ -117,13 +119,13 @@ const coords = (x: number, y: number): Coords => ({
   y
 });
 
-const detail = (element: SugarElement<HTMLTableCellElement | HTMLTableColElement>, rowspan: number, colspan: number): Detail => ({
+const detail = <T extends CellElement>(element: SugarElement<T>, rowspan: number, colspan: number): Detail<T> => ({
   element,
   rowspan,
   colspan
 });
 
-const detailnew = (element: SugarElement<HTMLTableCellElement>, rowspan: number, colspan: number, isNew: boolean): DetailNew => ({
+const detailnew = <T extends CellElement>(element: SugarElement<T>, rowspan: number, colspan: number, isNew: boolean): DetailNew<T> => ({
   element,
   rowspan,
   colspan,
@@ -139,26 +141,26 @@ const extended = (element: SugarElement<HTMLTableCellElement>, rowspan: number, 
   isLocked
 });
 
-const rowdetail = <T extends Detail> (element: SugarElement<HTMLTableRowElement | HTMLTableColElement>, cells: T[], section: Section): RowDetail<T> => ({
+const rowdetail = <T extends Detail<RowCell<R>>, R extends RowElement> (element: SugarElement<R>, cells: T[], section: Section): RowDetail<T, R> => ({
   element,
   cells,
   section
 });
 
-const rowdetailnew = <T extends Detail> (element: SugarElement, cells: T[], section: Section, isNew: boolean): RowDetailNew<T> => ({
+const rowdetailnew = <T extends Detail<RowCell<R>>, R extends RowElement> (element: SugarElement<R>, cells: T[], section: Section, isNew: boolean): RowDetailNew<T, R> => ({
   element,
   cells,
   section,
   isNew
 });
 
-const elementnew = (element: SugarElement, isNew: boolean, isLocked: boolean): ElementNew => ({
+const elementnew = <T extends CellElement>(element: SugarElement<T>, isNew: boolean, isLocked: boolean): ElementNew<T> => ({
   element,
   isNew,
   isLocked
 });
 
-const rowcells = (element: SugarElement<HTMLTableRowElement | HTMLTableColElement>, cells: ElementNew[], section: Section, isNew: boolean): RowCells => ({
+const rowcells = <R extends RowElement>(element: SugarElement<R>, cells: ElementNew<RowCell<R>>[], section: Section, isNew: boolean): RowCells<R> => ({
   element,
   cells,
   section,

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableContent.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableContent.ts
@@ -2,22 +2,20 @@ import { Arr } from '@ephox/katamari';
 import { DomStructure } from '@ephox/robin';
 import { Compare, CursorPosition, InsertAll, PredicateFind, Remove, SugarElement, SugarNode, SugarText, Traverse } from '@ephox/sugar';
 
-const merge = (cells: SugarElement[]): void => {
-  const isBr = (el: SugarElement) => {
-    return SugarNode.name(el) === 'br';
-  };
+const merge = (cells: SugarElement<HTMLTableCellElement>[]): void => {
+  const isBr = SugarNode.isTag('br');
 
-  const advancedBr = (children: SugarElement[]) => {
+  const advancedBr = (children: SugarElement<Node>[]) => {
     return Arr.forall(children, (c) => {
       return isBr(c) || (SugarNode.isText(c) && SugarText.get(c).trim().length === 0);
     });
   };
 
-  const isListItem = (el: SugarElement) => {
+  const isListItem = (el: SugarElement<Node>) => {
     return SugarNode.name(el) === 'li' || PredicateFind.ancestor(el, DomStructure.isList).isSome();
   };
 
-  const siblingIsBlock = (el: SugarElement) => {
+  const siblingIsBlock = (el: SugarElement<Node>) => {
     return Traverse.nextSibling(el).map((rightSibling) => {
       if (DomStructure.isBlock(rightSibling)) {
         return true;
@@ -29,7 +27,7 @@ const merge = (cells: SugarElement[]): void => {
     }).getOr(false);
   };
 
-  const markCell = (cell: SugarElement) => {
+  const markCell = (cell: SugarElement<HTMLTableCellElement>) => {
     return CursorPosition.last(cell).bind((rightEdge) => {
       const rightSiblingIsBlock = siblingIsBlock(rightEdge);
       return Traverse.parent(rightEdge).map((parent) => {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
@@ -29,7 +29,7 @@ const createRow = (doc: SugarElement<Document>) => () => {
   return SugarElement.fromTag('tr', doc.dom);
 };
 
-const replace = <K extends keyof HTMLElementTagNameMap>(cell: SugarElement, tag: K, attrs: Record<string, string | number | boolean | null>) => {
+const replace = (cell: SugarElement<HTMLTableCellElement>, tag: 'td' | 'th', attrs: Record<string, string | number | boolean | null>) => {
   const replica = Replication.copy(cell, tag);
   // TODO: Snooker passes null to indicate 'remove attribute'
   Obj.each(attrs, (v, k) => {
@@ -43,12 +43,12 @@ const replace = <K extends keyof HTMLElementTagNameMap>(cell: SugarElement, tag:
 };
 
 // eslint-disable-next-line @tinymce/prefer-fun
-const pasteReplace = (cell: SugarElement) => {
+const pasteReplace = (cell: SugarElement<HTMLTableCellElement>) => {
   // TODO: check for empty content and don't return anything
   return cell;
 };
 
-const cloneFormats = (oldCell: SugarElement, newCell: SugarElement, formats: string[]) => {
+const cloneFormats = (oldCell: SugarElement<Element>, newCell: SugarElement<Element>, formats: string[]) => {
   const first = CursorPosition.first(oldCell);
   return first.map((firstText) => {
     const formatSelector = formats.join(',');
@@ -74,7 +74,7 @@ const cloneAppropriateAttributes = <T extends HTMLElement>(original: SugarElemen
   );
 };
 
-const cellOperations = (mutate: (e1: SugarElement, e2: SugarElement) => void, doc: SugarElement<Document>, formatsToClone: Optional<string[]>): Generators => {
+const cellOperations = (mutate: <T>(e1: SugarElement<T>, e2: SugarElement<T>) => void, doc: SugarElement<Document>, formatsToClone: Optional<string[]>): Generators => {
   const cloneCss = <T extends HTMLElement> (prev: CellData, clone: SugarElement<T>) => {
     // inherit the style and width, dont inherit the row height
     Css.copy(prev.element, clone);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableGridSize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableGridSize.ts
@@ -3,7 +3,7 @@ import { SugarElement } from '@ephox/sugar';
 import { Grid } from './Structs';
 import { Warehouse } from './Warehouse';
 
-const getGridSize = (table: SugarElement): Grid => {
+const getGridSize = (table: SugarElement<HTMLTableElement>): Grid => {
   const warehouse = Warehouse.fromTable(table);
   return warehouse.grid;
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableLookup.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableLookup.ts
@@ -5,8 +5,10 @@ import { getAttrValue } from '../util/CellUtils';
 import * as LayerSelector from '../util/LayerSelector';
 import * as Structs from './Structs';
 
+type IsRootFn = (e: SugarElement<Node>) => boolean;
+
 // lookup inside this table
-const lookup = <T extends Element> (tags: string[], element: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean = Fun.never): Optional<SugarElement<T>> => {
+const lookup = <T extends Element> (tags: string[], element: SugarElement<Node>, isRoot: IsRootFn = Fun.never): Optional<SugarElement<T>> => {
   // If the element we're inspecting is the root, we definitely don't want it.
   if (isRoot(element)) {
     return Optional.none();
@@ -17,7 +19,7 @@ const lookup = <T extends Element> (tags: string[], element: SugarElement<Node>,
     return Optional.some(element as SugarElement<T>);
   }
 
-  const isRootOrUpperTable = (elm: SugarElement) => Selectors.is(elm, 'table') || isRoot(elm);
+  const isRootOrUpperTable = (elm: SugarElement<Node>) => Selectors.is(elm, 'table') || isRoot(elm);
 
   return SelectorFind.ancestor<T>(element, tags.join(','), isRootOrUpperTable);
 };
@@ -25,7 +27,7 @@ const lookup = <T extends Element> (tags: string[], element: SugarElement<Node>,
 /*
  * Identify the optional cell that element represents.
  */
-const cell = (element: SugarElement<Node>, isRoot?: (e: SugarElement) => boolean): Optional<SugarElement<HTMLTableCellElement>> =>
+const cell = (element: SugarElement<Node>, isRoot?: IsRootFn): Optional<SugarElement<HTMLTableCellElement>> =>
   lookup<HTMLTableCellElement>([ 'td', 'th' ], element, isRoot);
 
 const cells = (ancestor: SugarElement<Node>): SugarElement<HTMLTableCellElement>[] =>
@@ -41,7 +43,7 @@ const columns = (ancestor: SugarElement<Node>): SugarElement<HTMLTableColElement
   }
 };
 
-const notCell = (element: SugarElement<Node>, isRoot?: (e: SugarElement) => boolean): Optional<SugarElement<Element>> =>
+const notCell = (element: SugarElement<Node>, isRoot?: IsRootFn): Optional<SugarElement<Element>> =>
   lookup<Element>([ 'caption', 'tr', 'tbody', 'tfoot', 'thead' ], element, isRoot);
 
 const neighbours = <T extends Element = Element> (selector: string) => (element: SugarElement<Node>): Optional<SugarElement<T>[]> =>
@@ -53,10 +55,10 @@ const neighbourRows = neighbours<HTMLTableRowElement>('tr');
 const firstCell = (ancestor: SugarElement<Node>): Optional<SugarElement<HTMLTableCellElement>> =>
   SelectorFind.descendant<HTMLTableCellElement>(ancestor, 'th,td');
 
-const table = (element: SugarElement<Node>, isRoot?: (e: SugarElement) => boolean): Optional<SugarElement<HTMLTableElement>> =>
+const table = (element: SugarElement<Node>, isRoot?: IsRootFn): Optional<SugarElement<HTMLTableElement>> =>
   SelectorFind.closest<HTMLTableElement>(element, 'table', isRoot);
 
-const row = (element: SugarElement<Node>, isRoot?: (e: SugarElement) => boolean): Optional<SugarElement<HTMLTableRowElement>> =>
+const row = (element: SugarElement<Node>, isRoot?: IsRootFn): Optional<SugarElement<HTMLTableRowElement>> =>
   lookup<HTMLTableRowElement>([ 'tr' ], element, isRoot);
 
 const rows = (ancestor: SugarElement<Node>): SugarElement<HTMLTableRowElement>[] =>

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -1,7 +1,6 @@
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import { ContentEditable, Remove, SugarElement, Width } from '@ephox/sugar';
 
-import { TableSection } from '../api/TableSection';
 import * as Blocks from '../lookup/Blocks';
 import { findCommonCellType, findCommonRowType } from '../lookup/Type';
 import * as DetailsList from '../model/DetailsList';
@@ -14,15 +13,17 @@ import * as ModificationOperations from '../operate/ModificationOperations';
 import * as TransformOperations from '../operate/TransformOperations';
 import * as Adjustments from '../resize/Adjustments';
 import * as ColUtils from '../util/ColUtils';
+import { CompElm } from '../util/TableTypes';
 import { Generators, GeneratorsMerging, GeneratorsModification, GeneratorsTransform, SimpleGenerators } from './Generators';
 import * as Structs from './Structs';
 import * as TableContent from './TableContent';
 import * as TableLookup from './TableLookup';
+import { TableSection } from './TableSection';
 import { Warehouse } from './Warehouse';
 
 export interface TableOperationResult {
   readonly grid: Structs.RowCells[];
-  readonly cursor: Optional<SugarElement>;
+  readonly cursor: Optional<SugarElement<HTMLTableCellElement>>;
 }
 
 type ExtractMergable = RunOperation.ExtractMergable;
@@ -40,8 +41,6 @@ interface ExtractColsDetail {
   readonly pixelDelta: number;
 }
 
-type CompElm = (e1: SugarElement, e2: SugarElement) => boolean;
-
 // This uses a slight variation to the default `ContentEditable.isEditable` behaviour,
 // as when the element is detached we assume it is editable because it is a new cell.
 const isEditable = (elem: SugarElement<HTMLElement>) =>
@@ -54,12 +53,12 @@ const prune = (table: SugarElement<HTMLTableElement>) => {
   }
 };
 
-const outcome = (grid: Structs.RowCells[], cursor: Optional<SugarElement>): TableOperationResult => ({
+const outcome = (grid: Structs.RowCells[], cursor: Optional<SugarElement<HTMLTableCellElement>>): TableOperationResult => ({
   grid,
   cursor
 });
 
-const findEditableCursorPosition = (rows: Structs.RowCells[]) =>
+const findEditableCursorPosition = (rows: Structs.RowCells<HTMLTableRowElement>[]) =>
   Arr.findMap(rows, (row) =>
     Arr.findMap(row.cells, (cell) => {
       const elem = cell.element;
@@ -264,8 +263,8 @@ const opMergeCells = (grid: Structs.RowCells[], mergable: ExtractMergable, compa
   return outcome(newGrid, Optional.from(cells[0]));
 };
 
-const opUnmergeCells = (grid: Structs.RowCells[], unmergable: SugarElement[], comparator: CompElm, genWrappers: GeneratorsMerging) => {
-  const unmerge = (b: Structs.RowCells[], cell: SugarElement) =>
+const opUnmergeCells = (grid: Structs.RowCells[], unmergable: SugarElement<HTMLTableCellElement>[], comparator: CompElm, genWrappers: GeneratorsMerging) => {
+  const unmerge = (b: Structs.RowCells[], cell: SugarElement<HTMLTableCellElement>) =>
     MergingOperations.unmerge(b, cell, comparator, genWrappers.unmerge(cell));
 
   const newGrid = Arr.foldr(unmergable, unmerge, grid);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TablePositions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TablePositions.ts
@@ -7,19 +7,29 @@ import { Bounds } from './Structs';
 import * as TableLookup from './TableLookup';
 import { Warehouse } from './Warehouse';
 
-const moveBy = (cell: SugarElement, deltaRow: number, deltaColumn: number): Optional<SugarElement> => {
+const moveBy = (cell: SugarElement<HTMLTableCellElement>, deltaRow: number, deltaColumn: number): Optional<SugarElement<HTMLTableCellElement>> => {
   return TableLookup.table(cell).bind((table) => {
     const warehouse = getWarehouse(table);
     return CellFinder.moveBy(warehouse, cell, deltaRow, deltaColumn);
   });
 };
 
-const intercepts = (table: SugarElement, first: SugarElement, last: SugarElement): Optional<SugarElement[]> => {
+const intercepts = (
+  table: SugarElement<HTMLTableElement>,
+  first: SugarElement<HTMLTableCellElement>,
+  last: SugarElement<HTMLTableCellElement>
+): Optional<SugarElement<HTMLTableCellElement>[]> => {
   const warehouse = getWarehouse(table);
   return CellFinder.intercepts(warehouse, first, last);
 };
 
-const nestedIntercepts = (table: SugarElement, first: SugarElement, firstTable: SugarElement, last: SugarElement, lastTable: SugarElement): Optional<SugarElement[]> => {
+const nestedIntercepts = (
+  table: SugarElement<HTMLTableElement>,
+  first: SugarElement<HTMLTableCellElement>,
+  firstTable: SugarElement<HTMLTableElement>,
+  last: SugarElement<HTMLTableCellElement>,
+  lastTable: SugarElement<HTMLTableElement>
+): Optional<SugarElement<HTMLTableCellElement>[]> => {
   const warehouse = getWarehouse(table);
   const optStartCell = Compare.eq(table, firstTable) ? Optional.some(first) : CellFinder.parentCell(warehouse, first);
   const optLastCell = Compare.eq(table, lastTable) ? Optional.some(last) : CellFinder.parentCell(warehouse, last);
@@ -30,7 +40,7 @@ const nestedIntercepts = (table: SugarElement, first: SugarElement, firstTable: 
   );
 };
 
-const getBox = (table: SugarElement, first: SugarElement, last: SugarElement): Optional<Bounds> => {
+const getBox = (table: SugarElement<HTMLTableElement>, first: SugarElement<HTMLTableCellElement>, last: SugarElement<HTMLTableCellElement>): Optional<Bounds> => {
   const warehouse = getWarehouse(table);
   return CellGroup.getBox(warehouse, first, last);
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableResize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableResize.ts
@@ -12,12 +12,12 @@ type BarPositions<A> = BarPositions.BarPositions<A>;
 type ResizeType = 'row' | 'col';
 
 export interface BeforeTableResizeEvent {
-  readonly table: SugarElement;
+  readonly table: SugarElement<HTMLTableElement>;
   readonly type: ResizeType;
 }
 
 export interface AfterTableResizeEvent {
-  readonly table: SugarElement;
+  readonly table: SugarElement<HTMLTableElement>;
   readonly type: ResizeType;
 }
 
@@ -30,8 +30,8 @@ interface TableResizeEventRegistry {
 interface TableResizeEvents {
   readonly registry: TableResizeEventRegistry;
   readonly trigger: {
-    readonly beforeResize: (table: SugarElement, type: ResizeType) => void;
-    readonly afterResize: (table: SugarElement, type: ResizeType) => void;
+    readonly beforeResize: (table: SugarElement<HTMLTableElement>, type: ResizeType) => void;
+    readonly afterResize: (table: SugarElement<HTMLTableElement>, type: ResizeType) => void;
     readonly startDrag: () => void;
   };
 }

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableSection.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableSection.ts
@@ -2,26 +2,24 @@ import { Fun } from '@ephox/katamari';
 import { Replication, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { findTableRowHeaderType, RowHeaderType } from '../lookup/Type';
+import { CompElm, Subst } from '../util/TableTypes';
 import * as Structs from './Structs';
 import { Warehouse } from './Warehouse';
 
-type CompElm = (e1: SugarElement<Node>, e2: SugarElement<Node>) => boolean;
-type Subst = <T>(element: SugarElement<T>, comparator: CompElm) => SugarElement<T>;
-
 export interface TableSection {
-  readonly transformRow: (row: Structs.RowCells, section: Structs.Section) => Structs.RowCells;
-  readonly transformCell: (cell: Structs.ElementNew, comparator: CompElm, substitution: Subst) => Structs.ElementNew;
+  readonly transformRow: (row: Structs.RowCells<HTMLTableRowElement>, section: Structs.Section) => Structs.RowCells<HTMLTableRowElement>;
+  readonly transformCell: (cell: Structs.ElementNew<HTMLTableCellElement>, comparator: CompElm, substitution: Subst) => Structs.ElementNew<HTMLTableCellElement>;
 }
 
-const transformCell = (cell: Structs.ElementNew, comparator: CompElm, substitution: Subst) =>
+const transformCell = (cell: Structs.ElementNew<HTMLTableCellElement>, comparator: CompElm, substitution: Subst) =>
   Structs.elementnew(substitution(cell.element, comparator), true, cell.isLocked);
 
-const transformRow = (row: Structs.RowCells, section: Structs.Section) =>
+const transformRow = (row: Structs.RowCells<HTMLTableRowElement>, section: Structs.Section) =>
   row.section !== section ? Structs.rowcells(row.element, row.cells, section, row.isNew) : row;
 
 const section = (): TableSection => ({
   transformRow,
-  transformCell: (cell: Structs.ElementNew, comparator: CompElm, substitution: Subst) => {
+  transformCell: (cell: Structs.ElementNew<HTMLTableCellElement>, comparator: CompElm, substitution: Subst) => {
     const newCell = substitution(cell.element, comparator);
     // Convert the cell to a td element as "section" should always use td element
     const fixedCell = SugarNode.name(newCell) !== 'td' ? Replication.mutate(newCell, 'td') : newCell;
@@ -35,7 +33,7 @@ const sectionCells = (): TableSection => ({
 });
 
 const cells = (): TableSection => ({
-  transformRow: (row: Structs.RowCells, section: Structs.Section) => {
+  transformRow: (row: Structs.RowCells<HTMLTableRowElement>, section: Structs.Section) => {
     // Ensure that cells are always within the tbody for headers
     const newSection = section === 'thead' ? 'tbody' : section;
     return transformRow(row, newSection);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Warehouse.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Warehouse.ts
@@ -4,12 +4,13 @@ import { SugarElement } from '@ephox/sugar';
 import * as Structs from '../api/Structs';
 import * as DetailsList from '../model/DetailsList';
 import * as LockedColumnUtils from '../util/LockedColumnUtils';
+import { CompElm } from '../util/TableTypes';
 import * as TableLookup from './TableLookup';
 
 export interface Warehouse {
   readonly grid: Structs.Grid;
   readonly access: Record<string, Structs.DetailExt>;
-  readonly all: Structs.RowDetail<Structs.DetailExt>[];
+  readonly all: Structs.RowDetail<Structs.DetailExt, HTMLTableRowElement>[];
   readonly columns: Record<number, Structs.ColumnExt>;
   readonly colgroups: Structs.Colgroup<Structs.ColumnExt>[];
 }
@@ -21,12 +22,12 @@ const key = (row: number, column: number): string => {
 const getAt = (warehouse: Warehouse, row: number, column: number): Optional<Structs.DetailExt> =>
   Optional.from(warehouse.access[key(row, column)]);
 
-const findItem = <T>(warehouse: Warehouse, item: T, comparator: (a: T, b: SugarElement) => boolean): Optional<Structs.DetailExt> => {
+const findItem = (warehouse: Warehouse, item: SugarElement<HTMLTableCellElement>, comparator: CompElm): Optional<Structs.DetailExt> => {
   const filtered = filterItems(warehouse, (detail) => {
     return comparator(item, detail.element);
   });
 
-  return filtered.length > 0 ? Optional.some(filtered[0]) : Optional.none<Structs.DetailExt>();
+  return filtered.length > 0 ? Optional.some(filtered[0]) : Optional.none();
 };
 
 const filterItems = (warehouse: Warehouse, predicate: (x: Structs.DetailExt, i: number) => boolean): Structs.DetailExt[] => {
@@ -36,11 +37,11 @@ const filterItems = (warehouse: Warehouse, predicate: (x: Structs.DetailExt, i: 
   return Arr.filter(all, predicate);
 };
 
-const generateColumns = <T extends Structs.Detail>(rowData: Structs.RowDetail<T>): Record<number, Structs.ColumnExt> => {
+const generateColumns = (rowData: Structs.RowDetail<Structs.Detail<HTMLTableColElement>, HTMLTableColElement>): Record<number, Structs.ColumnExt> => {
   const columnsGroup: Record<number, Structs.ColumnExt> = {};
   let index = 0;
 
-  Arr.each(rowData.cells, (column: T) => {
+  Arr.each(rowData.cells, (column) => {
     const colspan = column.colspan;
 
     Arr.range(colspan, (columnIndex) => {
@@ -60,7 +61,7 @@ const generateColumns = <T extends Structs.Detail>(rowData: Structs.RowDetail<T>
  *  2. a data structure which can efficiently identify which cell is in which row,column position
  *  3. a list of all cells in order left-to-right, top-to-bottom
  */
-const generate = <T extends Structs.Detail>(list: Structs.RowDetail<T>[]): Warehouse => {
+const generate = (list: Structs.RowDetail<Structs.Detail>[]): Warehouse => {
   // list is an array of objects, made by cells and elements
   // elements: is the TR
   // cells: is an array of objects representing the cells in the row.
@@ -69,7 +70,7 @@ const generate = <T extends Structs.Detail>(list: Structs.RowDetail<T>[]): Wareh
   //          element
   //          rowspan (merge cols)
   const access: Record<string, Structs.DetailExt> = {};
-  const cells: Structs.RowDetail<Structs.DetailExt>[] = [];
+  const cells: Structs.RowDetail<Structs.DetailExt, HTMLTableRowElement>[] = [];
 
   const tableOpt = Arr.head(list).map((rowData) => rowData.element).bind(TableLookup.table);
   const lockedColumns: Record<string, true> = tableOpt.bind(LockedColumnUtils.getLockedColumnsFromTable).getOr({});
@@ -81,7 +82,7 @@ const generate = <T extends Structs.Detail>(list: Structs.RowDetail<T>[]): Wareh
   const { pass: colgroupRows, fail: rows } = Arr.partition(list, (rowData) => rowData.section === 'colgroup');
 
   // Handle rows first
-  Arr.each(rows, (rowData) => {
+  Arr.each(rows as Array<Structs.RowDetail<Structs.Detail<HTMLTableCellElement>, HTMLTableRowElement>>, (rowData) => {
     const currentRow: Structs.DetailExt[] = [];
     Arr.each(rowData.cells, (rowCell) => {
       let start = 0;
@@ -115,9 +116,9 @@ const generate = <T extends Structs.Detail>(list: Structs.RowDetail<T>[]): Wareh
 
   // Handle colgroups
   // Note: Currently only a single colgroup is supported so just use the last one
-  const { columns, colgroups } = Arr.last(colgroupRows).map((rowData) => {
-    const columns = generateColumns<T>(rowData);
-    const colgroup = Structs.colgroup(rowData.element as SugarElement<HTMLTableColElement>, Obj.values(columns));
+  const { columns, colgroups } = Arr.last(colgroupRows as Array<Structs.RowDetail<Structs.Detail<HTMLTableColElement>, HTMLTableColElement>>).map((rowData) => {
+    const columns = generateColumns(rowData);
+    const colgroup = Structs.colgroup(rowData.element, Obj.values(columns));
     return {
       colgroups: [ colgroup ],
       columns

--- a/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
@@ -31,7 +31,11 @@ const columns = (warehouse: Warehouse, isValidCell: ValidCellFn = Fun.always): O
   });
 };
 
-const decide = (getBlock: () => DetailExt[], isValid: (detail: DetailExt) => boolean, getFallback: () => Optional<DetailExt>): Optional<SugarElement> => {
+const decide = (
+  getBlock: () => DetailExt[],
+  isValid: (detail: DetailExt) => boolean,
+  getFallback: () => Optional<DetailExt>
+): Optional<SugarElement<HTMLTableCellElement>> => {
   const inBlock = getBlock();
   const validInBlock = Arr.find(inBlock, isValid);
   const detailOption = validInBlock.orThunk(() => Optional.from(inBlock[0]).orThunk(getFallback));

--- a/modules/snooker/src/main/ts/ephox/snooker/lookup/Type.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/lookup/Type.ts
@@ -3,6 +3,7 @@ import { SugarElement, SugarNode } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
 import { Warehouse } from '../api/Warehouse';
+import { CellElement } from '../util/TableTypes';
 
 export type RowHeaderType = 'section' | 'cells' | 'sectionCells';
 export type RowType = 'header' | 'body' | 'footer';
@@ -13,7 +14,7 @@ interface RowDetails {
 }
 
 interface CommonCellDetails {
-  readonly element: SugarElement;
+  readonly element: SugarElement<CellElement>;
 }
 
 interface CommonRowDetails {

--- a/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
@@ -1,8 +1,10 @@
 import { Arr, Fun, Obj, Result } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 
 import { SimpleGenerators } from '../api/Generators';
 import * as Structs from '../api/Structs';
 import * as LockedColumnUtils from '../util/LockedColumnUtils';
+import { CellElement } from '../util/TableTypes';
 import * as GridRow from './GridRow';
 
 export interface Delta {
@@ -62,7 +64,7 @@ const measureHeight = (gridA: Structs.RowCells[], gridB: Structs.RowCells[]): De
 
 const generateElements = (amount: number, row: Structs.RowCells, generators: SimpleGenerators, isLocked: (idx: number) => boolean): Structs.ElementNew[] => {
   const generator = row.section === 'colgroup' ? generators.col : generators.cell;
-  return Arr.range(amount, (idx) => Structs.elementnew(generator(), true, isLocked(idx)));
+  return Arr.range(amount, (idx) => Structs.elementnew(generator() as SugarElement<CellElement>, true, isLocked(idx)));
 };
 
 const rowFill = (grid: Structs.RowCells[], amount: number, generators: SimpleGenerators, lockedColumns: Record<string, boolean>): Structs.RowCells[] => {

--- a/modules/snooker/src/main/ts/ephox/snooker/model/GridRow.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/GridRow.ts
@@ -2,11 +2,12 @@ import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
+import { CellElement, RowCell, RowElement } from '../util/TableTypes';
 
-type RowMorphism = (element: SugarElement<HTMLTableRowElement | HTMLTableColElement>) => SugarElement<HTMLTableRowElement | HTMLTableColElement>;
-type CellMorphism = (element: Structs.ElementNew, index: number) => Structs.ElementNew;
+type RowMorphism<T extends RowElement> = (element: SugarElement<T>) => SugarElement<T>;
+type CellMorphism<T extends CellElement> = (element: Structs.ElementNew<T>, index: number) => Structs.ElementNew<T>;
 
-const addCells = (gridRow: Structs.RowCells, index: number, cells: Structs.ElementNew[]): Structs.RowCells => {
+const addCells = <R extends RowElement>(gridRow: Structs.RowCells<R>, index: number, cells: Structs.ElementNew<RowCell<R>>[]): Structs.RowCells<R> => {
   const existingCells = gridRow.cells;
   const before = existingCells.slice(0, index);
   const after = existingCells.slice(index);
@@ -14,41 +15,41 @@ const addCells = (gridRow: Structs.RowCells, index: number, cells: Structs.Eleme
   return setCells(gridRow, newCells);
 };
 
-const addCell = (gridRow: Structs.RowCells, index: number, cell: Structs.ElementNew): Structs.RowCells =>
+const addCell = <R extends RowElement>(gridRow: Structs.RowCells<R>, index: number, cell: Structs.ElementNew<RowCell<R>>): Structs.RowCells<R> =>
   addCells(gridRow, index, [ cell ]);
 
-const mutateCell = (gridRow: Structs.RowCells, index: number, cell: Structs.ElementNew): void => {
+const mutateCell = <R extends RowElement>(gridRow: Structs.RowCells<R>, index: number, cell: Structs.ElementNew<RowCell<R>>): void => {
   const cells = gridRow.cells;
   cells[index] = cell;
 };
 
-const setCells = (gridRow: Structs.RowCells, cells: Structs.ElementNew[]): Structs.RowCells =>
+const setCells = <R extends RowElement>(gridRow: Structs.RowCells<R>, cells: Structs.ElementNew<RowCell<R>>[]): Structs.RowCells<R> =>
   Structs.rowcells(gridRow.element, cells, gridRow.section, gridRow.isNew);
 
-const mapCells = (gridRow: Structs.RowCells, f: CellMorphism): Structs.RowCells => {
+const mapCells = <R extends RowElement>(gridRow: Structs.RowCells<R>, f: CellMorphism<RowCell<R>>): Structs.RowCells => {
   const cells = gridRow.cells;
   const r = Arr.map(cells, f);
   return Structs.rowcells(gridRow.element, r, gridRow.section, gridRow.isNew);
 };
 
-const getCell = (gridRow: Structs.RowCells, index: number): Structs.ElementNew =>
+const getCell = <R extends RowElement>(gridRow: Structs.RowCells<R>, index: number): Structs.ElementNew<RowCell<R>> =>
   gridRow.cells[index];
 
-const getCellElement = (gridRow: Structs.RowCells, index: number): SugarElement =>
+const getCellElement = <R extends RowElement>(gridRow: Structs.RowCells<R>, index: number): SugarElement<RowCell<R>> =>
   getCell(gridRow, index).element;
 
 const cellLength = (gridRow: Structs.RowCells): number =>
   gridRow.cells.length;
 
-const extractGridDetails = (grid: Structs.RowCells[]): { rows: Structs.RowCells[]; cols: Structs.RowCells[] } => {
+const extractGridDetails = (grid: Structs.RowCells[]): { rows: Structs.RowCells<HTMLTableRowElement>[]; cols: Structs.RowCells<HTMLTableColElement>[] } => {
   const result = Arr.partition(grid, (row) => row.section === 'colgroup');
   return {
-    rows: result.fail,
-    cols: result.pass
+    rows: result.fail as Structs.RowCells<HTMLTableRowElement>[],
+    cols: result.pass as Structs.RowCells<HTMLTableColElement>[]
   };
 };
 
-const clone = (gridRow: Structs.RowCells, cloneRow: RowMorphism, cloneCell: CellMorphism): Structs.RowCells => {
+const clone = <R extends RowElement>(gridRow: Structs.RowCells<R>, cloneRow: RowMorphism<R>, cloneCell: CellMorphism<RowCell<R>>): Structs.RowCells<R> => {
   const newCells = Arr.map(gridRow.cells, cloneCell);
   return Structs.rowcells(cloneRow(gridRow.element), newCells, gridRow.section, true);
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
@@ -13,11 +13,8 @@ import { Warehouse } from '../api/Warehouse';
 import * as Redraw from '../operate/Redraw';
 import * as Bars from '../resize/Bars';
 import * as LockedColumnUtils from '../util/LockedColumnUtils';
+import { CompElm, RowCell, RowElement } from '../util/TableTypes';
 import * as Transitions from './Transitions';
-
-type DetailExt = Structs.DetailExt;
-type DetailNew = Structs.DetailNew;
-type RowDetailNew<A extends Structs.Detail> = Structs.RowDetailNew<A>;
 
 export interface OperationBehaviours {
   readonly sizing?: TableSize;
@@ -26,17 +23,17 @@ export interface OperationBehaviours {
 }
 
 export interface RunOperationOutput {
-  readonly cursor: Optional<SugarElement>;
-  readonly newRows: SugarElement[];
-  readonly newCells: SugarElement[];
+  readonly cursor: Optional<SugarElement<HTMLTableCellElement>>;
+  readonly newRows: SugarElement<HTMLTableRowElement>[];
+  readonly newCells: SugarElement<HTMLTableCellElement>[];
 }
 
 export interface TargetElement {
-  readonly element: SugarElement;
+  readonly element: SugarElement<Node>;
 }
 
 export interface TargetSelection {
-  readonly selection: SugarElement[];
+  readonly selection: SugarElement<Node>[];
 }
 
 export interface TargetMergable {
@@ -44,51 +41,51 @@ export interface TargetMergable {
 }
 
 export interface TargetUnmergable {
-  readonly unmergable: Optional<SugarElement[]>;
+  readonly unmergable: Optional<SugarElement<HTMLTableCellElement>[]>;
 }
 
 // combines the above 4 interfaces because this is what data we actually get from TinyMCE
 export interface CombinedTargets extends TargetElement, TargetSelection, TargetMergable, TargetUnmergable { }
 
 export interface TargetPaste {
-  readonly element: SugarElement;
+  readonly element: SugarElement<Node>;
   readonly generators: SimpleGenerators;
-  readonly clipboard: SugarElement;
+  readonly clipboard: SugarElement<HTMLTableElement>;
 }
 
 export interface TargetPasteRows {
-  readonly selection: SugarElement[];
+  readonly selection: SugarElement<Node>[];
   readonly generators: SimpleGenerators;
-  readonly clipboard: SugarElement[];
+  readonly clipboard: SugarElement<RowElement>[];
 }
 
 export interface ExtractMergable {
-  readonly cells: SugarElement[];
+  readonly cells: SugarElement<HTMLTableCellElement>[];
   readonly bounds: Structs.Bounds;
 }
 
 export interface ExtractPaste extends Structs.DetailExt {
   readonly generators: SimpleGenerators;
-  readonly clipboard: SugarElement;
+  readonly clipboard: SugarElement<HTMLTableElement>;
 }
 
 export interface ExtractPasteRows {
   readonly cells: Structs.DetailExt[];
   readonly generators: SimpleGenerators;
-  readonly clipboard: SugarElement[];
+  readonly clipboard: SugarElement<RowElement>[];
 }
 
 const fromWarehouse = (warehouse: Warehouse, generators: Generators) =>
   Transitions.toGrid(warehouse, generators, false);
 
-const toDetailList = (grid: Structs.RowCells[]): RowDetailNew<DetailNew>[] =>
+const toDetailList = <R extends RowElement>(grid: Structs.RowCells<R>[]): Structs.RowDetailNew<Structs.DetailNew<RowCell<R>>, R>[] =>
   Transitions.toDetails(grid, Compare.eq);
 
-const findInWarehouse = (warehouse: Warehouse, element: SugarElement): Optional<DetailExt> => Arr.findMap(warehouse.all, (r) =>
+const findInWarehouse = (warehouse: Warehouse, element: SugarElement<HTMLTableCellElement>): Optional<Structs.DetailExt> => Arr.findMap(warehouse.all, (r) =>
   Arr.find(r.cells, (e) => Compare.eq(element, e.element))
 );
 
-const extractCells = (warehouse: Warehouse, target: TargetSelection, predicate: (detail: DetailExt) => boolean): Optional<DetailExt[]> => {
+const extractCells = (warehouse: Warehouse, target: TargetSelection, predicate: (detail: Structs.DetailExt) => boolean): Optional<Structs.DetailExt[]> => {
   const details = Arr.map(target.selection, (cell) => {
     return TableLookup.cell(cell)
       .bind((lc) => findInWarehouse(warehouse, lc))
@@ -98,11 +95,10 @@ const extractCells = (warehouse: Warehouse, target: TargetSelection, predicate: 
   return Optionals.someIf(cells.length > 0, cells);
 };
 
-type EqEle = (e1: SugarElement, e2: SugarElement) => boolean;
-export type Operation<INFO, GW extends GeneratorsWrapper> = (model: Structs.RowCells[], info: INFO, eq: EqEle, w: GW, headers: TableSection) => TableOperationResult;
+export type Operation<INFO, GW extends GeneratorsWrapper> = (model: Structs.RowCells[], info: INFO, eq: CompElm, w: GW, headers: TableSection) => TableOperationResult;
 export type Extract<RAW, INFO> = (warehouse: Warehouse, target: RAW) => Optional<INFO>;
-export type Adjustment<INFO> = <T extends Structs.DetailNew>(table: SugarElement, grid: Structs.RowDetailNew<T>[], info: INFO, behaviours: Required<OperationBehaviours>) => void;
-export type PostAction = (e: SugarElement) => void;
+export type Adjustment<INFO> = <T extends Structs.DetailNew>(table: SugarElement<HTMLTableElement>, grid: Structs.RowDetailNew<T>[], info: INFO, behaviours: Required<OperationBehaviours>) => void;
+export type PostAction = (e: SugarElement<HTMLTableElement>) => void;
 export type GenWrap<GW extends GeneratorsWrapper> = (g: Generators) => GW;
 
 export type OperationCallback<T> = (wire: ResizeWire, table: SugarElement<HTMLTableElement>, target: T, generators: Generators, behaviours?: OperationBehaviours) => Optional<RunOperationOutput>;
@@ -145,7 +141,7 @@ const run = <RAW, INFO, GW extends GeneratorsWrapper>
     });
   };
 
-const onCell = (warehouse: Warehouse, target: TargetElement): Optional<DetailExt> =>
+const onCell = (warehouse: Warehouse, target: TargetElement): Optional<Structs.DetailExt> =>
   TableLookup.cell(target.element).bind((cell) => findInWarehouse(warehouse, cell));
 
 const onPaste = (warehouse: Warehouse, target: TargetPaste): Optional<ExtractPaste> =>
@@ -168,10 +164,10 @@ const onPasteByEditor = (warehouse: Warehouse, target: TargetPasteRows): Optiona
 const onMergable = (_warehouse: Warehouse, target: TargetMergable): Optional<ExtractMergable> =>
   target.mergable;
 
-const onUnmergable = (_warehouse: Warehouse, target: TargetUnmergable): Optional<SugarElement[]> =>
+const onUnmergable = (_warehouse: Warehouse, target: TargetUnmergable): Optional<SugarElement<HTMLTableCellElement>[]> =>
   target.unmergable;
 
-const onCells = (warehouse: Warehouse, target: TargetSelection): Optional<DetailExt[]> =>
+const onCells = (warehouse: Warehouse, target: TargetSelection): Optional<Structs.DetailExt[]> =>
   extractCells(warehouse, target, Fun.always);
 
 // Custom unlocked extractors
@@ -182,15 +178,18 @@ const onUnlockedCell = (warehouse: Warehouse, target: TargetElement): Optional<S
 const onUnlockedCells = (warehouse: Warehouse, target: TargetSelection): Optional<Structs.DetailExt[]> =>
   extractCells(warehouse, target, (detail) => !detail.isLocked);
 
-const isUnlockedTableCell = (warehouse: Warehouse, cell: SugarElement) => findInWarehouse(warehouse, cell).exists((detail) => !detail.isLocked);
-const allUnlocked = (warehouse: Warehouse, cells: SugarElement[]) => Arr.forall(cells, (cell) => isUnlockedTableCell(warehouse, cell));
+const isUnlockedTableCell = (warehouse: Warehouse, cell: SugarElement<HTMLTableCellElement>) =>
+  findInWarehouse(warehouse, cell).exists((detail) => !detail.isLocked);
+
+const allUnlocked = (warehouse: Warehouse, cells: SugarElement<HTMLTableCellElement>[]) =>
+  Arr.forall(cells, (cell) => isUnlockedTableCell(warehouse, cell));
 
 // If any locked columns are present in the selection, then don't want to be able to merge
 const onUnlockedMergable = (warehouse: Warehouse, target: TargetMergable): Optional<ExtractMergable> =>
   onMergable(warehouse, target).filter((mergeable) => allUnlocked(warehouse, mergeable.cells));
 
 // If any locked columns are present in the selection, then don't want to be able to unmerge
-const onUnlockedUnmergable = (warehouse: Warehouse, target: TargetUnmergable): Optional<SugarElement[]> =>
+const onUnlockedUnmergable = (warehouse: Warehouse, target: TargetUnmergable): Optional<SugarElement<HTMLTableCellElement>[]> =>
   onUnmergable(warehouse, target).filter((cells) => allUnlocked(warehouse, cells));
 
 export {

--- a/modules/snooker/src/main/ts/ephox/snooker/model/TableGrid.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/TableGrid.ts
@@ -1,7 +1,7 @@
 import { Arr } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
 
 import { ElementNew, RowCells } from '../api/Structs';
+import { CompElm } from '../util/TableTypes';
 import * as GridRow from './GridRow';
 
 const getColumn = (grid: RowCells[], index: number): ElementNew[] => {
@@ -14,7 +14,7 @@ const getRow = (grid: RowCells[], index: number) => {
   return grid[index];
 };
 
-const findDiff = (xs: ElementNew[], comp: (a: SugarElement, b: SugarElement) => boolean) => {
+const findDiff = (xs: ElementNew[], comp: CompElm) => {
   if (xs.length === 0) {
     return 0;
   }
@@ -34,7 +34,7 @@ const findDiff = (xs: ElementNew[], comp: (a: SugarElement, b: SugarElement) => 
  *   colspan: column span of the cell at (row, column)
  *   rowspan: row span of the cell at (row, column)
  */
-const subgrid = (grid: RowCells[], row: number, column: number, comparator: (a: SugarElement, b: SugarElement) => boolean): { colspan: number; rowspan: number } => {
+const subgrid = (grid: RowCells[], row: number, column: number, comparator: CompElm): { colspan: number; rowspan: number } => {
   const gridRow = getRow(grid, row);
   const isColRow = gridRow.section === 'colgroup';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/model/Transitions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/Transitions.ts
@@ -1,12 +1,12 @@
 import { Arr, Fun } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
 
 import { Generators } from '../api/Generators';
 import * as Structs from '../api/Structs';
 import { Warehouse } from '../api/Warehouse';
+import { CompElm, RowCell, RowElement } from '../util/TableTypes';
 import * as TableGrid from './TableGrid';
 
-const toDetails = (grid: Structs.RowCells[], comparator: (a: SugarElement, b: SugarElement) => boolean): Structs.RowDetailNew<Structs.DetailNew>[] => {
+const toDetails = <R extends RowElement>(grid: Structs.RowCells<R>[], comparator: CompElm): Structs.RowDetailNew<Structs.DetailNew<RowCell<R>>, R>[] => {
   const seen: boolean[][] = Arr.map(grid, (row) =>
     Arr.map(row.cells, Fun.never)
   );
@@ -27,7 +27,7 @@ const toDetails = (grid: Structs.RowCells[], comparator: (a: SugarElement, b: Su
         updateSeen(rowIndex, columnIndex, result.rowspan, result.colspan);
         return [ Structs.detailnew(cell.element, result.rowspan, result.colspan, cell.isNew) ];
       } else {
-        return [] as Structs.DetailNew[];
+        return [] as Structs.DetailNew<RowCell<R>>[];
       }
     });
     return Structs.rowdetailnew(row.element, details, row.section, row.isNew);
@@ -38,7 +38,7 @@ const toGrid = (warehouse: Warehouse, generators: Generators, isNew: boolean): S
   const grid: Structs.RowCells[] = [];
 
   Arr.each(warehouse.colgroups, (colgroup) => {
-    const colgroupCols: Structs.ElementNew[] = [];
+    const colgroupCols: Structs.ElementNew<HTMLTableColElement>[] = [];
     // This will add missing cols as well as clamp the number of cols to the max number of actual columns
     // Note: Spans on cols are unsupported so clamping cols may result in a span on a col element being incorrect
     for (let columnIndex = 0; columnIndex < warehouse.grid.columns; columnIndex++) {
@@ -51,7 +51,7 @@ const toGrid = (warehouse: Warehouse, generators: Generators, isNew: boolean): S
   });
 
   for (let rowIndex = 0; rowIndex < warehouse.grid.rows; rowIndex++) {
-    const rowCells: Structs.ElementNew[] = [];
+    const rowCells: Structs.ElementNew<HTMLTableCellElement>[] = [];
     for (let columnIndex = 0; columnIndex < warehouse.grid.columns; columnIndex++) {
       // The element is going to be the element at that position, or a newly generated gap.
       const element = Warehouse.getAt(warehouse, rowIndex, columnIndex).map((item) =>

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/ModificationOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/ModificationOperations.ts
@@ -1,14 +1,12 @@
 import { Arr } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
 import * as GridRow from '../model/GridRow';
+import { CompElm, Subst } from '../util/TableTypes';
 
-type CompElm = <T>(e1: SugarElement<T>, e2: SugarElement<T>) => boolean;
-type Subst = <T>(element: SugarElement<T>, comparator: CompElm) => SugarElement<T>;
-type CloneCell = (elem: Structs.ElementNew, index: number) => Structs.ElementNew;
+type CloneCell = (elem: Structs.ElementNew<HTMLTableCellElement>, index: number) => Structs.ElementNew<HTMLTableCellElement>;
 
-const cloneRow = (row: Structs.RowCells, cloneCell: CloneCell, comparator: CompElm, substitution: Subst) =>
+const cloneRow = (row: Structs.RowCells<HTMLTableRowElement>, cloneCell: CloneCell, comparator: CompElm, substitution: Subst) =>
   GridRow.clone(row, (elem) => substitution(elem, comparator), cloneCell);
 
 // substitution :: (item, comparator) -> item
@@ -25,7 +23,12 @@ const insertRowAt = (grid: Structs.RowCells[], index: number, example: number, c
     return ret;
   }, comparator, substitution);
 
-  return cols.concat(before).concat([ newRow ]).concat(after);
+  return [
+    ...cols,
+    ...before,
+    newRow,
+    ...after
+  ];
 };
 
 const getElementFor = (row: Structs.RowCells, column: number, section: string, withinSpan: boolean, example: number, comparator: CompElm, substitution: Subst): Structs.ElementNew => {
@@ -80,7 +83,12 @@ const splitCellIntoRows = (grid: Structs.RowCells[], exampleRow: number, example
     return isTargetCell ? Structs.elementnew(substitution(ex.element, comparator), true, ex.isLocked) : ex;
   }, comparator, substitution);
 
-  return cols.concat(before).concat([ newRow ]).concat(after);
+  return [
+    ...cols,
+    ...before,
+    newRow,
+    ...after
+  ];
 };
 
 const deleteColumnsAt = (grid: Structs.RowCells[], columns: number[]): Structs.RowCells[] =>
@@ -92,7 +100,11 @@ const deleteColumnsAt = (grid: Structs.RowCells[], columns: number[]): Structs.R
 
 const deleteRowsAt = (grid: Structs.RowCells[], start: number, finish: number): Structs.RowCells[] => {
   const { rows, cols } = GridRow.extractGridDetails(grid);
-  return cols.concat(rows.slice(0, start)).concat(rows.slice(finish + 1));
+  return [
+    ...cols,
+    ...rows.slice(0, start),
+    ...rows.slice(finish + 1)
+  ];
 };
 
 export {

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
@@ -4,11 +4,11 @@ import { Attribute, Insert, InsertAll, Remove, Replication, SelectorFilter, Sele
 import { Detail, DetailNew, RowDetailNew, Section } from '../api/Structs';
 
 interface NewRowsAndCells {
-  readonly newRows: SugarElement[];
-  readonly newCells: SugarElement[];
+  readonly newRows: SugarElement<HTMLTableRowElement>[];
+  readonly newCells: SugarElement<HTMLTableCellElement>[];
 }
 
-const setIfNot = (element: SugarElement, property: string, value: number, ignore: number): void => {
+const setIfNot = (element: SugarElement<Element>, property: string, value: number, ignore: number): void => {
   if (value === ignore) {
     Attribute.remove(element, property);
   } else {
@@ -41,11 +41,11 @@ const generateSection = (table: SugarElement<HTMLTableElement>, sectionName: Sec
   return section;
 };
 
-const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, grid: RowDetailNew<T>[]): NewRowsAndCells => {
-  const newRows: SugarElement[] = [];
-  const newCells: SugarElement[] = [];
+const render = (table: SugarElement<HTMLTableElement>, grid: RowDetailNew<DetailNew>[]): NewRowsAndCells => {
+  const newRows: SugarElement<HTMLTableRowElement>[] = [];
+  const newCells: SugarElement<HTMLTableCellElement>[] = [];
 
-  const syncRows = (gridSection: RowDetailNew<T>[]) =>
+  const syncRows = (gridSection: RowDetailNew<DetailNew<HTMLTableCellElement>, HTMLTableRowElement>[]) =>
     Arr.map(gridSection, (row) => {
       if (row.isNew) {
         newRows.push(row.element);
@@ -64,7 +64,7 @@ const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, gri
     });
 
   // Assumption we should only ever have 1 colgroup. The spec allows for multiple, however it's currently unsupported
-  const syncColGroup = (gridSection: RowDetailNew<T>[]) =>
+  const syncColGroup = (gridSection: RowDetailNew<DetailNew<HTMLTableColElement>, HTMLTableColElement>[]) =>
     Arr.bind(gridSection, (colGroup) =>
       Arr.map(colGroup.cells, (col) => {
         setIfNot(col.element, 'span', col.colspan, 1);
@@ -72,10 +72,10 @@ const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, gri
       })
     );
 
-  const renderSection = (gridSection: RowDetailNew<T>[], sectionName: Section) => {
+  const renderSection = (gridSection: RowDetailNew<DetailNew>[], sectionName: Section) => {
     const section = generateSection(table, sectionName);
     const sync = sectionName === 'colgroup' ? syncColGroup : syncRows;
-    const sectionElems = sync(gridSection);
+    const sectionElems = sync(gridSection as RowDetailNew<any, any>[]);
     InsertAll.append(section, sectionElems);
   };
 
@@ -83,7 +83,7 @@ const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, gri
     SelectorFind.child(table, sectionName).each(Remove.remove);
   };
 
-  const renderOrRemoveSection = (gridSection: RowDetailNew<T>[], sectionName: Section) => {
+  const renderOrRemoveSection = (gridSection: RowDetailNew<DetailNew>[], sectionName: Section) => {
     if (gridSection.length > 0) {
       renderSection(gridSection, sectionName);
     } else {
@@ -91,10 +91,10 @@ const render = <T extends DetailNew> (table: SugarElement<HTMLTableElement>, gri
     }
   };
 
-  const headSection: RowDetailNew<T>[] = [];
-  const bodySection: RowDetailNew<T>[] = [];
-  const footSection: RowDetailNew<T>[] = [];
-  const columnGroupsSection: RowDetailNew<T>[] = [];
+  const headSection: RowDetailNew<DetailNew>[] = [];
+  const bodySection: RowDetailNew<DetailNew>[] = [];
+  const footSection: RowDetailNew<DetailNew>[] = [];
+  const columnGroupsSection: RowDetailNew<DetailNew>[] = [];
 
   Arr.each(grid, (row) => {
     switch (row.section) {

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
@@ -7,6 +7,7 @@ import { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
 import * as Deltas from '../calc/Deltas';
 import * as CellUtils from '../util/CellUtils';
+import { CellElement } from '../util/TableTypes';
 import { BarPositions, RowInfo } from './BarPositions';
 import * as ColumnSizes from './ColumnSizes';
 import * as Recalculations from './Recalculations';
@@ -14,7 +15,7 @@ import * as Sizes from './Sizes';
 
 const sumUp = (newSize: number[]) => Arr.foldr(newSize, (b, a) => b + a, 0);
 
-const recalculate = (warehouse: Warehouse, widths: number[]): Recalculations.CellWidthSpan[] => {
+const recalculate = (warehouse: Warehouse, widths: number[]): Recalculations.CellWidthSpan<CellElement>[] => {
   if (Warehouse.hasColumns(warehouse)) {
     return Recalculations.recalculateWidthForColumns(warehouse, widths);
   } else {
@@ -31,7 +32,7 @@ const recalculateAndApply = (warehouse: Warehouse, widths: number[], tableSize: 
   });
 };
 
-const adjustWidth = (table: SugarElement, delta: number, index: number, resizing: ResizeBehaviour, tableSize: TableSize): void => {
+const adjustWidth = (table: SugarElement<HTMLTableElement>, delta: number, index: number, resizing: ResizeBehaviour, tableSize: TableSize): void => {
   const warehouse = Warehouse.fromTable(table);
   const step = tableSize.getCellDelta(delta);
   const widths = tableSize.getWidths(warehouse, tableSize);
@@ -46,7 +47,7 @@ const adjustWidth = (table: SugarElement, delta: number, index: number, resizing
   resizing.resizeTable(tableSize.adjustTableWidth, clampedStep, isLastColumn);
 };
 
-const adjustHeight = (table: SugarElement, delta: number, index: number, direction: BarPositions<RowInfo>): void => {
+const adjustHeight = (table: SugarElement<HTMLTableElement>, delta: number, index: number, direction: BarPositions<RowInfo>): void => {
   const warehouse = Warehouse.fromTable(table);
   const heights = ColumnSizes.getPixelHeights(warehouse, table, direction);
 
@@ -79,7 +80,7 @@ const adjustAndRedistributeWidths = <T extends Detail> (_table: SugarElement<HTM
 };
 
 // Ensure that the width of table cells match the passed in table information.
-const adjustWidthTo = <T extends Detail> (_table: SugarElement, list: RowDetail<T>[], _info: { }, tableSize: TableSize): void => {
+const adjustWidthTo = <T extends Detail> (_table: SugarElement<HTMLTableElement>, list: RowDetail<T>[], _info: { }, tableSize: TableSize): void => {
   const warehouse = Warehouse.generate(list);
   const widths = tableSize.getWidths(warehouse, tableSize);
 

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
@@ -52,7 +52,7 @@ export const BarManager = (wire: ResizeWire): BarManager => {
 
   let hoverTable = Optional.none<SugarElement<HTMLTableElement>>();
 
-  const getResizer = (element: SugarElement, type: string) => {
+  const getResizer = (element: SugarElement<Element>, type: string) => {
     return Optional.from(Attribute.get(element, type));
   };
 
@@ -69,7 +69,7 @@ export const BarManager = (wire: ResizeWire): BarManager => {
     });
   });
 
-  const getDelta = (target: SugarElement, dir: string) => {
+  const getDelta = (target: SugarElement<Element>, dir: string) => {
     const newX = CellUtils.getCssValue(target, dir);
     const oldX = CellUtils.getAttrValue(target, 'data-initial-' + dir, 0);
     return newX - oldX;
@@ -97,7 +97,7 @@ export const BarManager = (wire: ResizeWire): BarManager => {
 
   });
 
-  const handler = (target: SugarElement, dir: string) => {
+  const handler = (target: SugarElement<Element>, dir: string) => {
     events.trigger.startAdjust();
     mutation.assign(target);
     Attribute.set(target, 'data-initial-' + dir, CellUtils.getCssValue(target, dir));
@@ -117,11 +117,11 @@ export const BarManager = (wire: ResizeWire): BarManager => {
     }
   });
 
-  const isRoot = (e: SugarElement) => {
+  const isRoot = (e: SugarElement<Node>) => {
     return Compare.eq(e, wire.view());
   };
 
-  const findClosestEditableTable = (target: SugarElement): Optional<SugarElement<HTMLTableElement>> =>
+  const findClosestEditableTable = (target: SugarElement<Node>): Optional<SugarElement<HTMLTableElement>> =>
     SelectorFind.closest<HTMLTableElement>(target, 'table', isRoot).filter(ContentEditable.isEditable);
 
   /* mouseover on table: When the mouse moves within the CONTENT AREA (NOT THE TABLE), refresh the bars. */

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarMutation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarMutation.ts
@@ -5,7 +5,7 @@ import { SugarElement } from '@ephox/sugar';
 import { DragDistanceEvent, Mutation } from './Mutation';
 
 export interface DragEvent extends DragDistanceEvent {
-  readonly target: SugarElement;
+  readonly target: SugarElement<Element>;
 }
 
 interface DragDistanceEvents {
@@ -13,13 +13,13 @@ interface DragDistanceEvents {
     drag: Bindable<DragEvent>;
   };
   trigger: {
-    drag: (xDelta: number, yDelta: number, target: SugarElement) => void;
+    drag: (xDelta: number, yDelta: number, target: SugarElement<Element>) => void;
   };
 }
 
 export interface BarMutation {
-  assign: (t: SugarElement) => void;
-  get: () => Optional<SugarElement>;
+  assign: (t: SugarElement<Element>) => void;
+  get: () => Optional<SugarElement<Element>>;
   mutate: (x: number, y: number) => void;
   events: {
     drag: Bindable<DragEvent>;
@@ -31,7 +31,7 @@ export const BarMutation = (): BarMutation => {
     drag: Event([ 'xDelta', 'yDelta', 'target' ])
   });
 
-  let target = Optional.none<SugarElement>();
+  let target = Optional.none<SugarElement<Element>>();
 
   const delegate = Mutation();
 
@@ -42,7 +42,7 @@ export const BarMutation = (): BarMutation => {
     });
   });
 
-  const assign = (t: SugarElement) => {
+  const assign = (t: SugarElement<Element>) => {
     target = Optional.some(t);
   };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
@@ -12,9 +12,9 @@ export interface ColInfo {
 }
 
 export interface BarPositions<T> {
-  readonly delta: (delta: number, table: SugarElement) => number;
-  readonly edge: (e: SugarElement) => number;
-  readonly positions: (array: Optional<SugarElement>[], table: SugarElement) => Optional<T>[];
+  readonly delta: (delta: number, table: SugarElement<HTMLTableElement>) => number;
+  readonly edge: (e: SugarElement<HTMLElement>) => number;
+  readonly positions: (array: Optional<SugarElement<HTMLTableCellElement>>[], table: SugarElement<HTMLTableElement>) => Optional<T>[];
 }
 
 const rowInfo = (row: number, y: number): RowInfo => ({
@@ -27,36 +27,40 @@ const colInfo = (col: number, x: number): ColInfo => ({
   x
 });
 
-const rtlEdge = (cell: SugarElement): number => {
+const rtlEdge = (cell: SugarElement<HTMLElement>): number => {
   const pos = SugarLocation.absolute(cell);
   return pos.left + Width.getOuter(cell);
 };
 
-const ltrEdge = (cell: SugarElement): number => {
+const ltrEdge = (cell: SugarElement<HTMLElement>): number => {
   return SugarLocation.absolute(cell).left;
 };
 
-const getLeftEdge = (index: number, cell: SugarElement): ColInfo => {
+const getLeftEdge = (index: number, cell: SugarElement<HTMLTableCellElement>): ColInfo => {
   return colInfo(index, ltrEdge(cell));
 };
 
-const getRightEdge = (index: number, cell: SugarElement): ColInfo => {
+const getRightEdge = (index: number, cell: SugarElement<HTMLTableCellElement>): ColInfo => {
   return colInfo(index, rtlEdge(cell));
 };
 
-const getTop = (cell: SugarElement): number => {
+const getTop = (cell: SugarElement<HTMLElement>): number => {
   return SugarLocation.absolute(cell).top;
 };
 
-const getTopEdge = (index: number, cell: SugarElement): RowInfo => {
+const getTopEdge = (index: number, cell: SugarElement<HTMLTableCellElement>): RowInfo => {
   return rowInfo(index, getTop(cell));
 };
 
-const getBottomEdge = (index: number, cell: SugarElement): RowInfo => {
+const getBottomEdge = (index: number, cell: SugarElement<HTMLTableCellElement>): RowInfo => {
   return rowInfo(index, getTop(cell) + Height.getOuter(cell));
 };
 
-const findPositions = <T> (getInnerEdge: (idx: number, ele: SugarElement) => T, getOuterEdge: (idx: number, ele: SugarElement) => T, array: Optional<SugarElement>[]): Optional<T>[] => {
+const findPositions = <T> (
+  getInnerEdge: (idx: number, ele: SugarElement<HTMLTableCellElement>) => T,
+  getOuterEdge: (idx: number, ele: SugarElement<HTMLTableCellElement>) => T,
+  array: Optional<SugarElement<HTMLTableCellElement>>[]
+): Optional<T>[] => {
   if (array.length === 0 ) {
     return [];
   }
@@ -79,28 +83,28 @@ const negate = (step: number): number => {
 
 const height: BarPositions<RowInfo> = {
   delta: Fun.identity,
-  positions: (optElements: Optional<SugarElement>[]) => findPositions(getTopEdge, getBottomEdge, optElements),
+  positions: (optElements) => findPositions(getTopEdge, getBottomEdge, optElements),
   edge: getTop
 };
 
 const ltr: BarPositions<ColInfo> = {
   delta: Fun.identity,
   edge: ltrEdge,
-  positions: (optElements: Optional<SugarElement>[]) => findPositions(getLeftEdge, getRightEdge, optElements)
+  positions: (optElements) => findPositions(getLeftEdge, getRightEdge, optElements)
 };
 
 const rtl: BarPositions<ColInfo> = {
   delta: negate,
   edge: rtlEdge,
-  positions: (optElements: Optional<SugarElement>[]) => findPositions(getRightEdge, getLeftEdge, optElements)
+  positions: (optElements) => findPositions(getRightEdge, getLeftEdge, optElements)
 };
 
 const detect = Direction.onDirection(ltr, rtl);
 
 const width: BarPositions<ColInfo> = {
-  delta: (amount: number, table: SugarElement) => detect(table).delta(amount, table),
-  positions: (cols: Optional<SugarElement>[], table: SugarElement) => detect(table).positions(cols, table),
-  edge: (cell: SugarElement) => detect(cell).edge(cell)
+  delta: (amount: number, table: SugarElement<HTMLTableElement>) => detect(table).delta(amount, table),
+  positions: (cols: Optional<SugarElement<HTMLTableCellElement>>[], table: SugarElement<HTMLTableElement>) => detect(table).positions(cols, table),
+  edge: (cell: SugarElement<HTMLElement>) => detect(cell).edge(cell)
 };
 
 export { height, width, rtl, ltr };

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Bars.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Bars.ts
@@ -106,11 +106,11 @@ const show = (wire: ResizeWire): void => {
   });
 };
 
-const isRowBar = (element: SugarElement<Node>): boolean => {
+const isRowBar = (element: SugarElement<Node>): element is SugarElement<HTMLDivElement> => {
   return Class.has(element, resizeRowBar);
 };
 
-const isColBar = (element: SugarElement<Node>): boolean => {
+const isColBar = (element: SugarElement<Node>): element is SugarElement<HTMLDivElement> => {
   return Class.has(element, resizeColBar);
 };
 

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
@@ -6,6 +6,7 @@ import { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
 import * as Blocks from '../lookup/Blocks';
 import * as CellUtils from '../util/CellUtils';
+import { CellElement } from '../util/TableTypes';
 import * as Util from '../util/Util';
 import { BarPositions, RowInfo, width } from './BarPositions';
 import * as Sizes from './Sizes';
@@ -47,7 +48,7 @@ const getDimension = <T extends HTMLElement, U>(
 const getWidthFrom = <T>(
   warehouse: Warehouse,
   table: SugarElement<HTMLTableElement>,
-  getWidth: (cell: SugarElement) => T,
+  getWidth: (cell: SugarElement<CellElement>) => T,
   fallback: (deduced: Optional<number>) => T
 ): T[] => {
   // Only treat a cell as being valid for a column representation if it has a raw width, otherwise we won't be able to calculate the expected width.
@@ -102,7 +103,13 @@ const getPixelWidths = (warehouse: Warehouse, table: SugarElement<HTMLTableEleme
   });
 };
 
-const getHeightFrom = <T> (warehouse: Warehouse, table: SugarElement<HTMLTableElement>, direction: BarPositions<RowInfo>, getHeight: (cell: SugarElement) => T, fallback: (deduced: Optional<number>) => T): T[] => {
+const getHeightFrom = <T> (
+  warehouse: Warehouse,
+  table: SugarElement<HTMLTableElement>,
+  direction: BarPositions<RowInfo>,
+  getHeight: (cell: SugarElement<HTMLTableCellElement>) => T,
+  fallback: (deduced: Optional<number>) => T
+): T[] => {
   const rows = Blocks.rows(warehouse);
 
   const backups = [ Optional.some(direction.edge(table)) ].concat(Arr.map(direction.positions(rows, table), (pos) =>

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Recalculations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Recalculations.ts
@@ -1,8 +1,8 @@
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
-import * as Structs from '../api/Structs';
 import { Warehouse } from '../api/Warehouse';
+import { CellElement } from '../util/TableTypes';
 
 // Returns the sum of elements of measures in the half-open range [start, end)
 // Measures is in pixels, treated as an array of integers or integers in string format.
@@ -15,24 +15,24 @@ const total = (start: number, end: number, measures: number[]): number => {
   return r;
 };
 
-interface CellWidthSpan {
+interface CellWidthSpan<T extends CellElement> {
   readonly colspan: number;
   readonly width: number;
-  readonly element: SugarElement;
+  readonly element: SugarElement<T>;
 }
 
-interface CellHeight {
+interface CellHeight<T extends HTMLTableRowElement | HTMLTableCellElement> {
   readonly height: number;
-  readonly element: SugarElement;
+  readonly element: SugarElement<T>;
 }
 
-interface CellHeightSpan extends CellHeight {
+interface CellHeightSpan extends CellHeight<HTMLTableCellElement> {
   readonly rowspan: number;
 }
 
 // Returns an array of all cells in warehouse with updated cell-widths, using
 // the array 'widths' of the representative widths of each column of the table 'warehouse'
-const recalculateWidthForCells = (warehouse: Warehouse, widths: number[]): CellWidthSpan[] => {
+const recalculateWidthForCells = (warehouse: Warehouse, widths: number[]): CellWidthSpan<HTMLTableCellElement>[] => {
   const all = Warehouse.justCells(warehouse);
 
   return Arr.map(all, (cell) => {
@@ -46,10 +46,10 @@ const recalculateWidthForCells = (warehouse: Warehouse, widths: number[]): CellW
   });
 };
 
-const recalculateWidthForColumns = (warehouse: Warehouse, widths: number[]): CellWidthSpan[] => {
+const recalculateWidthForColumns = (warehouse: Warehouse, widths: number[]): CellWidthSpan<HTMLTableColElement>[] => {
   const groups = Warehouse.justColumns(warehouse);
 
-  return Arr.map(groups, (column: Structs.Column, index: number) => ({
+  return Arr.map(groups, (column, index) => ({
     element: column.element,
     width: widths[index],
     colspan: column.colspan
@@ -68,7 +68,7 @@ const recalculateHeightForCells = (warehouse: Warehouse, heights: number[]): Cel
   });
 };
 
-const matchRowHeight = (warehouse: Warehouse, heights: number[]): CellHeight[] => {
+const matchRowHeight = (warehouse: Warehouse, heights: number[]): CellHeight<HTMLTableRowElement>[] => {
   return Arr.map(warehouse.all, (row, i) => {
     return {
       element: row.element,

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -53,7 +53,7 @@ const getTotalHeight = (cell: SugarElement<HTMLTableCellElement>): number => {
   return normalizePixelSize(value, cell, Height.get, setHeight);
 };
 
-const get = (cell: SugarElement<HTMLTableCellElement>, type: 'rowspan' | 'colspan', f: (e: SugarElement) => number): number => {
+const get = (cell: SugarElement<HTMLTableCellElement>, type: 'rowspan' | 'colspan', f: (e: SugarElement<HTMLTableCellElement>) => number): number => {
   const v = f(cell);
   const span = getSpan(cell, type);
   return v / span;

--- a/modules/snooker/src/main/ts/ephox/snooker/selection/CellFinder.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/selection/CellFinder.ts
@@ -5,7 +5,7 @@ import { Warehouse } from '../api/Warehouse';
 import * as CellBounds from './CellBounds';
 import * as CellGroup from './CellGroup';
 
-const moveBy = (warehouse: Warehouse, cell: SugarElement, row: number, column: number): Optional<SugarElement> => {
+const moveBy = (warehouse: Warehouse, cell: SugarElement<HTMLTableCellElement>, row: number, column: number): Optional<SugarElement<HTMLTableCellElement>> => {
   return Warehouse.findItem(warehouse, cell, Compare.eq).bind((detail) => {
     const startRow = row > 0 ? detail.row + detail.rowspan - 1 : detail.row;
     const startCol = column > 0 ? detail.column + detail.colspan - 1 : detail.column;
@@ -16,7 +16,7 @@ const moveBy = (warehouse: Warehouse, cell: SugarElement, row: number, column: n
   });
 };
 
-const intercepts = (warehouse: Warehouse, start: SugarElement, finish: SugarElement): Optional<SugarElement[]> => {
+const intercepts = (warehouse: Warehouse, start: SugarElement<HTMLTableCellElement>, finish: SugarElement<HTMLTableCellElement>): Optional<SugarElement<HTMLTableCellElement>[]> => {
   return CellGroup.getAnyBox(warehouse, start, finish).map((bounds) => {
     const inside = Warehouse.filterItems(warehouse, Fun.curry(CellBounds.inSelection, bounds));
     return Arr.map(inside, (detail) => {
@@ -25,8 +25,8 @@ const intercepts = (warehouse: Warehouse, start: SugarElement, finish: SugarElem
   });
 };
 
-const parentCell = (warehouse: Warehouse, innerCell: SugarElement): Optional<SugarElement> => {
-  const isContainedBy = (c1: SugarElement, c2: SugarElement) => {
+const parentCell = (warehouse: Warehouse, innerCell: SugarElement<HTMLTableCellElement>): Optional<SugarElement<HTMLTableCellElement>> => {
+  const isContainedBy = (c1: SugarElement<HTMLElement>, c2: SugarElement<HTMLElement>) => {
     return Compare.contains(c2, c1);
   };
   return Warehouse.findItem(warehouse, innerCell, isContainedBy).map((detail) => {

--- a/modules/snooker/src/main/ts/ephox/snooker/selection/CellGroup.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/selection/CellGroup.ts
@@ -14,7 +14,7 @@ const getBounds = (detailA: Structs.DetailExt, detailB: Structs.DetailExt): Stru
   );
 };
 
-const getAnyBox = (warehouse: Warehouse, startCell: SugarElement, finishCell: SugarElement): Optional<Structs.Bounds> => {
+const getAnyBox = (warehouse: Warehouse, startCell: SugarElement<HTMLTableCellElement>, finishCell: SugarElement<HTMLTableCellElement>): Optional<Structs.Bounds> => {
   const startCoords = Warehouse.findItem(warehouse, startCell, Compare.eq);
   const finishCoords = Warehouse.findItem(warehouse, finishCell, Compare.eq);
   return startCoords.bind((sc) => {
@@ -24,7 +24,7 @@ const getAnyBox = (warehouse: Warehouse, startCell: SugarElement, finishCell: Su
   });
 };
 
-const getBox = (warehouse: Warehouse, startCell: SugarElement, finishCell: SugarElement): Optional<Structs.Bounds> => {
+const getBox = (warehouse: Warehouse, startCell: SugarElement<HTMLTableCellElement>, finishCell: SugarElement<HTMLTableCellElement>): Optional<Structs.Bounds> => {
   return getAnyBox(warehouse, startCell, finishCell).bind((bounds) => {
     return CellBounds.isRectangular(warehouse, bounds);
   });

--- a/modules/snooker/src/main/ts/ephox/snooker/util/TableTypes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/util/TableTypes.ts
@@ -1,0 +1,9 @@
+import { SugarElement } from '@ephox/sugar';
+
+export type RowElement = HTMLTableRowElement | HTMLTableColElement;
+export type CellElement = HTMLTableCellElement | HTMLTableColElement;
+export type RowCell<R extends RowElement> = R extends HTMLTableRowElement ? HTMLTableCellElement : HTMLTableColElement;
+
+export type CompElm = (a: SugarElement<HTMLElement>, b: SugarElement<HTMLElement>) => boolean;
+export type Subst = <T extends RowElement | CellElement>(element: SugarElement<T>, comparator: CompElm) => SugarElement<T>;
+

--- a/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
@@ -9,7 +9,7 @@ import * as TableMerge from 'ephox/snooker/test/TableMerge';
 
 UnitTest.test('FitmentIVTest', () => {
   const en = (fakeElement: any, isNew: boolean) =>
-    Structs.elementnew(fakeElement as SugarElement, isNew, false);
+    Structs.elementnew(fakeElement as SugarElement<any>, isNew, false);
 
   // Spend 5 seconds running as many iterations as we can (there are three cycles, so 15s total)
   const CYCLE_TIME = 5000;

--- a/modules/snooker/src/test/ts/atomic/model/FitmentTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/FitmentTest.ts
@@ -14,7 +14,7 @@ UnitTest.test('FitmentTest', () => {
   const tailorTest = Fitment.tailorTest;
   const mergeGridsTest = TableMerge.mergeTest;
 
-  const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement, isNew, false);
+  const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement<any>, isNew, false);
 
   const check = <T extends (...args: A) => void, A extends any[]>(test: T, ...args: A) => {
     test.apply(null, args);

--- a/modules/snooker/src/test/ts/atomic/model/TableGridTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/TableGridTest.ts
@@ -8,9 +8,9 @@ import * as TableGrid from 'ephox/snooker/model/TableGrid';
 
 describe('TableGridTest', () => {
   const r = Structs.rowcells;
-  const re = () => 'row' as unknown as SugarElement;
-  const ce = () => 'colgroup' as unknown as SugarElement;
-  const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement, isNew, false);
+  const re = () => 'row' as unknown as SugarElement<any>;
+  const ce = () => 'colgroup' as unknown as SugarElement<any>;
+  const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement<any>, isNew, false);
 
   const check = (expected: { colspan: number; rowspan: number }, row: number, column: number, grid: Structs.RowCells[]) => {
     const actual = TableGrid.subgrid(grid, row, column, Fun.tripleEquals);

--- a/modules/snooker/src/test/ts/atomic/model/TableMergeTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/TableMergeTest.ts
@@ -11,7 +11,7 @@ UnitTest.test('TableMergeTest', () => {
   const start = Structs.address;
   const suite = TableMerge.suite;
 
-  const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement, isNew, false);
+  const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement<any>, isNew, false);
 
   // Advanced Spans
   const gridAdvancedOne = () => [

--- a/modules/snooker/src/test/ts/atomic/operate/MergeOperationsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/operate/MergeOperationsTest.ts
@@ -8,13 +8,13 @@ import * as MergingOperations from 'ephox/snooker/operate/MergingOperations';
 UnitTest.test('MergeOperationsTest', () => {
   const b = Structs.bounds;
   const r = Structs.rowcells;
-  const re = () => 'row' as unknown as SugarElement;
-  const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement, isNew, false);
+  const re = () => 'row' as unknown as SugarElement<any>;
+  const en = (fakeElement: any, isNew: boolean) => Structs.elementnew(fakeElement as SugarElement<any>, isNew, false);
 
   // Test basic merge.
   (() => {
     const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], bounds: Structs.Bounds, lead: string) => {
-      const actual = MergingOperations.merge(grid, bounds, Fun.tripleEquals, Fun.constant(lead as unknown as SugarElement));
+      const actual = MergingOperations.merge(grid, bounds, Fun.tripleEquals, Fun.constant(lead as unknown as SugarElement<any>));
       assert.eq(expected.length, actual.length);
       Arr.each(expected, (row, i) => {
         Arr.each(row.cells, (cell, j) => {
@@ -108,7 +108,7 @@ UnitTest.test('MergeOperationsTest', () => {
   // Test basic unmerge.
   (() => {
     const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], target: string) => {
-      const actual = MergingOperations.unmerge(grid, target as unknown as SugarElement, Fun.tripleEquals, Fun.constant('?') as any);
+      const actual = MergingOperations.unmerge(grid, target as unknown as SugarElement<any>, Fun.tripleEquals, Fun.constant('?') as any);
       assert.eq(expected.length, actual.length);
       Arr.each(expected, (row, i) => {
         Arr.each(row.cells, (cell, j) => {

--- a/modules/snooker/src/test/ts/browser/BarsTest.ts
+++ b/modules/snooker/src/test/ts/browser/BarsTest.ts
@@ -11,14 +11,14 @@ const isResizable = (elm: SugarElement<Element>) => Attribute.get(elm, resizeAtt
 const tableHtml = '<table style="width: 400px"><tbody><tr><td style="width: 200px"></td><td style="width: 200px"></td></tr></tbody></table>';
 const colgroupTableHtml = '<table style="width: 400px"><colgroup><col style="width: 200px" /><col style="width: 200px" /></colgroup><tbody><tr><td></td><td></td></tr></tbody></table>';
 
-const assertdBarCounts = (scope: SugarElement, rows: number, cols: number) => {
+const assertdBarCounts = (scope: SugarElement<Node>, rows: number, cols: number) => {
   const rowBars = SelectorFilter.descendants(scope, 'div[data-row]');
   const colBars = SelectorFilter.descendants(scope, 'div[data-column]');
   Assert.eq(`Should be ${rows} row bar in the dom`, rows, rowBars.length);
   Assert.eq(`Should be ${cols} col bars in the dom`, cols, colBars.length);
 };
 
-const setResizeAttr = (scope: SugarElement, selector: string, value: string) => {
+const setResizeAttr = (scope: SugarElement<Node>, selector: string, value: string) => {
   const elm = SelectorFind.descendant(scope, selector).getOrDie(`Could not find ${selector}`);
   Attribute.set(elm, resizeAttribute, value);
 };

--- a/modules/snooker/src/test/ts/browser/CopySelectedTest.ts
+++ b/modules/snooker/src/test/ts/browser/CopySelectedTest.ts
@@ -23,7 +23,7 @@ UnitTest.test('CopySelectedTest', () => {
   const SEL_CLASS = 'copy-selected';
 
   // traverse really needs this built in
-  const traverseChildElements = (e: SugarElement) => {
+  const traverseChildElements = (e: SugarElement<Element>) => {
     return Arr.map(e.dom.children, SugarElement.fromDom);
   };
 
@@ -112,7 +112,7 @@ UnitTest.test('CopySelectedTest', () => {
       const domCells = traverseChildElements(domRows[i]);
       assertWithInfo(row.length, domCells.length, 'number of cells in output row ' + i + ' to be ');
       Arr.each(row, (cell, j) => {
-        const domCell = domCells[j];
+        const domCell = domCells[j] as SugarElement<HTMLElement>;
         assertWithInfo(cell.html, Html.get(domCell), 'cell text');
         assertWithInfo(cell.rowspan, Attribute.get(domCell, 'rowspan'), 'rowspan');
         assertWithInfo(cell.colspan, Attribute.get(domCell, 'colspan'), 'colspan');

--- a/modules/snooker/src/test/ts/browser/RedrawSectionOrderTest.ts
+++ b/modules/snooker/src/test/ts/browser/RedrawSectionOrderTest.ts
@@ -11,7 +11,7 @@ import * as Bridge from 'ephox/snooker/test/Bridge';
 
 UnitTest.asynctest('Redraw Section Order Test', (success, failure) => {
 
-  const getRowData = (table: SugarElement) => {
+  const getRowData = (table: SugarElement<HTMLTableElement>) => {
     const warehouse = Warehouse.fromTable(table);
     const model = Transitions.toGrid(warehouse, Bridge.generators, false);
     return Transitions.toDetails(model, Compare.eq);

--- a/modules/snooker/src/test/ts/browser/TableGridSizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableGridSizeTest.ts
@@ -5,7 +5,7 @@ import * as TableGridSize from 'ephox/snooker/api/TableGridSize';
 
 UnitTest.test('Table grid size test', () => {
   const testGridSize = (html: string, expectedColumnCount: number, expectedRowCount: number) => {
-    const tbl = SugarElement.fromHtml(html);
+    const tbl = SugarElement.fromHtml<HTMLTableElement>(html);
     const size = TableGridSize.getGridSize(tbl);
 
     assert.eq(expectedColumnCount, size.columns, 'Should be expected column count');

--- a/modules/snooker/src/test/ts/browser/TablePositionsTest.ts
+++ b/modules/snooker/src/test/ts/browser/TablePositionsTest.ts
@@ -1,5 +1,5 @@
 import { assert, UnitTest } from '@ephox/bedrock-client';
-import { Optional } from '@ephox/katamari';
+import { Arr, Optional } from '@ephox/katamari';
 import { Insert, InsertAll, Remove, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import * as TablePositions from 'ephox/snooker/api/TablePositions';
@@ -9,7 +9,7 @@ UnitTest.test('RectangularTest', () => {
   const div = SugarElement.fromTag('div');
   Insert.append(body, div);
 
-  const table = SugarElement.fromHtml(
+  const table = SugarElement.fromHtml<HTMLTableElement>(
     '<table id="tableA" border=1>' +
        '<tbody>' +
          '<tr>' +
@@ -40,7 +40,7 @@ UnitTest.test('RectangularTest', () => {
      '</table>'
   );
 
-  const table2 = SugarElement.fromHtml('<table id="tableB" border="1" cellspacing="0" cellpadding="0" style="border-collapse:collapse;border:none;">' +
+  const table2 = SugarElement.fromHtml<HTMLTableElement>('<table id="tableB" border="1" cellspacing="0" cellpadding="0" style="border-collapse:collapse;border:none;">' +
    '<tbody><tr>' +
       '<td id="TBA0" style="min-width: 100px; height: 40px" rowspan="3">A0</td>' +
       '<td id="TBA1" style="min-width: 100px; height: 40px">A1 </td>' +
@@ -73,14 +73,14 @@ UnitTest.test('RectangularTest', () => {
 
   InsertAll.append(div, [ table, table2 ] );
 
-  const check = (tableTarget: SugarElement, from: string, to: string, expected: boolean) => {
-    [].forEach.call(tableTarget.dom.querySelectorAll('td'), (td: HTMLElement) => {
+  const check = (tableTarget: SugarElement<HTMLTableElement>, from: string, to: string, expected: boolean) => {
+    Arr.each(tableTarget.dom.querySelectorAll('td'), (td) => {
       td.style.background = '';
     });
-    Optional.from(document.querySelector(from) as HTMLElement).getOrDie('Missing element for "from" selector').style.background = '#cadbee';
-    Optional.from(document.querySelector(to) as HTMLElement).getOrDie('Missing element for "to" selector').style.background = '#5adb33';
-    const start = SelectorFilter.descendants(tableTarget, from)[0];
-    const finish = SelectorFilter.descendants(tableTarget, to)[0];
+    Optional.from(document.querySelector(from) as HTMLTableCellElement).getOrDie('Missing element for "from" selector').style.background = '#cadbee';
+    Optional.from(document.querySelector(to) as HTMLTableCellElement).getOrDie('Missing element for "to" selector').style.background = '#5adb33';
+    const start = SelectorFilter.descendants<HTMLTableCellElement>(tableTarget, from)[0];
+    const finish = SelectorFilter.descendants<HTMLTableCellElement>(tableTarget, to)[0];
     const c = TablePositions.getBox(tableTarget, start, finish);
     assert.eq(expected, c.isSome());
   };

--- a/modules/snooker/src/test/ts/browser/TableSizesTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableSizesTest.ts
@@ -105,7 +105,7 @@ UnitTest.test('Table Sizes Test (fusebox)', () => {
 
   assert.eq([[ '1px', '2px' ], [ '1px', '2px' ]], readWidth(generateW([[ '1px', '2px' ], [ '1px', '2px' ]], '3px')));
 
-  const checkWidth = (expected: string[][], table: SugarElement, newWidth: string) => {
+  const checkWidth = (expected: string[][], table: SugarElement<HTMLTableElement>, newWidth: string) => {
     Insert.append(SugarBody.body(), table);
     Sizes.redistribute(table, Optional.some(newWidth), Optional.none());
     assert.eq(expected, readWidth(table));
@@ -117,7 +117,7 @@ UnitTest.test('Table Sizes Test (fusebox)', () => {
     checkWidth(expected, table, newWidth);
   };
 
-  const checkHeight = (expected: string[][], table: SugarElement, newHeight: string) => {
+  const checkHeight = (expected: string[][], table: SugarElement<HTMLTableElement>, newHeight: string) => {
     Insert.append(SugarBody.body(), table);
     Sizes.redistribute(table, Optional.none(), Optional.some(newHeight));
     assert.eq(expected, readHeight(table));

--- a/modules/snooker/src/test/ts/browser/lookup/BlocksTest.ts
+++ b/modules/snooker/src/test/ts/browser/lookup/BlocksTest.ts
@@ -12,7 +12,7 @@ UnitTest.test('BlocksTest', () => {
     return elem;
   };
   const s = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText), rowspan, colspan);
-  const f = (cells: Structs.Detail[], section: 'tbody' | 'thead' | 'tfoot') => Structs.rowdetail(SugarElement.fromTag('tr'), cells, section);
+  const f = (cells: Structs.Detail<HTMLTableCellElement>[], section: 'tbody' | 'thead' | 'tfoot') => Structs.rowdetail(SugarElement.fromTag('tr'), cells, section);
 
   const warehouse = Warehouse.generate([
     f([ s('a', 1, 1), s('b', 1, 2) ], 'thead'),

--- a/modules/snooker/src/test/ts/browser/model/WarehouseTest.ts
+++ b/modules/snooker/src/test/ts/browser/model/WarehouseTest.ts
@@ -41,9 +41,9 @@ describe('WarehouseTest', () => {
   };
 
   const s = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText), rowspan, colspan);
-  const f = (cells: Structs.Detail[], section: 'tbody' | 'thead' | 'tfoot') => Structs.rowdetail(SugarElement.fromTag('tr'), cells, section);
+  const f = (cells: Structs.Detail<HTMLTableCellElement>[], section: 'tbody' | 'thead' | 'tfoot') => Structs.rowdetail(SugarElement.fromTag('tr'), cells, section);
   const c = (id: string, colspan: number) => Structs.detail(createCol(id), 1, colspan);
-  const cg = (cols: Structs.Detail[]) => Structs.rowdetail(SugarElement.fromTag('colgroup'), cols, 'colgroup');
+  const cg = (cols: Structs.Detail<HTMLTableColElement>[]) => Structs.rowdetail(SugarElement.fromTag('colgroup'), cols, 'colgroup');
 
   const testTable = [
     f([ s('a', 1, 2), s('b', 1, 1), s('c', 1, 1), s('d', 1, 1), s('e', 1, 1), s('f', 1, 1) ], 'thead'),

--- a/modules/snooker/src/test/ts/browser/operate/ModificationOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/operate/ModificationOperationsTest.ts
@@ -8,6 +8,8 @@ import * as Structs from 'ephox/snooker/api/Structs';
 import * as ModificationOperations from 'ephox/snooker/operate/ModificationOperations';
 import BrowserTestGenerator from 'ephox/snooker/test/BrowserTestGenerator';
 
+type Grid = Structs.ElementNew<HTMLTableCellElement>[][];
+
 UnitTest.test('ModificationOperationsTest', () => {
   const r = Structs.rowcells;
   const re = () => SugarElement.fromTag('tr');
@@ -16,7 +18,7 @@ UnitTest.test('ModificationOperationsTest', () => {
     Html.set(elem, content);
     return Structs.elementnew(elem, isNew, false);
   };
-  const mapToStructGrid = (grid: Structs.ElementNew[][]) => {
+  const mapToStructGrid = (grid: Grid) => {
     return Arr.map(grid, (row) => {
       return Structs.rowcells(re(), row, 'tbody', false);
     });
@@ -36,7 +38,8 @@ UnitTest.test('ModificationOperationsTest', () => {
     });
   };
 
-  const compare = (a: SugarElement, b: SugarElement) => SugarNode.name(a) === SugarNode.name(b) && Html.get(a) === Html.get(b);
+  const compare = (a: SugarElement<HTMLElement>, b: SugarElement<HTMLElement>) =>
+    SugarNode.name(a) === SugarNode.name(b) && Html.get(a) === Html.get(b);
 
   // Test basic insert column
   (() => {
@@ -45,7 +48,7 @@ UnitTest.test('ModificationOperationsTest', () => {
       assertGrids(expected, actual, checkIsNew);
     };
 
-    const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], example: number, index: number) => {
+    const checkBody = (expected: Grid, grid: Grid, example: number, index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
       check(structExpected, structGrid, example, index, false);
@@ -139,7 +142,7 @@ UnitTest.test('ModificationOperationsTest', () => {
       assertGrids(expected, actual, checkIsNew);
     };
 
-    const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], example: number, index: number) => {
+    const checkBody = (expected: Grid, grid: Grid, example: number, index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
       check(structExpected, structGrid, example, index, false);
@@ -191,7 +194,7 @@ UnitTest.test('ModificationOperationsTest', () => {
       assertGrids(expected, actual, checkIsNew);
     };
 
-    const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], index: number) => {
+    const checkBody = (expected: Grid, grid: Grid, index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
       check(structExpected, structGrid, index, false);
@@ -226,7 +229,7 @@ UnitTest.test('ModificationOperationsTest', () => {
       assertGrids(expected, actual, checkIsNew);
     };
 
-    const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], indexes: number[]) => {
+    const checkBody = (expected: Grid, grid: Grid, indexes: number[]) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
       check(structExpected, structGrid, indexes, false);
@@ -261,7 +264,7 @@ UnitTest.test('ModificationOperationsTest', () => {
       assertGrids(expected, actual, checkIsNew);
     };
 
-    const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], index: number) => {
+    const checkBody = (expected: Grid, grid: Grid, index: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
       check(structExpected, structGrid, index, false);
@@ -298,7 +301,7 @@ UnitTest.test('ModificationOperationsTest', () => {
       assertGrids(expected, actual, checkIsNew);
     };
 
-    const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], exRow: number, exCol: number) => {
+    const checkBody = (expected: Grid, grid: Grid, exRow: number, exCol: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
       check(structExpected, structGrid, exRow, exCol, false);
@@ -495,7 +498,7 @@ UnitTest.test('ModificationOperationsTest', () => {
       assertGrids(expected, actual, checkIsNew);
     };
 
-    const checkBody = (expected: Structs.ElementNew[][], grid: Structs.ElementNew[][], exRow: number, exCol: number) => {
+    const checkBody = (expected: Grid, grid: Grid, exRow: number, exCol: number) => {
       const structExpected = mapToStructGrid(expected);
       const structGrid = mapToStructGrid(grid);
       check(structExpected, structGrid, exRow, exCol, false);

--- a/modules/snooker/src/test/ts/browser/operate/TransformOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/operate/TransformOperationsTest.ts
@@ -33,7 +33,11 @@ UnitTest.test('TransformOperationsTest', () => {
   const mapToStructGrid = (grid: Structs.ElementNew[][]) => {
     return Arr.map(grid, (row) => {
       const hasCol = Arr.exists(row, (elementNew) => SugarNode.isTag('col')(elementNew.element));
-      return Structs.rowcells(SugarElement.fromTag('tr'), row, hasCol ? 'colgroup' : 'tbody', false);
+      if (hasCol) {
+        return Structs.rowcells(SugarElement.fromTag('colgroup'), row as Structs.ElementNew<HTMLTableColElement>[], 'colgroup', false);
+      } else {
+        return Structs.rowcells(SugarElement.fromTag('tr'), row as Structs.ElementNew<HTMLTableCellElement>[], 'tbody', false);
+      }
     });
   };
 

--- a/modules/snooker/src/test/ts/browser/resize/RecalculationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/resize/RecalculationsTest.ts
@@ -54,14 +54,15 @@ UnitTest.test('RecalculationsTest', () => {
     });
   };
 
-  const createCell = (text: string): SugarElement<HTMLTableCellElement> => {
-    const elem = SugarElement.fromTag('td');
+  const createCell = <K extends 'col' | 'td' | 'th'>(text: string, tag: K): SugarElement<HTMLElementTagNameMap[K]> => {
+    const elem = SugarElement.fromTag(tag);
     TextContent.set(elem, text);
     return elem;
   };
-  const makeDetail = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText), rowspan, colspan);
-  const makeRow = (cells: Structs.Detail[]) => Structs.rowdetail(SugarElement.fromTag('tr'), cells, 'tbody');
-  const makeColumnGroup = (cols: Structs.Detail[]) => Structs.rowdetail(SugarElement.fromTag('col'), cols, 'colgroup');
+  const makeCellDetail = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText, 'td'), rowspan, colspan);
+  const makeColDetail = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText, 'col'), rowspan, colspan);
+  const makeRow = (cells: Structs.Detail<HTMLTableCellElement>[]) => Structs.rowdetail(SugarElement.fromTag('tr'), cells, 'tbody');
+  const makeColumnGroup = (cols: Structs.Detail<HTMLTableColElement>[]) => Structs.rowdetail(SugarElement.fromTag('col'), cols, 'colgroup');
 
   check(
     [
@@ -77,7 +78,7 @@ UnitTest.test('RecalculationsTest', () => {
     ],
     [
       makeRow([
-        makeDetail('a', 1, 1)
+        makeCellDetail('a', 1, 1)
       ])
     ],
     dimensions([ 10 ], [ 10 ])
@@ -99,10 +100,10 @@ UnitTest.test('RecalculationsTest', () => {
     ],
     [
       makeColumnGroup([
-        makeDetail('c', 1, 1)
+        makeColDetail('c', 1, 1)
       ]),
       makeRow([
-        makeDetail('a', 1, 1)
+        makeCellDetail('a', 1, 1)
       ])
     ],
     dimensions([ 10 ], [ 10 ])
@@ -118,8 +119,8 @@ UnitTest.test('RecalculationsTest', () => {
       )
     ],
     [
-      makeRow([ makeDetail('a00', 1, 1), makeDetail('a01', 1, 1) ]),
-      makeRow([ makeDetail('a10', 1, 1), makeDetail('a11', 1, 1) ])
+      makeRow([ makeCellDetail('a00', 1, 1), makeCellDetail('a01', 1, 1) ]),
+      makeRow([ makeCellDetail('a10', 1, 1), makeCellDetail('a11', 1, 1) ])
     ],
     dimensions([ 20, 20 ], [ 15, 9 ])
   );
@@ -134,9 +135,9 @@ UnitTest.test('RecalculationsTest', () => {
       )
     ],
     [
-      makeColumnGroup([ makeDetail('c00', 1, 1), makeDetail('c01', 1, 1) ]),
-      makeRow([ makeDetail('a00', 1, 1), makeDetail('a01', 1, 1) ]),
-      makeRow([ makeDetail('a10', 1, 1), makeDetail('a11', 1, 1) ])
+      makeColumnGroup([ makeColDetail('c00', 1, 1), makeColDetail('c01', 1, 1) ]),
+      makeRow([ makeCellDetail('a00', 1, 1), makeCellDetail('a01', 1, 1) ]),
+      makeRow([ makeCellDetail('a10', 1, 1), makeCellDetail('a11', 1, 1) ])
     ],
     dimensions([ 20, 20 ], [ 15, 9 ])
   );
@@ -151,7 +152,7 @@ UnitTest.test('RecalculationsTest', () => {
       )
     ],
     [
-      makeRow([ makeDetail('a', 2, 2) ]),
+      makeRow([ makeCellDetail('a', 2, 2) ]),
       makeRow([]) // optional
     ],
     dimensions([ 20, 20, 99999 ], [ 30, 30, 999999 ])
@@ -167,8 +168,8 @@ UnitTest.test('RecalculationsTest', () => {
       )
     ],
     [
-      makeRow([ makeDetail('a', 2, 2), makeDetail('b', 1, 1) ]),
-      makeRow([ makeDetail('c', 1, 1) ])
+      makeRow([ makeCellDetail('a', 2, 2), makeCellDetail('b', 1, 1) ]),
+      makeRow([ makeCellDetail('c', 1, 1) ])
     ],
     dimensions([ 20, 20, 15, 99999 ], [ 30, 30, 999999 ])
   );
@@ -182,8 +183,8 @@ UnitTest.test('RecalculationsTest', () => {
       )
     ],
     [
-      makeRow([ makeDetail('a', 2, 2), makeDetail('b', 1, 1) ]),
-      makeRow([ makeDetail('c', 1, 1) ])
+      makeRow([ makeCellDetail('a', 2, 2), makeCellDetail('b', 1, 1) ]),
+      makeRow([ makeCellDetail('c', 1, 1) ])
     ],
     dimensions([ 20, 10, 11 ], [ 15, 13 ]));
 
@@ -205,9 +206,9 @@ UnitTest.test('RecalculationsTest', () => {
       )
     ],
     [
-      makeRow([ makeDetail('g', 1, 1), makeDetail('h', 1, 1), makeDetail('i', 1, 1), makeDetail('j', 1, 1), makeDetail('k', 1, 3) ]),
-      makeRow([ makeDetail('l', 1, 1), makeDetail('m', 3, 2), makeDetail('n', 1, 1), makeDetail('o', 1, 1), makeDetail('p', 1, 1), makeDetail('q', 1, 1) ]),
-      makeRow([ makeDetail('r', 2, 1), makeDetail('s', 1, 1), makeDetail('t', 2, 1), makeDetail('u', 1, 1), makeDetail('v', 1, 1) ])
+      makeRow([ makeCellDetail('g', 1, 1), makeCellDetail('h', 1, 1), makeCellDetail('i', 1, 1), makeCellDetail('j', 1, 1), makeCellDetail('k', 1, 3) ]),
+      makeRow([ makeCellDetail('l', 1, 1), makeCellDetail('m', 3, 2), makeCellDetail('n', 1, 1), makeCellDetail('o', 1, 1), makeCellDetail('p', 1, 1), makeCellDetail('q', 1, 1) ]),
+      makeRow([ makeCellDetail('r', 2, 1), makeCellDetail('s', 1, 1), makeCellDetail('t', 2, 1), makeCellDetail('u', 1, 1), makeCellDetail('v', 1, 1) ])
     ],
     dimensions([ 10, 10, 10, 10, 10, 10, 10 ], [ 20, 15, 10 ])
   );

--- a/modules/snooker/src/test/ts/browser/selection/CellBoundsTest.ts
+++ b/modules/snooker/src/test/ts/browser/selection/CellBoundsTest.ts
@@ -13,7 +13,7 @@ UnitTest.test('CellBounds.isWithin Test', () => {
     return elem;
   };
   const s = (elemText: string, rowspan: number, colspan: number) => Structs.detail(createCell(elemText), rowspan, colspan);
-  const f = (cells: Structs.Detail[], section: 'tbody') => Structs.rowdetail(SugarElement.fromTag('tr'), cells, section);
+  const f = (cells: Structs.Detail<HTMLTableCellElement>[], section: 'tbody') => Structs.rowdetail(SugarElement.fromTag('tr'), cells, section);
 
   const testTableA = [
     f([ s('a', 1, 1), s('b', 1, 1), s('c', 1, 1), s('d', 1, 1), s('e', 1, 1) ], 'tbody'),

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
@@ -301,7 +301,7 @@ const checkUnmerge = (
   Insert.append(SugarBody.body(), container);
   const wire = ResizeWire.only(SugarBody.body(), isResizable);
   const unmergables = Arr.map(unmergablePaths, (path) =>
-    Hierarchy.follow(table, [ path.section, path.row, path.column ])
+    Hierarchy.follow(table, [ path.section, path.row, path.column ]) as Optional<SugarElement<HTMLTableCellElement>>
   );
 
   const unmergable = Optional.some(Optionals.cat(unmergables));

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
@@ -7,9 +7,9 @@ import { TargetMergable } from 'ephox/snooker/model/RunOperation';
 
 // Mock/Stub out helper functions
 
-const targetStub = (selection: { section: number; row: number; column: number}[], bounds: { startRow: number; startCol: number; finishRow: number; finishCol: number}, table: SugarElement): TargetMergable => {
+const targetStub = (selection: { section: number; row: number; column: number}[], bounds: { startRow: number; startCol: number; finishRow: number; finishCol: number}, table: SugarElement<HTMLTableElement>): TargetMergable => {
   const cells = Optionals.cat(Arr.map(selection, (path) => {
-    return Hierarchy.follow(table, [ path.section, path.row, path.column ]);
+    return Hierarchy.follow(table, [ path.section, path.row, path.column ]) as Optional<SugarElement<HTMLTableCellElement>>;
   }));
 
   return {

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/MockStructs.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/MockStructs.ts
@@ -4,7 +4,7 @@ import { SugarElement, SugarNode, TextContent } from '@ephox/sugar';
 import * as Structs from 'ephox/snooker/api/Structs';
 
 // Creates an elementNew (or returns from elements array if it already exists)
-const getElementNew = (elements: Structs.ElementNew[], tagName: keyof HTMLElementTagNameMap, text: string, isNew: boolean, isLocked: boolean): Structs.ElementNew => {
+const getElementNew = (elements: Structs.ElementNew[], tagName: 'td' | 'th' | 'col', text: string, isNew: boolean, isLocked: boolean): Structs.ElementNew => {
   const createAndAppendElement = () => {
     const elm = SugarElement.fromTag(tagName);
     TextContent.set(elm, text);

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/SizeUtils.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/SizeUtils.ts
@@ -23,7 +23,7 @@ const reducePrecision = (value: string, precision: number = 1): string => {
   }
 };
 
-const readWidth = (element: SugarElement): (string | null)[][] => {
+const readWidth = (element: SugarElement<HTMLTableElement>): (string | null)[][] => {
   const rows = SelectorFilter.descendants(element, 'tr');
   return Arr.map(rows, (row) => {
     const cells = SelectorFilter.descendants(row, 'td,th');
@@ -33,7 +33,7 @@ const readWidth = (element: SugarElement): (string | null)[][] => {
   });
 };
 
-const readHeight = (element: SugarElement): (string | null)[][] => {
+const readHeight = (element: SugarElement<HTMLTableElement>): (string | null)[][] => {
   const rows = SelectorFilter.descendants(element, 'tr');
   return Arr.map(rows, (row) => {
     const cells = SelectorFilter.descendants(row, 'td,th');

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
@@ -30,7 +30,7 @@ const mergeTest = (
   gridA: Structs.ElementNew[][],
   gridB: Structs.ElementNew[][],
   generator: () => SimpleGenerators,
-  comparator: (a: SugarElement, b: SugarElement) => boolean
+  comparator: (a: SugarElement<HTMLElement>, b: SugarElement<HTMLElement>) => boolean
 ): void => {
   // The last step, merge cells from gridB into gridA
   const nuGrid = TableMerge.merge(
@@ -63,7 +63,7 @@ const mergeIVTest = (
   gridSpecA: Spec,
   gridSpecB: Spec,
   generator: () => SimpleGenerators,
-  comparator: (a: SugarElement, b: SugarElement) => boolean
+  comparator: (a: SugarElement<HTMLElement>, b: SugarElement<HTMLElement>) => boolean
 ): void => {
   // The last step, merge cells from gridB into gridA
   const nuGrid = TableMerge.merge(
@@ -82,7 +82,7 @@ const suite = (
   gridA: Structs.ElementNew[][],
   gridB: Structs.ElementNew[][],
   generator: () => SimpleGenerators,
-  comparator: (a: SugarElement, b: SugarElement) => boolean,
+  comparator: (a: SugarElement<HTMLElement>, b: SugarElement<HTMLElement>) => boolean,
   expectedMeasure: { rowDelta: number; colDelta: number },
   expectedTailor: Structs.ElementNew[][],
   expectedMergeGrids: Structs.ElementNew[][]

--- a/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/ResizeHandler.ts
@@ -20,7 +20,7 @@ import * as TableWire from './TableWire';
 
 export interface ResizeHandler {
   readonly lazyResize: () => Optional<TableResize>;
-  readonly lazyWire: () => any;
+  readonly lazyWire: () => ResizeWire;
   readonly destroy: () => void;
 }
 
@@ -49,7 +49,7 @@ export const getResizeHandler = (editor: Editor): ResizeHandler => {
   const lazyResizingBehaviour = () =>
     Options.isPreserveTableColumnResizing(editor) ? ResizeBehaviour.preserveTable() : ResizeBehaviour.resizeTable();
 
-  const getNumColumns = (table: SugarElement<Element>) =>
+  const getNumColumns = (table: SugarElement<HTMLTableElement>) =>
     TableGridSize.getGridSize(table).columns;
 
   const afterCornerResize = (table: SugarElement<HTMLTableElement>, origin: string, width: number) => {

--- a/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/actions/TableActions.ts
@@ -31,7 +31,7 @@ export type AdvancedPasteTableAction = TableAction<RunOperation.TargetPasteRows>
 export type LookupAction = (table: SugarElement<HTMLTableElement>, target: RunOperation.TargetSelection) => string;
 
 type GuardFn = (table: SugarElement<HTMLTableElement>) => boolean;
-type MutateFn = (e1: SugarElement<any>, e2: SugarElement<any>) => void;
+type MutateFn = <T>(e1: SugarElement<T>, e2: SugarElement<T>) => void;
 
 export interface TableActions {
   readonly deleteRow: CombinedTargetsTableAction;

--- a/modules/tinymce/src/plugins/table/main/ts/queries/TableTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/queries/TableTargets.ts
@@ -26,7 +26,7 @@ const forMenu = (selections: Selections, table: SugarElement<HTMLTableElement>, 
   selection: CellOpSelection.selection(selections)
 });
 
-const paste = (element: SugarElement<Element>, clipboard: SugarElement<HTMLTableElement>, generators: SimpleGenerators): RunOperation.TargetPaste => ({
+const paste = (element: SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>, clipboard: SugarElement<HTMLTableElement>, generators: SimpleGenerators): RunOperation.TargetPaste => ({
   element,
   clipboard,
   generators

--- a/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/CellSelection.ts
@@ -150,7 +150,7 @@ export default (editor: Editor, lazyResize: () => Optional<TableResize>, selecti
 
       const touchEnd = (t: TouchEvent) => {
         const target = SugarElement.fromDom(t.target as Node);
-        if (SugarNode.name(target) === 'td' || SugarNode.name(target) === 'th') {
+        if (SugarNode.isTag('td')(target) || SugarNode.isTag('th')(target)) {
           const lT = lastTarget.get();
           const lTS = lastTimeStamp.get();
           if (Compare.eq(lT, target) && (t.timeStamp - lTS) < 300) {


### PR DESCRIPTION
Related Ticket: TINY-8331

Description of Changes:

This is a second PR to start cleaning up some of the `any` types we have for `SugarElement` in the hopes that we maybe able to remove the `any` default we currently have. This one was pretty involved as I had to update the Snooker `Struct` types to be generic so that they tracked which element they contained (a cell or col for example). I also added the `TableTypes.ts` file to store some duplicate types I found through out the snooker code.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
