### PR TITLE
TINY-8169: added new approach for adding noneditable fake carets

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dialog `redial` API will now only rerender the changed components instead of the whole dialog #TINY-8334
 - The dialog API `setData` method now uses a deep merge algorithm to support partial nested objects #TINY-8333
 - The dialog spec `initialData` type is now `Partial<T>` to match the underlying implementation details #TINY-8334
-- Improved support for placing the caret before/after noneditable elements within the editor #TINY-8169
+- Improved support for placing the caret before or after noneditable elements within the editor #TINY-8169
 
 ### Changed
 - The `editor.getContent()` API can provide custom content by preventing and overriding `content` in the `BeforeGetContent` event. This makes it consistent with the `editor.selection.getContent()` API #TINY-8018

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dialog `redial` API will now only rerender the changed components instead of the whole dialog #TINY-8334
 - The dialog API `setData` method now uses a deep merge algorithm to support partial nested objects #TINY-8333
 - The dialog spec `initialData` type is now `Partial<T>` to match the underlying implementation details #TINY-8334
+- Improved support for placing the caret before/after noneditable elements within the editor #TINY-8169
 
 ### Changed
 - The `editor.getContent()` API can provide custom content by preventing and overriding `content` in the `BeforeGetContent` event. This makes it consistent with the `editor.selection.getContent()` API #TINY-8018

--- a/modules/tinymce/src/core/demo/html/content_editable_false_demo.html
+++ b/modules/tinymce/src/core/demo/html/content_editable_false_demo.html
@@ -9,8 +9,14 @@
     <div id="ephox-ui">
       <textarea class="tinymce" rows="15" cols="80" style="width: 80%">
         <p contentEditable="false">[cE=false]</p>
+        <div contentEditable="false" style="padding: 20px">
+          <div contentEditable="true">dd
+            <div contentEditable="false" style="margin: 20px"><div contentEditable="true" style="margin: 20px">[cE=true]</div></div>
+            <div contentEditable="false" style="margin: 20px"><div contentEditable="true" style="margin: 20px">[cE=true]</div></div>
+          </div>
+        </div>
         <p>[cE=true]<span contentEditable="false">[cE=false:1]</span>abc<span contentEditable="false">[cE=false:2]</span><span contentEditable="false">[cE=false:3]</span><span contentEditable="false">[cE=false:4]</span><span contentEditable="false">[cE=false:5]</span></p>
-        <p>Nam nisi elit, cursus in rhoncus sit amet, pulvinar laoreet leo. Nam <a href="#">sed</a> lectus quam, ut sagittis tellus. Quisque dignissim mauris a augue rutrum tempor. Donec vitae purus nec massa vestibulum ornare sit ame<span contentEditable="false">[cE=false]</span>t id tellus. Nunc quam mauris, fermentum nec lacinia eget, sollicitudin nec ante. Aliquam molestie volutpat dapibus. Nunc interdum viverra sodales. Morbi laoreet pulvinar gravida. Quisque ut turpis sagittis nunc accumsan vehicula. Duis elementum congue ultrices. Cras faucibus feugiat arcu quis lacinia. In hac habitasse platea dictumst. Pellentesque fermentum magna sit amet tellus varius ullamcorper. Vestibulum at urna augue, eget varius neque. Fusce facilisis venenatis dapibus. Integer non sem at arcu euismod tempor nec sed nisl. Morbi ultricies, mauris ut ultricies adipiscing, felis odio condimentum massa, et luctus est nunc nec eros.</p>
+        <p style="line-height: 30px">Nam nisi elit, cursus in rhoncus sit amet, pulvinar laoreet leo. Nam <a href="#">sed</a> lectus quam, ut sagittis tellus. Quisque dignissim mauris a augue rutrum tempor. Donec vitae purus nec massa vestibulum ornare sit ame<span contentEditable="false">[cE=false]</span>t id tellus. Nunc quam mauris, fermentum nec lacinia eget, sollicitudin nec ante. Aliquam molestie volutpat dapibus. Nunc interdum viverra sodales. Morbi l<span contentEditable="false">[cE=false:1]</span><span contentEditable="false">[cE=false:2]</span>aoreet pulvinar gravida. Quisque ut turpis sagittis nunc accumsan vehicula. Duis elementum congue ultrices. Cras faucibus feugiat arcu quis lacinia. In hac habitasse platea dictumst. Pellentesque fermentum magna sit amet tellus varius ullamcorper. Vestibulum at urna augue, eget varius neque. Fusce facilisis venenatis dapibus. Integer non sem at arcu euismod tempor nec sed nisl. Morbi ultricies, mauris ut ultricies adipiscing, felis odio condimentum massa, et luctus est nunc nec eros.</p>
         <p><span contentEditable="false">[cE=false<span contentEditable="true">[cE=true]</span>]</span></p>
         <p contentEditable="false">[cE=false]</p>
         <p contentEditable="false">[cE=false]</p>

--- a/modules/tinymce/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
@@ -67,7 +67,7 @@ export default () => {
     add_unload_trigger: false,
     toolbar: 'insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify' +
     ' | bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample',
-    plugins: [ 'list' ],
+    plugins: [ 'code' ],
     content_css: '../css/content_editable.css',
     height: 400
   });
@@ -79,7 +79,7 @@ export default () => {
     add_unload_trigger: false,
     toolbar: 'insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify' +
     ' | bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample',
-    plugins: [ 'list' ],
+    plugins: [ 'code' ],
     content_css: '../css/content_editable.css'
   });
 

--- a/modules/tinymce/src/core/main/ts/caret/CaretContainerInput.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretContainerInput.ts
@@ -23,6 +23,7 @@ const findBlockCaretContainer = (editor: Editor): HTMLElement | null =>
 const showBlockCaretContainer = (editor: Editor, blockCaretContainer: HTMLElement): void => {
   if (blockCaretContainer.hasAttribute('data-mce-caret')) {
     CaretContainer.showCaretContainerBlock(blockCaretContainer);
+    editor.selection.setRng(editor.selection.getRng()); // Clears the fake caret state
     editor.selection.scrollIntoView(blockCaretContainer);
   }
 };

--- a/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
+++ b/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
@@ -62,23 +62,23 @@ const horizontalDistance: distanceFn = (rect, x, _y) => Math.min(Math.abs(rect.l
 
 const closestChildCaretCandidateNodeRect = (children: ChildNode[], clientX: number, clientY: number): Optional<NodeClientRect> => {
   const findClosestCaretCandidateNodeRect = (rects: NodeClientRect[], distance: distanceFn): Optional<NodeClientRect> => {
-    const helper = (i: number, rects: NodeClientRect[]): Optional<NodeClientRect> => {
-      if (i === rects.length) {
-        return Optional.none();
-      } else {
-        const rect = rects[i];
-        const node = rect.node;
+    const sortedRects = Arr.sort(rects, (r1, r2) => distance(r1, clientX, clientY) - distance(r2, clientX, clientY));
 
-        if (CaretCandidate.isCaretCandidate(node)) {
-          return Optional.some(rect);
-        } else if (NodeType.isElement(node)) {
-          const childRect = closestChildCaretCandidateNodeRect(Arr.from(node.childNodes), clientX, clientY);
-          return childRect.isSome() ? childRect : helper(i + 1, rects);
+    for (let i = 0; i < sortedRects.length; i++) {
+      const rect = sortedRects[i];
+      const node = rect.node;
+
+      if (CaretCandidate.isCaretCandidate(node)) {
+        return Optional.some(rect);
+      } else if (NodeType.isElement(node)) {
+        const childRect = closestChildCaretCandidateNodeRect(Arr.from(node.childNodes), clientX, clientY);
+        if (childRect.isSome()) {
+          return childRect;
         }
       }
-    };
+    }
 
-    return helper(0, rects.sort((r1, r2) => distance(r1, clientX, clientY) - distance(r2, clientX, clientY)));
+    return Optional.none();
   };
 
   const [ horizontalRects, verticalRects ] = splitRectsPerAxis(getClientRects(children), clientY);

--- a/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
+++ b/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
@@ -62,23 +62,18 @@ const horizontalDistance: distanceFn = (rect, x, _y) => Math.min(Math.abs(rect.l
 
 const closestChildCaretCandidateNodeRect = (children: ChildNode[], clientX: number, clientY: number): Optional<NodeClientRect> => {
   const findClosestCaretCandidateNodeRect = (rects: NodeClientRect[], distance: distanceFn): Optional<NodeClientRect> => {
-    const sortedRects = Arr.sort(rects, (r1, r2) => distance(r1, clientX, clientY) - distance(r2, clientX, clientY));
-
-    for (let i = 0; i < sortedRects.length; i++) {
-      const rect = sortedRects[i];
-      const node = rect.node;
-
-      if (CaretCandidate.isCaretCandidate(node)) {
-        return Optional.some(rect);
-      } else if (NodeType.isElement(node)) {
-        const childRect = closestChildCaretCandidateNodeRect(Arr.from(node.childNodes), clientX, clientY);
-        if (childRect.isSome()) {
-          return childRect;
+    return Arr.findMap(
+      Arr.sort(rects, (r1, r2) => distance(r1, clientX, clientY) - distance(r2, clientX, clientY)),
+      (rect) => {
+        if (CaretCandidate.isCaretCandidate(rect.node)) {
+          return Optional.some(rect);
+        } else if (NodeType.isElement(rect.node)) {
+          return closestChildCaretCandidateNodeRect(Arr.from(rect.node.childNodes), clientX, clientY);
+        } else {
+          return Optional.none();
         }
       }
-    }
-
-    return Optional.none();
+    );
   };
 
   const [ horizontalRects, verticalRects ] = splitRectsPerAxis(getClientRects(children), clientY);

--- a/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
+++ b/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
@@ -26,7 +26,7 @@ export interface FakeCaretInfo {
   position: FakeCaretPosition;
 }
 
-type distanceFn = <T extends GeomClientRect>(rect: T, x: number, y: number) => number;
+type DistanceFn = <T extends GeomClientRect>(rect: T, x: number, y: number) => number;
 
 const distanceToRectLeft = (clientRect: GeomClientRect, clientX: number) => Math.abs(clientRect.left - clientX);
 const distanceToRectRight = (clientRect: GeomClientRect, clientX: number) => Math.abs(clientRect.right - clientX);
@@ -58,10 +58,10 @@ const clientInfo = (rect: NodeClientRect, clientX: number): FakeCaretInfo => {
   };
 };
 
-const horizontalDistance: distanceFn = (rect, x, _y) => Math.min(Math.abs(rect.left - x), Math.abs(rect.right - x));
+const horizontalDistance: DistanceFn = (rect, x, _y) => Math.min(Math.abs(rect.left - x), Math.abs(rect.right - x));
 
 const closestChildCaretCandidateNodeRect = (children: ChildNode[], clientX: number, clientY: number): Optional<NodeClientRect> => {
-  const findClosestCaretCandidateNodeRect = (rects: NodeClientRect[], distance: distanceFn): Optional<NodeClientRect> => {
+  const findClosestCaretCandidateNodeRect = (rects: NodeClientRect[], distance: DistanceFn): Optional<NodeClientRect> => {
     return Arr.findMap(
       Arr.sort(rects, (r1, r2) => distance(r1, clientX, clientY) - distance(r2, clientX, clientY)),
       (rect) => {

--- a/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
+++ b/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import { Arr, Optional } from '@ephox/katamari';
+import { Compare, SugarElement, Traverse } from '@ephox/sugar';
+
+import { getClientRects, NodeClientRect } from '../dom/Dimensions';
+import * as NodeType from '../dom/NodeType';
+import * as ClientRect from '../geom/ClientRect';
+import * as CaretCandidate from './CaretCandidate';
+import { isFakeCaretTarget } from './FakeCaret';
+
+type GeomClientRect = ClientRect.ClientRect;
+
+export enum FakeCaretPosition {
+  Before = 'before',
+  After = 'after'
+}
+
+export interface FakeCaretInfo {
+  node: Node;
+  position: FakeCaretPosition;
+}
+
+type distanceFn = <T extends GeomClientRect>(rect: T, x: number, y: number) => number;
+
+const distanceToRectLeft = (clientRect: GeomClientRect, clientX: number) => Math.abs(clientRect.left - clientX);
+const distanceToRectRight = (clientRect: GeomClientRect, clientX: number) => Math.abs(clientRect.right - clientX);
+const isInsideY = <T extends GeomClientRect>(clientY: number, clientRect: T): boolean => clientY >= clientRect.top && clientY <= clientRect.bottom;
+const collidesY = <T extends GeomClientRect>(r1: T, r2: T): boolean => r1.top < r2.bottom && r1.bottom > r2.top;
+
+const isOverlapping = <T extends GeomClientRect>(r1: T, r2: T) => {
+  // Rectangles might overlap a bit so this checks if the overlap is more than 50% then we count that as on the same line
+  const overlap = ClientRect.overlapY(r1, r2) / Math.min(r1.height, r2.height);
+  return collidesY(r1, r2) && overlap > 0.5;
+};
+
+const splitRectsPerAxis = <T extends GeomClientRect>(rects: T[], y: number): [T[], T[]] => {
+  const intersectingRects = Arr.filter(rects, (rect) => isInsideY(y, rect));
+
+  return ClientRect.boundingClientRectFromRects(intersectingRects).fold(
+    () => ([[], rects ]),
+    (boundingRect) => {
+      const { pass: horizontal, fail: vertical } = Arr.partition(rects, (rect) => isOverlapping(rect, boundingRect));
+      return [ horizontal, vertical ];
+    }
+  );
+};
+
+const clientInfo = (rect: NodeClientRect, clientX: number): FakeCaretInfo => {
+  return {
+    node: rect.node,
+    position: distanceToRectLeft(rect, clientX) < distanceToRectRight(rect, clientX) ? FakeCaretPosition.Before : FakeCaretPosition.After
+  };
+};
+
+const horizontalDistance: distanceFn = (rect, x, _y) => Math.min(Math.abs(rect.left - x), Math.abs(rect.right - x));
+
+const closestChildCaretCandidateNodeRect = (children: ChildNode[], clientX: number, clientY: number): Optional<NodeClientRect> => {
+  const findClosestCaretCandidateNodeRect = (rects: NodeClientRect[], distance: distanceFn): Optional<NodeClientRect> => {
+    const helper = (i: number, rects: NodeClientRect[]): Optional<NodeClientRect> => {
+      if (i === rects.length) {
+        return Optional.none();
+      } else {
+        const rect = rects[i];
+        const node = rect.node;
+
+        if (CaretCandidate.isCaretCandidate(node)) {
+          return Optional.some(rect);
+        } else if (NodeType.isElement(node)) {
+          const childRect = closestChildCaretCandidateNodeRect(Arr.from(node.childNodes), clientX, clientY);
+          return childRect.isSome() ? childRect : helper(i + 1, rects);
+        }
+      }
+    };
+
+    return helper(0, rects.sort((r1, r2) => distance(r1, clientX, clientY) - distance(r2, clientX, clientY)));
+  };
+
+  const [ horizontalRects, verticalRects ] = splitRectsPerAxis(getClientRects(children), clientY);
+  const { pass: above, fail: below } = Arr.partition(verticalRects, (rect) => rect.top < clientY);
+
+  return findClosestCaretCandidateNodeRect(horizontalRects, horizontalDistance)
+    .orThunk(() => findClosestCaretCandidateNodeRect(below, ClientRect.distanceToRectEdgeFromXY))
+    .orThunk(() => findClosestCaretCandidateNodeRect(above, ClientRect.distanceToRectEdgeFromXY));
+};
+
+const traverseUp = (rootElm: SugarElement<Node>, scope: SugarElement<Element>, clientX: number, clientY: number): Optional<NodeClientRect> => {
+  const helper = (scope: SugarElement<Element>, prevScope: Optional<SugarElement<Element>>) => {
+    return prevScope.fold(
+      () => closestChildCaretCandidateNodeRect(Arr.from(scope.dom.childNodes), clientX, clientY),
+      (prevScope) => {
+        const uncheckedChildren = Arr.filter(Arr.from(scope.dom.childNodes), (node) => node !== prevScope.dom);
+        return closestChildCaretCandidateNodeRect(uncheckedChildren, clientX, clientY);
+      }
+    ).orThunk(() => {
+      const parent = Compare.eq(scope, rootElm) ? Optional.none() : Traverse.parentElement(scope);
+      return parent
+        .filter((newScope) => !Compare.eq(newScope, rootElm))
+        .bind((newScope) => helper(newScope, Optional.some(scope)));
+    });
+  };
+
+  return helper(scope, Optional.none());
+};
+
+// Rough description of how this algorithm works:
+// 1. It starts by finding the element at the specified X, Y coordinate.
+// 2. Then it checks its children for the closest one and traverses down into those repeating step 2, 3 until it finds a caret candidate.
+// 3. If no caret candidate is found in the closest child node then it checks the second closest and so on until all decendants have been checked.
+// 4. If no caret candidate is found, it traverses up skips the element it already checked and checks its siblings using steps 2, 3.
+// 5. If no caret candidate is found, it continues step 4 until it finds the root. Then we have checked all the nodes in the document.
+//
+// This is less accurate but more performant, since for the common case you are likely to find a caret candidate close to where you are clicking.
+// The more accurate algorithm would be to read all caret candidates rects in the whole document in and in one big step to find the closest one, but that is just too slow for bigger documents.
+const closestCaretCandidateNodeRect = (root: HTMLElement, clientX: number, clientY: number): Optional<NodeClientRect> => {
+  const rootElm = SugarElement.fromDom(root);
+  const ownerDoc = Traverse.documentOrOwner(rootElm);
+  const elementAtPoint = SugarElement.fromPoint(ownerDoc, clientX, clientY).filter((elm) => Compare.contains(rootElm, elm));
+  const element = elementAtPoint.getOr(rootElm);
+
+  return traverseUp(rootElm, element, clientX, clientY);
+};
+
+const closestFakeCaretCandidate = (root: HTMLElement, clientX: number, clientY: number): Optional<FakeCaretInfo> =>
+  closestCaretCandidateNodeRect(root, clientX, clientY)
+    .filter((rect) => isFakeCaretTarget(rect.node))
+    .map((rect) => clientInfo(rect, clientX));
+
+export {
+  closestCaretCandidateNodeRect,
+  closestFakeCaretCandidate
+};

--- a/modules/tinymce/src/core/main/ts/caret/LineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/caret/LineUtils.ts
@@ -5,44 +5,22 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Obj } from '@ephox/katamari';
+import { Obj } from '@ephox/katamari';
 
-import { getClientRects, NodeClientRect } from '../dom/Dimensions';
+import { NodeClientRect } from '../dom/Dimensions';
 import * as NodeType from '../dom/NodeType';
 import * as ClientRect from '../geom/ClientRect';
 import * as ArrUtils from '../util/ArrUtils';
-import * as CaretCandidate from './CaretCandidate';
-import * as CaretUtils from './CaretUtils';
-import { isFakeCaretTarget } from './FakeCaret';
-import { VDirection } from './LineWalker';
 
 type GeomClientRect = ClientRect.ClientRect;
 
-export interface CaretInfo {
-  node: Node;
-  before: boolean;
-}
-
 const isContentEditableFalse = NodeType.isContentEditableFalse;
-const findNode = CaretUtils.findNode;
 const distanceToRectLeft = (clientRect: GeomClientRect, clientX: number) => Math.abs(clientRect.left - clientX);
 const distanceToRectRight = (clientRect: GeomClientRect, clientX: number) => Math.abs(clientRect.right - clientX);
-const isInsideX = (clientX: number, clientRect: GeomClientRect): boolean => clientX >= clientRect.left && clientX <= clientRect.right;
-const isInsideY = (clientY: number, clientRect: GeomClientRect): boolean => clientY >= clientRect.top && clientY <= clientRect.bottom;
 const isNodeClientRect = (rect: GeomClientRect): rect is NodeClientRect => Obj.hasNonNullableKey((rect as any), 'node');
 
-const findClosestClientRect = <T extends GeomClientRect>(clientRects: T[], clientX: number, allowInside: (rect: T) => boolean = Fun.always): T =>
+const findClosestClientRect = <T extends GeomClientRect>(clientRects: T[], clientX: number): T =>
   ArrUtils.reduce(clientRects, (oldClientRect, clientRect) => {
-    // Ignore the current rect if it's inside for certain node types
-    if (isInsideX(clientX, clientRect)) {
-      return allowInside(clientRect) ? clientRect : oldClientRect;
-    }
-
-    // Ignore the previous rect if it's inside for certain node types and just use the new rect
-    if (isInsideX(clientX, oldClientRect)) {
-      return allowInside(oldClientRect) ? oldClientRect : clientRect;
-    }
-
     const oldDistance = Math.min(distanceToRectLeft(oldClientRect, clientX), distanceToRectRight(oldClientRect, clientX));
     const newDistance = Math.min(distanceToRectLeft(clientRect, clientX), distanceToRectRight(clientRect, clientX));
 
@@ -58,66 +36,6 @@ const findClosestClientRect = <T extends GeomClientRect>(clientRects: T[], clien
     return oldClientRect;
   });
 
-const walkUntil = (direction: VDirection, root: Node, predicateFn: (node: Node) => boolean, startNode: Node, includeChildren: boolean): void => {
-  let node = findNode(startNode, direction, CaretCandidate.isEditableCaretCandidate, root, !includeChildren);
-  do {
-    if (!node || predicateFn(node)) {
-      return;
-    }
-  } while ((node = findNode(node, direction, CaretCandidate.isEditableCaretCandidate, root)));
-};
-
-const findLineNodeRects = (root: Node, targetNodeRect: NodeClientRect, includeChildren: boolean = true): NodeClientRect[] => {
-  let clientRects: NodeClientRect[] = [];
-
-  const collect = (checkPosFn: (clientRect: GeomClientRect, targetRect: NodeClientRect) => boolean, node: Node) => {
-    const lineRects = Arr.filter(getClientRects([ node ]), (clientRect) => {
-      return !checkPosFn(clientRect, targetNodeRect);
-    });
-
-    clientRects = clientRects.concat(lineRects);
-
-    return lineRects.length === 0;
-  };
-
-  clientRects.push(targetNodeRect);
-  walkUntil(VDirection.Up, root, Fun.curry(collect, ClientRect.isAbove), targetNodeRect.node, includeChildren);
-  walkUntil(VDirection.Down, root, Fun.curry(collect, ClientRect.isBelow), targetNodeRect.node, includeChildren);
-
-  return clientRects;
-};
-
-const getFakeCaretTargets = (root: HTMLElement): HTMLElement[] =>
-  Arr.filter(Arr.from(root.getElementsByTagName('*')), isFakeCaretTarget) as HTMLElement[];
-
-const caretInfo = (clientRect: NodeClientRect, clientX: number): CaretInfo => ({
-  node: clientRect.node,
-  before: distanceToRectLeft(clientRect, clientX) < distanceToRectRight(clientRect, clientX)
-});
-
-const closestFakeCaret = (root: HTMLElement, clientX: number, clientY: number): CaretInfo => {
-  const fakeTargetNodeRects = getClientRects(getFakeCaretTargets(root));
-  const targetNodeRects = Arr.filter<NodeClientRect>(fakeTargetNodeRects, Fun.curry(isInsideY, clientY));
-
-  // TINY-6057: Don't include children nodes within a table when finding the line
-  // rects, as that will never be a valid position for a table fake caret and can
-  // lead to performance issues with large tables.
-  const checkInside = (clientRect: NodeClientRect) => !NodeType.isTable(clientRect.node) && !NodeType.isMedia(clientRect.node);
-
-  let closestNodeRect = findClosestClientRect(targetNodeRects, clientX, checkInside);
-  if (closestNodeRect) {
-    const includeChildren = checkInside(closestNodeRect);
-    closestNodeRect = findClosestClientRect(findLineNodeRects(root, closestNodeRect, includeChildren), clientX, checkInside);
-    if (closestNodeRect && isFakeCaretTarget(closestNodeRect.node)) {
-      return caretInfo(closestNodeRect, clientX);
-    }
-  }
-
-  return null;
-};
-
 export {
-  findClosestClientRect,
-  findLineNodeRects,
-  closestFakeCaret
+  findClosestClientRect
 };

--- a/modules/tinymce/src/core/main/ts/geom/ClientRect.ts
+++ b/modules/tinymce/src/core/main/ts/geom/ClientRect.ts
@@ -5,6 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
+import { Arr, Optional } from '@ephox/katamari';
+
 export interface ClientRect {
   left: number;
   top: number;
@@ -110,23 +112,37 @@ const containsXY = (rect: ClientRect, clientX: number, clientY: number): boolean
     clientY <= rect.bottom
 );
 
-const overflowX = (outer: ClientRect, inner: ClientRect) => {
-  if (inner.left > outer.left && inner.right < outer.right) {
-    return 0;
-  } else {
-    return inner.left < outer.left ? inner.left - outer.left : inner.right - outer.right;
-  }
+const boundingClientRectFromRects = (rects: ClientRect[]): Optional<ClientRect> => {
+  return Arr.foldl(rects, (acc, rect) => {
+    return acc.fold(
+      () => Optional.some(rect),
+      (prevRect) => {
+        const left = Math.min(rect.left, prevRect.left);
+        const top = Math.min(rect.top, prevRect.top);
+        const right = Math.max(rect.right, prevRect.right);
+        const bottom = Math.max(rect.bottom, prevRect.bottom);
+
+        return Optional.some({
+          top,
+          right,
+          bottom,
+          left,
+          width: right - left,
+          height: bottom - top
+        });
+      }
+    );
+  }, Optional.none());
 };
 
-const overflowY = (outer: ClientRect, inner: ClientRect) => {
-  if (inner.top > outer.top && inner.bottom < outer.bottom) {
-    return 0;
-  } else {
-    return inner.top < outer.top ? inner.top - outer.top : inner.bottom - outer.bottom;
-  }
+const distanceToRectEdgeFromXY = <T extends ClientRect>(rect: T, x: number, y: number) => {
+  const cx = Math.max(Math.min(x, rect.left + rect.width), rect.left);
+  const cy = Math.max(Math.min(y, rect.top + rect.height), rect.top);
+  return Math.sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy));
 };
 
-const getOverflow = (outer: ClientRect, inner: ClientRect) => ({ x: overflowX(outer, inner), y: overflowY(outer, inner) });
+const overlapX = <T extends ClientRect>(r1: T, r2: T) => Math.max(0, Math.min(r1.right, r2.right) - Math.max(r1.left, r2.left));
+const overlapY = <T extends ClientRect>(r1: T, r2: T) => Math.max(0, Math.min(r1.bottom, r2.bottom) - Math.max(r1.top, r2.top));
 
 export {
   clone,
@@ -138,5 +154,8 @@ export {
   isRight,
   compare,
   containsXY,
-  getOverflow
+  boundingClientRectFromRects,
+  distanceToRectEdgeFromXY,
+  overlapX,
+  overlapY
 };

--- a/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
@@ -7,16 +7,16 @@ import { assert } from 'chai';
 import { FakeCaretPosition, closestCaretCandidateNodeRect, closestFakeCaretCandidate } from 'tinymce/core/caret/ClosestCaretCandidate';
 
 interface TestCaretInfo {
-  path: number[];
-  position: FakeCaretPosition;
+  readonly path: number[];
+  readonly position: FakeCaretPosition;
 }
 
 interface TestArgs<T> {
-  html: string;
-  targetPath: number[];
-  dx: number;
-  dy: number;
-  expected: Optional<T>;
+  readonly html: string;
+  readonly targetPath: number[];
+  readonly dx: number;
+  readonly dy: number;
+  readonly expected: Optional<T>;
 }
 
 describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {

--- a/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
@@ -1,0 +1,581 @@
+import { Cursors } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
+import { Css, Html, Insert, Remove, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import { FakeCaretPosition, closestCaretCandidateNodeRect, closestFakeCaretCandidate } from 'tinymce/core/caret/ClosestCaretCandidate';
+
+interface TestCaretInfo {
+  path: number[];
+  position: FakeCaretPosition;
+}
+
+interface TestArgs<T> {
+  html: string;
+  targetPath: number[];
+  dx: number;
+  dy: number;
+  expected: Optional<T>;
+}
+
+describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {
+  const drawHelperPoint = (container: SugarElement<Element>, x: number, y: number, color: string) => {
+    const cpos = SugarLocation.absolute(container);
+    const elm = SugarElement.fromTag('div');
+
+    Css.setAll(elm, {
+      'position': 'absolute',
+      'left': `${x - cpos.left}px`,
+      'top': `${y - cpos.top}px`,
+      'width': '1px',
+      'height': '1px',
+      'outline': '1px solid red',
+      'background-color': color,
+    });
+
+    Insert.append(container, elm);
+
+    // Uncomment the following line to see the X, Y spot for each test
+    // debugger
+  };
+
+  const createContainer = (html: string) => {
+    const container = SugarElement.fromTag('div');
+    Html.set(container, html);
+    Css.setAll(container, {
+      outline: '1px solid black',
+      position: 'relative',
+      padding: '10px',
+      margin: '10px'
+    });
+    Insert.append(SugarBody.body(), container);
+    return container;
+  };
+
+  context('closestCaretCandidateNodeRect', () => {
+    const testClosestCaretCandidate = (args: TestArgs<number[]>) => {
+      const container = createContainer(args.html);
+      const target = Cursors.calculateOne(container, args.targetPath) as SugarElement<Element>;
+      const pos = SugarLocation.absolute(target);
+      const actualDomRect = closestCaretCandidateNodeRect(container.dom, pos.left + args.dx, pos.top + args.dy);
+
+      drawHelperPoint(container, pos.left + args.dx, pos.top + args.dy, 'red');
+
+      actualDomRect.fold(
+        () => args.expected.each((_) => assert.fail('Expected caret info got none')),
+        (nodeRect) => {
+          args.expected.fold(
+            () => assert.fail('Expected none caret info got some'),
+            (expectedPath) => {
+              const expectedTarget = Cursors.calculateOne(container, expectedPath) as SugarElement<Element>;
+
+              assert.equal(nodeRect.node, expectedTarget.dom, 'should be expected node');
+            }
+          );
+        }
+      );
+
+      Remove.remove(container);
+    };
+
+    context('inline caret candidates', () => {
+      it('TINY-8169: should find the closest text node in the last child node when point is after all of the children', () =>
+        testClosestCaretCandidate({
+          html: 'a<span>b</span>',
+          targetPath: [ 1 ],
+          dx: 50, dy: 5,
+          expected: Optional.some([ 1, 0 ])
+        })
+      );
+
+      it('TINY-8169: should find the last img element if the point is after all of the children', () =>
+        testClosestCaretCandidate({
+          html: 'a<img src="about:blank" style="width: 10px; height: 10px">',
+          targetPath: [ 1 ],
+          dx: 50, dy: 5,
+          expected: Optional.some([ 1 ])
+        })
+      );
+
+      it('TINY-8169: should find the closest br element if the point is after all of the children', () =>
+        testClosestCaretCandidate({
+          html: '<span style="display: inline-block; margin: 10px">a</span><br>',
+          targetPath: [ 1 ],
+          dx: 50, dy: 10,
+          expected: Optional.some([ 1 ])
+        })
+      );
+
+      it('TINY-8169: should find the closest noneditable element if the point is after the children', () =>
+        testClosestCaretCandidate({
+          html: 'a<span contenteditable="false" style="display: inline-block; width: 10px; height: 10px; background: green"></span>',
+          targetPath: [ 1 ],
+          dx: 50, dy: 5,
+          expected: Optional.some([ 1 ])
+        })
+      );
+
+      it('TINY-8169: should find the closest text node when there is a empty visual element in between point and text node', () =>
+        testClosestCaretCandidate({
+          html: 'a<span style="display: inline-block; width: 10px; height: 10px; background: green"></span>',
+          targetPath: [ 1 ],
+          dx: 50, dy: 5,
+          expected: Optional.some([ 0 ])
+        })
+      );
+
+      it('TINY-8169: should find the closest text node when there is multiple visual element with no valid caret candidates between point and text node', () =>
+        testClosestCaretCandidate({
+          html: [
+            'a<span style="display: inline-block; width: 10px; height: 10px; background: green"><b></b></span>',
+            '<span style="display: inline-block; width: 10px; height: 10px; background: cyan"><b></b></span>'
+          ].join(''),
+          targetPath: [ 1 ],
+          dx: 50, dy: 5,
+          expected: Optional.some([ 0 ])
+        })
+      );
+
+      it('TINY-8169: should not find any caret candidate since there is none', () =>
+        testClosestCaretCandidate({
+          html: '<span style="display: inline-block; width: 10px; height: 10px; background: green"><b></b></span>',
+          targetPath: [ 0 ],
+          dx: 50, dy: 5,
+          expected: Optional.none()
+        })
+      );
+
+      it('TINY-8169: should find the closest nested text node when there is multiple visual element with no valid caret candidates between point and text node', () =>
+        testClosestCaretCandidate({
+          html: [
+            '<span><b>a</b></span><span style="display: inline-block; width: 10px; height: 10px; background: green"><b></b></span>',
+            '<span style="display: inline-block; width: 10px; height: 10px; background: cyan"><b></b></span>'
+          ].join(''),
+          targetPath: [ 1 ],
+          dx: 50, dy: 5,
+          expected: Optional.some([ 0, 0, 0 ])
+        })
+      );
+
+      it('TINY-8169: should find the closest vertical noneditable even if point is above text', () =>
+        testClosestCaretCandidate({
+          html: 'hello<span contenteditable="false" style="display: inline-block; margin-top: 40px; border-top: 10px solid black; background: green">x</span>',
+          targetPath: [ 1 ],
+          dx: -15, dy: -25,
+          expected: Optional.some([ 1 ])
+        })
+      );
+
+      it('TINY-8169: should find the table as the closest caret candidate when the point is before the table', () =>
+        testClosestCaretCandidate({
+          html: '<table style="background: green"><tbody><tr><td>a</td></tr></tbody></table>',
+          targetPath: [ 0 ],
+          dx: -5, dy: 5,
+          expected: Optional.some([ 0 ])
+        })
+      );
+    });
+  });
+
+  context('closestFakeCaretCandidate', () => {
+    const testClosestFakeCaret = (args: TestArgs<TestCaretInfo>) => {
+      const container = createContainer(args.html);
+      const target = Cursors.calculateOne(container, args.targetPath) as SugarElement<Element>;
+      const pos = SugarLocation.absolute(target);
+      const actualCaretInfo = closestFakeCaretCandidate(container.dom, pos.left + args.dx, pos.top + args.dy);
+
+      drawHelperPoint(container, pos.left + args.dx, pos.top + args.dy, 'red');
+
+      actualCaretInfo.fold(
+        () => args.expected.each((_) => assert.fail('Expected caret info got none')),
+        (caretInfo) => {
+          args.expected.fold(
+            () => assert.fail('Expected none caret info got some'),
+            (expectedCaretInfo) => {
+              const expectedTarget = Cursors.calculateOne(container, expectedCaretInfo.path) as SugarElement<Element>;
+
+              assert.equal(caretInfo.node, expectedTarget.dom, 'should be expected node');
+              assert.equal(caretInfo.position, expectedCaretInfo.position, 'should be expected before');
+            }
+          );
+        }
+      );
+
+      Remove.remove(container);
+    };
+
+    context('inline noneditables', () => {
+      it('TINY-8169: should not produce a fake caret location when point is on the margin before the noneditable but closer to the text', () =>
+        testClosestFakeCaret({
+          html: 'a<span contenteditable="false" style="display: inline-block; margin: 10px; background: green">b</span>c',
+          targetPath: [ 1 ],
+          dx: -5, dy: 5,
+          expected: Optional.none()
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the noneditable when point is on the margin before it closer further from the text', () =>
+        testClosestFakeCaret({
+          html: 'a<span contenteditable="false" style="display: inline-block; margin: 10px; background: green">b</span>c',
+          targetPath: [ 1 ],
+          dx: -3, dy: 5,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should not find a fake caret position when the point is on the margin after the noneditable but closer to the text', () =>
+        testClosestFakeCaret({
+          html: 'a<span contenteditable="false" style="display: inline-block; margin: 10px; height: 40px; background: green">b</span>c',
+          targetPath: [ 1 ],
+          dx: 47, dy: 5,
+          expected: Optional.none()
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the noneditable when the point is the margin after it further from the text', () =>
+        testClosestFakeCaret({
+          html: 'a<span contenteditable="false" style="display: inline-block; margin: 10px; width: 40px; background: green">b</span>c',
+          targetPath: [ 1 ],
+          dx: 43, dy: 5,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should not find a caret position if the point is above the text in a block', () =>
+        testClosestFakeCaret({
+          html: '<p>a<span contenteditable="false" style="display: inline-block; margin: 20px; background: green">b</span></p>',
+          targetPath: [ 0 ],
+          dx: 5, dy: 5,
+          expected: Optional.none()
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the noneditable if the point is above left of the noneditable closer to the noneditable', () =>
+        testClosestFakeCaret({
+          html: '<span style="font-size: 50px;">a</span><span style="margin: 10px; background: green" contenteditable="false">b</span>',
+          targetPath: [ 1 ],
+          dx: -3, dy: -15,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the noneditable if the point is above right of the noneditable closer to the noneditable', () =>
+        testClosestFakeCaret({
+          html: '<span style="font-size: 50px;">a</span><span style="margin: 10px; display: inline-block; width: 30px; background: green" contenteditable="false">b</span>',
+          targetPath: [ 1 ],
+          dx: 33, dy: -15,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the left noneditable if the point is closer to that with two adjacent noneditables', () =>
+        testClosestFakeCaret({
+          html: [
+            '<span contenteditable="false" style="display: inline-block; margin: 10px; background: green">a</span>',
+            '<span contenteditable="false" style="display: inline-block; margin: 10px; background: cyan">b</span>'
+          ].join(''),
+          targetPath: [ 1 ],
+          dx: -12, dy: 5,
+          expected: Optional.some({ path: [ 0 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the right noneditable if the point closer to that to that with two adjacent noneditables', () =>
+        testClosestFakeCaret({
+          html: [
+            '<span contenteditable="false" style="display: inline-block; margin: 10px; background: green">a</span>',
+            '<span contenteditable="false" style="display: inline-block; margin: 10px; background: cyan">b</span>'
+          ].join(''),
+          targetPath: [ 1 ],
+          dx: -7, dy: 5,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+    });
+
+    context('overlaping', () => {
+      it('TINY-8169: should find a caret postion before the second noneditable even if the first is closer the overlap in Y is only 33%', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div style="display: flex; flex-direction: row; align-items: flex-start">',
+            '<div contenteditable="false" style="margin: 30px 20px 0 0; width: 30px; min-height: 50px; background: green">a</div>',
+            '<div contenteditable="false" style="margin: 10px; width: 30px; min-height: 30px; background: cyan">b</div>',
+            '</div>'
+          ].join(''),
+          targetPath: [ 0, 0 ],
+          dx: 35, dy: -7,
+          expected: Optional.some({ path: [ 0, 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret postion after the first noneditable even since the overlap in Y is 66%', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div style="display: flex; flex-direction: row; align-items: flex-start">',
+            '<div contenteditable="false" style="margin: 20px 20px 0 0; width: 30px; min-height: 50px; background: green">a</div>',
+            '<div contenteditable="false" style="margin: 10px; width: 30px; min-height: 30px; background: cyan">b</div>',
+            '</div>'
+          ].join(''),
+          targetPath: [ 0, 0 ],
+          dx: 35, dy: -7,
+          expected: Optional.some({ path: [ 0, 0 ], position: FakeCaretPosition.After })
+        })
+      );
+    });
+
+    context('block noneditables', () => {
+      it('TINY-8169: should find a caret position before block if the point is top, left of it', () =>
+        testClosestFakeCaret({
+          html: '<div contenteditable="false" style="background: green">a</div>',
+          targetPath: [ 0 ],
+          dx: -3, dy: -3,
+          expected: Optional.some({ path: [ 0 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after block if the point is top, right of it', () =>
+        testClosestFakeCaret({
+          html: '<div contenteditable="false" style="width: 40px; background: green">a</div>',
+          targetPath: [ 0 ],
+          dx: 45, dy: -3,
+          expected: Optional.some({ path: [ 0 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before block if the point is bottom, left of it', () =>
+        testClosestFakeCaret({
+          html: '<div contenteditable="false" style="height: 40px; background: green">a</div>',
+          targetPath: [ 0 ],
+          dx: -3, dy: 43,
+          expected: Optional.some({ path: [ 0 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after block if the point is bottom, right of it', () =>
+        testClosestFakeCaret({
+          html: '<div contenteditable="false" style="width: 40px; height: 40px; background: green">a</div>',
+          targetPath: [ 0 ],
+          dx: 43, dy: 43,
+          expected: Optional.some({ path: [ 0 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should favor horizontal noneditables over vertical even when the vertical is closer', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div contenteditable="false" style="width: 100px; height: 30px; background: green">a</div>',
+            '<div contenteditable="false" style="width: 30px; height: 30px; background: cyan">b</div>'
+          ].join(''),
+          targetPath: [ 1 ],
+          dx: 90, dy: 5,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the second element if the point is closer to the first between two elements', () =>
+        testClosestFakeCaret({
+          html: '<div contenteditable="false" style="margin: 10px; background: green">a</div><div contenteditable="false" style="margin: 10px; background: cyan">b</div>',
+          targetPath: [ 1 ],
+          dx: 10, dy: -7,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the second element if the point is closer to the second between two elements', () =>
+        testClosestFakeCaret({
+          html: '<div contenteditable="false" style="margin: 10px; background: green">a</div><div contenteditable="false" style="margin: 10px; background: cyan">b</div>',
+          targetPath: [ 1 ],
+          dx: 10, dy: -3,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the second element if the point is closer to the second between two elements and after the second element', () =>
+        testClosestFakeCaret({
+          html: '<div contenteditable="false" style="margin: 10px; background: green">a</div><div contenteditable="false" style="margin: 10px; width: 40px; background: cyan">b</div>',
+          targetPath: [ 1 ],
+          dx: 43, dy: -3,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the first noneditable element if the point is top, left outside the container element', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div><div contenteditable="false" style="margin: 10px; background: green">a</div><div contenteditable="false" style="margin: 10px; background: cyan">b</div>',
+          ].join(''),
+          targetPath: [ 0 ],
+          dx: -7, dy: -7,
+          expected: Optional.some({ path: [ 0, 0 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the first noneditable element if the point is top, right outside the container element', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div style="width: 100px"><div contenteditable="false" style="margin: 10px; background: green">a</div><div contenteditable="false" style="margin: 10px; background: cyan">b</div>',
+          ].join(''),
+          targetPath: [ 0 ],
+          dx: 107, dy: -7,
+          expected: Optional.some({ path: [ 0, 0 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the second noneditable element if the point is bottom, left outside the container element', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div style="height: 100px"><div contenteditable="false" style="margin: 10px; background: green">a</div><div contenteditable="false" style="margin: 10px; background: cyan">b</div>',
+          ].join(''),
+          targetPath: [ 0 ],
+          dx: -7, dy: 107,
+          expected: Optional.some({ path: [ 0, 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the second noneditable element if the point is bottom, right outside the container element', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div style="width: 100px; height: 100px"><div contenteditable="false" style="margin: 10px; background: green">a</div><div contenteditable="false" style="margin: 10px; background: cyan">b</div>',
+          ].join(''),
+          targetPath: [ 0 ],
+          dx: 107, dy: 107,
+          expected: Optional.some({ path: [ 0, 1 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the second noneditable element if the point is left of it outside the container element', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div><div contenteditable="false" style="margin: 10px; background: green">a</div><div contenteditable="false" style="margin: 10px; background: cyan">b</div>',
+          ].join(''),
+          targetPath: [ 0, 1 ],
+          dx: -14, dy: 5,
+          expected: Optional.some({ path: [ 0, 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the second noneditable element if the point is right of it outside the container element', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div style="width: 100px"><div contenteditable="false" style="margin: 10px; background: green">a</div><div contenteditable="false" style="margin: 10px; background: cyan">b</div>',
+          ].join(''),
+          targetPath: [ 0, 1 ],
+          dx: 114, dy: 5,
+          expected: Optional.some({ path: [ 0, 1 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the second noneditable when the element partially intersects the boundary box of the inline elements', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div contenteditable="false" style="margin-left: 20px; background: green">a</div>',
+            '<div contenteditable="false" style="margin-left: 5px; margin-top: 10px; background: cyan; width: 50px">b</div>',
+            '<div contenteditable="false" style="margin-left: 20px; background: yellow">c</div>',
+          ].join(''),
+          targetPath: [ 1 ],
+          dx: 70, dy: -7,
+          expected: Optional.some({ path: [ 1 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the second nested element if the point is closer to the first element but between two elements', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div contenteditable="false">a<div contenteditable="true"><div contenteditable="false" style="margin: 10px; background: green">b</div>',
+            '<div contenteditable="false" style="margin: 10px; background: cyan">c</div></div>d</div>'
+          ].join(''),
+          targetPath: [ 0, 1, 1 ],
+          dx: 10, dy: -7,
+          expected: Optional.some({ path: [ 0, 1, 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the second nested element if the point is closer to the second element but between two elements', () =>
+        testClosestFakeCaret({
+          html: [
+            '<div contenteditable="false">a<div contenteditable="true"><div contenteditable="false" style="margin: 10px; background: green">b</div>',
+            '<div contenteditable="false" style="margin: 10px; background: cyan">c</div></div>d</div>'
+          ].join(''),
+          targetPath: [ 0, 1, 1 ],
+          dx: 10, dy: -3,
+          expected: Optional.some({ path: [ 0, 1, 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+    });
+
+    context('inside tables', () => {
+      it('TINY-8169: should not find caret position for a plain text node in a cell at the left of a cell with a noneditable element', () =>
+        testClosestFakeCaret({
+          html: '<table style="width: 100px"><tbody><tr><td>1</td><td><div contenteditable="false" style="background: green">2</div></td></tr></tbody></table>',
+          targetPath: [ 0, 0, 0, 0 ],
+          dx: 3, dy: 3,
+          expected: Optional.none()
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the noneditable element if coordinate is top, left next to the noneditable', () =>
+        testClosestFakeCaret({
+          html: '<table style="width: 100px"><tbody><tr><td>1</td><td><div contenteditable="false" style="margin: 10px; background: green">2</div></td></tr></tbody></table>',
+          targetPath: [ 0, 0, 0, 1 ],
+          dx: 5, dy: 5,
+          expected: Optional.some({ path: [ 0, 0, 0, 1, 0 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the noneditable element if coordinate is top, right next to the noneditable', () =>
+        testClosestFakeCaret({
+          html: '<table style="width: 100px"><tbody><tr><td>1</td><td><div contenteditable="false" style="margin: 10px; width: 40px; background: green">2</div></td></tr></tbody></table>',
+          targetPath: [ 0, 0, 0, 1 ],
+          dx: 45, dy: 5,
+          expected: Optional.some({ path: [ 0, 0, 0, 1, 0 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the noneditable element if coordinate is bottom, left next to the noneditable', () =>
+        testClosestFakeCaret({
+          html: '<table style="width: 100px"><tbody><tr><td>1</td><td><div contenteditable="false" style="margin: 10px; height: 40px; background: green">2</div></td></tr></tbody></table>',
+          targetPath: [ 0, 0, 0, 1 ],
+          dx: 5, dy: 45,
+          expected: Optional.some({ path: [ 0, 0, 0, 1, 0 ], position: FakeCaretPosition.Before })
+        })
+      );
+
+      it('TINY-8169: should find a caret position after the noneditable element if coordinate is bottom, right next to the noneditable', () =>
+        testClosestFakeCaret({
+          html: '<table style="width: 100px"><tbody><tr><td>1</td><td><div contenteditable="false" style="margin: 10px; width: 40px; height: 40px; background: green">2</div></td></tr></tbody></table>',
+          targetPath: [ 0, 0, 0, 1 ],
+          dx: 55, dy: 55,
+          expected: Optional.some({ path: [ 0, 0, 0, 1, 0 ], position: FakeCaretPosition.After })
+        })
+      );
+
+      it('TINY-8169: should not produce a fake caret location if the point is on text above a noneditable in table cell', () =>
+        testClosestFakeCaret({
+          html: '<table style="width: 100px"><tbody><tr><td>1<div contenteditable="false" style="margin: 10px; background: green">2</div></td></tr></tbody></table>',
+          targetPath: [ 0, 0, 0, 0 ],
+          dx: 5, dy: 5,
+          expected: Optional.none()
+        })
+      );
+
+      it('TINY-8169: should not produce a fake caret location if the point is on text after a noneditable in table cell', () =>
+        testClosestFakeCaret({
+          html: '<table style="width: 100px"><tbody><tr><td><div contenteditable="false" style="margin: 10px; height: 40px; background: green">1</div>2</td></tr></tbody></table>',
+          targetPath: [ 0, 0, 0, 0 ],
+          dx: 5, dy: 55,
+          expected: Optional.none()
+        })
+      );
+
+      it('TINY-8169: should find a caret position before the noneditable if the point is on the margin between the noneditable and text', () =>
+        testClosestFakeCaret({
+          html: '<table style="width: 100px"><tbody><tr><td>1<div contenteditable="false" style="margin: 10px; background: green">2</div></td></tr></tbody></table>',
+          targetPath: [ 0, 0, 0, 0, 1 ],
+          dx: 5, dy: -5,
+          expected: Optional.some({ path: [ 0, 0, 0, 0, 1 ], position: FakeCaretPosition.Before })
+        })
+      );
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTypeTest.ts
@@ -1,0 +1,30 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections, TinyAssertions, TinyContentActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import TablePlugin from 'tinymce/plugins/table/Plugin';
+
+describe('browser.tinymce.core.FakeCaretTypeTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    indent: false
+  }, [ TablePlugin ]);
+
+  it('typing after a noneditable block should remove the fake caret', () => {
+    const editor = hook.editor();
+    editor.setContent('<div contenteditable="false">a</div>');
+    TinySelections.setCursor(editor, [], 1);
+    TinyAssertions.assertContentPresence(editor, {
+      'p[data-mce-caret="after"]': 1,
+      'div.mce-visual-caret': 1
+    });
+
+    TinyContentActions.type(editor, 'b');
+
+    TinyAssertions.assertContent(editor, '<div contenteditable="false">a</div><p>b</p>');
+    TinyAssertions.assertContentPresence(editor, {
+      'p[data-mce-caret="after"]': 0,
+      'div.mce-visual-caret': 0
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTypeTest.ts
@@ -2,13 +2,12 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinySelections, TinyAssertions, TinyContentActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import TablePlugin from 'tinymce/plugins/table/Plugin';
 
 describe('browser.tinymce.core.FakeCaretTypeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, [ TablePlugin ]);
+  }, [ ]);
 
   it('typing after a noneditable block should remove the fake caret', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/caret/LineUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/LineUtilsTest.ts
@@ -1,9 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { Insert, InsertAll, Remove, SelectorFind, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import * as LineUtils from 'tinymce/core/caret/LineUtils';
-import { getClientRects } from 'tinymce/core/dom/Dimensions';
 
 const rect = (x: number, y: number, w: number, h: number) => ({
   left: x,
@@ -20,49 +18,5 @@ describe('browser.tinymce.core.LineUtilsTest', () => {
     assert.deepEqual(LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(30, 10, 10, 10) ], 27), rect(30, 10, 10, 10));
     assert.deepEqual(LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(30, 10, 10, 10) ], 23), rect(10, 10, 10, 10));
     assert.deepEqual(LineUtils.findClosestClientRect([ rect(10, 10, 10, 10), rect(20, 10, 10, 10) ], 13), rect(10, 10, 10, 10));
-  });
-
-  it('findLineNodeRects', () => {
-    const container = SugarElement.fromTag('div');
-    const para = SugarElement.fromHtml('<p>Paragraph with content</p>');
-    const multiLinePara = SugarElement.fromHtml('<p>Multiple line <br>paragraph with content</p>');
-    const table = SugarElement.fromHtml('<table border="1"><tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody></table>');
-    const paraWithCef = SugarElement.fromHtml('<p>Before <span contenteditable="false">Noneditable</span> After</p>');
-    const cef = SelectorFind.descendant(paraWithCef, 'span').getOrDie();
-    const paraWithVideo = SugarElement.fromHtml('<p>Before <video controls="controls"><source src="custom/video.mp4" /></video> After</p>');
-    const video = SelectorFind.descendant(paraWithVideo, 'video').getOrDie();
-    InsertAll.append(container, [ para, multiLinePara, table, paraWithCef, paraWithVideo ]);
-    Insert.append(SugarBody.body(), container);
-
-    const paraLines = LineUtils.findLineNodeRects(container.dom, getClientRects([ para.dom.firstChild ])[0]);
-    const multiParaLines = LineUtils.findLineNodeRects(container.dom, getClientRects([ multiLinePara.dom.lastChild ])[0]);
-    const tableLines = LineUtils.findLineNodeRects(container.dom, getClientRects([ table.dom ])[0], false);
-    const tableLinesWithChildren = LineUtils.findLineNodeRects(container.dom, getClientRects([ table.dom ])[0]);
-    const cefLines = LineUtils.findLineNodeRects(container.dom, getClientRects([ cef.dom ])[0]);
-    const videoLines = LineUtils.findLineNodeRects(container.dom, getClientRects([ video.dom ])[0]);
-
-    assert.lengthOf(paraLines, 1, 'Should only find one line rect for a para');
-    assert.lengthOf(multiParaLines, 1, 'Should only find one line rect for a multiline para');
-    assert.lengthOf(tableLines, 1, 'Should only find one line rect for a table');
-    assert.lengthOf(tableLinesWithChildren, 5, 'Should find multiple line rects for a table plus children');
-    assert.lengthOf(cefLines, 3, 'Should find multiple line rects for an inline cef element');
-    assert.lengthOf(videoLines, 3, 'Should find multiple line rects for a video element');
-
-    Remove.remove(container);
-  });
-
-  it('TINY-7736: Nested CEF element within table should prefer the cef element', () => {
-    const container = SugarElement.fromTag('div');
-    const table = SugarElement.fromHtml('<table style="width: 100px;"><tbody><tr><td>1</td><td><div contenteditable="false">2</div></td></tr></tbody></table>');
-    const cef = SelectorFind.descendant(table, 'div').getOrDie();
-    Insert.append(container, table);
-    Insert.append(SugarBody.body(), container);
-    const cefPos = SugarLocation.absolute(cef);
-
-    const result = LineUtils.closestFakeCaret(container.dom, cefPos.left - 10, cefPos.top + 5);
-    assert.equal(result.node, cef.dom, 'Should be the cef element');
-    assert.isTrue(result.before, 'Should be placed before');
-
-    Remove.remove(container);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/geom/ClientRectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/geom/ClientRectTest.ts
@@ -81,12 +81,38 @@ describe('browser.tinymce.core.geom.ClientRectTest', () => {
     assert.isTrue(ClientRect.containsXY(rect(10, 70, 10, 40), 15, 75));
   });
 
-  it('getOverflow', () => {
-    assert.deepEqual(ClientRect.getOverflow(rect(10, 10, 10, 10), rect(10, 10, 10, 10)), { x: 0, y: 0 });
-    assert.deepEqual(ClientRect.getOverflow(rect(10, 10, 20, 20), rect(15, 15, 10, 10)), { x: 0, y: 0 });
-    assert.deepEqual(ClientRect.getOverflow(rect(10, 10, 10, 10), rect(5, 10, 10, 10)), { x: -5, y: 0 });
-    assert.deepEqual(ClientRect.getOverflow(rect(10, 10, 10, 10), rect(10, 5, 10, 10)), { x: 0, y: -5 });
-    assert.deepEqual(ClientRect.getOverflow(rect(10, 10, 10, 10), rect(15, 10, 10, 10)), { x: 5, y: 0 });
-    assert.deepEqual(ClientRect.getOverflow(rect(10, 10, 10, 10), rect(10, 15, 10, 10)), { x: 0, y: 5 });
+  it('overlapX', () => {
+    assert.equal(ClientRect.overlapX(rect(10, 10, 20, 30), rect(10, 10, 20, 30)), 20, 'overlaps 100%');
+    assert.equal(ClientRect.overlapX(rect(10, 10, 20, 30), rect(10, 10, 30, 30)), 20, 'r1 overlaps r2 by 20 pixels');
+    assert.equal(ClientRect.overlapX(rect(10, 10, 30, 30), rect(10, 10, 20, 30)), 20, 'r2 overlaps r1 by 20 pixels');
+    assert.equal(ClientRect.overlapX(rect(10, 10, 20, 30), rect(15, 10, 20, 30)), 15, 'r1 overlaps r2 by 15 pixels');
+    assert.equal(ClientRect.overlapX(rect(15, 10, 20, 30), rect(10, 10, 20, 30)), 15, 'r2 overlaps r1 by 15 pixels');
+    assert.equal(ClientRect.overlapX(rect(10, 10, 20, 30), rect(30, 10, 20, 30)), 0, 'no overlap');
+  });
+
+  it('overlapY', () => {
+    assert.equal(ClientRect.overlapY(rect(10, 10, 20, 30), rect(10, 10, 20, 30)), 30, 'overlaps 100%');
+    assert.equal(ClientRect.overlapY(rect(10, 10, 30, 20), rect(10, 10, 30, 30)), 20, 'r1 overlaps r2 by 20 pixels');
+    assert.equal(ClientRect.overlapY(rect(10, 10, 30, 30), rect(10, 10, 30, 20)), 20, 'r2 overlaps r1 by 20 pixels');
+    assert.equal(ClientRect.overlapY(rect(10, 10, 20, 30), rect(10, 15, 20, 30)), 25, 'r1 overlaps r2 by 25 pixels');
+    assert.equal(ClientRect.overlapY(rect(10, 15, 20, 30), rect(10, 10, 20, 30)), 25, 'r2 overlaps r1 by 25 pixels');
+    assert.equal(ClientRect.overlapY(rect(10, 10, 20, 30), rect(10, 40, 20, 30)), 0, 'no overlap');
+  });
+
+  it('boundingClientRectFromRects', () => {
+    assert.isTrue(ClientRect.boundingClientRectFromRects([]).isNone(), 'no rects no bounding rect');
+    assert.deepEqual(ClientRect.boundingClientRectFromRects([ rect(11, 12, 13, 14) ]).getOrDie(), rect(11, 12, 13, 14), 'should be the same rect');
+    assert.deepEqual(ClientRect.boundingClientRectFromRects([ rect(10, 10, 10, 10), rect(30, 30, 10, 10) ]).getOrDie(), rect(10, 10, 30, 30), 'expand bottom right');
+    assert.deepEqual(ClientRect.boundingClientRectFromRects([ rect(10, 10, 10, 10), rect(5, 5, 10, 10) ]).getOrDie(), rect(5, 5, 15, 15), 'expand top left');
+    assert.deepEqual(ClientRect.boundingClientRectFromRects([ rect(10, 10, 10, 10), rect(5, 5, 10, 10), rect(30, 30, 10, 10) ]).getOrDie(), rect(5, 5, 35, 35), 'expand all directions');
+  });
+
+  it('distanceToRectEdgeFromXY', () => {
+    assert.equal(ClientRect.distanceToRectEdgeFromXY(rect(10, 10, 20, 20), 15, 15), 0, 'should be 0 when point is inside rect');
+    assert.equal(Math.round(ClientRect.distanceToRectEdgeFromXY(rect(10, 10, 20, 20), 0, 0)), 14, 'should be the distance at a 45 degree angle');
+    assert.equal(Math.round(ClientRect.distanceToRectEdgeFromXY(rect(10, 10, 20, 20), 15, 5)), 5, 'above and closer to the top');
+    assert.equal(Math.round(ClientRect.distanceToRectEdgeFromXY(rect(10, 10, 20, 20), 5, 15)), 5, 'left and closer to the left');
+    assert.equal(Math.round(ClientRect.distanceToRectEdgeFromXY(rect(10, 10, 20, 20), 15, 35)), 5, 'below and closer to the below');
+    assert.equal(Math.round(ClientRect.distanceToRectEdgeFromXY(rect(10, 10, 20, 20), 35, 15)), 5, 'right and closer to the right');
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/FakeSelectionTest.ts
@@ -139,7 +139,7 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
 
   it('TINY-7724: does not select CEF cell if contenteditable=true child is selected', () => {
     const editor = hook.editor();
-    editor.setContent('<table><tr><td contenteditable="false"><p contenteditable="true">1</p></td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>');
+    editor.setContent('<table><tbody><tr><td contenteditable="false"><p contenteditable="true">1</p></td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>');
 
     // Check the CEF cell is not annotated when the contenteditable="true" child is selected
     const editablePara = SelectorFind.descendant(TinyDom.body(editor), 'p[contenteditable="true"]').getOrDie('Could not find paragraph');
@@ -148,7 +148,6 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
       'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 0,
       'p[data-mce-selected="1"]': 0
     });
-    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0, 0 ], 0);
 
     // Check the CEF cell is annotated if the cell itself is selected
     const noneditableCell = SelectorFind.descendant(TinyDom.body(editor), 'td[contenteditable="false"]').getOrDie('Could not find cell');
@@ -162,7 +161,7 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
 
   it('TINY-7724: does not select CEF cell if contenteditable=false child is selected', () => {
     const editor = hook.editor();
-    editor.setContent('<table><tr><td contenteditable="false"><p contenteditable="false"><strong>1</strong></p></td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>');
+    editor.setContent('<table><tbody><tr><td contenteditable="false"><p contenteditable="false"><strong>1</strong></p></td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>');
 
     // Check the CEF cell is not annotated when the contenteditable="false" child is selected
     const noneditablePara = SelectorFind.descendant(TinyDom.body(editor), 'p[contenteditable="false"]').getOrDie('Could not find paragraph');
@@ -214,7 +213,7 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
 
     assertTableSelection(
       editor,
-      '<table><tr><td contenteditable="false">1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>',
+      '<table><tbody><tr><td contenteditable="false">1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>',
       [ '1', '1' ],
       [ '1' ]
     );
@@ -236,7 +235,7 @@ describe('browser.tinymce.plugins.table.FakeSelectionTest', () => {
 
     assertTableSelection(
       editor,
-      '<table><tr><td contenteditable="false">1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>',
+      '<table><tbody><tr><td contenteditable="false">1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>',
       [ '1', '1' ],
       [ '1' ]
     );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
@@ -98,6 +98,7 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
 
   it('TINY-8313: Click on the horizontal rule toolbar button and assert hr is added to the editor', () => {
     const editor = hook.editor();
+    editor.setContent('');
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Horizontal line"]');
     TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s) => {
       return s.element('body', {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
@@ -98,6 +98,7 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
 
   it('Keyboard events', () => {
     const component = hook.component();
+    setCheckboxState(component, true);
     pressKeyOnCheckbox(component, Keys.space());
     assertCheckboxState('checked > unchecked', component, false);
     pressKeyOnCheckbox(component, Keys.space());


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Adds a new approach to figuring out where to render fake carets.
* Also fixed two unrelated tests that where failing while the 100 test chunk pivot point was moving around. They are depending on state from the previous test.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
