### PR TITLE
TINY-8383: Added back `validate: false` support for the parser

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
@@ -28,14 +28,13 @@ describe('browser.tinymce.core.html.SerializerTest', () => {
     );
   });
 
-  // TODO: TINY-4627/TINY-8383
-  it.skip('Serialize with validate: true, when parsing with validate:false bug', () => {
+  it('Serialize with validate: true, when parsing with validate:false bug', () => {
     const schema = Schema({ valid_elements: 'b' });
     const serializer = HtmlSerializer({}, schema);
 
     assert.equal(
       serializer.serialize(DomParser({ validate: false }, schema).parse('<b a="1" b="2">a</b><i a="1" b="2">b</i>')),
-      '<b a="1" b="2">a</b><i a="1" b="2">b</i>'
+      '<b b="2" a="1">a</b><i b="2" a="1">b</i>'
     );
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8383

Description of Changes:
* Make `validate: false` work again by ignoring the configured schema rules and added some basic tests since we largely had none
* Split out the parsing and sanitizing logic so DOMPurify only handles sanitization
* Made some minor performance improvements
* Did some minor code clean up (largely for legacy code)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
