### PR TITLE
TINY-4627: Patch dompurify to apply some minor performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('You must use Yarn to install, not NPM')\"",
+    "postinstall": "patch-package",
     "tinymce-grunt": "grunt --gruntfile modules/tinymce/Gruntfile.js",
     "tinymce-rollup": "run-s \"tinymce-grunt dev rollup\"",
     "oxide-icons-build": "yarn -s --cwd modules/oxide-icons-default build",
@@ -76,6 +77,7 @@
     "load-grunt-tasks": "^5.1.0",
     "moxie-zip": "0.0.4",
     "npm-run-all": "^4.1.5",
+    "patch-package": "^6.4.7",
     "resolve": "^1.18.1",
     "source-map-loader": "^1.1.0",
     "string-replace-loader": "^2.1.1",

--- a/patches/dompurify+2.3.4.patch
+++ b/patches/dompurify+2.3.4.patch
@@ -1,0 +1,104 @@
+diff --git a/node_modules/dompurify/dist/purify.es.js b/node_modules/dompurify/dist/purify.es.js
+index 899e471..5844faf 100644
+--- a/node_modules/dompurify/dist/purify.es.js
++++ b/node_modules/dompurify/dist/purify.es.js
+@@ -617,6 +617,12 @@ function createDOMPurify() {
+ 
+   var HTML_INTEGRATION_POINTS = addToSet({}, ['foreignobject', 'desc', 'title', 'annotation-xml']);
+ 
++  // Certain elements are allowed in both SVG and HTML
++  // namespace. We need to specify them explicitly
++  // so that they don't get erronously deleted from
++  // HTML namespace.
++  var COMMON_SVG_AND_HTML_ELEMENTS = addToSet({}, ['title', 'style', 'font', 'a', 'script']);
++
+   /* Keep track of all possible SVG and MathML tags
+    * so that we can perform the namespace checks
+    * correctly. */
+@@ -701,15 +707,9 @@ function createDOMPurify() {
+         return false;
+       }
+ 
+-      // Certain elements are allowed in both SVG and HTML
+-      // namespace. We need to specify them explicitly
+-      // so that they don't get erronously deleted from
+-      // HTML namespace.
+-      var commonSvgAndHTMLElements = addToSet({}, ['title', 'style', 'font', 'a', 'script']);
+-
+       // We disallow tags that are specific for MathML
+       // or SVG and should never appear in HTML namespace
+-      return !ALL_MATHML_TAGS[tagName] && (commonSvgAndHTMLElements[tagName] || !ALL_SVG_TAGS[tagName]);
++      return !ALL_MATHML_TAGS[tagName] && (COMMON_SVG_AND_HTML_ELEMENTS[tagName] || !ALL_SVG_TAGS[tagName]);
+     }
+ 
+     // The code should never reach this place (this means
+@@ -902,7 +902,7 @@ function createDOMPurify() {
+     }
+ 
+     /* Check if tagname contains Unicode */
+-    if (stringMatch(currentNode.nodeName, /[\u0080-\uFFFF]/)) {
++    if (regExpTest(/[\u0080-\uFFFF]/, currentNode.nodeName)) {
+       _forceRemove(currentNode);
+       return true;
+     }
+@@ -917,7 +917,7 @@ function createDOMPurify() {
+     });
+ 
+     /* Detect mXSS attempts abusing namespace confusion */
+-    if (!_isNode(currentNode.firstElementChild) && (!_isNode(currentNode.content) || !_isNode(currentNode.content.firstElementChild)) && regExpTest(/<[/\w]/g, currentNode.innerHTML) && regExpTest(/<[/\w]/g, currentNode.textContent)) {
++    if (currentNode.hasChildNodes() && !_isNode(currentNode.firstElementChild) && (!_isNode(currentNode.content) || !_isNode(currentNode.content.firstElementChild)) && regExpTest(/<[/\w]/g, currentNode.innerHTML) && regExpTest(/<[/\w]/g, currentNode.textContent)) {
+       _forceRemove(currentNode);
+       return true;
+     }
+diff --git a/node_modules/dompurify/dist/purify.js b/node_modules/dompurify/dist/purify.js
+index 68bc40f..03bd803 100644
+--- a/node_modules/dompurify/dist/purify.js
++++ b/node_modules/dompurify/dist/purify.js
+@@ -623,6 +623,12 @@
+ 
+     var HTML_INTEGRATION_POINTS = addToSet({}, ['foreignobject', 'desc', 'title', 'annotation-xml']);
+ 
++    // Certain elements are allowed in both SVG and HTML
++    // namespace. We need to specify them explicitly
++    // so that they don't get erronously deleted from
++    // HTML namespace.
++    var COMMON_SVG_AND_HTML_ELEMENTS = addToSet({}, ['title', 'style', 'font', 'a', 'script']);
++
+     /* Keep track of all possible SVG and MathML tags
+      * so that we can perform the namespace checks
+      * correctly. */
+@@ -707,15 +713,9 @@
+           return false;
+         }
+ 
+-        // Certain elements are allowed in both SVG and HTML
+-        // namespace. We need to specify them explicitly
+-        // so that they don't get erronously deleted from
+-        // HTML namespace.
+-        var commonSvgAndHTMLElements = addToSet({}, ['title', 'style', 'font', 'a', 'script']);
+-
+         // We disallow tags that are specific for MathML
+         // or SVG and should never appear in HTML namespace
+-        return !ALL_MATHML_TAGS[tagName] && (commonSvgAndHTMLElements[tagName] || !ALL_SVG_TAGS[tagName]);
++        return !ALL_MATHML_TAGS[tagName] && (COMMON_SVG_AND_HTML_ELEMENTS[tagName] || !ALL_SVG_TAGS[tagName]);
+       }
+ 
+       // The code should never reach this place (this means
+@@ -908,7 +908,7 @@
+       }
+ 
+       /* Check if tagname contains Unicode */
+-      if (stringMatch(currentNode.nodeName, /[\u0080-\uFFFF]/)) {
++      if (regExpTest(/[\u0080-\uFFFF]/, currentNode.nodeName)) {
+         _forceRemove(currentNode);
+         return true;
+       }
+@@ -923,7 +923,7 @@
+       });
+ 
+       /* Detect mXSS attempts abusing namespace confusion */
+-      if (!_isNode(currentNode.firstElementChild) && (!_isNode(currentNode.content) || !_isNode(currentNode.content.firstElementChild)) && regExpTest(/<[/\w]/g, currentNode.innerHTML) && regExpTest(/<[/\w]/g, currentNode.textContent)) {
++      if (currentNode.hasChildNodes() && !_isNode(currentNode.firstElementChild) && (!_isNode(currentNode.content) || !_isNode(currentNode.content.firstElementChild)) && regExpTest(/<[/\w]/g, currentNode.innerHTML) && regExpTest(/<[/\w]/g, currentNode.textContent)) {
+         _forceRemove(currentNode);
+         return true;
+       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,6 +1718,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -5155,6 +5160,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 findup-sync@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
@@ -5310,6 +5322,15 @@ fs-extra@8.1.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   dependencies:
     graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -7035,7 +7056,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is-wsl@^2.2.0:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -7296,6 +7317,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 known-css-properties@^0.21.0:
   version "0.21.0"
@@ -8763,6 +8791,14 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -9081,6 +9117,25 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
+  integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
 
 path-browserify@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
Related Ticket: TINY-4627

Description of Changes:

This patch is only meant to be short-lived as we should contribute this back upstream if all works well, but this just makes some fairly minor performance improvements I was able to find for DOMPurify.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
