### PR TITLE
TINY-8261: Update the schema option to default to `html5`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `rel_list` option has been renamed to `link_rel_list` for the `link` plugin #TINY-4603
 - The `target_list` option has been renamed to `link_target_list` for the `link` plugin #TINY-4603
 - The `element_format` option has been set to `html` by default #TINY-8263
+- The `schema` option has been set to `html5` by default #TINY-8261
 - The `primary` property on dialog buttons has been deprecated. Use the new `buttonType` property instead #TINY-8304
 - The default value for the `link_default_protocol` option has been changed to `https` instead of `http` #TINY-7824
 - Moved the `paste` plugin's functionality to TinyMCE core #TINY-8310

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -566,7 +566,8 @@ const register = (editor: Editor) => {
   });
 
   registerOption('schema', {
-    processor: 'string'
+    processor: 'string',
+    default: 'html5'
   });
 
   registerOption('convert_urls', {

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun, Obj } from '@ephox/katamari';
+import { Arr, Fun, Obj } from '@ephox/katamari';
 
 import Tools from '../util/Tools';
 
@@ -91,6 +91,14 @@ interface Schema {
   addValidChildren: (validChildren: any) => void;
 }
 
+interface SchemaLookupTable {
+  [key: string]: {
+    attributes: Record<string, {}>;
+    attributesOrder: string[];
+    children: Record<string, {}>;
+  };
+}
+
 /**
  * Schema validator class.
  *
@@ -106,7 +114,7 @@ interface Schema {
  * @version 3.4
  */
 
-const mapCache: any = {}, dummyObj = {};
+const mapCache: Record<string, SchemaLookupTable> = {}, dummyObj = {};
 const makeMap = Tools.makeMap, each = Tools.each, extend = Tools.extend, explode = Tools.explode, inArray = Tools.inArray;
 
 const split = (items: string, delim?: string): string[] => {
@@ -121,57 +129,33 @@ const split = (items: string, delim?: string): string[] => {
  * @param {String} type html4, html5 or html5-strict schema type.
  * @return {Object} Schema lookup table.
  */
-// TODO: Improve return type
-const compileSchema = (type: SchemaType): Record<string, any> => {
-  const schema: Record<string, any> = {};
+const compileSchema = (type: SchemaType = 'html5'): SchemaLookupTable => {
+  const schema: SchemaLookupTable = {};
   let globalAttributes, blockContent;
   let phrasingContent, flowContent, html4BlockContent, html4PhrasingContent;
 
-  const add = (name: string, attributes?: string, children?: string | string[]) => {
-    let ni, attributesOrder, element;
-
-    const arrayToMap = (array, obj?) => {
-      const map = {};
-      let i, l;
-
-      for (i = 0, l = array.length; i < l; i++) {
-        map[array[i]] = obj || {};
-      }
-
-      return map;
-    };
-
-    children = children || [];
-    attributes = attributes || '';
-
-    if (typeof children === 'string') {
-      children = split(children);
-    }
-
+  const add = (name: string, attributes: string = '', children: string = '') => {
+    const childNames = split(children);
     const names = split(name);
-    ni = names.length;
+    let ni = names.length;
     while (ni--) {
-      attributesOrder = split([ globalAttributes, attributes ].join(' '));
+      const attributesOrder = split([ globalAttributes, attributes ].join(' '));
 
-      element = {
-        attributes: arrayToMap(attributesOrder),
+      schema[names[ni]] = {
+        attributes: Arr.mapToObject(attributesOrder, () => ({})),
         attributesOrder,
-        children: arrayToMap(children, dummyObj)
+        children: Arr.mapToObject(childNames, Fun.constant(dummyObj))
       };
-
-      schema[names[ni]] = element;
     }
   };
 
   const addAttrs = (name: string, attributes?: string) => {
-    let ni, schemaItem, i, l;
-
     const names = split(name);
-    ni = names.length;
     const attrs = split(attributes);
+    let ni = names.length;
     while (ni--) {
-      schemaItem = schema[names[ni]];
-      for (i = 0, l = attrs.length; i < l; i++) {
+      const schemaItem = schema[names[ni]];
+      for (let i = 0, l = attrs.length; i < l; i++) {
         schemaItem.attributes[attrs[i]] = {};
         schemaItem.attributesOrder.push(attrs[i]);
       }
@@ -762,13 +746,11 @@ const Schema = (settings?: SchemaSettings): Schema => {
       children[name] = element.children;
     });
 
-    // Switch these on HTML4
-    if (settings.schema !== 'html5') {
-      each(split('strong/b em/i'), (item) => {
-        const items = split(item, '/');
-        elements[items[1]].outputName = items[0];
-      });
-    }
+    // Prefer strong/em over b/i
+    each(split('strong/b em/i'), (item) => {
+      const items = split(item, '/');
+      elements[items[1]].outputName = items[0];
+    });
 
     // Add default alt attribute for images, removed since alt="" is treated as presentational.
     // elements.img.attributesDefault = [{name: 'alt', value: ''}];

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -574,8 +574,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const schema = Schema({ schema: 'html5' });
 
     const parser = DomParser({}, schema);
-    const root = parser.parse('<b>1</b> 2<p>3</p>');
-    assert.equal(serializer.serialize(root), '<b>1</b> 2<p>3</p>');
+    const root = parser.parse('<strong>1</strong> 2<p>3</p>');
+    assert.equal(serializer.serialize(root), '<strong>1</strong> 2<p>3</p>');
   });
 
   it('Invalid text blocks within a li', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
@@ -68,11 +68,11 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
 
   it('Enter before first wrapped IMG in P', () => {
     const editor = hook.editor();
-    editor.setContent('<p><b><img src="about:blank" /></b></p>');
+    editor.setContent('<p><strong><img src="about:blank" /></strong></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild.firstChild, 0);
     pressEnter(editor);
     assert.equal((editor.getBody().firstChild as HTMLElement).innerHTML, '<br data-mce-bogus="1">');
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p><b><img src="about:blank"></b></p>');
+    assert.equal(editor.getContent(), '<p>\u00a0</p><p><strong><img src="about:blank"></strong></p>');
   });
 
   it('Enter before last IMG in P with text', () => {
@@ -447,18 +447,18 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
 
   it('Shift+Enter in the middle of B with a BR after it', () => {
     const editor = hook.editor();
-    editor.getBody().innerHTML = '<p><b>abcd</b><br></p>';
-    LegacyUnit.setSelection(editor, 'b', 2);
+    editor.getBody().innerHTML = '<p><strong>abcd</strong><br></p>';
+    LegacyUnit.setSelection(editor, 'strong', 2);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p><b>ab<br>cd</b></p>');
+    assert.equal(editor.getContent(), '<p><strong>ab<br>cd</strong></p>');
   });
 
   it('Shift+Enter at the end of B with a BR after it', () => {
     const editor = hook.editor();
-    editor.getBody().innerHTML = '<p><b>abcd</b><br></p>';
-    LegacyUnit.setSelection(editor, 'b', 4);
+    editor.getBody().innerHTML = '<p><strong>abcd</strong><br></p>';
+    LegacyUnit.setSelection(editor, 'strong', 4);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p><b>abcd<br></b></p>');
+    assert.equal(editor.getContent(), '<p><strong>abcd<br></strong></p>');
   });
 
   it('Enter in beginning of PRE', () => {
@@ -704,13 +704,13 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
 
   it('Enter after span with space', () => {
     const editor = hook.editor();
-    editor.setContent('<p><b>abc </b></p>');
-    LegacyUnit.setSelection(editor, 'b', 3);
+    editor.setContent('<p><strong>abc </strong></p>');
+    LegacyUnit.setSelection(editor, 'strong', 3);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p><b>abc</b></p><p>\u00a0</p>');
+    assert.equal(editor.getContent(), '<p><strong>abc</strong></p><p>\u00a0</p>');
 
     const rng = editor.selection.getRng();
-    assert.equal(rng.startContainer.nodeName, 'B');
+    assert.equal(rng.startContainer.nodeName, 'STRONG');
     assert.equal(rng.startContainer.textContent !== ' ', true);
   });
 


### PR DESCRIPTION
Related Ticket: TINY-8261

Description of Changes:
* Updated the `schema` option to default to `html5` instead of `undefined` (they were fairly similar but it did have slight differences)
* Cleaned up the schema code (removed code duplication, added types and cleaned up variables)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
