### PR TITLE
TINY-8331: Added some SugarElement types for Alloy

### DIFF
--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/DraggableResizerDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/DraggableResizerDemo.ts
@@ -20,7 +20,7 @@ export default (): void => {
   Attachment.attachSystem(body, gui);
   Css.set(body, 'margin-bottom', '2000px');
 
-  const onDrag = (comp: AlloyComponent, targetElement: SugarElement, delta: SugarPosition) => {
+  const onDrag = (comp: AlloyComponent, targetElement: SugarElement<Node>, delta: SugarPosition) => {
     Traverse.parent(targetElement).bind(Traverse.parent).bind(Traverse.firstChild).each((box) => {
       Css.getRaw(box, 'height').each((h) => {
         const parsedHeight = parseInt(h, 10);

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/DragnDropDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/DragnDropDemo.ts
@@ -79,7 +79,7 @@ export default (): void => {
           return data;
         },
         getImage: (component) => {
-          const clone = Replication.deep(component.element);
+          const clone = Replication.deep<HTMLElement>(component.element);
           Css.set(clone, 'background-color', 'blue');
           return {
             element: clone,

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/ForeignGuiDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/ForeignGuiDemo.ts
@@ -13,7 +13,7 @@ import * as ForeignGui from 'ephox/alloy/api/system/ForeignGui';
 
 import * as Frames from './frames/Frames';
 
-const resize = (element: SugarElement, changeX: number, changeY: number): void => {
+const resize = (element: SugarElement<HTMLElement>, changeX: number, changeY: number): void => {
   const heading = document.querySelector('h2');
   if (heading === null) {
     throw new Error('heading not found');
@@ -30,7 +30,7 @@ export default (): void => {
   const ephoxUi = SelectorFind.first('#ephox-ui').getOrDie();
   const platform = PlatformDetection.detect();
 
-  const onNode = (name: string) => (elem: SugarElement): Optional<SugarElement> =>
+  const onNode = (name: string) => (elem: SugarElement<Node>): Optional<SugarElement<Node>> =>
     Optionals.someIf(SugarNode.name(elem) === name, elem);
 
   const contents = '<div><strong>drag1</strong> and <code>click1</code> and <strong>drag2</strong> ' +
@@ -59,11 +59,11 @@ export default (): void => {
     addAsForeign(root);
   });
 
-  const inlineContainer = SugarElement.fromHtml(
+  const inlineContainer = SugarElement.fromHtml<HTMLDivElement>(
     contents
   );
 
-  const addAsForeign = (root: SugarElement) => {
+  const addAsForeign = (root: SugarElement<HTMLElement>) => {
     const connection = ForeignGui.engage({
       root,
       dispatchers: [

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/PinchingDemo.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/PinchingDemo.ts
@@ -10,7 +10,7 @@ export default (): void => {
   const ephoxUi = SelectorFind.first('#ephox-ui').getOrDie();
 
   // Naive resize handler
-  const resize = (element: SugarElement, changeX: number, changeY: number) => {
+  const resize = (element: SugarElement<HTMLElement>, changeX: number, changeY: number) => {
     const width = Css.getRaw(element, 'width').map((w) => parseInt(w, 10)).getOrThunk(() => Width.get(element));
 
     const height = Css.getRaw(element, 'height').map((h) => parseInt(h, 10)).getOrThunk(() => Height.get(element));

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/frames/Frames.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/frames/Frames.ts
@@ -3,7 +3,7 @@ import { SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 
 /* eslint-disable no-console */
 
-const iframeDoc = (element: SugarElement<HTMLFrameElement>): Optional<SugarElement<Document>> => {
+const iframeDoc = (element: SugarElement<HTMLIFrameElement>): Optional<SugarElement<Document>> => {
   const dom = element.dom;
   try {
     const idoc = dom.contentWindow ? dom.contentWindow.document : dom.contentDocument;
@@ -17,7 +17,7 @@ const iframeDoc = (element: SugarElement<HTMLFrameElement>): Optional<SugarEleme
 };
 
 // NOTE: This looks like it is only used in the demo. Move out.
-const readDoc = (element: SugarElement): SugarElement<Document> => {
+const readDoc = (element: SugarElement<HTMLIFrameElement>): SugarElement<Document> => {
   const optDoc = iframeDoc(element);
   return optDoc.getOrThunk(() =>
     // INVESTIGATE: This is new, but there is nothing else than can be done here atm. Rethink.
@@ -25,7 +25,7 @@ const readDoc = (element: SugarElement): SugarElement<Document> => {
   );
 };
 
-const write = (element: SugarElement, content: string): void => {
+const write = (element: SugarElement<HTMLIFrameElement>, content: string): void => {
   if (!SugarBody.inBody(element)) {
     throw new Error('Internal error: attempted to write to an iframe that is not n the DOM');
   }

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/ComponentStructure.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/ComponentStructure.ts
@@ -5,13 +5,13 @@ import { AlloyComponent } from '../api/component/ComponentApi';
 import * as AriaOwner from '../aria/AriaOwner';
 import { AnchorSpec } from '../positioning/mode/Anchoring';
 
-const isAriaPartOf = (component: AlloyComponent, queryElem: SugarElement): boolean =>
-  AriaOwner.find(queryElem).exists((owner: SugarElement) => isPartOf(component, owner));
+const isAriaPartOf = (component: AlloyComponent, queryElem: SugarElement<Node>): boolean =>
+  AriaOwner.find(queryElem).exists((owner) => isPartOf(component, owner));
 
-const isPartOf = (component: AlloyComponent, queryElem: SugarElement): boolean =>
-  PredicateExists.closest(queryElem, (el: SugarElement) => Compare.eq(el, component.element), Fun.never) || isAriaPartOf(component, queryElem);
+const isPartOf = (component: AlloyComponent, queryElem: SugarElement<Node>): boolean =>
+  PredicateExists.closest(queryElem, (el) => Compare.eq(el, component.element), Fun.never) || isAriaPartOf(component, queryElem);
 
-const isPartOfAnchor = (anchor: AnchorSpec, queryElem: SugarElement): boolean =>
+const isPartOfAnchor = (anchor: AnchorSpec, queryElem: SugarElement<Node>): boolean =>
   anchor.type === 'hotspot' && isPartOf(anchor.hotspot, queryElem);
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Descend.ts
@@ -12,7 +12,7 @@ const point = <T extends Node> (element: SugarElement<T>, offset: number): Eleme
 
 // NOTE: This only descends once.
 const descendOnce = (element: SugarElement<Node>, offset: number): ElementAndOffset<Node> => {
-  const children: SugarElement[] = Traverse.children(element);
+  const children = Traverse.children(element);
   if (children.length === 0) {
     return point(element, offset);
   } else if (offset < children.length) {

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/DomState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/DomState.ts
@@ -6,10 +6,11 @@ const attrName = Id.generate('dom-data');
 // garbage collected rather than stored in a separate list that needs to be in sync with the DOM.
 // We don't want people to use this very often (it's used for ForeignGui), and we especially don't
 // want to try and store more than one thing on the DOM node, so the attribute name is hard-coded.
-const getOrCreate = <A>(element: SugarElement, f: () => A): A => {
-  const existing = Obj.get(element.dom, attrName);
+const getOrCreate = <A>(element: SugarElement<Node>, f: () => A): A => {
+  const elem = element.dom as any;
+  const existing = Obj.get<Record<string, A>, string>(elem, attrName);
   const data = existing.getOrThunk(f);
-  element.dom[attrName] = data;
+  elem[attrName] = data;
   return data;
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/EditableFields.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/EditableFields.ts
@@ -1,8 +1,8 @@
 import { Attribute, SugarElement, SugarNode } from '@ephox/sugar';
 
-const inside = (target: SugarElement): boolean => (
-  (SugarNode.name(target) === 'input' && Attribute.get(target, 'type') !== 'radio') ||
-  SugarNode.name(target) === 'textarea'
+const inside = (target: SugarElement<Node>): boolean => (
+  (SugarNode.isTag('input')(target) && Attribute.get(target, 'type') !== 'radio') ||
+  SugarNode.isTag('textarea')(target)
 );
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/ElementFromPoint.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/ElementFromPoint.ts
@@ -3,16 +3,11 @@ import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import { AlloyComponent } from '../api/component/ComponentApi';
 
-// Note, elementFromPoint gives a different answer than caretRangeFromPoint
-const elementFromPoint = (doc: SugarElement<HTMLDocument>, x: number, y: number): Optional<SugarElement> => Optional.from(
-  doc.dom.elementFromPoint(x, y)
-).map(SugarElement.fromDom);
+const insideComponent = (component: AlloyComponent, x: number, y: number): Optional<SugarElement<Element>> => {
+  const isInside = (node: SugarElement<Element>) => component.element.dom.contains(node.dom);
 
-const insideComponent = (component: AlloyComponent, x: number, y: number): Optional<SugarElement> => {
-  const isInside = (node: SugarElement) => component.element.dom.contains(node.dom);
-
-  const hasValidRect = (node: SugarElement): boolean => {
-    const elem: Optional<SugarElement> = SugarNode.isText(node) ? Traverse.parent(node) : Optional.some(node);
+  const hasValidRect = (node: SugarElement<Element>): boolean => {
+    const elem = SugarNode.isText(node) ? Traverse.parentElement(node) : Optional.some(node);
     return elem.exists((e) => {
       const rect = e.dom.getBoundingClientRect();
       return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
@@ -20,7 +15,7 @@ const insideComponent = (component: AlloyComponent, x: number, y: number): Optio
   };
 
   const doc = Traverse.owner(component.element);
-  return elementFromPoint(doc, x, y).filter(isInside).filter(hasValidRect);
+  return SugarElement.fromPoint(doc, x, y).filter(isInside).filter(hasValidRect);
 };
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/OffsetOrigin.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/OffsetOrigin.ts
@@ -1,7 +1,7 @@
 import { Optional, Optionals } from '@ephox/katamari';
 import { Css, Insert, Remove, SugarElement, SugarLocation, SugarPosition, Traverse } from '@ephox/sugar';
 
-const getOffsetParent = (element: SugarElement): Optional<SugarElement<HTMLElement>> => {
+const getOffsetParent = (element: SugarElement<HTMLElement>): Optional<SugarElement<HTMLElement>> => {
   // Firefox sets the offsetParent to the body when fixed instead of null like
   // all other browsers. So we need to check if the element is fixed and if so then
   // disregard the elements offsetParent.
@@ -24,7 +24,7 @@ const getOffsetParent = (element: SugarElement): Optional<SugarElement<HTMLEleme
  * This allows the absolute coordinates to be obtained by adding the
  * origin to the offset coordinates and not needing to know scroll.
  */
-const getOrigin = (element: SugarElement): SugarPosition =>
+const getOrigin = (element: SugarElement<HTMLElement>): SugarPosition =>
   getOffsetParent(element).map(SugarLocation.absolute).getOrThunk(() => SugarPosition(0, 0));
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/ComponentApi.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/ComponentApi.ts
@@ -20,7 +20,7 @@ export interface AlloyComponent {
   readonly connect: (newApi: AlloySystemApi) => void;
   readonly disconnect: () => void;
   readonly getApis: <A>() => A;
-  readonly element: SugarElement;
+  readonly element: SugarElement<any>;
   readonly syncComponents: () => void;
   readonly components: () => AlloyComponent[];
   readonly events: ReadonlyRecord<string, UncurriedHandler>;

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/ComponentUtil.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/ComponentUtil.ts
@@ -3,7 +3,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import { AlloyComponent } from './ComponentApi';
 
-const toElem = (component: AlloyComponent): SugarElement => component.element;
+const toElem = (component: AlloyComponent): SugarElement<any> => component.element;
 
 const getByUid = (component: AlloyComponent, uid: string): Optional<AlloyComponent> => component.getSystem().getByUid(uid).toOptional();
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
@@ -44,9 +44,9 @@ const text = (textContent: string): PremadeSpec => {
 };
 
 // Rename.
-export interface ExternalElement { uid?: string; element: SugarElement }
+export interface ExternalElement { uid?: string; element: SugarElement<Node> }
 const external = (spec: ExternalElement): PremadeSpec => {
-  const extSpec: { uid: Optional<string>; element: SugarElement } = StructureSchema.asRawOrDie('external.component', StructureSchema.objOfOnly([
+  const extSpec: { uid: Optional<string>; element: SugarElement<Node> } = StructureSchema.asRawOrDie('external.component', StructureSchema.objOfOnly([
     FieldSchema.required('element'),
     FieldSchema.option('uid')
   ]), spec);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyTriggers.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyTriggers.ts
@@ -16,11 +16,11 @@ const emitExecute = (component: AlloyComponent): void => {
   emit(component, SystemEvents.execute());
 };
 
-const dispatch = (component: AlloyComponent, target: SugarElement, event: string): void => {
+const dispatch = (component: AlloyComponent, target: SugarElement<Node>, event: string): void => {
   dispatchWith(component, target, event, { });
 };
 
-const dispatchWith = (component: AlloyComponent, target: SugarElement, event: string, properties: Record<string, any>): void => {
+const dispatchWith = (component: AlloyComponent, target: SugarElement<Node>, event: string, properties: Record<string, any>): void => {
   const data = {
     target,
     ...properties
@@ -28,11 +28,11 @@ const dispatchWith = (component: AlloyComponent, target: SugarElement, event: st
   component.getSystem().triggerEvent(event, target, data);
 };
 
-const dispatchEvent = <T extends EventFormat>(component: AlloyComponent, target: SugarElement, event: string, simulatedEvent: SimulatedEvent<T>): void => {
+const dispatchEvent = <T extends EventFormat>(component: AlloyComponent, target: SugarElement<Node>, event: string, simulatedEvent: SimulatedEvent<T>): void => {
   component.getSystem().triggerEvent(event, target, simulatedEvent.event);
 };
 
-const dispatchFocus = (component: AlloyComponent, target: SugarElement): void => {
+const dispatchFocus = (component: AlloyComponent, target: SugarElement<HTMLElement>): void => {
   component.getSystem().triggerFocus(target, component.element);
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/events/SystemEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/events/SystemEvents.ts
@@ -74,8 +74,8 @@ const dismissRequested = prefixName('system.dismissRequested');
 const repositionRequested = prefixName('system.repositionRequested');
 
 export interface AlloyFocusShiftedEvent extends CustomEvent {
-  readonly prevFocus: Optional<SugarElement>;
-  readonly newFocus: Optional<SugarElement>;
+  readonly prevFocus: Optional<SugarElement<HTMLElement>>;
+  readonly newFocus: Optional<SugarElement<HTMLElement>>;
 }
 
 const focusShifted = prefixName('focusmanager.shifted');

--- a/modules/alloy/src/main/ts/ephox/alloy/api/focus/FocusManagers.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/focus/FocusManagers.ts
@@ -6,7 +6,7 @@ import { AlloyComponent } from '../component/ComponentApi';
 import * as AlloyTriggers from '../events/AlloyTriggers';
 import * as SystemEvents from '../events/SystemEvents';
 
-const reportFocusShifting = (component: AlloyComponent, prevFocus: Optional<SugarElement>, newFocus: Optional<SugarElement>) => {
+const reportFocusShifting = (component: AlloyComponent, prevFocus: Optional<SugarElement<HTMLElement>>, newFocus: Optional<SugarElement<HTMLElement>>) => {
   const noChange = prevFocus.exists((p) => newFocus.exists((n) => Compare.eq(n, p)));
   if (!noChange) {
     AlloyTriggers.emitWith(component, SystemEvents.focusShifted(), {
@@ -17,14 +17,14 @@ const reportFocusShifting = (component: AlloyComponent, prevFocus: Optional<Suga
 };
 
 export interface FocusManager {
-  get: (component: AlloyComponent) => Optional<SugarElement>;
-  set: (component: AlloyComponent, focusee: SugarElement) => void;
+  get: (component: AlloyComponent) => Optional<SugarElement<HTMLElement>>;
+  set: (component: AlloyComponent, focusee: SugarElement<HTMLElement>) => void;
 }
 
 const dom = (): FocusManager => {
   const get = (component: AlloyComponent) => Focus.search(component.element);
 
-  const set = (component: AlloyComponent, focusee: SugarElement) => {
+  const set = (component: AlloyComponent, focusee: SugarElement<HTMLElement>) => {
     const prevFocus = get(component);
     component.getSystem().triggerFocus(focusee, component.element);
     const newFocus = get(component);
@@ -40,7 +40,7 @@ const dom = (): FocusManager => {
 const highlights = (): FocusManager => {
   const get = (component: AlloyComponent) => Highlighting.getHighlighted(component).map((item) => item.element);
 
-  const set = (component: AlloyComponent, element: SugarElement) => {
+  const set = (component: AlloyComponent, element: SugarElement<HTMLElement>) => {
     const prevFocus = get(component);
     component.getSystem().getByDom(element).fold(Fun.noop, (item) => {
       Highlighting.highlight(component, item);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/Attachment.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/Attachment.ts
@@ -9,7 +9,7 @@ const attach = (parent: AlloyComponent, child: AlloyComponent): void => {
   attachWith(parent, child, Insert.append);
 };
 
-const attachWith = (parent: AlloyComponent, child: AlloyComponent, insertion: (parent: SugarElement, child: SugarElement) => void): void => {
+const attachWith = (parent: AlloyComponent, child: AlloyComponent, insertion: (parent: SugarElement<Node>, child: SugarElement<Node>) => void): void => {
   parent.getSystem().addToWorld(child);
   insertion(parent.element, child.element);
   if (SugarBody.inBody(parent.element)) {
@@ -42,15 +42,15 @@ const detachChildren = (component: AlloyComponent): void => {
   component.syncComponents();
 };
 
-const attachSystem = (element: SugarElement, guiSystem: GuiSystem): void => {
+const attachSystem = (element: SugarElement<Node>, guiSystem: GuiSystem): void => {
   attachSystemWith(element, guiSystem, Insert.append);
 };
 
-const attachSystemAfter = (element: SugarElement, guiSystem: GuiSystem): void => {
+const attachSystemAfter = (element: SugarElement<Node>, guiSystem: GuiSystem): void => {
   attachSystemWith(element, guiSystem, Insert.after);
 };
 
-const attachSystemWith = (element: SugarElement, guiSystem: GuiSystem, inserter: (marker: SugarElement, element: SugarElement) => void): void => {
+const attachSystemWith = (element: SugarElement<Node>, guiSystem: GuiSystem, inserter: (marker: SugarElement<Node>, element: SugarElement<Node>) => void): void => {
   inserter(element, guiSystem.element);
   const children = Traverse.children(guiSystem.element);
   Arr.each(children, (child) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/ForeignGui.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/ForeignGui.ts
@@ -13,9 +13,9 @@ import { AlloyEventRecord } from '../events/AlloyEvents';
 import * as Gui from './Gui';
 
 export interface ForeignGuiSpec {
-  readonly root: SugarElement;
+  readonly root: SugarElement<Node>;
   readonly dispatchers: Dispatcher[];
-  readonly insertion?: (root: SugarElement, system: Gui.GuiSystem) => void;
+  readonly insertion?: (root: SugarElement<Node>, system: Gui.GuiSystem) => void;
 }
 
 export interface DispatchedAlloyConfig {
@@ -25,18 +25,18 @@ export interface DispatchedAlloyConfig {
 }
 
 export interface Dispatcher {
-  readonly getTarget: (elem: SugarElement) => Optional<SugarElement>;
+  readonly getTarget: (elem: SugarElement<Node>) => Optional<SugarElement<Node>>;
   readonly alloyConfig: DispatchedAlloyConfig;
 }
 
 export interface ForeignGuiDetail {
-  readonly root: SugarElement;
+  readonly root: SugarElement<Node>;
   readonly dispatchers: Dispatcher[];
-  readonly insertion: (root: SugarElement, system: Gui.GuiSystem) => void;
+  readonly insertion: (root: SugarElement<Node>, system: Gui.GuiSystem) => void;
 }
 
 interface DispatcherMission {
-  readonly target: SugarElement;
+  readonly target: SugarElement<Node>;
   readonly dispatcher: Dispatcher;
 }
 
@@ -54,7 +54,7 @@ const schema = StructureSchema.objOfOnly([
     // The configuration for the behaviours
     FieldSchema.required('alloyConfig')
   ]),
-  FieldSchema.defaulted('insertion', (root: SugarElement, system: AlloyComponent) => {
+  FieldSchema.defaulted('insertion', (root: SugarElement<Node>, system: AlloyComponent) => {
     Insert.append(root, system.element);
   })
 ]);
@@ -99,13 +99,13 @@ const supportedEvents = [
 
 // Find the dispatcher information for the target if available. Note, the
 // dispatcher may also change the target.
-const findDispatcher = (dispatchers: Dispatcher[], target: SugarElement): Optional<DispatcherMission> =>
+const findDispatcher = (dispatchers: Dispatcher[], target: SugarElement<Node>): Optional<DispatcherMission> =>
   Arr.findMap(dispatchers, (dispatcher: Dispatcher) => dispatcher.getTarget(target).map((newTarget) => ({
     target: newTarget,
     dispatcher
   })));
 
-const getProxy = <T extends SimulatedEvent.EventFormat>(event: T, target: SugarElement) => {
+const getProxy = <T extends SimulatedEvent.EventFormat>(event: T, target: SugarElement<Node>) => {
   // Setup the component wrapping for the target element
   const component = GuiFactory.build(
     GuiFactory.external({ element: target })
@@ -133,7 +133,7 @@ const engage = (spec: ForeignGuiSpec): ForeignGuiConnection => {
     dispatchTo(type, event);
   }));
 
-  const proxyFor = <T extends SimulatedEvent.EventFormat>(event: T, target: SugarElement, descHandler: UncurriedHandler) => {
+  const proxyFor = <T extends SimulatedEvent.EventFormat>(event: T, target: SugarElement<Node>, descHandler: UncurriedHandler) => {
     // create a simple alloy wrapping around the element, and add it to the world
     const proxy = getProxy(event, target);
     const component = proxy.component;

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/SystemApi.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/SystemApi.ts
@@ -13,7 +13,7 @@ export interface AlloySystemApi {
   broadcastEvent: (eventName: string, event: EventArgs) => void;
   build: (spec: AlloySpec) => AlloyComponent;
   debugInfo: () => string;
-  getByDom: (element: SugarElement) => Result<AlloyComponent, Error>;
+  getByDom: (element: SugarElement<Node>) => Result<AlloyComponent, Error>;
   getByUid: (uid: string) => Result<AlloyComponent, Error>;
   removeFromGui: (component: AlloyComponent) => void;
   removeFromWorld: (component: AlloyComponent) => void;
@@ -22,6 +22,6 @@ export interface AlloySystemApi {
   // Weird method. Required?
   triggerEscape: (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent) => void;
 
-  triggerEvent: (eventName: string, target: SugarElement, data: {}) => void;
-  triggerFocus: (target: SugarElement, originator: SugarElement) => void;
+  triggerEvent: (eventName: string, target: SugarElement<Node>, data: {}) => void;
+  triggerFocus: (target: SugarElement<HTMLElement>, originator: SugarElement<Node>) => void;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/api/testhelpers/GuiSetup.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/testhelpers/GuiSetup.ts
@@ -8,6 +8,7 @@ import * as Gui from '../system/Gui';
 import { TestStore } from './TestStore';
 
 type RootNode = SugarShadowDom.RootNode;
+type ContentContainer<T extends RootNode> = T extends ShadowRoot ? ShadowRoot : HTMLElement;
 
 export interface KeyLoggerState {
   readonly log: string[];
@@ -33,14 +34,15 @@ export interface Hook<T extends RootNode> {
 
 const setupIn = <T extends RootNode>(
   root: T,
-  createComponent: (store: TestStore, doc: T, body: SugarElement<Node>) => AlloyComponent,
-  f: (doc: T, body: SugarElement, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore
-  ) => Array<Step<any, any>>, success: () => void, failure: (err: any, logs?: TestLogs) => void
+  createComponent: (store: TestStore, doc: T, body: SugarElement<ContentContainer<T>>) => AlloyComponent,
+  f: (doc: T, body: SugarElement<ContentContainer<T>>, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Array<Step<any, any>>,
+  success: () => void,
+  failure: (err: any, logs?: TestLogs) => void
 ) => {
   const store = TestStore();
 
   const gui = Gui.create();
-  const contentContainer = SugarShadowDom.getContentContainer(root);
+  const contentContainer = SugarShadowDom.getContentContainer(root) as SugarElement<ContentContainer<T>>;
 
   Attachment.attachSystem(contentContainer, gui);
 
@@ -123,7 +125,7 @@ const bddSetupIn = <T extends RootNode>(
  * @param failure
  */
 const setup = (
-  createComponent: (store: TestStore, doc: SugarElement<Document>, body: SugarElement<Node>) => AlloyComponent,
+  createComponent: (store: TestStore, doc: SugarElement<Document>, body: SugarElement<HTMLElement>) => AlloyComponent,
   f: (doc: SugarElement<Document>, body: SugarElement<HTMLElement>, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Array<Step<any, any>>,
   success: () => void,
   failure: (err: any, logs?: TestLogs) => void
@@ -199,8 +201,8 @@ const setupInBodyAndShadowRoot = (
  * @param success
  * @param failure
  */
-const guiSetup = <A, B> (createComponent: (store: TestStore, doc: SugarElement, body: SugarElement) => AlloyComponent,
-  f: (doc: SugarElement<Document>, body: SugarElement<Node>, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Step<A, B>,
+const guiSetup = <A, B> (createComponent: (store: TestStore, doc: SugarElement<Document>, body: SugarElement<HTMLElement>) => AlloyComponent,
+  f: (doc: SugarElement<Document>, body: SugarElement<HTMLElement>, gui: Gui.GuiSystem, component: AlloyComponent, store: TestStore) => Step<A, B>,
   success: () => void, failure: (err: any, logs?: TestLogs) => void): void => {
   setup(createComponent, (doc, body, gui, component, store) => [
     f(doc, body, gui, component, store)

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -1,5 +1,4 @@
 import { Fun, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
 
 import * as ComponentStructure from '../../alien/ComponentStructure';
 import * as AriaOwner from '../../aria/AriaOwner';
@@ -95,7 +94,7 @@ const makeSandbox = (button: AlloyComponent, spec: FloatingToolbarButtonSpec, de
         Sandboxing.config({
           onOpen,
           onClose,
-          isPartOf: (container: AlloyComponent, data: AlloyComponent, queryElem: SugarElement): boolean => {
+          isPartOf: (container, data, queryElem): boolean => {
             return ComponentStructure.isPartOf(data, queryElem) || ComponentStructure.isPartOf(button, queryElem);
           },
           getAttachPoint: () => {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
@@ -96,7 +96,7 @@ const makeMenu = (detail: InlineViewDetail, menuSandbox: AlloyComponent, placeme
 };
 
 const factory: SingleSketchFactory<InlineViewDetail, InlineViewSpec> = (detail: InlineViewDetail, spec): SketchSpec => {
-  const isPartOfRelated = (sandbox: AlloyComponent, queryElem: SugarElement) => {
+  const isPartOfRelated = (sandbox: AlloyComponent, queryElem: SugarElement<Node>) => {
     const related = detail.getRelated(sandbox);
     return related.exists((rel) => ComponentStructure.isPartOf(rel, queryElem));
   };
@@ -110,7 +110,7 @@ const factory: SingleSketchFactory<InlineViewDetail, InlineViewSpec> = (detail: 
     showWithin(sandbox, thing, placementSpec, Optional.none());
   };
 
-  const showWithin = (sandbox: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec, boxElement: Optional<SugarElement>) => {
+  const showWithin = (sandbox: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec, boxElement: Optional<SugarElement<HTMLElement>>) => {
     showWithinBounds(sandbox, thing, placementSpec, () => boxElement.map((elem) => Boxes.box(elem)));
   };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/TouchMenu.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/TouchMenu.ts
@@ -172,10 +172,10 @@ const factory: CompositeSketchFactory<TouchMenuDetail, TouchMenuSpec> = (detail,
             Focus.active(dos).each(Focus.blur);
 
             // could not find an item, so check the button itself
-            const hoverF = ElementFromPoint.insideComponent(component, e.clientX, e.clientY).fold(
+            const hoverF = ElementFromPoint.insideComponent(component, e.clientX, e.clientY).fold<TouchHoverState>(
               Fun.constant(hoverOff),
               Fun.constant(hoverOn)
-            ) as TouchHoverState;
+            );
 
             hoverF(component);
           }, (elem) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaDescribe.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaDescribe.ts
@@ -1,7 +1,7 @@
 import { Fun, Id, Optional } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
-const describedBy = (describedElement: SugarElement, describeElement: SugarElement): void => {
+const describedBy = (describedElement: SugarElement<Element>, describeElement: SugarElement<Element>): void => {
   const describeId = Optional.from(Attribute.get(describedElement, 'id'))
     .fold(() => {
       const id = Id.generate('dialog-describe');

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaFocus.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaFocus.ts
@@ -1,18 +1,18 @@
 import { Fun, Optional } from '@ephox/katamari';
 import { Compare, Focus, PredicateFind, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
-const preserve = <T>(f: (e: SugarElement) => T, container: SugarElement): T => {
+const preserve = <T extends Node, R>(f: (e: SugarElement<T>) => R, container: SugarElement<T>): R => {
   const dos = SugarShadowDom.getRootNode(container);
 
-  const refocus = Focus.active(dos).bind((focused: SugarElement) => {
-    const hasFocus = (elem: SugarElement) => Compare.eq(focused, elem);
+  const refocus = Focus.active(dos).bind((focused): Optional<SugarElement<HTMLElement>> => {
+    const hasFocus = (elem: SugarElement<Node>): elem is SugarElement<HTMLElement> => Compare.eq(focused, elem);
     return hasFocus(container) ? Optional.some(container) : PredicateFind.descendant(container, hasFocus);
   });
 
   const result = f(container);
 
   // If there is a focussed element, the F function may cause focus to be lost (such as by hiding elements). Restore it afterwards.
-  refocus.each((oldFocus: SugarElement) => {
+  refocus.each((oldFocus) => {
     Focus.active(dos).filter((newFocus) => Compare.eq(newFocus, oldFocus)).fold(() => {
       // Only refocus if the focus has changed, otherwise we break IE
       Focus.focus(oldFocus);

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaLabel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaLabel.ts
@@ -1,7 +1,7 @@
 import { Fun, Id } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
-export const labelledBy = (labelledElement: SugarElement, labelElement: SugarElement): void => {
+export const labelledBy = (labelledElement: SugarElement<Element>, labelElement: SugarElement<Element>): void => {
   const labelId = Attribute.getOpt(labelledElement, 'id')
     .fold(() => {
       const id = Id.generate('dialog-label');

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaOwner.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaOwner.ts
@@ -1,8 +1,8 @@
 import { Id, Optional } from '@ephox/katamari';
 import { Attribute, PredicateFind, SelectorFind, SugarElement, SugarNode, SugarShadowDom } from '@ephox/sugar';
 
-const find = (queryElem: SugarElement): Optional<SugarElement> => {
-  const dependent: Optional<SugarElement> = PredicateFind.closest(queryElem, (elem) => {
+const find = (queryElem: SugarElement<Node>): Optional<SugarElement<Element>> => {
+  const dependent = PredicateFind.closest(queryElem, (elem): elem is SugarElement<Element> => {
     if (!SugarNode.isElement(elem)) {
       return false;
     }
@@ -20,18 +20,18 @@ const find = (queryElem: SugarElement): Optional<SugarElement> => {
 
 export interface AriaManager {
   id: string;
-  link: (elem: SugarElement) => void;
-  unlink: (elem: SugarElement) => void;
+  link: (elem: SugarElement<Element>) => void;
+  unlink: (elem: SugarElement<Element>) => void;
 }
 
 const manager = (): AriaManager => {
   const ariaId = Id.generate('aria-owns');
 
-  const link = (elem: SugarElement) => {
+  const link = (elem: SugarElement<Element>) => {
     Attribute.set(elem, 'aria-owns', ariaId);
   };
 
-  const unlink = (elem: SugarElement) => {
+  const unlink = (elem: SugarElement<Element>) => {
     Attribute.remove(elem, 'aria-owns');
   };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaVoice.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaVoice.ts
@@ -10,22 +10,22 @@ const offscreen = {
 const tokenSelector = Fun.constant('span[id^="ephox-alloy-aria-voice"]');
 
 // INVESTIGATE: Aria is special for insertion. Think about it more.
-const create = (doc: SugarElement<HTMLDocument>, text: string): SugarElement => {
-  const span: SugarElement = SugarElement.fromTag('span', doc.dom);
+const create = (doc: SugarElement<Document>, text: string): SugarElement<HTMLSpanElement> => {
+  const span = SugarElement.fromTag('span', doc.dom);
   Attribute.set(span, 'role', 'presentation');
   // This stops it saying other things (possibly blank) between transitions.
-  const contents: SugarElement = SugarElement.fromText(text, doc.dom);
+  const contents = SugarElement.fromText(text, doc.dom);
   Insert.append(span, contents);
   return span;
 };
 
-const linkToDescription = (item: SugarElement, token: SugarElement): void => {
+const linkToDescription = (item: SugarElement<Element>, token: SugarElement<Element>): void => {
   const id = Id.generate('ephox-alloy-aria-voice');
   Attribute.set(token, 'id', id);
   Attribute.set(item, 'aria-describedby', id);
 };
 
-const describe = (item: SugarElement, description: string): SugarElement => {
+const describe = (item: SugarElement<Element>, description: string): SugarElement<HTMLSpanElement> => {
   const doc = Traverse.owner(item);
   const token = create(doc, description);
 
@@ -39,7 +39,7 @@ const describe = (item: SugarElement, description: string): SugarElement => {
   return token;
 };
 
-const base = (getAttrs: (string: string) => { }, parent: SugarElement, text: string): void => {
+const base = (getAttrs: (string: string) => { }, parent: SugarElement<Element>, text: string): void => {
   const doc = Traverse.owner(parent);
 
   // firefox needs aria-describedby to speak a role=alert token, which causes IE11 to read twice
@@ -76,9 +76,9 @@ const getShoutAttrs = (_text: string) => ({
   'role': 'alert'
 });
 
-const speak = (parent: SugarElement, text: string): void => base(getSpeakAttrs, parent, text);
+const speak = (parent: SugarElement<Element>, text: string): void => base(getSpeakAttrs, parent, text);
 
-const shout = (parent: SugarElement, text: string): void => base(getShoutAttrs, parent, text);
+const shout = (parent: SugarElement<Element>, text: string): void => base(getShoutAttrs, parent, text);
 
 export {
   describe,

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/highlighting/HighlightApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/highlighting/HighlightApis.ts
@@ -1,5 +1,5 @@
 import { Arr, Num, Optional, Optionals, Result } from '@ephox/katamari';
-import { Class, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Class, SelectorFilter, SelectorFind } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
@@ -85,8 +85,8 @@ const getFirst = (component: AlloyComponent, hConfig: HighlightingConfig, _hStat
   SelectorFind.descendant(component.element, '.' + hConfig.itemClass).bind((e) => component.getSystem().getByDom(e).toOptional());
 
 const getLast = (component: AlloyComponent, hConfig: HighlightingConfig, _hState: Stateless): Optional<AlloyComponent> => {
-  const items: SugarElement[] = SelectorFilter.descendants(component.element, '.' + hConfig.itemClass);
-  const last = items.length > 0 ? Optional.some(items[items.length - 1]) : Optional.none<SugarElement>();
+  const items = SelectorFilter.descendants(component.element, '.' + hConfig.itemClass);
+  const last = items.length > 0 ? Optional.some(items[items.length - 1]) : Optional.none();
   return last.bind((c) => component.getSystem().getByDom(c).toOptional());
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/InvalidateApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/InvalidateApis.ts
@@ -10,7 +10,7 @@ const ariaElements = [
   'textarea'
 ];
 
-const isAriaElement = (elem: SugarElement) => {
+const isAriaElement = (elem: SugarElement<Node>): elem is SugarElement<HTMLInputElement | HTMLTextAreaElement> => {
   const name = SugarNode.name(elem);
   return Arr.contains(ariaElements, name);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/InvalidateTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/InvalidateTypes.ts
@@ -16,10 +16,10 @@ export interface InvalidatingBehaviour extends Behaviour.AlloyBehaviour<Invalida
 
 export interface InvalidatingConfigSpec extends Behaviour.BehaviourConfigSpec {
   invalidClass: string;
-  getRoot?: (comp: AlloyComponent) => Optional<SugarElement>;
+  getRoot?: (comp: AlloyComponent) => Optional<SugarElement<Element>>;
   notify?: {
     aria?: string;
-    getContainer?: (input: AlloyComponent) => Optional<SugarElement>;
+    getContainer?: (input: AlloyComponent) => Optional<SugarElement<Node>>;
     validHtml?: string;
     onValid?: (comp: AlloyComponent) => void;
     onInvalid?: (comp: AlloyComponent, err: string) => void;
@@ -36,13 +36,13 @@ export interface InvalidatingConfig extends Behaviour.BehaviourConfigDetail {
   invalidClass: string;
   notify: Optional<{
     aria: string;
-    getContainer: (input: AlloyComponent) => Optional<SugarElement>;
+    getContainer: (input: AlloyComponent) => Optional<SugarElement<Node>>;
     onValid: (comp: AlloyComponent) => void;
     validHtml: string;
     onInvalid: (comp: AlloyComponent, err: string) => void;
     onValidate: (comp: AlloyComponent) => void;
   }>;
-  getRoot: (comp: AlloyComponent) => Optional<SugarElement>;
+  getRoot: (comp: AlloyComponent) => Optional<SugarElement<Element>>;
   validator: Optional<{
     validate: (input: AlloyComponent) => Future<Result<any, string>>;
     onEvent: string;

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/pinching/PinchingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/pinching/PinchingTypes.ts
@@ -14,13 +14,13 @@ export interface PinchingBehaviour extends Behaviour.AlloyBehaviour<PinchingConf
 }
 
 export interface PinchingConfig extends Behaviour.BehaviourConfigDetail {
-  readonly onPinch: (element: SugarElement, changeX: number, changeY: number) => void;
-  readonly onPunch: (element: SugarElement, changeX: number, changeY: number) => void;
+  readonly onPinch: (element: SugarElement<HTMLElement>, changeX: number, changeY: number) => void;
+  readonly onPunch: (element: SugarElement<HTMLElement>, changeX: number, changeY: number) => void;
 }
 
 export interface PinchingConfigSpec extends Behaviour.BehaviourConfigSpec {
-  readonly onPinch: (element: SugarElement, changeX: number, changeY: number) => void;
-  readonly onPunch: (element: SugarElement, changeX: number, changeY: number) => void;
+  readonly onPinch: (element: SugarElement<HTMLElement>, changeX: number, changeY: number) => void;
+  readonly onPunch: (element: SugarElement<HTMLElement>, changeX: number, changeY: number) => void;
 }
 
 export interface PinchingState extends BaseDraggingState<PinchDragData> { }

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
@@ -40,7 +40,7 @@ const position = (component: AlloyComponent, posConfig: PositioningConfig, posSt
   positionWithin(component, posConfig, posState, placee, placementSpec, Optional.none());
 };
 
-const positionWithin = (component: AlloyComponent, posConfig: PositioningConfig, posState: PositioningState, placee: AlloyComponent, placementSpec: PlacementSpec, boxElement: Optional<SugarElement>): void => {
+const positionWithin = (component: AlloyComponent, posConfig: PositioningConfig, posState: PositioningState, placee: AlloyComponent, placementSpec: PlacementSpec, boxElement: Optional<SugarElement<HTMLElement>>): void => {
   const boundsBox = boxElement.map(box);
   return positionWithinBounds(component, posConfig, posState, placee, placementSpec, boundsBox);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningTypes.ts
@@ -32,7 +32,7 @@ export interface PlacementDetail {
 export interface PositioningBehaviour extends Behaviour.AlloyBehaviour<PositioningConfigSpec, PositioningConfig> {
   readonly config: (config: PositioningConfigSpec) => Behaviour.NamedConfiguredBehaviour<PositioningConfigSpec, PositioningConfig>;
   readonly position: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec) => void;
-  readonly positionWithin: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec, boxElement: Optional<SugarElement>) => void;
+  readonly positionWithin: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec, boxElement: Optional<SugarElement<HTMLElement>>) => void;
   readonly positionWithinBounds: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec, bounds: Optional<Bounds>) => void;
   readonly getMode: (component: AlloyComponent) => string;
   readonly reset: (component: AlloyComponent, placee: AlloyComponent) => void;

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/replacing/ReplaceApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/replacing/ReplaceApis.ts
@@ -19,7 +19,7 @@ const set = (component: AlloyComponent, replaceConfig: ReplacingConfig, replaceS
   }, component.element);
 };
 
-const insert = (component: AlloyComponent, replaceConfig: ReplacingConfig, insertion: (p: SugarElement, c: SugarElement) => void, childSpec: AlloySpec): void => {
+const insert = (component: AlloyComponent, replaceConfig: ReplacingConfig, insertion: (p: SugarElement<Node>, c: SugarElement<Node>) => void, childSpec: AlloySpec): void => {
   const child = component.getSystem().build(childSpec);
   Attachment.attachWith(component, child, insertion);
 };
@@ -50,7 +50,7 @@ const replaceAt = (component: AlloyComponent, replaceConfig: ReplacingConfig, re
     remove(component, replaceConfig, replaceState, replacee);
 
     replacer.each((r) => {
-      insert(component, replaceConfig, (p: SugarElement, c: SugarElement) => {
+      insert(component, replaceConfig, (p: SugarElement<Node>, c: SugarElement<Node>) => {
         Insert.appendAt(p, c, replaceeIndex);
       }, r);
     });

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxApis.ts
@@ -56,7 +56,7 @@ const close = (sandbox: AlloyComponent, sConfig: SandboxingConfig, sState: Sandb
 const isOpen = (_sandbox: AlloyComponent, _sConfig: SandboxingConfig, sState: SandboxingState): boolean =>
   sState.isOpen();
 
-const isPartOf = (sandbox: AlloyComponent, sConfig: SandboxingConfig, sState: SandboxingState, queryElem: SugarElement): boolean =>
+const isPartOf = (sandbox: AlloyComponent, sConfig: SandboxingConfig, sState: SandboxingState, queryElem: SugarElement<Node>): boolean =>
   isOpen(sandbox, sConfig, sState) && sState.get().exists(
     (data) => sConfig.isPartOf(sandbox, data, queryElem)
   );
@@ -88,7 +88,7 @@ const cloak = (sandbox: AlloyComponent, sConfig: SandboxingConfig, _sState: Sand
   store(sandbox, 'visibility', sConfig.cloakVisibilityAttr, 'hidden');
 };
 
-const hasPosition = (element: SugarElement): boolean => Arr.exists(
+const hasPosition = (element: SugarElement<HTMLElement>): boolean => Arr.exists(
   [ 'top', 'left', 'right', 'bottom' ],
   (pos) => Css.getRaw(element, pos).isSome()
 );

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxingTypes.ts
@@ -14,7 +14,7 @@ export interface SandboxingBehaviour extends Behaviour.AlloyBehaviour<Sandboxing
   openWhileCloaked: (sandbox: AlloyComponent, thing: AlloySpec, transaction: () => void) => AlloyComponent;
   close: (sandbox: AlloyComponent) => void;
   isOpen: (sandbox: AlloyComponent) => boolean;
-  isPartOf: (sandbox: AlloyComponent, candidate: SugarElement) => boolean;
+  isPartOf: (sandbox: AlloyComponent, candidate: SugarElement<Node>) => boolean;
   getState: (sandbox: AlloyComponent) => Optional<AlloyComponent>;
   setContent: (sandbox: AlloyComponent, thing: AlloySpec) => Optional<AlloyComponent>;
   closeSandbox: (sandbox: AlloyComponent) => void;
@@ -22,7 +22,7 @@ export interface SandboxingBehaviour extends Behaviour.AlloyBehaviour<Sandboxing
 
 export interface SandboxingConfigSpec extends Behaviour.BehaviourConfigSpec {
   getAttachPoint: (sandbox: AlloyComponent) => AlloyComponent;
-  isPartOf: (sandbox: AlloyComponent, data: AlloyComponent, queryElem: SugarElement) => boolean;
+  isPartOf: (sandbox: AlloyComponent, data: AlloyComponent, queryElem: SugarElement<Node>) => boolean;
   onOpen?: (sandbox: AlloyComponent, menu: AlloyComponent) => void;
   onClose?: (sandbox: AlloyComponent, menu: AlloyComponent) => void;
   cloakVisibilityAttr?: string;
@@ -33,7 +33,7 @@ export interface SandboxingConfig extends Behaviour.BehaviourConfigDetail {
   getAttachPoint: (sandbox: AlloyComponent) => AlloyComponent;
   onOpen: (sandbox: AlloyComponent, thing: AlloyComponent) => void;
   onClose: (sandbox: AlloyComponent, thing: AlloyComponent) => void;
-  isPartOf: (sandbox: AlloyComponent, data: AlloyComponent, queryElem: SugarElement) => boolean;
+  isPartOf: (sandbox: AlloyComponent, data: AlloyComponent, queryElem: SugarElement<Node>) => boolean;
 }
 
 export interface SandboxingState extends BehaviourState {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingApis.ts
@@ -8,7 +8,7 @@ import { getAnimationRoot } from './SlidingUtils';
 const getDimensionProperty = (slideConfig: SlidingConfig): string =>
   slideConfig.dimension.property;
 
-const getDimension = (slideConfig: SlidingConfig, elem: SugarElement): string =>
+const getDimension = (slideConfig: SlidingConfig, elem: SugarElement<HTMLElement>): string =>
   slideConfig.dimension.getDimension(elem);
 
 const disableTransitions = (component: AlloyComponent, slideConfig: SlidingConfig): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingSchema.ts
@@ -21,11 +21,11 @@ export default [
     'property', {
       width: [
         Fields.output('property', 'width'),
-        Fields.output('getDimension', (elem: SugarElement) => Width.get(elem) + 'px')
+        Fields.output('getDimension', (elem: SugarElement<HTMLElement>) => Width.get(elem) + 'px')
       ],
       height: [
         Fields.output('property', 'height'),
-        Fields.output('getDimension', (elem: SugarElement) => Height.get(elem) + 'px')
+        Fields.output('getDimension', (elem: SugarElement<HTMLElement>) => Height.get(elem) + 'px')
       ]
     }
   ))

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingTypes.ts
@@ -26,7 +26,7 @@ export interface SlidingConfig extends Behaviour.BehaviourConfigDetail {
   closedClass: string;
   dimension: {
     property: string;
-    getDimension: (elem: SugarElement) => string;
+    getDimension: (elem: SugarElement<HTMLElement>) => string;
   };
   onGrown: (comp: AlloyComponent) => void;
   onShrunk: (comp: AlloyComponent) => void;
@@ -34,7 +34,7 @@ export interface SlidingConfig extends Behaviour.BehaviourConfigDetail {
   growingClass: string;
   onStartGrow: (comp: AlloyComponent) => void;
   onStartShrink: (comp: AlloyComponent) => void;
-  getAnimationRoot: Optional<(comp: AlloyComponent) => SugarElement>;
+  getAnimationRoot: Optional<(comp: AlloyComponent) => SugarElement<Element>>;
 
 }
 
@@ -54,7 +54,7 @@ export interface SlidingConfigSpec extends Behaviour.BehaviourConfigSpec {
   shrinkingClass: string;
   growingClass: string;
   onStartGrow?: (component: AlloyComponent) => void;
-  getAnimationRoot?: (component: AlloyComponent) => SugarElement;
+  getAnimationRoot?: (component: AlloyComponent) => SugarElement<Element>;
   onStartShrink?: (component: AlloyComponent) => void;
   onShrunk?: (component: AlloyComponent) => void;
   onGrown?: (component: AlloyComponent) => void;

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingUtils.ts
@@ -3,7 +3,7 @@ import { SugarElement } from '@ephox/sugar';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { SlidingConfig } from './SlidingTypes';
 
-export const getAnimationRoot = (component: AlloyComponent, slideConfig: SlidingConfig): SugarElement =>
+export const getAnimationRoot = (component: AlloyComponent, slideConfig: SlidingConfig): SugarElement<Element> =>
   slideConfig.getAnimationRoot.fold(
     () => component.element,
     (get) => get(component)

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/swapping/SwapApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/swapping/SwapApis.ts
@@ -4,7 +4,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import { Stateless } from '../common/BehaviourState';
 import { SwappingConfig } from './SwappingTypes';
 
-const swap = (element: SugarElement, addCls: string, removeCls: string): void => {
+const swap = (element: SugarElement<Element>, addCls: string, removeCls: string): void => {
   Class.remove(element, removeCls);
   Class.add(element, addCls);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/debugging/Debugging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/debugging/Debugging.ts
@@ -8,11 +8,11 @@ import { GuiSystem } from '../api/system/Gui';
 import * as AlloyLogger from '../log/AlloyLogger';
 
 export interface DebuggerLogger {
-  logEventCut: (eventName: string, target: SugarElement, purpose: string) => void;
-  logEventStopped: (eventName: string, target: SugarElement, purpose: string) => void;
-  logNoParent: (eventName: string, target: SugarElement, purpose: string) => void;
-  logEventNoHandlers: (eventName: string, target: SugarElement) => void;
-  logEventResponse: (eventName: string, target: SugarElement, purpose: string) => void;
+  logEventCut: (eventName: string, target: SugarElement<Node>, purpose: string) => void;
+  logEventStopped: (eventName: string, target: SugarElement<Node>, purpose: string) => void;
+  logNoParent: (eventName: string, target: SugarElement<Node>, purpose: string) => void;
+  logEventNoHandlers: (eventName: string, target: SugarElement<Node>) => void;
+  logEventResponse: (eventName: string, target: SugarElement<Node>, purpose: string) => void;
   write: () => void;
 }
 
@@ -65,24 +65,24 @@ const eventConfig = Cell<Record<string, EventConfiguration>>({ });
 
 export type EventProcessor = (logger: DebuggerLogger) => boolean;
 
-const makeEventLogger = (eventName: string, initialTarget: SugarElement): DebuggerLogger => {
-  const sequence: Array<{ outcome: string; target: SugarElement; purpose?: string }> = [ ];
+const makeEventLogger = (eventName: string, initialTarget: SugarElement<Node>): DebuggerLogger => {
+  const sequence: Array<{ outcome: string; target: SugarElement<Node>; purpose?: string }> = [ ];
   const startTime = new Date().getTime();
 
   return {
-    logEventCut: (_name: string, target: SugarElement, purpose: string) => {
+    logEventCut: (_name: string, target: SugarElement<Node>, purpose: string) => {
       sequence.push({ outcome: 'cut', target, purpose });
     },
-    logEventStopped: (_name: string, target: SugarElement, purpose: string) => {
+    logEventStopped: (_name: string, target: SugarElement<Node>, purpose: string) => {
       sequence.push({ outcome: 'stopped', target, purpose });
     },
-    logNoParent: (_name: string, target: SugarElement, purpose: string) => {
+    logNoParent: (_name: string, target: SugarElement<Node>, purpose: string) => {
       sequence.push({ outcome: 'no-parent', target, purpose });
     },
-    logEventNoHandlers: (_name: string, target: SugarElement) => {
+    logEventNoHandlers: (_name: string, target: SugarElement<Node>) => {
       sequence.push({ outcome: 'no-handlers-left', target });
     },
-    logEventResponse: (_name: string, target: SugarElement, purpose: string) => {
+    logEventResponse: (_name: string, target: SugarElement<Node>, purpose: string) => {
       sequence.push({ outcome: 'response', purpose, target });
     },
     write: () => {
@@ -107,7 +107,7 @@ const makeEventLogger = (eventName: string, initialTarget: SugarElement): Debugg
   };
 };
 
-const processEvent = (eventName: string, initialTarget: SugarElement, f: EventProcessor) => {
+const processEvent = (eventName: string, initialTarget: SugarElement<Node>, f: EventProcessor) => {
   const status = Obj.get(eventConfig.get(), eventName).orThunk(() => {
     const patterns = Obj.keys(eventConfig.get());
     return Arr.findMap(patterns, (p) => eventName.indexOf(p) > -1 ? Optional.some(eventConfig.get()[p]) : Optional.none());
@@ -162,7 +162,7 @@ const ignoreEvent = {
   write: Fun.noop
 };
 
-const monitorEvent = (eventName: string, initialTarget: SugarElement, f: EventProcessor): boolean =>
+const monitorEvent = (eventName: string, initialTarget: SugarElement<Node>, f: EventProcessor): boolean =>
   processEvent(eventName, initialTarget, f);
 
 const inspectorInfo = (comp: AlloyComponent) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/dom/DomDefinition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dom/DomDefinition.ts
@@ -13,7 +13,7 @@ export interface GeneralDefinitionSpec<EC> {
   // defChildren?: DC[];
 }
 
-export interface DomDefinitionSpec extends GeneralDefinitionSpec<SugarElement> {
+export interface DomDefinitionSpec extends GeneralDefinitionSpec<SugarElement<Node>> {
 
 }
 
@@ -28,16 +28,16 @@ export interface GeneralDefinitionDetail<EC> {
   domChildren: EC[];
 }
 
-export interface DomDefinitionDetail extends GeneralDefinitionDetail<SugarElement> {
+export interface DomDefinitionDetail extends GeneralDefinitionDetail<SugarElement<Node>> {
 
 }
 
-const defToStr = (defn: GeneralDefinitionDetail<any>): string => {
+const defToStr = <EC>(defn: GeneralDefinitionDetail<EC>): string => {
   const raw = defToRaw(defn);
   return JSON.stringify(raw, null, 2);
 };
 
-const defToRaw = (defn: GeneralDefinitionDetail<SugarElement>): GeneralDefinitionSpec<string> => ({
+const defToRaw = <EC>(defn: GeneralDefinitionDetail<EC>): GeneralDefinitionSpec<string> => ({
   uid: defn.uid,
   tag: defn.tag,
   classes: defn.classes,

--- a/modules/alloy/src/main/ts/ephox/alloy/dom/DomRender.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dom/DomRender.ts
@@ -3,7 +3,7 @@ import { Attribute, Classes, Css, Html, InsertAll, SugarElement, Value } from '@
 import * as Tagger from '../registry/Tagger';
 import * as DomDefinition from './DomDefinition';
 
-const renderToDom = (definition: DomDefinition.GeneralDefinitionDetail<SugarElement>): SugarElement => {
+const renderToDom = (definition: DomDefinition.GeneralDefinitionDetail<SugarElement<Node>>): SugarElement<HTMLElement> => {
   const subject = SugarElement.fromTag(definition.tag);
   Attribute.setAll(subject, definition.attributes);
   Classes.add(subject, definition.classes);

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragMovement.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragMovement.ts
@@ -7,7 +7,7 @@ import * as DragCoord from '../../api/data/DragCoord';
 import * as Snappables from '../snap/Snappables';
 import { DraggingConfig, DragStartData, SnapsConfig } from './DraggingTypes';
 
-const getCurrentCoord = (target: SugarElement): DragCoord.CoordAdt =>
+const getCurrentCoord = (target: SugarElement<HTMLElement>): DragCoord.CoordAdt =>
   Optionals.lift3(Css.getRaw(target, 'left'), Css.getRaw(target, 'top'), Css.getRaw(target, 'position'), (left, top, position) => {
     const nu = position === 'fixed' ? DragCoord.fixed : DragCoord.offset;
     return nu(
@@ -52,7 +52,7 @@ const calcNewCoord = <E>(component: AlloyComponent, optSnaps: Optional<SnapsConf
     return DragCoord.fixed(fixedCoord.left, fixedCoord.top);
   }, (snapInfo) => {
     const snapping = Snappables.moveOrSnap(component, snapInfo, currentCoord, delta, scroll, origin);
-    snapping.extra.each((extra: any) => {
+    snapping.extra.each((extra) => {
       snapInfo.onSensor(component, extra);
     });
     return snapping.coord;

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DraggingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DraggingTypes.ts
@@ -70,11 +70,11 @@ export interface SnapsConfigSpec<E> {
 }
 
 export interface DraggingConfig<E> {
-  readonly getTarget: (comp: SugarElement) => SugarElement;
+  readonly getTarget: (comp: SugarElement<HTMLElement>) => SugarElement<HTMLElement>;
   readonly snaps: Optional<SnapsConfig<E>>;
-  readonly onDrop: (comp: AlloyComponent, target: SugarElement) => void;
+  readonly onDrop: (comp: AlloyComponent, target: SugarElement<HTMLElement>) => void;
   readonly repositionTarget: boolean;
-  readonly onDrag: (comp: AlloyComponent, target: SugarElement, delta: SugarPosition) => void;
+  readonly onDrag: (comp: AlloyComponent, target: SugarElement<HTMLElement>, delta: SugarPosition) => void;
   readonly getBounds: () => Bounds;
   readonly blockerClass: string;
   readonly dragger: {
@@ -84,10 +84,10 @@ export interface DraggingConfig<E> {
 
 export interface CommonDraggingConfigSpec<E> {
   readonly useFixed?: () => boolean;
-  readonly onDrop?: (comp: AlloyComponent, target: SugarElement) => void;
+  readonly onDrop?: (comp: AlloyComponent, target: SugarElement<HTMLElement>) => void;
   readonly repositionTarget?: boolean;
-  readonly onDrag?: (comp: AlloyComponent, target: SugarElement, delta: SugarPosition) => void;
-  readonly getTarget?: (elem: SugarElement) => SugarElement;
+  readonly onDrag?: (comp: AlloyComponent, target: SugarElement<HTMLElement>, delta: SugarPosition) => void;
+  readonly getTarget?: (elem: SugarElement<HTMLElement>) => SugarElement<HTMLElement>;
   readonly getBounds?: () => Bounds;
   readonly snaps?: SnapsConfigSpec<E>;
   readonly blockerClass: string;

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DragStarting.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DragStarting.ts
@@ -10,7 +10,7 @@ import * as DataTransfers from './DataTransfers';
 import { DragStartingConfig } from './DragnDropTypes';
 import { setImageClone } from './ImageClone';
 
-const dragStart = (component: AlloyComponent, target: SugarElement, config: DragStartingConfig, transfer: DataTransfer) => {
+const dragStart = (component: AlloyComponent, target: SugarElement<Node>, config: DragStartingConfig, transfer: DataTransfer) => {
   DataTransfers.setEffectAllowed(transfer, config.effectAllowed);
 
   config.getData.each((getData) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DragnDropTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DragnDropTypes.ts
@@ -22,9 +22,9 @@ export interface StartingDragndropConfigSpec {
   phoneyTypes?: string[];
   effectAllowed?: string;
   getData?: (component: AlloyComponent) => string;
-  getImageParent?: (component: AlloyComponent) => SugarElement;
+  getImageParent?: (component: AlloyComponent) => SugarElement<Element>;
   getImage?: (component: AlloyComponent) => DragnDropImageClone;
-  canDrag?: (component: AlloyComponent, target: SugarElement) => boolean;
+  canDrag?: (component: AlloyComponent, target: SugarElement<Node>) => boolean;
   onDragstart?: (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<DragEvent>) => void;
   onDragover?: (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<DragEvent>) => void;
   onDragend?: (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<DragEvent>) => void;
@@ -35,9 +35,9 @@ export interface DragStartingConfig {
   phoneyTypes: string[];
   effectAllowed: DataTransfer['effectAllowed'];
   getData: Optional<(component: AlloyComponent) => string>;
-  getImageParent: Optional<(component: AlloyComponent) => SugarElement>;
+  getImageParent: Optional<(component: AlloyComponent) => SugarElement<Element>>;
   getImage: Optional<(component: AlloyComponent) => DragnDropImageClone>;
-  canDrag: (component: AlloyComponent, target: SugarElement) => boolean;
+  canDrag: (component: AlloyComponent, target: SugarElement<Node>) => boolean;
   onDragstart: (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<DragEvent>) => void;
   onDragover: (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<DragEvent>) => void;
   onDragend: (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<DragEvent>) => void;

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/ImageClone.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/ImageClone.ts
@@ -3,12 +3,12 @@ import { Css, Insert, Remove, Replication, SugarElement } from '@ephox/sugar';
 import * as DataTransfers from './DataTransfers';
 
 export interface DragnDropImageClone {
-  readonly element: SugarElement;
+  readonly element: SugarElement<HTMLElement>;
   readonly x: number;
   readonly y: number;
 }
 
-const createGhostClone = (image: DragnDropImageClone): SugarElement => {
+const createGhostClone = (image: DragnDropImageClone): SugarElement<HTMLElement> => {
   const ghost = Replication.deep(image.element);
 
   // Firefox will scale down non ghost images to 175px so lets limit the size to 175px in general

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/snap/Presnaps.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/snap/Presnaps.ts
@@ -4,7 +4,7 @@ import { Attribute, SugarElement, SugarPosition } from '@ephox/sugar';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { SnapsConfig } from '../common/DraggingTypes';
 
-const parseAttrToInt = (element: SugarElement, name: string): number => {
+const parseAttrToInt = (element: SugarElement<Element>, name: string): number => {
   const value = Attribute.get(element, name);
   return Type.isUndefined(value) ? NaN : parseInt(value, 10);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Future, Optional, Result } from '@ephox/katamari';
-import { Css, SugarElement, Width } from '@ephox/sugar';
+import { Css, Width } from '@ephox/sugar';
 
 import * as ComponentStructure from '../alien/ComponentStructure';
 import { Composing } from '../api/behaviour/Composing';
@@ -258,7 +258,7 @@ const makeSandbox = (
         Sandboxing.config({
           onOpen,
           onClose,
-          isPartOf: (container: AlloyComponent, data: AlloyComponent, queryElem: SugarElement): boolean => {
+          isPartOf: (container, data, queryElem): boolean => {
             return ComponentStructure.isPartOf(data, queryElem) || ComponentStructure.isPartOf(hotspot, queryElem);
           },
           getAttachPoint: () => {

--- a/modules/alloy/src/main/ts/ephox/alloy/events/DefaultEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/DefaultEvents.ts
@@ -10,8 +10,8 @@ import { FocusingEvent } from './SimulatedEvent';
 // to recurse infinitely. Essentially, if the originator of the focus call is the same
 // as the element receiving it, and it wasn't its own target, then stop the focus call
 // and log a warning.
-const isRecursive = (component: AlloyComponent, originator: SugarElement, target: SugarElement): boolean => Compare.eq(originator, component.element) &&
-    !Compare.eq(originator, target);
+const isRecursive = (component: AlloyComponent, originator: SugarElement<Node>, target: SugarElement<Node>): boolean =>
+  Compare.eq(originator, component.element) && !Compare.eq(originator, target);
 
 const events: AlloyEvents.AlloyEventRecord = AlloyEvents.derive([
   AlloyEvents.can<FocusingEvent>(SystemEvents.focus(), (component, simulatedEvent) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
@@ -5,7 +5,7 @@ import * as Tagger from '../registry/Tagger';
 import * as DescribedHandler from './DescribedHandler';
 
 export interface ElementAndHandler {
-  readonly element: SugarElement;
+  readonly element: SugarElement<Node>;
   readonly descHandler: CurriedHandler;
 }
 
@@ -28,10 +28,10 @@ export interface EventRegistry {
   readonly registerId: (extraArgs: any[], id: string, events: Record<EventName, UncurriedHandler>) => void;
   readonly unregisterId: (id: string) => void;
   readonly filterByType: (type: string) => UidAndHandler[];
-  readonly find: (isAboveRoot: (elem: SugarElement) => boolean, type: string, target: SugarElement) => Optional<ElementAndHandler>;
+  readonly find: (isAboveRoot: (elem: SugarElement<Node>) => boolean, type: string, target: SugarElement<Node>) => Optional<ElementAndHandler>;
 }
 
-const eventHandler = (element: SugarElement, descHandler: CurriedHandler): ElementAndHandler => ({
+const eventHandler = (element: SugarElement<Node>, descHandler: CurriedHandler): ElementAndHandler => ({
   element,
   descHandler
 });
@@ -55,7 +55,7 @@ export const EventRegistry = (): EventRegistry => {
     });
   };
 
-  const findHandler = (handlers: Record<Uid, CurriedHandler>, elem: SugarElement): Optional<ElementAndHandler> =>
+  const findHandler = (handlers: Record<Uid, CurriedHandler>, elem: SugarElement<Node>): Optional<ElementAndHandler> =>
     Tagger.read(elem)
       .bind((id) => Obj.get(handlers, id))
       .map((descHandler) => eventHandler(elem, descHandler));
@@ -67,7 +67,7 @@ export const EventRegistry = (): EventRegistry => {
       .getOr([ ]);
 
   // Given event type, and element, find the handler.
-  const find = (isAboveRoot: (elem: SugarElement) => boolean, type: string, target: SugarElement): Optional<ElementAndHandler> =>
+  const find = (isAboveRoot: (elem: SugarElement<Node>) => boolean, type: string, target: SugarElement<Node>): Optional<ElementAndHandler> =>
     Obj.get(registry, type)
       .bind((handlers) => TransformFind.closest(target, (elem) => findHandler(handlers, elem), isAboveRoot));
 

--- a/modules/alloy/src/main/ts/ephox/alloy/events/EventSource.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/EventSource.ts
@@ -3,7 +3,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import { EventFormat } from './SimulatedEvent';
 
-const derive = (rawEvent: EventFormat, rawTarget: SugarElement): Cell<SugarElement> => {
+const derive = (rawEvent: EventFormat, rawTarget: SugarElement<Node>): Cell<SugarElement<Node>> => {
   const source = Obj.get(rawEvent, 'target').getOr(rawTarget);
 
   return Cell(source);

--- a/modules/alloy/src/main/ts/ephox/alloy/events/SimulatedEvent.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/SimulatedEvent.ts
@@ -2,7 +2,7 @@ import { Cell, Fun } from '@ephox/katamari';
 import { EventArgs, SugarElement } from '@ephox/sugar';
 
 export interface EventFormat {
-  readonly target: SugarElement;
+  readonly target: SugarElement<Node>;
   readonly kill: () => void;
   readonly prevent: () => void;
 }
@@ -14,11 +14,11 @@ export interface SimulatedEvent<T extends EventFormat> {
   readonly isCut: () => boolean;
   readonly event: T;
 
-  readonly getSource: () => SugarElement;
-  readonly setSource: (elem: SugarElement) => void;
+  readonly getSource: () => SugarElement<Node>;
+  readonly setSource: (elem: SugarElement<Node>) => void;
 }
 
-export type NativeSimulatedEvent<T = any> = SimulatedEvent<EventArgs<T>>;
+export type NativeSimulatedEvent<T = Event> = SimulatedEvent<EventArgs<T>>;
 export type CustomSimulatedEvent = SimulatedEvent<CustomEvent>;
 
 export interface CustomEvent extends EventFormat {
@@ -45,10 +45,10 @@ export interface ReceivingEvent extends EventFormat {
 }
 
 export interface FocusingEvent extends EventFormat {
-  readonly originator: SugarElement;
+  readonly originator: SugarElement<Node>;
 }
 
-const fromSource = <T extends EventFormat>(event: T, source: Cell<SugarElement>): SimulatedEvent<T> => {
+const fromSource = <T extends EventFormat>(event: T, source: Cell<SugarElement<Node>>): SimulatedEvent<T> => {
   const stopper = Cell(false);
 
   const cutter = Cell(false);
@@ -93,7 +93,7 @@ const fromExternal = <T extends EventFormat>(event: T): SimulatedEvent<T> => {
   };
 };
 
-const fromTarget = <T extends EventFormat>(event: T, target: SugarElement): SimulatedEvent<T> => {
+const fromTarget = <T extends EventFormat>(event: T, target: SugarElement<Node>): SimulatedEvent<T> => {
   const source = Cell(target);
   return fromSource(event, source);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/events/TapEvent.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/TapEvent.ts
@@ -12,7 +12,7 @@ type EventHandler = (event: EventArgs<Event>) => Optional<boolean>;
 export interface TouchHistoryData {
   readonly x: number;
   readonly y: number;
-  readonly target: SugarElement;
+  readonly target: SugarElement<Node>;
 }
 
 interface Monitor {

--- a/modules/alloy/src/main/ts/ephox/alloy/foreign/ForeignCache.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/foreign/ForeignCache.ts
@@ -12,16 +12,16 @@ import * as ComponentEvents from '../construct/ComponentEvents';
 import { UncurriedHandler } from '../events/EventRegistry';
 
 interface Events {
-  readonly elem: SugarElement;
+  readonly elem: SugarElement<Node>;
   readonly evts: Record<string, UncurriedHandler>;
 }
 
 export interface ForeignCache {
-  readonly getEvents: (elem: SugarElement, spec: DispatchedAlloyConfig) => Events;
+  readonly getEvents: (elem: SugarElement<Node>, spec: DispatchedAlloyConfig) => Events;
 }
 
 export default (): ForeignCache => {
-  const getEvents = (elem: SugarElement, spec: DispatchedAlloyConfig): Events => {
+  const getEvents = (elem: SugarElement<Node>, spec: DispatchedAlloyConfig): Events => {
     const evts = DomState.getOrCreate(elem, () => {
       // If we haven't already setup this particular element, then generate any state and config
       // required by its behaviours and put it in the cache.

--- a/modules/alloy/src/main/ts/ephox/alloy/frame/Frames.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/frame/Frames.ts
@@ -3,7 +3,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import { Navigation } from './Navigation';
 
-const walkUp = (navigation: Navigation, doc: SugarElement<HTMLDocument>): SugarElement[] => {
+const walkUp = (navigation: Navigation, doc: SugarElement<Document>): SugarElement<Element>[] => {
   const frame = navigation.view(doc);
   return frame.fold(Fun.constant([]), (f) => {
     const parent = navigation.owner(f);
@@ -13,7 +13,7 @@ const walkUp = (navigation: Navigation, doc: SugarElement<HTMLDocument>): SugarE
 };
 
 // TODO: Why is this an option if it is always some?
-const pathTo = (element: SugarElement, navigation: Navigation): Optional<SugarElement[]> => {
+const pathTo = (element: SugarElement<Node>, navigation: Navigation): Optional<SugarElement<Element>[]> => {
   const d = navigation.owner(element);
   const paths = walkUp(navigation, d);
   return Optional.some(paths);

--- a/modules/alloy/src/main/ts/ephox/alloy/frame/OuterPosition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/frame/OuterPosition.ts
@@ -1,11 +1,11 @@
 import { Arr, Fun } from '@ephox/katamari';
-import { Scroll, SugarElement, SugarLocation, SugarPosition } from '@ephox/sugar';
+import { Scroll, SugarDocument, SugarElement, SugarLocation, SugarPosition } from '@ephox/sugar';
 
 import * as Frames from './Frames';
 import * as Navigation from './Navigation';
 
-const find = (element: SugarElement): SugarPosition => {
-  const doc = SugarElement.fromDom(document);
+const find = (element: SugarElement<Element>): SugarPosition => {
+  const doc = SugarDocument.getDocument();
   const scroll = Scroll.get(doc);
 
   // Get the path of iframe elements to this element.

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/FlatgridType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/FlatgridType.ts
@@ -25,12 +25,12 @@ const schema = [
 ];
 
 const focusIn = (component: AlloyComponent, gridConfig: FlatgridConfig, _gridState: FlatgridState): void => {
-  SelectorFind.descendant(component.element, gridConfig.selector).each((first: SugarElement) => {
+  SelectorFind.descendant<HTMLElement>(component.element, gridConfig.selector).each((first) => {
     gridConfig.focusManager.set(component, first);
   });
 };
 
-const findCurrent = (component: AlloyComponent, gridConfig: FlatgridConfig): Optional<SugarElement> =>
+const findCurrent = (component: AlloyComponent, gridConfig: FlatgridConfig): Optional<SugarElement<HTMLElement>> =>
   gridConfig.focusManager.get(component).bind((elem) => SelectorFind.closest(elem, gridConfig.selector));
 
 const execute = (

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/FlowType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/FlowType.ts
@@ -26,7 +26,7 @@ const schema = [
 
 // TODO: Remove dupe.
 // TODO: Probably use this for not just execution.
-const findCurrent = (component: AlloyComponent, flowConfig: FlowConfig): Optional<SugarElement> =>
+const findCurrent = (component: AlloyComponent, flowConfig: FlowConfig): Optional<SugarElement<HTMLElement>> =>
   flowConfig.focusManager.get(component).bind((elem) => SelectorFind.closest(elem, flowConfig.selector));
 
 const execute = (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent, flowConfig: FlowConfig): Optional<boolean> =>
@@ -34,16 +34,16 @@ const execute = (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent
 
 const focusIn = (component: AlloyComponent, flowConfig: FlowConfig, _state: Stateless): void => {
   flowConfig.getInitial(component).orThunk(
-    () => SelectorFind.descendant(component.element, flowConfig.selector)
+    () => SelectorFind.descendant<HTMLElement>(component.element, flowConfig.selector)
   ).each((first) => {
     flowConfig.focusManager.set(component, first);
   });
 };
 
-const moveLeft = (element: SugarElement, focused: SugarElement, info: FlowConfig): Optional<SugarElement> =>
+const moveLeft = (element: SugarElement<HTMLElement>, focused: SugarElement<HTMLElement>, info: FlowConfig): Optional<SugarElement<HTMLElement>> =>
   DomNavigation.horizontal(element, info.selector, focused, -1);
 
-const moveRight = (element: SugarElement, focused: SugarElement, info: FlowConfig): Optional<SugarElement> =>
+const moveRight = (element: SugarElement<HTMLElement>, focused: SugarElement<HTMLElement>, info: FlowConfig): Optional<SugarElement<HTMLElement>> =>
   DomNavigation.horizontal(element, info.selector, focused, +1);
 
 const doMove = (movement: KeyRuleHandler<FlowConfig, Stateless>): KeyRuleHandler<FlowConfig, Stateless> =>

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingModeTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingModeTypes.ts
@@ -7,9 +7,9 @@ import { FocusManager } from '../api/focus/FocusManagers';
 import { BehaviourState, Stateless } from '../behaviour/common/BehaviourState';
 import { NativeSimulatedEvent, SimulatedEvent } from '../events/SimulatedEvent';
 
-export type KeyHandlerApi = (comp: AlloyComponent, se: NativeSimulatedEvent) => Optional<boolean>;
+export type KeyHandlerApi = (comp: AlloyComponent, se: NativeSimulatedEvent<KeyboardEvent>) => Optional<boolean>;
 
-export type KeyRuleHandler<C, S> = (comp: AlloyComponent, se: NativeSimulatedEvent, config: C, state: S) => Optional<boolean>;
+export type KeyRuleHandler<C, S> = (comp: AlloyComponent, se: NativeSimulatedEvent<KeyboardEvent>, config: C, state: S) => Optional<boolean>;
 
 export enum FocusInsideModes {
   OnFocusMode = 'onFocus',
@@ -37,7 +37,7 @@ export interface TabbingConfigSpec extends GeneralKeyingConfigSpec {
   onEnter?: KeyHandlerApi;
   selector?: string;
   firstTabstop?: number;
-  useTabstopAt?: (elem: SugarElement) => boolean;
+  useTabstopAt?: (elem: SugarElement<HTMLElement>) => boolean;
   visibilitySelector?: string;
 }
 
@@ -46,7 +46,7 @@ export interface TabbingConfig extends GeneralKeyingConfig {
   onEnter: Optional<KeyHandlerApi>;
   selector: string;
   firstTabstop: number;
-  useTabstopAt: (elem: SugarElement) => boolean;
+  useTabstopAt: (elem: SugarElement<HTMLElement>) => boolean;
   visibilitySelector: Optional<string>;
   cyclic: boolean;
 }
@@ -81,7 +81,7 @@ export interface EscapingConfig extends GeneralKeyingConfig {
 export interface ExecutingConfigSpec extends GeneralKeyingConfigSpec {
   mode: 'execution';
   // NOTE: inconsistent.
-  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
   useSpace?: boolean;
   useEnter?: boolean;
   useControlEnter?: boolean;
@@ -89,7 +89,7 @@ export interface ExecutingConfigSpec extends GeneralKeyingConfigSpec {
 }
 
 export interface ExecutingConfig extends GeneralKeyingConfig {
-  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
   useSpace: boolean;
   useEnter: boolean;
   useControlEnter: boolean;
@@ -100,7 +100,7 @@ export interface ExecutingConfig extends GeneralKeyingConfig {
 export interface FlatgridConfigSpec extends GeneralKeyingConfigSpec {
   mode: 'flatgrid';
   selector: string;
-  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
   onEscape?: KeyHandlerApi;
   captureTab?: boolean;
   initSize: {
@@ -111,7 +111,7 @@ export interface FlatgridConfigSpec extends GeneralKeyingConfigSpec {
 
 export interface FlatgridConfig extends GeneralKeyingConfig {
   selector: string;
-  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
   onEscape: KeyHandlerApi;
   captureTab: boolean;
   initSize: {
@@ -130,18 +130,18 @@ export interface FlatgridState extends BehaviourState {
 export interface FlowConfigSpec extends GeneralKeyingConfigSpec {
   mode: 'flow';
   selector: string;
-  getInitial?: (comp: AlloyComponent) => Optional<SugarElement>;
+  getInitial?: (comp: AlloyComponent) => Optional<SugarElement<HTMLElement>>;
   onEscape?: KeyHandlerApi;
-  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
   executeOnMove?: boolean;
   allowVertical?: boolean;
 }
 
 export interface FlowConfig extends GeneralKeyingConfig {
   selector: string;
-  getInitial: (comp: AlloyComponent) => Optional<SugarElement>;
+  getInitial: (comp: AlloyComponent) => Optional<SugarElement<HTMLElement>>;
   onEscape: KeyHandlerApi;
-  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
   executeOnMove: boolean;
   allowVertical: boolean;
 }
@@ -154,8 +154,8 @@ export interface MatrixConfigSpec extends GeneralKeyingConfigSpec {
     cell: string;
   };
   cycles?: boolean;
-  previousSelector?: (comp: AlloyComponent) => Optional<SugarElement>;
-  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  previousSelector?: (comp: AlloyComponent) => Optional<SugarElement<HTMLElement>>;
+  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
 }
 
 export interface MatrixConfig extends GeneralKeyingConfig {
@@ -164,21 +164,21 @@ export interface MatrixConfig extends GeneralKeyingConfig {
     cell: string;
   };
   cycles: boolean;
-  previousSelector: (comp: AlloyComponent) => Optional<SugarElement>;
-  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  previousSelector: (comp: AlloyComponent) => Optional<SugarElement<HTMLElement>>;
+  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
 }
 
 // Menu type
 export interface MenuConfigSpec extends GeneralKeyingConfigSpec {
   mode: 'menu';
   selector: string;
-  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  execute?: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
   moveOnTab?: boolean;
 }
 
 export interface MenuConfig extends GeneralKeyingConfig {
   selector: string;
-  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement) => Optional<boolean>;
+  execute: (comp: AlloyComponent, se: NativeSimulatedEvent, focused: SugarElement<HTMLElement>) => Optional<boolean>;
   moveOnTab: boolean;
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingType.ts
@@ -20,7 +20,7 @@ type GetRulesFunc<C extends GeneralKeyingConfig, S extends BehaviourState> = (co
 
 export interface KeyingType <C extends GeneralKeyingConfig, S extends BehaviourState> {
   readonly schema: () => FieldProcessor[];
-  readonly processKey: (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent, getRules: GetRulesFunc<C, S>, keyingConfig: C, keyingState: S) => Optional<boolean>;
+  readonly processKey: (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<KeyboardEvent>, getRules: GetRulesFunc<C, S>, keyingConfig: C, keyingState: S) => Optional<boolean>;
   readonly toEvents: (keyingConfig: C, keyingState: S) => AlloyEvents.AlloyEventRecord;
 }
 
@@ -38,7 +38,7 @@ const typical = <C extends GeneralKeyingConfig, S extends BehaviourState>(
     Fields.output('sendFocusIn', optFocusIn)
   ]);
 
-  const processKey = (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent, getRules: GetRulesFunc<C, S>, keyingConfig: C, keyingState: S): Optional<boolean> => {
+  const processKey = (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<KeyboardEvent>, getRules: GetRulesFunc<C, S>, keyingConfig: C, keyingState: S): Optional<boolean> => {
     const rules = getRules(component, simulatedEvent, keyingConfig, keyingState);
 
     return KeyRules.choose(rules, simulatedEvent.event).bind((rule) => rule(component, simulatedEvent, keyingConfig, keyingState));

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingTypes.ts
@@ -12,19 +12,19 @@ import { GeneralKeyingConfig, KeyRuleHandler } from './KeyingModeTypes';
 
 const doDefaultExecute = (
   component: AlloyComponent,
-  _simulatedEvent: NativeSimulatedEvent,
-  focused: SugarElement
+  _simulatedEvent: NativeSimulatedEvent<KeyboardEvent>,
+  focused: SugarElement<HTMLElement>
 ): Optional<boolean> => {
   // Note, we use to pass through simulatedEvent here and make target: component. This simplification
   // may be a problem
   AlloyTriggers.dispatch(component, focused, SystemEvents.execute());
-  return Optional.some<boolean>(true);
+  return Optional.some(true);
 };
 
 const defaultExecute = (
   component: AlloyComponent,
-  simulatedEvent: NativeSimulatedEvent,
-  focused: SugarElement
+  simulatedEvent: NativeSimulatedEvent<KeyboardEvent>,
+  focused: SugarElement<HTMLElement>
 ): Optional<boolean> => {
   const isComplex = EditableFields.inside(focused) && KeyMatch.inSet(Keys.SPACE)(simulatedEvent.event);
   return isComplex ? Optional.none() : doDefaultExecute(component, simulatedEvent, focused);
@@ -36,7 +36,7 @@ const defaultExecute = (
 // keyup also. This does make the name confusing, though.
 const stopEventForFirefox: KeyRuleHandler<GeneralKeyingConfig, any> = (
   _component: AlloyComponent,
-  _simulatedEvent: NativeSimulatedEvent
+  _simulatedEvent: NativeSimulatedEvent<KeyboardEvent>
 ) => Optional.some<boolean>(true);
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/MatrixType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/MatrixType.ts
@@ -29,7 +29,7 @@ const schema = [
 const focusIn = (component: AlloyComponent, matrixConfig: MatrixConfig, _state: Stateless): void => {
   const focused = matrixConfig.previousSelector(component).orThunk(() => {
     const selectors = matrixConfig.selectors;
-    return SelectorFind.descendant(component.element, selectors.cell);
+    return SelectorFind.descendant<HTMLElement>(component.element, selectors.cell);
   });
 
   focused.each((cell) => {
@@ -39,15 +39,16 @@ const focusIn = (component: AlloyComponent, matrixConfig: MatrixConfig, _state: 
 
 const execute: KeyRuleHandler<MatrixConfig, Stateless> = (component, simulatedEvent, matrixConfig) => Focus.search(component.element).bind((focused) => matrixConfig.execute(component, simulatedEvent, focused));
 
-const toMatrix = (rows: SugarElement[], matrixConfig: MatrixConfig): SugarElement[][] => Arr.map(rows, (row) => SelectorFilter.descendants(row, matrixConfig.selectors.cell));
+const toMatrix = (rows: SugarElement<HTMLElement>[], matrixConfig: MatrixConfig): SugarElement<HTMLElement>[][] =>
+  Arr.map(rows, (row) => SelectorFilter.descendants(row, matrixConfig.selectors.cell));
 
-const doMove = (ifCycle: MatrixNavigation.MatrixNavigationFunc<SugarElement>, ifMove: MatrixNavigation.MatrixNavigationFunc<SugarElement>): DomMovement.ElementMover<MatrixConfig, Stateless> => (element, focused, matrixConfig) => {
+const doMove = (ifCycle: MatrixNavigation.MatrixNavigationFunc<SugarElement<HTMLElement>>, ifMove: MatrixNavigation.MatrixNavigationFunc<SugarElement<HTMLElement>>): DomMovement.ElementMover<MatrixConfig, Stateless> => (element, focused, matrixConfig) => {
   const move = matrixConfig.cycles ? ifCycle : ifMove;
   return SelectorFind.closest(focused, matrixConfig.selectors.row).bind((inRow) => {
     const cellsInRow = SelectorFilter.descendants(inRow, matrixConfig.selectors.cell);
 
     return DomPinpoint.findIndex(cellsInRow, focused).bind((colIndex) => {
-      const allRows = SelectorFilter.descendants(element, matrixConfig.selectors.row);
+      const allRows = SelectorFilter.descendants<HTMLElement>(element, matrixConfig.selectors.row);
       return DomPinpoint.findIndex(allRows, inRow).bind((rowIndex) => {
         // Now, make the matrix.
         const matrix = toMatrix(allRows, matrixConfig);

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/MenuType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/MenuType.ts
@@ -23,7 +23,7 @@ const execute: KeyRuleHandler<MenuConfig, Stateless> = (component, simulatedEven
 
 const focusIn = (component: AlloyComponent, menuConfig: MenuConfig, _state: Stateless): void => {
   // Maybe keep selection if it was there before
-  SelectorFind.descendant(component.element, menuConfig.selector).each((first) => {
+  SelectorFind.descendant<HTMLElement>(component.element, menuConfig.selector).each((first) => {
     menuConfig.focusManager.set(component, first);
   });
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
@@ -35,18 +35,18 @@ const create = (cyclicField: FieldProcessor): KeyingType.KeyingType<TabbingConfi
     return Height.get(target) > 0;
   };
 
-  const findInitial = (component: AlloyComponent, tabbingConfig: TabbingConfig): Optional<SugarElement> => {
-    const tabstops: SugarElement[] = SelectorFilter.descendants(component.element, tabbingConfig.selector);
-    const visibles: SugarElement[] = Arr.filter(tabstops, (elem) => isVisible(tabbingConfig, elem));
+  const findInitial = (component: AlloyComponent, tabbingConfig: TabbingConfig): Optional<SugarElement<HTMLElement>> => {
+    const tabstops: SugarElement<HTMLElement>[] = SelectorFilter.descendants<HTMLElement>(component.element, tabbingConfig.selector);
+    const visibles: SugarElement<HTMLElement>[] = Arr.filter(tabstops, (elem) => isVisible(tabbingConfig, elem));
 
     return Optional.from(visibles[tabbingConfig.firstTabstop]);
   };
 
-  const findCurrent = (component: AlloyComponent, tabbingConfig: TabbingConfig): Optional<SugarElement> =>
+  const findCurrent = (component: AlloyComponent, tabbingConfig: TabbingConfig): Optional<SugarElement<HTMLElement>> =>
     tabbingConfig.focusManager.get(component)
-      .bind((elem) => SelectorFind.closest(elem, tabbingConfig.selector));
+      .bind((elem) => SelectorFind.closest<HTMLElement>(elem, tabbingConfig.selector));
 
-  const isTabstop = (tabbingConfig: TabbingConfig, element: SugarElement): boolean =>
+  const isTabstop = (tabbingConfig: TabbingConfig, element: SugarElement<HTMLElement>): boolean =>
     isVisible(tabbingConfig, element) && tabbingConfig.useTabstopAt(element);
 
   // Fire an alloy focus on the first visible element that matches the selector
@@ -58,12 +58,12 @@ const create = (cyclicField: FieldProcessor): KeyingType.KeyingType<TabbingConfi
 
   const goFromTabstop = (
     component: AlloyComponent,
-    tabstops: SugarElement[],
+    tabstops: SugarElement<HTMLElement>[],
     stopIndex: number,
     tabbingConfig: TabbingConfig,
-    cycle: ArrNavigation.ArrCycle<SugarElement>
+    cycle: ArrNavigation.ArrCycle<SugarElement<HTMLElement>>
   ): Optional<boolean> =>
-    cycle(tabstops, stopIndex, (elem: SugarElement) => isTabstop(tabbingConfig, elem))
+    cycle(tabstops, stopIndex, (elem) => isTabstop(tabbingConfig, elem))
       .fold(
         // Even if there is only one, still capture the event if cycling
         () => tabbingConfig.cyclic ? Optional.some<boolean>(true) : Optional.none(),
@@ -78,13 +78,13 @@ const create = (cyclicField: FieldProcessor): KeyingType.KeyingType<TabbingConfi
     component: AlloyComponent,
     _simulatedEvent: NativeSimulatedEvent,
     tabbingConfig: TabbingConfig,
-    cycle: ArrNavigation.ArrCycle<SugarElement>
+    cycle: ArrNavigation.ArrCycle<SugarElement<HTMLElement>>
   ): Optional<boolean> => {
     // 1. Find our current tabstop
     // 2. Find the index of that tabstop
     // 3. Cycle the tabstop
     // 4. Fire alloy focus on the resultant tabstop
-    const tabstops: SugarElement[] = SelectorFilter.descendants(component.element, tabbingConfig.selector);
+    const tabstops = SelectorFilter.descendants<HTMLElement>(component.element, tabbingConfig.selector);
     return findCurrent(component, tabbingConfig).bind((tabstop) => {
       // focused component
       const optStopIndex = Arr.findIndex(tabstops, Fun.curry(Compare.eq, tabstop));

--- a/modules/alloy/src/main/ts/ephox/alloy/log/AlloyLogger.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/log/AlloyLogger.ts
@@ -1,6 +1,6 @@
 import { SugarElement, Truncate } from '@ephox/sugar';
 
-const element = (elem: SugarElement): string => Truncate.getHtml(elem);
+const element = (elem: SugarElement<Node>): string => Truncate.getHtml(elem);
 
 export {
   element

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/build/WidgetType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/build/WidgetType.ts
@@ -27,14 +27,15 @@ const builder = (detail: WidgetItemDetail) => {
     return widget;
   });
 
-  const onHorizontalArrow = (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent): Optional<boolean> => EditableFields.inside(simulatedEvent.event.target) ? Optional.none<boolean>() : (() => {
-    if (detail.autofocus) {
-      simulatedEvent.setSource(component.element);
-      return Optional.none<boolean>();
-    } else {
-      return Optional.none<boolean>();
-    }
-  })();
+  const onHorizontalArrow = (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<KeyboardEvent>): Optional<boolean> =>
+    EditableFields.inside(simulatedEvent.event.target) ? Optional.none<boolean>() : (() => {
+      if (detail.autofocus) {
+        simulatedEvent.setSource(component.element);
+        return Optional.none<boolean>();
+      } else {
+        return Optional.none<boolean>();
+      }
+    })();
 
   return {
     dom: detail.dom,

--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/DomMovement.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/DomMovement.ts
@@ -5,11 +5,11 @@ import { AlloyComponent } from '../api/component/ComponentApi';
 import { NativeSimulatedEvent } from '../events/SimulatedEvent';
 import { GeneralKeyingConfig, KeyRuleHandler } from '../keying/KeyingModeTypes';
 
-export type ElementMover <C, S> = (elem: SugarElement, focused: SugarElement, config: C, state: S) => Optional<SugarElement>;
+export type ElementMover <C, S> = (elem: SugarElement<HTMLElement>, focused: SugarElement<HTMLElement>, config: C, state: S) => Optional<SugarElement<HTMLElement>>;
 
 // Looks up direction (considering LTR and RTL), finds the focused element,
 // and tries to move. If it succeeds, triggers focus and kills the event.
-const useH = <C extends GeneralKeyingConfig, S>(movement: (elem: SugarElement) => ElementMover<C, S>): KeyRuleHandler<C, S> =>
+const useH = <C extends GeneralKeyingConfig, S>(movement: (elem: SugarElement<Element>) => ElementMover<C, S>): KeyRuleHandler<C, S> =>
   (component, simulatedEvent, config, state) => {
     const move = movement(component.element);
     return use(move, component, simulatedEvent, config, state);

--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/DomNavigation.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/DomNavigation.ts
@@ -3,7 +3,7 @@ import { Attribute, SugarElement, SugarNode } from '@ephox/sugar';
 
 import * as DomPinpoint from './DomPinpoint';
 
-const horizontal = (container: SugarElement<HTMLElement>, selector: string, current: SugarElement<HTMLElement>, delta: number): Optional<SugarElement> => {
+const horizontal = (container: SugarElement<HTMLElement>, selector: string, current: SugarElement<HTMLElement>, delta: number): Optional<SugarElement<HTMLElement>> => {
 
   const isDisabledButton = (candidate: SugarElement<HTMLElement>) =>
     SugarNode.name(candidate) === 'button' && Attribute.get(candidate, 'disabled') === 'disabled';

--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/DomPinpoint.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/DomPinpoint.ts
@@ -4,7 +4,7 @@ import { Compare, SelectorFilter, SugarElement, Visibility } from '@ephox/sugar'
 import * as ArrPinpoint from './ArrPinpoint';
 
 const locateVisible = (container: SugarElement<HTMLElement>, current: SugarElement<HTMLElement>, selector: string): Optional<ArrPinpoint.IndexInfo<SugarElement<HTMLElement>>> => {
-  const predicate = (x: SugarElement) => Compare.eq(x, current);
+  const predicate = (x: SugarElement<Node>) => Compare.eq(x, current);
   const candidates = SelectorFilter.descendants<HTMLElement>(container, selector);
   const visible = Arr.filter(candidates, Visibility.isVisible);
   return ArrPinpoint.locate(visible, predicate);

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Anchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Anchor.ts
@@ -18,7 +18,7 @@ const anchor = (anchorBox: AnchorBox, origin: Origins.OriginAdt): Anchor => ({
   origin
 });
 
-const element = (anchorElement: SugarElement, origin: Origins.OriginAdt): Anchor => {
+const element = (anchorElement: SugarElement<HTMLElement>, origin: Origins.OriginAdt): Anchor => {
   const anchorBox = Origins.toBox(origin, anchorElement);
 
   return anchor(anchorBox, origin);

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/MaxHeight.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/MaxHeight.ts
@@ -2,12 +2,12 @@ import { Fun } from '@ephox/katamari';
 import { Css, Height, SugarElement } from '@ephox/sugar';
 
 // applies the max-height as determined by Bounder
-const setMaxHeight = (element: SugarElement, maxHeight: number): void => {
+const setMaxHeight = (element: SugarElement<HTMLElement>, maxHeight: number): void => {
   Height.setMax(element, Math.floor(maxHeight));
 };
 
 // adds both max-height and overflow to constrain it
-const anchored = Fun.constant((element: SugarElement, available: number): void => {
+const anchored = Fun.constant((element: SugarElement<HTMLElement>, available: number): void => {
   setMaxHeight(element, available);
   Css.setAll(element, {
     'overflow-x': 'hidden',
@@ -21,7 +21,7 @@ const anchored = Fun.constant((element: SugarElement, available: number): void =
  *
  * If the element expands below the screen height it will be cut off, but we were already doing that.
  */
-const expandable = Fun.constant((element: SugarElement, available: number): void => {
+const expandable = Fun.constant((element: SugarElement<HTMLElement>, available: number): void => {
   setMaxHeight(element, available);
 });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/MaxWidth.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/MaxWidth.ts
@@ -2,7 +2,7 @@ import { Fun } from '@ephox/katamari';
 import { SugarElement, Width } from '@ephox/sugar';
 
 // applies the max-width as determined by Bounder
-const expandable = Fun.constant((element: SugarElement, available: number): void => {
+const expandable = Fun.constant((element: SugarElement<HTMLElement>, available: number): void => {
   Width.setMax(element, Math.floor(available));
 });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Origins.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Origins.ts
@@ -71,7 +71,7 @@ const reposition = (origin: OriginAdt, decision: RepositionDecision): PositionCs
   return positionWithDirection('fixed', decision, x, y, width, height);
 });
 
-const toBox = (origin: OriginAdt, element: SugarElement): Boxes.Bounds => {
+const toBox = (origin: OriginAdt, element: SugarElement<HTMLElement>): Boxes.Bounds => {
   const rel = Fun.curry(OuterPosition.find, element);
   const position = origin.fold(rel, rel, () => {
     const scroll = Scroll.get();

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
@@ -27,7 +27,7 @@ const defaultOr = <K extends keyof AnchorOverrides>(options: AnchorOverrides, ke
 // This takes care of everything when you are positioning UI that can go anywhere on the screen
 const simple = (
   anchor: Anchor,
-  element: SugarElement,
+  element: SugarElement<HTMLElement>,
   bubble: Bubble,
   layouts: LayoutTypes.AnchorLayout[],
   lastPlacement: Optional<PlacerResult>,
@@ -56,7 +56,7 @@ const simple = (
 };
 
 // This is the old public API. If we ever need full customisability again, this is how to expose it
-const go = (anchorBox: LayoutTypes.AnchorBox, element: SugarElement, bubble: Bubble, options: ReparteeOptions): PlacerResult => {
+const go = (anchorBox: LayoutTypes.AnchorBox, element: SugarElement<HTMLElement>, bubble: Bubble, options: ReparteeOptions): PlacerResult => {
   const decision = Callouts.layout(anchorBox, element, bubble, options);
 
   Callouts.position(element, decision, options);

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/AnchorLayouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/AnchorLayouts.ts
@@ -14,13 +14,13 @@ const schema = (): FieldProcessor => FieldSchema.optionObjOf('layouts', [
 ]);
 
 const get = (
-  elem: SugarElement,
+  elem: SugarElement<Element>,
   info: HasLayoutAnchor,
   defaultLtr: AnchorLayout[],
   defaultRtl: AnchorLayout[],
   defaultBottomLtr: AnchorLayout[],
   defaultBottomRtl: AnchorLayout[],
-  dirElement: Optional<SugarElement>
+  dirElement: Optional<SugarElement<Element>>
 ): AnchorLayout[] => {
   const isBottomToTop = dirElement.map(isBottomToTopDir).getOr(false);
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
@@ -29,18 +29,18 @@ export interface AnchorDetail<D> {
   placement: (comp: AlloyComponent, anchor: D, origin: OriginAdt) => Optional<Anchoring>;
 }
 
-export type MaxHeightFunction = (elem: SugarElement, available: number) => void;
-export type MaxWidthFunction = (elem: SugarElement, available: number) => void;
+export type MaxHeightFunction = (elem: SugarElement<HTMLElement>, available: number) => void;
+export type MaxWidthFunction = (elem: SugarElement<HTMLElement>, available: number) => void;
 export interface AnchorOverrides {
   maxHeightFunction?: MaxHeightFunction;
   maxWidthFunction?: MaxWidthFunction;
 }
 
 export interface LayoutsDetail {
-  onLtr: (elem: SugarElement) => AnchorLayout[];
-  onRtl: (elem: SugarElement) => AnchorLayout[];
-  onBottomLtr: Optional<(elem: SugarElement) => AnchorLayout[]>;
-  onBottomRtl: Optional<(elem: SugarElement) => AnchorLayout[]>;
+  onLtr: (elem: SugarElement<Element>) => AnchorLayout[];
+  onRtl: (elem: SugarElement<Element>) => AnchorLayout[];
+  onBottomLtr: Optional<(elem: SugarElement<Element>) => AnchorLayout[]>;
+  onBottomRtl: Optional<(elem: SugarElement<Element>) => AnchorLayout[]>;
 }
 
 export interface HasLayoutAnchor {
@@ -48,10 +48,10 @@ export interface HasLayoutAnchor {
 }
 
 export interface Layouts {
-  onLtr: (elem: SugarElement) => AnchorLayout[];
-  onRtl: (elem: SugarElement) => AnchorLayout[];
-  onBottomLtr?: (elem: SugarElement) => AnchorLayout[];
-  onBottomRtl?: (elem: SugarElement) => AnchorLayout[];
+  onLtr: (elem: SugarElement<Element>) => AnchorLayout[];
+  onRtl: (elem: SugarElement<Element>) => AnchorLayout[];
+  onBottomLtr?: (elem: SugarElement<Element>) => AnchorLayout[];
+  onBottomRtl?: (elem: SugarElement<Element>) => AnchorLayout[];
 }
 
 export interface HasLayoutAnchorSpec {
@@ -61,7 +61,7 @@ export interface HasLayoutAnchorSpec {
 export interface SelectionAnchorSpec extends CommonAnchorSpec, HasLayoutAnchorSpec {
   type: 'selection';
   getSelection?: () => Optional<SimRange>;
-  root: SugarElement;
+  root: SugarElement<Node>;
   bubble?: Bubble;
   overrides?: AnchorOverrides;
   showAbove?: boolean;
@@ -69,7 +69,7 @@ export interface SelectionAnchorSpec extends CommonAnchorSpec, HasLayoutAnchorSp
 
 export interface SelectionAnchor extends AnchorDetail<SelectionAnchor>, HasLayoutAnchor {
   getSelection: Optional<() => Optional<SimRange>>;
-  root: SugarElement;
+  root: SugarElement<Node>;
   bubble: Optional<Bubble>;
   overrides: AnchorOverrides;
   showAbove: boolean;
@@ -77,16 +77,16 @@ export interface SelectionAnchor extends AnchorDetail<SelectionAnchor>, HasLayou
 
 export interface NodeAnchorSpec extends CommonAnchorSpec, HasLayoutAnchorSpec {
   type: 'node';
-  node: Optional<SugarElement>;
-  root: SugarElement;
+  node: Optional<SugarElement<Element>>;
+  root: SugarElement<Node>;
   bubble?: Bubble;
   overrides?: AnchorOverrides;
   showAbove?: boolean;
 }
 
 export interface NodeAnchor extends AnchorDetail<NodeAnchor>, HasLayoutAnchor {
-  node: Optional<SugarElement>;
-  root: SugarElement;
+  node: Optional<SugarElement<Element>>;
+  root: SugarElement<Node>;
   bubble: Optional<Bubble>;
   overrides: AnchorOverrides;
   showAbove: boolean;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
@@ -14,7 +14,7 @@ const getBox = (left: number, top: number, width: number, height: number): Optio
   return Optional.some(Boxes.pointed(point, width, height));
 };
 
-const calcNewAnchor = (optBox: Optional<Boxes.BoxByPoint>, rootPoint: CssPosition.CssPositionAdt, anchorInfo: SelectionAnchor | NodeAnchor, origin: Origins.OriginAdt, elem: SugarElement): Optional<Anchoring> =>
+const calcNewAnchor = (optBox: Optional<Boxes.BoxByPoint>, rootPoint: CssPosition.CssPositionAdt, anchorInfo: SelectionAnchor | NodeAnchor, origin: Origins.OriginAdt, elem: SugarElement<Element>): Optional<Anchoring> =>
   optBox.map((box) => {
     const points = [ rootPoint, box.point ];
     const topLeft = Origins.cata(origin,

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -12,7 +12,7 @@ import * as ContainerOffsets from './ContainerOffsets';
 import * as ContentAnchorCommon from './ContentAnchorCommon';
 
 // A range from (a, 1) to (body, end) was giving the wrong bounds.
-const descendOnce = (element: SugarElement, offset: number): Descend.ElementAndOffset<Node> =>
+const descendOnce = (element: SugarElement<Node>, offset: number): Descend.ElementAndOffset<Node> =>
   SugarNode.isText(element) ? Descend.point(element, offset) : Descend.descendOnce(element, offset);
 
 const getAnchorSelection = (win: Window, anchorInfo: SelectionAnchor): Optional<SimRange> => {
@@ -44,8 +44,8 @@ const placement = (component: AlloyComponent, anchorInfo: SelectionAnchor, origi
     return optRect.bind((rawRect) => ContentAnchorCommon.getBox(rawRect.left, rawRect.top, rawRect.width, rawRect.height));
   });
 
-  const targetElement: Optional<SugarElement> = getAnchorSelection(win, anchorInfo)
-    .bind((sel) => SugarNode.isElement(sel.start) ? Optional.some<SugarElement<Node>>(sel.start) : Traverse.parentNode(sel.start));
+  const targetElement = getAnchorSelection(win, anchorInfo)
+    .bind((sel) => SugarNode.isElement(sel.start) ? Optional.some(sel.start) : Traverse.parentElement(sel.start));
   const elem = targetElement.getOr(component.element);
 
   return ContentAnchorCommon.calcNewAnchor(selectionBox, rootPoint, anchorInfo, origin, elem);

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/VerticalDir.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/VerticalDir.ts
@@ -7,7 +7,7 @@ export enum AttributeValue {
 
 export const Attribute = 'data-alloy-vertical-dir';
 
-const isBottomToTopDir = (el: SugarElement): boolean => PredicateExists.closest(el, (current) =>
+const isBottomToTopDir = (el: SugarElement<Element>): boolean => PredicateExists.closest(el, (current) =>
   SugarNode.isElement(current) && Attrib.get(current, 'data-alloy-vertical-dir') === AttributeValue.BottomToTop);
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
@@ -15,12 +15,12 @@ import { applyTransitionCss } from './Transitions';
  * in case we decide to bring back the flexibility of working with non-standard positioning.
  */
 
-const elementSize = (p: SugarElement): AnchorElement => ({
+const elementSize = (p: SugarElement<HTMLElement>): AnchorElement => ({
   width: Width.getOuter(p),
   height: Height.getOuter(p)
 });
 
-const layout = (anchorBox: AnchorBox, element: SugarElement, bubbles: Bubble, options: ReparteeOptions): RepositionDecision => {
+const layout = (anchorBox: AnchorBox, element: SugarElement<HTMLElement>, bubbles: Bubble, options: ReparteeOptions): RepositionDecision => {
   // clear the potentially limiting factors before measuring
   Css.remove(element, 'max-height');
   Css.remove(element, 'max-width');
@@ -29,7 +29,7 @@ const layout = (anchorBox: AnchorBox, element: SugarElement, bubbles: Bubble, op
   return Bounder.attempts(element, options.preference, anchorBox, elementBox, bubbles, options.bounds);
 };
 
-const setClasses = (element: SugarElement, decision: RepositionDecision): void => {
+const setClasses = (element: SugarElement<HTMLElement>, decision: RepositionDecision): void => {
   const classInfo = decision.classes;
   Classes.remove(element, classInfo.off);
   Classes.add(element, classInfo.on);
@@ -41,19 +41,19 @@ const setClasses = (element: SugarElement, decision: RepositionDecision): void =
  *
  * There are a few cases where we specifically don't want a max-height, which is why it's optional.
  */
-const setHeight = (element: SugarElement, decision: RepositionDecision, options: ReparteeOptions): void => {
+const setHeight = (element: SugarElement<HTMLElement>, decision: RepositionDecision, options: ReparteeOptions): void => {
   // The old API enforced MaxHeight.anchored() for fixed position. That no longer seems necessary.
   const maxHeightFunction = options.maxHeightFunction;
 
   maxHeightFunction(element, decision.maxHeight);
 };
 
-const setWidth = (element: SugarElement, decision: RepositionDecision, options: ReparteeOptions): void => {
+const setWidth = (element: SugarElement<HTMLElement>, decision: RepositionDecision, options: ReparteeOptions): void => {
   const maxWidthFunction = options.maxWidthFunction;
   maxWidthFunction(element, decision.maxWidth);
 };
 
-const position = (element: SugarElement, decision: RepositionDecision, options: ReparteeOptions): void => {
+const position = (element: SugarElement<HTMLElement>, decision: RepositionDecision, options: ReparteeOptions): void => {
   // This is a point of difference between Alloy and Repartee. Repartee appears to use Measure to calculate the available space for fixed origin
   // That is not ported yet.
   const positionCss = Origins.reposition(options.origin, decision);
@@ -63,7 +63,7 @@ const position = (element: SugarElement, decision: RepositionDecision, options: 
   applyPositionCss(element, positionCss);
 };
 
-const setPlacement = (element: SugarElement, decision: RepositionDecision): void => {
+const setPlacement = (element: SugarElement<HTMLElement>, decision: RepositionDecision): void => {
   Placement.setPlacement(element, decision.placement);
 };
 

--- a/modules/alloy/src/main/ts/ephox/alloy/registry/Registry.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/registry/Registry.ts
@@ -7,7 +7,7 @@ import * as AlloyLogger from '../log/AlloyLogger';
 import * as Tagger from './Tagger';
 
 export interface Registry {
-  readonly find: (isAboveRoot: (elem: SugarElement) => boolean, type: string, target: SugarElement) => Optional<ElementAndHandler>;
+  readonly find: (isAboveRoot: (elem: SugarElement<Node>) => boolean, type: string, target: SugarElement<Node>) => Optional<ElementAndHandler>;
   readonly filter: (type: string) => UidAndHandler[];
   readonly register: (component: AlloyComponent) => void;
   readonly unregister: (component: AlloyComponent) => void;
@@ -60,7 +60,7 @@ export const Registry = (): Registry => {
 
   const filter = (type: string): UidAndHandler[] => events.filterByType(type);
 
-  const find = (isAboveRoot: (elem: SugarElement) => boolean, type: string, target: SugarElement): Optional<ElementAndHandler> =>
+  const find = (isAboveRoot: (elem: SugarElement<Node>) => boolean, type: string, target: SugarElement<Node>): Optional<ElementAndHandler> =>
     events.find(isAboveRoot, type, target);
 
   const getById = (id: string): Optional<AlloyComponent> => Obj.get(components, id);

--- a/modules/alloy/src/main/ts/ephox/alloy/registry/Tagger.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/registry/Tagger.ts
@@ -7,29 +7,29 @@ import * as AlloyLogger from '../log/AlloyLogger';
 const prefix = AlloyTags.prefix();
 const idAttr = AlloyTags.idAttr();
 
-const write = (label: string, elem: SugarElement): string => {
+const write = (label: string, elem: SugarElement<Element>): string => {
   const id: string = Id.generate(prefix + label);
   writeOnly(elem, id);
   return id;
 };
 
-const writeOnly = (elem: SugarElement, uid: string | null): void => {
+const writeOnly = (elem: SugarElement<Node>, uid: string | null): void => {
   Object.defineProperty(elem.dom, idAttr, {
     value: uid,
     writable: true
   });
 };
 
-const read = (elem: SugarElement): Optional<string> => {
+const read = (elem: SugarElement<Node>): Optional<string> => {
   const id = SugarNode.isElement(elem) ? (elem.dom as any)[idAttr] : null;
   return Optional.from(id);
 };
 
-const readOrDie = (elem: SugarElement): string => read(elem).getOrDie('Could not find alloy uid in: ' + AlloyLogger.element(elem));
+const readOrDie = (elem: SugarElement<Node>): string => read(elem).getOrDie('Could not find alloy uid in: ' + AlloyLogger.element(elem));
 
 const generate = (prefix: string): string => Id.generate(prefix);
 
-const revoke = (elem: SugarElement): void => {
+const revoke = (elem: SugarElement<Node>): void => {
   // This looks like it is only used by ForeignGui, which is experimental.
   writeOnly(elem, null);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/sandbox/Dismissal.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/sandbox/Dismissal.ts
@@ -12,14 +12,14 @@ import * as Channels from '../api/messages/Channels';
 import { ReceivingChannelSpec, ReceivingConfig, ReceivingConfigSpec } from '../behaviour/receiving/ReceivingTypes';
 
 interface DismissalReceivingDetail {
-  isExtraPart: (sandbox: AlloyComponent, target: SugarElement) => boolean;
+  isExtraPart: (sandbox: AlloyComponent, target: SugarElement<Node>) => boolean;
   fireEventInstead: Optional<{
     event: string;
   }>;
 }
 
 export interface DismissalReceivingSpec {
-  isExtraPart?: (sandbox: AlloyComponent, target: SugarElement) => boolean;
+  isExtraPart?: (sandbox: AlloyComponent, target: SugarElement<Node>) => boolean;
   fireEventInstead?: {
     event?: string;
   };
@@ -46,7 +46,7 @@ const receivingChannel = (rawSpec: DismissalReceivingSpec): Record<string, Recei
       schema: StructureSchema.objOfOnly([
         FieldSchema.required('target')
       ]),
-      onReceive: (sandbox: AlloyComponent, data: { target: SugarElement }) => {
+      onReceive: (sandbox: AlloyComponent, data: { target: SugarElement<Node> }) => {
         if (Sandboxing.isOpen(sandbox)) {
           const isPart = Sandboxing.isPartOf(sandbox, data.target) || detail.isExtraPart(sandbox, data.target);
           if (!isPart) {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/ModalDialogSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/ModalDialogSchema.ts
@@ -34,7 +34,7 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
           Dragging.config({
             mode: 'mouse',
             getTarget: (handle) => {
-              return SelectorFind.ancestor(handle, '[role="dialog"]').getOr(handle);
+              return SelectorFind.ancestor<HTMLElement>(handle, '[role="dialog"]').getOr(handle);
             },
             blockerClass: detail.dragBlockClass.getOrDie(
               // TODO: Support errors in Optional getOrDie.

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
@@ -68,7 +68,7 @@ const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail:
   moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
 
 // get x offset from event
-const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent): Optional<number> => {
+const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>): Optional<number> => {
   const pos = ModelCommon.getEventSource(simulatedEvent);
   return pos.map((p) => p.left);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
@@ -99,7 +99,8 @@ const spectrumPart = PartType.required({
     const modelDetail = detail.model;
     const model = modelDetail.manager;
 
-    const setValueFrom = (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent) => model.getValueFromEvent(simulatedEvent).map((value: number | SugarPosition) => model.setValueFrom(component, detail, value));
+    const setValueFrom = (component: AlloyComponent, simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>) =>
+      model.getValueFromEvent(simulatedEvent).map((value: number | SugarPosition) => model.setValueFrom(component, detail, value));
 
     return {
       behaviours: Behaviour.derive([
@@ -120,7 +121,7 @@ const spectrumPart = PartType.required({
         AlloyEvents.run(NativeEvents.touchstart(), setValueFrom),
         AlloyEvents.run(NativeEvents.touchmove(), setValueFrom),
         AlloyEvents.run(NativeEvents.mousedown(), setValueFrom),
-        AlloyEvents.run<EventArgs>(NativeEvents.mousemove(), (spectrum, se) => {
+        AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousemove(), (spectrum, se) => {
           if (detail.mouseIsDown.get()) {
             setValueFrom(spectrum, se);
           }

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
@@ -62,7 +62,8 @@ const setToMax = (spectrum: AlloyComponent, detail: TwoDSliderDetail): void => {
 };
 
 // get event data as a SugarPosition
-const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent): Optional<SugarPosition> => ModelCommon.getEventSource(simulatedEvent);
+const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>): Optional<SugarPosition> =>
+  ModelCommon.getEventSource(simulatedEvent);
 
 // update the position of the thumb from the slider's current value
 const setPositionFromValue = (slider: AlloyComponent, thumb: AlloyComponent, detail: TwoDSliderDetail, edges: SliderModelDetailParts): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
@@ -68,7 +68,7 @@ const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail:
   moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
 
 // get y offset from event
-const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent): Optional<number> => {
+const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>): Optional<number> => {
   const pos = ModelCommon.getEventSource(simulatedEvent);
   return pos.map((p) => {
     return p.top;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
@@ -20,7 +20,7 @@ export interface InlineViewDetail extends SingleSketchDetail {
   onHide: (component: AlloyComponent) => void;
   onEscape: Optional<(component: AlloyComponent) => void>;
   getRelated: (component: AlloyComponent) => Optional<AlloyComponent>;
-  isExtraPart: (component: AlloyComponent, target: SugarElement) => boolean;
+  isExtraPart: (component: AlloyComponent, target: SugarElement<Node>) => boolean;
   lazySink: LazySink;
   eventOrder: Record<string, string[]>;
   fireDismissalEventInstead: Optional<{
@@ -41,7 +41,7 @@ export interface InlineViewSpec extends SingleSketchSpec {
   onHide?: (component: AlloyComponent) => void;
   onEscape?: (component: AlloyComponent) => void;
   getRelated?: (component: AlloyComponent) => Optional<AlloyComponent>;
-  isExtraPart?: (component: AlloyComponent, target: SugarElement) => boolean;
+  isExtraPart?: (component: AlloyComponent, target: SugarElement<Node>) => boolean;
   eventOrder?: Record<string, string[]>;
   fireDismissalEventInstead?: {
     event?: string;
@@ -59,7 +59,7 @@ export interface InlineMenuSpec {
 
 export interface InlineViewApis {
   showAt: (component: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec) => void;
-  showWithin: (component: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec, boxElement: Optional<SugarElement>) => void;
+  showWithin: (component: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec, boxElement: Optional<SugarElement<HTMLElement>>) => void;
   showWithinBounds: (component: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec, getBounds: () => Optional<Bounds>) => void;
   showMenuAt: (component: AlloyComponent, placementSpec: PlacementSpec, menuSpec: InlineMenuSpec) => void;
   showMenuWithinBounds: (component: AlloyComponent, placementSpec: PlacementSpec, menuSpec: InlineMenuSpec, getBounds: () => Optional<Bounds>) => void;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/ModalDialogTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/ModalDialogTypes.ts
@@ -19,7 +19,7 @@ export interface ModalDialogDetail extends CompositeSketchDetail {
 
   onExecute: (comp: AlloyComponent, simulatedEvent: NativeSimulatedEvent) => Optional<boolean>;
   onEscape: (comp: AlloyComponent, simulatedEvent: NativeSimulatedEvent) => Optional<boolean>;
-  useTabstopAt: (elem: SugarElement) => boolean;
+  useTabstopAt: (elem: SugarElement<HTMLElement>) => boolean;
 
   lazySink: LazySink;
   dragBlockClass: Optional<string>;
@@ -34,7 +34,7 @@ export interface ModalDialogSpec extends CompositeSketchSpec {
   eventOrder?: Record<string, string[]>;
 
   lazySink?: LazySink;
-  useTabstopAt?: (comp: SugarElement) => boolean;
+  useTabstopAt?: (comp: SugarElement<HTMLElement>) => boolean;
   onExecute?: (comp: AlloyComponent, simulatedEvent: NativeSimulatedEvent) => Optional<boolean>;
   onEscape?: (comp: AlloyComponent, simulatedEvent: NativeSimulatedEvent) => Optional<boolean>;
   dragBlockClass?: string;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SliderTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SliderTypes.ts
@@ -46,7 +46,7 @@ export interface Manager {
   setValueFrom: (spectrum: AlloyComponent, detail: SliderDetail, value: number | SugarPosition) => void;
   setToMin: (spectrum: AlloyComponent, detail: SliderDetail) => void;
   setToMax: (spectrum: AlloyComponent, detail: SliderDetail) => void;
-  getValueFromEvent: (simulatedEvent: NativeSimulatedEvent) => Optional<number | SugarPosition>;
+  getValueFromEvent: (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>) => Optional<number | SugarPosition>;
   setPositionFromValue: (slider: AlloyComponent, thumb: AlloyComponent, detail: SliderDetail, parts: SliderModelDetailParts) => void;
   onLeft: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
   onRight: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;

--- a/modules/alloy/src/test/ts/browser/behaviour/InvalidatingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/InvalidatingTest.ts
@@ -12,7 +12,7 @@ import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 
 UnitTest.asynctest('InvalidatingTest', (success, failure) => {
 
-  const root = Singleton.value<SugarElement<any>>();
+  const root = Singleton.value<SugarElement<Element>>();
 
   GuiSetup.setup((_store, _doc, _body) => GuiFactory.build({
     dom: {

--- a/modules/alloy/src/test/ts/browser/behaviour/dragging/MouseDragEventTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/dragging/MouseDragEventTest.ts
@@ -31,7 +31,7 @@ UnitTest.asynctest('MouseDragEventTest', (success, failure) => {
       ])
     })
   ), (_doc, _body, gui, component, store) => {
-    const cAssertNoPositionInfo = Chain.op((box: SugarElement) => {
+    const cAssertNoPositionInfo = Chain.op((box: SugarElement<HTMLElement>) => {
       Assertions.assertEq('Should be no "left"', true, Css.getRaw(box, 'left').isNone());
       Assertions.assertEq('Should be no "top"', true, Css.getRaw(box, 'top').isNone());
     });

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/FocusManagersTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/FocusManagersTest.ts
@@ -16,11 +16,11 @@ UnitTest.asynctest('Browser Test: behaviour.keying.FocusManagersTest', (success,
   const createManager = (prefix: string) => {
     let active: string | undefined = '';
 
-    const set = (_component: AlloyComponent, focusee: SugarElement) => {
+    const set = (_component: AlloyComponent, focusee: SugarElement<HTMLElement>) => {
       active = Attribute.get(focusee, 'class');
     };
 
-    const get = (component: AlloyComponent) => SelectorFind.descendant(component.element, '.' + active);
+    const get = (component: AlloyComponent) => SelectorFind.descendant<HTMLElement>(component.element, '.' + active);
 
     // Test only method
     const sAssert = (label: string, expected: string) => Step.sync(() => {

--- a/modules/alloy/src/test/ts/browser/behaviour/keying/FocusModesTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/keying/FocusModesTest.ts
@@ -77,7 +77,7 @@ UnitTest.asynctest('Focus Modes Test', (success, failure) => {
       Keying.focusIn(comp);
     });
 
-    const sTriggerFocus = (target: SugarElement) => Step.sync(() => {
+    const sTriggerFocus = (target: SugarElement<HTMLElement>) => Step.sync(() => {
       component.getSystem().triggerFocus(target, component.element);
     });
 

--- a/modules/alloy/src/test/ts/browser/events/EventRegistryTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/EventRegistryTest.ts
@@ -95,7 +95,7 @@ UnitTest.asynctest('EventRegistryTest', (success, failure) => {
   );
 
   const sAssertFind = (label: string, expected: ExpectedType, type: string, id: string) => {
-    const cFindHandler = Chain.binder((target: SugarElement) => events.find(isRoot, type, target).fold(
+    const cFindHandler = Chain.binder((target: SugarElement<Element>) => events.find(isRoot, type, target).fold(
       () => Result.error<ElementAndHandler, string>('No event handler for ' + type + ' on ' + target.dom),
       Result.value
     ));
@@ -115,7 +115,7 @@ UnitTest.asynctest('EventRegistryTest', (success, failure) => {
             Assertions.assertEq(
               'find(' + type + ', ' + id + ') = true',
               expected.target,
-              Attribute.get(section.element, 'data-test-uid')
+              Attribute.get(section.element as SugarElement<Element>, 'data-test-uid')
             );
             Assertions.assertEq(
               () => 'find(' + type + ', ' + id + ') = ' + JSON.stringify(expected.handler),

--- a/modules/alloy/src/test/ts/browser/events/TapEventsTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/TapEventsTest.ts
@@ -21,7 +21,7 @@ UnitTest.asynctest('browser events.TapEventsTest', (success, failure) => {
 
   const alpha = SugarElement.fromText('alpha');
 
-  const touches = (x: number, y: number, target: SugarElement) => ({
+  const touches = (x: number, y: number, target: SugarElement<Node>) => ({
     raw: {
       touches: [
         { clientX: x, clientY: y }

--- a/modules/alloy/src/test/ts/browser/events/TriggersTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/TriggersTest.ts
@@ -62,8 +62,8 @@ UnitTest.asynctest('TriggersTest', (success, failure) => {
 
   const logger = Debugging.noLogger();
 
-  const lookup = (eventType: string, target: SugarElement) =>
-    Attribute.getOpt(target, 'data-event-id').bind((targetId) =>
+  const lookup = (eventType: string, target: SugarElement<Node>) =>
+    Attribute.getOpt(target as SugarElement<Element>, 'data-event-id').bind((targetId) =>
       Obj.get(domEvents as any, eventType).bind((x) => Obj.get(x, targetId)).map((h: Function) => ({
         descHandler: {
           cHandler: h,

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/GridMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/GridMenuTest.ts
@@ -57,11 +57,11 @@ UnitTest.asynctest('GridMenuTest', (success, failure) => {
     })
   ), (_doc, _body, _gui, component, store) => {
     // TODO: Flesh out test.
-    const cAssertStructure = (label: string, expected: StructAssert) => Chain.op((element: SugarElement) => {
+    const cAssertStructure = (label: string, expected: StructAssert) => Chain.op((element: SugarElement<HTMLOListElement>) => {
       Assertions.assertStructure(label, expected, element);
     });
 
-    const cTriggerFocusItem = Chain.op((target: SugarElement) => {
+    const cTriggerFocusItem = Chain.op((target: SugarElement<HTMLLIElement>) => {
       AlloyTriggers.dispatch(component, target, SystemEvents.focusItem());
     });
 

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/MatrixMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/MatrixMenuTest.ts
@@ -65,11 +65,11 @@ UnitTest.asynctest('MatrixMenuTest', (success, failure) => {
     })
   ), (_doc, _body, _gui, component, store) => {
     // TODO: Flesh out test.
-    const cAssertStructure = (label: string, expected: StructAssert) => Chain.op((element: SugarElement) => {
+    const cAssertStructure = (label: string, expected: StructAssert) => Chain.op((element: SugarElement<HTMLOListElement>) => {
       Assertions.assertStructure(label, expected, element);
     });
 
-    const cTriggerFocusItem = Chain.op((target: SugarElement) => {
+    const cTriggerFocusItem = Chain.op((target: SugarElement<HTMLLIElement>) => {
       AlloyTriggers.dispatch(component, target, SystemEvents.focusItem());
     });
 

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/MenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/MenuTest.ts
@@ -44,11 +44,11 @@ UnitTest.asynctest('MenuTest', (success, failure) => {
     })
   ), (_doc, _body, _gui, component, store) => {
     // TODO: Flesh out test.
-    const cAssertStructure = (label: string, expected: StructAssert) => Chain.op((element: SugarElement) => {
+    const cAssertStructure = (label: string, expected: StructAssert) => Chain.op((element: SugarElement<HTMLOListElement>) => {
       Assertions.assertStructure(label, expected, element);
     });
 
-    const cTriggerFocusItem = Chain.op((target: SugarElement) => {
+    const cTriggerFocusItem = Chain.op((target: SugarElement<HTMLLIElement>) => {
       AlloyTriggers.dispatch(component, target, SystemEvents.focusItem());
     });
 

--- a/modules/alloy/src/test/ts/browser/ui/inline/InlineViewRepositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/inline/InlineViewRepositionTest.ts
@@ -85,7 +85,7 @@ UnitTest.asynctest('InlineViewRepositionTest', (success, failure) => {
       ])
     );
 
-    const sCheckPosition = (label: string, element: SugarElement, x: number, y: number) => Logger.t(
+    const sCheckPosition = (label: string, element: SugarElement<HTMLDivElement>, x: number, y: number) => Logger.t(
       label,
       Step.sync(() => {
         const top = parseInt(Css.get(element, 'top').replace('px', ''), 10);

--- a/modules/alloy/src/test/ts/browser/ui/slider/HorizontalSliderTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/slider/HorizontalSliderTest.ts
@@ -56,9 +56,9 @@ UnitTest.asynctest('Browser Test: ui.slider.HorizontalSliderTest', (success, fai
     })
   ), (doc, _body, _gui, component, _store) => {
 
-    const cGetBounds = Chain.mapper((elem: SugarElement) => elem.dom.getBoundingClientRect());
+    const cGetBounds = Chain.mapper((elem: SugarElement<Element>) => elem.dom.getBoundingClientRect());
 
-    const cGetComponent = Chain.binder((elem: SugarElement) => component.getSystem().getByDom(elem));
+    const cGetComponent = Chain.binder((elem: SugarElement<Element>) => component.getSystem().getByDom(elem));
 
     const cGetParts = NamedChain.asChain([
       NamedChain.writeValue('slider', component.element),

--- a/modules/alloy/src/test/ts/browser/ui/slider/TwoDSliderTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/slider/TwoDSliderTest.ts
@@ -90,9 +90,9 @@ UnitTest.asynctest('Browser Test: ui.slider.TwoDSliderTest', (success, failure) 
     })
   ), (doc, _body, _gui, component, _store) => {
 
-    const cGetBounds = Chain.mapper((elem: SugarElement) => elem.dom.getBoundingClientRect());
+    const cGetBounds = Chain.mapper((elem: SugarElement<Element>) => elem.dom.getBoundingClientRect());
 
-    const cGetComponent = Chain.binder((elem: SugarElement) => component.getSystem().getByDom(elem));
+    const cGetComponent = Chain.binder((elem: SugarElement<Element>) => component.getSystem().getByDom(elem));
 
     const cGetParts = NamedChain.asChain([
       NamedChain.writeValue('slider', component.element),

--- a/modules/alloy/src/test/ts/browser/ui/slider/VerticalSliderTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/slider/VerticalSliderTest.ts
@@ -57,9 +57,9 @@ UnitTest.asynctest('Browser Test: ui.slider.VerticalSliderTest', (success, failu
     })
   ), (doc, _body, _gui, component, _store) => {
 
-    const cGetBounds = Chain.mapper((elem: SugarElement) => elem.dom.getBoundingClientRect());
+    const cGetBounds = Chain.mapper((elem: SugarElement<Element>) => elem.dom.getBoundingClientRect());
 
-    const cGetComponent = Chain.binder((elem: SugarElement) => component.getSystem().getByDom(elem));
+    const cGetComponent = Chain.binder((elem: SugarElement<Element>) => component.getSystem().getByDom(elem));
 
     const cGetParts = NamedChain.asChain([
       NamedChain.writeValue('slider', component.element),

--- a/modules/alloy/src/test/ts/browser/ui/tabs/TabSectionTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/tabs/TabSectionTest.ts
@@ -89,7 +89,7 @@ UnitTest.asynctest('TabSection Test', (success, failure) => {
       SelectorFind.descendant(component.element, '.test-tabview').getOrDie('Could not find tabview')
     ).getOrDie();
 
-    const sAssertTabSelection = (label: string, expected: boolean, element: SugarElement) =>
+    const sAssertTabSelection = (label: string, expected: boolean, element: SugarElement<HTMLButtonElement>) =>
       Assertions.sAssertStructure(label + ' (asserting structure)', ApproxStructure.build((s, str, arr) => s.element('button', {
         attrs: {
           'aria-selected': expected ? str.is('true') : str.is('false')

--- a/modules/alloy/src/test/ts/module/ephox/alloy/log/AlloyLogger.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/log/AlloyLogger.ts
@@ -2,7 +2,7 @@ import { Fun } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 // Used for atomic testing where window is not available.
-const element: (elem: SugarElement) => SugarElement = Fun.identity;
+const element: <T>(elem: SugarElement<T>) => SugarElement<T> = Fun.identity;
 
 export {
   element

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/ChainUtils.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/ChainUtils.ts
@@ -28,7 +28,7 @@ const cFindUids = <T>(gui: Record<string, any>, lookups: Record<string, string>)
 
 const cToElement = Chain.mapper((comp: AlloyComponent) => comp.element);
 
-const eToComponent = (other: AlloyComponent): Chain<SugarElement, AlloyComponent> =>
+const eToComponent = (other: AlloyComponent): Chain<SugarElement<Node>, AlloyComponent> =>
   Chain.binder((elem) => other.getSystem().getByDom(elem));
 
 export {

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/NavigationUtils.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/NavigationUtils.ts
@@ -7,7 +7,7 @@ const range = <T, R>(num: number, f: (v: T, i: number) => R[]): R[] => {
   return Arr.bind(array, f);
 };
 
-const sequence = <T>(doc: SugarElement<HTMLDocument>, key: number, modifiers: { }, identifiers: Array<{ label: string; selector: string }>): Step<T, T> => {
+const sequence = <T>(doc: SugarElement<Document>, key: number, modifiers: { }, identifiers: Array<{ label: string; selector: string }>): Step<T, T> => {
   const array = range(identifiers.length, (_, i) => [
     Keyboard.sKeydown(doc, key, modifiers),
     FocusTools.sTryOnSelector(
@@ -22,7 +22,7 @@ const sequence = <T>(doc: SugarElement<HTMLDocument>, key: number, modifiers: { 
 };
 
 // Selector based
-const highlights = <T>(container: SugarElement, key: number, modifiers: { }, identifiers: Array<{ label: string; selector: string }>): Step<T, T> => {
+const highlights = <T>(container: SugarElement<Node>, key: number, modifiers: { }, identifiers: Array<{ label: string; selector: string }>): Step<T, T> => {
   const array = range(identifiers.length, (_, i) => {
     const msg = 'Highlight should move from ' + (i > 0 ? identifiers[i - 1].label : '(start)') + ' to ' + identifiers[i].label;
     const doc = Traverse.owner(container);

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/PositionTestUtils.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/PositionTestUtils.ts
@@ -54,7 +54,7 @@ const pTestSink = async (sinkName: string, sink: AlloyComponent, popup: AlloyCom
   await pTestPopupPosition(sinkName, popup, sink);
 };
 
-const pTestSinkWithin = async (sinkName: string, sink: AlloyComponent, popup: AlloyComponent, placementSpec: PlacementSpec, elem: SugarElement): Promise<void> => {
+const pTestSinkWithin = async (sinkName: string, sink: AlloyComponent, popup: AlloyComponent, placementSpec: PlacementSpec, elem: SugarElement<HTMLElement>): Promise<void> => {
   addPopupToSinkWithin(popup, placementSpec, sink, elem);
   await pTestPopupPosition(sinkName, popup, sink);
 };
@@ -74,7 +74,7 @@ const cAddPopupToSink = (sinkName: string): NamedChain => NamedChain.bundle((dat
   return Result.value(data);
 });
 
-const cAddPopupToSinkWithin = (sinkName: string, elem: SugarElement): NamedChain => NamedChain.bundle((data) => {
+const cAddPopupToSinkWithin = (sinkName: string, elem: SugarElement<HTMLElement>): NamedChain => NamedChain.bundle((data) => {
   addPopupToSinkWithin(data.popup, { anchor: data.anchor }, data[sinkName], elem);
   return Result.value(data);
 });
@@ -129,7 +129,7 @@ const cTestSink = (label: string, sinkName: string): NamedChain => ChainUtils.cL
   ]
 );
 
-const cTestSinkWithin = (label: string, sinkName: string, elem: SugarElement): NamedChain => ChainUtils.cLogging(
+const cTestSinkWithin = (label: string, sinkName: string, elem: SugarElement<HTMLElement>): NamedChain => ChainUtils.cLogging(
   label,
   [
     cAddPopupToSinkWithin(sinkName, elem),

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/Sinks.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/Sinks.ts
@@ -62,7 +62,7 @@ const popup = (): AlloyComponent => GuiFactory.build(
 );
 
 const isInside = (sinkComponent: AlloyComponent, popupComponent: AlloyComponent): boolean => {
-  const isSink = (el: SugarElement) => Compare.eq(el, sinkComponent.element);
+  const isSink = (el: SugarElement<Node>) => Compare.eq(el, sinkComponent.element);
 
   return PredicateExists.closest(popupComponent.element, isSink);
 };

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/TestBroadcasts.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/TestBroadcasts.ts
@@ -3,7 +3,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import { GuiSystem } from 'ephox/alloy/api/system/Gui';
 
-const dismiss = (gui: GuiSystem, element: SugarElement): void => {
+const dismiss = (gui: GuiSystem, element: SugarElement<Element>): void => {
   gui.broadcastOn([
     'dismiss.popups'
   ], {
@@ -17,7 +17,7 @@ const reposition = (gui: GuiSystem): void => {
   ], { });
 };
 
-const sDismiss = <T>(label: string, gui: GuiSystem, element: SugarElement): Step<T, T> =>
+const sDismiss = <T>(label: string, gui: GuiSystem, element: SugarElement<Element>): Step<T, T> =>
   Logger.t(
     'Broadcast dismiss: ' + label,
     GeneralSteps.sequence([

--- a/modules/alloy/src/test/ts/touch/ui/touch/TouchMenuTest.ts
+++ b/modules/alloy/src/test/ts/touch/ui/touch/TouchMenuTest.ts
@@ -109,7 +109,7 @@ UnitTest.asynctest('Browser Test: ui.touch.TouchMenuTest', (success, failure) =>
     );
   }, (doc, _body, gui, component, store) => {
 
-    const fireTouchstart = (target: SugarElement, x: number, y: number) => {
+    const fireTouchstart = (target: SugarElement<Node>, x: number, y: number) => {
       AlloyTriggers.dispatchWith(component, target, NativeEvents.touchstart(), {
         raw: {
           touches: [
@@ -119,15 +119,15 @@ UnitTest.asynctest('Browser Test: ui.touch.TouchMenuTest', (success, failure) =>
       });
     };
 
-    const fireTouchend = (target: SugarElement) => {
+    const fireTouchend = (target: SugarElement<Node>) => {
       AlloyTriggers.dispatch(component, target, NativeEvents.touchend());
     };
 
-    const fireLongpress = (target: SugarElement) => {
+    const fireLongpress = (target: SugarElement<Node>) => {
       AlloyTriggers.dispatch(component, target, SystemEvents.longpress());
     };
 
-    const sFireTouchmoveOn = (container: SugarElement, selector: string) => Chain.asStep(gui.element, [
+    const sFireTouchmoveOn = (container: SugarElement<Node>, selector: string) => Chain.asStep(gui.element, [
       UiFinder.cFindIn(selector),
       Chain.op((target) => {
         const rect = target.dom.getBoundingClientRect();

--- a/modules/tinymce/src/core/main/ts/frames/Frames.ts
+++ b/modules/tinymce/src/core/main/ts/frames/Frames.ts
@@ -10,7 +10,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import { Navigation } from './Navigation';
 
-const walkUp = (navigation: Navigation, doc: SugarElement): SugarElement[] => {
+const walkUp = (navigation: Navigation, doc: SugarElement<Document>): SugarElement<Element>[] => {
   const frame = navigation.view(doc);
   return frame.fold(Fun.constant([]), (f) => {
     const parent = navigation.owner(f);
@@ -19,7 +19,7 @@ const walkUp = (navigation: Navigation, doc: SugarElement): SugarElement[] => {
   });
 };
 
-const pathTo = (element: SugarElement, navigation: Navigation): SugarElement[] => {
+const pathTo = (element: SugarElement<Node>, navigation: Navigation): SugarElement<Element>[] => {
   const d = navigation.owner(element);
   return walkUp(navigation, d);
 };

--- a/modules/tinymce/src/core/main/ts/frames/OuterPosition.ts
+++ b/modules/tinymce/src/core/main/ts/frames/OuterPosition.ts
@@ -6,13 +6,13 @@
  */
 
 import { Arr } from '@ephox/katamari';
-import { Scroll, SugarElement, SugarLocation, SugarPosition } from '@ephox/sugar';
+import { Scroll, SugarDocument, SugarElement, SugarLocation, SugarPosition } from '@ephox/sugar';
 
 import * as Frames from './Frames';
 import * as Navigation from './Navigation';
 
-const find = (element: SugarElement): SugarPosition => {
-  const doc = SugarElement.fromDom(document);
+const find = (element: SugarElement<Element>): SugarPosition => {
+  const doc = SugarDocument.getDocument();
   const scroll = Scroll.get(doc);
   const frames = Frames.pathTo(element, Navigation);
   const offset = SugarLocation.viewport(element);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
@@ -55,7 +55,7 @@ export const renderColorInput = (spec: ColorInputSpec, sharedBackstage: UiFactor
       Tabstopping.config({ }),
       Invalidating.config({
         invalidClass: 'tox-textbox-field-invalid',
-        getRoot: (comp) => Traverse.parent(comp.element),
+        getRoot: (comp) => Traverse.parentElement(comp.element),
         notify: {
           onValid: (comp) => {
             // onValid should pass through the value here
@@ -100,7 +100,7 @@ export const renderColorInput = (spec: ColorInputSpec, sharedBackstage: UiFactor
     });
   };
 
-  const onItemAction = (comp: AlloyComponent, value) => {
+  const onItemAction = (comp: AlloyComponent, value: string) => {
     memColorButton.getOpt(comp).each((colorBit) => {
       if (value === 'custom') {
         colorInputBackstage.colorPicker((valueOpt) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -49,7 +49,7 @@ const renderTextField = (spec: TextField, providersBackstage: UiFactoryBackstage
 
   const validatingBehaviours = spec.validation.map((vl) => Invalidating.config({
     getRoot: (input) => {
-      return Traverse.parent(input.element);
+      return Traverse.parentElement(input.element);
     },
     invalidClass: 'tox-invalid',
     validator: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -89,7 +89,7 @@ export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage
     typeaheadBehaviours: Behaviour.derive(Arr.flatten([
       urlBackstage.getValidationHandler().map(
         (handler) => Invalidating.config({
-          getRoot: (comp) => Traverse.parent(comp.element),
+          getRoot: (comp) => Traverse.parentElement(comp.element),
           invalidClass: 'tox-control-wrap--status-invalid',
           notify: {
             onInvalid: (comp: AlloyComponent, err: string) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
@@ -27,7 +27,7 @@ export interface SwatchPanelButtonSpec {
   columns: number;
   presets: Toolbar.PresetTypes;
   getHotspot?: (comp: AlloyComponent) => Optional<AlloyComponent>;
-  onItemAction: (comp: AlloyComponent, value) => void;
+  onItemAction: (comp: AlloyComponent, value: string) => void;
   layouts?: Layouts;
 }
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -85,7 +85,7 @@ const renderInlineHeader = (
       mode: 'mouse',
       blockerClass: 'blocker',
       getTarget: (handle) => {
-        return SelectorFind.closest(handle, '[role="dialog"]').getOrDie();
+        return SelectorFind.closest<HTMLElement>(handle, '[role="dialog"]').getOrDie();
       },
       snaps: {
         getSnapPoints: () => [ ],


### PR DESCRIPTION
Related Ticket: TINY-8331

Description of Changes:

This is the third (and final for now) PR to start cleaning up some of the `any` types we have for `SugarElement` in the hopes that we maybe able to remove the `any` default we currently have. Unfortunately for Alloy the `Component` element type is going to be very hard to type (if not impossible with the current setup), so I've marked that specifically as `<any>` for now.

Note: I did leave a `SugarElement<any>` in `ImageClone` but that's because it's been deleted in the IE/Edge cleanup PR.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
