### PR TITLE
TINY-8236: Removed the editor.settings property and updated the getParam API to use the Options API

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `toHex` function for the `DOMUtils` and `Styles` APIs #TINY-8163
 - Removed the `tabfocus` plugin #TINY-8315
 - Removed the `textpattern` plugin's API as part of moving it to core #TINY-8312
+- Removed the `editor.settings` property as it's been replaced by the new Options API #TINY-8236
 
 ### Deprecated
 - The dialog button component `primary` property has been deprecated in favour of the new `buttonType` property #TINY-8304

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -15,7 +15,7 @@ import { BlobInfoImagePair } from '../file/ImageScanner';
 import * as EditorFocus from '../focus/EditorFocus';
 import * as Render from '../init/Render';
 import { NodeChange } from '../NodeChange';
-import { normalizeOptions, getParam } from '../options/NormalizeOptions';
+import { normalizeOptions } from '../options/NormalizeOptions';
 import SelectionOverrides from '../SelectionOverrides';
 import { UndoManager } from '../undo/UndoManagerTypes';
 import Quirks from '../util/Quirks';
@@ -90,17 +90,6 @@ const extend = Tools.extend, each = Tools.each;
 class Editor implements EditorObservable {
   public documentBaseUrl: string;
   public baseUri: URI;
-
-  /**
-   * Name/value collection with editor settings.
-   *
-   * @property settings
-   * @type Object
-   * @example
-   * // Get the value of the theme setting
-   * tinymce.activeEditor.windowManager.alert("You are using the " + tinymce.activeEditor.options.get('theme') + " theme");
-   */
-  public settings: NormalizedEditorOptions;
 
   /**
    * Editor instance id, normally the same as the div/textarea that was replaced.
@@ -273,7 +262,6 @@ class Editor implements EditorObservable {
 
     this.id = id;
     const normalizedOptions = normalizeOptions(editorManager.defaultOptions, options);
-    this.settings = normalizedOptions;
 
     this.options = createOptions(self, normalizedOptions);
     Options.register(self);
@@ -384,12 +372,15 @@ class Editor implements EditorObservable {
 
   /**
    * Returns a configuration parameter by name.
+   * <br>
+   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use the <code>editor.options.get<code> API instead.</em>
    *
    * @method getParam
-   * @param {String} name Configruation parameter to retrieve.
+   * @param {String} name Configuration parameter to retrieve.
    * @param {String} defaultVal Optional default value to return.
    * @param {String} type Optional type parameter.
    * @return {String} Configuration parameter value or default value.
+   * @deprecated Use editor.options.get instead
    * @example
    * // Returns a specific config value from the currently active editor
    * var someval = tinymce.activeEditor.getParam('myvalue');
@@ -397,11 +388,23 @@ class Editor implements EditorObservable {
    * // Returns a specific config value from a specific editor instance by id
    * var someval2 = tinymce.get('my_editor').getParam('myvalue');
    */
-  public getParam <K extends Exclude<BuiltInOptionType, 'function'>>(name: string, defaultVal: BuiltInOptionTypeMap[K], type: K): BuiltInOptionTypeMap[K];
-  public getParam <K extends keyof NormalizedEditorOptions>(name: K, defaultVal?: NormalizedEditorOptions[K], type?: string): NormalizedEditorOptions[K];
-  public getParam <T>(name: string, defaultVal: T, type?: string): T;
-  public getParam(name: string, defaultVal?: any, type?: string): any {
-    return getParam(this, name, defaultVal, type);
+  public getParam <K extends BuiltInOptionType>(name: string, defaultVal: BuiltInOptionTypeMap[K], type: K): BuiltInOptionTypeMap[K];
+  public getParam <K extends keyof NormalizedEditorOptions>(name: K, defaultVal?: NormalizedEditorOptions[K], type?: BuiltInOptionType): NormalizedEditorOptions[K];
+  public getParam <T>(name: string, defaultVal: T, type?: BuiltInOptionType): T;
+  public getParam(name: string, defaultVal?: any, type?: BuiltInOptionType): any {
+    const options = this.options;
+
+    // To keep the legacy API we need to register the option if it's not already been registered
+    if (!options.isRegistered(name)) {
+      if (Type.isNonNullable(type)) {
+        options.register(name, { processor: type, default: defaultVal });
+      } else {
+        options.register(name, { processor: Fun.always, default: defaultVal });
+      }
+    }
+
+    // Attempt to use the passed default value if nothing has been set already
+    return !options.isSet(name) && !Type.isUndefined(defaultVal) ? defaultVal : options.get(name);
   }
 
   /**

--- a/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
@@ -220,8 +220,6 @@ const create = (editor: Editor, initialOptions: Record<string, unknown>): Option
     const result = processValue(value, processor);
     if (isValidResult(result)) {
       values[name] = result.value;
-      // TODO: TINY-8236 (TINY-8234) Remove this later once all settings have been converted
-      editor.settings[name] = result.value;
       return true;
     } else {
       // eslint-disable-next-line no-console
@@ -277,8 +275,6 @@ const create = (editor: Editor, initialOptions: Record<string, unknown>): Option
     const registered = isRegistered(name);
     if (registered) {
       delete values[name];
-      // TODO: TINY-8236 (TINY-8234) Remove this later once all settings have been converted
-      delete editor.settings[name];
     }
     return registered;
   };

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -758,7 +758,6 @@ const register = (editor: Editor) => {
   });
 
   // These options must be registered later in the init sequence due to their default values
-  // TODO: TINY-8234 Should we have a way to lazily load the default values?
   editor.on('ScriptsLoaded', () => {
     registerOption('directionality', {
       processor: 'string',

--- a/modules/tinymce/src/core/main/ts/options/NormalizeOptions.ts
+++ b/modules/tinymce/src/core/main/ts/options/NormalizeOptions.ts
@@ -5,10 +5,9 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Merger, Obj, Optional, Strings, Type } from '@ephox/katamari';
+import { Arr, Fun, Merger, Obj, Strings, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
-import Editor from '../api/Editor';
 import { NormalizedEditorOptions, RawEditorOptions } from '../api/OptionTypes';
 import Tools from '../api/util/Tools';
 
@@ -150,53 +149,8 @@ const combineOptions = (isMobileDevice: boolean, isPhone: boolean, defaultOption
 const normalizeOptions = (defaultOverrideOptions: RawEditorOptions, options: RawEditorOptions): NormalizedEditorOptions =>
   combineOptions(isPhone || isTablet, isPhone, options, defaultOverrideOptions, options);
 
-const getFiltered = <K extends keyof NormalizedEditorOptions> (predicate: (x: any) => boolean, editor: Editor, name: K): Optional<NormalizedEditorOptions[K]> => Optional.from(editor.settings[name]).filter(predicate);
-
-const getParamObject = (value: string) => {
-  let output = {};
-
-  if (typeof value === 'string') {
-    Arr.each(value.indexOf('=') > 0 ? value.split(/[;,](?![^=;,]*(?:[;,]|$))/) : value.split(','), (val: string) => {
-      const arr = val.split('=');
-
-      if (arr.length > 1) {
-        output[Tools.trim(arr[0])] = Tools.trim(arr[1]);
-      } else {
-        output[Tools.trim(arr[0])] = Tools.trim(arr[0]);
-      }
-    });
-  } else {
-    output = value;
-  }
-
-  return output;
+export {
+  normalizeOptions,
+  combineOptions,
+  getMobileOverrideOptions
 };
-
-const isArrayOf = (p: (a: any) => boolean) => (a: any) => Type.isArray(a) && Arr.forall(a, p);
-
-// TODO: TINY-8236 (TINY-8234) Remove this once all settings are converted
-const getParam = (editor: Editor, name: string, defaultVal?: any, type?: string) => {
-  const value = name in editor.settings ? editor.settings[name] : defaultVal;
-
-  if (type === 'hash') {
-    return getParamObject(value);
-  } else if (type === 'string') {
-    return getFiltered(Type.isString, editor, name).getOr(defaultVal);
-  } else if (type === 'number') {
-    return getFiltered(Type.isNumber, editor, name).getOr(defaultVal);
-  } else if (type === 'boolean') {
-    return getFiltered(Type.isBoolean, editor, name).getOr(defaultVal);
-  } else if (type === 'object') {
-    return getFiltered(Type.isObject, editor, name).getOr(defaultVal);
-  } else if (type === 'array') {
-    return getFiltered(Type.isArray, editor, name).getOr(defaultVal);
-  } else if (type === 'string[]') {
-    return getFiltered(isArrayOf(Type.isString), editor, name).getOr(defaultVal);
-  } else if (type === 'function') {
-    return getFiltered(Type.isFunction, editor, name).getOr(defaultVal);
-  } else {
-    return value;
-  }
-};
-
-export { normalizeOptions, getParam, combineOptions, getMobileOverrideOptions };

--- a/modules/tinymce/src/core/test/ts/browser/EditorManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorManagerTest.ts
@@ -143,10 +143,13 @@ describe('browser.tinymce.core.EditorManagerTest', () => {
       }
     });
 
+    const editor = new Editor('ed1', {}, EditorManager);
+    editor.options.register('test', { processor: 'number' });
+
     assert.strictEqual(EditorManager.baseURI.path, '/base');
     assert.strictEqual(EditorManager.baseURL, 'http://www.EditorManager.com/base');
     assert.strictEqual(EditorManager.suffix, 'x');
-    assert.strictEqual(new Editor('ed1', {}, EditorManager).settings.test, 42);
+    assert.strictEqual(editor.options.get('test'), 42);
     assert.strictEqual(PluginManager.urls.testplugin, 'http://custom.ephox.com/dir/testplugin');
 
     assert.deepEqual(new Editor('ed2', {
@@ -158,7 +161,7 @@ describe('browser.tinymce.core.EditorManagerTest', () => {
       plugin_base_urls: {
         testplugin: 'http://custom.ephox.com/dir/testplugin'
       }
-    }, EditorManager).settings.external_plugins, {
+    }, EditorManager).options.get('external_plugins'), {
       plugina: '//domain/plugina2.js',
       pluginb: '//domain/pluginb.js',
       pluginc: '//domain/pluginc.js'
@@ -166,7 +169,7 @@ describe('browser.tinymce.core.EditorManagerTest', () => {
 
     assert.deepEqual(new Editor('ed3', {
       base_url: '/project/tinymce/js/tinymce'
-    }, EditorManager).settings.external_plugins, {
+    }, EditorManager).options.get('external_plugins'), {
       plugina: '//domain/plugina.js',
       pluginb: '//domain/pluginb.js'
     });

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -23,6 +23,8 @@ describe('browser.tinymce.core.EditorTest', () => {
     extended_valid_elements: 'custom1,custom2,script[*]',
     entities: 'raw',
     indent: false,
+    custom_prop1: 5,
+    custom_prop2: 5,
     base_url: '/project/tinymce/js/tinymce'
   }, []);
 
@@ -149,24 +151,19 @@ describe('browser.tinymce.core.EditorTest', () => {
     assert.equal(editor.getContent(), '<p>123</p><table><tbody><tr><td>X</td></tr></tbody></table><p>456</p>', 'WebKit Serialization range bug');
   });
 
-  it('TBA: editor_methods - getParam', function () {
-    // TODO: TINY-8236 (TINY-8234) Remove the skip once getParam uses the options API internally
-    this.skip();
+  it('TBA: editor_methods - getParam', () => {
     const editor = hook.editor();
-    editor.options.set('test', 'a,b,c');
-    assert.equal(editor.getParam('test', '', 'hash').c, 'c', 'editor_methods - getParam');
 
-    editor.options.set('test', 'a');
-    assert.equal(editor.getParam('test', '', 'hash').a, 'a', 'editor_methods - getParam');
+    assert.isUndefined(editor.getParam('test1'), 'unregistered with no default');
+    assert.equal(editor.getParam('test2', ''), '', 'unregistered with default');
+    assert.equal(editor.getParam('test2', 'blah'), 'blah', 'unregistered with different default');
 
-    editor.options.set('test', 'a=b');
-    assert.equal(editor.getParam('test', '', 'hash').a, 'b', 'editor_methods - getParam');
+    assert.equal(editor.getParam('custom_prop1', 10, 'number'), 5, 'unregistered with correct type');
+    assert.equal(editor.getParam('custom_prop2', '10', 'string'), '10', 'unregistered with incorrect type');
 
-    editor.options.set('test', 'a=b;c=d,e');
-    assert.equal(editor.getParam('test', '', 'hash').c, 'd,e', 'editor_methods - getParam');
-
-    editor.options.set('test', 'a=b,c=d');
-    assert.equal(editor.getParam('test', '', 'hash').c, 'd', 'editor_methods - getParam');
+    editor.options.register('test4', { processor: 'string', default: 'default' });
+    assert.equal(editor.getParam('test4'), 'default', 'registered with no passed default');
+    assert.equal(editor.getParam('test4', 'override'), 'override', 'registered with passed default');
   });
 
   it('TBA: setContent', () => {


### PR DESCRIPTION
Related Ticket: TINY-8236

Description of Changes:
* Removed the `editor.settings` property
* Updated the `editor.getParam` API to delegate to the Options API for better backwards compatibility and marked it as deprecated.
* Cleaned up any old `getParam` specific logic

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
