### PR TITLE
TINY-8334: Pass initial data when rendering dialog components

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/api/Dialog.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/Dialog.ts
@@ -3,7 +3,7 @@ import { Bar, BarSpec, createBarFields } from '../components/dialog/Bar';
 import { BodyComponent, BodyComponentSpec } from '../components/dialog/BodyComponent';
 import { Button, ButtonSpec, createButton } from '../components/dialog/Button';
 import { Checkbox, CheckboxSpec, createCheckbox } from '../components/dialog/Checkbox';
-import { Collection, collectionDataProcessor, CollectionSpec, createCollection } from '../components/dialog/Collection';
+import { Collection, collectionDataProcessor, CollectionItem, CollectionSpec, createCollection } from '../components/dialog/Collection';
 import { ColorInput, ColorInputSpec, createColorInput } from '../components/dialog/ColorInput';
 import { ColorPicker, ColorPickerSpec, createColorPicker } from '../components/dialog/ColorPicker';
 import {
@@ -38,7 +38,7 @@ import {
   createUrlDialog, UrlDialog, UrlDialogActionDetails, UrlDialogActionHandler, UrlDialogCancelHandler, UrlDialogCloseHandler, UrlDialogFooterButton,
   UrlDialogFooterButtonSpec, UrlDialogInstanceApi, UrlDialogMessage, UrlDialogMessageHandler, UrlDialogSpec
 } from '../components/dialog/UrlDialog';
-import { createUrlInput, UrlInput, UrlInputSpec } from '../components/dialog/UrlInput';
+import { createUrlInput, UrlInput, UrlInputData, UrlInputSpec } from '../components/dialog/UrlInput';
 
 // These are the types that are to be used internally in implementations
 export {
@@ -62,6 +62,7 @@ export {
   createCheckbox,
 
   Collection,
+  CollectionItem,
   CollectionSpec,
   createCollection,
   collectionDataProcessor,
@@ -190,6 +191,7 @@ export {
   createUrlDialog,
 
   UrlInput,
+  UrlInputData,
   UrlInputSpec,
   createUrlInput
 };

--- a/modules/bridge/src/main/ts/ephox/bridge/api/PublicDialog.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/PublicDialog.ts
@@ -3,7 +3,7 @@ import { BarSpec } from '../components/dialog/Bar';
 import { BodyComponentSpec } from '../components/dialog/BodyComponent';
 import { ButtonSpec } from '../components/dialog/Button';
 import { CheckboxSpec } from '../components/dialog/Checkbox';
-import { CollectionSpec } from '../components/dialog/Collection';
+import { CollectionItem, CollectionSpec } from '../components/dialog/Collection';
 import { ColorInputSpec } from '../components/dialog/ColorInput';
 import { ColorPickerSpec } from '../components/dialog/ColorPicker';
 import { CustomEditorInit, CustomEditorInitFn, CustomEditorSpec } from '../components/dialog/CustomEditor';
@@ -29,7 +29,7 @@ import { TextAreaSpec } from '../components/dialog/Textarea';
 import {
   UrlDialogActionDetails, UrlDialogFooterButtonSpec, UrlDialogInstanceApi, UrlDialogMessage, UrlDialogSpec
 } from '../components/dialog/UrlDialog';
-import { UrlInputSpec } from '../components/dialog/UrlInput';
+import { UrlInputData, UrlInputSpec } from '../components/dialog/UrlInput';
 
 // These are the types that are exposed though a public end user api
 
@@ -44,6 +44,7 @@ export {
 
   CheckboxSpec,
 
+  CollectionItem,
   CollectionSpec,
 
   ColorInputSpec,
@@ -98,6 +99,7 @@ export {
 
   TextAreaSpec,
 
+  UrlInputData,
   UrlInputSpec,
 
   UrlDialogSpec,

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Collection.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Collection.ts
@@ -15,6 +15,12 @@ export interface Collection extends FormComponentWithLabel {
   columns: number | 'auto';
 }
 
+export interface CollectionItem {
+  value: string;
+  text: string;
+  icon: string;
+}
+
 const collectionFields: FieldProcessor[] = formComponentWithLabelFields.concat([
   ComponentSchema.defaultedColumns('auto')
 ]);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/UrlInput.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/UrlInput.ts
@@ -16,6 +16,13 @@ export interface UrlInput extends FormComponentWithLabel {
   disabled: boolean;
 }
 
+export interface UrlInputData {
+  value: string;
+  meta: {
+    text?: string;
+  };
+}
+
 const urlInputFields = formComponentWithLabelFields.concat([
   FieldSchema.defaultedStringEnum('filetype', 'file', [ 'image', 'media', 'file' ]),
   ComponentSchema.disabled

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -68,7 +68,7 @@ const init = (sink: AlloyComponent, editor: Editor, lazyAnchorbar: () => AlloyCo
         isDisabled: () => editor.mode.isReadOnly() || editor.ui.isDisabled(),
         getOption: editor.options.get
       },
-      interpreter: (s) => UiFactory.interpretWithoutForm(s, backstage),
+      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, backstage),
       anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),
       header: toolbar,
       getSink: () => Result.value(sink)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/RepresentingConfigs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/RepresentingConfigs.ts
@@ -7,7 +7,7 @@
 
 import { AlloyComponent, MementoRecord, Representing } from '@ephox/alloy';
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Fun, Merger, Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { Html, SugarElement, Value } from '@ephox/sugar';
 
 const processors = StructureSchema.objOf([
@@ -34,22 +34,14 @@ const memento = (mem: MementoRecord, rawProcessors) => {
   });
 };
 
-const withComp = <D>(optInitialValue: Optional<D>, getter: (c: AlloyComponent) => D, setter: (c: AlloyComponent, v: D) => void) => Representing.config(
-  Merger.deepMerge(
-    {
-      store: {
-        mode: 'manual' as 'manual',
-        getValue: getter,
-        setValue: setter
-      }
-    },
-    optInitialValue.map((initialValue) => ({
-      store: {
-        initialValue
-      }
-    })).getOr({ } as any)
-  )
-);
+const withComp = <D>(optInitialValue: Optional<D>, getter: (c: AlloyComponent) => D, setter: (c: AlloyComponent, v: D) => void) => Representing.config({
+  store: {
+    mode: 'manual' as 'manual',
+    ...optInitialValue.map((initialValue) => ({ initialValue })).getOr({}),
+    getValue: getter,
+    setValue: setter
+  }
+});
 
 const withElement = <D>(initialValue: Optional<D>, getter: (elem: SugarElement) => D, setter: (elem: SugarElement, v: D) => void) => withComp(
   initialValue,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
@@ -18,7 +18,7 @@ import { interpretInForm } from '../general/UiFactory';
 
 export type BodyPanelSpec = Omit<Dialog.Panel, 'type'>;
 
-const renderBodyPanel = (spec: BodyPanelSpec, backstage: UiFactoryBackstage): SimpleSpec => {
+const renderBodyPanel = (spec: BodyPanelSpec, dialogData: Dialog.DialogData, backstage: UiFactoryBackstage): SimpleSpec => {
   const memForm = Memento.record(
     AlloyForm.sketch((parts) => ({
       dom: {
@@ -27,7 +27,7 @@ const renderBodyPanel = (spec: BodyPanelSpec, backstage: UiFactoryBackstage): Si
       },
       // All of the items passed through the form need to be put through the interpreter
       // with their form part preserved.
-      components: Arr.map(spec.items, (item) => interpretInForm(parts, item, backstage))
+      components: Arr.map(spec.items, (item) => interpretInForm(parts, item, dialogData, backstage))
     }))
   );
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
@@ -10,7 +10,7 @@ import {
   NativeEvents, Replacing, Representing, SimulatedEvent, SketchSpec, SystemEvents, Tabstopping
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr, Fun } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Attribute, Class, EventArgs, Focus, Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Entities from 'tinymce/core/api/html/Entities';
@@ -26,7 +26,11 @@ import { deriveCollectionMovement } from '../menus/menu/MenuMovement';
 
 type CollectionSpec = Omit<Dialog.Collection, 'type'>;
 
-export const renderCollection = (spec: CollectionSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
+export const renderCollection = (
+  spec: CollectionSpec,
+  providersBackstage: UiFactoryBackstageProviders,
+  initialData: Optional<Dialog.CollectionItem[]>
+): SketchSpec => {
   // DUPE with TextField.
   const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
 
@@ -36,7 +40,7 @@ export const renderCollection = (spec: CollectionSpec, providersBackstage: UiFac
     });
   };
 
-  const setContents = (comp, items) => {
+  const setContents = (comp: AlloyComponent, items: Dialog.CollectionItem[]) => {
     const htmlLines = Arr.map(items, (item) => {
       const itemText = I18n.translate(item.text);
       const textContent = spec.columns === 1 ? `<div class="tox-collection__item-label">${itemText}</div>` : '';
@@ -133,7 +137,7 @@ export const renderCollection = (spec: CollectionSpec, providersBackstage: UiFac
       Representing.config({
         store: {
           mode: 'memory',
-          initialValue: [ ]
+          initialValue: initialData.getOr([])
         },
         onSetValue: (comp, items) => {
           setContents(comp, items);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
@@ -40,10 +40,16 @@ interface ColorPickerCancelEvent extends CustomEvent {
 
 type ColorInputSpec = Omit<Dialog.ColorInput, 'type'>;
 
-export const renderColorInput = (spec: ColorInputSpec, sharedBackstage: UiFactoryBackstageShared, colorInputBackstage: UiFactoryBackstageForColorInput): SimpleSpec => {
+export const renderColorInput = (
+  spec: ColorInputSpec,
+  sharedBackstage: UiFactoryBackstageShared,
+  colorInputBackstage: UiFactoryBackstageForColorInput,
+  initialData: Optional<string>
+): SimpleSpec => {
   const pField = FormField.parts.field({
     factory: Input,
     inputClasses: [ 'tox-textfield' ],
+    data: initialData,
 
     onSetValue: (c) => Invalidating.run(c).get(Fun.noop),
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -12,6 +12,7 @@ import { Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
+import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 import { formActionEvent } from '../general/FormEvents';
 
 const english = {
@@ -34,7 +35,7 @@ const translate = (providerBackstage: UiFactoryBackstageProviders) => (key: stri
 
 type ColorPickerSpec = Omit<Dialog.ColorPicker, 'type'>;
 
-export const renderColorPicker = (_spec: ColorPickerSpec, providerBackstage: UiFactoryBackstageProviders): SimpleSpec => {
+export const renderColorPicker = (_spec: ColorPickerSpec, providerBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SimpleSpec => {
   const getClass = (key: string) => 'tox-' + key;
 
   const colourPickerFactory = ColourPicker.makeFactory(translate(providerBackstage), getClass);
@@ -70,39 +71,37 @@ export const renderColorPicker = (_spec: ColorPickerSpec, providerBackstage: UiF
     ],
     behaviours: Behaviour.derive([
       // We'll allow invalid values
-      Representing.config({
-        store: {
-          mode: 'manual',
-          getValue: (comp) => {
-            const picker = memPicker.get(comp);
-            const optRgbForm = Composing.getCurrent(picker);
-            const optHex = optRgbForm.bind((rgbForm) => {
-              const formValues = Representing.getValue(rgbForm);
-              return formValues.hex as Optional<string>;
-            }) ;
-            return optHex.map((hex) => '#' + hex).getOr('');
-          },
-          setValue: (comp, newValue) => {
-            const pattern = /^#([a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?)/;
-            const m = pattern.exec(newValue);
-            const picker = memPicker.get(comp);
-            const optRgbForm = Composing.getCurrent(picker);
-            optRgbForm.fold(() => {
-              // eslint-disable-next-line no-console
-              console.log('Can not find form');
-            }, (rgbForm) => {
-              Representing.setValue(rgbForm, {
-                hex: Optional.from(m[1]).getOr('')
-              });
-
-              // So not the way to do this.
-              Form.getField(rgbForm, 'hex').each((hexField) => {
-                AlloyTriggers.emit(hexField, NativeEvents.input());
-              });
+      RepresentingConfigs.withComp(
+        initialData,
+        (comp) => {
+          const picker = memPicker.get(comp);
+          const optRgbForm = Composing.getCurrent(picker);
+          const optHex = optRgbForm.bind((rgbForm) => {
+            const formValues = Representing.getValue(rgbForm);
+            return formValues.hex as Optional<string>;
+          });
+          return optHex.map((hex) => '#' + hex).getOr('');
+        },
+        (comp, newValue) => {
+          const pattern = /^#([a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?)/;
+          const m = pattern.exec(newValue);
+          const picker = memPicker.get(comp);
+          const optRgbForm = Composing.getCurrent(picker);
+          optRgbForm.fold(() => {
+            // eslint-disable-next-line no-console
+            console.log('Can not find form');
+          }, (rgbForm) => {
+            Representing.setValue(rgbForm, {
+              hex: Optional.from(m[1]).getOr('')
             });
-          }
+
+            // So not the way to do this.
+            Form.getField(rgbForm, 'hex').each((hexField) => {
+              AlloyTriggers.emit(hexField, NativeEvents.input());
+            });
+          });
         }
-      }),
+      ),
       ComposingConfigs.self()
     ])
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -5,13 +5,14 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AddEventsBehaviour, AlloyEvents, Behaviour, Memento, Representing, SimpleSpec } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, Memento, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Obj, Singleton } from '@ephox/katamari';
+import { Obj, Optional, Singleton } from '@ephox/katamari';
 
 import Resource from 'tinymce/core/api/Resource';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';
+import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 
 type CustomEditorSpec = Dialog.CustomEditor;
 type CustomEditorInitFn = Dialog.CustomEditorInitFn;
@@ -55,23 +56,19 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
           });
         })
       ]),
-      Representing.config({
-        store: {
-          mode: 'manual',
-          getValue: () => editorApi.get().fold(
-            () => initialValue.get().getOr(''),
-            (ed) => ed.getValue()
-          ),
-          setValue: (component, value) => {
-            editorApi.get().fold(
-              () => {
-                initialValue.set(value);
-              },
-              (ed) => ed.setValue(value)
-            );
-          }
+      RepresentingConfigs.withComp(
+        Optional.none(),
+        () => editorApi.get().fold(
+          () => initialValue.get().getOr(''),
+          (ed) => ed.getValue()
+        ),
+        (component, value) => {
+          editorApi.get().fold(
+            () => initialValue.set(value),
+            (ed) => ed.setValue(value)
+          );
         }
-      }),
+      ),
 
       ComposingConfigs.self()
     ]),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -11,7 +11,7 @@ import {
   SystemEvents, Tabstopping, Toggling
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr, Strings } from '@ephox/katamari';
+import { Arr, Optional, Strings } from '@ephox/katamari';
 import { EventArgs } from '@ephox/sugar';
 
 import Tools from 'tinymce/core/api/util/Tools';
@@ -33,7 +33,7 @@ const filterByExtension = (files: FileList, providersBackstage: UiFactoryBacksta
 
 type DropZoneSpec = Omit<Dialog.DropZone, 'type'>;
 
-export const renderDropZone = (spec: DropZoneSpec, providersBackstage: UiFactoryBackstageProviders): SimpleSpec => {
+export const renderDropZone = (spec: DropZoneSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string[]>): SimpleSpec => {
 
   // TODO: Consider moving to alloy
   const stopper: AlloyEvents.EventRunHandler<EventArgs> = (_: AlloyComponent, se: SimulatedEvent<EventArgs>): void => {
@@ -59,7 +59,7 @@ export const renderDropZone = (spec: DropZoneSpec, providersBackstage: UiFactory
     handleFiles(component, input.files);
   };
 
-  const handleFiles = (component, files: FileList) => {
+  const handleFiles = (component: AlloyComponent, files: FileList) => {
     Representing.setValue(component, filterByExtension(files, providersBackstage));
     AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name });
   };
@@ -92,7 +92,7 @@ export const renderDropZone = (spec: DropZoneSpec, providersBackstage: UiFactory
       classes: [ 'tox-dropzone-container' ]
     },
     behaviours: Behaviour.derive([
-      RepresentingConfigs.memory([ ]),
+      RepresentingConfigs.memory(initialData.getOr([])),
       ComposingConfigs.self(),
       Disabling.config({}),
       Toggling.config({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -22,8 +22,8 @@ interface IFrameSourcing {
 
 type IframeSpec = Omit<Dialog.Iframe, 'type'>;
 
-const getDynamicSource = (): IFrameSourcing => {
-  const cachedValue = Cell('');
+const getDynamicSource = (initialData: Optional<string>): IFrameSourcing => {
+  const cachedValue = Cell(initialData.getOr(''));
   return {
     getValue: (_frameComponent: AlloyComponent): string =>
       // Ideally we should fetch data from the iframe...innerHtml, this triggers Cors errors
@@ -31,21 +31,24 @@ const getDynamicSource = (): IFrameSourcing => {
     setValue: (frameComponent: AlloyComponent, html: string) => {
       // TINY-3769: We need to use srcdoc here, instead of src with a data URI, otherwise browsers won't retain the Origin.
       // See https://bugs.chromium.org/p/chromium/issues/detail?id=58999#c11
-      Attribute.set(frameComponent.element, 'srcdoc', html);
+      if (cachedValue.get() !== html) {
+        Attribute.set(frameComponent.element, 'srcdoc', html);
+      }
       cachedValue.set(html);
     }
   };
 };
 
-const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstageProviders) => {
+const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>) => {
   const isSandbox = spec.sandboxed;
 
   const attributes = {
     ...spec.label.map<{ title?: string }>((title) => ({ title })).getOr({}),
+    ...initialData.map((html) => ({ srcdoc: html })).getOr({}),
     ...isSandbox ? { sandbox: 'allow-scripts allow-same-origin' } : { }
   };
 
-  const sourcing = getDynamicSource();
+  const sourcing = getDynamicSource(initialData);
 
   const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
 
@@ -60,7 +63,7 @@ const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstagePr
       behaviours: Behaviour.derive([
         Tabstopping.config({ }),
         Focusing.config({ }),
-        RepresentingConfigs.withComp(Optional.none(), sourcing.getValue, sourcing.setValue)
+        RepresentingConfigs.withComp(initialData, sourcing.getValue, sourcing.setValue)
       ])
     }
   );

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
@@ -21,7 +21,7 @@ import { formChangeEvent } from '../general/FormEvents';
 
 type SelectBoxSpec = Omit<Dialog.SelectBox, 'type'>;
 
-export const renderSelectBox = (spec: SelectBoxSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
+export const renderSelectBox = (spec: SelectBoxSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => {
   const translatedOptions = Arr.map(spec.items, (item) => ({
     text: providersBackstage.translate(item.text),
     value: item.value
@@ -33,6 +33,7 @@ export const renderSelectBox = (spec: SelectBoxSpec, providersBackstage: UiFacto
   const pField = AlloyFormField.parts.field({
     // TODO: Alloy should not allow dom changing of an HTML select!
     dom: { },
+    ...initialData.map((data) => ({ data })).getOr({}),
     selectAttributes: {
       size: spec.size
     },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
@@ -7,7 +7,7 @@
 
 import { AlloyTriggers, Behaviour, Focusing, SimpleSpec, Slider, SliderTypes } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Fun } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -15,7 +15,7 @@ import { formChangeEvent } from '../general/FormEvents';
 
 type SliderSpec = Omit<Dialog.Slider, 'type'>;
 
-export const renderSlider = (spec: SliderSpec, providerBackstage: UiFactoryBackstageProviders): SimpleSpec => {
+export const renderSlider = (spec: SliderSpec, providerBackstage: UiFactoryBackstageProviders, initialData: Optional<number>): SimpleSpec => {
   const labelPart = Slider.parts.label({
     dom: {
       tag: 'label',
@@ -56,7 +56,7 @@ export const renderSlider = (spec: SliderSpec, providerBackstage: UiFactoryBacks
       mode: 'x',
       minX: spec.min,
       maxX: spec.max,
-      getInitialValue: Fun.constant((Math.abs(spec.max) - Math.abs(spec.min)) / 2)
+      getInitialValue: Fun.constant(initialData.getOrThunk(() => (Math.abs(spec.max) - Math.abs(spec.min)) / 2))
     },
     components: [
       labelPart,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -19,6 +19,28 @@ import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
 import { formChangeEvent, formSubmitEvent } from '../general/FormEvents';
 
+export type Validator = (v: string) => true | string;
+
+export interface TextField {
+  multiline: boolean;
+  name: string;
+  classname: string;
+  flex: boolean;
+  label: Optional<string>;
+  inputMode: Optional<string>;
+  placeholder: Optional<string>;
+  disabled: boolean;
+  validation: Optional<{
+    validator: Validator;
+    validateOnLoad?: boolean;
+  }>;
+  maximized: boolean;
+  data: Optional<string>;
+}
+
+type InputSpec = Omit<Dialog.Input, 'type'>;
+type TextAreaSpec = Omit<Dialog.TextArea, 'type'>;
+
 const renderTextField = (spec: TextField, providersBackstage: UiFactoryBackstageProviders) => {
   const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
 
@@ -72,6 +94,7 @@ const renderTextField = (spec: TextField, providersBackstage: UiFactoryBackstage
 
   const pField = AlloyFormField.parts.field({
     tag: spec.multiline === true ? 'textarea' : 'input',
+    ...spec.data.map((data) => ({ data })).getOr({}),
     inputAttributes,
     inputClasses: [ spec.classname ],
     inputBehaviours: Behaviour.derive(
@@ -103,29 +126,7 @@ const renderTextField = (spec: TextField, providersBackstage: UiFactoryBackstage
   return renderFormFieldWith(pLabel, pField, extraClasses2, extraBehaviours);
 };
 
-export type Validator = (v: string) => true | string;
-
-export interface TextField {
-  multiline: boolean;
-  name: string;
-  classname: string;
-  flex: boolean;
-  label: Optional<string>;
-  inputMode: Optional<string>;
-  placeholder: Optional<string>;
-  disabled: boolean;
-  validation: Optional<{
-    validator: Validator;
-    validateOnLoad?: boolean;
-  }>;
-  maximized: boolean;
-}
-
-type InputSpec = Omit<Dialog.Input, 'type'>;
-
-type TextAreaSpec = Omit<Dialog.TextArea, 'type'>;
-
-const renderInput = (spec: InputSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => renderTextField({
+const renderInput = (spec: InputSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => renderTextField({
   name: spec.name,
   multiline: false,
   label: spec.label,
@@ -135,10 +136,11 @@ const renderInput = (spec: InputSpec, providersBackstage: UiFactoryBackstageProv
   disabled: spec.disabled,
   classname: 'tox-textfield',
   validation: Optional.none(),
-  maximized: spec.maximized
+  maximized: spec.maximized,
+  data: initialData
 }, providersBackstage);
 
-const renderTextarea = (spec: TextAreaSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => renderTextField({
+const renderTextarea = (spec: TextAreaSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => renderTextField({
   name: spec.name,
   multiline: true,
   label: spec.label,
@@ -148,7 +150,8 @@ const renderTextarea = (spec: TextAreaSpec, providersBackstage: UiFactoryBacksta
   disabled: spec.disabled,
   classname: 'tox-textarea',
   validation: Optional.none(),
-  maximized: spec.maximized
+  maximized: spec.maximized,
+  data: initialData
 }, providersBackstage);
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -53,7 +53,12 @@ const getItems = (fileType: 'image' | 'media' | 'file', input: AlloyComponent, u
 
 const errorId = Id.generate('aria-invalid');
 
-export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage, urlBackstage: UiFactoryBackstageForUrlInput): SketchSpec => {
+export const renderUrlInput = (
+  spec: UrlInputSpec,
+  backstage: UiFactoryBackstage,
+  urlBackstage: UiFactoryBackstageForUrlInput,
+  initialData: Optional<Dialog.UrlInputData>
+): SketchSpec => {
   const providersBackstage = backstage.shared.providers;
 
   const updateHistory = (component: AlloyComponent): void => {
@@ -64,6 +69,7 @@ export const renderUrlInput = (spec: UrlInputSpec, backstage: UiFactoryBackstage
   // TODO: Make alloy's typeahead only swallow enter and escape if menu is open
   const pField = AlloyFormField.parts.field({
     factory: AlloyTypeahead,
+    ...initialData.map((initialData) => ({ initialData })).getOr({}),
     dismissOnBlur: true,
     inputClasses: [ 'tox-textfield' ],
     sandboxClasses: [ 'tox-dialog__popups' ],

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -7,35 +7,23 @@
 
 import {
   AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Disabling, Focusing, FormField as AlloyFormField, Keying, Memento,
-  NativeEvents, Representing, SimpleSpec, Tabstopping, Unselecting
+  NativeEvents, SimpleSpec, Tabstopping, Unselecting
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Fun, Optional } from '@ephox/katamari';
+import { Checked } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
+import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 import * as Icons from '../icons/Icons';
 import { formChangeEvent } from './FormEvents';
 
 type CheckboxSpec = Omit<Dialog.Checkbox, 'type'>;
 
-export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryBackstageProviders): SimpleSpec => {
-  const repBehaviour = Representing.config({
-    store: {
-      mode: 'manual',
-      getValue: (comp: AlloyComponent): boolean => {
-        const el = comp.element.dom as HTMLInputElement;
-        return el.checked;
-      },
-      setValue: (comp: AlloyComponent, value: boolean) => {
-        const el = comp.element.dom as HTMLInputElement;
-        el.checked = value;
-      }
-    }
-  });
-
-  const toggleCheckboxHandler = (comp) => {
+export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryBackstageProviders, initialData: Optional<boolean>): SimpleSpec => {
+  const toggleCheckboxHandler = (comp: AlloyComponent) => {
     comp.element.dom.click();
     return Optional.some(true);
   };
@@ -57,7 +45,7 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
       }),
       Tabstopping.config({}),
       Focusing.config({ }),
-      repBehaviour,
+      RepresentingConfigs.withElement(initialData, Checked.get, Checked.set),
       Keying.config({
         mode: 'special',
         onEnter: toggleCheckboxHandler,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
@@ -7,7 +7,7 @@
 
 import { AlloyParts, AlloySpec, FormTypes, SimpleOrSketchSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge/';
-import { Fun, Merger, Obj } from '@ephox/katamari';
+import { Fun, Merger, Obj, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderBar } from '../dialog/Bar';
@@ -35,43 +35,43 @@ import { renderHtmlPanel } from './HtmlPanel';
 
 /* eslint-disable no-console */
 
-export type FormPartRenderer<T extends Dialog.BodyComponent> = (parts: FormTypes.FormParts, spec: T, backstage: UiFactoryBackstage) => AlloySpec;
-export type NoFormRenderer<T extends Dialog.BodyComponent> = (spec: T, backstage: UiFactoryBackstage) => AlloySpec;
+export type FormPartRenderer<T extends Dialog.BodyComponent> = (parts: FormTypes.FormParts, spec: T, dialogData: Dialog.DialogData, backstage: UiFactoryBackstage) => AlloySpec;
+export type NoFormRenderer<T extends Dialog.BodyComponent, U> = (spec: T, backstage: UiFactoryBackstage, data: Optional<U>) => AlloySpec;
 
-const make = <T extends Dialog.BodyComponent>(render: NoFormRenderer<T>): FormPartRenderer<T> => {
-  return (parts, spec, backstage) =>
+const make = <T extends Dialog.BodyComponent, U = unknown>(render: NoFormRenderer<T, U>): FormPartRenderer<T> => {
+  return (parts, spec, dialogData, backstage) =>
     Obj.get(spec as Record<string, any>, 'name').fold(
-      () => render(spec, backstage),
-      (fieldName) => parts.field(fieldName, render(spec, backstage) as SimpleOrSketchSpec)
+      () => render(spec, backstage, Optional.none()),
+      (fieldName) => parts.field(fieldName, render(spec, backstage, Obj.get(dialogData, fieldName)) as SimpleOrSketchSpec)
     );
 };
 
-const makeIframe = (render: NoFormRenderer<Dialog.Iframe>): FormPartRenderer<Dialog.Iframe> => (parts, spec, backstage) => {
+const makeIframe = (render: NoFormRenderer<Dialog.Iframe, string>): FormPartRenderer<Dialog.Iframe> => (parts, spec, dialogData, backstage) => {
   const iframeSpec = Merger.deepMerge(spec, {
     source: 'dynamic'
   });
-  return make(render)(parts, iframeSpec, backstage);
+  return make(render)(parts, iframeSpec, dialogData, backstage);
 };
 
 const factories: Record<string, FormPartRenderer<any>> = {
   bar: make<Dialog.Bar>((spec, backstage) => renderBar(spec, backstage.shared)),
-  collection: make<Dialog.Collection>((spec, backstage) => renderCollection(spec, backstage.shared.providers)),
+  collection: make<Dialog.Collection, Dialog.CollectionItem[]>((spec, backstage, data) => renderCollection(spec, backstage.shared.providers, data)),
   alertbanner: make<Dialog.AlertBanner>((spec, backstage) => renderAlertBanner(spec, backstage.shared.providers)),
-  input: make<Dialog.Input>((spec, backstage) => renderInput(spec, backstage.shared.providers)),
-  textarea: make<Dialog.TextArea>((spec, backstage) => renderTextarea(spec, backstage.shared.providers)),
+  input: make<Dialog.Input, string>((spec, backstage, data) => renderInput(spec, backstage.shared.providers, data)),
+  textarea: make<Dialog.TextArea, string>((spec, backstage, data) => renderTextarea(spec, backstage.shared.providers, data)),
   label: make<Dialog.Label>((spec, backstage) => renderLabel(spec, backstage.shared)),
-  iframe: makeIframe((spec, backstage) => renderIFrame(spec, backstage.shared.providers)),
+  iframe: makeIframe((spec, backstage, data) => renderIFrame(spec, backstage.shared.providers, data)),
   button: make<Dialog.Button>((spec, backstage) => renderDialogButton(spec, backstage.shared.providers)),
-  checkbox: make<Dialog.Checkbox>((spec, backstage) => renderCheckbox(spec, backstage.shared.providers)),
-  colorinput: make<Dialog.ColorInput>((spec, backstage) => renderColorInput(spec, backstage.shared, backstage.colorinput)),
-  colorpicker: make<Dialog.ColorPicker>((spec, backstage) => renderColorPicker(spec, backstage.shared.providers)), // Not sure if this needs name.
-  dropzone: make<Dialog.DropZone>((spec, backstage) => renderDropZone(spec, backstage.shared.providers)),
+  checkbox: make<Dialog.Checkbox, boolean>((spec, backstage, data) => renderCheckbox(spec, backstage.shared.providers, data)),
+  colorinput: make<Dialog.ColorInput, string>((spec, backstage, data) => renderColorInput(spec, backstage.shared, backstage.colorinput, data)),
+  colorpicker: make<Dialog.ColorPicker, string>((spec, backstage, data) => renderColorPicker(spec, backstage.shared.providers, data)), // Not sure if this needs name.
+  dropzone: make<Dialog.DropZone, string[]>((spec, backstage, data) => renderDropZone(spec, backstage.shared.providers, data)),
   grid: make<Dialog.Grid>((spec, backstage) => renderGrid(spec, backstage.shared)),
-  listbox: make<Dialog.ListBox>((spec, backstage) => renderListBox(spec, backstage)),
-  selectbox: make<Dialog.SelectBox>((spec, backstage) => renderSelectBox(spec, backstage.shared.providers)),
+  listbox: make<Dialog.ListBox, string>((spec, backstage, data) => renderListBox(spec, backstage, data)),
+  selectbox: make<Dialog.SelectBox, string>((spec, backstage, data) => renderSelectBox(spec, backstage.shared.providers, data)),
   sizeinput: make<Dialog.SizeInput>((spec, backstage) => renderSizeInput(spec, backstage.shared.providers)),
-  slider: make<Dialog.Slider>((spec, backstage) => renderSlider(spec, backstage.shared.providers)),
-  urlinput: make<Dialog.UrlInput>((spec, backstage) => renderUrlInput(spec, backstage, backstage.urlinput)),
+  slider: make<Dialog.Slider, number>((spec, backstage, data) => renderSlider(spec, backstage.shared.providers, data)),
+  urlinput: make<Dialog.UrlInput, Dialog.UrlInputData>((spec, backstage, data) => renderUrlInput(spec, backstage, backstage.urlinput, data)),
   customeditor: make<Dialog.CustomEditor>(renderCustomEditor),
   htmlpanel: make<Dialog.HtmlPanel>(renderHtmlPanel),
   imagetools: make<Dialog.ImageTools>((spec, backstage) => renderImageTools(spec, backstage.shared.providers)),
@@ -85,31 +85,31 @@ const noFormParts: FormTypes.FormParts = {
   record: Fun.constant([])
 };
 
-const interpretInForm = <T extends Dialog.BodyComponent>(parts: FormTypes.FormParts, spec: T, oldBackstage: UiFactoryBackstage) => {
+const interpretInForm = <T extends Dialog.BodyComponent>(parts: FormTypes.FormParts, spec: T, dialogData: Dialog.DialogData, oldBackstage: UiFactoryBackstage) => {
   // Now, we need to update the backstage to use the parts variant.
   const newBackstage = Merger.deepMerge(
     oldBackstage,
     {
       // Add the interpreter based on the form parts.
       shared: {
-        interpreter: (childSpec) => interpretParts(parts, childSpec, newBackstage)
+        interpreter: (childSpec) => interpretParts(parts, childSpec, dialogData, newBackstage)
       }
     }
   );
 
-  return interpretParts(parts, spec, newBackstage);
+  return interpretParts(parts, spec, dialogData, newBackstage);
 };
 
-const interpretParts = <T extends Dialog.BodyComponent>(parts: FormTypes.FormParts, spec: T, backstage: UiFactoryBackstage) =>
+const interpretParts = <T extends Dialog.BodyComponent>(parts: FormTypes.FormParts, spec: T, dialogData: Dialog.DialogData, backstage: UiFactoryBackstage) =>
   Obj.get(factories, spec.type).fold(
     () => {
       console.error(`Unknown factory type "${spec.type}", defaulting to container: `, spec);
       return spec as unknown as AlloySpec;
     },
-    (factory) => factory(parts, spec, backstage)
+    (factory) => factory(parts, spec, dialogData, backstage)
   );
 
-const interpretWithoutForm = <T extends Dialog.BodyComponent>(spec: T, backstage: UiFactoryBackstage) =>
-  interpretParts(noFormParts, spec, backstage);
+const interpretWithoutForm = <T extends Dialog.BodyComponent>(spec: T, dialogData: Dialog.DialogData, backstage: UiFactoryBackstage) =>
+  interpretParts(noFormParts, spec, dialogData, backstage);
 
 export { interpretInForm, interpretWithoutForm };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -33,7 +33,8 @@ const renderDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: SilverD
   const header = SilverDialogCommon.getHeader(internalDialog.title, dialogId, backstage);
 
   const body = renderModalBody({
-    body: dialogInit.internalDialog.body
+    body: internalDialog.body,
+    initialData: internalDialog.initialData
   }, dialogId, backstage);
 
   const storagedMenuButtons = SilverDialogCommon.mapMenuButtons(internalDialog.buttons);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, AlloySpec, Behaviour, Focusing, Keying, ModalDialog, Reflecting, Tabstopping } from '@ephox/alloy';
+import { AlloyComponent, Behaviour, Focusing, Keying, ModalDialog, Reflecting, SimpleSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Fun, Optional } from '@ephox/katamari';
 
@@ -19,23 +19,24 @@ import { bodyChannel } from './DialogChannels';
 // TypeScript allows some pretty weird stuff.
 interface WindowBodySpec {
   body: Dialog.Dialog<unknown>['body'];
+  initialData: Dialog.DialogData;
 }
 
 // ariaAttrs is being passed through to silver inline dialog
 // from the WindowManager as a property of 'params'
-const renderBody = (spec: WindowBodySpec, dialogId: string, contentId: Optional<string>, backstage: UiFactoryBackstage, ariaAttrs: boolean): AlloySpec => {
+const renderBody = (spec: WindowBodySpec, dialogId: string, contentId: Optional<string>, backstage: UiFactoryBackstage, ariaAttrs: boolean): SimpleSpec => {
   const renderComponents = (incoming: WindowBodySpec) => {
     const body = incoming.body;
     switch (body.type) {
       case 'tabpanel': {
         return [
-          renderTabPanel(body, backstage)
+          renderTabPanel(body, incoming.initialData, backstage)
         ];
       }
 
       default: {
         return [
-          renderBodyPanel(body, backstage)
+          renderBodyPanel(body, incoming.initialData, backstage)
         ];
       }
     }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogFooter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogFooter.ts
@@ -5,7 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyComponent, Behaviour, Container, DomFactory, Memento, MementoRecord, ModalDialog, Reflecting, SketchSpec } from '@ephox/alloy';
+import {
+  AlloyComponent, Behaviour, Container, DomFactory, Memento, MementoRecord, ModalDialog, Reflecting, SimpleSpec, SketchSpec
+} from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Arr, Optional } from '@ephox/katamari';
 
@@ -53,7 +55,7 @@ const renderComponents = (_data: WindowFooterSpec, state: Optional<FooterState>)
   return [ startButtons, endButtons ];
 };
 
-const renderFooter = (initSpec: WindowFooterSpec, dialogId: string, backstage: UiFactoryBackstage) => {
+const renderFooter = (initSpec: WindowFooterSpec, dialogId: string, backstage: UiFactoryBackstage): SimpleSpec => {
   const updateState = (comp: AlloyComponent, data: WindowFooterSpec) => {
     const footerButtons: DialogMemButton[] = Arr.map(data.buttons, (button) => {
       const memButton = Memento.record(makeButton(button, backstage));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  AlloySpec, AlloyTriggers, Behaviour, Button, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting
+  AlloySpec, AlloyTriggers, Behaviour, Button, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting, SketchSpec
 } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
@@ -77,7 +77,7 @@ const renderInlineHeader = (
   dialogId: string,
   titleId: string,
   providersBackstage: UiFactoryBackstageProviders
-): AlloySpec => Container.sketch({
+): SketchSpec => Container.sketch({
   dom: DomFactory.fromHtml('<div class="tox-dialog__header"></div>'),
   components: [
     renderTitle(spec, dialogId, Optional.some(titleId), providersBackstage),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -8,7 +8,7 @@
 // DUPE with SilverDialog. Cleaning up.
 import {
   AddEventsBehaviour, AlloyEvents, AlloyTriggers, Behaviour, Blocking, Composing, Focusing, GuiFactory, Keying, Memento, NativeEvents,
-  Receiving, Reflecting, Replacing, SimpleSpec, SystemEvents
+  Receiving, Reflecting, Replacing, SystemEvents
 } from '@ephox/alloy';
 import { DialogManager } from '@ephox/bridge';
 import { Fun, Id, Optional } from '@ephox/katamari';
@@ -30,23 +30,25 @@ const renderInlineDialog = <T>(dialogInit: DialogManager.DialogInit<T>, extra: S
   const dialogId = Id.generate('dialog');
   const dialogLabelId = Id.generate('dialog-label');
   const dialogContentId = Id.generate('dialog-content');
+  const internalDialog = dialogInit.internalDialog;
 
   const updateState = (_comp, incoming: DialogManager.DialogInit<T>) => Optional.some(incoming);
 
   const memHeader = Memento.record(
     renderInlineHeader({
-      title: dialogInit.internalDialog.title,
+      title: internalDialog.title,
       draggable: true
-    }, dialogId, dialogLabelId, backstage.shared.providers) as SimpleSpec
+    }, dialogId, dialogLabelId, backstage.shared.providers)
   );
 
   const memBody = Memento.record(
     renderInlineBody({
-      body: dialogInit.internalDialog.body
-    }, dialogId, dialogContentId, backstage, ariaAttrs) as SimpleSpec
+      body: internalDialog.body,
+      initialData: internalDialog.initialData,
+    }, dialogId, dialogContentId, backstage, ariaAttrs)
   );
 
-  const storagedMenuButtons = SilverDialogCommon.mapMenuButtons(dialogInit.internalDialog.buttons);
+  const storagedMenuButtons = SilverDialogCommon.mapMenuButtons(internalDialog.buttons);
 
   const objOfCells = SilverDialogCommon.extractCellsToObject(storagedMenuButtons);
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
@@ -1,6 +1,7 @@
 import { ApproxStructure, Assertions, Keyboard, Keys, UiFinder } from '@ephox/agar';
 import { AlloyComponent, Disabling, GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import { renderCheckbox } from 'tinymce/themes/silver/ui/general/Checkbox';
@@ -21,7 +22,7 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
       label: 'TestCheckbox',
       name: 'test-check-box',
       disabled: false
-    }, providers)
+    }, providers, Optional.none())
   ));
 
   const assertCheckboxState = (label: string, component: AlloyComponent, expChecked: boolean) => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/CheckboxFormChangeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/CheckboxFormChangeTest.ts
@@ -1,6 +1,7 @@
 import { FocusTools, Keyboard, Keys } from '@ephox/agar';
 import { AddEventsBehaviour, AlloyEvents, Behaviour, GuiFactory, TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
 
 import { renderCheckbox } from 'tinymce/themes/silver/ui/general/Checkbox';
 import { FormChangeEvent, formChangeEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
@@ -17,7 +18,7 @@ describe('headless.tinymce.themes.silver.components.checkbox.CheckboxFormChangeT
         label: 'TestCheckbox',
         name: 'test-check-box',
         disabled: false
-      }, TestProviders)
+      }, TestProviders, Optional.none())
     ],
     behaviours: Behaviour.derive([
       AddEventsBehaviour.config('test-checkbox', [

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
@@ -35,7 +35,7 @@ describe('headless.tinymce.themes.silver.components.colorinput.ColorInputTest', 
             { type: 'choiceitem', text: 'Navy Blue', value: '#34495E' }
           ],
           getColorCols: Fun.constant(3)
-        })
+        }, Optional.none())
       ]
     })
   ));

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
@@ -16,7 +16,7 @@ describe('headless.tinymce.themes.silver.components.colorpicker.ColorPickerTest'
     renderColorPicker({
       label: Optional.some('ColorPicker label'),
       name: 'col1'
-    }, TestProviders)
+    }, TestProviders, Optional.none())
   ));
 
   const fireEvent = (elem: SugarElement<Node>, event: string) => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/dropzone/DropzoneTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/dropzone/DropzoneTest.ts
@@ -13,7 +13,7 @@ describe('headless.tinymce.themes.silver.components.dropzone.DropzoneTest', () =
     renderDropZone({
       name: 'drop1',
       label: Optional.some('Dropzone Label')
-    }, TestProviders)
+    }, TestProviders, Optional.none())
   ));
 
   it('Check basic structure', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -13,7 +13,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
       name: 'frame-a',
       label: Optional.some('iframe label'),
       sandboxed: true
-    }, TestProviders)
+    }, TestProviders, Optional.none())
   ));
 
   const assertInitialIframeStructure = (component: AlloyComponent) => Assertions.assertStructure(

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/input/InputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/input/InputTest.ts
@@ -18,7 +18,7 @@ describe('headless.tinymce.themes.silver.components.input.InputTest', () => {
       placeholder: Optional.none(),
       maximized: false,
       disabled: false
-    }, TestProviders)
+    }, TestProviders, Optional.none())
   ));
 
   it('Check basic structure', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxTest.ts
@@ -25,7 +25,7 @@ describe('headless.tinymce.themes.silver.components.listbox.ListBoxTest', () => 
           { value: 'three', text: 'Three' }
         ] }
       ]
-    }, helpers.backstage())
+    }, helpers.backstage(), Optional.none())
   ));
 
   const assertValue = (component: AlloyComponent, expected: string) => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxTest.ts
@@ -29,7 +29,7 @@ describe('headless.tinymce.themes.silver.components.selectbox.SelectboxTest', ()
         { value: 'two', text: 'Two' },
         { value: 'three', text: 'Three' }
       ]
-    }, providers)
+    }, providers, Optional.none())
   ));
 
   it('Check basic structure', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxWithSizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxWithSizeTest.ts
@@ -23,7 +23,7 @@ describe('headless.tinymce.themes.silver.components.selectbox.SelectboxWithSizeT
         { value: 'four', text: 'Four' },
         { value: 'five', text: 'Five' }
       ]
-    }, TestProviders)
+    }, TestProviders, Optional.none())
   ));
 
   it('Check basic structure', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/slider/SliderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/slider/SliderTest.ts
@@ -1,6 +1,7 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { GuiFactory, TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
 
 import { renderSlider } from 'tinymce/themes/silver/ui/dialog/Slider';
 
@@ -13,7 +14,7 @@ describe('headless.tinymce.themes.silver.components.slider.SliderTest', () => {
       label: 'test label',
       min: 0,
       max: 100,
-    }, TestProviders)
+    }, TestProviders, Optional.none())
   ));
 
   it('TINY-8304: Check basic structure', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/textarea/TextareaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/textarea/TextareaTest.ts
@@ -17,7 +17,7 @@ describe('headless.tinymce.themes.silver.components.textarea.TextareaTest', () =
       placeholder: Optional.none(),
       maximized: false,
       disabled: false
-    }, TestProviders)
+    }, TestProviders, Optional.none())
   ));
 
   // TODO: Fix dupe with Input test. Test Ctrl+Enter.

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -48,7 +48,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
         store.adder('urlpicker')();
         return Future.pure({ value: 'http://tiny.cloud', meta: { before: entry.value }, fieldname: 'test' });
       })
-    })
+    }, Optional.none())
   ));
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogReuseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogReuseTest.ts
@@ -1,7 +1,8 @@
 import { ApproxStructure, Assertions, FocusTools, StructAssert, UiFinder } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { afterEach, before, describe, it } from '@ephox/bedrock-client';
 import { Dialog as BridgeSpec } from '@ephox/bridge';
+import { Optional } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
@@ -18,6 +19,10 @@ describe('headless.tinymce.themes.silver.window.SilverDialogReuseTest', () => {
   let dialogApi: Dialog.DialogInstanceApi<any>;
   before(() => {
     windowManager = WindowManager.setup(helpers.extras());
+  });
+
+  afterEach(() => {
+    Optional.from(dialogApi).each((api) => api.close());
   });
 
   const baseDialogActions = {


### PR DESCRIPTION
Related Ticket: TINY-8334

Description of Changes:

This updates the silver dialog rendering to pass through the initial data from the dialog spec to the relevant render functions so that we can set various attributes or initial state within the initial spec. This is needed to be able stop quick flashes due to for example image urls changing/loading due to the initial spec having not having the data and it being patched in later via the dialog instance `setData` API.

Pre-checks:
* [x] ~Changelog entry added~ no user facing changes here
* [x] ~Tests have been added (if applicable)~ works the same as before atm, so nothing to test
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
