### PR TITLE
TINY-8353: Add FakeClipboard to tinymce global

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `AutocompleterStart`, `AutocompleterUpdate` and `AutocompleterEnd` events #TINY-8279
 - New `mceAutocompleterClose`, `mceAutocompleterReload` commands #TINY-8279
 - New `slider` dialog component #TINY-8304
+- New `FakeClipboard` API to the `tinymce` global #TINY-8353
 - New `buttonType` property on dialog button components, supporting `toolbar` style in addition to `primary` and `secondary` #TINY-8304
 
 ### Improved

--- a/modules/tinymce/src/core/main/json/globals.json
+++ b/modules/tinymce/src/core/main/json/globals.json
@@ -39,6 +39,7 @@
       "tinymce.core.api.Shortcuts",
       "tinymce.core.api.ThemeManager",
       "tinymce.core.api.UndoManager",
+      "tinymce.core.api.FakeClipboard",
       "tinymce.core.api.util.Delay",
       "tinymce.core.api.util.EventDispatcher",
       "tinymce.core.api.util.I18n",

--- a/modules/tinymce/src/core/main/ts/api/FakeClipboard.ts
+++ b/modules/tinymce/src/core/main/ts/api/FakeClipboard.ts
@@ -1,0 +1,63 @@
+
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Singleton } from '@ephox/katamari';
+
+/**
+  * TinyMCE FakeClipboard API.
+  *
+  * @class tinymce.FakeClipboard
+  */
+
+interface FakeClipboard {
+
+  /**
+   * Writes arbitrary data to the fake clipboard.
+   *
+   * @method write
+   * @param {any} data data to be written to the fake clipboard
+   */
+  readonly write: <T>(data: T) => void;
+
+  /**
+   * Requests arbitrary data from the fake clipboard.
+   *
+   * @method read
+   */
+  readonly read: <T>() => T | undefined;
+
+  /**
+   * Clear arbitrary data on the fake clipboard.
+   *
+   * @method clear
+   */
+  readonly clear: () => void;
+}
+
+const setup = (): FakeClipboard => {
+  const dataValue = Singleton.value<any>();
+
+  const write = <T>(data: T): void => {
+    dataValue.set(data);
+  };
+
+  const read = <T>(): T | undefined =>
+    dataValue.get().getOrUndefined();
+
+  const clear = dataValue.clear;
+
+  return {
+    write,
+    read,
+    clear
+  };
+};
+
+const FakeClipboard = setup();
+
+export default FakeClipboard;

--- a/modules/tinymce/src/core/main/ts/api/FakeClipboard.ts
+++ b/modules/tinymce/src/core/main/ts/api/FakeClipboard.ts
@@ -29,8 +29,8 @@ interface FakeClipboard {
    * Create a FakeClipboardItem instance that is used when reading or writing data via the FakeClipboard API.
    *
    * @method FakeClipboardItem
-   * @param {Record<string, any>} items an object with the type as the key and any data as the value
-   * @returns {FakeClipboardItem} FakeClipboardItem
+   * @param {Object} items An object with the type as the key and any data as the value.
+   * @returns {tinymce.FakeClipboard.FakeClipboardItem} A new fake clipboard item to represent the specified items.
    */
   readonly FakeClipboardItem: (items: Record<string, any>) => FakeClipboardItem;
 
@@ -38,7 +38,7 @@ interface FakeClipboard {
    * Writes arbitrary data to the fake clipboard.
    *
    * @method write
-   * @param {any} data data to be written to the fake clipboard
+   * @param {Array} data An array of FakeClipboardItems to be written to the fake clipboard.
    */
   readonly write: (data: FakeClipboardItem[]) => void;
 
@@ -46,7 +46,7 @@ interface FakeClipboard {
    * Requests arbitrary data from the fake clipboard.
    *
    * @method read
-   * @returns {FakeClipboardItem} FakeClipboardItem or undefined
+   * @returns {Array} An array of FakeClipboardItems if items exist on the fake clipboard, otherwise undefined.
    */
   readonly read: () => FakeClipboardItem[] | undefined;
 

--- a/modules/tinymce/src/core/main/ts/api/PublicApi.ts
+++ b/modules/tinymce/src/core/main/ts/api/PublicApi.ts
@@ -26,6 +26,7 @@ import EditorManager from './EditorManager';
 import EditorObservable from './EditorObservable';
 import Env from './Env';
 import * as Events from './EventTypes';
+import FakeClipboard from './FakeClipboard';
 import * as Formats from './fmt/Format';
 import FocusManager from './FocusManager';
 import Formatter from './Formatter';
@@ -120,6 +121,7 @@ export {
   ThemeManager,
   UndoManager,
   WindowManager,
+  FakeClipboard,
 
   // other useful types
   RawEditorOptions,

--- a/modules/tinymce/src/core/main/ts/api/Tinymce.ts
+++ b/modules/tinymce/src/core/main/ts/api/Tinymce.ts
@@ -25,6 +25,7 @@ import EditorCommands, { EditorCommandsConstructor } from './EditorCommands';
 import EditorManager from './EditorManager';
 import EditorObservable from './EditorObservable';
 import Env from './Env';
+import FakeClipboard from './FakeClipboard';
 import FocusManager from './FocusManager';
 import Formatter from './Formatter';
 import Rect from './geom/Rect';
@@ -159,6 +160,7 @@ interface TinyMCE extends EditorManager {
   ThemeManager: ThemeManager;
   IconManager: IconManager;
   Resource: Resource;
+  FakeClipboard: FakeClipboard;
 
   // Global utility functions
   trim: Tools['trim'];
@@ -254,6 +256,7 @@ const publicApi = {
   ThemeManager,
   IconManager,
   Resource,
+  FakeClipboard,
 
   // Global utility functions
   trim: Tools.trim,

--- a/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
@@ -1,0 +1,37 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import FakeClipboard from 'tinymce/core/api/FakeClipboard';
+
+describe('browser.tinymce.core.FakeClipboardTest', () => {
+  TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  it('fake clipboard returns undefined when not set', () => {
+    assert.isUndefined(FakeClipboard.read());
+  });
+
+  it('can write to and read from fake clipboard', () => {
+    FakeClipboard.write('hello');
+    assert.equal(FakeClipboard.read(), 'hello');
+  });
+
+  it('can clear fake clipboard after being written to', () => {
+    FakeClipboard.write('hello');
+    assert.equal(FakeClipboard.read(), 'hello');
+    FakeClipboard.clear();
+    assert.isUndefined(FakeClipboard.read());
+  });
+
+  it('can store an object', () => {
+    const testObj = {
+      a: 1,
+      b: 2
+    };
+    FakeClipboard.write(testObj);
+    assert.deepEqual(FakeClipboard.read(), testObj);
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
@@ -10,28 +10,69 @@ describe('browser.tinymce.core.FakeClipboardTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, []);
 
-  it('fake clipboard returns undefined when not set', () => {
+  it('TINY-8353: fake clipboard returns undefined when not set', () => {
     assert.isUndefined(FakeClipboard.read());
   });
 
-  it('can write to and read from fake clipboard', () => {
-    FakeClipboard.write('hello');
-    assert.equal(FakeClipboard.read(), 'hello');
+  it('TINY-8353: can create a FakeClipboardItem', () => {
+    const data = {
+      text: 'This is text',
+      test: 1
+    };
+
+    const item = FakeClipboard.FakeClipboardItem(data);
+    assert.deepEqual(item.types, [ 'text', 'test' ]);
+    assert.deepEqual(item.items, data);
+    assert.equal(item.getType('text'), 'This is text');
+    assert.equal(item.getType('test'), 1);
+    assert.isUndefined(item.getType('noexist'));
   });
 
-  it('can clear fake clipboard after being written to', () => {
-    FakeClipboard.write('hello');
-    assert.equal(FakeClipboard.read(), 'hello');
+  it('TINY-8353: can write to and read from fake clipboard', () => {
+    const item = FakeClipboard.FakeClipboardItem({
+      text: 'hello',
+    });
+    FakeClipboard.write([ item ]);
+
+    const clipboardItems = FakeClipboard.read();
+    assert.lengthOf(clipboardItems, 1);
+    assert.equal(clipboardItems[0].getType('text'), 'hello');
+  });
+
+  it('TINY-8353: can write to and read multiple clipboard items', () => {
+    FakeClipboard.write([
+      FakeClipboard.FakeClipboardItem({ text: 'item1' }),
+      FakeClipboard.FakeClipboardItem({ text: 'item2' }),
+    ]);
+
+    const clipboardItems = FakeClipboard.read();
+    assert.lengthOf(clipboardItems, 2);
+    assert.equal(clipboardItems[0].getType('text'), 'item1');
+    assert.equal(clipboardItems[1].getType('text'), 'item2');
+  });
+
+  it('TINY-8353: can clear fake clipboard after being written to', () => {
+    const item = FakeClipboard.FakeClipboardItem({
+      text: 'hello',
+    });
+    FakeClipboard.write([ item ]);
+
+    const clipboardItems = FakeClipboard.read();
+    assert.lengthOf(clipboardItems, 1);
+
     FakeClipboard.clear();
     assert.isUndefined(FakeClipboard.read());
   });
 
-  it('can store an object', () => {
+  it('TINY-8353: can store an object', () => {
     const testObj = {
       a: 1,
       b: 2
     };
-    FakeClipboard.write(testObj);
-    assert.deepEqual(FakeClipboard.read(), testObj);
+    FakeClipboard.write([
+      FakeClipboard.FakeClipboardItem({ obj: testObj })
+    ]);
+
+    assert.deepEqual(FakeClipboard.read()[0].getType('obj'), testObj);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8353

Description of Changes:
* Add a fake clipboard to the tinymce global that can be used by the table copy row/column logic as well by the paste plugin

Note: I didn't have an exact spec to work with so have just done a basic read, write, clear API as a starting point.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
