### PR TITLE
TINY-8195: Change the annotation api to avoid dom mutation in plugins using it

### DIFF
--- a/modules/oxide/src/less/theme/content/comments/comments.less
+++ b/modules/oxide/src/less/theme/content/comments/comments.less
@@ -16,6 +16,6 @@
   background-color: @document-comment-background-color;
 }
 
-.tox-comments-visible .tox-comment--active {
+.tox-comments-visible .tox-comment[data-mce-annotation-active="true"]:not([data-mce-selected="inline-boundary"]) {
   background-color: @document-comment-active-background-color;
 }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `slider` dialog component #TINY-8304
 - New `buttonType` property on dialog button components, supporting `toolbar` style in addition to `primary` and `secondary` #TINY-8304
 - New `imagepreview` dialog component, allowing preview and zoom of any image URL #TINY-8333
+- New `editor.annotator.removeAll` API to remove all annotations by name. #TINY-8195
 
 ### Improved
 - The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload #TINY-7735

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `slider` dialog component #TINY-8304
 - New `buttonType` property on dialog button components, supporting `toolbar` style in addition to `primary` and `secondary` #TINY-8304
 - New `imagepreview` dialog component, allowing preview and zoom of any image URL #TINY-8333
-- New `editor.annotator.removeAll` API to remove all annotations by name. #TINY-8195
+- New `editor.annotator.removeAll` API to remove all annotations by name #TINY-8195
 
 ### Improved
 - The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload #TINY-7735
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `GetContent` event was not fired when getting `tree` or `text` formats using the `editor.selection.getContent()` API #TINY-8018
 - The `table` plugin would sometimes not correctly handle headers in the `tfoot` section #TINY-8104
 - The aria labels for the color picker dialog were not translated #TINY-8381
+- The `editor.annotator.remove` did not keep selection when removing the annotation #TINY-8195
 
 ### Removed
 - Removed the deprecated `$`, `Class`, `DomQuery` and `Sizzle` APIs #TINY-4520 #TINY-8326

--- a/modules/tinymce/src/core/demo/html/annotations_demo.html
+++ b/modules/tinymce/src/core/demo/html/annotations_demo.html
@@ -7,10 +7,12 @@
   <body>
   <h2>annotations demo Page</h2>
     <div id="ephox-ui">
-      <textarea class="tinymce">
-        &lt;p&gt;dsfdsafs&lt;span class="mce-annotation" data-mce-annotation-uid="mce-annotation_94269650211529705226881" data-mce-annotation="alpha" data-mce-comment="dsaf"&gt;dfasdf&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br data-mce-bogus="1"&gt;&lt;/p&gt;&lt;p&gt;&lt;span class="mce-annotation" data-mce-annotation-uid="mce-annotation_94269650211529705226881" data-mce-annotation="alpha" data-mce-comment="dsaf"&gt;dsafs&lt;/span&gt;adf&lt;/p&gt;
-
-      </textarea>
+      <div class="tinymce">
+        <p>abc <span class="mce-annotation" data-mce-annotation-uid="mce-annotation_94269650211529705226881" data-mce-annotation="alpha" data-mce-comment="abc">alpha 1</span></p>
+        <p><span class="mce-annotation" data-mce-annotation-uid="mce-annotation_94269650211529705226882" data-mce-annotation="alpha" data-mce-comment="def">alpha 1</span> def</p>
+        <p>abc <span class="mce-annotation" data-mce-annotation-uid="mce-annotation_94269650211529705226883" data-mce-annotation="alpha" data-mce-comment="123">alpha 2 [<span class="mce-annotation" data-mce-annotation-uid="mce-annotation_942696502115297052268413" data-mce-annotation="alpha" data-mce-comment="123">nested alpha 3</span>] 2</span> def</p>
+        <p>abc <span class="mce-annotation" data-mce-annotation-uid="mce-annotation_94269650211529705226884" data-mce-annotation="beta">beta 1</span></p>
+      </div>
     </div>
 
     <script src="../../../../js/tinymce/tinymce.js"></script>

--- a/modules/tinymce/src/core/demo/ts/demo/AnnotationsDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/AnnotationsDemo.ts
@@ -4,23 +4,22 @@ import Editor from 'tinymce/core/api/Editor';
 
 declare let tinymce: any;
 
+const contentStyles = `
+.mce-annotation { background-color: lightgreen; }
+[data-mce-annotation-active] { outline: 2px solid red }
+[data-mce-annotation="beta"][data-mce-annotation-active] { background-color: yellow; }
+`;
+
 export default () => {
-
-  const button = document.createElement('button');
-  button.innerHTML = 'Get all annotations';
-  button.addEventListener('click', () => {
-    // eslint-disable-next-line no-console
-    console.log('annotations', tinymce.activeEditor.annotator.getAll('alpha'));
-  });
-  document.body.appendChild(button);
-
   tinymce.init({
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
-    selector: 'textarea.tinymce',
-    toolbar: 'annotate-alpha',
+    selector: 'div.tinymce',
+    toolbar: 'annotate-alpha get-all-alpha remove-all-alpha remove-alpha',
     plugins: [ ],
 
-    content_style: '.mce-annotation { background-color: darkgreen; color: white; }',
+    inline_boundaries: false,
+    height: 400,
+    content_style: contentStyles,
 
     setup: (editor: Editor) => {
       editor.ui.registry.addButton('annotate-alpha', {
@@ -40,6 +39,37 @@ export default () => {
         }
       });
 
+      editor.ui.registry.addButton('get-all-alpha', {
+        text: 'Get all',
+        onAction: () => {
+          // eslint-disable-next-line no-console
+          console.log('annotations', editor.annotator.getAll('alpha'));
+        }
+      });
+
+      editor.ui.registry.addButton('remove-all-alpha', {
+        text: 'Remove all',
+        onAction: () => {
+          editor.annotator.removeAll('alpha');
+          editor.focus();
+        }
+      });
+
+      editor.ui.registry.addButton('remove-alpha', {
+        text: 'Remove closest',
+        onAction: () => {
+          editor.annotator.remove('alpha');
+          editor.focus();
+        },
+        disabled: true,
+        onSetup: (btnApi) => {
+          editor.annotator.annotationChanged('alpha', (state, _name, _obj) => {
+            btnApi.setDisabled(!state);
+          });
+          return Fun.noop;
+        }
+      });
+
       editor.on('init', () => {
         editor.annotator.register('alpha', {
           persistent: true,
@@ -48,6 +78,13 @@ export default () => {
               'data-mce-comment': data.comment ? data.comment : '',
               'data-mce-author': data.author ? data.author : 'anonymous'
             }
+          })
+        });
+
+        editor.annotator.register('beta', {
+          persistent: true,
+          decorate: (_uid, _data) => ({
+            attributes: {}
           })
         });
       });

--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationChanges.ts
@@ -10,8 +10,8 @@ import { Attribute } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import { AnnotationsRegistry } from './AnnotationsRegistry';
-import { findMarkers, identify } from './Identification';
-import { dataAnnotationActive } from './Markings';
+import * as Identification from './Identification';
+import * as Markings from './Markings';
 
 export interface AnnotationChanges {
   readonly addListener: (name: string, f: AnnotationListener) => void;
@@ -65,11 +65,11 @@ const setup = (editor: Editor, registry: AnnotationsRegistry): AnnotationChanges
   };
 
   const toggleActiveAttr = (uid: string, state: boolean) => {
-    Arr.each(findMarkers(editor, uid), (span) => {
+    Arr.each(Identification.findMarkers(editor, uid), (span) => {
       if (state) {
-        Attribute.set(span, dataAnnotationActive(), 'true');
+        Attribute.set(span, Markings.dataAnnotationActive(), 'true');
       } else {
-        Attribute.remove(span, dataAnnotationActive());
+        Attribute.remove(span, Markings.dataAnnotationActive());
       }
     });
   };
@@ -80,7 +80,7 @@ const setup = (editor: Editor, registry: AnnotationsRegistry): AnnotationChanges
     Arr.each(annotations, (name) => {
       updateCallbacks(name, (data) => {
         const prev = data.previous.get();
-        identify(editor, Optional.some(name)).fold(
+        Identification.identify(editor, Optional.some(name)).fold(
           () => {
             prev.each((uid) => {
               // Changed from something to nothing.

--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationFilter.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationFilter.ts
@@ -15,14 +15,13 @@ import * as Markings from './Markings';
 const setup = (editor: Editor, registry: AnnotationsRegistry): void => {
   const identifyParserNode = (span: AstNode): Optional<AnnotatorSettings> => Optional.from(span.attr(Markings.dataAnnotation())).bind(registry.lookup);
 
-  editor.on('init', () => {
-    editor.serializer.addNodeFilter('span', (spans) => {
-      Arr.each(spans, (span) => {
-        identifyParserNode(span).each((settings) => {
-          if (settings.persistent === false) {
-            span.unwrap();
-          }
-        });
+  editor.serializer.addTempAttr(Markings.dataAnnotationActive());
+  editor.serializer.addNodeFilter('span', (spans) => {
+    Arr.each(spans, (span) => {
+      identifyParserNode(span).each((settings) => {
+        if (settings.persistent === false) {
+          span.unwrap();
+        }
       });
     });
   });

--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationsRegistry.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationsRegistry.ts
@@ -17,6 +17,7 @@ export interface AnnotatorSettings {
 export interface AnnotationsRegistry {
   register: (name: string, settings: AnnotatorSettings) => void;
   lookup: (name: string) => Optional<AnnotatorSettings>;
+  getNames: () => string[];
 }
 
 interface Annotation {
@@ -37,9 +38,12 @@ const create = (): AnnotationsRegistry => {
   const lookup = (name: string): Optional<AnnotatorSettings> =>
     Obj.get(annotations, name).map((a) => a.settings);
 
+  const getNames = (): string[] => Obj.keys(annotations);
+
   return {
     register,
-    lookup
+    lookup,
+    getNames
   };
 };
 

--- a/modules/tinymce/src/core/main/ts/annotate/Identification.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/Identification.ts
@@ -49,7 +49,7 @@ const identify = (editor: Editor, annotationName: Optional<string>): Optional<{u
 
 const isAnnotation = (elem: any): boolean => SugarNode.isElement(elem) && Class.has(elem, Markings.annotation());
 
-const findMarkers = (editor: Editor, uid: string): any[] => {
+const findMarkers = (editor: Editor, uid: string): Array<SugarElement<Element>> => {
   const body = SugarElement.fromDom(editor.getBody());
   return SelectorFilter.descendants(body, `[${Markings.dataAnnotationId()}="${uid}"]`);
 };
@@ -69,5 +69,6 @@ const findAll = (editor: Editor, name: string): Record<string, SugarElement[]> =
 export {
   identify,
   isAnnotation,
+  findMarkers,
   findAll
 };

--- a/modules/tinymce/src/core/main/ts/annotate/Markings.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/Markings.ts
@@ -11,9 +11,11 @@ const annotation = Fun.constant('mce-annotation');
 
 const dataAnnotation = Fun.constant('data-mce-annotation');
 const dataAnnotationId = Fun.constant('data-mce-annotation-uid');
+const dataAnnotationActive = Fun.constant('data-mce-annotation-active');
 
 export {
   annotation,
   dataAnnotation,
-  dataAnnotationId
+  dataAnnotationId,
+  dataAnnotationActive
 };

--- a/modules/tinymce/src/core/main/ts/api/Annotator.ts
+++ b/modules/tinymce/src/core/main/ts/api/Annotator.ts
@@ -33,6 +33,7 @@ interface Annotator {
   annotate: (name: string, data: DecoratorData) => void;
   annotationChanged: (name: string, f: AnnotationListenerApi) => void;
   remove: (name: string) => void;
+  removeAll: (name: string) => void;
   getAll: (name: string) => Record<string, Element[]>;
 }
 
@@ -90,6 +91,18 @@ const Annotator = (editor: Editor): Annotator => {
       identify(editor, Optional.some(name)).each(({ elements }) => {
         Arr.each(elements, Remove.unwrap);
       });
+    },
+
+    /**
+     * Removes all annotations that match the specified name from the entire document.
+     *
+     * @method removeAll
+     * @param {String} name the name of the annotation to remove
+     */
+    removeAll: (name: string): void => {
+      const bookmark = editor.selection.getBookmark();
+      Obj.each(findAll(editor, name), (spans, _) => Arr.each(spans, Remove.unwrap));
+      editor.selection.moveToBookmark(bookmark);
     },
 
     /**

--- a/modules/tinymce/src/core/main/ts/api/Annotator.ts
+++ b/modules/tinymce/src/core/main/ts/api/Annotator.ts
@@ -88,9 +88,11 @@ const Annotator = (editor: Editor): Annotator => {
      * @param {String} name the name of the annotation to remove
      */
     remove: (name: string): void => {
+      const bookmark = editor.selection.getBookmark();
       identify(editor, Optional.some(name)).each(({ elements }) => {
         Arr.each(elements, Remove.unwrap);
       });
+      editor.selection.moveToBookmark(bookmark);
     },
 
     /**

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationChangedTest.ts
@@ -1,7 +1,7 @@
 import { Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -11,6 +11,7 @@ import { annotate, assertHtmlContent, assertMarker } from '../../module/test/Ann
 describe('browser.tinymce.core.annotate.AnnotationChangedTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
+    indent: false,
     setup: (ed: Editor) => {
       ed.on('init', () => {
         ed.annotator.register('alpha', {
@@ -259,8 +260,6 @@ describe('browser.tinymce.core.annotate.AnnotationChangedTest', () => {
     clearChanges();
 
     TinySelections.setSelection(editor, [ 4, 0, 1, 0 ], 'a'.length, [ 4, 0, 1, 0 ], 'a'.length);
-    // Give it time to throttle a node change.
-    await Waiter.pWait(400);
     await Waiter.pTryUntil(
       'Moving selection inside delta (which is inside gamma)',
       () => assertChanges('checking changes',
@@ -272,8 +271,6 @@ describe('browser.tinymce.core.annotate.AnnotationChangedTest', () => {
     );
 
     TinySelections.setSelection(editor, [ 4, 0, 0 ], 'p'.length, [ 4, 0, 0 ], 'p'.length);
-    // Give it time to throttle a node change.
-    await Waiter.pWait(400);
     await Waiter.pTryUntil(
       'Moving selection inside just gamma (but not delta)',
       () => assertChanges('checking changes',
@@ -283,6 +280,65 @@ describe('browser.tinymce.core.annotate.AnnotationChangedTest', () => {
           { state: false, name: 'delta', uid: null }
         ]
       )
+    );
+  });
+
+  it('TINY-8195: annotation change active attribute', async () => {
+    const editor = hook.editor();
+
+    editor.setContent('<p>one two three</p><p>outside</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'one two three'.length);
+    annotate(editor, 'alpha', 'id-one', { anything: 'comment-1' });
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 'one '.length, [ 0, 0, 0 ], 'one two three'.length);
+    annotate(editor, 'beta', 'id-two', { something: 'comment-2' });
+    TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 'two '.length, [ 0, 0, 1, 0 ], 'two three'.length);
+    annotate(editor, 'beta', 'id-three', { something: 'comment-3' });
+
+    // Content should not include the view only active state attributes
+    TinyAssertions.assertContent(editor, [
+      '<p>',
+      '<span class="mce-annotation" data-mce-annotation-uid="id-one" data-mce-annotation="alpha" data-test-anything="comment-1">one ',
+      '<span class="mce-annotation" data-mce-annotation-uid="id-two" data-mce-annotation="beta" data-test-something="comment-2">two ',
+      '<span class="mce-annotation" data-mce-annotation-uid="id-three" data-mce-annotation="beta" data-test-something="comment-3">three</span></span></span>',
+      '</p>',
+      '<p>outside</p>'
+    ].join(''));
+
+    await Waiter.pTryUntil(
+      'The latest added annotation (nested beta) should be active and the parent alpha but not the parent beta',
+      () => TinyAssertions.assertContentPresence(editor, {
+        'span[data-mce-annotation="alpha"][data-mce-annotation-active="true"]': 1,
+        'span[data-mce-annotation="beta"][data-mce-annotation-active="true"]': 1,
+        'span[data-mce-annotation="beta"] span[data-mce-annotation="beta"][data-mce-annotation-active="true"]': 1
+      })
+    );
+
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+    await Waiter.pTryUntil(
+      'Alpha should be the only active annotation',
+      () => TinyAssertions.assertContentPresence(editor, {
+        'span[data-mce-annotation="alpha"][data-mce-annotation-active="true"]': 1,
+        'span[data-mce-annotation="beta"][data-mce-annotation-active="true"]': 0
+      })
+    );
+
+    TinySelections.setCursor(editor, [ 0, 0, 1, 1, 0 ], 1);
+    await Waiter.pTryUntil(
+      'Both alpha and beta should be active again but not parent beta',
+      () => TinyAssertions.assertContentPresence(editor, {
+        'span[data-mce-annotation="alpha"][data-mce-annotation-active="true"]': 1,
+        'span[data-mce-annotation="beta"][data-mce-annotation-active="true"]': 1,
+        'span[data-mce-annotation="beta"] span[data-mce-annotation="beta"][data-mce-annotation-active="true"]': 1
+      })
+    );
+
+    TinySelections.setCursor(editor, [ 1, 0 ], 0);
+    await Waiter.pTryUntil(
+      'No annotation should be active since selection was moved to plain text',
+      () => TinyAssertions.assertContentPresence(editor, {
+        'span[data-mce-annotation="alpha"][data-mce-annotation-active="true"]': 0,
+        'span[data-mce-annotation="beta"][data-mce-annotation-active="true"]': 0
+      })
     );
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
@@ -151,7 +151,20 @@ describe('browser.tinymce.core.annotate.AnnotationRemovedTest', () => {
     }, 'alpha');
   });
 
-  it('TINY-8195: remove all alpha annotations and retain selection', () => {
+  it('TINY-8195: remove alpha annotation and keep selection', () => {
+    const editor = hook.editor();
+
+    TinySelections.setCursor(editor, [ 0, 1, 0 ], 2);
+    editor.annotator.remove('alpha');
+
+    TinyAssertions.assertContentPresence(editor, {
+      'span[data-mce-annotation="alpha"]': 1,
+      'span[data-mce-annotation="beta"]': 1
+    });
+    TinyAssertions.assertCursor(editor, [ 0, 1 ], 2);
+  });
+
+  it('TINY-8195: remove all alpha annotations and keep selection', () => {
     const editor = hook.editor();
 
     TinySelections.setCursor(editor, [ 0, 2 ], 2);

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
@@ -1,5 +1,5 @@
 import { Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -32,8 +32,9 @@ describe('browser.tinymce.core.annotate.AnnotationRemovedTest', () => {
     }
   }, [], true);
 
-  before(() => {
+  beforeEach(() => {
     const editor = hook.editor();
+
     // '<p>This |is the first paragraph</p><p>This is the second.</p><p>This is| the third.</p>'
     editor.setContent('<p>This was the first paragraph</p><p>This is the second.</p><p>This is the third.</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 'This '.length, [ 0, 0 ], 'This was'.length);
@@ -132,10 +133,8 @@ describe('browser.tinymce.core.annotate.AnnotationRemovedTest', () => {
 
     // There should be no beta annotations',
     assertGetAll(editor, {}, 'beta');
-  });
 
-  it('remove second alpha annotation - inside annotation', async () => {
-    const editor = hook.editor();
+    // remove second alpha annotation - inside annotation
     TinySelections.setSelection(editor, inside1.path, inside1.offset, inside1.path, inside1.offset);
     editor.annotator.remove('alpha');
 
@@ -150,5 +149,18 @@ describe('browser.tinymce.core.annotate.AnnotationRemovedTest', () => {
     assertGetAll(editor, {
       'id-two': 1
     }, 'alpha');
+  });
+
+  it('TINY-8195: remove all alpha annotations and retain selection', () => {
+    const editor = hook.editor();
+
+    TinySelections.setCursor(editor, [ 0, 2 ], 2);
+    editor.annotator.removeAll('alpha');
+
+    TinyAssertions.assertContentPresence(editor, {
+      'span[data-mce-annotation="alpha"]': 0,
+      'span[data-mce-annotation="beta"]': 1
+    });
+    TinyAssertions.assertCursor(editor, [ 0, 2 ], 2);
   });
 });


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* This does some changes to the annotation part of the core to avoid direct dom mutation by the remark plugin. Check the JIRA ticket for details.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
