### PR TITLE
TINY-8334: Cleaned up the the bridge schemas and some unused code for silver dialogs

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/Autocompleter.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/Autocompleter.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { CardMenuItemSpec } from '../menu/CardMenuItem';
 import { SeparatorMenuItem, separatorMenuItemSchema, SeparatorMenuItemSpec } from '../menu/SeparatorMenuItem';
 
@@ -58,24 +59,24 @@ export interface Autocompleter {
 
 const autocompleterItemSchema = StructureSchema.objOf([
   // Currently, autocomplete items don't support configuring type, active, disabled, meta
-  FieldSchema.defaulted('type', 'autocompleteitem'),
-  FieldSchema.defaulted('active', false),
-  FieldSchema.defaulted('disabled', false),
-  FieldSchema.defaulted('meta', {}),
-  FieldSchema.requiredString('value'),
-  FieldSchema.optionString('text'),
-  FieldSchema.optionString('icon')
+  ComponentSchema.defaultedType('autocompleteitem'),
+  ComponentSchema.active,
+  ComponentSchema.disabled,
+  ComponentSchema.defaultedMeta,
+  ComponentSchema.value,
+  ComponentSchema.optionalText,
+  ComponentSchema.optionalIcon
 ]);
 
 const autocompleterSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.requiredString('ch'),
   FieldSchema.defaultedNumber('minChars', 1),
-  FieldSchema.defaulted('columns', 1),
+  ComponentSchema.defaultedColumns(1),
   FieldSchema.defaultedNumber('maxResults', 10),
   FieldSchema.optionFunction('matches'),
-  FieldSchema.requiredFunction('fetch'),
-  FieldSchema.requiredFunction('onAction'),
+  ComponentSchema.fetch,
+  ComponentSchema.onAction,
   FieldSchema.defaultedArrayOf('highlightOn', [], ValueType.string)
 ]);
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Fun, Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { BaseToolbarButton, baseToolbarButtonFields, BaseToolbarButtonInstanceApi, BaseToolbarButtonSpec } from '../toolbar/ToolbarButton';
 import {
   BaseToolbarToggleButton, baseToolbarToggleButtonFields, BaseToolbarToggleButtonInstanceApi, BaseToolbarToggleButtonSpec
@@ -81,25 +82,25 @@ export interface ContextForm extends ContextBar {
 }
 
 const contextButtonFields = baseToolbarButtonFields.concat([
-  FieldSchema.defaulted('type', 'contextformbutton'),
-  FieldSchema.defaulted('primary', false),
-  FieldSchema.requiredFunction('onAction'),
+  ComponentSchema.defaultedType('contextformbutton'),
+  ComponentSchema.primary,
+  ComponentSchema.onAction,
   FieldSchema.customField('original', Fun.identity)
 ]);
 
 const contextToggleButtonFields = baseToolbarToggleButtonFields.concat([
-  FieldSchema.defaulted('type', 'contextformbutton'),
-  FieldSchema.defaulted('primary', false),
-  FieldSchema.requiredFunction('onAction'),
+  ComponentSchema.defaultedType('contextformbutton'),
+  ComponentSchema.primary,
+  ComponentSchema.onAction,
   FieldSchema.customField('original', Fun.identity)
 ]);
 
 const launchButtonFields = baseToolbarButtonFields.concat([
-  FieldSchema.defaulted('type', 'contextformbutton')
+  ComponentSchema.defaultedType('contextformbutton')
 ]);
 
 const launchToggleButtonFields = baseToolbarToggleButtonFields.concat([
-  FieldSchema.defaulted('type', 'contextformtogglebutton')
+  ComponentSchema.defaultedType('contextformtogglebutton')
 ]);
 
 const toggleOrNormal = StructureSchema.choose('type', {
@@ -108,9 +109,9 @@ const toggleOrNormal = StructureSchema.choose('type', {
 });
 
 const contextFormSchema = StructureSchema.objOf([
-  FieldSchema.defaulted('type', 'contextform'),
+  ComponentSchema.defaultedType('contextform'),
   FieldSchema.defaultedFunction('initValue', Fun.constant('')),
-  FieldSchema.optionString('label'),
+  ComponentSchema.optionalLabel,
   FieldSchema.requiredArrayOf('commands', toggleOrNormal),
   FieldSchema.optionOf('launch', StructureSchema.choose('type', {
     contextformbutton: launchButtonFields,

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextToolbar.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextToolbar.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { ContextBar, contextBarFields, ContextBarSpec } from './ContextBar';
 
 export interface ContextToolbarSpec extends ContextBarSpec {
@@ -14,7 +15,7 @@ export interface ContextToolbar extends ContextBar {
 }
 
 const contextToolbarSchema = StructureSchema.objOf([
-  FieldSchema.defaulted('type', 'contexttoolbar'),
+  ComponentSchema.defaultedType('contexttoolbar'),
   FieldSchema.requiredString('items')
 ].concat(contextBarFields));
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/AlertBanner.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/AlertBanner.ts
@@ -1,6 +1,8 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
+
 export interface AlertBannerSpec {
   type: 'alertbanner';
   level: 'info' | 'warn' | 'error' | 'success';
@@ -18,10 +20,10 @@ export interface AlertBanner {
 }
 
 const alertBannerFields = [
-  FieldSchema.requiredString('type'),
-  FieldSchema.requiredString('text'),
+  ComponentSchema.type,
+  ComponentSchema.text,
   FieldSchema.requiredStringEnum('level', [ 'info', 'warn', 'error', 'success' ]),
-  FieldSchema.requiredString('icon'),
+  ComponentSchema.icon,
   FieldSchema.defaulted('url', '')
 ];
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Bar.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Bar.ts
@@ -1,5 +1,6 @@
-import { FieldProcessor, FieldSchema } from '@ephox/boulder';
+import { FieldProcessor } from '@ephox/boulder';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
 
 export interface BarSpec {
@@ -13,6 +14,6 @@ export interface Bar {
 }
 
 export const createBarFields = (itemsField: FieldProcessor): FieldProcessor[] => [
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   itemsField
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Button.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Button.ts
@@ -1,5 +1,7 @@
-import { FieldPresence, FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
-import { Id, Optional, Result } from '@ephox/katamari';
+import { FieldSchema, StructureSchema } from '@ephox/boulder';
+import { Optional, Result } from '@ephox/katamari';
+
+import * as ComponentSchema from '../../core/ComponentSchema';
 
 export interface ButtonSpec {
   type: 'button';
@@ -26,21 +28,16 @@ export interface Button {
 }
 
 const buttonFields = [
-  FieldSchema.requiredString('type'),
-  FieldSchema.requiredString('text'),
-  FieldSchema.defaultedBoolean('disabled', false),
-  FieldSchema.field(
-    'name',
-    'name',
-    FieldPresence.defaultedThunk(() => Id.generate('button-name')),
-    ValueType.string
-  ),
-  FieldSchema.optionString('icon'),
-  FieldSchema.defaultedBoolean('borderless', false),
+  ComponentSchema.type,
+  ComponentSchema.text,
+  ComponentSchema.disabled,
+  ComponentSchema.generatedName('button'),
+  ComponentSchema.optionalIcon,
+  ComponentSchema.borderless,
   // this should be defaulted to `secondary` but the implementation needs to manage the deprecation
   FieldSchema.optionStringEnum('buttonType', [ 'primary', 'secondary', 'toolbar' ]),
   // this should be removed, but must live here because FieldSchema doesn't have a way to manage deprecated fields
-  FieldSchema.defaultedBoolean('primary', false),
+  ComponentSchema.primary,
 ];
 
 export const buttonSchema = StructureSchema.objOf(buttonFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Checkbox.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Checkbox.ts
@@ -1,26 +1,25 @@
-import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
+import { StructureSchema, ValueType } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
-export interface CheckboxSpec {
-  name: string;
+import * as ComponentSchema from '../../core/ComponentSchema';
+import { FormComponent, formComponentFields, FormComponentSpec } from './FormComponent';
+
+export interface CheckboxSpec extends FormComponentSpec {
   type: 'checkbox';
   label: string;
   disabled?: boolean;
 }
 
-export interface Checkbox {
-  name: string;
+export interface Checkbox extends FormComponent {
   type: 'checkbox';
   label: string;
   disabled: boolean;
 }
 
-const checkboxFields = [
-  FieldSchema.requiredString('type'),
-  FieldSchema.requiredString('name'),
-  FieldSchema.requiredString('label'),
-  FieldSchema.defaultedBoolean('disabled', false)
-];
+const checkboxFields = formComponentFields.concat([
+  ComponentSchema.label,
+  ComponentSchema.disabled
+]);
 
 export const checkboxSchema = StructureSchema.objOf(checkboxFields);
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Collection.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Collection.ts
@@ -1,6 +1,7 @@
-import { FieldProcessor, FieldSchema, StructureSchema } from '@ephox/boulder';
+import { FieldProcessor, StructureSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponentWithLabel, FormComponentWithLabelSpec, formComponentWithLabelFields } from './FormComponent';
 
 export interface CollectionSpec extends FormComponentWithLabelSpec {
@@ -15,16 +16,16 @@ export interface Collection extends FormComponentWithLabel {
 }
 
 const collectionFields: FieldProcessor[] = formComponentWithLabelFields.concat([
-  FieldSchema.defaulted('columns', 'auto')
+  ComponentSchema.defaultedColumns('auto')
 ]);
 
 export const collectionSchema = StructureSchema.objOf(collectionFields);
 
 // TODO: Make type for CollectionItem
 export const collectionDataProcessor = StructureSchema.arrOfObj([
-  FieldSchema.requiredString('value'),
-  FieldSchema.requiredString('text'),
-  FieldSchema.requiredString('icon')
+  ComponentSchema.value,
+  ComponentSchema.text,
+  ComponentSchema.icon
 ]);
 
 export const createCollection = (spec: CollectionSpec): Result<Collection, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Dialog.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Dialog.ts
@@ -100,7 +100,7 @@ export const dialogSchema = StructureSchema.objOf([
   FieldSchema.defaultedFunction('onSubmit', Fun.noop),
   FieldSchema.defaultedFunction('onClose', Fun.noop),
   FieldSchema.defaultedFunction('onCancel', Fun.noop),
-  FieldSchema.defaulted('onTabChange', Fun.noop)
+  FieldSchema.defaultedFunction('onTabChange', Fun.noop)
 ]);
 
 export const createDialog = <T>(spec: DialogSpec<T>): Result<Dialog<T>, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
@@ -1,6 +1,7 @@
-import { FieldPresence, FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
-import { Id, Optional, Result } from '@ephox/katamari';
+import { FieldSchema, StructureSchema } from '@ephox/boulder';
+import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { DialogToggleMenuItem, dialogToggleMenuItemSchema, DialogToggleMenuItemSpec } from './ToggleMenuItem';
 
 export type DialogFooterMenuButtonItemSpec = DialogToggleMenuItemSpec;
@@ -54,21 +55,16 @@ export interface DialogFooterMenuButton extends BaseDialogFooterButton {
 export type DialogFooterButton = DialogFooterNormalButton | DialogFooterMenuButton;
 
 const baseFooterButtonFields = [
-  FieldSchema.field(
-    'name',
-    'name',
-    FieldPresence.defaultedThunk(() => Id.generate('button-name')),
-    ValueType.string
-  ),
-  FieldSchema.optionString('icon'),
+  ComponentSchema.generatedName('button'),
+  ComponentSchema.optionalIcon,
   FieldSchema.defaultedStringEnum('align', 'end', [ 'start', 'end' ]),
-  FieldSchema.defaultedBoolean('primary', false),
-  FieldSchema.defaultedBoolean('disabled', false)
+  ComponentSchema.primary,
+  ComponentSchema.disabled
 ];
 
 export const dialogFooterButtonFields = [
   ...baseFooterButtonFields,
-  FieldSchema.requiredString('text')
+  ComponentSchema.text
 ];
 
 const normalFooterButtonFields = [
@@ -78,9 +74,9 @@ const normalFooterButtonFields = [
 
 const menuFooterButtonFields = [
   FieldSchema.requiredStringEnum('type', [ 'menu' ]),
-  FieldSchema.optionString('text'),
-  FieldSchema.optionString('tooltip'),
-  FieldSchema.optionString('icon'),
+  ComponentSchema.optionalText,
+  ComponentSchema.optionalTooltip,
+  ComponentSchema.optionalIcon,
   FieldSchema.requiredArrayOf('items', dialogToggleMenuItemSchema),
   ...baseFooterButtonFields
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/FormComponent.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/FormComponent.ts
@@ -1,5 +1,6 @@
-import { FieldSchema } from '@ephox/boulder';
 import { Optional } from '@ephox/katamari';
+
+import * as ComponentSchema from '../../core/ComponentSchema';
 
 export interface FormComponentSpec {
   type: string;
@@ -20,10 +21,10 @@ export interface FormComponentWithLabel extends FormComponent {
 }
 
 export const formComponentFields = [
-  FieldSchema.requiredString('type'),
-  FieldSchema.requiredString('name')
+  ComponentSchema.type,
+  ComponentSchema.name
 ];
 
 export const formComponentWithLabelFields = formComponentFields.concat([
-  FieldSchema.optionString('label')
+  ComponentSchema.optionalLabel
 ]);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Grid.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Grid.ts
@@ -1,5 +1,6 @@
 import { FieldProcessor, FieldSchema } from '@ephox/boulder';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
 
 export interface GridSpec {
@@ -15,7 +16,7 @@ export interface Grid {
 }
 
 export const createGridFields = (itemsField: FieldProcessor): FieldProcessor[] => [
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.requiredNumber('columns'),
   itemsField
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/HtmlPanel.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/HtmlPanel.ts
@@ -1,6 +1,8 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
+
 export interface HtmlPanelSpec {
   type: 'htmlpanel';
   html: string;
@@ -15,7 +17,7 @@ export interface HtmlPanel {
 }
 
 const htmlPanelFields = [
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.requiredString('html'),
   FieldSchema.defaultedStringEnum('presets', 'presentation', [ 'presentation', 'document' ])
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Input.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Input.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponentWithLabel, formComponentWithLabelFields, FormComponentWithLabelSpec } from './FormComponent';
 
 export interface InputSpec extends FormComponentWithLabelSpec {
@@ -23,7 +24,7 @@ const inputFields = formComponentWithLabelFields.concat([
   FieldSchema.optionString('inputMode'),
   FieldSchema.optionString('placeholder'),
   FieldSchema.defaultedBoolean('maximized', false),
-  FieldSchema.defaultedBoolean('disabled', false)
+  ComponentSchema.disabled
 ]);
 
 export const inputSchema = StructureSchema.objOf(inputFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
@@ -1,5 +1,6 @@
-import { FieldProcessor, FieldSchema } from '@ephox/boulder';
+import { FieldProcessor } from '@ephox/boulder';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
 
 export interface LabelSpec {
@@ -15,7 +16,7 @@ export interface Label {
 }
 
 export const createLabelFields = (itemsField: FieldProcessor): FieldProcessor[] => [
-  FieldSchema.requiredString('type'),
-  FieldSchema.requiredString('label'),
+  ComponentSchema.type,
+  ComponentSchema.label,
   itemsField
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/ListBox.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/ListBox.ts
@@ -1,6 +1,7 @@
 import { FieldProcessor, FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponentWithLabel, formComponentWithLabelFields, FormComponentWithLabelSpec } from './FormComponent';
 
 export interface ListBoxSingleItemSpec {
@@ -40,12 +41,12 @@ export interface ListBox extends FormComponentWithLabel {
 }
 
 const listBoxSingleItemFields = [
-  FieldSchema.requiredString('text'),
-  FieldSchema.requiredString('value')
+  ComponentSchema.text,
+  ComponentSchema.value
 ];
 
 const listBoxNestedItemFields = [
-  FieldSchema.requiredString('text'),
+  ComponentSchema.text,
   FieldSchema.requiredArrayOf('items', StructureSchema.thunkOf('items', () => listBoxItemSchema))
 ];
 
@@ -56,7 +57,7 @@ const listBoxItemSchema = StructureSchema.oneOf([
 
 const listBoxFields: FieldProcessor[] = formComponentWithLabelFields.concat([
   FieldSchema.requiredArrayOf('items', listBoxItemSchema),
-  FieldSchema.defaultedBoolean('disabled', false)
+  ComponentSchema.disabled
 ]);
 
 export const listBoxSchema = StructureSchema.objOf(listBoxFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Panel.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Panel.ts
@@ -1,6 +1,7 @@
 import { FieldPresence, FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { alertBannerSchema } from './AlertBanner';
 import { createBarFields } from './Bar';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
@@ -77,7 +78,7 @@ export const itemSchema = StructureSchema.valueThunkOf(
 );
 
 const panelFields = [
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.defaulted('classes', []),
   FieldSchema.requiredArrayOf('items', itemSchema)
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/SelectBox.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/SelectBox.ts
@@ -1,6 +1,7 @@
 import { FieldProcessor, FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponentWithLabel, formComponentWithLabelFields, FormComponentWithLabelSpec } from './FormComponent';
 
 export interface SelectBoxItemSpec {
@@ -29,11 +30,11 @@ export interface SelectBox extends FormComponentWithLabel {
 
 const selectBoxFields: FieldProcessor[] = formComponentWithLabelFields.concat([
   FieldSchema.requiredArrayOfObj('items', [
-    FieldSchema.requiredString('text'),
-    FieldSchema.requiredString('value')
+    ComponentSchema.text,
+    ComponentSchema.value
   ]),
   FieldSchema.defaultedNumber('size', 1),
-  FieldSchema.defaultedBoolean('disabled', false)
+  ComponentSchema.disabled
 ]);
 
 export const selectBoxSchema = StructureSchema.objOf(selectBoxFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/SizeInput.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/SizeInput.ts
@@ -1,6 +1,7 @@
 import { StructureSchema, FieldSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponentWithLabel, FormComponentWithLabelSpec, formComponentWithLabelFields } from './FormComponent';
 
 export interface SizeInputSpec extends FormComponentWithLabelSpec {
@@ -17,7 +18,7 @@ export interface SizeInput extends FormComponentWithLabel {
 
 const sizeInputFields = formComponentWithLabelFields.concat([
   FieldSchema.defaultedBoolean('constrain', true),
-  FieldSchema.defaultedBoolean('disabled', false)
+  ComponentSchema.disabled
 ]);
 
 export const sizeInputSchema = StructureSchema.objOf(sizeInputFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Slider.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Slider.ts
@@ -1,5 +1,6 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { formComponentFields, FormComponent, FormComponentSpec } from './FormComponent';
 
 export interface SliderSpec extends FormComponentSpec {
@@ -16,12 +17,12 @@ export interface Slider extends FormComponent {
   max: number;
 }
 
-export const sliderSchema = StructureSchema.objOf(
-  formComponentFields.concat([
-    FieldSchema.requiredString('label'),
-    FieldSchema.defaultedNumber('min', 0),
-    FieldSchema.defaultedNumber('max', 0),
-  ])
-);
+const sliderFields = formComponentFields.concat([
+  ComponentSchema.label,
+  FieldSchema.defaultedNumber('min', 0),
+  FieldSchema.defaultedNumber('max', 0),
+]);
+
+export const sliderSchema = StructureSchema.objOf(sliderFields);
 
 export const sliderInputDataProcessor = ValueType.number;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/TabPanel.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/TabPanel.ts
@@ -1,6 +1,7 @@
-import { FieldPresence, FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
-import { Id, Result } from '@ephox/katamari';
+import { FieldSchema, StructureSchema } from '@ephox/boulder';
+import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
 import { itemSchema } from './Panel';
 
@@ -27,18 +28,13 @@ export interface TabPanel {
 }
 
 export const tabFields = [
-  FieldSchema.field(
-    'name',
-    'name',
-    FieldPresence.defaultedThunk(() => Id.generate('tab-name')),
-    ValueType.string
-  ),
-  FieldSchema.requiredString('title'),
+  ComponentSchema.generatedName('tab'),
+  ComponentSchema.title,
   FieldSchema.requiredArrayOf('items', itemSchema)
 ];
 
 export const tabPanelFields = [
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.requiredArrayOfObj('tabs', tabFields)
 ];
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Table.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Table.ts
@@ -1,6 +1,8 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
+
 export interface TableSpec {
   type: 'table';
   header: string[];
@@ -14,7 +16,7 @@ export interface Table {
 }
 
 const tableFields = [
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.requiredArrayOf('header', ValueType.string),
   FieldSchema.requiredArrayOf('cells', StructureSchema.arrOf(ValueType.string))
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Textarea.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Textarea.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponentWithLabel, formComponentWithLabelFields, FormComponentWithLabelSpec } from './FormComponent';
 
 export interface TextAreaSpec extends FormComponentWithLabelSpec {
@@ -20,7 +21,7 @@ export interface TextArea extends FormComponentWithLabel {
 const textAreaFields = formComponentWithLabelFields.concat([
   FieldSchema.optionString('placeholder'),
   FieldSchema.defaultedBoolean('maximized', false),
-  FieldSchema.defaultedBoolean('disabled', false)
+  ComponentSchema.disabled
 ]);
 
 export const textAreaSchema = StructureSchema.objOf(textAreaFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/ToggleMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/ToggleMenuItem.ts
@@ -1,6 +1,7 @@
-import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
+import { StructureSchema, ValueType } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { CommonMenuItem, commonMenuItemFields, CommonMenuItemSpec } from '../menu/CommonMenuItem';
 
 export interface DialogToggleMenuItemSpec extends CommonMenuItemSpec {
@@ -14,8 +15,8 @@ export interface DialogToggleMenuItem extends CommonMenuItem {
 }
 
 export const dialogToggleMenuItemSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
-  FieldSchema.requiredString('name')
+  ComponentSchema.type,
+  ComponentSchema.name
 ].concat(commonMenuItemFields));
 
 export const dialogToggleMenuItemDataProcessor = ValueType.boolean;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/UrlInput.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/UrlInput.ts
@@ -1,6 +1,7 @@
 import { StructureSchema, FieldSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponentWithLabel, FormComponentWithLabelSpec, formComponentWithLabelFields } from './FormComponent';
 
 export interface UrlInputSpec extends FormComponentWithLabelSpec {
@@ -17,14 +18,14 @@ export interface UrlInput extends FormComponentWithLabel {
 
 const urlInputFields = formComponentWithLabelFields.concat([
   FieldSchema.defaultedStringEnum('filetype', 'file', [ 'image', 'media', 'file' ]),
-  FieldSchema.defaulted('disabled', false)
+  ComponentSchema.disabled
 ]);
 
 export const urlInputSchema = StructureSchema.objOf(urlInputFields);
 
 export const urlInputDataProcessor = StructureSchema.objOf([
-  FieldSchema.requiredString('value'),
-  FieldSchema.defaulted('meta', { })
+  ComponentSchema.value,
+  ComponentSchema.defaultedMeta
 ]);
 
 export const createUrlInput = (spec: UrlInputSpec): Result<UrlInput, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/CardMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/CardMenuItem.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Fun, Optional, Result } from '@ephox/katamari';
+import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { itemSchema } from './card/CardContainer';
 import { CardItem, CardItemSpec } from './card/CardItem';
 import { CommonMenuItem, commonMenuItemFields, CommonMenuItemInstanceApi, CommonMenuItemSpec } from './CommonMenuItem';
@@ -24,11 +25,11 @@ export interface CardMenuItem extends Omit<CommonMenuItem, 'text' | 'shortcut'> 
 }
 
 const cardMenuItemSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
-  FieldSchema.optionString('label'),
+  ComponentSchema.type,
+  ComponentSchema.optionalLabel,
   FieldSchema.requiredArrayOf('items', itemSchema),
-  FieldSchema.defaultedFunction('onSetup', () => Fun.noop),
-  FieldSchema.defaultedFunction('onAction', Fun.noop)
+  ComponentSchema.onSetup,
+  ComponentSchema.defaultedOnAction
 ].concat(commonMenuItemFields));
 
 export const createCardMenuItem = (spec: CardMenuItemSpec): Result<CardMenuItem, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/ChoiceMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/ChoiceMenuItem.ts
@@ -1,6 +1,7 @@
-import { FieldSchema, StructureSchema } from '@ephox/boulder';
+import { StructureSchema } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { CommonMenuItem, CommonMenuItemSpec, commonMenuItemFields, CommonMenuItemInstanceApi } from './CommonMenuItem';
 
 export interface ChoiceMenuItemSpec extends CommonMenuItemSpec {
@@ -20,9 +21,9 @@ export interface ChoiceMenuItem extends CommonMenuItem {
 }
 
 export const choiceMenuItemSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
-  FieldSchema.defaultedBoolean('active', false),
-  FieldSchema.optionString('icon')
+  ComponentSchema.type,
+  ComponentSchema.active,
+  ComponentSchema.optionalIcon
 ].concat(commonMenuItemFields));
 
 export const createChoiceMenuItem = (spec: ChoiceMenuItemSpec): Result<ChoiceMenuItem, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/CommonMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/CommonMenuItem.ts
@@ -1,5 +1,7 @@
-import { FieldPresence, FieldProcessor, FieldSchema, ValueType } from '@ephox/boulder';
-import { Id, Optional } from '@ephox/katamari';
+import { FieldProcessor } from '@ephox/boulder';
+import { Optional } from '@ephox/katamari';
+
+import * as ComponentSchema from '../../core/ComponentSchema';
 
 export interface CommonMenuItemSpec {
   disabled?: boolean;
@@ -23,14 +25,9 @@ export interface CommonMenuItem {
 }
 
 export const commonMenuItemFields: FieldProcessor[] = [
-  FieldSchema.defaultedBoolean('disabled', false),
-  FieldSchema.optionString('text'),
-  FieldSchema.optionString('shortcut'),
-  FieldSchema.field(
-    'value',
-    'value',
-    FieldPresence.defaultedThunk(() => Id.generate('menuitem-value')),
-    ValueType.anyValue()
-  ),
-  FieldSchema.defaulted('meta', { })
+  ComponentSchema.disabled,
+  ComponentSchema.optionalText,
+  ComponentSchema.optionalShortcut,
+  ComponentSchema.generatedValue('menuitem'),
+  ComponentSchema.defaultedMeta
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/FancyMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/FancyMenuItem.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
-import { Result, Fun, Optional } from '@ephox/katamari';
+import { Result, Optional } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { ChoiceMenuItemSpec } from './ChoiceMenuItem';
 
 export interface FancyActionArgsMap {
@@ -53,9 +54,9 @@ export interface ColorSwatchMenuItem extends BaseFancyMenuItem<'colorswatch'> {
 export type FancyMenuItem = InsertTableMenuItem | ColorSwatchMenuItem;
 
 const baseFields = [
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.requiredString('fancytype'),
-  FieldSchema.defaultedFunction('onAction', Fun.noop)
+  ComponentSchema.defaultedOnAction
 ];
 
 const insertTableFields = [

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/MenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/MenuItem.ts
@@ -1,6 +1,7 @@
-import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Fun, Optional, Result } from '@ephox/katamari';
+import { StructureSchema } from '@ephox/boulder';
+import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { CommonMenuItem, CommonMenuItemSpec, commonMenuItemFields, CommonMenuItemInstanceApi } from './CommonMenuItem';
 
 export interface MenuItemSpec extends CommonMenuItemSpec {
@@ -21,10 +22,10 @@ export interface MenuItem extends CommonMenuItem {
 }
 
 export const menuItemSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
-  FieldSchema.defaultedFunction('onSetup', () => Fun.noop),
-  FieldSchema.defaultedFunction('onAction', Fun.noop),
-  FieldSchema.optionString('icon')
+  ComponentSchema.type,
+  ComponentSchema.onSetup,
+  ComponentSchema.defaultedOnAction,
+  ComponentSchema.optionalIcon
 ].concat(commonMenuItemFields));
 
 export const createMenuItem = (spec: MenuItemSpec): Result<MenuItem, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/NestedMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/NestedMenuItem.ts
@@ -1,7 +1,8 @@
-import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Fun, Optional, Result } from '@ephox/katamari';
+import { StructureSchema } from '@ephox/boulder';
+import { Optional, Result } from '@ephox/katamari';
 
 import { FancyMenuItemSpec, MenuItemSpec, SeparatorMenuItemSpec, ToggleMenuItemSpec } from '../../api/Menu';
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { CommonMenuItem, CommonMenuItemSpec, commonMenuItemFields, CommonMenuItemInstanceApi } from './CommonMenuItem';
 
 export type NestedMenuItemContents = string | MenuItemSpec | NestedMenuItemSpec | ToggleMenuItemSpec | SeparatorMenuItemSpec | FancyMenuItemSpec;
@@ -24,10 +25,10 @@ export interface NestedMenuItem extends CommonMenuItem {
 }
 
 export const nestedMenuItemSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
-  FieldSchema.requiredFunction('getSubmenuItems'),
-  FieldSchema.defaultedFunction('onSetup', () => Fun.noop),
-  FieldSchema.optionString('icon')
+  ComponentSchema.type,
+  ComponentSchema.getSubmenuItems,
+  ComponentSchema.onSetup,
+  ComponentSchema.optionalIcon
 ].concat(commonMenuItemFields));
 
 export const createNestedMenuItem = (spec: NestedMenuItemSpec): Result<NestedMenuItem, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/SeparatorMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/SeparatorMenuItem.ts
@@ -1,5 +1,7 @@
-import { FieldSchema, StructureSchema } from '@ephox/boulder';
+import { StructureSchema } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
+
+import * as ComponentSchema from '../../core/ComponentSchema';
 
 export interface SeparatorMenuItemSpec {
   type?: 'separator';
@@ -15,8 +17,8 @@ export interface SeparatorMenuItem {
 }
 
 export const separatorMenuItemSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
-  FieldSchema.optionString('text')
+  ComponentSchema.type,
+  ComponentSchema.optionalText
 ]);
 
 export const createSeparatorMenuItem = (spec: SeparatorMenuItemSpec): Result<SeparatorMenuItem, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/ToggleMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/ToggleMenuItem.ts
@@ -1,6 +1,7 @@
-import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Fun, Optional, Result } from '@ephox/katamari';
+import { StructureSchema } from '@ephox/boulder';
+import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { CommonMenuItem, CommonMenuItemSpec, commonMenuItemFields, CommonMenuItemInstanceApi } from './CommonMenuItem';
 
 export interface ToggleMenuItemSpec extends CommonMenuItemSpec {
@@ -25,11 +26,11 @@ export interface ToggleMenuItem extends CommonMenuItem {
 }
 
 export const toggleMenuItemSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
-  FieldSchema.optionString('icon'),
-  FieldSchema.defaultedBoolean('active', false),
-  FieldSchema.defaultedFunction('onSetup', () => Fun.noop),
-  FieldSchema.requiredFunction('onAction')
+  ComponentSchema.type,
+  ComponentSchema.optionalIcon,
+  ComponentSchema.active,
+  ComponentSchema.onSetup,
+  ComponentSchema.onAction
 ].concat(commonMenuItemFields));
 
 export const createToggleMenuItem = (spec: ToggleMenuItemSpec): Result<ToggleMenuItem, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/card/CardContainer.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/card/CardContainer.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../../core/ComponentSchema';
 import { cardImageSchema } from './CardImage';
 import { CardItem, CardItemSpec } from './CardItem';
 import { cardTextSchema } from './CardText';
@@ -34,7 +35,7 @@ export const itemSchema = StructureSchema.valueThunkOf(
 );
 
 export const cardContainerSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.defaultedString('direction', 'horizontal'),
   FieldSchema.defaultedString('align', 'left'),
   FieldSchema.defaultedString('valign', 'middle'),

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/card/CardImage.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/card/CardImage.ts
@@ -1,6 +1,8 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../../core/ComponentSchema';
+
 export interface CardImageSpec {
   type: 'cardimage';
   src: string;
@@ -16,7 +18,7 @@ export interface CardImage {
 }
 
 const cardImageFields = [
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.requiredString('src'),
   FieldSchema.optionString('alt'),
   FieldSchema.defaultedArrayOf('classes', [], ValueType.string)

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/card/CardText.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/card/CardText.ts
@@ -1,6 +1,8 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../../core/ComponentSchema';
+
 export interface CardTextSpec {
   type: 'cardtext';
   text: string;
@@ -16,9 +18,9 @@ export interface CardText {
 }
 
 const cardTextFields = [
-  FieldSchema.requiredString('type'),
-  FieldSchema.requiredString('text'),
-  FieldSchema.optionString('name'),
+  ComponentSchema.type,
+  ComponentSchema.text,
+  ComponentSchema.optionalName,
   FieldSchema.defaultedArrayOf('classes', [ 'tox-collection__item-label' ], ValueType.string)
 ];
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/sidebar/Sidebar.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/sidebar/Sidebar.ts
@@ -1,6 +1,8 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Fun, Optional, Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
+
 export interface SidebarInstanceApi {
   element: () => HTMLElement;
 }
@@ -22,11 +24,11 @@ export interface Sidebar {
 }
 
 export const sidebarSchema = StructureSchema.objOf([
-  FieldSchema.optionString('icon'),
-  FieldSchema.optionString('tooltip'),
+  ComponentSchema.optionalIcon,
+  ComponentSchema.optionalTooltip,
   FieldSchema.defaultedFunction('onShow', Fun.noop),
   FieldSchema.defaultedFunction('onHide', Fun.noop),
-  FieldSchema.defaultedFunction('onSetup', () => Fun.noop)
+  ComponentSchema.onSetup
 ]);
 
 export const createSidebar = (spec: SidebarSpec): Result<Sidebar, StructureSchema.SchemaError<any>> => StructureSchema.asRaw('sidebar', sidebarSchema, spec);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/GroupToolbarButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/GroupToolbarButton.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { BaseToolbarButton, baseToolbarButtonFields, BaseToolbarButtonInstanceApi, BaseToolbarButtonSpec } from './ToolbarButton';
 
 interface ToolbarGroupSetting {
@@ -26,10 +27,10 @@ export interface GroupToolbarButton extends BaseToolbarButton<GroupToolbarButton
 }
 
 export const groupToolbarButtonSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   FieldSchema.requiredOf('items', StructureSchema.oneOf([
     StructureSchema.arrOfObj([
-      FieldSchema.requiredString('name'),
+      ComponentSchema.name,
       FieldSchema.requiredArrayOf('items', ValueType.string)
     ]),
     ValueType.string

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
@@ -1,5 +1,7 @@
-import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Fun, Optional, Result } from '@ephox/katamari';
+import { StructureSchema } from '@ephox/boulder';
+import { Optional, Result } from '@ephox/katamari';
+
+import * as ComponentSchema from '../../core/ComponentSchema';
 
 export interface BaseToolbarButtonSpec<I extends BaseToolbarButtonInstanceApi> {
   disabled?: boolean;
@@ -38,16 +40,16 @@ export interface ToolbarButton extends BaseToolbarButton<ToolbarButtonInstanceAp
 }
 
 export const baseToolbarButtonFields = [
-  FieldSchema.defaultedBoolean('disabled', false),
-  FieldSchema.optionString('tooltip'),
-  FieldSchema.optionString('icon'),
-  FieldSchema.optionString('text'),
-  FieldSchema.defaultedFunction('onSetup', () => Fun.noop)
+  ComponentSchema.disabled,
+  ComponentSchema.optionalTooltip,
+  ComponentSchema.optionalIcon,
+  ComponentSchema.optionalText,
+  ComponentSchema.onSetup
 ];
 
 export const toolbarButtonSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
-  FieldSchema.requiredFunction('onAction')
+  ComponentSchema.type,
+  ComponentSchema.onAction
 ].concat(baseToolbarButtonFields));
 
 export const createToolbarButton = (spec: ToolbarButtonSpec): Result<ToolbarButton, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarMenuButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarMenuButton.ts
@@ -1,6 +1,7 @@
-import { StructureSchema, FieldSchema } from '@ephox/boulder';
+import { StructureSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { BaseMenuButton, BaseMenuButtonSpec, baseMenuButtonFields, BaseMenuButtonInstanceApi, MenuButtonItemTypes } from '../../core/MenuButton';
 
 export type ToolbarMenuButtonItemTypes = MenuButtonItemTypes;
@@ -19,7 +20,7 @@ export interface ToolbarMenuButton extends BaseMenuButton {
 export interface ToolbarMenuButtonInstanceApi extends BaseMenuButtonInstanceApi { }
 
 export const MenuButtonSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
+  ComponentSchema.type,
   ...baseMenuButtonFields
 ]);
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarSplitButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarSplitButton.ts
@@ -1,7 +1,8 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Fun, Optional, Result } from '@ephox/katamari';
+import { Optional, Result } from '@ephox/katamari';
 
 import { ChoiceMenuItemSpec, SeparatorMenuItemSpec } from '../../api/Menu';
+import * as ComponentSchema from '../../core/ComponentSchema';
 
 // Temporarily disable separators until things are clearer
 export type ToolbarSplitButtonItemTypes = ChoiceMenuItemSpec | SeparatorMenuItemSpec;
@@ -49,18 +50,18 @@ export interface ToolbarSplitButtonInstanceApi {
 }
 
 export const splitButtonSchema = StructureSchema.objOf([
-  FieldSchema.requiredString('type'),
-  FieldSchema.optionString('tooltip'),
-  FieldSchema.optionString('icon'),
-  FieldSchema.optionString('text'),
-  FieldSchema.optionFunction('select'),
-  FieldSchema.requiredFunction('fetch'),
-  FieldSchema.defaultedFunction('onSetup', () => Fun.noop),
+  ComponentSchema.type,
+  ComponentSchema.optionalTooltip,
+  ComponentSchema.optionalIcon,
+  ComponentSchema.optionalText,
+  ComponentSchema.optionalSelect,
+  ComponentSchema.fetch,
+  ComponentSchema.onSetup,
   // TODO: Validate the allowed presets
   FieldSchema.defaultedStringEnum('presets', 'normal', [ 'normal', 'color', 'listpreview' ]),
-  FieldSchema.defaulted('columns', 1),
-  FieldSchema.requiredFunction('onAction'),
-  FieldSchema.requiredFunction('onItemAction')
+  ComponentSchema.defaultedColumns(1),
+  ComponentSchema.onAction,
+  ComponentSchema.onItemAction
 ]);
 
 export const isSplitButtonButton = (spec: any): spec is ToolbarSplitButton => spec.type === 'splitbutton';

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarToggleButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarToggleButton.ts
@@ -1,6 +1,7 @@
-import { FieldSchema, StructureSchema } from '@ephox/boulder';
+import { StructureSchema } from '@ephox/boulder';
 import { Result } from '@ephox/katamari';
 
+import * as ComponentSchema from '../../core/ComponentSchema';
 import { BaseToolbarButton, BaseToolbarButtonSpec, baseToolbarButtonFields, BaseToolbarButtonInstanceApi } from './ToolbarButton';
 
 export interface BaseToolbarToggleButtonSpec<I extends BaseToolbarButtonInstanceApi> extends BaseToolbarButtonSpec<I> {
@@ -32,13 +33,13 @@ export interface ToolbarToggleButtonInstanceApi extends BaseToolbarToggleButtonI
 }
 
 export const baseToolbarToggleButtonFields = [
-  FieldSchema.defaultedBoolean('active', false)
+  ComponentSchema.active
 ].concat(baseToolbarButtonFields);
 
 export const toggleButtonSchema = StructureSchema.objOf(
   baseToolbarToggleButtonFields.concat([
-    FieldSchema.requiredString('type'),
-    FieldSchema.requiredFunction('onAction')
+    ComponentSchema.type,
+    ComponentSchema.onAction
   ])
 );
 

--- a/modules/bridge/src/main/ts/ephox/bridge/core/ComponentSchema.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/core/ComponentSchema.ts
@@ -1,0 +1,48 @@
+import { FieldPresence, FieldProcessor, FieldSchema, ValueType } from '@ephox/boulder';
+import { Fun, Id } from '@ephox/katamari';
+
+export const type = FieldSchema.requiredString('type');
+export const name = FieldSchema.requiredString('name');
+export const label = FieldSchema.requiredString('label');
+export const text = FieldSchema.requiredString('text');
+export const title = FieldSchema.requiredString('title');
+export const icon = FieldSchema.requiredString('icon');
+export const value = FieldSchema.requiredString('value');
+export const fetch = FieldSchema.requiredFunction('fetch');
+export const getSubmenuItems = FieldSchema.requiredFunction('getSubmenuItems');
+export const onAction = FieldSchema.requiredFunction('onAction');
+export const onItemAction = FieldSchema.requiredFunction('onItemAction');
+export const onSetup = FieldSchema.defaultedFunction('onSetup', () => Fun.noop);
+
+export const optionalName = FieldSchema.optionString('name');
+export const optionalText = FieldSchema.optionString('text');
+export const optionalIcon = FieldSchema.optionString('icon');
+export const optionalTooltip = FieldSchema.optionString('tooltip');
+export const optionalLabel = FieldSchema.optionString('label');
+export const optionalShortcut = FieldSchema.optionString('shortcut');
+export const optionalSelect = FieldSchema.optionFunction('select');
+
+export const active = FieldSchema.defaultedBoolean('active', false);
+export const borderless = FieldSchema.defaultedBoolean('borderless', false);
+export const disabled = FieldSchema.defaultedBoolean('disabled', false);
+export const primary = FieldSchema.defaultedBoolean('primary', false);
+export const defaultedColumns = (num: number | 'auto'): FieldProcessor => FieldSchema.defaulted('columns', num);
+export const defaultedMeta = FieldSchema.defaulted('meta', {});
+export const defaultedOnAction = FieldSchema.defaultedFunction('onAction', Fun.noop);
+export const defaultedType = (type: string): FieldProcessor => FieldSchema.defaultedString('type', type);
+
+export const generatedName = (namePrefix: string): FieldProcessor =>
+  FieldSchema.field(
+    'name',
+    'name',
+    FieldPresence.defaultedThunk(() => Id.generate(`${namePrefix}-name`)),
+    ValueType.string
+  );
+
+export const generatedValue = (valuePrefix: string): FieldProcessor =>
+  FieldSchema.field(
+    'value',
+    'value',
+    FieldPresence.defaultedThunk(() => Id.generate(`${valuePrefix}-value`)),
+    ValueType.anyValue()
+  );

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -5,8 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, AlloySpec, FormTypes, HotspotAnchorSpec, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import { AlloyComponent, AlloySpec, HotspotAnchorSpec, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
+import { Dialog, Menu } from '@ephox/bridge';
 import { Cell, Optional, Result } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
@@ -23,9 +23,6 @@ import { HeaderBackstage, UiFactoryBackstageForHeader } from './HeaderBackstage'
 import { init as initStyleFormatBackstage } from './StyleFormatsBackstage';
 import { UiFactoryBackstageForUrlInput, UrlInputBackstage } from './UrlInputBackstage';
 
-// INVESTIGATE: Make this a body component API ?
-export type BridgedType = any;
-
 export interface UiFactoryBackstageProviders {
   icons: IconProvider;
   menuItems: () => Record<string, Menu.MenuItemSpec | Menu.NestedMenuItemSpec | Menu.ToggleMenuItemSpec>;
@@ -38,7 +35,7 @@ type UiFactoryBackstageForStyleButton = SelectData;
 
 export interface UiFactoryBackstageShared {
   providers?: UiFactoryBackstageProviders;
-  interpreter?: (spec: BridgedType) => AlloySpec;
+  interpreter?: (spec: Dialog.BodyComponent) => AlloySpec;
   anchors?: {
     inlineDialog: () => HotspotAnchorSpec | NodeAnchorSpec;
     banner: () => HotspotAnchorSpec | NodeAnchorSpec;
@@ -46,7 +43,6 @@ export interface UiFactoryBackstageShared {
     node: (elem: Optional<SugarElement>) => NodeAnchorSpec;
   };
   header?: UiFactoryBackstageForHeader;
-  formInterpreter?: (parts: FormTypes.FormParts, spec: BridgedType, backstage: UiFactoryBackstage) => AlloySpec;
   getSink?: () => Result<AlloyComponent, any>;
 }
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/AlertBanner.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/AlertBanner.ts
@@ -16,7 +16,7 @@ import * as Icons from '../icons/Icons';
 type AlertBannerSpec = Omit<Dialog.AlertBanner, 'type'>;
 
 export interface AlertBannerWrapper extends AlertBannerSpec {
-  iconTooltip: string;
+  iconTooltip?: string;
 }
 
 export const renderAlertBanner = (spec: AlertBannerWrapper, providersBackstage: UiFactoryBackstageProviders): SketchSpec =>

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/FormValues.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/FormValues.ts
@@ -5,10 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Form, Invalidating, Representing } from '@ephox/alloy';
-import { Arr, Future, Futures, Merger, Obj, Optional, Result, Results } from '@ephox/katamari';
-
-export interface FormValidator { 'value': string | number; 'text': string }
+import { Obj, Optional, Result } from '@ephox/katamari';
 
 const toValidValues = <T> (values: { [key: string]: Optional<T[keyof T]> }) => {
   const errors: string[] = [];
@@ -26,57 +23,6 @@ const toValidValues = <T> (values: { [key: string]: Optional<T[keyof T]> }) => {
     Result.value<{ [key: string]: T[keyof T] }, string[]>(result);
 };
 
-const toValuesOrDefaults = (optionValues, defaults) => {
-  const r = {};
-  Obj.each(optionValues, (v, k) => {
-    v.each((someValue) => {
-      r[k] = someValue;
-    });
-  });
-  return Merger.deepMerge(defaults, r);
-};
-
-interface ValueHolder {
-  value: any;
-  text: any;
-}
-
-const isValueHolder = (v: any): v is ValueHolder => Obj.hasNonNullableKey(v, 'value') && Obj.hasNonNullableKey(v, 'text');
-
-const extract = <T>(form) => {
-  // FIX: May hit race conditions here is the validation is ongoing and I fire
-  // another one.
-  const rawValues: { [key: string]: Optional<T[keyof T]> } = Representing.getValue(form);
-  const values = toValidValues(rawValues);
-
-  // TODO: Consider how to work "required" into this
-  return values.fold((_errs) => {
-    // TODO: Something went very wrong (could not find fields)
-    return Future.pure(Result.error([]));
-  }, (vs) => {
-    const keys: string[] = Obj.keys(vs);
-    const validations: Array<Future<Result<any, { field: any; message: string }>>> = Arr.map(keys, (key: string) => {
-      // TODO: This should be fine because we just got the value.
-      const field = Form.getField(form, key).getOrDie('Could not find field: ' + key);
-      // TODO: check this refactored line if it breaks.
-      return field.hasConfigured(Invalidating) ? Invalidating.run(field).map(Result.value) : Future.pure(Result.value(true));
-    });
-
-    return Futures.par(validations).map((answers) => {
-      // Answers is an array of results
-      const partition = Results.partition(answers);
-      return partition.errors.length > 0 ? Result.error(partition.errors) : Result.value(
-        Obj.map(vs, (v) => {
-          // Replace { value, text } with just value.
-          return isValueHolder(v) ? v.value : v;
-        })
-      );
-    });
-  });
-};
-
 export {
-  toValidValues,
-  extract,
-  toValuesOrDefaults
+  toValidValues
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
@@ -5,10 +5,11 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloySpec, FormTypes, SimpleOrSketchSpec } from '@ephox/alloy';
-import { Merger, Obj } from '@ephox/katamari';
+import { AlloyParts, AlloySpec, FormTypes, SimpleOrSketchSpec } from '@ephox/alloy';
+import { Dialog } from '@ephox/bridge/';
+import { Fun, Merger, Obj } from '@ephox/katamari';
 
-import { BridgedType, UiFactoryBackstage } from '../../backstage/Backstage';
+import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderBar } from '../dialog/Bar';
 import { renderCollection } from '../dialog/Collection';
 import { renderColorInput } from '../dialog/ColorInput';
@@ -34,54 +35,57 @@ import { renderHtmlPanel } from './HtmlPanel';
 
 /* eslint-disable no-console */
 
-export type FormPartRenderer = (parts: FormTypes.FormParts, spec: BridgedType, backstage: UiFactoryBackstage) => AlloySpec;
-export type NoFormRenderer = (spec: BridgedType, backstage: UiFactoryBackstage) => AlloySpec;
+export type FormPartRenderer<T extends Dialog.BodyComponent> = (parts: FormTypes.FormParts, spec: T, backstage: UiFactoryBackstage) => AlloySpec;
+export type NoFormRenderer<T extends Dialog.BodyComponent> = (spec: T, backstage: UiFactoryBackstage) => AlloySpec;
 
-const make = (render: NoFormRenderer): FormPartRenderer => {
-  return (parts, spec, backstage) => Obj.get(spec, 'name').fold(
-    () => render(spec, backstage),
-    (fieldName) => parts.field(fieldName, render(spec, backstage) as SimpleOrSketchSpec)
-  );
+const make = <T extends Dialog.BodyComponent>(render: NoFormRenderer<T>): FormPartRenderer<T> => {
+  return (parts, spec, backstage) =>
+    Obj.get(spec as Record<string, any>, 'name').fold(
+      () => render(spec, backstage),
+      (fieldName) => parts.field(fieldName, render(spec, backstage) as SimpleOrSketchSpec)
+    );
 };
 
-const makeIframe = (render: NoFormRenderer): FormPartRenderer => (parts, spec, backstage) => {
+const makeIframe = (render: NoFormRenderer<Dialog.Iframe>): FormPartRenderer<Dialog.Iframe> => (parts, spec, backstage) => {
   const iframeSpec = Merger.deepMerge(spec, {
     source: 'dynamic'
   });
   return make(render)(parts, iframeSpec, backstage);
 };
 
-const factories: Record<string, FormPartRenderer> = {
-  bar: make((spec, backstage) => renderBar(spec, backstage.shared)),
-  collection: make((spec, backstage) => renderCollection(spec, backstage.shared.providers)),
-  alertbanner: make((spec, backstage) => renderAlertBanner(spec, backstage.shared.providers)),
-  input: make((spec, backstage) => renderInput(spec, backstage.shared.providers)),
-  textarea: make((spec, backstage) => renderTextarea(spec, backstage.shared.providers)),
-  label: make((spec, backstage) => renderLabel(spec, backstage.shared)),
+const factories: Record<string, FormPartRenderer<any>> = {
+  bar: make<Dialog.Bar>((spec, backstage) => renderBar(spec, backstage.shared)),
+  collection: make<Dialog.Collection>((spec, backstage) => renderCollection(spec, backstage.shared.providers)),
+  alertbanner: make<Dialog.AlertBanner>((spec, backstage) => renderAlertBanner(spec, backstage.shared.providers)),
+  input: make<Dialog.Input>((spec, backstage) => renderInput(spec, backstage.shared.providers)),
+  textarea: make<Dialog.TextArea>((spec, backstage) => renderTextarea(spec, backstage.shared.providers)),
+  label: make<Dialog.Label>((spec, backstage) => renderLabel(spec, backstage.shared)),
   iframe: makeIframe((spec, backstage) => renderIFrame(spec, backstage.shared.providers)),
-  button: make((spec, backstage) => renderDialogButton(spec, backstage.shared.providers)),
-  checkbox: make((spec, backstage) => renderCheckbox(spec, backstage.shared.providers)),
-  colorinput: make((spec, backstage) => renderColorInput(spec, backstage.shared, backstage.colorinput)),
-  colorpicker: make(renderColorPicker), // Not sure if this needs name.
-  dropzone: make((spec, backstage) => renderDropZone(spec, backstage.shared.providers)),
-  grid: make((spec, backstage) => renderGrid(spec, backstage.shared)),
-  listbox: make((spec, backstage) => renderListBox(spec, backstage)),
-  selectbox: make((spec, backstage) => renderSelectBox(spec, backstage.shared.providers)),
-  sizeinput: make((spec, backstage) => renderSizeInput(spec, backstage.shared.providers)),
-  slider: make((spec, backstage) => renderSlider(spec, backstage.shared.providers)),
-  urlinput: make((spec, backstage) => renderUrlInput(spec, backstage, backstage.urlinput)),
-  customeditor: make(renderCustomEditor),
-  htmlpanel: make(renderHtmlPanel),
-  imagetools: make((spec, backstage) => renderImageTools(spec, backstage.shared.providers)),
-  table: make((spec, backstage) => renderTable(spec, backstage.shared.providers)),
-  panel: make((spec, backstage) => renderPanel(spec, backstage))
+  button: make<Dialog.Button>((spec, backstage) => renderDialogButton(spec, backstage.shared.providers)),
+  checkbox: make<Dialog.Checkbox>((spec, backstage) => renderCheckbox(spec, backstage.shared.providers)),
+  colorinput: make<Dialog.ColorInput>((spec, backstage) => renderColorInput(spec, backstage.shared, backstage.colorinput)),
+  colorpicker: make<Dialog.ColorPicker>(renderColorPicker), // Not sure if this needs name.
+  dropzone: make<Dialog.DropZone>((spec, backstage) => renderDropZone(spec, backstage.shared.providers)),
+  grid: make<Dialog.Grid>((spec, backstage) => renderGrid(spec, backstage.shared)),
+  listbox: make<Dialog.ListBox>((spec, backstage) => renderListBox(spec, backstage)),
+  selectbox: make<Dialog.SelectBox>((spec, backstage) => renderSelectBox(spec, backstage.shared.providers)),
+  sizeinput: make<Dialog.SizeInput>((spec, backstage) => renderSizeInput(spec, backstage.shared.providers)),
+  slider: make<Dialog.Slider>((spec, backstage) => renderSlider(spec, backstage.shared.providers)),
+  urlinput: make<Dialog.UrlInput>((spec, backstage) => renderUrlInput(spec, backstage, backstage.urlinput)),
+  customeditor: make<Dialog.CustomEditor>(renderCustomEditor),
+  htmlpanel: make<Dialog.HtmlPanel>(renderHtmlPanel),
+  imagetools: make<Dialog.ImageTools>((spec, backstage) => renderImageTools(spec, backstage.shared.providers)),
+  table: make<Dialog.Table>((spec, backstage) => renderTable(spec, backstage.shared.providers)),
+  panel: make<Dialog.Panel>((spec, backstage) => renderPanel(spec, backstage))
 };
 
-const noFormParts: any = {
-  field: (_name, spec) => spec
+const noFormParts: FormTypes.FormParts = {
+  // This is cast as we only actually want an alloy spec and don't need the actual part here
+  field: (_name: string, spec: SimpleOrSketchSpec) => spec as unknown as AlloyParts.ConfiguredPart,
+  record: Fun.constant([])
 };
 
-const interpretInForm = (parts, spec, oldBackstage) => {
+const interpretInForm = <T extends Dialog.BodyComponent>(parts: FormTypes.FormParts, spec: T, oldBackstage: UiFactoryBackstage) => {
   // Now, we need to update the backstage to use the parts variant.
   const newBackstage = Merger.deepMerge(
     oldBackstage,
@@ -96,17 +100,16 @@ const interpretInForm = (parts, spec, oldBackstage) => {
   return interpretParts(parts, spec, newBackstage);
 };
 
-const interpretParts: FormPartRenderer = (parts, spec, backstage) => Obj.get(factories, spec.type).fold(
-  () => {
-    console.error(`Unknown factory type "${spec.type}", defaulting to container: `, spec);
-    return spec as AlloySpec;
-  },
-  (factory: FormPartRenderer) => factory(parts, spec, backstage)
-);
+const interpretParts = <T extends Dialog.BodyComponent>(parts: FormTypes.FormParts, spec: T, backstage: UiFactoryBackstage) =>
+  Obj.get(factories, spec.type).fold(
+    () => {
+      console.error(`Unknown factory type "${spec.type}", defaulting to container: `, spec);
+      return spec as unknown as AlloySpec;
+    },
+    (factory) => factory(parts, spec, backstage)
+  );
 
-const interpretWithoutForm: NoFormRenderer = (spec, backstage: UiFactoryBackstage) => {
-  const parts = noFormParts;
-  return interpretParts(parts, spec, backstage);
-};
+const interpretWithoutForm = <T extends Dialog.BodyComponent>(spec: T, backstage: UiFactoryBackstage) =>
+  interpretParts(noFormParts, spec, backstage);
 
 export { interpretInForm, interpretWithoutForm };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -7,7 +7,7 @@
 
 import { AlloyComponent, Composing, ModalDialog } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, Id, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderModalBody } from './SilverDialogBody';
@@ -27,20 +27,22 @@ const getDialogSizeClasses = (size: Dialog.DialogSize): string[] => {
   }
 };
 
-const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverDialogCommon.WindowExtra, backstage: UiFactoryBackstage) => {
-  const header = SilverDialogCommon.getHeader(dialogInit.internalDialog.title, backstage);
+const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverDialogCommon.WindowExtra<T>, backstage: UiFactoryBackstage) => {
+  const dialogId = Id.generate('dialog');
+  const internalDialog = dialogInit.internalDialog;
+  const header = SilverDialogCommon.getHeader(internalDialog.title, dialogId, backstage);
 
   const body = renderModalBody({
     body: dialogInit.internalDialog.body
-  }, backstage);
+  }, dialogId, backstage);
 
-  const storagedMenuButtons = SilverDialogCommon.mapMenuButtons(dialogInit.internalDialog.buttons);
+  const storagedMenuButtons = SilverDialogCommon.mapMenuButtons(internalDialog.buttons);
 
   const objOfCells = SilverDialogCommon.extractCellsToObject(storagedMenuButtons);
 
   const footer = renderModalFooter({
     buttons: storagedMenuButtons
-  }, backstage);
+  }, dialogId, backstage);
 
   const dialogEvents = SilverDialogEvents.initDialog(
     () => instanceApi,
@@ -48,9 +50,10 @@ const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverD
     backstage.shared.getSink
   );
 
-  const dialogSize = getDialogSizeClasses(dialogInit.internalDialog.size);
+  const dialogSize = getDialogSizeClasses(internalDialog.size);
 
   const spec = {
+    id: dialogId,
     header,
     body,
     footer: Optional.some(footer),
@@ -68,6 +71,7 @@ const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverD
     };
 
     return {
+      getId: Fun.constant(dialogId),
       getRoot: Fun.constant(dialog),
       getBody: () => ModalDialog.getBody(dialog),
       getFooter: () => ModalDialog.getFooter(dialog),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloySpec, Behaviour, Focusing, Keying, ModalDialog, Reflecting, Tabstopping } from '@ephox/alloy';
+import { AlloyComponent, AlloySpec, Behaviour, Focusing, Keying, ModalDialog, Reflecting, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Fun, Optional } from '@ephox/katamari';
 
@@ -23,24 +23,25 @@ interface WindowBodySpec {
 
 // ariaAttrs is being passed through to silver inline dialog
 // from the WindowManager as a property of 'params'
-const renderBody = (spec: WindowBodySpec, id: Optional<string>, backstage: UiFactoryBackstage, ariaAttrs: boolean): AlloySpec => {
+const renderBody = (spec: WindowBodySpec, dialogId: string, contentId: Optional<string>, backstage: UiFactoryBackstage, ariaAttrs: boolean): AlloySpec => {
   const renderComponents = (incoming: WindowBodySpec) => {
-    switch (incoming.body.type) {
+    const body = incoming.body;
+    switch (body.type) {
       case 'tabpanel': {
         return [
-          renderTabPanel(incoming.body, backstage)
+          renderTabPanel(body, backstage)
         ];
       }
 
       default: {
         return [
-          renderBodyPanel(incoming.body, backstage)
+          renderBodyPanel(body, backstage)
         ];
       }
     }
   };
 
-  const updateState = (_comp, incoming: WindowBodySpec) => Optional.some({
+  const updateState = (_comp: AlloyComponent, incoming: WindowBodySpec) => Optional.some({
     isTabPanel: () => incoming.body.type === 'tabpanel'
   });
 
@@ -53,15 +54,15 @@ const renderBody = (spec: WindowBodySpec, id: Optional<string>, backstage: UiFac
       tag: 'div',
       classes: [ 'tox-dialog__content-js' ],
       attributes: {
-        ...id.map((x): {id?: string} => ({ id: x })).getOr({}),
+        ...contentId.map((x): {id?: string} => ({ id: x })).getOr({}),
         ...ariaAttrs ? ariaAttributes : {}
       }
     },
-    components: [ ],
+    components: [],
     behaviours: Behaviour.derive([
       ComposingConfigs.childAt(0),
       Reflecting.config({
-        channel: bodyChannel,
+        channel: `${bodyChannel}-${dialogId}`,
         updateState,
         renderComponents,
         initialData: spec
@@ -70,10 +71,11 @@ const renderBody = (spec: WindowBodySpec, id: Optional<string>, backstage: UiFac
   };
 };
 
-const renderInlineBody = (spec: WindowBodySpec, contentId: string, backstage: UiFactoryBackstage, ariaAttrs: boolean) => renderBody(spec, Optional.some(contentId), backstage, ariaAttrs);
+const renderInlineBody = (spec: WindowBodySpec, dialogId: string, contentId: string, backstage: UiFactoryBackstage, ariaAttrs: boolean) =>
+  renderBody(spec, dialogId, Optional.some(contentId), backstage, ariaAttrs);
 
-const renderModalBody = (spec: WindowBodySpec, backstage: UiFactoryBackstage) => {
-  const bodySpec = renderBody(spec, Optional.none(), backstage, false);
+const renderModalBody = (spec: WindowBodySpec, dialogId: string, backstage: UiFactoryBackstage) => {
+  const bodySpec = renderBody(spec, dialogId, Optional.none(), backstage, false);
   return ModalDialog.parts.body(
     bodySpec
   );

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogFooter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogFooter.ts
@@ -13,27 +13,34 @@ import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderFooterButton } from '../general/Button';
 import { footerChannel } from './DialogChannels';
 
-// FIX spelling and import location
 export interface DialogMemButton {
-  name: Dialog.DialogFooterButton['name'];
-  align: Dialog.DialogFooterButton['align'];
-  memento: MementoRecord;
+  readonly name: Dialog.DialogFooterButton['name'];
+  readonly align: Dialog.DialogFooterButton['align'];
+  readonly memento: MementoRecord;
 }
 
 export interface WindowFooterSpec {
   buttons: Dialog.DialogFooterButton[];
 }
 
-const makeButton = (button: Dialog.DialogFooterButton, backstage: UiFactoryBackstage) => renderFooterButton(button, button.type, backstage);
+export interface FooterState {
+  readonly lookupByName: (buttonName: string) => Optional<AlloyComponent>;
+  readonly footerButtons: DialogMemButton[];
+}
 
-const lookup = (compInSystem: AlloyComponent, footerButtons: DialogMemButton[], buttonName: string) => Arr.find(footerButtons, (button) => button.name === buttonName).bind((memButton) => memButton.memento.getOpt(compInSystem));
+const makeButton = (button: Dialog.DialogFooterButton, backstage: UiFactoryBackstage) =>
+  renderFooterButton(button, button.type, backstage);
 
-const renderComponents = (_data, state) => {
+const lookup = (compInSystem: AlloyComponent, footerButtons: DialogMemButton[], buttonName: string) =>
+  Arr.find(footerButtons, (button) => button.name === buttonName)
+    .bind((memButton) => memButton.memento.getOpt(compInSystem));
+
+const renderComponents = (_data: WindowFooterSpec, state: Optional<FooterState>) => {
   // default group is 'end'
   const footerButtons = state.map((s) => s.footerButtons).getOr([ ]);
   const buttonGroups = Arr.partition(footerButtons, (button) => button.align === 'start');
 
-  const makeGroup = (edge, buttons): SketchSpec => Container.sketch({
+  const makeGroup = (edge: string, buttons: DialogMemButton[]): SketchSpec => Container.sketch({
     dom: {
       tag: 'div',
       classes: [ `tox-dialog__footer-${edge}` ]
@@ -46,8 +53,8 @@ const renderComponents = (_data, state) => {
   return [ startButtons, endButtons ];
 };
 
-const renderFooter = (initSpec: WindowFooterSpec, backstage: UiFactoryBackstage) => {
-  const updateState = (_comp, data: WindowFooterSpec) => {
+const renderFooter = (initSpec: WindowFooterSpec, dialogId: string, backstage: UiFactoryBackstage) => {
+  const updateState = (comp: AlloyComponent, data: WindowFooterSpec) => {
     const footerButtons: DialogMemButton[] = Arr.map(data.buttons, (button) => {
       const memButton = Memento.record(makeButton(button, backstage));
       return {
@@ -57,12 +64,10 @@ const renderFooter = (initSpec: WindowFooterSpec, backstage: UiFactoryBackstage)
       };
     });
 
-    const lookupByName = (
-      compInSystem: AlloyComponent,
-      buttonName: string
-    ) => lookup(compInSystem, footerButtons, buttonName);
+    const lookupByName = (buttonName: string) =>
+      lookup(comp, footerButtons, buttonName);
 
-    return Optional.some({
+    return Optional.some<FooterState>({
       lookupByName,
       footerButtons
     });
@@ -70,10 +75,10 @@ const renderFooter = (initSpec: WindowFooterSpec, backstage: UiFactoryBackstage)
 
   return {
     dom: DomFactory.fromHtml('<div class="tox-dialog__footer"></div>'),
-    components: [ ],
+    components: [],
     behaviours: Behaviour.derive([
       Reflecting.config({
-        channel: footerChannel,
+        channel: `${footerChannel}-${dialogId}`,
         initialData: initSpec,
         updateState,
         renderComponents
@@ -82,10 +87,11 @@ const renderFooter = (initSpec: WindowFooterSpec, backstage: UiFactoryBackstage)
   };
 };
 
-const renderInlineFooter = (initSpec: WindowFooterSpec, backstage: UiFactoryBackstage) => renderFooter(initSpec, backstage);
+const renderInlineFooter = (initSpec: WindowFooterSpec, dialogId: string, backstage: UiFactoryBackstage) =>
+  renderFooter(initSpec, dialogId, backstage);
 
-const renderModalFooter = (initSpec: WindowFooterSpec, backstage: UiFactoryBackstage) => ModalDialog.parts.footer(
-  renderFooter(initSpec, backstage)
+const renderModalFooter = (initSpec: WindowFooterSpec, dialogId: string, backstage: UiFactoryBackstage) => ModalDialog.parts.footer(
+  renderFooter(initSpec, dialogId, backstage)
 );
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -5,8 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-/* eslint-disable max-len */
-import { AlloySpec, AlloyTriggers, Behaviour, Button, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting } from '@ephox/alloy';
+import {
+  AlloySpec, AlloyTriggers, Behaviour, Button, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting
+} from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
 
@@ -42,7 +43,8 @@ const renderClose = (providersBackstage: UiFactoryBackstageProviders) => Button.
 
 const renderTitle = (
   spec: WindowHeaderSpec,
-  id: Optional<string>,
+  dialogId: string,
+  titleId: Optional<string>,
   providersBackstage: UiFactoryBackstageProviders
 ): AlloySpec => {
   const renderComponents = (data: WindowHeaderSpec) => [ GuiFactory.text(providersBackstage.translate(data.title)) ];
@@ -52,13 +54,14 @@ const renderTitle = (
       tag: 'div',
       classes: [ 'tox-dialog__title' ],
       attributes: {
-        ...id.map((x) => ({ id: x }) as {id?: string}).getOr({})
+        ...titleId.map((x) => ({ id: x })).getOr({})
       }
     },
-    components: renderComponents(spec),
+    components: [],
     behaviours: Behaviour.derive([
       Reflecting.config({
-        channel: titleChannel,
+        channel: `${titleChannel}-${dialogId}`,
+        initialData: spec,
         renderComponents
       })
     ])
@@ -71,12 +74,13 @@ const renderDragHandle = () => ({
 
 const renderInlineHeader = (
   spec: WindowHeaderSpec,
+  dialogId: string,
   titleId: string,
   providersBackstage: UiFactoryBackstageProviders
 ): AlloySpec => Container.sketch({
   dom: DomFactory.fromHtml('<div class="tox-dialog__header"></div>'),
   components: [
-    renderTitle(spec, Optional.some(titleId), providersBackstage),
+    renderTitle(spec, dialogId, Optional.some(titleId), providersBackstage),
     renderDragHandle(),
     renderClose(providersBackstage)
   ],
@@ -88,7 +92,7 @@ const renderInlineHeader = (
         return SelectorFind.closest<HTMLElement>(handle, '[role="dialog"]').getOrDie();
       },
       snaps: {
-        getSnapPoints: () => [ ],
+        getSnapPoints: () => [],
         leftAttr: 'data-drag-left',
         topAttr: 'data-drag-top'
       }
@@ -96,9 +100,9 @@ const renderInlineHeader = (
   ])
 });
 
-const renderModalHeader = (spec: WindowHeaderSpec, providersBackstage: UiFactoryBackstageProviders): AlloySpec => {
+const renderModalHeader = (spec: WindowHeaderSpec, dialogId: string, providersBackstage: UiFactoryBackstageProviders): AlloySpec => {
   const pTitle = ModalDialog.parts.title(
-    renderTitle(spec, Optional.none(), providersBackstage)
+    renderTitle(spec, dialogId, Optional.none(), providersBackstage)
   );
 
   const pHandle = ModalDialog.parts.draghandle(

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -26,7 +26,8 @@ import { renderInlineFooter } from './SilverDialogFooter';
 import { renderInlineHeader } from './SilverDialogHeader';
 import { getDialogApi } from './SilverDialogInstanceApi';
 
-const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverDialogCommon.WindowExtra, backstage: UiFactoryBackstage, ariaAttrs: boolean) => {
+const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverDialogCommon.WindowExtra<T>, backstage: UiFactoryBackstage, ariaAttrs: boolean) => {
+  const dialogId = Id.generate('dialog');
   const dialogLabelId = Id.generate('dialog-label');
   const dialogContentId = Id.generate('dialog-content');
 
@@ -36,13 +37,13 @@ const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: S
     renderInlineHeader({
       title: dialogInit.internalDialog.title,
       draggable: true
-    }, dialogLabelId, backstage.shared.providers) as SimpleSpec
+    }, dialogId, dialogLabelId, backstage.shared.providers) as SimpleSpec
   );
 
   const memBody = Memento.record(
     renderInlineBody({
       body: dialogInit.internalDialog.body
-    }, dialogContentId, backstage, ariaAttrs) as SimpleSpec
+    }, dialogId, dialogContentId, backstage, ariaAttrs) as SimpleSpec
   );
 
   const storagedMenuButtons = SilverDialogCommon.mapMenuButtons(dialogInit.internalDialog.buttons);
@@ -52,7 +53,7 @@ const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: S
   const memFooter = Memento.record(
     renderInlineFooter({
       buttons: storagedMenuButtons
-    }, backstage)
+    }, dialogId, backstage)
   );
 
   const dialogEvents = SilverDialogEvents.initDialog(
@@ -99,7 +100,7 @@ const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: S
         )
       }),
       Reflecting.config({
-        channel: dialogChannel,
+        channel: `${dialogChannel}-${dialogId}`,
         updateState,
         initialData: dialogInit
       }),
@@ -128,6 +129,7 @@ const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: S
 
   // TODO: Clean up the dupe between this (InlineDialog) and SilverDialog
   const instanceApi = getDialogApi<T>({
+    getId: Fun.constant(dialogId),
     getRoot: Fun.constant(dialog),
     getFooter: () => memFooter.get(dialog),
     getBody: () => memBody.get(dialog),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialog.ts
@@ -7,7 +7,7 @@
 
 import { AddEventsBehaviour, AlloyEvents, AlloyParts, Receiving } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Obj, Optional, Singleton, Type } from '@ephox/katamari';
+import { Id, Obj, Optional, Singleton, Type } from '@ephox/katamari';
 import { DomEvent, EventUnbinder, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -52,15 +52,16 @@ const handleMessage = (editor: Editor, api: Dialog.UrlDialogInstanceApi, data: a
   }
 };
 
-const renderUrlDialog = (internalDialog: Dialog.UrlDialog, extra: WindowExtra, editor: Editor, backstage: UiFactoryBackstage) => {
-  const header = getHeader(internalDialog.title, backstage);
+const renderUrlDialog = (internalDialog: Dialog.UrlDialog, extra: WindowExtra<unknown>, editor: Editor, backstage: UiFactoryBackstage) => {
+  const dialogId = Id.generate('dialog');
+  const header = getHeader(internalDialog.title, dialogId, backstage);
   const body = renderIframeBody(internalDialog);
   const footer = internalDialog.buttons.bind((buttons) => {
     // Don't render a footer if no buttons are specified
     if (buttons.length === 0) {
       return Optional.none<AlloyParts.ConfiguredPart>();
     } else {
-      return Optional.some(renderModalFooter({ buttons }, backstage));
+      return Optional.some(renderModalFooter({ buttons }, dialogId, backstage));
     }
   });
 
@@ -123,6 +124,7 @@ const renderUrlDialog = (internalDialog: Dialog.UrlDialog, extra: WindowExtra, e
   ];
 
   const spec: DialogSpec = {
+    id: dialogId,
     header,
     body,
     footer,

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/grid/BasicGridTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/grid/BasicGridTest.ts
@@ -8,7 +8,7 @@ import { renderGrid } from 'tinymce/themes/silver/ui/dialog/Grid';
 
 describe('headless.tinymce.themes.silver.components.grid.GridTest', () => {
   const sharedBackstage = {
-    interpreter: Fun.identity,
+    interpreter: Fun.identity as any,
     translate: I18n.translate
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
@@ -10,7 +10,7 @@ import TestProviders from '../../../module/TestProviders';
 describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
   const sharedBackstage = {
     providers: TestProviders,
-    interpreter: Fun.identity
+    interpreter: Fun.identity as any
   };
 
   const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
@@ -77,7 +77,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogEventTest', () => {
       {
         redial: () => dialogSpec(store),
         closeWindow: () => store.adder('closeWindow')
-      } as WindowExtra,
+      } as WindowExtra<{}>,
       {
         shared: {
           getSink: () => Result.value(sink),

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
@@ -18,7 +18,7 @@ export default (sink?: AlloyComponent): UiFactoryBackstage => {
   return {
     shared: {
       providers: TestProviders,
-      interpreter: Fun.identity,
+      interpreter: Fun.identity as any,
       anchors: {
         inlineDialog: hotspotAnchorFn,
         banner: hotspotAnchorFn,


### PR DESCRIPTION
Related Ticket: TINY-8334

Description of Changes:

This is pretty much just a whole lot of cleanup/tidying of things that as I've been working through looking at the partial redial that I've found or changed that aren't going to be related. You'll notice I've tried to remove a bunch of duplication for the bridge schemas so that common fields are now defined in `ComponentSchema` (this will also help marginally with memory usage as it's not redefining the same schema multiple times and also minify better).

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
