### PR TITLE
TINY-8381: Fixed color picker not getting translated

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `editor.selection.getContent()` API did not respect the `no_events` argument #TINY-8018
 - The `GetContent` event was not fired when getting `tree` or `text` formats using the `editor.selection.getContent()` API #TINY-8018
 - The `table` plugin would sometimes not correctly handle headers in the `tfoot` section #TINY-8104
+- The aria labels for the color picker dialog were not translated #TINY-8381
 
 ### Removed
 - Removed the deprecated `$`, `Class`, `DomQuery` and `Sizzle` APIs #TINY-4520 #TINY-8326

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -6,14 +6,13 @@
  */
 
 import { ColourPicker } from '@ephox/acid';
-import { AlloyTriggers, Behaviour, Composing, Form, Memento, NativeEvents, Representing, SimpleSpec } from '@ephox/alloy';
+import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Form, Memento, NativeEvents, Representing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
 
+import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { formActionEvent } from '../general/FormEvents';
-
-// import I18n from 'tinymce/core/api/util/I18n';
 
 const english = {
   'colorcustom.rgb.red.label': 'R',
@@ -25,40 +24,26 @@ const english = {
   'colorcustom.rgb.hex.label': '#',
   'colorcustom.rgb.hex.description': 'Hex color code',
   'colorcustom.rgb.range': 'Range 0 to 255',
-  'colorcustom.sb.saturation': 'Saturation',
-  'colorcustom.sb.brightness': 'Brightness',
-  'colorcustom.sb.picker': 'Saturation and Brightness Picker',
-  'colorcustom.sb.palette': 'Saturation and Brightness Palette',
-  'colorcustom.sb.instructions': 'Use arrow keys to select saturation and brightness, on x and y axes',
-  'colorcustom.hue.hue': 'Hue',
-  'colorcustom.hue.slider': 'Hue Slider',
-  'colorcustom.hue.palette': 'Hue Palette',
-  'colorcustom.hue.instructions': 'Use arrow keys to select a hue',
   'aria.color.picker': 'Color Picker',
   'aria.input.invalid': 'Invalid input'
 };
 
-const getEnglishText = (key) => {
-  return english[key];
-};
-
-const translate = (key) => {
-  // TODO: use this: I18n.translate()
-  return getEnglishText(key);
+const translate = (providerBackstage: UiFactoryBackstageProviders) => (key: string) => {
+  return providerBackstage.translate(english[key]);
 };
 
 type ColorPickerSpec = Omit<Dialog.ColorPicker, 'type'>;
 
-export const renderColorPicker = (_spec: ColorPickerSpec): SimpleSpec => {
+export const renderColorPicker = (_spec: ColorPickerSpec, providerBackstage: UiFactoryBackstageProviders): SimpleSpec => {
   const getClass = (key: string) => 'tox-' + key;
 
-  const colourPickerFactory = ColourPicker.makeFactory(translate, getClass);
+  const colourPickerFactory = ColourPicker.makeFactory(translate(providerBackstage), getClass);
 
-  const onValidHex = (form) => {
+  const onValidHex = (form: AlloyComponent) => {
     AlloyTriggers.emitWith(form, formActionEvent, { name: 'hex-valid', value: true });
   };
 
-  const onInvalidHex = (form) => {
+  const onInvalidHex = (form: AlloyComponent) => {
     AlloyTriggers.emitWith(form, formActionEvent, { name: 'hex-valid', value: false });
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
@@ -64,7 +64,7 @@ const factories: Record<string, FormPartRenderer<any>> = {
   button: make<Dialog.Button>((spec, backstage) => renderDialogButton(spec, backstage.shared.providers)),
   checkbox: make<Dialog.Checkbox>((spec, backstage) => renderCheckbox(spec, backstage.shared.providers)),
   colorinput: make<Dialog.ColorInput>((spec, backstage) => renderColorInput(spec, backstage.shared, backstage.colorinput)),
-  colorpicker: make<Dialog.ColorPicker>(renderColorPicker), // Not sure if this needs name.
+  colorpicker: make<Dialog.ColorPicker>((spec, backstage) => renderColorPicker(spec, backstage.shared.providers)), // Not sure if this needs name.
   dropzone: make<Dialog.DropZone>((spec, backstage) => renderDropZone(spec, backstage.shared.providers)),
   grid: make<Dialog.Grid>((spec, backstage) => renderGrid(spec, backstage.shared)),
   listbox: make<Dialog.ListBox>((spec, backstage) => renderListBox(spec, backstage)),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
@@ -9,13 +9,14 @@ import { assert } from 'chai';
 import { renderColorPicker } from 'tinymce/themes/silver/ui/dialog/ColorPicker';
 
 import * as RepresentingUtils from '../../../module/RepresentingUtils';
+import TestProviders from '../../../module/TestProviders';
 
 describe('headless.tinymce.themes.silver.components.colorpicker.ColorPickerTest', () => {
   const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
     renderColorPicker({
       label: Optional.some('ColorPicker label'),
       name: 'col1'
-    })
+    }, TestProviders)
   ));
 
   const fireEvent = (elem: SugarElement<Node>, event: string) => {


### PR DESCRIPTION
Related Ticket: TINY-8381

Description of Changes:
* Fixed color picker aria label strings not getting passed for translation
* Removed unused key to english strings

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ Nothing currently tests strings are passed for translation, so that's a separate task
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
