### PR TITLE
TINY-8138: Rework `mceAddEditor` command to use an object value

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `tinymce.settings` global property is no longer set upon initialization #TINY-7359
 - Add-ons such as plugins and themes are no longer constructed using the `new` operator #TINY-8256
 - A number of APIs that were not proper classes, are no longer constructed using the `new` operator #TINY-8322
-- The `mceAddEditor` command can now take an object as its value to specify the id and editor options #TINY-8138
+- The `mceAddEditor` command now takes an object as its value to specify the id and editor options #TINY-8138
 - The `default_link_target` option has been renamed to `link_default_target` for both `link` and `autolink` plugins #TINY-4603
 - The `rel_list` option has been renamed to `link_rel_list` for the `link` plugin #TINY-4603
 - The `target_list` option has been renamed to `link_target_list` for the `link` plugin #TINY-4603

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `tinymce.settings` global property is no longer set upon initialization #TINY-7359
 - Add-ons such as plugins and themes are no longer constructed using the `new` operator #TINY-8256
 - A number of APIs that were not proper classes, are no longer constructed using the `new` operator #TINY-8322
-- The `mceAddEditor` command now takes an object as its value to specify the id and editor options #TINY-8138
+- The `mceAddEditor` and `mceToggleEditor` command now takes an object as its value to specify the id and editor options #TINY-8138
 - The `default_link_target` option has been renamed to `link_default_target` for both `link` and `autolink` plugins #TINY-4603
 - The `rel_list` option has been renamed to `link_rel_list` for the `link` plugin #TINY-4603
 - The `target_list` option has been renamed to `link_target_list` for the `link` plugin #TINY-4603

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `tinymce.settings` global property is no longer set upon initialization #TINY-7359
 - Add-ons such as plugins and themes are no longer constructed using the `new` operator #TINY-8256
 - A number of APIs that were not proper classes, are no longer constructed using the `new` operator #TINY-8322
-- The `mceAddEditor` and `mceToggleEditor` command now takes an object as its value to specify the id and editor options #TINY-8138
+- The `mceAddEditor` and `mceToggleEditor` commands now take an object as their value to specify the id and editor options #TINY-8138
 - The `default_link_target` option has been renamed to `link_default_target` for both `link` and `autolink` plugins #TINY-4603
 - The `rel_list` option has been renamed to `link_rel_list` for the `link` plugin #TINY-4603
 - The `target_list` option has been renamed to `link_target_list` for the `link` plugin #TINY-4603

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -617,33 +617,35 @@ const EditorManager: EditorManager = {
    * @method execCommand
    * @param {String} cmd Command to perform for example Bold.
    * @param {Boolean} ui Optional boolean state if a UI should be presented for the command or not.
-   * @param {String} value Optional value parameter like for example an URL to a link.
+   * @param {any} value Optional value parameter like for example an URL to a link.
    * @return {Boolean} true/false if the command was executed or not.
    */
   execCommand(cmd, ui, value) {
-    const self = this, editor = self.get(value);
+    const self = this;
+    const editorId = Type.isObject(value) ? value.id ?? value.index : value;
 
     // Manager commands
     switch (cmd) {
-      case 'mceAddEditor':
-        const isObj = Type.isObject(value);
-        const editorId = isObj ? value.id : value;
-
+      case 'mceAddEditor': {
         if (!self.get(editorId)) {
-          const editorOptions = isObj ? value.options : {};
+          const editorOptions = value.options;
           new Editor(editorId, editorOptions, self).render();
         }
 
         return true;
+      }
 
-      case 'mceRemoveEditor':
+      case 'mceRemoveEditor': {
+        const editor = self.get(editorId);
         if (editor) {
           editor.remove();
         }
 
         return true;
+      }
 
-      case 'mceToggleEditor':
+      case 'mceToggleEditor': {
+        const editor = self.get(editorId);
         if (!editor) {
           self.execCommand('mceAddEditor', false, value);
           return true;
@@ -656,6 +658,7 @@ const EditorManager: EditorManager = {
         }
 
         return true;
+      }
     }
 
     // Run command on active editor

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -628,7 +628,7 @@ const EditorManager: EditorManager = {
     switch (cmd) {
       case 'mceAddEditor': {
         if (!self.get(editorId)) {
-          const editorOptions = value.options;
+          const editorOptions = value.options ?? {};
           new Editor(editorId, editorOptions, self).render();
         }
 

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -617,7 +617,7 @@ const EditorManager: EditorManager = {
    * @method execCommand
    * @param {String} cmd Command to perform for example Bold.
    * @param {Boolean} ui Optional boolean state if a UI should be presented for the command or not.
-   * @param {any} value Optional value parameter like for example an URL to a link.
+   * @param {Object/String/Number/Boolean} value Optional value parameter like for example an URL to a link.
    * @return {Boolean} true/false if the command was executed or not.
    */
   execCommand(cmd, ui, value) {

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -628,7 +628,7 @@ const EditorManager: EditorManager = {
     switch (cmd) {
       case 'mceAddEditor': {
         if (!self.get(editorId)) {
-          const editorOptions = value.options ?? {};
+          const editorOptions = value.options;
           new Editor(editorId, editorOptions, self).render();
         }
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorManagerCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorManagerCommandsTest.ts
@@ -1,4 +1,5 @@
 import { after, afterEach, before, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import 'tinymce';
@@ -26,48 +27,42 @@ describe('browser.tinymce.core.EditorManagerCommandsTest', () => {
     }, 0);
   });
 
-  it('mceToggleEditor', (done) => {
-    viewBlock.update('<textarea class="tinymce"></textarea>');
-    EditorManager.init({
-      selector: 'textarea.tinymce',
-      init_instance_callback: (editor1) => {
-        assert.isFalse(editor1.isHidden(), 'editor should be visible');
-        EditorManager.execCommand('mceToggleEditor', false, 0);
-        assert.isTrue(editor1.isHidden(), 'editor should be hidden');
-        EditorManager.execCommand('mceToggleEditor', false, 0);
-        assert.isFalse(editor1.isHidden(), 'editor should be visible');
-        done();
-      }
+  Arr.each([
+    { label: 'index', value: 0 },
+    { label: 'id', value: 'ed_1' },
+    { label: 'object with index', value: { index: 0 }},
+    { label: 'object with id', value: { id: 'ed_1' }}
+  ], (test) => {
+    it(`mceToggleEditor (${test.label})`, (done) => {
+      viewBlock.update('<textarea id="ed_1" class="tinymce"></textarea>');
+      EditorManager.init({
+        selector: 'textarea.tinymce',
+        init_instance_callback: (editor1) => {
+          assert.isFalse(editor1.isHidden(), 'editor should be visible');
+          EditorManager.execCommand('mceToggleEditor', false, test.value);
+          assert.isTrue(editor1.isHidden(), 'editor should be hidden');
+          EditorManager.execCommand('mceToggleEditor', false, test.value);
+          assert.isFalse(editor1.isHidden(), 'editor should be visible');
+          done();
+        }
+      });
+    });
+
+    it(`mceRemoveEditor (${test.label})`, (done) => {
+      viewBlock.update('<textarea id="ed_1" class="tinymce"></textarea>');
+      EditorManager.init({
+        selector: 'textarea.tinymce',
+        init_instance_callback: (_editor1) => {
+          assert.lengthOf(EditorManager.get(), 1);
+          EditorManager.execCommand('mceRemoveEditor', false, test.value);
+          assert.lengthOf(EditorManager.get(), 0);
+          done();
+        }
+      });
     });
   });
 
-  it('mceRemoveEditor', (done) => {
-    viewBlock.update('<textarea class="tinymce"></textarea>');
-    EditorManager.init({
-      selector: 'textarea.tinymce',
-      init_instance_callback: (_editor1) => {
-        assert.lengthOf(EditorManager.get(), 1);
-        EditorManager.execCommand('mceRemoveEditor', false, 0);
-        assert.lengthOf(EditorManager.get(), 0);
-        done();
-      }
-    });
-  });
-
-  it('mceAddEditor - passing id directly as value', (done) => {
-    viewBlock.update('<textarea id="ed_1" class="tinymce"></textarea><textarea id="ed_2" class="tinymce"></textarea>');
-    EditorManager.init({
-      selector: 'textarea#ed_1',
-      init_instance_callback: (_editor1) => {
-        assert.lengthOf(EditorManager.get(), 1);
-        EditorManager.execCommand('mceAddEditor', false, 'ed_2');
-        assert.lengthOf(EditorManager.get(), 2);
-        done();
-      }
-    });
-  });
-
-  it('mceAddEditor - passing id and options as value', (done) => {
+  it('mceAddEditor', (done) => {
     viewBlock.update('<textarea id="ed_1" class="tinymce"></textarea><textarea id="ed_2" class="tinymce"></textarea>');
     EditorManager.init({
       selector: 'textarea#ed_1',


### PR DESCRIPTION
Related Ticket: TINY-8138

Description of Changes:
* Rework the `mceAddEditor`  command so that editor options have to specified in addition to the id
Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
