### PR TITLE
TINY-8411: Various fixes to be able to upgrade to the latest bedrock/monorepo libraries

### DIFF
--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -24,8 +24,8 @@
   "author": "Tiny Technologies, Inc",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/bedrock-client": "^11.0.0",
-    "@ephox/bedrock-common": "^11.0.0",
+    "@ephox/bedrock-client": "11 || 12 || 13",
+    "@ephox/bedrock-common": "11 || 12 || 13",
     "@ephox/jax": "^7.0.0-alpha.2",
     "@ephox/sand": "^6.0.0-alpha.2",
     "@ephox/sugar": "^9.0.0-alpha.2",

--- a/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
+++ b/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
@@ -1,4 +1,4 @@
-import { Assert, assert, TestLabel } from '@ephox/bedrock-client';
+import { Assert, TestLabel } from '@ephox/bedrock-client';
 import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
 import { Attribute, Classes, Css, Html, SugarElement, SugarNode, SugarText, Traverse, Truncate, Value } from '@ephox/sugar';
 
@@ -129,10 +129,10 @@ const element = (tag: string, fields: ElementFields): StructAssert => {
 const text = (s: StringAssert, combineSiblings = false): StructAssert => {
   const doAssert = (queue: ElementQueue): void => {
     queue.take().fold(() => {
-      assert.fail('No more nodes, so cannot check if its text is: ' + s.show() + ' for ' + queue.context());
+      Assert.fail('No more nodes, so cannot check if its text is: ' + s.show() + ' for ' + queue.context());
     }, (actual) => {
       SugarText.getOption(actual).fold(() => {
-        assert.fail('Node is not a text node, so cannot check if its text is: ' + s.show() + ' for ' + queue.context());
+        Assert.fail('Node is not a text node, so cannot check if its text is: ' + s.show() + ' for ' + queue.context());
       }, (t: string) => {
         let text = t;
         if (combineSiblings) {
@@ -159,7 +159,7 @@ const applyAssert = (structAssert: StructAssert, queue: ElementQueue) => {
     structAssert.doAssert(queue);
   } else {
     queue.take().fold(() => {
-      assert.fail('Expected more children to satisfy assertion for ' + queue.context());
+      Assert.fail('Expected more children to satisfy assertion for ' + queue.context());
     }, (item) => {
       structAssert.doAssert(item);
     });
@@ -291,14 +291,14 @@ const assertChildren = (expectedChildren: Optional<StructAssert[]>, actual: Suga
         structExpectation.doAssert(children);
       } else {
         children.take().fold(() => {
-          assert.fail('Expected more children to satisfy assertion ' + i + ' for ' + children.context());
+          Assert.fail('Expected more children to satisfy assertion ' + i + ' for ' + children.context());
         }, (item) => {
           structExpectation.doAssert(item);
         });
       }
     });
     if (children.peek().isSome()) {
-      assert.fail('More children than expected for ' + children.context());
+      Assert.fail('More children than expected for ' + children.context());
     }
   });
 };

--- a/modules/agar/src/test/ts/atomic/api/LoggerTest.ts
+++ b/modules/agar/src/test/ts/atomic/api/LoggerTest.ts
@@ -1,4 +1,5 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { UnitTest } from '@ephox/bedrock-client';
+import { assert } from 'chai';
 
 import * as Logger from 'ephox/agar/api/Logger';
 
@@ -11,9 +12,9 @@ UnitTest.test('LoggerTest', () => {
     });
     assert.fail('Expected test1 to fail');
   } catch (err) {
-    assert.eq(0,
-      err.message.indexOf('test 1. Foo is not a function\nTypeError:'),
-      'Expected enchanced error message.'
+    assert.include(err.message,
+      'test 1. Foo is not a function\nTypeError:',
+      'Expected enhanced error message.'
     );
   }
 });

--- a/modules/agar/src/test/ts/atomic/api/StepTest.ts
+++ b/modules/agar/src/test/ts/atomic/api/StepTest.ts
@@ -1,4 +1,5 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { UnitTest } from '@ephox/bedrock-client';
+import { assert } from 'chai';
 
 import * as Logger from 'ephox/agar/api/Logger';
 import { Pipeline } from 'ephox/agar/api/Pipeline';
@@ -38,7 +39,7 @@ UnitTest.asynctest('StepTest', (success, failure) => {
   }, (err) => {
     const expected = '[Basic API: Step.fail]\n\nFake failure: last test';
     try {
-      assert.eq(expected, err, '\nFailure incorrect. \nExpected:\n' + expected + '\nActual: ' + err);
+      assert.equal(err, expected, '\nFailure incorrect. \nExpected:\n' + expected + '\nActual: ' + err);
     } catch (e) {
       failure(e);
     }
@@ -60,7 +61,7 @@ UnitTest.asynctest('Step.predicate false Test', (success, failure) => {
   }, (err) => {
     const expected = '[ Predicate false ]\npredicate did not succeed';
     try {
-      assert.eq(expected, err, '\nFailure incorrect. \nExpected:\n' + expected + '\nActual: ' + err);
+      assert.equal(err, expected, '\nFailure incorrect. \nExpected:\n' + expected + '\nActual: ' + err);
     } catch (e) {
       failure(e);
     }

--- a/modules/agar/src/test/ts/browser/AssertionsTest.ts
+++ b/modules/agar/src/test/ts/browser/AssertionsTest.ts
@@ -1,4 +1,5 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { UnitTest } from '@ephox/bedrock-client';
+import { assert } from 'chai';
 
 import * as Assertions from 'ephox/agar/api/Assertions';
 
@@ -15,7 +16,7 @@ UnitTest.test('AssertionsTest', () => {
   try {
     Assertions.assertEq('test 1 (assert.eq)', 10, 5);
   } catch (err) {
-    assert.eq('test 1 (assert.eq)', err.message);
+    assert.equal(err.message, 'test 1 (assert.eq)');
   }
 
   try {

--- a/modules/agar/src/test/ts/browser/api/CleanerTest.ts
+++ b/modules/agar/src/test/ts/browser/api/CleanerTest.ts
@@ -1,4 +1,5 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { UnitTest } from '@ephox/bedrock-client';
+import { assert } from 'chai';
 
 import { Cleaner } from 'ephox/agar/api/Cleaner';
 
@@ -10,6 +11,6 @@ UnitTest.test('Cleaner', () => {
     args = [ a, b, c, d ];
     return token;
   })('a', 3, 2, 'cat');
-  assert.eq([ 'a', 3, 2, 'cat' ], args, 'Cleaner.wrap should pass arguments through');
-  assert.eq(token, ret, 'Cleaner.wrap should pass return value up');
+  assert.deepEqual(args, [ 'a', 3, 2, 'cat' ], 'Cleaner.wrap should pass arguments through');
+  assert.equal(ret, token, 'Cleaner.wrap should pass return value up');
 });

--- a/modules/agar/src/test/ts/browser/api/DragnDropTest.ts
+++ b/modules/agar/src/test/ts/browser/api/DragnDropTest.ts
@@ -1,5 +1,6 @@
-import { Assert, assert, UnitTest } from '@ephox/bedrock-client';
+import { UnitTest } from '@ephox/bedrock-client';
 import { DomEvent, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
 
 import { dragnDrop, dropFiles, isDraggable, sDragnDrop, sDropFiles, sDropItems } from 'ephox/agar/api/DragnDrop';
 import { createFile } from 'ephox/agar/api/Files';
@@ -10,7 +11,7 @@ import { Step } from 'ephox/agar/api/Step';
 
 UnitTest.test('DragDrop.isDraggable', () => {
   const check = (expected: boolean, html: string) => {
-    assert.eq(expected, isDraggable(SugarElement.fromHtml(html)));
+    assert.equal(isDraggable(SugarElement.fromHtml(html)), expected);
   };
   check(false, '<div/>');
   check(false, '<a/>');
@@ -33,7 +34,7 @@ UnitTest.asynctest('DragnDropTest', (success, failure) => {
   });
 
   const sAssertStoreItems = (expectedStoreItems: string[]) => Step.sync(() => {
-    Assert.eq('Should have the expetec items', expectedStoreItems, store);
+    assert.deepEqual(store, expectedStoreItems, 'Should have the expected items');
   });
 
   const dragStartUnbinder = DomEvent.bind(draggable, 'dragstart', (evt) => {

--- a/modules/agar/src/test/ts/browser/datatransfer/DataTransferItemListTest.ts
+++ b/modules/agar/src/test/ts/browser/datatransfer/DataTransferItemListTest.ts
@@ -1,5 +1,6 @@
-import { assert, Assert, UnitTest } from '@ephox/bedrock-client';
+import { UnitTest } from '@ephox/bedrock-client';
 import { Type } from '@ephox/katamari';
+import { assert } from 'chai';
 
 import { createFile } from 'ephox/agar/api/Files';
 import { createDataTransfer } from 'ephox/agar/datatransfer/DataTransfer';
@@ -11,18 +12,18 @@ UnitTest.test('DataTransferItemListTest', () => {
   const testAdding = () => {
     const items = createDataTransferItemList(createDataTransfer());
 
-    Assert.eq('Should not be an array', false, Type.isArray(items));
+    assert.isFalse(Type.isArray(items), 'Should not be an array');
 
     items.add(createFile('a.txt', 1234, new Blob([ '123' ], { type: 'text/html' })));
-    Assert.eq('Should be expected kind', 'file', items[0].kind);
-    Assert.eq('Should be expected length', 1, items.length);
+    assert.equal(items[0].kind, 'file', 'Should be expected kind');
+    assert.lengthOf(items, 1, 'Should be expected length');
 
     items.add('123', 'text/plain');
-    Assert.eq('Should be expected kind', 'string', items[1].kind);
-    Assert.eq('Should be expected length', 2, items.length);
-    Assert.eq('Should be expected data', '123', getData(items[1]).getOr(''));
+    assert.equal(items[1].kind, 'string', 'Should be expected kind');
+    assert.lengthOf(items, 2, 'Should be expected length');
+    assert.equal(getData(items[1]).getOr(''), '123', 'Should be expected data');
 
-    assert.throwsError(() => {
+    assert.throws(() => {
       items.add('123', 'text/plain');
     }, `Failed to execute 'add' on 'DataTransferItemList': An item already exists for type 'text/plain'.`);
   };
@@ -36,9 +37,9 @@ UnitTest.test('DataTransferItemListTest', () => {
 
     items.remove(1);
 
-    Assert.eq('Should be expected length', 2, items.length);
-    Assert.eq('Should be expected kind', 'file', items[0].kind);
-    Assert.eq('Should be expected kind', 'string', items[1].kind);
+    assert.lengthOf(items, 2, 'Should be expected length');
+    assert.equal(items[0].kind, 'file', 'Should be expected kind');
+    assert.equal(items[1].kind, 'string', 'Should be expected kind');
   };
 
   const testClearing = () => {
@@ -50,7 +51,7 @@ UnitTest.test('DataTransferItemListTest', () => {
 
     items.clear();
 
-    Assert.eq('Should be expected length', 0, items.length);
+    assert.lengthOf(items, 0, 'Should be expected length');
   };
 
   const testMutationWhileInProtectedMode = () => {
@@ -59,15 +60,15 @@ UnitTest.test('DataTransferItemListTest', () => {
 
     setProtectedMode(dataTransfer);
 
-    assert.throwsError(() => {
+    assert.throws(() => {
       items.add('123', 'text/plain');
     }, 'Invalid state dataTransfer is not in read/write mode');
 
-    assert.throwsError(() => {
+    assert.throws(() => {
       items.remove(0);
     }, 'Invalid state dataTransfer is not in read/write mode');
 
-    assert.throwsError(() => {
+    assert.throws(() => {
       items.clear();
     }, 'Invalid state dataTransfer is not in read/write mode');
   };
@@ -78,15 +79,15 @@ UnitTest.test('DataTransferItemListTest', () => {
 
     setReadOnlyMode(dataTransfer);
 
-    assert.throwsError(() => {
+    assert.throws(() => {
       items.add('123', 'text/plain');
     }, 'Invalid state dataTransfer is not in read/write mode');
 
-    assert.throwsError(() => {
+    assert.throws(() => {
       items.remove(0);
     }, 'Invalid state dataTransfer is not in read/write mode');
 
-    assert.throwsError(() => {
+    assert.throws(() => {
       items.clear();
     }, 'Invalid state dataTransfer is not in read/write mode');
   };

--- a/modules/sand/CHANGELOG.md
+++ b/modules/sand/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `isOSX` API has been renamed to `isMacOS` #TINY-8175
 - The `isChrome` API has been renamed to `isChromium` to better reflect its functionality #TINY-8300
 
+### Fixed
+- The `SandHTMLElement.isPrototypeOf` API would throw an illegal invocation error on Chromium based browsers #TINY-8414
+
 ## 5.0.0 - 2021-08-26
 
 ### Improved

--- a/modules/sand/src/main/ts/ephox/sand/api/SandHTMLElement.ts
+++ b/modules/sand/src/main/ts/ephox/sand/api/SandHTMLElement.ts
@@ -21,7 +21,7 @@ const isPrototypeOf = (x: any): x is HTMLElement => {
 
   // TINY-7374: We can't rely on looking at the owner window HTMLElement as the element may have
   // been constructed in a different window and then appended to the current window document.
-  return Type.isObject(x) && (sandHTMLElement(scope).prototype.isPrototypeOf(x) || /^\[object HTML\w*Element\]$/.test(getPrototypeOf(x).toString()));
+  return Type.isObject(x) && (sandHTMLElement(scope).prototype.isPrototypeOf(x) || /^HTML\w*Element$/.test(getPrototypeOf(x).constructor.name));
 };
 
 export {

--- a/modules/sand/src/test/ts/browser/HtmlElementTest.ts
+++ b/modules/sand/src/test/ts/browser/HtmlElementTest.ts
@@ -28,11 +28,14 @@ describe('HtmlElementTest', () => {
 
     it('same window elements should be true', () => {
       const div = document.createElement('div');
+      const a = document.createElement('a');
       assert.isTrue(SandHTMLElement.isPrototypeOf(div));
+      assert.isTrue(SandHTMLElement.isPrototypeOf(a));
     });
 
     it('TINY-7374: different window elements should be true', () => {
       const span = document.createElement('span');      // HTMLSpanElement
+      const a = document.createElement('a');            // HTMLAnchorElement
       const strong = document.createElement('strong');  // HTMLElement
       const iframe = document.createElement('iframe');
       document.body.appendChild(iframe);
@@ -43,8 +46,10 @@ describe('HtmlElementTest', () => {
       iframeDoc.close();
 
       iframeDoc.body.appendChild(span);
+      iframeDoc.body.appendChild(a);
       iframeDoc.body.appendChild(strong);
       assert.isTrue(SandHTMLElement.isPrototypeOf(span));
+      assert.isTrue(SandHTMLElement.isPrototypeOf(a));
       assert.isTrue(SandHTMLElement.isPrototypeOf(strong));
 
       document.body.removeChild(iframe);

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,7 +200,7 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@ephox/bedrock-client@^11.0.0", "@ephox/bedrock-client@^11.3.2":
+"@ephox/bedrock-client@11 || 12 || 13", "@ephox/bedrock-client@^11.0.0", "@ephox/bedrock-client@^11.3.2":
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/@ephox/bedrock-client/-/bedrock-client-11.3.2.tgz#b358d6f9857e751e115c19eb0f9d89bb4135eaf2"
   integrity sha512-tpsOMSfKPhzHBksyz5ZtM4gUjZsUw51i2cCaMuwSysOtiEbB4IKPceYyg4NxsbysSvHY8xAVrzobgj71MJDJvQ==
@@ -208,7 +208,7 @@
     "@ephox/bedrock-common" "^11.3.2"
     "@ephox/dispute" "^1.0.3"
 
-"@ephox/bedrock-common@^11.0.0", "@ephox/bedrock-common@^11.3.2":
+"@ephox/bedrock-common@11 || 12 || 13", "@ephox/bedrock-common@^11.3.2":
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/@ephox/bedrock-common/-/bedrock-common-11.3.2.tgz#91ac9b9b959d50acf7198463e5eddff692eceed0"
   integrity sha512-LmkoXqX8NZAr/hoWnuAcbrzKNb562/6G/g/xFF3Sul1By0XEJnW36FbYZo2LMffKB1DlsHS+OMhuqPKHQXhjSw==


### PR DESCRIPTION
Related Ticket: TINY-8411/TINY-8414

Description of Changes:
* Upgrade Agar to remove uses of the legacy `assert` API that was removed in Bedrock 13
* Upgrade Agar deps to allow using version 11, 12 or 13 of bedrock
* Fix `SandHTMLElement.isPrototypeOf` throwing an `Illegal invocation` error for `HTMLAnchorElement` on Chromium based browsers (it doesn't like calling `toString` on the prototype)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
