### PR TITLE
TINY-8263: Change default for `element_format` option to `html`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `default_link_target` option has been renamed to `link_default_target` for both `link` and `autolink` plugins #TINY-4603
 - The `rel_list` option has been renamed to `link_rel_list` for the `link` plugin #TINY-4603
 - The `target_list` option has been renamed to `link_target_list` for the `link` plugin #TINY-4603
+- The `element_format` option has been set to `html` by default #TINY-8263
 - The `primary` property on dialog buttons has been deprecated. Use the new `buttonType` property instead #TINY-8304
 - The default value for the `link_default_protocol` option has been changed to `https` instead of `http` #TINY-7824
 - Moved the `paste` plugin's functionality to TinyMCE core #TINY-8310

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -557,7 +557,8 @@ const register = (editor: Editor) => {
   });
 
   registerOption('element_format', {
-    processor: 'string'
+    processor: 'string',
+    default: 'html'
   });
 
   registerOption('entities', {

--- a/modules/tinymce/src/core/main/ts/api/html/Writer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Writer.ts
@@ -55,7 +55,7 @@ const Writer = (settings?: WriterSettings): Writer => {
   const indentBefore = makeMap(settings.indent_before || '');
   const indentAfter = makeMap(settings.indent_after || '');
   const encode = Entities.getEncodeFunc(settings.entity_encoding || 'raw', settings.entities);
-  const htmlOutput = settings.element_format === 'html';
+  const htmlOutput = settings.element_format !== 'xhtml';
 
   return {
     /**

--- a/modules/tinymce/src/core/test/ts/browser/EditorPaddEmptyWithBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorPaddEmptyWithBrTest.ts
@@ -19,7 +19,7 @@ describe('browser.tinymce.core.EditorPaddEmptyWithBrTest', () => {
   it('Padd empty elements with br', () => {
     const editor = hook.editor();
     editor.setContent('<p>a</p><p></p>');
-    assert.equal(editor.getContent(), '<p>a</p><p><br /></p>');
+    assert.equal(editor.getContent(), '<p>a</p><p><br></p>');
   });
 
   it('Padd empty elements with br on insert at caret', () => {
@@ -27,6 +27,6 @@ describe('browser.tinymce.core.EditorPaddEmptyWithBrTest', () => {
     editor.setContent('<p>a</p>');
     LegacyUnit.setSelection(editor, 'p', 1);
     editor.insertContent('<p>b</p><p></p>');
-    assert.equal(editor.getContent(), '<p>a</p><p>b</p><p><br /></p>');
+    assert.equal(editor.getContent(), '<p>a</p><p>b</p><p><br></p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -24,7 +24,7 @@ const assertResult = (editor: Editor, title: string, uploadUri: string, uploaded
   assert.equal(uploadedBlobInfo.base64(), firstResult.blobInfo.base64(), title);
   assert.equal(uploadedBlobInfo.blobUri(), firstResult.blobInfo.blobUri(), title);
   assert.equal(uploadedBlobInfo.uri(), firstResult.blobInfo.uri(), title);
-  assert.equal(editor.getContent(), '<p><img src="' + uploadedBlobInfo.filename() + '" /></p>', title);
+  assert.equal(editor.getContent(), '<p><img src="' + uploadedBlobInfo.filename() + '"></p>', title);
 
   return result;
 };
@@ -109,7 +109,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       assert.equal(editor.getBody().innerHTML, '<p><img src="' + blobInfo.blobUri() + '"></p>', '_scanForImages');
       assert.equal(
         editor.getContent(),
-        '<p><img src="data:' + blobInfo.blob().type + ';base64,' + blobInfo.base64() + '" /></p>',
+        '<p><img src="data:' + blobInfo.blob().type + ';base64,' + blobInfo.base64() + '"></p>',
         '_scanForImages'
       );
       assert.deepEqual(blobInfo, editor.editorUpload.blobCache.get(blobInfo.id()), '_scanForImages');
@@ -132,7 +132,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       return editor.uploadImages(() => {
         editor.setContent(imageHtml(blobUri));
         assert.isFalse(hasBlobAsSource(editor.dom.select('img')[0]), 'replace uploaded blob uri with result uri (copy/paste of an uploaded blob uri)');
-        assert.equal(editor.getContent(), '<p><img src="file.png" /></p>', 'replace uploaded blob uri with result uri (copy/paste of an uploaded blob uri)');
+        assert.equal(editor.getContent(), '<p><img src="file.png"></p>', 'replace uploaded blob uri with result uri (copy/paste of an uploaded blob uri)');
         assertEventsLength(1);
       });
     });
@@ -155,7 +155,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
         assertEventsLength(0);
         editor.setContent(imageHtml(blobUri));
         assert.isTrue(hasBlobAsSource(editor.dom.select('img')[0]), 'Has blob');
-        assert.equal(editor.getContent(), '<p><img src="file.png" /></p>', 'contains image');
+        assert.equal(editor.getContent(), '<p><img src="file.png"></p>', 'contains image');
       });
     });
   });
@@ -214,7 +214,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     const assertResultRetainsUrl = (result) => {
       assert.isTrue(result[0].status, 'uploadImages retain blob urls after upload');
       assert.isTrue(hasBlobAsSource(result[0].element), 'Not a blob url');
-      assert.equal(editor.getContent(), '<p><img src="' + uploadedBlobInfo.filename() + '" /></p>', 'uploadImages retain blob urls after upload');
+      assert.equal(editor.getContent(), '<p><img src="' + uploadedBlobInfo.filename() + '"></p>', 'uploadImages retain blob urls after upload');
 
       return result;
     };
@@ -254,7 +254,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     const assertResultReusesFilename = (editor: Editor, _uploadedBlobInfo: BlobInfo, result: UploadResult[]) => {
       assert.lengthOf(result, 1, 'uploadImages reuse filename');
       assert.isTrue(result[0].status, 'uploadImages reuse filename');
-      assert.equal(editor.getContent(), '<p><img src="custom.png?size=small" /></p>', 'uploadImages reuse filename');
+      assert.equal(editor.getContent(), '<p><img src="custom.png?size=small"></p>', 'uploadImages reuse filename');
 
       return result;
     };
@@ -268,7 +268,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
         assertEventsLength(1);
         assert.isFalse(hasBlobAsSource(img), 'uploadImages reuse filename');
         assert.include(img.src, 'custom.png?size=small&', 'Check the cache invalidation string was added');
-        assert.equal(editor.getContent(), '<p><img src="custom.png?size=small" /></p>', 'uploadImages reuse filename');
+        assert.equal(editor.getContent(), '<p><img src="custom.png?size=small"></p>', 'uploadImages reuse filename');
         editor.options.unset('images_reuse_filename');
       });
     });
@@ -286,7 +286,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
         assert.equal(uploadCount, 1, 'Should only be one upload.');
       }
 
-      assert.equal(editor.getContent(), '<p><img src="myimage.png" /></p>', 'uploadConcurrentImages');
+      assert.equal(editor.getContent(), '<p><img src="myimage.png"></p>', 'uploadConcurrentImages');
       LegacyUnit.equalDom(result[0].element, editor.dom.select('img')[0]);
       assert.isTrue(result[0].status, 'uploadConcurrentImages');
     };
@@ -453,7 +453,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
   it('TBA: Retain blobs not in blob cache', () => {
     const editor = hook.editor();
     editor.setContent('<img src="blob:http%3A//host/f8d1e462-8646-485f-87c5-f9bcee5873c6">');
-    assert.equal(editor.getContent(), '<p><img src="blob:http%3A//host/f8d1e462-8646-485f-87c5-f9bcee5873c6" /></p>', 'Retain blobs not in blob cache');
+    assert.equal(editor.getContent(), '<p><img src="blob:http%3A//host/f8d1e462-8646-485f-87c5-f9bcee5873c6"></p>', 'Retain blobs not in blob cache');
   });
 
   it('TINY-7735: UploadResult should contain the removed flag if the {remove: true} option was passed to the failure callback', () => {

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -1266,7 +1266,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     assert.equal(
       editor.getContent(),
       '<ol><li><strong>a</strong></li><li><strong>b</strong><ul><li><strong>c</strong></li><li><strong>d</strong>' +
-      '<br /><ol><li><strong>e</strong></li><li><strong>f</strong></li></ol></li></ul></li><li><strong>g</strong>' +
+      '<br><ol><li><strong>e</strong></li><li><strong>f</strong></li></ol></li></ul></li><li><strong>g</strong>' +
       '</li></ol>',
       'should be applied to all sublists'
     );
@@ -2330,7 +2330,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     assert.equal(getContent(editor),
       '<ul>' +
         '<li style="text-align: center;">a</li>' +
-        '<li style="text-align: center;">b<br />' +
+        '<li style="text-align: center;">b<br>' +
           '<ul>' +
             '<li style="text-align: center;">c</li>' +
             '<li style="text-align: center;">d</li>' +
@@ -2358,7 +2358,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     assert.equal(getContent(editor),
       '<ol>' +
         '<li style="text-align: center;">a</li>' +
-        '<li style="text-align: center;">b<br />' +
+        '<li style="text-align: center;">b<br>' +
           '<ol>' +
             '<li style="text-align: center;">c</li>' +
             '<li>d</li>' +
@@ -2386,7 +2386,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     assert.equal(getContent(editor),
       '<ul>' +
         '<li style="text-align: center;">a</li>' +
-        '<li style="text-align: center;"><strong>b</strong><br />' +
+        '<li style="text-align: center;"><strong>b</strong><br>' +
           '<ul>' +
             '<li style="text-align: center;">c</li>' +
             '<li style="text-align: center;">d</li>' +
@@ -2413,7 +2413,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     assert.equal(getContent(editor),
       '<ul>' +
         '<li style="text-align: right;">a</li>' +
-        '<li style="text-align: right;">b<br />' +
+        '<li style="text-align: right;">b<br>' +
           '<ul>' +
             '<li>c</li>' +
           '</ul>' +
@@ -2477,7 +2477,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     assert.equal(getContent(editor),
       '<div>' +
         '<div style="text-align: center;">a</div>' +
-        '<div style="text-align: center;"><br />b' +
+        '<div style="text-align: center;"><br>b' +
           '<div style="text-align: center;">1</div>' +
         '</div>' +
         '<div>c</div>' +

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveForcedRootBlockFalseTest.ts
@@ -25,6 +25,6 @@ describe('browser.tinymce.core.FormatterRemoveForcedRootBlockFalseTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1>b';
     LegacyUnit.setSelection(editor, 'h1', 0, 'h1', 1);
     editor.formatter.remove('format');
-    assert.equal(getContent(editor), 'a<br />b', 'Lines should be separated with br');
+    assert.equal(getContent(editor), 'a<br>b', 'Lines should be separated with br');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -145,20 +145,20 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
     editor.selection.select(editor.dom.select('img')[0]);
     editor.execCommand('JustifyLeft');
-    assert.equal(editor.getContent(), '<p><img style="float: left;" src="tinymce/ui/img/raster.gif" /></p>');
+    assert.equal(editor.getContent(), '<p><img style="float: left;" src="tinymce/ui/img/raster.gif"></p>');
 
     editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
     editor.selection.select(editor.dom.select('img')[0]);
     editor.execCommand('JustifyCenter');
     assert.equal(
       editor.getContent(),
-      '<p><img style="margin-right: auto; margin-left: auto; display: block;" src="tinymce/ui/img/raster.gif" /></p>'
+      '<p><img style="margin-right: auto; margin-left: auto; display: block;" src="tinymce/ui/img/raster.gif"></p>'
     );
 
     editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
     editor.selection.select(editor.dom.select('img')[0]);
     editor.execCommand('JustifyRight');
-    assert.equal(editor.getContent(), '<p><img style="float: right;" src="tinymce/ui/img/raster.gif" /></p>');
+    assert.equal(editor.getContent(), '<p><img style="float: right;" src="tinymce/ui/img/raster.gif"></p>');
   });
 
   it('mceBlockQuote', () => {
@@ -266,7 +266,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p><img style="float: right;" src="about:blank" /></p>');
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'link');
-    assert.equal(editor.getContent(), '<p><a href="link"><img style="float: right;" src="about:blank" /></a></p>');
+    assert.equal(editor.getContent(), '<p><a href="link"><img style="float: right;" src="about:blank"></a></p>');
   });
 
   it('mceInsertLink (link adjacent text)', () => {

--- a/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
@@ -52,7 +52,7 @@ describe('browser.tinymce.core.MiscCommandsTest', () => {
     rng.setEnd(editor.dom.select('p')[0].firstChild, 2);
     editor.selection.setRng(rng);
     editor.execCommand('InsertHorizontalRule');
-    assert.equal(editor.getContent(), '<p>1</p><hr /><p>3</p>');
+    assert.equal(editor.getContent(), '<p>1</p><hr><p>3</p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     Assertions.assertDomEq('Nodes are not equal', SugarElement.fromDom(editor.getBody().lastChild), SugarElement.fromDom(rng.startContainer));
@@ -77,12 +77,12 @@ describe('browser.tinymce.core.MiscCommandsTest', () => {
     editor.setContent('<p>123</p>');
     LegacyUnit.setSelection(editor, 'p', 2);
     editor.execCommand('InsertLineBreak');
-    assert.equal(editor.getContent(), '<p>12<br />3</p>');
+    assert.equal(editor.getContent(), '<p>12<br>3</p>');
 
     editor.setContent('<p>123</p>');
     LegacyUnit.setSelection(editor, 'p', 0);
     editor.execCommand('InsertLineBreak');
-    assert.equal(editor.getContent(), '<p><br />123</p>');
+    assert.equal(editor.getContent(), '<p><br>123</p>');
 
     editor.setContent('<p>123</p>');
     LegacyUnit.setSelection(editor, 'p', 3);

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
@@ -66,7 +66,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.getBody(), 0);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, 'x');
-    assert.equal(editor.getContent(), '<p>x</p><hr />');
+    assert.equal(editor.getContent(), '<p>x</p><hr>');
   });
 
   it('mceInsertContent HR at end of H1', () => {
@@ -76,7 +76,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.execCommand('mceInsertContent', false, '<hr>');
     LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild);
     assert.equal(editor.selection.getNode().nodeName, 'H1');
-    assert.equal(editor.getContent(), '<h1>abc</h1><hr /><h1>\u00a0</h1>');
+    assert.equal(editor.getContent(), '<h1>abc</h1><hr><h1>\u00a0</h1>');
   });
 
   it('mceInsertContent HR at end of H1 with P sibling', () => {
@@ -86,7 +86,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.execCommand('mceInsertContent', false, '<hr>');
     LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild);
     assert.equal(editor.selection.getNode().nodeName, 'P');
-    assert.equal(editor.getContent(), '<h1>abc</h1><hr /><p>def</p>');
+    assert.equal(editor.getContent(), '<h1>abc</h1><hr><p>def</p>');
   });
 
   it('mceInsertContent HR at end of H1 with inline elements with P sibling', () => {
@@ -96,7 +96,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.execCommand('mceInsertContent', false, '<hr>');
     LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild);
     assert.equal(editor.selection.getNode().nodeName, 'P');
-    assert.equal(editor.getContent(), '<h1><strong>abc</strong></h1><hr /><p>def</p>');
+    assert.equal(editor.getContent(), '<h1><strong>abc</strong></h1><hr><p>def</p>');
   });
 
   it('mceInsertContent empty block', () => {
@@ -260,7 +260,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('p')[0].firstChild, 1);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<img src="about:blank" />');
-    assert.equal(editor.getContent(), '<p><img src="about:blank" /></p>');
+    assert.equal(editor.getContent(), '<p><img src="about:blank"></p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     assert.equal(rng.startContainer.nodeName, 'P');
@@ -294,7 +294,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('p')[0].firstChild, 2);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<hr />');
-    assert.equal(editor.getContent(), '<p>1</p><hr /><p>3</p>');
+    assert.equal(editor.getContent(), '<p>1</p><hr><p>3</p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     LegacyUnit.equalDom(rng.startContainer, editor.getBody().lastChild);

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -285,13 +285,13 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     editor.focus();
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
     InsertContent.insertAtCaret(editor, ' c ');
-    TinyAssertions.assertContent(editor, '<p>a c\u00a0<br />b</p>');
+    TinyAssertions.assertContent(editor, '<p>a c\u00a0<br>b</p>');
 
     editor.setContent('<p>a&nbsp;<br>&nbsp;b</p>');
     editor.focus();
     TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 0, 0 ], 2);
     InsertContent.insertAtCaret(editor, 'c');
-    TinyAssertions.assertContent(editor, '<p>a c<br />\u00a0b</p>');
+    TinyAssertions.assertContent(editor, '<p>a c<br>\u00a0b</p>');
   });
 
   it('TINY-5966:  insertAtCaret - html content at a text node before br', () => {
@@ -300,7 +300,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     editor.focus();
     TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 0, 0 ], 2);
     InsertContent.insertAtCaret(editor, '<em>c</em>');
-    TinyAssertions.assertContent(editor, '<p>a <em>c</em><br />\u00a0b</p>');
+    TinyAssertions.assertContent(editor, '<p>a <em>c</em><br>\u00a0b</p>');
   });
 
   it('TINY-5966:  insertAtCaret - text content at a text node after br', () => {
@@ -309,13 +309,13 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     editor.focus();
     TinySelections.setSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
     InsertContent.insertAtCaret(editor, ' c ');
-    TinyAssertions.assertContent(editor, '<p>a<br />\u00a0c b</p>');
+    TinyAssertions.assertContent(editor, '<p>a<br>\u00a0c b</p>');
 
     editor.setContent('<p>a&nbsp;<br>&nbsp;b</p>');
     editor.focus();
     TinySelections.setSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
     InsertContent.insertAtCaret(editor, 'c');
-    TinyAssertions.assertContent(editor, '<p>a\u00a0<br />c b</p>');
+    TinyAssertions.assertContent(editor, '<p>a\u00a0<br>c b</p>');
   });
 
   it('TINY-5966:  insertAtCaret - html content at a text node after br', () => {
@@ -324,7 +324,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     editor.focus();
     TinySelections.setSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
     InsertContent.insertAtCaret(editor, '<em>c</em>');
-    TinyAssertions.assertContent(editor, '<p>a\u00a0<br /><em>c</em> b</p>');
+    TinyAssertions.assertContent(editor, '<p>a\u00a0<br><em>c</em> b</p>');
   });
 
   it('TINY-5966:  insertAtCaret - text content with spaces in pre', () => {
@@ -588,10 +588,10 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
           '<tr>' +
             '<td>' +
               '<button>' +
-                '<img />' +
+                '<img>' +
               '</button>' +
               '<button></button>' +
-              '<img />' +
+              '<img>' +
             '</td>' +
           '</tr>' +
         '</tbody>' +

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteElementTest.ts
@@ -45,7 +45,7 @@ describe('browser.tinymce.core.delete.DeleteElementTest', () => {
     editor.setContent('<p><img src="#1"><img src="#2"></p>');
     TinySelections.setCursor(editor, [ 0 ], 0);
     deleteElementPath(editor, true, [ 0, 0 ]);
-    TinyAssertions.assertContent(editor, '<p><img src="#2" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#2"></p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 0);
   });
 
@@ -54,7 +54,7 @@ describe('browser.tinymce.core.delete.DeleteElementTest', () => {
     editor.setContent('<p><img src="#1"><img src="#2"></p>');
     TinySelections.setCursor(editor, [ 0 ], 1);
     deleteElementPath(editor, true, [ 0, 0 ]);
-    TinyAssertions.assertContent(editor, '<p><img src="#2" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#2"></p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 0);
   });
 
@@ -63,7 +63,7 @@ describe('browser.tinymce.core.delete.DeleteElementTest', () => {
     editor.setContent('<p><img src="#1"><img src="#2"></p>');
     TinySelections.setCursor(editor, [ 0 ], 2);
     deleteElementPath(editor, false, [ 0, 0 ]);
-    TinyAssertions.assertContent(editor, '<p><img src="#2" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#2"></p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 0);
   });
 
@@ -72,7 +72,7 @@ describe('browser.tinymce.core.delete.DeleteElementTest', () => {
     editor.setContent('<p><img src="#1"><img src="#2"></p>');
     TinySelections.setCursor(editor, [ 0 ], 1);
     deleteElementPath(editor, true, [ 0, 1 ]);
-    TinyAssertions.assertContent(editor, '<p><img src="#1" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#1"></p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 1);
   });
 
@@ -81,7 +81,7 @@ describe('browser.tinymce.core.delete.DeleteElementTest', () => {
     editor.setContent('<p><img src="#1"><img src="#2"></p>');
     TinySelections.setCursor(editor, [ 0 ], 2);
     deleteElementPath(editor, true, [ 0, 1 ]);
-    TinyAssertions.assertContent(editor, '<p><img src="#1" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#1"></p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 1);
   });
 
@@ -90,7 +90,7 @@ describe('browser.tinymce.core.delete.DeleteElementTest', () => {
     editor.setContent('<p><img src="#1"><img src="#2"></p>');
     TinySelections.setCursor(editor, [ 0 ], 1);
     deleteElementPath(editor, false, [ 0, 1 ]);
-    TinyAssertions.assertContent(editor, '<p><img src="#1" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#1"></p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 1);
   });
 
@@ -99,7 +99,7 @@ describe('browser.tinymce.core.delete.DeleteElementTest', () => {
     editor.setContent('<p><img src="#1"><img src="#2"></p>');
     TinySelections.setCursor(editor, [ 0 ], 2);
     deleteElementPath(editor, false, [ 0, 1 ]);
-    TinyAssertions.assertContent(editor, '<p><img src="#1" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#1"></p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 1);
   });
 
@@ -144,7 +144,7 @@ describe('browser.tinymce.core.delete.DeleteElementTest', () => {
     editor.setContent('<p><img src="#1" /></p><p><img src="#2" /></p>');
     TinySelections.setCursor(editor, [ 0 ], 1);
     deleteElementPath(editor, true, [ 0 ]);
-    TinyAssertions.assertContent(editor, '<p><img src="#2" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#2"></p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 0);
   });
 
@@ -153,7 +153,7 @@ describe('browser.tinymce.core.delete.DeleteElementTest', () => {
     editor.setContent('<p><img src="#1" /></p><p><img src="#2" /></p>');
     TinySelections.setCursor(editor, [ 1 ], 0);
     deleteElementPath(editor, false, [ 0 ]);
-    TinyAssertions.assertContent(editor, '<p><img src="#2" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#2"></p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 0);
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/delete/InlineBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/InlineBoundaryDeleteTest.ts
@@ -69,8 +69,8 @@ describe('browser.tinymce.core.delete.InlineBoundaryDeleteTest', () => {
   });
 
   it('Backspace key on image', () => {
-    testBackspace('<p>a<a href="#"><img src="#" /></a>c</p>', [ 0, 2 ], 0, '<p>a<a href="#"><img src="#" /></a>c</p>', 'end', [ 0, 1, 1 ], 0);
-    testBackspace('<p>a<a href="#"><img src="#" /></a>c</p>', [ 0, 1 ], 0, '<p>a<a href="#"><img src="#" /></a>c</p>', 'before', [ 0, 0 ], 1);
+    testBackspace('<p>a<a href="#"><img src="#" /></a>c</p>', [ 0, 2 ], 0, '<p>a<a href="#"><img src="#"></a>c</p>', 'end', [ 0, 1, 1 ], 0);
+    testBackspace('<p>a<a href="#"><img src="#" /></a>c</p>', [ 0, 1 ], 0, '<p>a<a href="#"><img src="#"></a>c</p>', 'before', [ 0, 0 ], 1);
     testBackspace('<p>a<a href="#"><img src="#" />c</a>d</p>', [ 0, 1 ], 1, '<p>a<a href="#">c</a>d</p>', 'start', [ 0, 1, 0 ], 1);
   });
 
@@ -81,15 +81,15 @@ describe('browser.tinymce.core.delete.InlineBoundaryDeleteTest', () => {
   });
 
   it('Delete key on image', () => {
-    testDelete('<p>a<a href="#"><img src="#" /></a>c</p>', [ 0, 0 ], 1, '<p>a<a href="#"><img src="#" /></a>c</p>', 'start', [ 0, 1, 0 ], 1);
-    testDelete('<p>a<a href="#"><img src="#" /></a>c</p>', [ 0, 1 ], 1, '<p>a<a href="#"><img src="#" /></a>c</p>', 'after', [ 0, 2 ], 1);
+    testDelete('<p>a<a href="#"><img src="#" /></a>c</p>', [ 0, 0 ], 1, '<p>a<a href="#"><img src="#"></a>c</p>', 'start', [ 0, 1, 0 ], 1);
+    testDelete('<p>a<a href="#"><img src="#" /></a>c</p>', [ 0, 1 ], 1, '<p>a<a href="#"><img src="#"></a>c</p>', 'after', [ 0, 2 ], 1);
     testDelete('<p>a<a href="#">b<img src="#" /></a>d</p>', [ 0, 1, 0 ], 1, '<p>a<a href="#">b</a>d</p>', 'end', [ 0, 1, 0 ], 1);
   });
 
   it('Backspace/delete last character', () => {
     const editor = hook.editor();
     testDelete('<p>a<a href="#">b</a>c</p>', [ 0, 1, 0 ], 0, '<p>ac</p>', 'none', [ 0, 0 ], 1);
-    testDelete('<p><img src="#1" /><a href="#">b</a><img src="#2" /></p>', [ 0, 1, 0 ], 0, '<p><img src="#1" /><img src="#2" /></p>', 'none', [ 0 ], 1);
+    testDelete('<p><img src="#1" /><a href="#">b</a><img src="#2" /></p>', [ 0, 1, 0 ], 0, '<p><img src="#1"><img src="#2"></p>', 'none', [ 0 ], 1);
     testDelete('<p>a<a href="#">b</a>c</p>', [ 0, 1, 0 ], 0, '<p>ac</p>', 'none', [ 0, 0 ], 1);
     TinyAssertions.assertContentStructure(editor, paragraphWithText('ac'));
     testBackspace('<p>a<a href="#">b</a>c</p>', [ 0, 1, 0 ], 1, '<p>ac</p>', 'none', [ 0, 0 ], 1);

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -101,7 +101,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     rng.setEnd(editor.getBody(), 1);
     editor.selection.setRng(rng);
     editor.selection.setContent('<img src="a" onerror="alert(1)" />');
-    LegacyUnit.equal(editor.getContent(), '<img src="a" />', 'Set XSS at selection');
+    LegacyUnit.equal(editor.getContent(), '<img src="a">', 'Set XSS at selection');
 
     // Set contents at selection (collapsed)
     editor.setContent('<p>text</p>');
@@ -119,7 +119,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     rng.setEnd(editor.getBody().firstChild.firstChild, 'before'.length);
     editor.selection.setRng(rng);
     editor.selection.setContent('<br />');
-    LegacyUnit.equal(editor.getContent(), '<p>before<br />after</p>', 'Set contents at selection (inside paragraph)');
+    LegacyUnit.equal(editor.getContent(), '<p>before<br>after</p>', 'Set contents at selection (inside paragraph)');
 
     // Check the caret is left in the correct position.
     rng = editor.selection.getRng();

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -29,7 +29,7 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     assert.equal(
       ser.serialize(DOM.get('test'), { getInner: true }),
       '<img title="test" class="test" src="tinymce/ui/img/raster.gif" ' +
-      'alt="test" border="0" /><span id="test2">test</span><hr />', 'Global rule'
+      'alt="test" border="0"><span id="test2">test</span><hr>', 'Global rule'
     );
 
     ser.setRules('*a[*],em/i[*],strong/b[*i*]');
@@ -42,19 +42,19 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
       '<span id="test2" class="no"><b class="no">abc</b><em class="no">123</em></span>123<a href="file.html" ' +
       'data-mce-href="file.html">link</a><a name="anchor"></a><a>no</a><img src="tinymce/ui/img/raster.gif" ' +
       'data-mce-src="tinymce/ui/img/raster.gif" />');
-    assert.equal(ser.serialize(DOM.get('test')), '<div id="test"><br /><hr /><input type="text" name="test" value="val" />' +
+    assert.equal(ser.serialize(DOM.get('test')), '<div id="test"><br><hr><input type="text" name="test" value="val">' +
       '<span id="test2"><strong>abc</strong><em>123</em></span>123<a href="file.html">link</a>' +
-      '<a name="anchor"></a>no<img src="tinymce/ui/img/raster.gif" border="0" title="mce_0" /></div>', 'Output name and attribute rules');
+      '<a name="anchor"></a>no<img src="tinymce/ui/img/raster.gif" border="0" title="mce_0"></div>', 'Output name and attribute rules');
 
     ser.setRules('img[src|border=0|alt=]');
     DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" border="0" alt="" />');
-    assert.equal(ser.serialize(DOM.get('test')), '<img src="tinymce/ui/img/raster.gif" border="0" alt="" />', 'Default attribute with empty value');
+    assert.equal(ser.serialize(DOM.get('test')), '<img src="tinymce/ui/img/raster.gif" border="0" alt="">', 'Default attribute with empty value');
 
     ser.setRules('img[src|border=0|alt=],div[style|id],*[*]');
     DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" /><hr />');
     assert.equal(
       ser.serialize(DOM.get('test'), { getInner: true }),
-      '<img src="tinymce/ui/img/raster.gif" border="0" alt="" /><hr />'
+      '<img src="tinymce/ui/img/raster.gif" border="0" alt=""><hr>'
     );
 
     ser = DomSerializer({
@@ -64,14 +64,14 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" alt="" />');
     assert.equal(
       ser.serialize(DOM.get('test')),
-      '<div id="test"><img src="tinymce/ui/img/raster.gif" alt="" /></div>'
+      '<div id="test"><img src="tinymce/ui/img/raster.gif" alt=""></div>'
     );
 
     ser = DomSerializer({ invalid_elements: 'hr,br' });
     DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" /><hr /><br />');
     assert.equal(
       ser.serialize(DOM.get('test'), { getInner: true }),
-      '<img src="tinymce/ui/img/raster.gif" />'
+      '<img src="tinymce/ui/img/raster.gif">'
     );
   });
 
@@ -158,13 +158,13 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     );
 
     DOM.setHTML('test', '<input type="text" />');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="text" />');
+    assert.equal(ser.serialize(DOM.get('test')), '<input type="text">');
 
     DOM.setHTML('test', '<input type="text" value="text" length="128" maxlength="129" />');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="text" value="text" length="128" maxlength="129" />');
+    assert.equal(ser.serialize(DOM.get('test')), '<input type="text" value="text" length="128" maxlength="129">');
 
     DOM.setHTML('test', '<form method="post"><input type="hidden" name="formmethod" value="get" /></form>');
-    assert.equal(ser.serialize(DOM.get('test')), '<form method="post"><input type="hidden" name="formmethod" value="get" /></form>');
+    assert.equal(ser.serialize(DOM.get('test')), '<form method="post"><input type="hidden" name="formmethod" value="get"></form>');
 
     DOM.setHTML('test', '<label for="test">label</label>');
     assert.equal(ser.serialize(DOM.get('test')), '<label for="test">label</label>');
@@ -174,7 +174,7 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     // Edge will add an empty input value so remove that to normalize test since it doesn't break anything
     assert.equal(
       ser.serialize(DOM.get('test')).replace(/ value=""/g, ''),
-      '<input type="checkbox" value="test" /><input type="button" /><textarea></textarea>'
+      '<input type="checkbox" value="test"><input type="button"><textarea></textarea>'
     );
   });
 
@@ -184,16 +184,16 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     ser.setRules('form[method],label[for],input[type|name|value|checked|disabled|readonly|length|maxlength],select[multiple],option[value|selected]');
 
     DOM.setHTML('test', '<input type="checkbox" value="1">');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" />');
+    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1">');
 
     DOM.setHTML('test', '<input type="checkbox" value="1" checked disabled readonly>');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly" />');
+    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly">');
 
     DOM.setHTML('test', '<input type="checkbox" value="1" checked="1" disabled="1" readonly="1">');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly" />');
+    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly">');
 
     DOM.setHTML('test', '<input type="checkbox" value="1" checked="true" disabled="true" readonly="true">');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly" />');
+    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly">');
   });
 
   it('Form elements (select)', () => {
@@ -308,9 +308,9 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     ser.setRules('#p,table,tr,#td,br');
 
     DOM.setHTML('test', '<p>a</p><p></p>');
-    assert.equal(ser.serialize(DOM.get('test')), '<p>a</p><p><br /></p>');
+    assert.equal(ser.serialize(DOM.get('test')), '<p>a</p><p><br></p>');
     DOM.setHTML('test', '<p>a</p><table><tr><td><br></td></tr></table>');
-    assert.equal(ser.serialize(DOM.get('test')), '<p>a</p><table><tr><td><br /></td></tr></table>');
+    assert.equal(ser.serialize(DOM.get('test')), '<p>a</p><table><tr><td><br></td></tr></table>');
   });
 
   it('Do not padd empty elements with padded children', () => {
@@ -669,7 +669,7 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     );
     assert.equal(
       ser.serialize(DOM.get('test')).toLowerCase(),
-      '<map id="planetmap" name="planetmap"><area shape="rect" coords="0,0,82,126" href="sun.htm" target="_blank" alt="sun" /></map>'
+      '<map id="planetmap" name="planetmap"><area shape="rect" coords="0,0,82,126" href="sun.htm" target="_blank" alt="sun"></map>'
     );
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/HooksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/HooksTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.core.fmt.HooksTest', () => {
     assertPreHook(
       '<pre>a</pre><pre>b</pre>',
       [ 'pre:nth-child(1)', 0, 'pre:nth-child(2)', 1 ],
-      '<pre>a<br /><br />b</pre>'
+      '<pre>a<br><br>b</pre>'
     );
 
     assertPreHook(
@@ -44,7 +44,7 @@ describe('browser.tinymce.core.fmt.HooksTest', () => {
     assertPreHook(
       '<pre>a</pre><pre>b</pre><pre>c</pre>',
       [ 'pre:nth-child(1)', 0, 'pre:nth-child(3)', 1 ],
-      '<pre>a<br /><br />b<br /><br />c</pre>'
+      '<pre>a<br><br>b<br><br>c</pre>'
     );
 
     assertPreHook(
@@ -62,7 +62,7 @@ describe('browser.tinymce.core.fmt.HooksTest', () => {
     assertPreHook(
       '<pre>a</pre><pre>b</pre><p>c</p><pre>d</pre><pre>e</pre>',
       [ 'pre:nth-child(1)', 0, 'pre:nth-child(5)', 1 ],
-      '<pre>a<br /><br />b</pre><p>c</p><pre>d<br /><br />e</pre>'
+      '<pre>a<br><br>b</pre><p>c</p><pre>d<br><br>e</pre>'
     );
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
@@ -41,8 +41,8 @@ describe('browser.tinymce.core.fmt.MediaAlignTest', () => {
   };
 
   Arr.each([
-    { type: 'video', content: '<p><video controls="controls"><source src="custom/video.mp4" /></video></p>' },
-    { type: 'audio', content: '<p><audio controls="controls"><source src="custom/audio.mp3" /></audio></p>' },
+    { type: 'video', content: '<p><video controls="controls"><source src="custom/video.mp4"></video></p>' },
+    { type: 'audio', content: '<p><audio controls="controls"><source src="custom/audio.mp3"></audio></p>' },
   ], (test) => {
     const { type, content } = test;
 

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -90,7 +90,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     );
     assert.equal(
       serializer.serialize(root),
-      '<div><img src="file.gif" data-mce-src="file.gif" /></div>',
+      '<div><img src="file.gif" data-mce-src="file.gif"></div>',
       'Whitespace where SaxParser will produce multiple whitespace nodes'
     );
     assert.deepEqual(
@@ -396,7 +396,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     root = parser.parse('<span></span><a href="#"><img src="about:blank" /></a>');
     assert.equal(
       serializer.serialize(root),
-      '<span></span><a href="#"><img src="about:blank" /></a>',
+      '<span></span><a href="#"><img src="about:blank"></a>',
       'Leave elements with img in it'
     );
   });
@@ -425,7 +425,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     );
     assert.equal(
       serializer.serialize(root),
-      '<p>a</p><p>a<br />b</p><p>a<br /><br /></p><p>a<br /><br /></p><p>a</p>',
+      '<p>a</p><p>a<br>b</p><p>a<br><br></p><p>a<br><br></p><p>a</p>',
       'Remove traling br elements.'
     );
   });
@@ -451,7 +451,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ remove_trailing_brs: true }, schema);
     const root = parser.parse('<strong><br /><br /></strong>');
-    assert.equal(serializer.serialize(root), '<strong><br /><br /></strong>');
+    assert.equal(serializer.serialize(root), '<strong><br><br></strong>');
   });
 
   it(`Don't replace br inside root element when there is siblings`, () => {
@@ -459,7 +459,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ remove_trailing_brs: true }, schema);
     const root = parser.parse('<strong><br /></strong><em>x</em>');
-    assert.equal(serializer.serialize(root), '<strong><br /></strong><em>x</em>');
+    assert.equal(serializer.serialize(root), '<strong><br></strong><em>x</em>');
   });
 
   it('Remove br in invalid parent bug', () => {
@@ -623,15 +623,15 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const parser = DomParser({ padd_empty_with_br: true }, schema);
     const serializer = HtmlSerializer({ }, schema);
     const root = parser.parse('<p>a</p><p></p>');
-    assert.equal(serializer.serialize(root), '<p>a</p><p><br /></p>');
+    assert.equal(serializer.serialize(root), '<p>a</p><p><br></p>');
   });
 
-  it('Pad empty and preffer br on insert', () => {
+  it('Pad empty and prefer br on insert', () => {
     const schema = Schema();
 
     const parser = DomParser({}, schema);
     const root = parser.parse('<ul><li></li><li> </li><li><br /></li><li>\u00a0</li><li>a</li></ul>', { insert: true });
-    assert.equal(serializer.serialize(root), '<ul><li><br /></li><li><br /></li><li><br /></li><li><br /></li><li>a</li></ul>');
+    assert.equal(serializer.serialize(root), '<ul><li><br></li><li><br></li><li><br></li><li><br></li><li>a</li></ul>');
   });
 
   it('Preserve space in inline span', () => {
@@ -669,7 +669,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     assert.equal(
       serializer.serialize(DomParser().parse('<p>a<br />\nb</p>')),
-      '<p>a<br />b</p>'
+      '<p>a<br>b</p>'
     );
   });
 
@@ -678,7 +678,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     assert.equal(
       serializer.serialize(DomParser().parse('<iframe><textarea></iframe><img src="a" onerror="alert(document.domain)" />')),
-      '<iframe><textarea></iframe><img src="a" />'
+      '<iframe><textarea></iframe><img src="a">'
     );
   });
 
@@ -708,7 +708,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     assert.equal(
       serializedHtml,
-      `<p><img src="${blobUri}" /></p>`,
+      `<p><img src="${blobUri}"></p>`,
       'Should be html with blob uri'
     );
 
@@ -759,7 +759,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
   it('do not extract base64 uris if blob cache is not provided', () => {
     const parser = DomParser();
-    const html = '<p><img src="data:image/gif;base64,R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==" /></p>';
+    const html = '<p><img src="data:image/gif;base64,R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw=="></p>';
     const serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml, html, 'Should be html with base64 uri retained');
@@ -804,11 +804,11 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
           '<tr>' +
             '<td>' +
               '<button>' +
-                '<img />' +
+                '<img>' +
                 '<button>' +
                   '<a></a>' +
                 '</button>' +
-                '<img />' +
+                '<img>' +
               '</button>' +
             '</td>' +
           '</tr>' +

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -148,21 +148,21 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
     parser = SaxParser(counter, schema);
     writer.reset();
     parser.parse('<img src="test">');
-    assert.equal(writer.getContent(), '<img src="test" />', 'Parse empty element.');
+    assert.equal(writer.getContent(), '<img src="test">', 'Parse empty element.');
     assert.deepEqual(counter.counts, { start: 1 }, 'Parse empty element counts.');
 
     counter = createCounter(writer);
     parser = SaxParser(counter, schema);
     writer.reset();
     parser.parse('<img\nsrc="test"\ntitle="row1\nrow2">');
-    assert.equal(writer.getContent(), '<img src="test" title="row1\nrow2" />', 'Parse attributes with linebreak.');
+    assert.equal(writer.getContent(), '<img src="test" title="row1\nrow2">', 'Parse attributes with linebreak.');
     assert.deepEqual(counter.counts, { start: 1 }, 'Parse attributes with linebreak counts.');
 
     counter = createCounter(writer);
     parser = SaxParser(counter, schema);
     writer.reset();
     parser.parse('<img     \t  \t   src="test"     \t  \t   title="\t    row1\t     row2">');
-    assert.equal(writer.getContent(), '<img src="test" title="\t    row1\t     row2" />', 'Parse attributes with whitespace.');
+    assert.equal(writer.getContent(), '<img src="test" title="\t    row1\t     row2">', 'Parse attributes with whitespace.');
     assert.deepEqual(counter.counts, { start: 1 }, 'Parse attributes with whitespace counts.');
 
     counter = createCounter(writer);
@@ -268,7 +268,7 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
     parser = SaxParser(counter, schema);
     writer.reset();
     parser.parse('<br><br /><br/>');
-    assert.equal(writer.getContent(), '<br /><br /><br />', 'Parse short ended elements.');
+    assert.equal(writer.getContent(), '<br><br><br>', 'Parse short ended elements.');
     assert.deepEqual(counter.counts, { start: 3 }, 'Parse short ended elements counts.');
 
     counter = createCounter(writer);
@@ -786,7 +786,7 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
     assert.equal(
       writer.getContent(),
       '<a>1</a>' +
-      '<img />'
+      '<img>'
     );
   });
 
@@ -833,7 +833,7 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
       '<table><tr></tr><tr>13</tr></table>' +
       '<a>14</a>' +
       '<a>15</a>' +
-      '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />' +
+      '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
       '<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>'
     );
   });
@@ -855,7 +855,7 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
       '<iframe></iframe>' +
       '<a>1</a>' +
       '<object></object>' +
-      '<img src="data:image/svg+xml;base64,x" />' +
+      '<img src="data:image/svg+xml;base64,x">' +
       '<video poster="data:image/svg+xml;base64,x"></video>'
     );
   });
@@ -878,7 +878,7 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
       '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
       '<a href="data:image/svg+xml;base64,x">1</a>' +
       '<object data="data:image/svg+xml;base64,x"></object>' +
-      '<img src="data:image/svg+xml;base64,x" />' +
+      '<img src="data:image/svg+xml;base64,x">' +
       '<video poster="data:image/svg+xml;base64,x"></video>'
     );
   });
@@ -901,7 +901,7 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
       '<iframe></iframe>' +
       '<a>1</a>' +
       '<object></object>' +
-      '<img />' +
+      '<img>' +
       '<video></video>'
     );
   });
@@ -1099,8 +1099,8 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
     );
     assert.equal(writer.getContent(),
       'a' +
-      '<img src="data:image/gif;base64,R0/yw==" />' +
-      '<img src="data:image/jpeg;base64,R1/yw==" />' +
+      '<img src="data:image/gif;base64,R0/yw==">' +
+      '<img src="data:image/jpeg;base64,R1/yw==">' +
       '<div style="background-image: url(\'data:image/png;base64,R2/yw==\')">b</div>' +
       '<!-- <img src="data:image/jpeg;base64,R1/yw==" /> -->' +
       'c'
@@ -1139,9 +1139,9 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
       '</form>'
     );
     assert.equal(writer.getContent(),
-      '<img src="x" />' +
+      '<img src="x">' +
       '<form>' +
-        '<input />' +
+        '<input>' +
         '<output></output>' +
         '<button></button>' +
         '<select></select>' +

--- a/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
@@ -12,7 +12,7 @@ describe('browser.tinymce.core.html.SerializerTest', () => {
     assert.equal(serializer.serialize(DomParser().parse('text<text&')), 'text&lt;text&amp;');
     assert.equal(
       serializer.serialize(DomParser().parse('<B>text</B><IMG src="1.gif">')),
-      '<strong>text</strong><img src="1.gif" />'
+      '<strong>text</strong><img src="1.gif">'
     );
     assert.equal(serializer.serialize(DomParser().parse('<!-- comment -->')), '<!-- comment -->');
     assert.equal(serializer.serialize(DomParser().parse('<![CDATA[cdata]]>', { format: 'xml' })), '<![CDATA[cdata]]>');

--- a/modules/tinymce/src/core/test/ts/browser/html/WriterTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/WriterTest.ts
@@ -97,11 +97,11 @@ describe('browser.tinymce.core.html.WriterTest', () => {
 
     writer = Writer();
     writer.start('img', [{ name: 'attr1', value: 'value1' }, { name: 'attr2', value: 'value2' }], true);
-    assert.equal(writer.getContent(), '<img attr1="value1" attr2="value2" />');
+    assert.equal(writer.getContent(), '<img attr1="value1" attr2="value2">');
 
     writer = Writer();
     writer.start('br', null, true);
-    assert.equal(writer.getContent(), '<br />');
+    assert.equal(writer.getContent(), '<br>');
   });
 
   it('End', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointBrModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointBrModeTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointBrModeTest', () 
       editor.setContent('<figure><figcaption>a</figcaption></figure>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
       TinyContentActions.keystroke(editor, Keys.up());
-      TinyAssertions.assertContent(editor, '<br /><figure><figcaption>a</figcaption></figure>');
+      TinyAssertions.assertContent(editor, '<br><figure><figcaption>a</figcaption></figure>');
       TinyAssertions.assertSelection(editor, [], 0, [], 0);
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
@@ -53,7 +53,7 @@ describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointTest', () => {
       editor.setContent('<figure><figcaption>a<br />b</figcaption></figure>');
       TinySelections.setCursor(editor, [ 0, 0, 2 ], 0);
       TinyContentActions.keystroke(editor, Keys.up());
-      TinyAssertions.assertContent(editor, '<figure><figcaption>a<br />b</figcaption></figure>');
+      TinyAssertions.assertContent(editor, '<figure><figcaption>a<br>b</figcaption></figure>');
       TinyAssertions.assertSelection(editor, [ 0, 0, 2 ], 0, [ 0, 0, 2 ], 0);
     });
 
@@ -62,7 +62,7 @@ describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointTest', () => {
       editor.setContent('<figure><figcaption>a<br />b</figcaption></figure>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
       TinyContentActions.keystroke(editor, Keys.down());
-      TinyAssertions.assertContent(editor, '<figure><figcaption>a<br />b</figcaption></figure>');
+      TinyAssertions.assertContent(editor, '<figure><figcaption>a<br>b</figcaption></figure>');
       TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
@@ -15,7 +15,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     editor.setContent('<hr /><p>a</p>');
     TinySelections.setCursor(editor, [], 0);
     TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><hr /><p>a</p>');
+    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><hr><p>a</p>');
     TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 0);
   });
 
@@ -24,7 +24,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     editor.setContent('<hr /><p>a</p>');
     TinySelections.setCursor(editor, [], 1);
     TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContent(editor, '<hr /><p>&nbsp;</p><p>a</p>');
+    TinyAssertions.assertContent(editor, '<hr><p>&nbsp;</p><p>a</p>');
     TinyAssertions.assertSelection(editor, [ 2, 0 ], 0, [ 2, 0 ], 0);
   });
 
@@ -33,7 +33,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     editor.setContent('<p>a</p><hr /><p>b</p>');
     TinySelections.setCursor(editor, [], 1);
     TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContent(editor, '<p>a</p><p>&nbsp;</p><hr /><p>b</p>');
+    TinyAssertions.assertContent(editor, '<p>a</p><p>&nbsp;</p><hr><p>b</p>');
     TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
   });
 
@@ -42,7 +42,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     editor.setContent('<p>a</p><hr /><p>b</p>');
     TinySelections.setCursor(editor, [], 2);
     TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContent(editor, '<p>a</p><hr /><p>&nbsp;</p><p>b</p>');
+    TinyAssertions.assertContent(editor, '<p>a</p><hr><p>&nbsp;</p><p>b</p>');
     TinyAssertions.assertSelection(editor, [ 3, 0 ], 0, [ 3, 0 ], 0);
   });
 
@@ -51,7 +51,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     editor.setContent('<p>a</p><hr />');
     TinySelections.setCursor(editor, [], 1);
     TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContent(editor, '<p>a</p><p>&nbsp;</p><hr />');
+    TinyAssertions.assertContent(editor, '<p>a</p><p>&nbsp;</p><hr>');
     TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
   });
 
@@ -60,7 +60,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     editor.setContent('<p>a</p><hr />');
     TinySelections.setCursor(editor, [], 2);
     TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContent(editor, '<p>a</p><hr /><p>&nbsp;</p>');
+    TinyAssertions.assertContent(editor, '<p>a</p><hr><p>&nbsp;</p>');
     TinyAssertions.assertSelection(editor, [ 2 ], 0, [ 2 ], 0);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyInlineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyInlineTest.ts
@@ -16,7 +16,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyInlineTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0 ], 1);
     TinyContentActions.keystroke(editor, Keys.enter(), { shift: true });
-    TinyAssertions.assertContent(editor, 'a<br />b');
+    TinyAssertions.assertContent(editor, 'a<br>b');
     McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
@@ -449,7 +449,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<ol><li><p><br />abcd</p></li></ol>');
+    assert.equal(editor.getContent(), '<ol><li><p><br>abcd</p></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -458,7 +458,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 2);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<ol><li><p>ab<br />cd</p></li></ol>');
+    assert.equal(editor.getContent(), '<ol><li><p>ab<br>cd</p></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -469,7 +469,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     pressEnter(editor, { shiftKey: true });
     assert.equal(
       editor.getContent(),
-      '<ol><li><p>abcd<br /><br /></p></li></ol>'
+      '<ol><li><p>abcd<br><br></p></li></ol>'
     );
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
@@ -507,7 +507,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ul><li>text</li></ul>';
     LegacyUnit.setSelection(editor, 'li', 2);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<ul><li>te<br />xt</li></ul>');
+    assert.equal(editor.getContent(), '<ul><li>te<br>xt</li></ul>');
     editor.options.set('forced_root_block', 'p');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
@@ -7,7 +7,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 
 import * as HtmlUtils from '../../module/test/HtmlUtils';
 
-describe('browser.tinymce.core.keyboard.EnterKey', () => {
+describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     disable_nodechange: true,
@@ -63,7 +63,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.setContent('<p><img src="about:blank" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild, 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p><img src="about:blank" /></p>');
+    assert.equal(editor.getContent(), '<p>\u00a0</p><p><img src="about:blank"></p>');
   });
 
   it('Enter before first wrapped IMG in P', () => {
@@ -72,7 +72,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.selection.setCursorLocation(editor.getBody().firstChild.firstChild, 0);
     pressEnter(editor);
     assert.equal((editor.getBody().firstChild as HTMLElement).innerHTML, '<br data-mce-bogus="1">');
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p><b><img src="about:blank" /></b></p>');
+    assert.equal(editor.getContent(), '<p>\u00a0</p><p><b><img src="about:blank"></b></p>');
   });
 
   it('Enter before last IMG in P with text', () => {
@@ -80,7 +80,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.setContent('<p>abc<img src="about:blank" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild, 1);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p>abc</p><p><img src="about:blank" /></p>');
+    assert.equal(editor.getContent(), '<p>abc</p><p><img src="about:blank"></p>');
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startContainer.childNodes[rng.startOffset].nodeName, 'IMG');
@@ -91,7 +91,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.setContent('<p><img src="about:blank" /><img src="about:blank" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild, 1);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p><img src="about:blank" /></p><p><img src="about:blank" /></p>');
+    assert.equal(editor.getContent(), '<p><img src="about:blank"></p><p><img src="about:blank"></p>');
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startContainer.childNodes[rng.startOffset].nodeName, 'IMG');
@@ -102,7 +102,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.setContent('<p>abc<img src="about:blank" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild, 2);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p>abc<img src="about:blank" /></p><p>\u00a0</p>');
+    assert.equal(editor.getContent(), '<p>abc<img src="about:blank"></p><p>\u00a0</p>');
   });
 
   it('Enter before last INPUT in P with text', () => {
@@ -110,7 +110,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.setContent('<p>abc<input type="text" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild, 1);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p>abc</p><p><input type="text" /></p>');
+    assert.equal(editor.getContent(), '<p>abc</p><p><input type="text"></p>');
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startContainer.childNodes[rng.startOffset].nodeName, 'INPUT');
@@ -121,7 +121,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.setContent('<p><input type="text" /><input type="text" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild, 1);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p><input type="text" /></p><p><input type="text" /></p>');
+    assert.equal(editor.getContent(), '<p><input type="text"></p><p><input type="text"></p>');
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startContainer.childNodes[rng.startOffset].nodeName, 'INPUT');
@@ -132,7 +132,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.setContent('<p>abc<input type="text" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild, 2);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p>abc<input type="text" /></p><p>\u00a0</p>');
+    assert.equal(editor.getContent(), '<p>abc<input type="text"></p><p>\u00a0</p>');
   });
 
   it('Enter at end of P', () => {
@@ -321,7 +321,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<p>abc</p>';
     LegacyUnit.setSelection(editor, 'p', 2);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p>ab<br />c</p>');
+    assert.equal(editor.getContent(), '<p>ab<br>c</p>');
   });
 
   it('Enter at the end of text in P with forced_root_block set to false', () => {
@@ -426,7 +426,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<p>abc</p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p><br />abc</p>');
+    assert.equal(editor.getContent(), '<p><br>abc</p>');
   });
 
   it('Shift+Enter in the middle of P', () => {
@@ -434,7 +434,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<p>abcd</p>';
     LegacyUnit.setSelection(editor, 'p', 2);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p>ab<br />cd</p>');
+    assert.equal(editor.getContent(), '<p>ab<br>cd</p>');
   });
 
   it('Shift+Enter at the end of P', () => {
@@ -442,7 +442,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<p>abcd</p>';
     LegacyUnit.setSelection(editor, 'p', 4);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p>abcd<br /><br /></p>');
+    assert.equal(editor.getContent(), '<p>abcd<br><br></p>');
   });
 
   it('Shift+Enter in the middle of B with a BR after it', () => {
@@ -450,7 +450,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<p><b>abcd</b><br></p>';
     LegacyUnit.setSelection(editor, 'b', 2);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p><b>ab<br />cd</b></p>');
+    assert.equal(editor.getContent(), '<p><b>ab<br>cd</b></p>');
   });
 
   it('Shift+Enter at the end of B with a BR after it', () => {
@@ -458,7 +458,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<p><b>abcd</b><br></p>';
     LegacyUnit.setSelection(editor, 'b', 4);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p><b>abcd<br /></b></p>');
+    assert.equal(editor.getContent(), '<p><b>abcd<br></b></p>');
   });
 
   it('Enter in beginning of PRE', () => {
@@ -466,7 +466,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<pre>abc</pre>';
     LegacyUnit.setSelection(editor, 'pre', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<pre><br />abc</pre>');
+    assert.equal(editor.getContent(), '<pre><br>abc</pre>');
   });
 
   it('Enter in the middle of PRE', () => {
@@ -474,7 +474,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<pre>abcd</pre>';
     LegacyUnit.setSelection(editor, 'pre', 2);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<pre>ab<br />cd</pre>');
+    assert.equal(editor.getContent(), '<pre>ab<br>cd</pre>');
   });
 
   it('Enter at the end of PRE', () => {
@@ -482,7 +482,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<pre>abcd</pre>';
     LegacyUnit.setSelection(editor, 'pre', 4);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<pre>abcd<br /><br /></pre>');
+    assert.equal(editor.getContent(), '<pre>abcd<br><br></pre>');
   });
 
   it('Enter in beginning of PRE and br_in_pre: false', () => {
@@ -617,7 +617,7 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<p>a<br>b</p>';
     LegacyUnit.setSelection(editor, 'p', 1);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p>a</p><p><br />b</p>');
+    assert.equal(editor.getContent(), '<p>a</p><p><br>b</p>');
 
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
@@ -743,6 +743,6 @@ describe('browser.tinymce.core.keyboard.EnterKey', () => {
     editor.getBody().innerHTML = '<details><summary>ab</summary></details>';
     LegacyUnit.setSelection(editor, 'summary', 1);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<details><summary>a<br />b</summary></details>');
+    assert.equal(editor.getContent(), '<details><summary>a<br>b</summary></details>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysBrModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysBrModeTest.ts
@@ -62,7 +62,7 @@ describe('browser.tinymce.core.keyboard.InsertKeysBrModeTest', () => {
         TinySelections.setCursor(editor, [ 2 ], 0);
         fireInsert(editor);
         TinyAssertions.assertSelection(editor, [ 2 ], 0, [ 2 ], 0);
-        TinyAssertions.assertContent(editor, 'a<br />&nbsp;b');
+        TinyAssertions.assertContent(editor, 'a<br>&nbsp;b');
       });
 
       it('Insert at beginning of text node with leading nbsp within inline element followed by br', () => {
@@ -71,7 +71,7 @@ describe('browser.tinymce.core.keyboard.InsertKeysBrModeTest', () => {
         TinySelections.setCursor(editor, [ 2, 0 ], 0);
         fireInsert(editor);
         TinyAssertions.assertSelection(editor, [ 2, 0 ], 0, [ 2, 0 ], 0);
-        TinyAssertions.assertContent(editor, 'a<br /><em>&nbsp;b</em>');
+        TinyAssertions.assertContent(editor, 'a<br><em>&nbsp;b</em>');
       });
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InsertKeysTest.ts
@@ -74,7 +74,7 @@ describe('browser.tinymce.core.keyboard.InsertKeysTest', () => {
         TinySelections.setCursor(editor, [ 0, 2 ], 0);
         fireInsert(editor);
         TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
-        TinyAssertions.assertContent(editor, '<p>a<br />&nbsp;b</p>');
+        TinyAssertions.assertContent(editor, '<p>a<br>&nbsp;b</p>');
       });
 
       it('Insert at beginning of text node with leading nbsp within inline element followed by br', () => {
@@ -83,7 +83,7 @@ describe('browser.tinymce.core.keyboard.InsertKeysTest', () => {
         TinySelections.setCursor(editor, [ 0, 2, 0 ], 0);
         fireInsert(editor);
         TinyAssertions.assertSelection(editor, [ 0, 2, 0 ], 0, [ 0, 2, 0 ], 0);
-        TinyAssertions.assertContent(editor, '<p>a<br /><em>&nbsp;b</em></p>');
+        TinyAssertions.assertContent(editor, '<p>a<br><em>&nbsp;b</em></p>');
       });
     });
 
@@ -181,7 +181,7 @@ describe('browser.tinymce.core.keyboard.InsertKeysTest', () => {
         TinySelections.setCursor(editor, [ 0, 0 ], 1);
         fireInsert(editor);
         TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
-        TinyAssertions.assertContent(editor, '<p>&nbsp;<img src="about:blank" /></p>');
+        TinyAssertions.assertContent(editor, '<p>&nbsp;<img src="about:blank"></p>');
       });
 
       it('Insert nbsp between two images should remove nbsp', () => {
@@ -190,7 +190,7 @@ describe('browser.tinymce.core.keyboard.InsertKeysTest', () => {
         TinySelections.setCursor(editor, [ 0, 1 ], 1);
         fireInsert(editor);
         TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);
-        TinyAssertions.assertContent(editor, '<p><img src="about:blank" /> <img src="about:blank" /></p>');
+        TinyAssertions.assertContent(editor, '<p><img src="about:blank"> <img src="about:blank"></p>');
       });
 
       it('Insert nbsp after an image at the end of a block should not remove the nbsp', () => {
@@ -199,7 +199,7 @@ describe('browser.tinymce.core.keyboard.InsertKeysTest', () => {
         TinySelections.setCursor(editor, [ 0, 1 ], 1);
         fireInsert(editor);
         TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);
-        TinyAssertions.assertContent(editor, '<p><img src="about:blank" />&nbsp;</p>');
+        TinyAssertions.assertContent(editor, '<p><img src="about:blank">&nbsp;</p>');
       });
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/MediaNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/MediaNavigationTest.ts
@@ -27,10 +27,10 @@ describe('browser.tinymce.core.keyboard.MediaNavigationTest', () => {
   };
 
   Arr.each([
-    { type: 'video', content: '<video controls="controls"><source src="custom/video.mp4" /></video>', skip: false },
-    { type: 'audio', content: '<audio controls="controls"><source src="custom/audio.mp3" /></audio>', skip: false },
+    { type: 'video', content: '<video controls="controls"><source src="custom/video.mp4"></video>', skip: false },
+    { type: 'audio', content: '<audio controls="controls"><source src="custom/audio.mp3"></audio>', skip: false },
     // Firefox won't render without a valid embed/object, so skip
-    { type: 'embed', content: '<embed src="custom/video.mp4" />', skip: Env.browser.isFirefox() },
+    { type: 'embed', content: '<embed src="custom/video.mp4">', skip: Env.browser.isFirefox() },
     // TINY-7871: Safari 14.1 also appears to have a bug that causes it to freeze without a valid object
     { type: 'object', content: '<object data="custom/file.pdf"></object>', skip: Env.browser.isFirefox() || Env.browser.isSafari() }
   ], (test) => {

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.nodeChanged();
       InsertBr.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 2, 0 ], 1, [ 0, 2, 0 ], 1);
-      TinyAssertions.assertContent(editor, '<p>a<br /><a href="#">b</a>c</p>');
+      TinyAssertions.assertContent(editor, '<p>a<br><a href="#">b</a>c</p>');
     });
 
     it('Insert br in middle inline boundary link', () => {
@@ -36,7 +36,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.nodeChanged();
       InsertBr.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
-      TinyAssertions.assertContent(editor, '<p>a<a href="#">b<br />c</a>d</p>');
+      TinyAssertions.assertContent(editor, '<p>a<a href="#">b<br>c</a>d</p>');
     });
 
     it('Insert br at end of inline boundary link', () => {
@@ -46,7 +46,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.nodeChanged();
       InsertBr.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0 ], 3, [ 0 ], 3);
-      TinyAssertions.assertContent(editor, '<p>a<a href="#">b</a><br /><br />c</p>');
+      TinyAssertions.assertContent(editor, '<p>a<a href="#">b</a><br><br>c</p>');
     });
 
     it('Insert br at end of inline boundary link with trailing br', () => {
@@ -56,7 +56,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.nodeChanged();
       InsertBr.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0 ], 3, [ 0 ], 3);
-      TinyAssertions.assertContent(editor, '<p>a<a href="#">b</a><br /><br /></p>');
+      TinyAssertions.assertContent(editor, '<p>a<a href="#">b</a><br><br></p>');
     });
   });
 
@@ -68,7 +68,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.nodeChanged();
       InsertBr.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
-      TinyAssertions.assertContent(editor, '<p>a<code><br />b</code>c</p>');
+      TinyAssertions.assertContent(editor, '<p>a<code><br>b</code>c</p>');
     });
 
     it('Insert br at middle of boundary code', () => {
@@ -78,7 +78,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.nodeChanged();
       InsertBr.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
-      TinyAssertions.assertContent(editor, '<p>a<code>b<br />c</code>d</p>');
+      TinyAssertions.assertContent(editor, '<p>a<code>b<br>c</code>d</p>');
     });
 
     it('Insert br at end of boundary code', () => {
@@ -88,7 +88,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.nodeChanged();
       InsertBr.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 1, 2 ], 0, [ 0, 1, 2 ], 0);
-      TinyAssertions.assertContent(editor, '<p>a<code>b<br /></code>c</p>');
+      TinyAssertions.assertContent(editor, '<p>a<code>b<br></code>c</p>');
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as InsertNewLine from 'tinymce/core/newline/InsertNewLine';
 
-describe('browser.tinymce.core.newline.InsertNewLine', () => {
+describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
@@ -95,7 +95,7 @@ describe('browser.tinymce.core.newline.InsertNewLine', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
       insertNewline(editor, { });
       editor.nodeChanged();
-      TinyAssertions.assertContent(editor, '<p>a<br />b</p>');
+      TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
     });
 
     it('Insert newline where br is forced (div)', () => {
@@ -104,7 +104,7 @@ describe('browser.tinymce.core.newline.InsertNewLine', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
       insertNewline(editor, { });
       editor.nodeChanged();
-      TinyAssertions.assertContent(editor, '<div class="test">a<br />b</div>');
+      TinyAssertions.assertContent(editor, '<div class="test">a<br>b</div>');
     });
 
     it('Insert newline where br is not forced', () => {
@@ -159,7 +159,7 @@ describe('browser.tinymce.core.newline.InsertNewLine', () => {
     editor.setContent('<p><a href="#">a<img src="about:blank" /></a></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
     insertNewline(editor, { });
-    TinyAssertions.assertContent(editor, '<p><a href="#">a</a></p><p><a href="#"><img src="about:blank" /></a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="#">a</a></p><p><a href="#"><img src="about:blank"></a></p>');
     TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
@@ -92,7 +92,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
     await pWaitForSelector(editor, 'img');
-    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '" />a</p>');
+    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
   });
 
@@ -105,7 +105,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
     await pWaitForSelector(editor, 'img');
-    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '" />a</p>');
+    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
   });
 
@@ -119,7 +119,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
     await pWaitForSelector(editor, 'img');
-    TinyAssertions.assertContent(editor, '<p><img src="data:image/jpeg;base64,' + base64ImgSrc + '" />a</p>');
+    TinyAssertions.assertContent(editor, '<p><img src="data:image/jpeg;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
 
     const blobInfo = editor.editorUpload.blobCache.getByData(base64ImgSrc, 'image/jpeg');
@@ -138,7 +138,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
     await pWaitForSelector(editor, 'img');
-    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/tiff;base64,' + base64ImgSrc + '" />a</p>');
+    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/tiff;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
 
     editor.options.unset('images_file_types');
@@ -153,6 +153,6 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     });
 
     await pWaitForSelector(editor, 'img');
-    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '" />a</p>');
+    TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '">a</p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
@@ -157,7 +157,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
 
     editor.execCommand('mceInsertClipboardContent', false, { text: 'a\nb\nc ' });
-    TinyAssertions.assertContent(editor, '<p>ta<br />b<br />c&nbsp;xt</p>');
+    TinyAssertions.assertContent(editor, '<p>ta<br>b<br>c&nbsp;xt</p>');
   });
 
   it('TBA: paste plain text with double linefeeds', () => {
@@ -184,7 +184,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
 
     editor.execCommand('mceInsertClipboardContent', false, { text: 'a\n<b>b</b>\n\nc' });
-    TinyAssertions.assertContent(editor, '<p>t</p><p>a<br />&lt;b&gt;b&lt;/b&gt;</p><p>c</p><p>xt</p>');
+    TinyAssertions.assertContent(editor, '<p>t</p><p>a<br>&lt;b&gt;b&lt;/b&gt;</p><p>c</p><p>xt</p>');
   });
 
   it('TBA: paste data image with paste_data_images: false', () => {
@@ -203,14 +203,14 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
     editor.options.set('paste_data_images', true);
 
     editor.execCommand('mceInsertClipboardContent', false, { html: '<img src="data:image/gif;base64,R0lGODlhAQABAPAAAP8REf///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==">' });
-    TinyAssertions.assertContent(editor, '<p><img src="data:image/gif;base64,R0lGODlhAQABAPAAAP8REf///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="data:image/gif;base64,R0lGODlhAQABAPAAAP8REf///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=="></p>');
   });
 
   it('TBA: paste data with script', () => {
     const editor = hook.editor();
 
     editor.execCommand('mceInsertClipboardContent', false, { html: `<p><img src="non-existent.png" onerror="alert('!')" /></p>` });
-    TinyAssertions.assertContent(editor, '<p><img src="non-existent.png" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="non-existent.png"></p>');
   });
 
   it('TBA: paste pre process text (event)', () => {
@@ -223,7 +223,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     editor.on('PastePreProcess', callback);
     editor.execCommand('mceInsertClipboardContent', false, { text: 'b\n2' });
-    TinyAssertions.assertContent(editor, '<p>PRE:b<br />2</p>');
+    TinyAssertions.assertContent(editor, '<p>PRE:b<br>2</p>');
 
     editor.setContent('<p>a</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);

--- a/modules/tinymce/src/core/test/ts/browser/paste/PlainTextPasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PlainTextPasteTest.ts
@@ -20,9 +20,9 @@ describe('browser.tinymce.core.paste.PlainTextPaste', () => {
     }
   };
 
-  const expectedWithRootBlock = '<p>one<br />two</p><p>three</p><p><br />four</p><p>&nbsp;</p><p>.</p>';
-  const expectedWithRootBlockAndAttrs = '<p class="attr">one<br />two</p><p class="attr">three</p><p class="attr"><br />four</p><p class="attr">&nbsp;</p><p class="attr">.</p>';
-  const expectedWithoutRootBlock = 'one<br />two<br /><br />three<br /><br /><br />four<br /><br /><br /><br />.';
+  const expectedWithRootBlock = '<p>one<br>two</p><p>three</p><p><br>four</p><p>&nbsp;</p><p>.</p>';
+  const expectedWithRootBlockAndAttrs = '<p class="attr">one<br>two</p><p class="attr">three</p><p class="attr"><br>four</p><p class="attr">&nbsp;</p><p class="attr">.</p>';
+  const expectedWithoutRootBlock = 'one<br>two<br><br>three<br><br><br>four<br><br><br><br>.';
 
   const pCreateEditorFromSettings = (settings: RawEditorOptions) =>
     McEditor.pFromSettings<Editor>({

--- a/modules/tinymce/src/core/test/ts/browser/paste/SmartPasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/SmartPasteTest.ts
@@ -123,7 +123,7 @@ describe('browser.tinymce.core.paste.SmartPasteTest', () => {
       // svg detected as image
       editor.options.set('images_file_types', 'svg');
       editor.execCommand('mceInsertClipboardContent', false, { html: 'http://www.site.com/my.svg' });
-      TinyAssertions.assertContent(editor, '<p><img src="http://www.site.com/my.svg" /></p>');
+      TinyAssertions.assertContent(editor, '<p><img src="http://www.site.com/my.svg"></p>');
 
       editor.options.unset('images_file_types');
     });
@@ -146,7 +146,7 @@ describe('browser.tinymce.core.paste.SmartPasteTest', () => {
       editor.undoManager.add();
 
       editor.execCommand('mceInsertClipboardContent', false, { html: 'http://www.site.com/my.jpg' });
-      TinyAssertions.assertContent(editor, '<p>a<img src="http://www.site.com/my.jpg" />bc</p>');
+      TinyAssertions.assertContent(editor, '<p>a<img src="http://www.site.com/my.jpg">bc</p>');
       assert.lengthOf(editor.undoManager.data, 3);
     });
 
@@ -168,7 +168,7 @@ describe('browser.tinymce.core.paste.SmartPasteTest', () => {
       editor.undoManager.add();
 
       editor.execCommand('mceInsertClipboardContent', false, { html: '<img src="http://www.site.com/my.jpg" />' });
-      TinyAssertions.assertContent(editor, '<p>a<img src="http://www.site.com/my.jpg" />bc</p>');
+      TinyAssertions.assertContent(editor, '<p>a<img src="http://www.site.com/my.jpg">bc</p>');
       assert.lengthOf(editor.undoManager.data, 2);
     });
 
@@ -220,7 +220,7 @@ describe('browser.tinymce.core.paste.SmartPasteTest', () => {
       editor.undoManager.add();
 
       editor.execCommand('mceInsertClipboardContent', false, { html: '<img src="http://www.site.com/my.jpg" />' });
-      TinyAssertions.assertContent(editor, '<p>a<img src="http://www.site.com/my.jpg" />bc</p>');
+      TinyAssertions.assertContent(editor, '<p>a<img src="http://www.site.com/my.jpg">bc</p>');
       assert.lengthOf(editor.undoManager.data, 2);
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
@@ -292,6 +292,6 @@ describe('browser.tinymce.selection.SetSelectionContentTest', () => {
 
     SetSelectionContent.setContent(editor, '<img src="" onload="alert(1)">');
 
-    assert.equal(lastSetContent.content, '<img src="" />');
+    assert.equal(lastSetContent.content, '<img src="">');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
@@ -56,7 +56,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a<input type="text"></h1><p>b<span style="color:red">c</span></p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     editor.execCommand('Delete');
-    assert.equal(editor.getContent(), '<h1>a<input type="text" />b<span style="color: red;">c</span></h1>');
+    assert.equal(editor.getContent(), '<h1>a<input type="text">b<span style="color: red;">c</span></h1>');
     assert.equal(editor.selection.getNode().nodeName, 'H1');
   });
 
@@ -158,7 +158,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1><p><input type="text"><span style="color:red">b</span></p>';
     LegacyUnit.setSelection(editor, 'h1', 1);
     editor.execCommand('ForwardDelete');
-    assert.equal(editor.getContent(), '<h1>a<input type="text" /><span style="color: red;">b</span></h1>');
+    assert.equal(editor.getContent(), '<h1>a<input type="text"><span style="color: red;">b</span></h1>');
     assert.equal(editor.selection.getStart().nodeName, 'H1');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
@@ -35,7 +35,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<p>a</p><p><br></p><p><br></p><p>b</p>';
     LegacyUnit.setSelection(editor, 'p:last-of-type', 0);
     editor.execCommand('Delete');
-    assert.equal(HtmlUtils.normalizeHtml(HtmlUtils.cleanHtml(editor.getBody().innerHTML)), '<p>a</p><p><br /></p><p>b</p>');
+    assert.equal(HtmlUtils.normalizeHtml(HtmlUtils.cleanHtml(editor.getBody().innerHTML)), '<p>a</p><p><br></p><p>b</p>');
     assert.equal(editor.selection.getStart().nodeName, 'P');
   });
 
@@ -110,7 +110,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1><p>b<br>c</p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     editor.execCommand('Delete');
-    assert.equal(HtmlUtils.normalizeHtml(HtmlUtils.cleanHtml(editor.getBody().innerHTML)), '<h1>ab<br />c</h1>');
+    assert.equal(HtmlUtils.normalizeHtml(HtmlUtils.cleanHtml(editor.getBody().innerHTML)), '<h1>ab<br>c</h1>');
     assert.equal(editor.selection.getStart().nodeName, 'H1');
   });
 
@@ -122,7 +122,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     rng.setEndAfter(editor.dom.select('img')[0]);
     editor.selection.setRng(rng);
     editor.execCommand('Delete');
-    assert.equal(HtmlUtils.normalizeHtml(HtmlUtils.cleanHtml(editor.getBody().innerHTML)), '<p>a</p><p><br /></p>');
+    assert.equal(HtmlUtils.normalizeHtml(HtmlUtils.cleanHtml(editor.getBody().innerHTML)), '<p>a</p><p><br></p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -172,7 +172,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.selection.setRng(rng);
 
     editor.execCommand('ForwardDelete');
-    assert.equal(HtmlUtils.normalizeHtml(HtmlUtils.cleanHtml(editor.getBody().innerHTML)), '<h1>a<br />bc</h1>');
+    assert.equal(HtmlUtils.normalizeHtml(HtmlUtils.cleanHtml(editor.getBody().innerHTML)), '<h1>a<br>bc</h1>');
     assert.equal(editor.selection.getStart().nodeName, 'H1');
   });
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
@@ -76,7 +76,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
           value: 'src'
         }
       },
-      '<p><img src="src" alt="alt" /></p>'
+      '<p><img src="src" alt="alt"></p>'
     );
     await pTestUiStateEnabled(editor, 'alt');
   });
@@ -91,7 +91,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
         },
         decorative: true
       },
-      '<p><img role="presentation" src="src" alt="" /></p>'
+      '<p><img role="presentation" src="src" alt=""></p>'
     );
     await pTestUiStateDisabled(editor);
   });
@@ -107,7 +107,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
         },
         decorative: true
       },
-      '<p><img role="presentation" src="src" alt="" /></p>'
+      '<p><img role="presentation" src="src" alt=""></p>'
     );
     await pTestUiStateDisabled(editor);
   });
@@ -128,7 +128,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
         finish: { element: [ 0 ], offset: 1 }
       },
       '<p><img role="presentation" src="src" alt="" /></p>',
-      '<p><img src="src" alt="alt" /></p>'
+      '<p><img src="src" alt="alt"></p>'
     );
     await pTestUiStateEnabled(editor, 'alt');
   });
@@ -149,7 +149,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
         finish: { element: [ 0 ], offset: 1 }
       },
       '<p><img src="src" alt="alt" /></p>',
-      '<p><img role="presentation" src="src" alt="" /></p>'
+      '<p><img role="presentation" src="src" alt=""></p>'
     );
     await pTestUiStateDisabled(editor);
   });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
@@ -58,7 +58,7 @@ describe('browser.tinymce.plugins.image.DecorativeImageDialogTest', () => {
       alt: ''
     });
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img src="src" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img src="src"></p>');
   });
 
   it('TBA: Image update with decorative toggled on should produce empty alt and role=presentation', async () => {
@@ -74,7 +74,7 @@ describe('browser.tinymce.plugins.image.DecorativeImageDialogTest', () => {
       decorative: true
     });
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img role="presentation" src="#1" alt="" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img role="presentation" src="#1" alt=""></p>');
   });
 
   it('TBA: Image update with decorative toggled off should produce empty alt and role=presentation', async () => {
@@ -90,6 +90,6 @@ describe('browser.tinymce.plugins.image.DecorativeImageDialogTest', () => {
       decorative: false
     });
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img src="#1" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img src="#1"></p>');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -33,7 +33,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
       title: ''
     });
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img src="#2" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img src="#2"></p>');
   });
 
   it('TINY-6611: Setting src to empty should remove the existing dimensions settings', async () => {
@@ -62,6 +62,6 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     Mouse.clickOn(SugarBody.body(), 'button[title="Source"]');
     await Waiter.pTryUntil('Wait for width to be populated', () => assertInputValue(generalTabSelectors.width, '200'));
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200"></p>');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -59,7 +59,7 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
         },
         vspace: '10'
       },
-      '<p><img style="margin: 10px;" src="src" alt="alt" /></p>'
+      '<p><img style="margin: 10px;" src="src" alt="alt"></p>'
     )
   );
 
@@ -73,7 +73,7 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
         },
         style: 'border-width: 10px; border-style: solid;'
       },
-      '<p><img style="border-width: 10px; border-style: solid;" src="src" alt="alt" /></p>'
+      '<p><img style="border-width: 10px; border-style: solid;" src="src" alt="alt"></p>'
     )
   );
 
@@ -87,7 +87,7 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
         },
         style: 'margin: 10px;'
       },
-      '<p><img style="margin: 10px;" src="src" alt="alt" /></p>'
+      '<p><img style="margin: 10px;" src="src" alt="alt"></p>'
     )
   );
 
@@ -102,7 +102,7 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
         },
         style: 'border-width: 15px;'
       },
-      '<p><img style="border-width: 10px;" src="src" alt="alt" /></p>'
+      '<p><img style="border-width: 10px;" src="src" alt="alt"></p>'
     )
   );
 
@@ -118,7 +118,7 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
         style: 'margin-left: 15px; margin-top: 20px;',
         vspace: '10'
       },
-      '<p><img style="margin: 10px;" src="src" alt="alt" /></p>'
+      '<p><img style="margin: 10px;" src="src" alt="alt"></p>'
     )
   );
 
@@ -138,7 +138,8 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
           value: 'src'
         }
       },
-      '<p>a<img style="border-width: 10px; border-style: dashed;" src="src" alt="alt" /></p>')
+      '<p>a<img style="border-width: 10px; border-style: dashed;" src="src" alt="alt"></p>'
+    )
   );
 
   it('TBA: Advanced image dialog non-shorthand horizontal margin style change test', () =>

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
@@ -28,6 +28,6 @@ describe('browser.tinymce.plugins.image.ImageResizeTest', () => {
     setInputValue(generalTabSelectors.height, '5');
     await Waiter.pTryUntil('did not find width input with value 5', () => assertInputValue(generalTabSelectors.width, '5'));
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" width="5" height="5" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" width="5" height="5"></p>');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
@@ -120,7 +120,7 @@ describe('browser.tinymce.plugins.image.api.CommandsTest', () => {
     updateImage(editor, {
       alt: null
     });
-    TinyAssertions.assertContent(editor, '<p><img src="#1" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#1"></p>');
   });
 
   it('TBA: Update image with empty alt value', () => {
@@ -130,7 +130,7 @@ describe('browser.tinymce.plugins.image.api.CommandsTest', () => {
     updateImage(editor, {
       alt: ''
     });
-    TinyAssertions.assertContent(editor, '<p><img src="#1" alt="" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#1" alt=""></p>');
   });
 
   it('TBA: Update image with empty title, width, height should not produce empty attributes', () => {
@@ -142,7 +142,7 @@ describe('browser.tinymce.plugins.image.api.CommandsTest', () => {
       width: '',
       height: ''
     });
-    TinyAssertions.assertContent(editor, '<p><img src="#1" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="#1"></p>');
   });
 
   it('TINY-7998: Update image with dangerous URL should remove the src attribute', () => {
@@ -152,6 +152,6 @@ describe('browser.tinymce.plugins.image.api.CommandsTest', () => {
     updateImage(editor, {
       src: 'javascript:alert(1)'
     });
-    TinyAssertions.assertContent(editor, '<p><img alt="alt1" /></p>');
+    TinyAssertions.assertContent(editor, '<p><img alt="alt1"></p>');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
@@ -34,6 +34,6 @@ describe('browser.tinymce.plugins.image.plugin.DefaultEmptyTest', () => {
       }
     });
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img src="src" alt="alt" width="200" height="100" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img src="src" alt="alt" width="200" height="100"></p>');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DimensionsFalseTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DimensionsFalseTest.ts
@@ -26,6 +26,6 @@ describe('browser.tinymce.plugins.image.plugin.DimensionsFalseTest', () => {
       alt: 'alt'
     });
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img src="src" alt="alt" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img src="src" alt="alt"></p>');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/MainTabTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.plugins.image.plugin.MainTabTest', () => {
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, (
       '<figure class="image">' +
-      '<img class="class1" src="src" alt="alt" width="100" height="200" />' +
+      '<img class="class1" src="src" alt="alt" width="100" height="200">' +
       '<figcaption>Caption</figcaption>' +
       '</figure>'
     ));

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
@@ -31,6 +31,6 @@ describe('browser.tinymce.plugins.image.plugin.PrependAbsoluteTest', () => {
     const srcElem = UiFinder.findIn(SugarBody.body(), generalTabSelectors.src).getOrDie();
     fakeEvent(srcElem, 'change');
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img src="' + prependUrl + 'src" alt="alt" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img src="' + prependUrl + 'src" alt="alt"></p>');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
@@ -31,6 +31,6 @@ describe('browser.tinymce.plugins.image.plugin.PrependRelativeTest', () => {
     const srcElem = UiFinder.findIn(SugarBody.body(), generalTabSelectors.src).getOrDie();
     fakeEvent(srcElem, 'change');
     TinyUiActions.submitDialog(editor);
-    assertCleanHtml('Checking output', editor, '<p><img src="' + prependUrl + 'src" alt="alt" /></p>');
+    assertCleanHtml('Checking output', editor, '<p><img src="' + prependUrl + 'src" alt="alt"></p>');
   });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveForcedRootBlockFalseTest.ts
@@ -54,7 +54,7 @@ describe('browser.tinymce.plugins.lists.RemoveForcedRootBlockFalseTest', () => {
     editor.execCommand('InsertUnorderedList');
 
     TinyAssertions.assertContent(editor,
-      'a<br />' +
+      'a<br>' +
       'b'
     );
     assert.equal(editor.selection.getStart().nodeName, 'BODY');
@@ -76,7 +76,7 @@ describe('browser.tinymce.plugins.lists.RemoveForcedRootBlockFalseTest', () => {
 
     TinyAssertions.assertContent(editor,
       '<div>a</div>' +
-      '<br />' +
+      '<br>' +
       '<div>b</div>'
     );
     assert.equal(editor.selection.getStart().nodeName, 'BR');

--- a/modules/tinymce/src/plugins/media/test/ts/atomic/UpdateHtmlTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/atomic/UpdateHtmlTest.ts
@@ -20,7 +20,7 @@ describe('atomic.tinymce.plugins.media.core.UpdateHtmlTest', () => {
       poster: 'poster'
     },
     false,
-    '<video><source src="oldValue" /></video>'
+    '<video><source src="oldValue"></video>'
   ));
 
   it('If updating all, add missing sources and attributes', () => testHtmlUpdate(
@@ -33,6 +33,6 @@ describe('atomic.tinymce.plugins.media.core.UpdateHtmlTest', () => {
       poster: 'poster'
     },
     true,
-    '<video poster="poster"><source src="source1" type="source1mime" /><source src="source2" type="source2mime" /></video>'
+    '<video poster="poster"><source src="source1" type="source1mime"><source src="source2" type="source2mime"></video>'
   ));
 });

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -31,9 +31,9 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
 
     TinyAssertions.assertContent(editor,
       '<p><object width="425" height="355" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000">' +
-      '<param name="movie" value="someurl" />' +
-      '<param name="wmode" value="transparent" />' +
-      '<embed src="someurl" type="application/x-shockwave-flash" wmode="transparent" width="425" height="355" />' +
+      '<param name="movie" value="someurl">' +
+      '<param name="wmode" value="transparent">' +
+      '<embed src="someurl" type="application/x-shockwave-flash" wmode="transparent" width="425" height="355">' +
       '</object></p>'
     );
   });
@@ -84,8 +84,8 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
     TinyAssertions.assertContent(editor,
       '<p>' +
       '<audio src="sound.mp3">' +
-      '<track kind="captions" src="foo.en.vtt" srclang="en" label="English" />' +
-      '<track kind="captions" src="foo.sv.vtt" srclang="sv" label="Svenska" />' +
+      '<track kind="captions" src="foo.en.vtt" srclang="en" label="English">' +
+      '<track kind="captions" src="foo.sv.vtt" srclang="sv" label="Svenska">' +
       'text<a href="#">link</a>' +
       '</audio>' +
       '</p>'
@@ -116,11 +116,11 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
     TinyAssertions.assertContent(editor,
       '<p>' +
       '<video controls="controls" width="100" height="200">' +
-      '<source src="s" />' +
+      '<source src="s">' +
       '<object type="application/x-shockwave-flash" data="../../js/tinymce/plugins/media/moxieplayer.swf" width="100" height="200">' +
-      '<param name="allowfullscreen" value="true" />' +
-      '<param name="allowscriptaccess" value="always" />' +
-      '<param name="flashvars" value="video_src=s" />' +
+      '<param name="allowfullscreen" value="true">' +
+      '<param name="allowscriptaccess" value="always">' +
+      '<param name="flashvars" value="video_src=s">' +
       '<!-- [if IE]>' +
       '<param name="movie" value="../../js/tinymce/plugins/media/moxieplayer.swf" />' +
       '<![endif]-->' +
@@ -164,13 +164,13 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
     };
 
     testXss('<video><a href="javascript:alert(1);">a</a></video>', '<p><video width="300" height="150"><a>a</a></video></p>');
-    testXss('<video><img src="x" onload="alert(1)"></video>', '<p><video width="300" height=\"150\"><img src="x" /></video></p>');
-    testXss('<video><img src="x"></video>', '<p><video width="300" height="150"><img src="x" /></video></p>');
+    testXss('<video><img src="x" onload="alert(1)"></video>', '<p><video width="300" height=\"150\"><img src="x"></video></p>');
+    testXss('<video><img src="x"></video>', '<p><video width="300" height="150"><img src="x"></video></p>');
     testXss('<video><!--[if IE]><img src="x"><![endif]--></video>', '<p><video width="300" height="150"><!-- [if IE]><img src="x"><![endif]--></video></p>');
     testXss('<p><p><audio src=x onerror=alert(1)></audio>', '<p><audio src="x"></audio></p>');
     testXss('<p><html><audio><br /><audio src=x onerror=alert(1)></p>', '');
-    testXss('<p><audio><img src="javascript:alert(1)"></audio>', '<p><audio><img /></audio></p>');
-    testXss('<p><audio><img src="x" style="behavior:url(x); width: 1px"></audio>', '<p><audio><img src="x" style="width: 1px;" /></audio></p>');
+    testXss('<p><audio><img src="javascript:alert(1)"></audio>', '<p><audio><img></audio></p>');
+    testXss('<p><audio><img src="x" style="behavior:url(x); width: 1px"></audio>', '<p><audio><img src="x" style="width: 1px;"></audio></p>');
     testXss(
       '<p><video><noscript><svg onload="javascript:alert(1)"></svg></noscript></video>',
       '<p><video width="300" height="150"></video></p>'

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
@@ -65,7 +65,7 @@ describe('browser.tinymce.plugins.media.MediaPluginSanityTest', () => {
     await Utils.pOpenDialog(editor);
     await Utils.pPasteTextareaValue(editor, '<video controls="controls" width="300" height="150"><source src="a" onerror="alert(1)" /></video>');
     TinyUiActions.submitDialog(editor);
-    await Utils.pAssertEditorContent(editor, '<p><video controls="controls" width="300" height="150"><source src="a" /></video></p>');
+    await Utils.pAssertEditorContent(editor, '<p><video controls="controls" width="300" height="150"><source src="a"></video></p>');
   });
 
   it('TINY-3463: Ensure initial toolbar button state shows correctly', async () => {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
@@ -131,7 +131,7 @@ describe('browser.tinymce.plugins.media.core.PlaceholderTest', () => {
     it('TBA: Set and assert video placeholder structure', () => pTestPlaceholder(hook.editor(),
       '/custom/video.mp4',
       '<p><video controls="controls" width="300" height="150">\n' +
-      '<source src="custom/video.mp4" type="video/mp4" /></video></p>',
+      '<source src="custom/video.mp4" type="video/mp4"></video></p>',
       placeholderStructure
     ));
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/UpdateMediaPosterAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/UpdateMediaPosterAttributeTest.ts
@@ -34,7 +34,7 @@ describe('browser.tinymce.plugins.media.UpdateMediaPosterAttributeTest', () => {
     await Utils.pPastePosterValue(editor, poster1);
     await Utils.pAssertEmbedData(editor,
       `<video width="200" height="100" controls="controls" poster="${poster1}">\n` +
-      `<source src="${source}" />\n</video>`
+      `<source src="${source}">\n</video>`
     );
     TinyUiActions.submitDialog(editor);
 
@@ -44,7 +44,7 @@ describe('browser.tinymce.plugins.media.UpdateMediaPosterAttributeTest', () => {
     await Utils.pPastePosterValue(editor, poster2);
     await Utils.pAssertEmbedData(editor,
       `<video poster="${poster2}" controls="controls" width="200" height="100">\n` +
-      `<source src="${source}" /></video>`
+      `<source src="${source}"></video>`
     );
     TinyUiActions.submitDialog(editor);
   });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceInSelectionTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceInSelectionTest.ts
@@ -192,7 +192,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceInSelectionTest', (
     matches: 2,
     replace: 'x',
     replaceAll: true,
-    expectedContent: '<p>a&nbsp; xb<br /><br />abxc</p>',
+    expectedContent: '<p>a&nbsp; xb<br><br>abxc</p>',
     moreMatches: false,
     sel: { sPath: [ 0, 0 ], sOffset: 3, fPath: [ 0, 3 ], fOffset: 4 }
   }));

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
@@ -120,7 +120,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePluginTest', () => 
     editor.setContent('a&nbsp; &nbsp;b<br/><br/>ab&nbsp;c');
     editor.plugins.searchreplace.find(' ');
     assert.isFalse(editor.plugins.searchreplace.replace('x', true, true));
-    TinyAssertions.assertContent(editor, '<p>axxxb<br /><br />abxc</p>');
+    TinyAssertions.assertContent(editor, '<p>axxxb<br><br>abxc</p>');
   });
 
   it('TBA: SearchReplace: Find multiple matches, move to next and replace', () => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -579,7 +579,7 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
       cleanTableHtml(editor.getContent()),
 
       '<table>' +
-      '<colgroup><col /><col /><col /></colgroup>' +
+      '<colgroup><col><col><col></colgroup>' +
       '<tbody>' +
       '<tr><td>2</td><td>1</td><td>2</td></tr>' +
       '<tr><td>3</td><td>2</td><td>3</td></tr>' +
@@ -609,7 +609,7 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
       cleanTableHtml(editor.getContent()),
 
       '<table>' +
-      '<colgroup><col /><col /><col /><col /></colgroup>' +
+      '<colgroup><col><col><col><col></colgroup>' +
       '<tbody>' +
       '<tr><td>1</td><td>2</td><td>1</td><td>3</td></tr>' +
       '<tr><td>2</td><td>3</td><td>2</td><td>4</td></tr>' +
@@ -640,7 +640,7 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
       cleanTableHtml(editor.getContent()),
 
       '<table data-snooker-locked-cols="0">' +
-      '<colgroup><col /><col /><col /></colgroup>' +
+      '<colgroup><col><col><col></colgroup>' +
       '<tbody>' +
       '<tr><td>1</td><td>2</td><td>2</td></tr>' +
       '<tr><td>2</td><td>3</td><td>3</td></tr>' +
@@ -671,7 +671,7 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
       cleanTableHtml(editor.getContent()),
 
       '<table data-snooker-locked-cols="2">' +
-      '<colgroup><col /><col /><col /></colgroup>' +
+      '<colgroup><col><col><col></colgroup>' +
       '<tbody>' +
       '<tr><td>1</td><td>1</td><td>2</td></tr>' +
       '<tr><td>2</td><td>2</td><td>3</td></tr>' +

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableNoWidthTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableNoWidthTest.ts
@@ -36,8 +36,8 @@ describe('browser.tinymce.plugins.table.TableNoWidthTest', () => {
     editor.setContent('<table><tbody><tr><td data-mce-selected="1" data-mce-first-selected="1">1</td><td>2</td></tr><tr><td data-mce-selected="1" data-mce-last-selected="1">3</td><td>4</td></tr></tbody></table>');
     TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 0);
     editor.execCommand('mceTableMergeCells');
-    TinyAssertions.assertContent(editor, '<table><tbody><tr><td rowspan="2">1<br />3</td><td>2</td></tr><tr><td>4</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table><tbody><tr><td rowspan="2">1<br>3</td><td>2</td></tr><tr><td>4</td></tr></tbody></table>');
     editor.execCommand('mceTableSplitCells');
-    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>1<br />3</td><td>2</td></tr><tr><td>&nbsp;</td><td>4</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>1<br>3</td><td>2</td></tr><tr><td>&nbsp;</td><td>4</td></tr></tbody></table>');
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TwoCellsSelectionTest.ts
@@ -60,10 +60,10 @@ describe('browser.tinymce.plugins.table.TwoCellsSelectionTest', () => {
     editor.execCommand('mceTableMergeCells');
     TinyAssertions.assertContent(editor,
       '<table>' +
-      '<colgroup><col /><col /><col /></colgroup>' +
+      '<colgroup><col><col><col></colgroup>' +
       '<tbody>' +
       '<tr><td>A1</td><td>B1</td><td>C1</td></tr>' +
-      '<tr><td colspan="2">A2<br />B2</td><td>C2</td></tr>' +
+      '<tr><td colspan="2">A2<br>B2</td><td>C2</td></tr>' +
       '</tbody>' +
       '</table>'
     );
@@ -75,9 +75,9 @@ describe('browser.tinymce.plugins.table.TwoCellsSelectionTest', () => {
     editor.execCommand('mceTableMergeCells');
     TinyAssertions.assertContent(editor,
       '<table>' +
-      '<colgroup><col /><col /><col /></colgroup>' +
+      '<colgroup><col><col><col></colgroup>' +
       '<tbody>' +
-      '<tr><td>A1</td><td rowspan="2">B1<br />B2</td><td>C1</td></tr>' +
+      '<tr><td>A1</td><td rowspan="2">B1<br>B2</td><td>C1</td></tr>' +
       '<tr><td>A2</td><td>C2</td></tr>' +
       '</tbody>' +
       '</table>'

--- a/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/command/MergeCellCommandTest.ts
@@ -68,7 +68,7 @@ describe('browser.tinymce.plugins.table.command.MergeCellCommandTest', () => {
         '<table>' +
           '<tbody>' +
           '<tr><td colspan="2" rowspan="2">' +
-          'a1<br />b1<br />a2<br />b2' +
+          'a1<br>b1<br>a2<br>b2' +
           '</td></tr><tr></tr>' +
           '</tbody>' +
           '</table>'
@@ -92,7 +92,7 @@ describe('browser.tinymce.plugins.table.command.MergeCellCommandTest', () => {
       after: (
         '<table>' +
           '<tbody>' +
-          '<tr><td colspan="2" rowspan="2">a1<br />b1<br />a2<br />b2</td></tr>' +
+          '<tr><td colspan="2" rowspan="2">a1<br>b1<br>a2<br>b2</td></tr>' +
           '<tr></tr>' +
           '<tr><td>a3</td><td>b3</td></tr>' +
           '</tbody>' +
@@ -139,7 +139,7 @@ describe('browser.tinymce.plugins.table.command.MergeCellCommandTest', () => {
               '<td>c2</td>' +
             '</tr>' +
             '<tr>' +
-              '<td colspan="2">b3<br />c3</td>' +
+              '<td colspan="2">b3<br>c3</td>' +
             '</tr>' +
           '</tbody>' +
         '</table>'
@@ -282,7 +282,7 @@ describe('browser.tinymce.plugins.table.command.MergeCellCommandTest', () => {
           '<tbody>' +
           '<tr>' +
           '<td>a1</td>' +
-          '<td>b1<br />c1</td>' +
+          '<td>b1<br>c1</td>' +
           '</tr>' +
           '<tr>' +
           '<td colspan="2">a2</td>' +
@@ -318,7 +318,7 @@ describe('browser.tinymce.plugins.table.command.MergeCellCommandTest', () => {
           '<td rowspan="2">b1</td>' +
           '</tr>' +
           '<tr>' +
-          '<td>a2<br />a3</td>' +
+          '<td>a2<br>a3</td>' +
           '</tr>' +
           '</tbody>' +
           '</table>'


### PR DESCRIPTION
Related Ticket: TINY-8263

Description of Changes:
* Change default for `element_format` option from `undefined` to `html`
* Fix only the failing getContent test assertions

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
