### PR TITLE
TINY-8348: Fixed bugs from options conversion

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -285,7 +285,7 @@ const register = (editor: Editor) => {
           return { value: Arr.map(value.split(','), Strings.trim), valid };
         } else if (Type.isArray(value)) {
           return { value, valid };
-        } else if (value === false || editor.inline) {
+        } else if (value === false) {
           return { value: [], valid };
         } else {
           return { value, valid };
@@ -294,7 +294,7 @@ const register = (editor: Editor) => {
         return { valid: false, message: 'Must be false, a string or an array of strings.' };
       }
     },
-    default: [ 'default' ]
+    default: isInline(editor) ? [] : [ 'default' ]
   });
 
   registerOption('content_style', {

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionInlineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionInlineTest.ts
@@ -2,6 +2,7 @@ import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Insert, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -39,5 +40,10 @@ describe('browser.tinymce.core.init.InitEditorThemeFunctionInlineTest', () => {
     Assertions.assertDomEq('Should be expected editor body element', targetElement, TinyDom.body(editor));
     Assertions.assertDomEq('Should be expected editor target element', targetElement, TinyDom.targetElement(editor));
     Assertions.assertDomEq('Should be expected content area container', targetElement, TinyDom.contentAreaContainer(editor));
+  });
+
+  it('TINY-8348: no default content css loaded', () => {
+    const editor = hook.editor();
+    assert.lengthOf(editor.contentCSS, 0, 'Should not have loaded the default content css');
   });
 });

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -266,7 +266,8 @@ const register = (editor: Editor): void => {
   registerOption('resize', {
     processor: (value) => value === 'both' || Type.isBoolean(value),
     // TODO: TINY-8288 - This should be set to `true` once the issue with the theme rendering too early is resolved
-    default: !editor.hasPlugin('autoresize')
+    // Editor resize doesn't work on touch devices at this stage
+    default: !Env.deviceType.isTouch() && !editor.hasPlugin('autoresize')
   });
 };
 


### PR DESCRIPTION
Related Ticket: TINY-8348

Description of Changes:
* Fixed 2 separate minor issues found with the options conversion that caused incorrect defaults in inline mode and on touch devices.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable) -  No tests for the resize default since we don't have a way to test that at this stage. I have manually tested it though.
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #7458