### PR TITLE
TINY-7524: Fixed another case where text was being interpreted as HTML

### DIFF
--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/dialogbutton/DialogButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/dialogbutton/DialogButtonTest.ts
@@ -12,7 +12,7 @@ describe('headless.tinymce.themes.silver.components.dialogbutton.DialogButtonTes
     const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
       renderButton({
         name: 'test-button',
-        text: 'ButtonText',
+        text: 'Button<Text',
         disabled: false,
         primary: true,
         buttonType: Optional.some('primary'),
@@ -27,7 +27,7 @@ describe('headless.tinymce.themes.silver.components.dialogbutton.DialogButtonTes
         ApproxStructure.build((s, str, arr) => s.element('button', {
           classes: [ arr.has('tox-button'), arr.not('tox-button--secondary'), arr.not('tox-tbtn') ],
           children: [
-            s.text(str.is('ButtonText'))
+            s.text(str.is('Button<Text'))
           ]
         })),
         hook.component().element


### PR DESCRIPTION
Related Ticket: TINY-7524

Description of Changes:
* Found one more case while writing the QA notes where a `text` or `label` property was being rendered as HTML.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
