### PR TITLE
TINY-8365: Updated imagetools and toc names

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -65,8 +65,8 @@ const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'autocorrect', name: 'Autocorrect', type: PluginType.Premium },
   { key: 'casechange', name: 'Case Change', type: PluginType.Premium },
   { key: 'checklist', name: 'Checklist', type: PluginType.Premium },
+  { key: 'editimage', name: 'Edit Image', type: PluginType.Premium },
   { key: 'export', name: 'Export', type: PluginType.Premium },
-  { key: 'imagetools', name: 'Image Tools', type: PluginType.Premium },
   { key: 'mediaembed', name: 'Enhanced Media Embed', type: PluginType.Premium },
   { key: 'formatpainter', name: 'Format Painter', type: PluginType.Premium },
   { key: 'linkchecker', name: 'Link Checker', type: PluginType.Premium },
@@ -78,7 +78,7 @@ const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'tinymcespellchecker', name: 'Spell Checker Pro', type: PluginType.Premium },
   { key: 'tinycomments', name: 'Tiny Comments', type: PluginType.Premium, slug: 'comments' },
   { key: 'tinydrive', name: 'Tiny Drive', type: PluginType.Premium },
-  { key: 'toc', name: 'Table of Contents', type: PluginType.Premium },
+  { key: 'tableofcontents', name: 'Table of Contents', type: PluginType.Premium },
 ], (item) => ({
   ...item,
   // Set the defaults/fallbacks for the plugin urls

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Options.ts
@@ -42,7 +42,7 @@ const register = (editor: Editor): void => {
         return { valid: false, message: 'Must be false or a string.' };
       }
     },
-    default: 'link linkchecker image imagetools table spellchecker configurepermanentpen'
+    default: 'link linkchecker image editimage table spellchecker configurepermanentpen'
   });
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -29,7 +29,7 @@ const defaultMenus: Record<string, MenuSpec> = {
   file: { title: 'File', items: 'newdocument restoredraft | preview | export print | deleteallconversations' },
   edit: { title: 'Edit', items: 'undo redo | cut copy paste pastetext | selectall | searchreplace' },
   view: { title: 'View', items: 'code | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
-  insert: { title: 'Insert', items: 'image link media addcomment pageembed template codesample inserttable | charmap emoticons hr | pagebreak nonbreaking anchor toc | insertdatetime' },
+  insert: { title: 'Insert', items: 'image link media addcomment pageembed template codesample inserttable | charmap emoticons hr | pagebreak nonbreaking anchor tableofcontents | insertdatetime' },
   format: { title: 'Format', items: 'bold italic underline strikethrough superscript subscript codeformat | formats blockformats fontformats fontsizes align lineheight | forecolor backcolor | language | removeformat' },
   tools: { title: 'Tools', items: 'spellchecker spellcheckerlanguage | a11ycheck code wordcount' },
   table: { title: 'Table', items: 'inserttable | cell row column | advtablesort | tableprops deletetable' },


### PR DESCRIPTION
Related Ticket: TINY-8365

Description of Changes:
* Updated the help plugin names/id for Image Tools and Table of Contents
* Updated the default contextmenu/menu configuration to use the new names

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
