### PR TITLE
TINY-8163: test for paste not changing RGB color

### DIFF
--- a/modules/tinymce/src/plugins/paste/main/ts/core/Quirks.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Quirks.ts
@@ -73,7 +73,8 @@ const removeWebKitStyles = (editor: Editor, content: string, internal: boolean):
       }
 
       for (let i = 0; i < webKitStyles.length; i++) {
-        let compareInput = inputStyles[webKitStyles[i]];
+        const inputValue = inputStyles[webKitStyles[i]];
+        let compareInput = inputValue;
         let currentValue = dom.getStyle(node, webKitStyles[i], true);
 
         if (/color/.test(webKitStyles[i])) {
@@ -82,7 +83,7 @@ const removeWebKitStyles = (editor: Editor, content: string, internal: boolean):
         }
 
         if (currentValue !== compareInput) {
-          outputStyles[webKitStyles[i]] = compareInput;
+          outputStyles[webKitStyles[i]] = inputValue;
         }
       }
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/Quirks.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/Quirks.ts
@@ -73,8 +73,7 @@ const removeWebKitStyles = (editor: Editor, content: string, internal: boolean):
       }
 
       for (let i = 0; i < webKitStyles.length; i++) {
-        const inputValue = inputStyles[webKitStyles[i]];
-        let compareInput = inputValue;
+        let compareInput = inputStyles[webKitStyles[i]];
         let currentValue = dom.getStyle(node, webKitStyles[i], true);
 
         if (/color/.test(webKitStyles[i])) {
@@ -83,7 +82,7 @@ const removeWebKitStyles = (editor: Editor, content: string, internal: boolean):
         }
 
         if (currentValue !== compareInput) {
-          outputStyles[webKitStyles[i]] = inputValue;
+          outputStyles[webKitStyles[i]] = compareInput;
         }
       }
 

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteStylesTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteStylesTest.ts
@@ -67,6 +67,6 @@ describe('browser.tinymce.plugins.paste.PasteStylesTest', () => {
     editor.setContent('<p>test</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
     Clipboard.pasteItems(TinyDom.body(editor), { 'text/html': '<span style="color: rgb(224, 62, 45);">b</span>' });
-    TinyAssertions.assertContent(editor, `<p><span style="color: #e03e2d;">b</span></p>`);
+    TinyAssertions.assertContent(editor, `<p><span style="color: rgb(224, 62, 45);">b</span></p>`);
   });
 });

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/PasteStylesTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/PasteStylesTest.ts
@@ -1,5 +1,5 @@
 import { Clipboard } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -18,6 +18,12 @@ describe('browser.tinymce.plugins.paste.PasteStylesTest', () => {
     valid_styles: 'font-family,color',
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);
+
+  beforeEach(() => {
+    const editor = hook.editor();
+    editor.options.unset('paste_remove_styles_if_webkit');
+    editor.options.unset('paste_remove_styles');
+  });
 
   it('TBA: Paste span with encoded style attribute, paste_webkit_styles: font-family', () => {
     const editor = hook.editor();
@@ -53,5 +59,14 @@ describe('browser.tinymce.plugins.paste.PasteStylesTest', () => {
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
     Clipboard.pasteItems(TinyDom.body(editor), { 'text/html': '<span style="font-family: &quot;a b&quot;;">b</span>' });
     TinyAssertions.assertContent(editor, `<p><span style="font-family: 'a b';">b</span></p>`);
+  });
+
+  it('TINY-8163: Paste span with RGB color style, paste_webkit_styles: color', () => {
+    const editor = hook.editor();
+    editor.options.set('paste_webkit_styles', 'color');
+    editor.setContent('<p>test</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
+    Clipboard.pasteItems(TinyDom.body(editor), { 'text/html': '<span style="color: rgb(224, 62, 45);">b</span>' });
+    TinyAssertions.assertContent(editor, `<p><span style="color: #e03e2d;">b</span></p>`);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8163

Description of Changes:
* fix paste regression due to incorrect variable being used.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
