### PR TITLE
fix typo in execCommand docstring

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -546,7 +546,7 @@ class Editor implements EditorObservable {
 
   /**
    * Executes a command on the current instance. These commands can be TinyMCE internal commands prefixed with "mce" or
-   * they can be build in browser commands such as "Bold". A compleate list of browser commands is available on MSDN or Mozilla.org.
+   * they can be build in browser commands such as "Bold". A complete list of browser commands is available on MSDN or Mozilla.org.
    * This function will dispatch the execCommand function on each plugin, theme or the execcommand_callback option if none of these
    * return true it will handle the command as a internal browser command.
    *


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Corrected typo in execCommand documentation

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
