### PR TITLE
TINY-8280: added alt model decorations for autocompleter

### DIFF
--- a/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
@@ -6,15 +6,14 @@
  */
 
 import { Optional, Singleton, Throttler, Thunk, Type } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import { fireAutocompleterEnd, fireAutocompleterStart, fireAutocompleterUpdate } from '../api/Events';
 import { AutocompleteContext, getContext } from '../autocomplete/AutocompleteContext';
 import { AutocompleteLookupInfo, lookup, lookupWithContext } from '../autocomplete/AutocompleteLookup';
 import * as Autocompleters from '../autocomplete/Autocompleters';
-import * as AutocompleteTag from '../autocomplete/AutocompleteTag';
 import { AutocompleterReloadArgs } from '../autocomplete/AutocompleteTypes';
+import * as Rtc from '../Rtc';
 
 interface ActiveAutocompleter {
   readonly triggerChar: string;
@@ -50,7 +49,7 @@ export const setup = (editor: Editor): void => {
 
   const cancelIfNecessary = () => {
     if (isActive()) {
-      AutocompleteTag.remove(SugarElement.fromDom(editor.getBody()));
+      Rtc.removeAutocompleterDecoration(editor);
       fireAutocompleterEnd(editor);
       activeAutocompleter.clear();
     }
@@ -59,7 +58,7 @@ export const setup = (editor: Editor): void => {
   const commenceIfNecessary = (context: AutocompleteContext) => {
     if (!isActive()) {
       // Create the wrapper
-      AutocompleteTag.create(editor, context.range);
+      Rtc.addAutocompleterDecoration(editor, context.range);
 
       // store the element/context
       activeAutocompleter.set({

--- a/modules/tinymce/src/core/main/ts/keyboard/KeyboardOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/KeyboardOverrides.ts
@@ -22,6 +22,7 @@ import * as SpaceKey from './SpaceKey';
 
 const setup = (editor: Editor): Cell<Text> => {
   editor.addShortcut('Meta+P', '', 'mcePrint');
+  Autocompleter.setup(editor);
 
   if (Rtc.isRtc(editor)) {
     return Cell(null);
@@ -36,7 +37,6 @@ const setup = (editor: Editor): Cell<Text> => {
     InputKeys.setup(editor);
     HomeEndKeys.setup(editor, caret);
     PageUpDownKeys.setup(editor, caret);
-    Autocompleter.setup(editor);
 
     return caret;
   }


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Adds support for the rtc autocompleter

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
