### PR TITLE
TINY-7524: Ensure dialog labels and other text based fields only render as text

### DIFF
--- a/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
@@ -1,5 +1,5 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, EventFormat, Focusing, Form, FormField, FormTypes, Input, Invalidating,
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, EventFormat, Focusing, Form, FormField, FormTypes, GuiFactory, Input, Invalidating,
   Memento, Representing, SimulatedEvent, Sketcher, SketchSpec, Tabstopping, UiSketcher
 } from '@ephox/alloy';
 import { Cell, Fun, Future, Id, Merger, Optional, Result } from '@ephox/katamari';
@@ -90,7 +90,8 @@ const rgbFormFactory = (
     const helptext = translate(translatePrefix + 'range');
 
     const pLabel = FormField.parts.label({
-      dom: { tag: 'label', innerHtml: label, attributes: { 'aria-label': description }}
+      dom: { tag: 'label', attributes: { 'aria-label': description }},
+      components: [ GuiFactory.text(label) ]
     });
 
     const pField = FormField.parts.field({

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `table` plugin would sometimes not correctly handle headers in the `tfoot` section #TINY-8104
 - The aria labels for the color picker dialog were not translated #TINY-8381
 - The `editor.annotator.remove` did not keep selection when removing the annotation #TINY-8195
+- Dialog labels and other text-based UI properties did not escape HTML markup #TINY-7524
 
 ### Removed
 - Removed the deprecated `$`, `Class`, `DomQuery` and `Sizzle` APIs #TINY-4520 #TINY-8326

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/FieldLabeller.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/FieldLabeller.ts
@@ -5,8 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloySpec, Behaviour, FormField as AlloyFormField, RawDomSchema, SketchSpec } from '@ephox/alloy';
-// TODO: Export properly from alloy.
+import { AlloySpec, Behaviour, FormField as AlloyFormField, GuiFactory, RawDomSchema, SketchSpec } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
@@ -39,9 +38,11 @@ const renderFormFieldDomWith = (extraClasses): RawDomSchema => ({
 const renderLabel = (label: string, providersBackstage: UiFactoryBackstageProviders): AlloySpec => AlloyFormField.parts.label({
   dom: {
     tag: 'label',
-    classes: [ 'tox-label' ],
-    innerHtml: providersBackstage.translate(label)
-  }
+    classes: [ 'tox-label' ]
+  },
+  components: [
+    GuiFactory.text(providersBackstage.translate(label))
+  ]
 });
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/ButtonSlices.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/ButtonSlices.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Behaviour, Replacing, SimpleOrSketchSpec } from '@ephox/alloy';
+import { Behaviour, GuiFactory, Replacing, SimpleOrSketchSpec } from '@ephox/alloy';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as Icons from '../icons/Icons';
@@ -27,9 +27,11 @@ const renderReplacableIconFromPack = (iconName: string, iconsProvider: Icons.Ico
 const renderLabel = (text: string, prefix: string, providersBackstage: UiFactoryBackstageProviders) => ({
   dom: {
     tag: 'span',
-    innerHtml: providersBackstage.translate(text),
     classes: [ `${prefix}__select-label` ]
   },
+  components: [
+    GuiFactory.text(providersBackstage.translate(text))
+  ],
   behaviours: Behaviour.derive([
     Replacing.config({ })
   ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -7,7 +7,7 @@
 
 import {
   AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Button, Disabling,
-  FormField as AlloyFormField, Memento, NativeEvents, Representing, SimpleSpec, SimulatedEvent,
+  FormField as AlloyFormField, GuiFactory, Memento, NativeEvents, Representing, SimpleSpec, SimulatedEvent,
   SystemEvents, Tabstopping, Toggling
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
@@ -117,20 +117,22 @@ export const renderDropZone = (spec: DropZoneSpec, providersBackstage: UiFactory
         components: [
           {
             dom: {
-              tag: 'p',
-              innerHtml: providersBackstage.translate('Drop an image here')
-            }
+              tag: 'p'
+            },
+            components: [
+              GuiFactory.text(providersBackstage.translate('Drop an image here'))
+            ]
           },
           Button.sketch({
             dom: {
               tag: 'button',
-              innerHtml: providersBackstage.translate('Browse for an image'),
               styles: {
                 position: 'relative'
               },
               classes: [ 'tox-button', 'tox-button--secondary' ]
             },
             components: [
+              GuiFactory.text(providersBackstage.translate('Browse for an image')),
               memInput.asSpec()
             ],
             action: (comp) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloySpec, Behaviour, Keying, Replacing, SimpleSpec } from '@ephox/alloy';
+import { AlloySpec, Behaviour, GuiFactory, Keying, Replacing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Arr, Optional } from '@ephox/katamari';
 
@@ -16,13 +16,15 @@ import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 type LabelSpec = Omit<Dialog.Label, 'type'>;
 
 export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstageShared): SimpleSpec => {
-  const label = {
+  const label: AlloySpec = {
     dom: {
       tag: 'label',
-      innerHtml: backstageShared.providers.translate(spec.label),
       classes: [ 'tox-label' ]
-    }
-  } as AlloySpec;
+    },
+    components: [
+      GuiFactory.text(backstageShared.providers.translate(spec.label))
+    ]
+  };
   const comps = Arr.map(spec.items, backstageShared.interpreter);
   return {
     dom: {
@@ -30,8 +32,9 @@ export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstage
       classes: [ 'tox-form__group' ]
     },
     components: [
-      label
-    ].concat(comps),
+      label,
+      ...comps
+    ],
     behaviours: Behaviour.derive([
       ComposingConfigs.self(),
       Replacing.config({}),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -7,10 +7,10 @@
 
 import {
   AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, CustomEvent, Disabling, FormCoupledInputs as AlloyFormCoupledInputs,
-  FormField as AlloyFormField, Input as AlloyInput, NativeEvents, Representing, SketchSpec, Tabstopping
+  FormField as AlloyFormField, GuiFactory, Input as AlloyInput, NativeEvents, Representing, SketchSpec, Tabstopping
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Id } from '@ephox/katamari';
+import { Id, Unicode } from '@ephox/katamari';
 
 import { formChangeEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
@@ -86,9 +86,11 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
   const getLabel = (label: string) => ({
     dom: {
       tag: 'label',
-      classes: [ 'tox-label' ],
-      innerHtml: providersBackstage.translate(label)
-    }
+      classes: [ 'tox-label' ]
+    },
+    components: [
+      GuiFactory.text(providersBackstage.translate(label))
+    ]
   });
 
   const widthField = AlloyFormCoupledInputs.parts.field1(
@@ -115,7 +117,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
           widthField,
           heightField,
           formGroup([
-            getLabel('&nbsp;'),
+            getLabel(Unicode.nbsp),
             pLock
           ])
         ]

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AlloyTriggers, Behaviour, Focusing, SimpleSpec, Slider, SliderTypes } from '@ephox/alloy';
+import { AlloyTriggers, Behaviour, Focusing, GuiFactory, SimpleSpec, Slider, SliderTypes } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Fun, Optional } from '@ephox/katamari';
 
@@ -19,9 +19,11 @@ export const renderSlider = (spec: SliderSpec, providerBackstage: UiFactoryBacks
   const labelPart = Slider.parts.label({
     dom: {
       tag: 'label',
-      classes: [ 'tox-label' ],
-      innerHtml: providerBackstage.translate(spec.label)
-    }
+      classes: [ 'tox-label' ]
+    },
+    components: [
+      GuiFactory.text(providerBackstage.translate(spec.label))
+    ]
   });
 
   const spectrum = Slider.parts.spectrum({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Composing, Form as AlloyForm, Keying, Receiving, Representing,
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Composing, Form as AlloyForm, GuiFactory, Keying, Receiving, Representing,
   SketchSpec, Tabbar as AlloyTabbar, TabbarTypes, TabSection as AlloyTabSection, Tabstopping
 } from '@ephox/alloy';
 import { Objects } from '@ephox/boulder';
@@ -52,9 +52,11 @@ export const renderTabPanel = (spec: TabPanelSpec, dialogData: Dialog.DialogData
       value: tab.name,
       dom: {
         tag: 'div',
-        classes: [ 'tox-dialog__body-nav-item' ],
-        innerHtml: backstage.shared.providers.translate(tab.title)
+        classes: [ 'tox-dialog__body-nav-item' ]
       },
+      components: [
+        GuiFactory.text(backstage.shared.providers.translate(tab.title))
+      ],
       view: () => {
         return [
           // Dupe with SilverDialog

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Disabling, Focusing, FormField as AlloyFormField, Keying, Memento,
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Disabling, Focusing, FormField as AlloyFormField, GuiFactory, Keying, Memento,
   NativeEvents, SimpleSpec, Tabstopping, Unselecting
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
@@ -63,9 +63,11 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
   const pLabel = AlloyFormField.parts.label({
     dom: {
       tag: 'span',
-      classes: [ 'tox-checkbox__label' ],
-      innerHtml: providerBackstage.translate(spec.label)
+      classes: [ 'tox-checkbox__label' ]
     },
+    components: [
+      GuiFactory.text(providerBackstage.translate(spec.label))
+    ],
     behaviours: Behaviour.derive([
       Unselecting.config({})
     ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Tooltips.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Tooltips.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Tooltipping } from '@ephox/alloy';
+import { GuiFactory, Tooltipping } from '@ephox/alloy';
 
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 
@@ -29,9 +29,11 @@ const upConfig = (item, sharedBackstage: UiFactoryBackstageShared) => Tooltippin
     {
       dom: {
         tag: 'div',
-        classes: [ 'tox-tooltip__body' ],
-        innerHtml: item.text
-      }
+        classes: [ 'tox-tooltip__body' ]
+      },
+      components: [
+        GuiFactory.text(item.text)
+      ]
     },
     {
       dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/alien/ConvertShortcut.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/alien/ConvertShortcut.ts
@@ -15,11 +15,11 @@ import Env from 'tinymce/core/api/Env';
 const convertText = (source: string) => {
   const isMac = Env.os.isMacOS() || Env.os.isiOS();
   const mac = {
-    alt: '&#x2325;',
-    ctrl: '&#x2303;',
-    shift: '&#x21E7;',
-    meta: '&#x2318;',
-    access: '&#x2303;&#x2325;'
+    alt: '\u2325',
+    ctrl: '\u2303',
+    shift: '\u21E7',
+    meta: '\u2318',
+    access: '\u2303\u2325'
   };
   const other = {
     meta: 'Ctrl',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/SeparatorItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/SeparatorItem.ts
@@ -5,26 +5,19 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { ItemTypes } from '@ephox/alloy';
+import { GuiFactory, ItemTypes } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
 
 import * as ItemClasses from '../ItemClasses';
 
-const renderSeparatorItem = (spec: Menu.SeparatorMenuItem): ItemTypes.ItemSpec => {
-  const innerHtml = spec.text.fold(
-    () => ({ }),
-    (text) => ({ innerHtml: text })
-  );
-  return {
-    type: 'separator',
-    dom: {
-      tag: 'div',
-      classes: [ ItemClasses.selectableClass, ItemClasses.groupHeadingClass ],
-      ...innerHtml
-    },
-    components: [ ]
-  };
-};
+const renderSeparatorItem = (spec: Menu.SeparatorMenuItem): ItemTypes.ItemSpec => ({
+  type: 'separator',
+  dom: {
+    tag: 'div',
+    classes: [ ItemClasses.selectableClass, ItemClasses.groupHeadingClass ]
+  },
+  components: spec.text.map(GuiFactory.text).toArray()
+});
 
 export {
   renderSeparatorItem

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemSlices.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemSlices.ts
@@ -58,9 +58,11 @@ const renderStyledText = (style: StyleProps, text: string): AlloySpec => ({
 const renderShortcut = (shortcut: string): AlloySpec => ({
   dom: {
     tag: 'div',
-    classes: [ ItemClasses.accessoryClass ],
-    innerHtml: ConvertShortcut.convertText(shortcut)
-  }
+    classes: [ ItemClasses.accessoryClass ]
+  },
+  components: [
+    GuiFactory.text(ConvertShortcut.convertText(shortcut))
+  ]
 });
 
 const renderCheckmark = (icons: Icons.IconProvider): AlloySpec =>

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
@@ -71,7 +71,7 @@ const preprocessCollection = (items: ItemTypes.ItemSpec[], isSeparator: (a: Item
         allSplits.push(currentSplit);
       }
       currentSplit = [ ];
-      if (Obj.has(item.dom, 'innerHtml')) {
+      if (Obj.has(item.dom, 'innerHtml') || item.components.length > 0) {
         currentSplit.push(item);
       }
     } else {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { AddEventsBehaviour, AlloyEvents, Behaviour, Button, Disabling, Keying, Replacing, Tabstopping } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, Button, Disabling, GuiFactory, Keying, Replacing, Tabstopping } from '@ephox/alloy';
 import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -45,9 +45,11 @@ const renderElementPath = (editor: Editor, settings, providersBackstage: UiFacto
           'data-index': index,
           'tab-index': -1,
           'aria-level': index + 1
-        },
-        innerHtml: part.name
+        }
       },
+      components: [
+        GuiFactory.text(part.name)
+      ],
       action: (_btn) => {
         editor.focus();
         editor.selection.select(part.element);
@@ -65,9 +67,11 @@ const renderElementPath = (editor: Editor, settings, providersBackstage: UiFacto
         classes: [ 'tox-statusbar__path-divider' ],
         attributes: {
           'aria-hidden': true
-        },
-        innerHtml: ` ${settings.delimiter} `
-      }
+        }
+      },
+      components: [
+        GuiFactory.text(` ${settings.delimiter} `)
+      ]
     };
 
     return Arr.foldl(newPathElements.slice(1), (acc, element) => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/input/InputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/input/InputTest.ts
@@ -13,7 +13,8 @@ describe('headless.tinymce.themes.silver.components.input.InputTest', () => {
   const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
     renderInput({
       name: 'input',
-      label: Optional.some('LabelA'),
+      // Note: The label is intentionally HTML like to ensure the label is rendered as plain text
+      label: Optional.some('Solid<Liquid<Gas'),
       inputMode: Optional.none(),
       placeholder: Optional.none(),
       maximized: false,
@@ -29,7 +30,9 @@ describe('headless.tinymce.themes.silver.components.input.InputTest', () => {
         children: [
           s.element('label', {
             classes: [ arr.has('tox-label') ],
-            html: str.is('LabelA')
+            children: [
+              s.text(str.is('Solid<Liquid<Gas'))
+            ]
           }),
           s.element('input', {
             classes: [ arr.has('tox-textfield') ],

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
-import { GuiFactory, TestHelpers } from '@ephox/alloy';
+import { GuiFactory, Memento, TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 
@@ -13,21 +13,32 @@ describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
     interpreter: Fun.identity as any
   };
 
-  const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
-    renderLabel({
-      label: 'Group of Options',
-      items: [
-        {
-          dom: {
-            tag: 'label',
-            classes: [ 'tox-checkbox' ]
-          }
-        } as any
-      ]
-    }, sharedBackstage)
-  ));
+  const items = [
+    {
+      dom: {
+        tag: 'div',
+        classes: [ 'tox-checkbox' ]
+      }
+    } as any
+  ];
+
+  const memBasicLabel = Memento.record(renderLabel({
+    label: 'Group of Options',
+    items
+  }, sharedBackstage));
+
+  const memHtmlLabel = Memento.record(renderLabel({
+    label: 'Some <html> like content',
+    items
+  }, sharedBackstage));
+
+  const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build({
+    dom: { tag: 'div' },
+    components: [ memBasicLabel.asSpec(), memHtmlLabel.asSpec() ]
+  }));
 
   it('Check basic structure', () => {
+    const label = memBasicLabel.get(hook.component());
     Assertions.assertStructure(
       'Checking initial structure',
       ApproxStructure.build((s, str, arr) => s.element('div', {
@@ -39,12 +50,34 @@ describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
               s.text(str.is('Group of Options'))
             ]
           }),
-          s.element('label', {
+          s.element('div', {
             classes: [ arr.has('tox-checkbox') ]
           })
         ]
       })),
-      hook.component().element
+      label.element
+    );
+  });
+
+  it('TINY-7524: HTML like content should be rendered as plain text', () => {
+    const htmlLabel = memHtmlLabel.get(hook.component());
+    Assertions.assertStructure(
+      'Checking initial structure',
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-form__group') ],
+        children: [
+          s.element('label', {
+            classes: [ arr.has('tox-label') ],
+            children: [
+              s.text(str.is('Some <html> like content'))
+            ]
+          }),
+          s.element('div', {
+            classes: [ arr.has('tox-checkbox') ]
+          })
+        ]
+      })),
+      htmlLabel.element
     );
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-7524/TINY-8340

Description of Changes:
* Fixed a number of dialog labels and other text-based UI fields to ensure they are always rendered as text content only.

Note: I haven't touched `AlertBanner.ts` or `Notification.ts` as I know those do actually need to allow HTML at this stage.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
