### PR TITLE
TINY-8344: Rename getShortEndedElements to getVoidElements and seal the list of void elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed the `textpattern_patterns` option to `text_patterns` #TINY-8312
 - Moved the `hr` plugin's functionality to TinyMCE core #TINY-8313
 - Moved the `print` plugin's functionality to TinyMCE core #TINY-8314
+- Renamed the `getShortEndedElements` Schema API to `getVoidElements` #TINY-8344
 
 ### Fixed
 - The object returned from the `editor.fire()` API was incorrect if the editor had been removed #TINY-8018

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -255,7 +255,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
     editor.on('SetSelectionRange', (e) => {
       // If the range is set inside a short ended element, then move it
       // to the side as IE for example will try to add content inside
-      e.range = normalizeShortEndedElementSelection(e.range);
+      e.range = normalizeVoidElementSelection(e.range);
 
       const rng = setElementSelection(e.range, e.forward);
       if (rng) {
@@ -308,15 +308,15 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
   const isRangeInCaretContainer = (rng: Range) =>
     isWithinCaretContainer(rng.startContainer) || isWithinCaretContainer(rng.endContainer);
 
-  const normalizeShortEndedElementSelection = (rng: Range) => {
-    const shortEndedElements = editor.schema.getShortEndedElements();
+  const normalizeVoidElementSelection = (rng: Range) => {
+    const voidElements = editor.schema.getVoidElements();
     const newRng = dom.createRng();
     const startContainer = rng.startContainer;
     const startOffset = rng.startOffset;
     const endContainer = rng.endContainer;
     const endOffset = rng.endOffset;
 
-    if (Obj.has(shortEndedElements, startContainer.nodeName.toLowerCase())) {
+    if (Obj.has(voidElements, startContainer.nodeName.toLowerCase())) {
       if (startOffset === 0) {
         newRng.setStartBefore(startContainer);
       } else {
@@ -326,7 +326,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
       newRng.setStart(startContainer, startOffset);
     }
 
-    if (Obj.has(shortEndedElements, endContainer.nodeName.toLowerCase())) {
+    if (Obj.has(voidElements, endContainer.nodeName.toLowerCase())) {
       if (endOffset === 0) {
         newRng.setEndBefore(endContainer);
       } else {

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -72,7 +72,7 @@ interface Schema {
   getValidClasses: () => Record<string, SchemaMap> | undefined;
   getBlockElements: () => SchemaMap;
   getInvalidStyles: () => Record<string, SchemaMap> | undefined;
-  getShortEndedElements: () => SchemaMap;
+  getVoidElements: () => SchemaMap;
   getTextBlockElements: () => SchemaMap;
   getTextInlineElements: () => SchemaMap;
   getBoolAttrs: () => SchemaMap;
@@ -448,14 +448,14 @@ const Schema = (settings?: SchemaSettings): Schema => {
     'pre script noscript style textarea video audio iframe object code'
   );
   const selfClosingElementsMap = createLookupTable('self_closing_elements', 'colgroup dd dt li option p td tfoot th thead tr');
-  const shortEndedElementsMap = createLookupTable('short_ended_elements', 'area base basefont br col frame hr img input isindex link ' +
+  const voidElementsMap = createLookupTable('void_elements', 'area base basefont br col frame hr img input isindex link ' +
     'meta param embed source wbr track');
   const boolAttrMap = createLookupTable('boolean_attributes', 'checked compact declare defer disabled ismap multiple nohref noresize ' +
     'noshade nowrap readonly selected autoplay loop controls');
 
   const nonEmptyOrMoveCaretBeforeOnEnter = 'td th iframe video audio object script code';
-  const nonEmptyElementsMap = createLookupTable('non_empty_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' pre', shortEndedElementsMap);
-  const moveCaretBeforeOnEnterElementsMap = createLookupTable('move_caret_before_on_enter_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' table', shortEndedElementsMap);
+  const nonEmptyElementsMap = createLookupTable('non_empty_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' pre', voidElementsMap);
+  const moveCaretBeforeOnEnterElementsMap = createLookupTable('move_caret_before_on_enter_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' table', voidElementsMap);
 
   const textBlockElementsMap = createLookupTable('text_block_elements', 'h1 h2 h3 h4 h5 h6 p div address pre form ' +
     'blockquote center dir fieldset header footer article section hgroup aside main nav figure');
@@ -890,12 +890,12 @@ const Schema = (settings?: SchemaSettings): Schema => {
   const getTextInlineElements = Fun.constant(textInlineElementsMap);
 
   /**
-   * Returns a map with short ended elements. For example: <code>&#60;br&#62;</code> or <code>&#60;img&#62;</code>.
+   * Returns a map with void elements. For example: <code>&#60;br&#62;</code> or <code>&#60;img&#62;</code>.
    *
-   * @method getShortEndedElements
-   * @return {Object} Name/value lookup map for short ended elements.
+   * @method getVoidElements
+   * @return {Object} Name/value lookup map for void elements.
    */
-  const getShortEndedElements = Fun.constant(shortEndedElementsMap);
+  const getVoidElements = Fun.constant(Object.seal(voidElementsMap));
 
   /**
    * Returns a map with self closing tags. For example: <code>&#60;li&#62;</code>.
@@ -1055,7 +1055,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
     getValidClasses,
     getBlockElements,
     getInvalidStyles,
-    getShortEndedElements,
+    getVoidElements,
     getTextBlockElements,
     getTextInlineElements,
     getBoolAttrs,

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -112,7 +112,7 @@ const isPartOfFragment = (node: Element): boolean => {
 };
 
 const canHaveChildren = (editor: Editor, node: Node | undefined): boolean => {
-  return node && !editor.schema.getShortEndedElements()[node.nodeName];
+  return node && !editor.schema.getVoidElements()[node.nodeName];
 };
 
 const moveSelectionToMarker = (editor: Editor, marker: HTMLElement | null): void => {

--- a/modules/tinymce/src/core/main/ts/dom/TrimHtml.ts
+++ b/modules/tinymce/src/core/main/ts/dom/TrimHtml.ts
@@ -22,7 +22,7 @@ const trimInternal = (serializer: DomSerializer, html: string): string => {
   const schema = serializer.schema;
 
   let content = trimHtml(serializer.getTempAttrs(), html);
-  const shortEndedElements = schema.getShortEndedElements();
+  const voidElements = schema.getVoidElements();
 
   // Remove all bogus elements marked with "all"
   let matches: RegExpExecArray;
@@ -31,7 +31,7 @@ const trimInternal = (serializer: DomSerializer, html: string): string => {
     const matchLength = matches[0].length;
 
     let endTagIndex: number;
-    if (shortEndedElements[matches[1]]) {
+    if (voidElements[matches[1]]) {
       endTagIndex = index;
     } else {
       endTagIndex = SaxParser.findEndTag(schema, content, index);

--- a/modules/tinymce/src/core/main/ts/paste/PasteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/paste/PasteUtils.ts
@@ -38,7 +38,7 @@ const innerText = (html: string): string => {
   const schema = Schema();
   const domParser = DomParser({}, schema);
   let text = '';
-  const shortEndedElements = schema.getShortEndedElements();
+  const voidElements = schema.getVoidElements();
   const ignoreElements = Tools.makeMap('script noscript style textarea video audio iframe object', ' ');
   const blockElements = schema.getBlockElements();
 
@@ -56,7 +56,7 @@ const innerText = (html: string): string => {
     }
 
     // img/input/hr but ignore wbr as it's just a potential word break
-    if (shortEndedElements[name]) {
+    if (voidElements[name]) {
       text += ' ';
     }
 

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -216,9 +216,9 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     });
   });
 
-  it('getShortEndedElements', () => {
+  it('getVoidElements', () => {
     const schema = Schema();
-    assert.deepEqual(schema.getShortEndedElements(), {
+    assert.deepEqual(schema.getVoidElements(), {
       EMBED: {}, PARAM: {}, META: {}, LINK: {}, ISINDEX: {},
       INPUT: {}, IMG: {}, HR: {}, FRAME: {}, COL: {}, BR: {},
       BASEFONT: {}, BASE: {}, AREA: {}, SOURCE: {}, WBR: {}, TRACK: {},

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
@@ -25,7 +25,7 @@ interface CollectCallbacks {
   readonly text: (node: Text, section: TextSection) => void;
 }
 
-const isSimpleBoundary = (dom: DOMUtils, node: Node) => dom.isBlock(node) || Obj.has(dom.schema.getShortEndedElements(), node.nodeName);
+const isSimpleBoundary = (dom: DOMUtils, node: Node) => dom.isBlock(node) || Obj.has(dom.schema.getVoidElements(), node.nodeName);
 const isContentEditableFalse = (dom: DOMUtils, node: Node) => dom.getContentEditable(node) === 'false';
 const isContentEditableTrueInCef = (dom: DOMUtils, node: Node) => dom.getContentEditable(node) === 'true' && dom.getContentEditableParent(node.parentNode) === 'false';
 const isHidden = (dom: DOMUtils, node: Node) => !dom.isBlock(node) && Obj.has(dom.schema.getWhiteSpaceElements(), node.nodeName);

--- a/modules/tinymce/src/plugins/wordcount/main/ts/core/GetText.ts
+++ b/modules/tinymce/src/plugins/wordcount/main/ts/core/GetText.ts
@@ -12,9 +12,9 @@ import Schema, { SchemaMap } from 'tinymce/core/api/html/Schema';
 
 const getText = (node: Node, schema: Schema): string[] => {
   const blockElements: SchemaMap = schema.getBlockElements();
-  const shortEndedElements: SchemaMap = schema.getShortEndedElements();
+  const voidElements: SchemaMap = schema.getVoidElements();
 
-  const isNewline = (node: Node) => blockElements[node.nodeName] || shortEndedElements[node.nodeName];
+  const isNewline = (node: Node) => blockElements[node.nodeName] || voidElements[node.nodeName];
 
   const textBlocks: string[] = [];
   let txt = '';


### PR DESCRIPTION
Related Ticket: TINY-8344

Description of Changes:
* Rename the `getShortEndedElements` API to `getVoidElements` to match the actual name used in the HTML spec
* Seal the void elements list since it's not something that should be changed at runtime

Note: I didn't seal the special elements in this PR, as that's instead been done in https://github.com/tinymce/tinymce/pull/7535 since the media plugin needs to be updated first.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
