### PR TITLE
TINY-7631: Updated the emoticon plugin UI to use "Emojis" instead of "Emoticons"

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload #TINY-7735
+- The `emoticon` plugin dialog, toolbar and menu item has been updated to use the more accurate `Emojis` term #TINY-7631
 - The dialog `redial` API will now only rerender the changed components instead of the whole dialog #TINY-8334
 
 ### Changed

--- a/modules/tinymce/src/plugins/emoticons/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/Plugin.ts
@@ -24,8 +24,8 @@ import * as Buttons from './ui/Buttons';
 export default (): void => {
   PluginManager.add('emoticons', (editor, pluginUrl) => {
     Options.register(editor, pluginUrl);
-    const databaseUrl = Options.getEmoticonDatabaseUrl(editor);
-    const databaseId = Options.getEmoticonDatabaseId(editor);
+    const databaseUrl = Options.getEmojiDatabaseUrl(editor);
+    const databaseId = Options.getEmojiDatabaseId(editor);
 
     const database = initDatabase(editor, databaseUrl, databaseId);
 

--- a/modules/tinymce/src/plugins/emoticons/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/api/Options.ts
@@ -32,7 +32,7 @@ const register = (editor: Editor, pluginUrl: string): void => {
 
   registerOption('emoticons_database_url', {
     processor: 'string',
-    default: `${pluginUrl}/js/${getEmoticonDatabase(editor)}${editor.suffix}.js`
+    default: `${pluginUrl}/js/${getEmojiDatabase(editor)}${editor.suffix}.js`
   });
 
   registerOption('emoticons_database_id', {
@@ -51,17 +51,17 @@ const register = (editor: Editor, pluginUrl: string): void => {
   });
 };
 
-const getEmoticonDatabase = option<string>('emoticons_database');
-const getEmoticonDatabaseUrl = option<string>('emoticons_database_url');
-const getEmoticonDatabaseId = option<string>('emoticons_database_id');
-const getAppendedEmoticons = option<Record<string, UserEmojiEntry>>('emoticons_append');
-const getEmotionsImageUrl = option('emoticons_images_url');
+const getEmojiDatabase = option<string>('emoticons_database');
+const getEmojiDatabaseUrl = option<string>('emoticons_database_url');
+const getEmojiDatabaseId = option<string>('emoticons_database_id');
+const getAppendedEmoji = option<Record<string, UserEmojiEntry>>('emoticons_append');
+const getEmojiImageUrl = option('emoticons_images_url');
 
 export {
   register,
-  getEmoticonDatabase,
-  getEmoticonDatabaseUrl,
-  getEmoticonDatabaseId,
-  getAppendedEmoticons,
-  getEmotionsImageUrl
+  getEmojiDatabase,
+  getEmojiDatabaseUrl,
+  getEmojiDatabaseId,
+  getAppendedEmoji,
+  getEmojiImageUrl
 };

--- a/modules/tinymce/src/plugins/emoticons/main/ts/core/EmojiDatabase.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/core/EmojiDatabase.ts
@@ -47,8 +47,8 @@ const categoryNameMap = {
 const translateCategory = (categories: Record<string, string>, name: string): string =>
   Obj.has(categories, name) ? categories[name] : name;
 
-const getUserDefinedEmoticons = (editor: Editor): Record<string, RawEmojiEntry> => {
-  const userDefinedEmoticons = Options.getAppendedEmoticons(editor);
+const getUserDefinedEmoji = (editor: Editor): Record<string, RawEmojiEntry> => {
+  const userDefinedEmoticons = Options.getAppendedEmoji(editor);
   return Obj.map(userDefinedEmoticons, (value) =>
     // Set some sane defaults for the custom emoji entry
     ({ keywords: [], category: 'user', ...value })
@@ -60,7 +60,7 @@ const initDatabase = (editor: Editor, databaseUrl: string, databaseId: string): 
   const categories = Singleton.value<Record<string, EmojiEntry[]>>();
   const all = Singleton.value<EmojiEntry[]>();
 
-  const emojiImagesUrl = Options.getEmotionsImageUrl(editor);
+  const emojiImagesUrl = Options.getEmojiImageUrl(editor);
 
   const getEmoji = (lib: RawEmojiEntry) => {
     // Note: This is a little hacky, but the database doesn't provide a way for us to tell what sort of database is being used
@@ -94,11 +94,11 @@ const initDatabase = (editor: Editor, databaseUrl: string, databaseId: string): 
 
   editor.on('init', () => {
     Resource.load(databaseId, databaseUrl).then((emojis) => {
-      const userEmojis = getUserDefinedEmoticons(editor);
+      const userEmojis = getUserDefinedEmoji(editor);
       processEmojis(Merger.merge(emojis, userEmojis));
     }, (err) => {
       // eslint-disable-next-line no-console
-      console.log(`Failed to load emoticons: ${err}`);
+      console.log(`Failed to load emojis: ${err}`);
       categories.set({});
       all.set([]);
     });

--- a/modules/tinymce/src/plugins/emoticons/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/ui/Buttons.ts
@@ -11,13 +11,13 @@ const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceEmoticons');
 
   editor.ui.registry.addButton('emoticons', {
-    tooltip: 'Emoticons',
+    tooltip: 'Emojis',
     icon: 'emoji',
     onAction
   });
 
   editor.ui.registry.addMenuItem('emoticons', {
-    text: 'Emoticons...',
+    text: 'Emojis...',
     icon: 'emoji',
     onAction
   });

--- a/modules/tinymce/src/plugins/emoticons/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/ui/Dialog.ts
@@ -68,7 +68,7 @@ const open = (editor: Editor, database: EmojiDatabase): void => {
       }))
     };
     return {
-      title: 'Emoticons',
+      title: 'Emojis',
       size: 'normal',
       body,
       initialData: initialState,
@@ -98,7 +98,7 @@ const open = (editor: Editor, database: EmojiDatabase): void => {
   dialogApi.focus(patternName);
 
   if (!database.hasLoaded()) {
-    dialogApi.block('Loading emoticons...');
+    dialogApi.block('Loading emojis...');
     database.waitForLoad().then(() => {
       dialogApi.redial(getInitialState());
       updateFilter.throttle(dialogApi);
@@ -106,7 +106,7 @@ const open = (editor: Editor, database: EmojiDatabase): void => {
       dialogApi.unblock();
     }).catch((_err) => {
       dialogApi.redial({
-        title: 'Emoticons',
+        title: 'Emojis',
         body: {
           type: 'panel',
           items: [
@@ -114,7 +114,7 @@ const open = (editor: Editor, database: EmojiDatabase): void => {
               type: 'alertbanner',
               level: 'error',
               icon: 'warning',
-              text: '<p>Could not load emoticons</p>'
+              text: 'Could not load emojis'
             }
           ]
         },

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmojiAppendTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmojiAppendTest.ts
@@ -9,7 +9,7 @@ import Plugin from 'tinymce/plugins/emoticons/Plugin';
 
 import { fakeEvent } from '../module/test/Utils';
 
-describe('browser.tinymce.plugins.emoticons.AppendTest', () => {
+describe('browser.tinymce.plugins.emoticons.EmojiAppendTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'emoticons',
     toolbar: 'emoticons',
@@ -39,7 +39,7 @@ describe('browser.tinymce.plugins.emoticons.AppendTest', () => {
       ]
     });
 
-  it('TBA: Open dialog, verify custom categories listed and search for custom emoticon', async () => {
+  it('TBA: Open dialog, verify custom categories listed and search for custom emoji', async () => {
     const editor = hook.editor();
     const doc = SugarDocument.getDocument();
 

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmojiSearchTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmojiSearchTest.ts
@@ -1,6 +1,7 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
-import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { before, describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
+import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -9,31 +10,37 @@ import Plugin from 'tinymce/plugins/emoticons/Plugin';
 
 import { fakeEvent } from '../module/test/Utils';
 
-describe('browser.tinymce.plugins.emoticons.ImageEmoticonTest', () => {
+describe('browser.tinymce.plugins.emoticons.EmojiSearchTest', () => {
+  before(function () {
+    // TODO: TINY-6905: Test is flaking on Chromium Edge 86, so we need to investigate
+    const platform = PlatformDetection.detect();
+    if (platform.browser.isChromium() && platform.os.isWindows()) {
+      this.skip();
+    }
+  });
+
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'emoticons',
     toolbar: 'emoticons',
     base_url: '/project/tinymce/js/tinymce',
-    emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojiimages.js'
+    emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojis.js'
   }, [ Plugin ], true);
 
-  it('TBA: Open dialog, Search for "dog", Dog should be first option', async () => {
+  it('TBA: Open dialog, Search for "rainbow", Rainbow should be first option', async () => {
     const editor = hook.editor();
     const doc = SugarDocument.getDocument();
 
     TinyUiActions.clickOnToolbar(editor, 'button');
     await TinyUiActions.pWaitForDialog(editor);
     await FocusTools.pTryOnSelector('Focus should start on input', doc, 'input');
-    const input = FocusTools.setActiveValue(doc, 'dog');
+    const input = FocusTools.setActiveValue(doc, 'rainbow');
     fakeEvent(input, 'input');
     await Waiter.pTryUntil(
-      'Wait until dog is the first choice (search should filter)',
+      'Wait until rainbow is the first choice (search should filter)',
       () => {
         const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item:first').getOrDie();
-        const attr = Attribute.get(item, 'data-collection-item-value');
-        const img = SugarElement.fromHtml<HTMLImageElement>(attr);
-        const src = Attribute.get(img, 'src');
-        assert.equal(src, 'https://twemoji.maxcdn.com/v/13.0.1/72x72/1f436.png', 'Search should show a dog');
+        const value = Attribute.get(item, 'data-collection-item-value');
+        assert.equal(value, '🌈', 'Search should show rainbow');
       }
     );
     TinyUiActions.keydown(editor, Keys.tab());
@@ -41,13 +48,7 @@ describe('browser.tinymce.plugins.emoticons.ImageEmoticonTest', () => {
     TinyUiActions.keydown(editor, Keys.enter());
     await Waiter.pTryUntil(
       'Waiting for content update',
-      () => TinyAssertions.assertContentPresence(editor, {
-        'img[data-emoticon]': 1,
-        'img[data-mce-resize="false"]': 1,
-        'img[data-mce-placeholder="1"]': 1,
-        'img[alt="\ud83d\udc36"]': 1,
-        'img[src="https://twemoji.maxcdn.com/v/13.0.1/72x72/1f436.png"]': 1
-      })
+      () => TinyAssertions.assertContent(editor, '<p>🌈</p>')
     );
   });
 });

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAutocompletionTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmoticonAutocompletionTest.ts
@@ -5,7 +5,7 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiAc
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/emoticons/Plugin';
 
-describe('browser.tinymce.plugins.emoticons.AutocompletionTest', () => {
+describe('browser.tinymce.plugins.emoticons.EmoticonAutocompletionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'emoticons',
     toolbar: 'emoticons',

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmojiTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmojiTest.ts
@@ -1,7 +1,6 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
-import { PlatformDetection } from '@ephox/sand';
-import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
+import { describe, it } from '@ephox/bedrock-client';
+import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -10,37 +9,31 @@ import Plugin from 'tinymce/plugins/emoticons/Plugin';
 
 import { fakeEvent } from '../module/test/Utils';
 
-describe('browser.tinymce.plugins.emoticons.SearchTest', () => {
-  before(function () {
-    // TODO: TINY-6905: Test is flaking on Chromium Edge 86, so we need to investigate
-    const platform = PlatformDetection.detect();
-    if (platform.browser.isChromium() && platform.os.isWindows()) {
-      this.skip();
-    }
-  });
-
+describe('browser.tinymce.plugins.emoticons.ImageEmojiTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'emoticons',
     toolbar: 'emoticons',
     base_url: '/project/tinymce/js/tinymce',
-    emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojis.js'
+    emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojiimages.js'
   }, [ Plugin ], true);
 
-  it('TBA: Open dialog, Search for "rainbow", Rainbow should be first option', async () => {
+  it('TBA: Open dialog, Search for "dog", Dog should be first option', async () => {
     const editor = hook.editor();
     const doc = SugarDocument.getDocument();
 
     TinyUiActions.clickOnToolbar(editor, 'button');
     await TinyUiActions.pWaitForDialog(editor);
     await FocusTools.pTryOnSelector('Focus should start on input', doc, 'input');
-    const input = FocusTools.setActiveValue(doc, 'rainbow');
+    const input = FocusTools.setActiveValue(doc, 'dog');
     fakeEvent(input, 'input');
     await Waiter.pTryUntil(
-      'Wait until rainbow is the first choice (search should filter)',
+      'Wait until dog is the first choice (search should filter)',
       () => {
         const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item:first').getOrDie();
-        const value = Attribute.get(item, 'data-collection-item-value');
-        assert.equal(value, '🌈', 'Search should show rainbow');
+        const attr = Attribute.get(item, 'data-collection-item-value');
+        const img = SugarElement.fromHtml<HTMLImageElement>(attr);
+        const src = Attribute.get(img, 'src');
+        assert.equal(src, 'https://twemoji.maxcdn.com/v/13.0.1/72x72/1f436.png', 'Search should show a dog');
       }
     );
     TinyUiActions.keydown(editor, Keys.tab());
@@ -48,7 +41,13 @@ describe('browser.tinymce.plugins.emoticons.SearchTest', () => {
     TinyUiActions.keydown(editor, Keys.enter());
     await Waiter.pTryUntil(
       'Waiting for content update',
-      () => TinyAssertions.assertContent(editor, '<p>🌈</p>')
+      () => TinyAssertions.assertContentPresence(editor, {
+        'img[data-emoticon]': 1,
+        'img[data-mce-resize="false"]': 1,
+        'img[data-mce-placeholder="1"]': 1,
+        'img[alt="\ud83d\udc36"]': 1,
+        'img[src="https://twemoji.maxcdn.com/v/13.0.1/72x72/1f436.png"]': 1
+      })
     );
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-7631

Description of Changes:
* Updated the UI text and internal code to use the correct `Emojis` term instead of `Emoticons`

Note: As per the Jira the plugin name and options are not changing.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
