### PR TITLE
TINY-8202: More changes to get the parser working and passing tests

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
@@ -6,19 +6,17 @@ import Schema from 'tinymce/core/api/html/Schema';
 import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 
 describe('browser.tinymce.core.html.SerializerTest', () => {
-  // TODO: TINY-4627/TINY-8202: most of the things in this test currently have issues
-  it.skip('Basic serialization', () => {
+  it('Basic serialization', () => {
     const serializer = HtmlSerializer();
 
-    assert.equal(serializer.serialize(DomParser().parse('text<text&')), 'text&lt;text&amp;');
+    assert.equal(serializer.serialize(DomParser().parse('text < text&')), 'text &lt; text&amp;');
     assert.equal(
       serializer.serialize(DomParser().parse('<B>text</B><IMG src="1.gif">')),
       '<strong>text</strong><img src="1.gif">'
     );
     assert.equal(serializer.serialize(DomParser().parse('<!-- comment -->')), '<!-- comment -->');
-    assert.equal(serializer.serialize(DomParser().parse('<![CDATA[cdata]]>', { format: 'xml' })), '<![CDATA[cdata]]>');
-    assert.equal(serializer.serialize(DomParser().parse('<?xml attr="value" ?>', { format: 'xml' })), '<?xml attr="value" ?>');
-    assert.equal(serializer.serialize(DomParser().parse('<!DOCTYPE html>')), '<!DOCTYPE html>');
+    assert.equal(serializer.serialize(DomParser().parse('<![CDATA[cdata]]>', { format: 'xhtml' })), '<![CDATA[cdata]]>');
+    assert.equal(serializer.serialize(DomParser().parse('<?xml-stylesheet attr="value" ?>', { format: 'xhtml' })), '<?xml-stylesheet attr="value" ?>');
   });
 
   it('Sorting of attributes', () => {

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -54,9 +54,8 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assertIsLink(editor, 'http://www.domain.com', 'http://www.domain.com');
     assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com');
     assertIsLink(editor, 'file://www.domain.com', 'file://www.domain.com');
-    // TODO: TINY-4627/TINY-8202: improve our URL handling so that we don't need to add every possible custom protocol to our regex
-    // assertIsLink(editor, 'customprotocol://www.domain.com', 'customprotocol://www.domain.com');
-    // assertIsLink(editor, 'ssh://www.domain.com', 'ssh://www.domain.com');
+    assertIsLink(editor, 'customprotocol://www.domain.com', 'customprotocol://www.domain.com');
+    assertIsLink(editor, 'ssh://www.domain.com', 'ssh://www.domain.com');
     assertIsLink(editor, 'ftp://www.domain.com', 'ftp://www.domain.com');
     assertIsLink(editor, 'www.domain.com', 'https://www.domain.com');
     assertIsLink(editor, 'www.domain.com', 'https://www.domain.com', '.');
@@ -98,8 +97,7 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     const editor = hook.editor();
     typeAnEclipsedURL(editor, 'http://www.domain.com');
     typeAnEclipsedURL(editor, 'https://www.domain.com');
-    // TODO: TINY-4627/TINY-8202
-    // typeAnEclipsedURL(editor, 'ssh://www.domain.com');
+    typeAnEclipsedURL(editor, 'ssh://www.domain.com');
     typeAnEclipsedURL(editor, 'ftp://www.domain.com');
     typeAnEclipsedURL(editor, 'www.domain.com', 'https://www.domain.com');
     typeAnEclipsedURL(editor, 'www.domain.com', 'https://www.domain.com');
@@ -112,8 +110,7 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     const editor = hook.editor();
     typeNewlineURL(editor, 'http://www.domain.com');
     typeNewlineURL(editor, 'https://www.domain.com');
-    // TODO: TINY-4627/TINY-8202
-    // typeNewlineURL(editor, 'ssh://www.domain.com');
+    typeNewlineURL(editor, 'ssh://www.domain.com');
     typeNewlineURL(editor, 'ftp://www.domain.com');
     typeNewlineURL(editor, 'www.domain.com', 'https://www.domain.com');
     typeNewlineURL(editor, 'www.domain.com', 'https://www.domain.com', true);
@@ -147,8 +144,7 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     editor.options.set('link_default_protocol', 'https');
     assertIsLink(editor, 'http://www.domain.com', 'http://www.domain.com');
     assertIsLink(editor, 'https://www.domain.com', 'https://www.domain.com');
-    // TODO: TINY-4627/TINY-8202
-    // assertIsLink(editor, 'ssh://www.domain.com', 'ssh://www.domain.com');
+    assertIsLink(editor, 'ssh://www.domain.com', 'ssh://www.domain.com');
     assertIsLink(editor, 'ftp://www.domain.com', 'ftp://www.domain.com');
     assertIsLink(editor, 'www.domain.com', 'https://www.domain.com');
     assertIsLink(editor, 'www.domain.com', 'https://www.domain.com', '.');


### PR DESCRIPTION
Related Ticket: TINY-8202

Description of Changes:
* Got the `xhtml` parser side of things working again.
* Removed the parser `xml` format and replaced references in tests with `xhtml` instead as we've never actually parsed XML and the native DOM parser won't parse XML only XHTML.
* Fixed a few issues with the dom purify configuration I found while fixing tests
* Updated the various invalid tests to reflect how the native parser actually parser per the spec.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
