### PR TITLE
TINY-8138: Change `mceAddEditor` command to allow editor options

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `tinymce.settings` global property is no longer set upon initialization #TINY-7359
 - Add-ons such as plugins and themes are no longer constructed using the `new` operator #TINY-8256
 - A number of APIs that were not proper classes, are no longer constructed using the `new` operator #TINY-8322
+- The `mceAddEditor` command can now take an object as its value to specify the id and editor options #TINY-8138
 - The `default_link_target` option has been renamed to `link_default_target` for both `link` and `autolink` plugins #TINY-4603
 - The `rel_list` option has been renamed to `link_rel_list` for the `link` plugin #TINY-4603
 - The `target_list` option has been renamed to `link_target_list` for the `link` plugin #TINY-4603

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -110,7 +110,6 @@ interface EditorManager extends Observable<EditorManagerEventMap> {
   releaseDate: string;
   activeEditor: Editor;
   focusedEditor: Editor;
-  settings: RawEditorOptions;
   baseURI: URI;
   baseURL: string;
   documentBaseURL: string;
@@ -188,8 +187,6 @@ const EditorManager: EditorManager = {
    */
   activeEditor: null,
   focusedEditor: null,
-
-  settings: {},
 
   setup() {
     const self: EditorManager = this;
@@ -629,8 +626,12 @@ const EditorManager: EditorManager = {
     // Manager commands
     switch (cmd) {
       case 'mceAddEditor':
-        if (!self.get(value)) {
-          new Editor(value, self.settings, self).render();
+        const isObj = Type.isObject(value);
+        const editorId = isObj ? value.id : value;
+
+        if (!self.get(editorId)) {
+          const editorOptions = isObj ? value.options : {};
+          new Editor(editorId, editorOptions, self).render();
         }
 
         return true;

--- a/modules/tinymce/src/core/test/ts/browser/EditorManagerCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorManagerCommandsTest.ts
@@ -1,0 +1,91 @@
+import { after, afterEach, before, describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+
+import 'tinymce';
+import EditorManager from 'tinymce/core/api/EditorManager';
+import Theme from 'tinymce/themes/silver/Theme';
+
+import * as ViewBlock from '../module/test/ViewBlock';
+
+describe('browser.tinymce.core.EditorManagerCommandsTest', () => {
+  const viewBlock = ViewBlock.bddSetup();
+
+  before(() => {
+    Theme();
+    EditorManager._setBaseUrl('/project/tinymce/js/tinymce');
+  });
+
+  after(() => {
+    EditorManager.remove();
+  });
+
+  afterEach((done) => {
+    setTimeout(() => {
+      EditorManager.remove();
+      done();
+    }, 0);
+  });
+
+  it('mceToggleEditor', (done) => {
+    viewBlock.update('<textarea class="tinymce"></textarea>');
+    EditorManager.init({
+      selector: 'textarea.tinymce',
+      init_instance_callback: (editor1) => {
+        assert.isFalse(editor1.isHidden(), 'editor should be visible');
+        EditorManager.execCommand('mceToggleEditor', false, 0);
+        assert.isTrue(editor1.isHidden(), 'editor should be hidden');
+        EditorManager.execCommand('mceToggleEditor', false, 0);
+        assert.isFalse(editor1.isHidden(), 'editor should be visible');
+        done();
+      }
+    });
+  });
+
+  it('mceRemoveEditor', (done) => {
+    viewBlock.update('<textarea class="tinymce"></textarea>');
+    EditorManager.init({
+      selector: 'textarea.tinymce',
+      init_instance_callback: (_editor1) => {
+        assert.lengthOf(EditorManager.get(), 1);
+        EditorManager.execCommand('mceRemoveEditor', false, 0);
+        assert.lengthOf(EditorManager.get(), 0);
+        done();
+      }
+    });
+  });
+
+  it('mceAddEditor - passing id directly as value', (done) => {
+    viewBlock.update('<textarea id="ed_1" class="tinymce"></textarea><textarea id="ed_2" class="tinymce"></textarea>');
+    EditorManager.init({
+      selector: 'textarea#ed_1',
+      init_instance_callback: (_editor1) => {
+        assert.lengthOf(EditorManager.get(), 1);
+        EditorManager.execCommand('mceAddEditor', false, 'ed_2');
+        assert.lengthOf(EditorManager.get(), 2);
+        done();
+      }
+    });
+  });
+
+  it('mceAddEditor - passing id and options as value', (done) => {
+    viewBlock.update('<textarea id="ed_1" class="tinymce"></textarea><textarea id="ed_2" class="tinymce"></textarea>');
+    EditorManager.init({
+      selector: 'textarea#ed_1',
+      init_instance_callback: (_editor1) => {
+        assert.lengthOf(EditorManager.get(), 1);
+        assert.isFalse(EditorManager.get('ed_1').mode.isReadOnly());
+        EditorManager.execCommand('mceAddEditor', false, {
+          id: 'ed_2',
+          options: {
+            readonly: true,
+            init_instance_callback: (editor2) => {
+              assert.lengthOf(EditorManager.get(), 2);
+              assert.isTrue(editor2.mode.isReadOnly());
+              done();
+            }
+          }
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-8138

Description of Changes:
* Update the `mceAddEditor` command to either take an id string as its value or an object that contains the id and editor options to be used for the new editor

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
