### PR TITLE
TINY-8205: Fixes to add some forward compatibility with the new parser

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `toc` plugin, which is now classified as a Premium plugin #TINY-8250
 - Removed the `tinymce.utils.Promise` API #TINY-8241
 - Removed the `tabfocus` plugin #TINY-8315
+- Removed the `shortEnded` property on `tinymce.html.Node` class #TINY-8205
 
 ## 5.10.2 - 2021-11-17
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `toc` plugin, which is now classified as a Premium plugin #TINY-8250
 - Removed the `tinymce.utils.Promise` API #TINY-8241
 - Removed the `tabfocus` plugin #TINY-8315
-- Removed the `shortEnded` property on `tinymce.html.Node` class #TINY-8205
+- Removed the `shortEnded` and `fixed` properties on `tinymce.html.Node` class #TINY-8205
 
 ## 5.10.2 - 2021-11-17
 

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -201,7 +201,6 @@ const builder = (rootNode: AstNode, html: string, settings: DomParserSettings, s
     start: (name, attrs, empty) => {
       const newNode = new AstNode(name, 1);
       newNode.attributes = attrs;
-      newNode.shortEnded = empty;
 
       node.append(newNode);
 

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -117,7 +117,6 @@ class AstNode {
   public type: number;
   public attributes?: Attributes;
   public value?: string;
-  public shortEnded?: boolean;
   public parent?: AstNode;
   public firstChild?: AstNode;
   public lastChild?: AstNode;
@@ -273,7 +272,6 @@ class AstNode {
     }
 
     clone.value = self.value;
-    clone.shortEnded = self.shortEnded;
 
     return clone;
   }

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -123,7 +123,6 @@ class AstNode {
   public next?: AstNode;
   public prev?: AstNode;
   public raw?: boolean;
-  public fixed?: boolean;
 
   /**
    * Constructs a new Node instance.

--- a/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
@@ -89,7 +89,7 @@ const HtmlSerializer = (settings?: HtmlSerializerSettings, schema = Schema()): H
 
       if (!handler) {
         const name = node.name;
-        const isEmpty = node.shortEnded;
+        const isEmpty = name in schema.getShortEndedElements();
         let attrs = node.attributes;
 
         // Sort attributes

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Optional, Type } from '@ephox/katamari';
+import { Arr, Optional, Type } from '@ephox/katamari';
 import { Remove, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
@@ -24,6 +24,7 @@ import * as TableDelete from '../delete/TableDelete';
 import * as CefUtils from '../dom/CefUtils';
 import * as NodeType from '../dom/NodeType';
 import * as PaddingBr from '../dom/PaddingBr';
+import { cleanInvalidNodes } from '../html/InvalidNodes';
 import * as RangeNormalizer from '../selection/RangeNormalizer';
 import * as SelectionUtils from '../selection/SelectionUtils';
 import { InsertContentDetails } from './ContentTypes';
@@ -315,14 +316,19 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
 
       // Get the outer/inner HTML depending on if we are in the root and parser and serialize that
       value = parentNode === rootNode ? rootNode.innerHTML : dom.getOuterHTML(parentNode);
-      value = serializer.serialize(
-        parser.parse(
-          // Need to replace by using a function since $ in the contents would otherwise be a problem
-          value.replace(/<span (id="mce_marker"|id=mce_marker).+?<\/span>/i, () => {
-            return serializer.serialize(fragment);
-          })
-        )
-      );
+      const root = parser.parse(value);
+      for (let markerNode = root; markerNode; markerNode = markerNode.walk()) {
+        if (markerNode.attr('id') === 'mce_marker') {
+          markerNode.replace(fragment);
+          break;
+        }
+      }
+      const toExtract = fragment.children();
+      const parent = fragment.parent.name;
+      fragment.unwrap();
+      const invalidChildren = Arr.filter(toExtract, (node) => !editor.schema.isValidChild(parent, node.name));
+      cleanInvalidNodes(invalidChildren, editor.schema);
+      value = serializer.serialize(root);
 
       // Set the inner/outer HTML depending on if we are in the root or not
       if (parentNode === rootNode) {

--- a/modules/tinymce/src/core/main/ts/html/InvalidNodes.ts
+++ b/modules/tinymce/src/core/main/ts/html/InvalidNodes.ts
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Fun } from '@ephox/katamari';
+
+import AstNode from '../api/html/Node';
+import Schema from '../api/html/Schema';
+import Tools from '../api/util/Tools';
+import { hasOnlyChild, isEmpty } from './ParserUtils';
+
+const removeOrUnwrapInvalidNode = (node: AstNode, schema: Schema, originalNodeParent: AstNode = node.parent) => {
+  if (schema.getSpecialElements()[node.name]) {
+    node.empty().remove();
+  } else {
+    // are the children of `node` valid children of the top level parent?
+    // if not, remove or unwrap them too
+    const children = node.children();
+    for (const childNode of children) {
+      if (!schema.isValidChild(originalNodeParent.name, childNode.name)) {
+        removeOrUnwrapInvalidNode(childNode, schema, originalNodeParent);
+      }
+    }
+    node.unwrap();
+  }
+};
+
+const cleanInvalidNodes = (nodes: AstNode[], schema: Schema, onCreate: (newNode: AstNode) => void = Fun.noop): void => {
+  const textBlockElements = schema.getTextBlockElements();
+  const nonEmptyElements = schema.getNonEmptyElements();
+  const whitespaceElements = schema.getWhiteSpaceElements();
+  const nonSplittableElements = Tools.makeMap('tr,td,th,tbody,thead,tfoot,table');
+
+  const fixed = new Set<AstNode>();
+
+  for (let ni = 0; ni < nodes.length; ni++) {
+    const node = nodes[ni];
+    let parent: AstNode | undefined;
+    let newParent: AstNode | undefined;
+    let tempNode: AstNode | undefined;
+
+    // Don't bother if it's detached from the tree
+    if (!node.parent || fixed.has(node)) {
+      continue;
+    }
+
+    // If the invalid element is a text block, and the text block is within a parent LI element
+    // Then unwrap the first text block and convert other sibling text blocks to LI elements similar to Word/Open Office
+    if (textBlockElements[node.name] && node.parent.name === 'li') {
+      // Move sibling text blocks after LI element
+      let sibling = node.next;
+      while (sibling) {
+        if (textBlockElements[sibling.name]) {
+          sibling.name = 'li';
+          fixed.add(sibling);
+          node.parent.insert(sibling, node.parent);
+        } else {
+          break;
+        }
+
+        sibling = sibling.next;
+      }
+
+      // Unwrap current text block
+      node.unwrap();
+      continue;
+    }
+
+    // Get list of all parent nodes until we find a valid parent to stick the child into
+    const parents = [ node ];
+    for (parent = node.parent; parent && !schema.isValidChild(parent.name, node.name) &&
+    !nonSplittableElements[parent.name]; parent = parent.parent) {
+      parents.push(parent);
+    }
+
+    // Found a suitable parent
+    if (parent && parents.length > 1) {
+      // If the node is a valid child of the parent, then try to move it. Otherwise unwrap it
+      if (schema.isValidChild(parent.name, node.name)) {
+        // Reverse the array since it makes looping easier
+        parents.reverse();
+
+        // Clone the related parent and insert that after the moved node
+        newParent = parents[0].clone();
+        onCreate(newParent);
+
+        // Start cloning and moving children on the left side of the target node
+        let currentNode = newParent;
+        for (let i = 0; i < parents.length - 1; i++) {
+          if (schema.isValidChild(currentNode.name, parents[i].name)) {
+            tempNode = parents[i].clone();
+            onCreate(tempNode);
+            currentNode.append(tempNode);
+          } else {
+            tempNode = currentNode;
+          }
+
+          for (let childNode = parents[i].firstChild; childNode && childNode !== parents[i + 1];) {
+            const nextNode = childNode.next;
+            tempNode.append(childNode);
+            childNode = nextNode;
+          }
+
+          currentNode = tempNode;
+        }
+
+        if (!isEmpty(schema, nonEmptyElements, whitespaceElements, newParent)) {
+          parent.insert(newParent, parents[0], true);
+          parent.insert(node, newParent);
+        } else {
+          parent.insert(node, parents[0], true);
+        }
+
+        // Check if the element is empty by looking through its contents, with special treatment for <p><br /></p>
+        parent = parents[0];
+        if (isEmpty(schema, nonEmptyElements, whitespaceElements, parent) || hasOnlyChild(parent, 'br')) {
+          parent.empty().remove();
+        }
+      } else {
+        removeOrUnwrapInvalidNode(node, schema);
+      }
+    } else if (node.parent) {
+      // If it's an LI try to find a UL/OL for it or wrap it
+      if (node.name === 'li') {
+        let sibling = node.prev;
+        if (sibling && (sibling.name === 'ul' || sibling.name === 'ol')) {
+          sibling.append(node);
+          continue;
+        }
+
+        sibling = node.next;
+        if (sibling && (sibling.name === 'ul' || sibling.name === 'ol')) {
+          sibling.insert(node, sibling.firstChild, true);
+          continue;
+        }
+
+        const wrapper = new AstNode('ul', 1);
+        onCreate(wrapper);
+        node.wrap(wrapper);
+        continue;
+      }
+
+      // Try wrapping the element in a DIV
+      if (schema.isValidChild(node.parent.name, 'div') && schema.isValidChild('div', node.name)) {
+        const wrapper = new AstNode('div', 1);
+        onCreate(wrapper);
+        node.wrap(wrapper);
+      } else {
+        // We failed wrapping it, remove or unwrap it
+        removeOrUnwrapInvalidNode(node, schema);
+      }
+    }
+  }
+};
+
+export { cleanInvalidNodes };

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -15,7 +15,7 @@ const paddEmptyNode = (settings: DomParserSettings, args: ParserArgs, blockEleme
   const brPreferred = settings.padd_empty_with_br || args.insert;
 
   if (brPreferred && blockElements[node.name]) {
-    node.empty().append(new AstNode('br', 1)).shortEnded = true;
+    node.empty().append(new AstNode('br', 1));
   } else {
     node.empty().append(new AstNode('#text', 3)).value = Unicode.nbsp;
   }

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -203,7 +203,7 @@ const createParser = (editor: Editor): DomParser => {
       const node = nodes[i];
 
       if (node.isEmpty(nonEmptyElements) && node.getAll('br').length === 0) {
-        node.append(new AstNode('br', 1)).shortEnded = true;
+        node.append(new AstNode('br', 1));
       }
     }
   });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -816,4 +816,12 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       '</table>'
     );
   });
+
+  it('TINY-8205: Fixes up invalid children even when top-level element does not fit the context', () => {
+    const parser = DomParser();
+    const html = '<p>Hello world! <button>This is a button with a meta tag in it<meta /></button></p>';
+    const serializedHtml = serializer.serialize(parser.parse(html, { context: 'p' }));
+
+    assert.equal(serializedHtml, '<p>Hello world! <button>This is a button with a meta tag in it</button></p>');
+  });
 });

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -60,7 +60,6 @@ const createPlaceholderNode = (editor: Editor, node: AstNode): AstNode => {
   const name = node.name;
 
   const placeHolder = new AstNode('img', 1);
-  placeHolder.shortEnded = true;
 
   retainAttributesAndInnerHtml(editor, node, placeHolder);
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -45,7 +45,7 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
     );
 
     TinyAssertions.assertContent(editor,
-      '<p><embed src="320x240.ogg" width="100" height="200"></embed>text<a href="#">link</a></p>'
+      '<p><embed src="320x240.ogg" width="100" height="200" />text<a href="#">link</a></p>'
     );
   });
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.plugins.media.core.SubmitTest', () => {
   const customEmbed =
   '<div style="left: 0px; width: 100%; height: 0px; position: relative; padding-bottom: 56.338%; max-width: 650px;">' +
   '<iframe src="https://www.youtube.com/embed/IcgmSRJHu_8"' +
-  ' width="560" height="314" allowfullscreen="allowfullscreen" data-mce-fragment="1">' +
+  ' width="560" height="314" allowfullscreen="allowfullscreen">' +
   '</iframe></div>';
 
   const pTestResolvedEmbedContentSubmit = async (editor: Editor, url: string, expected: string) => {

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Utils.ts
@@ -79,7 +79,7 @@ const innerText = (html: string): string => {
     }
 
     // Walk all children
-    if (!node.shortEnded) {
+    if (!(node.name in schema.getShortEndedElements())) {
       if ((node = node.firstChild)) {
         do {
           walk(node);


### PR DESCRIPTION
Related Ticket: TINY-8205

Description of Changes:
* This one you could probably review commit by commit if you wanted to (and I'm thinking of rebasing it, instead of squashing, so it would be a good idea to look at the commits separately)
* Fixed a weird test thunking case we'd missed before
* Removed .shortEnded from AstNode
* Removed .fixed from AstNode
* Changed the way we handle inserting invalid content — previously we just parsed and serialised the whole tree it as a way of tidying up the structure, and now we perform tree operations manually (and refactored to take some of that logic out of DomParser)

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ nothing new added, just gotta make sure the old tests still pass
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable): N/A
