### PR TITLE
TINY-7824: Changed the default value for the link_default_protocol option

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `rel_list` option has been renamed to `link_rel_list` for the `link` plugin #TINY-4603
 - The `target_list` option has been renamed to `link_target_list` for the `link` plugin #TINY-4603
 - The `primary` property on dialog buttons has been deprecated. Use the new `buttonType` property instead #TINY-8304
+- The default value for the `link_default_protocol` option has been changed to `https` instead of `http` #TINY-7824
 
 ### Fixed
 - The object returned from the `editor.fire()` API was incorrect if the editor had been removed #TINY-8018

--- a/modules/tinymce/src/plugins/autolink/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/api/Options.ts
@@ -31,7 +31,7 @@ const register = (editor: Editor): void => {
 
   registerOption('link_default_protocol', {
     processor: 'string',
-    default: 'http'
+    default: 'https'
   });
 };
 

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -57,8 +57,8 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assertIsLink(editor, 'customprotocol://www.domain.com', 'customprotocol://www.domain.com');
     assertIsLink(editor, 'ssh://www.domain.com', 'ssh://www.domain.com');
     assertIsLink(editor, 'ftp://www.domain.com', 'ftp://www.domain.com');
-    assertIsLink(editor, 'www.domain.com', 'http://www.domain.com');
-    assertIsLink(editor, 'www.domain.com', 'http://www.domain.com', '.');
+    assertIsLink(editor, 'www.domain.com', 'https://www.domain.com');
+    assertIsLink(editor, 'www.domain.com', 'https://www.domain.com', '.');
     assertIsLink(editor, 'user@domain.com', 'mailto:user@domain.com');
     assertIsLink(editor, 'mailto:user@domain.com', 'mailto:user@domain.com');
     assertIsLink(editor, 'first-last@domain.com', 'mailto:first-last@domain.com');
@@ -99,8 +99,8 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     typeAnEclipsedURL(editor, 'https://www.domain.com');
     typeAnEclipsedURL(editor, 'ssh://www.domain.com');
     typeAnEclipsedURL(editor, 'ftp://www.domain.com');
-    typeAnEclipsedURL(editor, 'www.domain.com', 'http://www.domain.com');
-    typeAnEclipsedURL(editor, 'www.domain.com', 'http://www.domain.com');
+    typeAnEclipsedURL(editor, 'www.domain.com', 'https://www.domain.com');
+    typeAnEclipsedURL(editor, 'www.domain.com', 'https://www.domain.com');
 
     typeAnEclipsedURL(editor, 'https://www.domain.com', 'https://www.domain.com', '[', ']');
     typeAnEclipsedURL(editor, 'https://www.domain.com', 'https://www.domain.com', '{', '}');
@@ -112,8 +112,8 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     typeNewlineURL(editor, 'https://www.domain.com');
     typeNewlineURL(editor, 'ssh://www.domain.com');
     typeNewlineURL(editor, 'ftp://www.domain.com');
-    typeNewlineURL(editor, 'www.domain.com', 'http://www.domain.com');
-    typeNewlineURL(editor, 'www.domain.com', 'http://www.domain.com', true);
+    typeNewlineURL(editor, 'www.domain.com', 'https://www.domain.com');
+    typeNewlineURL(editor, 'www.domain.com', 'https://www.domain.com', true);
   });
 
   it('TBA: Url inside blank formatting wrapper', () => {

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/ConsecutiveLinkTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/ConsecutiveLinkTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.plugins.autolink.ConsecutiveLinkTest', () => {
     editor.setContent('<p><a href="http://www.domain.com">www.domain.com</a>&nbsp;www.domain.com</p>');
     TinySelections.setCursor(editor, [ 0, 1 ], 15);
     KeyUtils.type(editor, ' ');
-    TinyAssertions.assertContent(editor, '<p><a href="http://www.domain.com">www.domain.com</a>&nbsp;<a href="http://www.domain.com">www.domain.com</a>&nbsp;</p>');
+    TinyAssertions.assertContent(editor, '<p><a href="http://www.domain.com">www.domain.com</a>&nbsp;<a href="https://www.domain.com">www.domain.com</a>&nbsp;</p>');
   });
 
   it('TBA: FireFox does not seem to add a nbsp between link and text', () => {
@@ -25,6 +25,6 @@ describe('browser.tinymce.plugins.autolink.ConsecutiveLinkTest', () => {
     editor.setContent('<p><a href="http://www.domain.com">www.domain.com</a> www.domain.com</p>');
     TinySelections.setCursor(editor, [ 0, 1 ], 15);
     KeyUtils.type(editor, ' ');
-    TinyAssertions.assertContent(editor, '<p><a href="http://www.domain.com">www.domain.com</a> <a href="http://www.domain.com">www.domain.com</a>&nbsp;</p>');
+    TinyAssertions.assertContent(editor, '<p><a href="http://www.domain.com">www.domain.com</a> <a href="https://www.domain.com">www.domain.com</a>&nbsp;</p>');
   });
 });

--- a/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
@@ -57,7 +57,7 @@ const register = (editor: Editor): void => {
 
   registerOption('link_default_protocol', {
     processor: 'string',
-    default: 'http'
+    default: 'https'
   });
 
   registerOption('link_target_list', {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AssumeExternalTargetsTest.ts
@@ -14,18 +14,18 @@ describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
   }, [ Plugin ]);
 
   context('Default setting', () => {
-    it('TBA: www-urls are prompted to add http:// prefix, accept', async () => {
+    it('TBA: www-urls are prompted to add https:// prefix, accept', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'www.google.com');
-      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required https:// prefix?")');
       await TestLinkUi.pClickConfirmYes(editor);
-      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://www.google.com"]': 1 });
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="https://www.google.com"]': 1 });
     });
 
-    it('TBA: www-urls are prompted to add http:// prefix, cancel', async () => {
+    it('TBA: www-urls are prompted to add https:// prefix, cancel', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'www.google.com');
-      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required https:// prefix?")');
       await TestLinkUi.pClickConfirmNo(editor);
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="www.google.com"]': 1 });
     });
@@ -43,26 +43,26 @@ describe('browser.tinymce.plugins.link.AssumeExternalTargetsTest', () => {
       editor.options.set('link_assume_external_targets', true);
     });
 
-    it('TBA: www-urls are prompted to add http:// prefix', async () => {
+    it('TBA: www-urls are prompted to add https:// prefix', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'www.google.com');
-      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required https:// prefix?")');
       await TestLinkUi.pClickConfirmYes(editor);
-      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://www.google.com"]': 1 });
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="https://www.google.com"]': 1 });
     });
 
-    it('TBA: other urls are prompted to add http:// prefix', async () => {
+    it('TBA: other urls are prompted to add https:// prefix', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'google.com');
-      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required https:// prefix?")');
       await TestLinkUi.pClickConfirmYes(editor);
-      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="http://google.com"]': 1 });
+      await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="https://google.com"]': 1 });
     });
 
     it('TBA: url not updated when prompt canceled', async () => {
       const editor = hook.editor();
       await TestLinkUi.pInsertLink(editor, 'google.com');
-      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required http:// prefix?")');
+      await TinyUiActions.pWaitForPopup(editor, 'p:contains("The URL you entered seems to be an external link. Do you want to add the required https:// prefix?")');
       await TestLinkUi.pClickConfirmNo(editor);
       await TestLinkUi.pAssertContentPresence(editor, { 'a': 1, 'a[href="google.com"]': 1 });
     });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
@@ -69,8 +69,8 @@ describe('browser.tinymce.plugins.link.UrlProtocolTest', () => {
 
   it('TBA: Test regex for non relative link with no protocol', async () => {
     const editor = hook.editor();
-    await pTestProtocolConfirm(editor, 'www.http.com', 'http://');
-    await pTestProtocolConfirm(editor, 'www3.http.com', 'http://');
+    await pTestProtocolConfirm(editor, 'www.http.com', 'https://');
+    await pTestProtocolConfirm(editor, 'www3.http.com', 'https://');
   });
 
   it('TBA: Test regex for relative link', async () => {


### PR DESCRIPTION
Related Ticket: TINY-7824

Description of Changes:
* Changed the default value from `http` to `https` for the `link_default_protocol` option

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
