### PR TITLE
TINY-8296: Removed the unregistered options console warning

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj, Strings, Type } from '@ephox/katamari';
+import { Obj, Strings, Type } from '@ephox/katamari';
 
 import Editor from './Editor';
 import { EditorOptions, NormalizedEditorOptions } from './OptionTypes';
@@ -207,14 +207,6 @@ const processDefaultValue = <T, U>(name: string, defaultValue: T, processor: Pro
 const create = (editor: Editor, initialOptions: Record<string, unknown>): Options => {
   const registry: Record<string, OptionSpec<any, any>> = {};
   const values: Record<string, any> = {};
-
-  editor.on('init', () => {
-    const unregisteredOptions = Arr.filter(Obj.keys(initialOptions), (option) => !isRegistered(option) && option !== 'mobile');
-    if (unregisteredOptions.length > 0) {
-      // eslint-disable-next-line no-console
-      console.warn('The following options were specified but have not been registered:\n - ' + unregisteredOptions.join('\n - '));
-    }
-  });
 
   const setValue = <T, U>(name: string, value: T, processor: SimpleProcessor | Processor<U>): boolean => {
     const result = processValue(value, processor);

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -77,7 +77,7 @@ class ScriptLoader {
   /**
    * Loads a specific script directly without adding it to the load queue.
    *
-   * @method load
+   * @method loadScript
    * @param {String} url Absolute URL to script to add.
    * @param {function} success Optional success callback function when the script loaded successfully.
    * @param {function} failure Optional failure callback function when the script failed to load.


### PR DESCRIPTION
Related Ticket: TINY-8296

Description of Changes:
* Remove the unregistered options warning
* Sneak in a typo @RobinJoe found in the `ScriptLoader` API docs

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
