### PR TITLE
TINY-8325: Convert a number of APIs to use Promises instead of callbacks

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `editor.annotator.removeAll` API to remove all annotations by name #TINY-8195
 
 ### Improved
-- The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload #TINY-7735
+- The `ScriptLoader`, `StyleSheetLoader`, `AddOnManager`, `PluginManager` and `ThemeManager` APIs will now return a `Promise` when loading resources instead of using callbacks #TINY-8325
 - A `ThemeLoadError` event is now fired if the theme fails to load #TINY-8325
+- The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload #TINY-7735
 - The `emoticon` plugin dialog, toolbar and menu item has been updated to use the more accurate `Emojis` term #TINY-7631
 - The dialog `redial` API will now only rerender the changed components instead of the whole dialog #TINY-8334
 - The dialog API `setData` method now uses a deep merge algorithm to support partial nested objects #TINY-8333
@@ -27,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `editor.getContent()` API can provide custom content by preventing and overriding `content` in the `BeforeGetContent` event. This makes it consistent with the `editor.selection.getContent()` API #TINY-8018
-- The `ScriptLoader` API will now return a `Promise` when load scripts instead of using callbacks #TINY-8325
-- The `AddOnManager`, `PluginManager` and `ThemeManager` APIs will now return a `Promise` when loading instead of using callbacks #TINY-8325
 - RGB colors are no longer converted to hex values when parsing or serializing content #TINY-8163
 - The `tinymce.Env.os.isOSX` API has been renamed to `tinymce.Env.os.isMacOS` #TINY-8175
 - The `tinymce.Env.browser.isChrome` API has been renamed to `tinymce.Env.browser.isChromium` to better reflect its functionality #TINY-8300

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the deprecated `filepicker_validator_handler`, `force_p_newlines`, `gecko_spellcheck`, `tab_focus`, `table_responsive_width` and `toolbar_drawer` settings #TINY-7820
 - Removed the deprecated `editor_deselector`, `editor_selector`, `elements`, `mode` and `types` legacy TinyMCE init settings #TINY-7822
 - Removed support for the deprecated `false` value for the `forced_root_block` option #TINY-8260
+- Removed the callback for the `EditorUpload` APIs #TINY-8325
 - The legacy `mobile` theme has been removed #TINY-7832
 - Removed support for Microsoft Internet Explorer 11 #TINY-8194 #TINY-8241
 - Removed the deprecated `fullpage`, `spellchecker`, `bbcode`, `legacyoutput`, `colorpicker`, `contextmenu` and `textcolor` plugins #TINY-8192

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `editor.getContent()` API can provide custom content by preventing and overriding `content` in the `BeforeGetContent` event. This makes it consistent with the `editor.selection.getContent()` API #TINY-8018
+- The `ScriptLoader` API will now return a `Promise` when load scripts instead of using callbacks #TINY-8325
 - RGB colors are no longer converted to hex values when parsing or serializing content #TINY-8163
 - The `tinymce.Env.os.isOSX` API has been renamed to `tinymce.Env.os.isMacOS` #TINY-8175
 - The `tinymce.Env.browser.isChrome` API has been renamed to `tinymce.Env.browser.isChromium` to better reflect its functionality #TINY-8300

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload #TINY-7735
+- A `ThemeLoadError` event is now fired if the theme fails to load #TINY-8325
 - The `emoticon` plugin dialog, toolbar and menu item has been updated to use the more accurate `Emojis` term #TINY-7631
 - The dialog `redial` API will now only rerender the changed components instead of the whole dialog #TINY-8334
 - The dialog API `setData` method now uses a deep merge algorithm to support partial nested objects #TINY-8333
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `editor.getContent()` API can provide custom content by preventing and overriding `content` in the `BeforeGetContent` event. This makes it consistent with the `editor.selection.getContent()` API #TINY-8018
 - The `ScriptLoader` API will now return a `Promise` when load scripts instead of using callbacks #TINY-8325
+- The `AddOnManager`, `PluginManager` and `ThemeManager` APIs will now return a `Promise` when loading instead of using callbacks #TINY-8325
 - RGB colors are no longer converted to hex values when parsing or serializing content #TINY-8163
 - The `tinymce.Env.os.isOSX` API has been renamed to `tinymce.Env.os.isMacOS` #TINY-8175
 - The `tinymce.Env.browser.isChrome` API has been renamed to `tinymce.Env.browser.isChromium` to better reflect its functionality #TINY-8300

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `editor.getContent()` API can provide custom content by preventing and overriding `content` in the `BeforeGetContent` event. This makes it consistent with the `editor.selection.getContent()` API #TINY-8018
+- The `images_upload_handler` option is no longer passed a `success` or `failure` callback and instead requires a `Promise` to be returned with the upload result #TINY-8325
 - RGB colors are no longer converted to hex values when parsing or serializing content #TINY-8163
 - The `tinymce.Env.os.isOSX` API has been renamed to `tinymce.Env.os.isMacOS` #TINY-8175
 - The `tinymce.Env.browser.isChrome` API has been renamed to `tinymce.Env.browser.isChromium` to better reflect its functionality #TINY-8300

--- a/modules/tinymce/src/core/main/ts/ErrorReporter.ts
+++ b/modules/tinymce/src/core/main/ts/ErrorReporter.ts
@@ -52,6 +52,10 @@ const languageLoadError = (editor: Editor, url: string, name: string) => {
   logError(editor, 'LanguageLoadError', createLoadError('language', url, name));
 };
 
+const themeLoadError = (editor: Editor, url: string, name: string) => {
+  logError(editor, 'ThemeLoadError', createLoadError('theme', url, name));
+};
+
 const pluginInitError = (editor: Editor, name: string, err) => {
   const message = I18n.translate([ 'Failed to initialize plugin: {0}', name ]);
   fireError(editor, 'PluginLoadError', { message });
@@ -74,6 +78,7 @@ export {
   pluginLoadError,
   iconsLoadError,
   languageLoadError,
+  themeLoadError,
   pluginInitError,
   uploadError,
   displayError,

--- a/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Fun, Obj, Type } from '@ephox/katamari';
+import { Arr, Obj, Type } from '@ephox/katamari';
 
 import ScriptLoader from './dom/ScriptLoader';
 import Editor from './Editor';
@@ -107,26 +107,28 @@ interface AddOnManager<T> {
   items: AddOnConstructor<T>[];
   urls: Record<string, string>;
   lookup: Record<string, { instance: AddOnConstructor<T> }>;
-  _listeners: { name: string; state: WaitState; callback: () => void }[];
   get: (name: string) => AddOnConstructor<T>;
   requireLangPack: (name: string, languages: string) => void;
   add: (id: string, addOn: AddOnConstructor<T>) => AddOnConstructor<T>;
   remove: (name: string) => void;
   createUrl: (baseUrl: UrlObject, dep: string | UrlObject) => UrlObject;
-  load: (name: string, addOnUrl: string | UrlObject, success?: () => void, scope?: any, failure?: () => void) => void;
-  waitFor: (name: string, callback: () => void, state?: WaitState) => void;
+  load: (name: string, addOnUrl: string | UrlObject) => Promise<void>;
+  waitFor: (name: string, state?: WaitState) => Promise<void>;
 }
 
 const AddOnManager = <T>(): AddOnManager<T> => {
   const items: AddOnConstructor<T>[] = [];
   const urls: Record<string, string> = {};
   const lookup: Record<string, { instance: AddOnConstructor<T> }> = {};
-  const _listeners: { name: string; state: WaitState; callback: () => void }[] = [];
+  const _listeners: { name: string; state: WaitState; resolve: () => void }[] = [];
 
   const runListeners = (name: string, state: WaitState) => {
     const matchedListeners = Arr.filter(_listeners, (listener) => listener.name === name && listener.state === state);
-    Arr.each(matchedListeners, (listener) => listener.callback());
+    Arr.each(matchedListeners, (listener) => listener.resolve());
   };
+
+  const isLoaded = (name: string) => Obj.has(urls, name);
+  const isAdded = (name: string) => Obj.has(lookup, name);
 
   const get = (name: string) => {
     if (lookup[name]) {
@@ -136,18 +138,24 @@ const AddOnManager = <T>(): AddOnManager<T> => {
     return undefined;
   };
 
+  const loadLanguagePack = (name: string, languages: string): void => {
+    const language = I18n.getCode();
+    const wrappedLanguages = ',' + (languages || '') + ',';
+
+    if (!language || languages && wrappedLanguages.indexOf(',' + language + ',') === -1) {
+      return;
+    }
+
+    ScriptLoader.ScriptLoader.add(urls[ name ] + '/langs/' + language + '.js');
+  };
+
   const requireLangPack = (name: string, languages: string) => {
     if (AddOnManager.languageLoad !== false) {
-      waitFor(name, () => {
-        const language = I18n.getCode();
-        const wrappedLanguages = ',' + (languages || '') + ',';
-
-        if (!language || languages && wrappedLanguages.indexOf(',' + language + ',') === -1) {
-          return;
-        }
-
-        ScriptLoader.ScriptLoader.add(urls[ name ] + '/langs/' + language + '.js');
-      }, 'loaded');
+      if (isLoaded(name)) {
+        loadLanguagePack(name, languages);
+      } else {
+        waitFor(name, 'loaded').then(() => loadLanguagePack(name, languages));
+      }
     }
   };
 
@@ -166,21 +174,21 @@ const AddOnManager = <T>(): AddOnManager<T> => {
   };
 
   const createUrl = (baseUrl: string | UrlObject, dep: string | UrlObject): UrlObject => {
-    if (typeof dep === 'object') {
+    if (Type.isString(dep)) {
+      return Type.isString(baseUrl) ?
+        { prefix: '', resource: dep, suffix: '' } :
+        { prefix: baseUrl.prefix, resource: dep, suffix: baseUrl.suffix };
+    } else {
       return dep;
     }
-
-    return typeof baseUrl === 'string' ?
-      { prefix: '', resource: dep, suffix: '' } :
-      { prefix: baseUrl.prefix, resource: dep, suffix: baseUrl.suffix };
   };
 
-  const load = (name: string, addOnUrl: string | UrlObject, success?: () => void, scope?: any, failure?: () => void) => {
+  const load = (name: string, addOnUrl: string | UrlObject): Promise<void> => {
     if (urls[name]) {
-      return;
+      return Promise.resolve();
     }
 
-    let urlString = typeof addOnUrl === 'string' ? addOnUrl : addOnUrl.prefix + addOnUrl.resource + addOnUrl.suffix;
+    let urlString = Type.isString(addOnUrl) ? addOnUrl : addOnUrl.prefix + addOnUrl.resource + addOnUrl.suffix;
 
     if (urlString.indexOf('/') !== 0 && urlString.indexOf('://') === -1) {
       urlString = AddOnManager.baseURL + '/' + urlString;
@@ -190,25 +198,25 @@ const AddOnManager = <T>(): AddOnManager<T> => {
 
     const done = () => {
       runListeners(name, 'loaded');
-      if (Type.isFunction(success)) {
-        success();
-      }
+      return Promise.resolve();
     };
 
     if (lookup[name]) {
-      done();
+      return done();
     } else {
-      ScriptLoader.ScriptLoader.add(urlString).then(done, failure ?? Fun.noop);
+      return ScriptLoader.ScriptLoader.add(urlString).then(done);
     }
   };
 
-  const waitFor = (name: string, callback: () => void, state: 'added' | 'loaded' = 'added') => {
-    if (Obj.has(lookup, name) && state === 'added') {
-      callback();
-    } else if (Obj.has(urls, name) && state === 'loaded') {
-      callback();
+  const waitFor = (name: string, state: 'added' | 'loaded' = 'added'): Promise<void> => {
+    if (state === 'added' && isAdded(name)) {
+      return Promise.resolve();
+    } else if (state === 'loaded' && isLoaded(name)) {
+      return Promise.resolve();
     } else {
-      _listeners.push({ name, state, callback });
+      return new Promise((resolve) => {
+        _listeners.push({ name, state, resolve });
+      });
     }
   };
 
@@ -216,7 +224,6 @@ const AddOnManager = <T>(): AddOnManager<T> => {
     items,
     urls,
     lookup,
-    _listeners,
     /**
      * Returns the specified add on by the short name.
      *
@@ -273,9 +280,7 @@ const AddOnManager = <T>(): AddOnManager<T> => {
      * @method load
      * @param {String} name Short name of the add-on that gets loaded.
      * @param {String} addOnUrl URL to the add-on that will get loaded.
-     * @param {function} success Optional success callback to execute when an add-on is loaded.
-     * @param {Object} scope Optional scope to execute the callback in.
-     * @param {function} failure Optional failure callback to execute when an add-on failed to load.
+     * @return {Promise} A promise that will resolve when the add-on is loaded successfully or reject if it failed to load.
      * @example
      * // Loads a plugin from an external URL
      * tinymce.PluginManager.load('myplugin', '/some/dir/someplugin/plugin.js');

--- a/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj } from '@ephox/katamari';
+import { Arr, Fun, Obj, Type } from '@ephox/katamari';
 
 import ScriptLoader from './dom/ScriptLoader';
 import Editor from './Editor';
@@ -190,12 +190,15 @@ const AddOnManager = <T>(): AddOnManager<T> => {
 
     const done = () => {
       runListeners(name, 'loaded');
+      if (Type.isFunction(success)) {
+        success();
+      }
     };
 
     if (lookup[name]) {
       done();
     } else {
-      ScriptLoader.ScriptLoader.add(urlString, done, scope, failure);
+      ScriptLoader.ScriptLoader.add(urlString).then(done, failure ?? Fun.noop);
     }
   };
 

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -30,7 +30,7 @@ import EditorCommands, { EditorCommandCallback } from './EditorCommands';
 import EditorManager from './EditorManager';
 import EditorObservable from './EditorObservable';
 import { BuiltInOptionType, BuiltInOptionTypeMap, Options as EditorOptions, create as createOptions } from './EditorOptions';
-import EditorUpload, { UploadCallback, UploadResult } from './EditorUpload';
+import EditorUpload, { UploadResult } from './EditorUpload';
 import Env from './Env';
 import Formatter from './Formatter';
 import DomParser from './html/DomParser';
@@ -1070,11 +1070,10 @@ class Editor implements EditorObservable {
    * Uploads all data uri/blob uri images in the editor contents to server.
    *
    * @method uploadImages
-   * @param {function} callback Optional callback with images and status for each image.
-   * @return {Promise} Promise instance.
+   * @return {Promise} Promise instance with images and status for each image.
    */
-  public uploadImages(callback?: UploadCallback): Promise<UploadResult[]> {
-    return this.editorUpload.uploadImages(callback);
+  public uploadImages(): Promise<UploadResult[]> {
+    return this.editorUpload.uploadImages();
   }
 
   // Internal functions

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -36,13 +36,11 @@ export interface UploadResult {
   removed: boolean;
 }
 
-export type UploadCallback = (results: UploadResult[]) => void;
-
 interface EditorUpload {
   blobCache: BlobCache;
   addFilter: (filter: (img: HTMLImageElement) => boolean) => void;
-  uploadImages: (callback?: UploadCallback) => Promise<UploadResult[]>;
-  uploadImagesAuto: (callback?: UploadCallback) => void | Promise<UploadResult[]>;
+  uploadImages: () => Promise<UploadResult[]>;
+  uploadImagesAuto: () => Promise<UploadResult[]>;
   scanForImages: () => Promise<BlobInfoImagePair[]>;
   destroy: () => void;
 }
@@ -140,7 +138,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
     });
   };
 
-  const uploadImages = (callback?: UploadCallback): Promise<UploadResult[]> => {
+  const uploadImages = (): Promise<UploadResult[]> => {
     if (!uploader) {
       uploader = createUploader(editor, uploadStatus);
     }
@@ -195,20 +193,13 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           });
         }
 
-        if (callback) {
-          callback(filteredResult);
-        }
-
         return filteredResult;
       }));
     }));
   };
 
-  const uploadImagesAuto = (callback?: UploadCallback) => {
-    if (Options.isAutomaticUploadsEnabled(editor)) {
-      return uploadImages(callback);
-    }
-  };
+  const uploadImagesAuto = () =>
+    Options.isAutomaticUploadsEnabled(editor) ? uploadImages() : Promise.resolve([]);
 
   const isValidDataUriImage = (imgElm: HTMLImageElement) =>
     Arr.forall(urlFilters, (filter) => filter(imgElm));

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -162,7 +162,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
               replaceImageUriInView(image, uploadInfo.url);
             }
           } else if (uploadInfo.error) {
-            if (uploadInfo.error.options.remove) {
+            if (uploadInfo.error.remove) {
               replaceUrlInUndoStack(image.getAttribute('src'), Env.transparentSrc);
               imagesToRemove.push(image);
               removed = true;

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -90,6 +90,7 @@ export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
   'SkinLoadError': LoadErrorEvent;
   'PluginLoadError': LoadErrorEvent;
   'IconsLoadError': LoadErrorEvent;
+  'ThemeLoadError': LoadErrorEvent;
   'LanguageLoadError': LoadErrorEvent;
   'BeforeExecCommand': ExecCommandEvent;
   'ExecCommand': ExecCommandEvent;

--- a/modules/tinymce/src/core/main/ts/api/Resource.ts
+++ b/modules/tinymce/src/core/main/ts/api/Resource.ts
@@ -52,7 +52,7 @@ const create = (): Resource => {
       const task = new Promise<any>((resolve, reject) => {
         const waiter = awaiter(resolve, reject);
         resultFns[id] = waiter.resolve;
-        ScriptLoader.ScriptLoader.loadScript(url, () => waiter.start(runErrMsg), () => waiter.reject(loadErrMsg));
+        ScriptLoader.ScriptLoader.loadScript(url).then(() => waiter.start(runErrMsg), () => waiter.reject(loadErrMsg));
       });
       tasks[id] = task;
       return task;

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -786,7 +786,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
 
     Arr.each(urls.split(','), (url) => {
       files[url] = true;
-      styleSheetLoader.load(url, Fun.noop);
+      styleSheetLoader.load(url).catch(Fun.noop);
     });
   };
 

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Type } from '@ephox/katamari';
+import { Arr, Obj, Unique } from '@ephox/katamari';
 
 import Tools from '../util/Tools';
 import DOMUtils from './DOMUtils';
@@ -37,7 +37,6 @@ import DOMUtils from './DOMUtils';
  */
 
 const DOM = DOMUtils.DOM;
-const each = Tools.each, grep = Tools.grep;
 
 export interface ScriptLoaderSettings {
   referrerPolicy?: ReferrerPolicy;
@@ -62,9 +61,7 @@ class ScriptLoader {
   private settings: ScriptLoaderSettings;
   private states: Record<string, number> = {};
   private queue: string[] = [];
-  private scriptLoadedCallbacks: Record<string, Array<{success: () => void; failure: () => void; scope: any}>> = {};
-  private queueLoadedCallbacks: Array<{success: () => void; failure: (urls: string[]) => void; scope: any}> = [];
-  private loading = 0;
+  private scriptLoadedCallbacks: Record<string, Array<{ resolve: () => void; reject: (reason: any) => void }>> = {};
 
   public constructor(settings: ScriptLoaderSettings = {}) {
     this.settings = settings;
@@ -79,66 +76,55 @@ class ScriptLoader {
    *
    * @method loadScript
    * @param {String} url Absolute URL to script to add.
-   * @param {function} success Optional success callback function when the script loaded successfully.
-   * @param {function} failure Optional failure callback function when the script failed to load.
+   * @return {Promise} A promise that will resolve when the script loaded successfully or reject if it failed to load.
    */
-  public loadScript(url: string, success?: () => void, failure?: () => void) {
-    const dom = DOM;
-    let elm;
+  public loadScript(url: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const dom = DOM;
+      let elm: HTMLScriptElement;
 
-    const cleanup = () => {
-      dom.remove(id);
-      if (elm) {
-        elm.onerror = elm.onload = elm = null;
-      }
-    };
-
-    // Execute callback when script is loaded
-    const done = () => {
-      cleanup();
-      success();
-    };
-
-    const error = () => {
-      cleanup();
-
-      // We can't mark it as done if there is a load error since
-      // A) We don't want to produce 404 errors on the server and
-      // B) the onerror event won't fire on all browsers.
-      // done();
-
-      if (Type.isFunction(failure)) {
-        failure();
-      } else {
-        // Report the error so it's easier for people to spot loading errors
-        // eslint-disable-next-line no-console
-        if (typeof console !== 'undefined' && console.log) {
-          // eslint-disable-next-line no-console
-          console.log('Failed to load script: ' + url);
+      const cleanup = () => {
+        dom.remove(id);
+        if (elm) {
+          elm.onerror = elm.onload = elm = null;
         }
+      };
+
+      // Execute callback when script is loaded
+      const done = () => {
+        cleanup();
+        resolve();
+      };
+
+      const error = () => {
+        // We can't mark it as done if there is a load error since
+        // A) We don't want to produce 404 errors on the server and
+        // B) the onerror event won't fire on all browsers.
+        cleanup();
+        reject('Failed to load script: ' + url);
+      };
+
+      const id = dom.uniqueId();
+
+      // Create new script element
+      elm = document.createElement('script');
+      elm.id = id;
+      elm.type = 'text/javascript';
+      elm.src = Tools._addCacheSuffix(url);
+
+      if (this.settings.referrerPolicy) {
+        // Note: Don't use elm.referrerPolicy = ... here as it doesn't work on Safari
+        dom.setAttrib(elm, 'referrerpolicy', this.settings.referrerPolicy);
       }
-    };
 
-    const id = dom.uniqueId();
+      elm.onload = done;
 
-    // Create new script element
-    elm = document.createElement('script');
-    elm.id = id;
-    elm.type = 'text/javascript';
-    elm.src = Tools._addCacheSuffix(url);
+      // Add onerror event will get fired on some browsers but not all of them
+      elm.onerror = error;
 
-    if (this.settings.referrerPolicy) {
-      // Note: Don't use elm.referrerPolicy = ... here as it doesn't work on Safari
-      dom.setAttrib(elm, 'referrerpolicy', this.settings.referrerPolicy);
-    }
-
-    elm.onload = done;
-
-    // Add onerror event will get fired on some browsers but not all of them
-    elm.onerror = error;
-
-    // Add script to document
-    (document.getElementsByTagName('head')[0] || document.body).appendChild(elm);
+      // Add script to document
+      (document.getElementsByTagName('head')[0] || document.body).appendChild(elm);
+    });
   }
 
   /**
@@ -168,35 +154,33 @@ class ScriptLoader {
    *
    * @method add
    * @param {String} url Absolute URL to script to add.
-   * @param {function} success Optional success callback function to execute when the script loades successfully.
-   * @param {Object} scope Optional scope to execute callback in.
-   * @param {function} failure Optional failure callback function to execute when the script failed to load.
+   * @return {Promise} A promise that will resolve when the script loaded successfully or reject if it failed to load.
    */
-  public add(url: string, success?: () => void, scope?: any, failure?: () => void) {
-    const state = this.states[url];
-    this.queue.push(url);
+  public add(url: string): Promise<void> {
+    const self = this;
+    self.queue.push(url);
 
     // Add url to load queue
+    const state = self.states[url];
     if (state === undefined) {
-      this.states[url] = QUEUED;
+      self.states[url] = QUEUED;
     }
 
-    if (success) {
+    return new Promise((resolve, reject) => {
       // Store away callback for later execution
-      if (!this.scriptLoadedCallbacks[url]) {
-        this.scriptLoadedCallbacks[url] = [];
+      if (!self.scriptLoadedCallbacks[url]) {
+        self.scriptLoadedCallbacks[url] = [];
       }
 
-      this.scriptLoadedCallbacks[url].push({
-        success,
-        failure,
-        scope: scope || this
+      self.scriptLoadedCallbacks[url].push({
+        resolve,
+        reject
       });
-    }
+    });
   }
 
-  public load(url: string, success?: () => void, scope?: any, failure?: () => void) {
-    return this.add(url, success, scope, failure);
+  public load(url: string): Promise<void> {
+    return this.add(url);
   }
 
   public remove(url: string) {
@@ -208,12 +192,12 @@ class ScriptLoader {
    * Starts the loading of the queue.
    *
    * @method loadQueue
-   * @param {function} success Optional callback to execute when all queued items are loaded.
-   * @param {function} failure Optional callback to execute when queued items failed to load.
-   * @param {Object} scope Optional scope to execute the callback in.
+   * @return {Promise} A promise that is resolved when all queued items are loaded or rejected with the script urls that failed to load.
    */
-  public loadQueue(success?: () => void, scope?: any, failure?: (urls: string[]) => void) {
-    this.loadScripts(this.queue, success, scope, failure);
+  public loadQueue(): Promise<void> {
+    const queue = this.queue;
+    this.queue = [];
+    return this.loadScripts(queue);
   }
 
   /**
@@ -222,97 +206,49 @@ class ScriptLoader {
    *
    * @method loadScripts
    * @param {Array} scripts Array of queue items to load.
-   * @param {function} success Optional callback to execute when scripts is loaded successfully.
-   * @param {Object} scope Optional scope to execute callback in.
-   * @param {function} failure Optional callback to execute if scripts failed to load.
+   * @return {Promise} A promise that is resolved when all scripts are loaded or rejected with the script urls that failed to load.
    */
-  public loadScripts(scripts: string[], success?: () => void, scope?: any, failure?: (urls: string[]) => void) {
+  public loadScripts(scripts: string[]): Promise<void> {
     const self = this;
-    const failures = [];
+    const uniqueScripts = Unique.stringArray(scripts);
 
-    const execCallbacks = (name, url) => {
+    const execCallbacks = (name: 'resolve' | 'reject', url: string) => {
       // Execute URL callback functions
-      each(self.scriptLoadedCallbacks[url], (callback) => {
-        if (Type.isFunction(callback[name])) {
-          callback[name].call(callback.scope);
-        }
+      Obj.get(self.scriptLoadedCallbacks, url).each((callbacks) => {
+        Arr.each(callbacks, (callback) => callback[name](url));
       });
 
-      self.scriptLoadedCallbacks[url] = undefined;
+      delete self.scriptLoadedCallbacks[url];
     };
 
-    self.queueLoadedCallbacks.push({
-      success,
-      failure,
-      scope: scope || this
-    });
+    // Load scripts that needs to be loaded
+    return Promise.allSettled(Arr.map(uniqueScripts, (url): Promise<void> => {
+      // Script is already loaded then execute script callbacks directly
+      if (self.states[url] === LOADED) {
+        execCallbacks('resolve', url);
+        return Promise.resolve();
+      } else if (self.states[url] === FAILED) {
+        execCallbacks('reject', url);
+        return Promise.reject(url);
+      } else {
+        // Script is not already loaded, so load it
+        self.states[url] = LOADING;
 
-    const loadScripts = () => {
-      const loadingScripts = grep(scripts);
-
-      // Current scripts has been handled
-      scripts.length = 0;
-
-      // Load scripts that needs to be loaded
-      each(loadingScripts, (url) => {
-        // Script is already loaded then execute script callbacks directly
-        if (self.states[url] === LOADED) {
-          execCallbacks('success', url);
-          return;
-        }
-
-        if (self.states[url] === FAILED) {
-          execCallbacks('failure', url);
-          return;
-        }
-
-        // Is script not loading then start loading it
-        if (self.states[url] !== LOADING) {
-          self.states[url] = LOADING;
-          self.loading++;
-
-          self.loadScript(url, () => {
-            self.states[url] = LOADED;
-            self.loading--;
-
-            execCallbacks('success', url);
-
-            // Load more scripts if they where added by the recently loaded script
-            loadScripts();
-          }, () => {
-            self.states[url] = FAILED;
-            self.loading--;
-
-            failures.push(url);
-            execCallbacks('failure', url);
-
-            // Load more scripts if they where added by the recently loaded script
-            loadScripts();
-          });
-        }
-      });
-
-      // No scripts are currently loading then execute all pending queue loaded callbacks
-      if (!self.loading) {
-        // We need to clone the notifications and empty the pending callbacks so that callbacks can load more resources
-        const notifyCallbacks = self.queueLoadedCallbacks.slice(0);
-        self.queueLoadedCallbacks.length = 0;
-
-        each(notifyCallbacks, (callback) => {
-          if (failures.length === 0) {
-            if (Type.isFunction(callback.success)) {
-              callback.success.call(callback.scope);
-            }
-          } else {
-            if (Type.isFunction(callback.failure)) {
-              callback.failure.call(callback.scope, failures);
-            }
-          }
+        return self.loadScript(url).then(() => {
+          self.states[url] = LOADED;
+          execCallbacks('resolve', url);
+        }, () => {
+          self.states[url] = FAILED;
+          execCallbacks('reject', url);
+          return Promise.reject(url);
         });
       }
-    };
-
-    loadScripts();
+    })).then((results) => {
+      const failures = Arr.filter(results, (result): result is PromiseRejectedResult => result.status === 'rejected');
+      if (failures.length > 0) {
+        return Promise.reject(Arr.map(failures, (failure) => failure.reason));
+      }
+    });
   }
 }
 

--- a/modules/tinymce/src/core/main/ts/file/Uploader.ts
+++ b/modules/tinymce/src/core/main/ts/file/Uploader.ts
@@ -145,7 +145,7 @@ export const Uploader = (uploadStatus: UploadStatus, settings): Uploader => {
           }
         };
 
-        const success = (url) => {
+        const success = (url: string) => {
           closeNotification();
           uploadStatus.markUploaded(blobInfo.blobUri(), url);
           resolvePending(blobInfo.blobUri(), handlerSuccess(blobInfo, url));

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -265,14 +265,14 @@ const getStyleSheetLoader = (editor: Editor): StyleSheetLoader =>
 
 const makeStylesheetLoadingPromises = (editor: Editor, css: string[], framedFonts: string[]): Promise<unknown>[] => {
   const promises = [
-    new Promise((resolve, reject) => getStyleSheetLoader(editor).loadAll(css, resolve, reject)),
+    getStyleSheetLoader(editor).loadAll(css)
   ];
 
   if (editor.inline) {
     return promises;
   } else {
     return promises.concat([
-      new Promise((resolve, reject) => editor.ui.styleSheetLoader.loadAll(framedFonts, resolve, reject)),
+      editor.ui.styleSheetLoader.loadAll(framedFonts)
     ]);
   }
 };

--- a/modules/tinymce/src/core/test/ts/browser/AddOnManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AddOnManagerTest.ts
@@ -56,11 +56,9 @@ describe('browser.tinymce.core.AddOnManagerTest', () => {
     return languagePackUrl;
   };
 
-  before(() => patch(ScriptLoader.ScriptLoader, 'add', (origFunc, url, scriptSuccess) => {
+  before(() => patch(ScriptLoader.ScriptLoader, 'add', (origFunc, url) => {
     languagePackUrl = url;
-    if (scriptSuccess) {
-      scriptSuccess();
-    }
+    return Promise.resolve();
   }));
 
   after(() => unpatch(ScriptLoader.ScriptLoader));

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -39,10 +39,11 @@ describe('browser.tinymce.core.EditorRemoveTest', () => {
           // Hook the function called when stylesheets are loaded
           // so we can remove the editor right after starting to load them.
           const realLoadAll = editor.ui.styleSheetLoader.loadAll;
-          editor.ui.styleSheetLoader.loadAll = (...args) => {
-            realLoadAll.apply(editor.ui.styleSheetLoader, args);
+          editor.ui.styleSheetLoader.loadAll = (urls: string[]) => {
+            const result = realLoadAll.call(editor.ui.styleSheetLoader, urls);
             editor.ui.styleSheetLoader.loadAll = realLoadAll;
             editor.remove();
+            return result;
           };
         });
       }

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
@@ -33,7 +33,7 @@ describe('browser.tinymce.core.EditorRemovedApiTest', () => {
     editor.queryCommandState('bold');
     editor.queryCommandValue('bold');
     editor.queryCommandSupported('bold');
-    editor.uploadImages(Fun.noop);
+    editor.uploadImages();
     editor.setContent('a');
     editor.insertContent('a');
     editor.execCommand('bold');

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, before, describe, it } from '@ephox/bedrock-client';
-import { Fun, Arr } from '@ephox/katamari';
+import { Arr } from '@ephox/katamari';
 import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -129,7 +129,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       const blobUri = result[0].blobInfo.blobUri();
 
       assertEventsLength(0);
-      return editor.uploadImages(() => {
+      return editor.uploadImages().then(() => {
         editor.setContent(imageHtml(blobUri));
         assert.isFalse(hasBlobAsSource(editor.dom.select('img')[0]), 'replace uploaded blob uri with result uri (copy/paste of an uploaded blob uri)');
         assert.equal(editor.getContent(), '<p><img src="file.png"></p>', 'replace uploaded blob uri with result uri (copy/paste of an uploaded blob uri)');
@@ -151,7 +151,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       const blobUri = result[0].blobInfo.blobUri();
 
       assertEventsLength(0);
-      return editor.uploadImages(() => {
+      return editor.uploadImages().then(() => {
         assertEventsLength(0);
         editor.setContent(imageHtml(blobUri));
         assert.isTrue(hasBlobAsSource(editor.dom.select('img')[0]), 'Has blob');
@@ -173,12 +173,13 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     });
 
     assertEventsLength(0);
-    return editor.uploadImages((result) => {
-      assertResult(editor, 'Upload the images', uploadUri, uploadedBlobInfo, result);
+    return editor.uploadImages().then((firstResult) => {
+      assertResult(editor, 'Upload the images', uploadUri, uploadedBlobInfo, firstResult);
       assertEventsLength(1);
-    }).then(() => editor.uploadImages((result) => {
-      assert.lengthOf(result, 0, 'Upload the images');
-    }));
+      return editor.uploadImages().then((secondResult) => {
+        assert.lengthOf(secondResult, 0, 'Upload the images');
+      });
+    });
   });
 
   it('TBA: uploadImages (promise)', () => {
@@ -211,12 +212,12 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     const editor = hook.editor();
     let uploadedBlobInfo;
 
-    const assertResultRetainsUrl = (result) => {
-      assert.isTrue(result[0].status, 'uploadImages retain blob urls after upload');
-      assert.isTrue(hasBlobAsSource(result[0].element), 'Not a blob url');
+    const assertResultRetainsUrl = (results: UploadResult[]) => {
+      assert.isTrue(results[0].status, 'uploadImages retain blob urls after upload');
+      assert.isTrue(hasBlobAsSource(results[0].element), 'Not a blob url');
       assert.equal(editor.getContent(), '<p><img src="' + uploadedBlobInfo.filename() + '"></p>', 'uploadImages retain blob urls after upload');
 
-      return result;
+      return results;
     };
 
     setInitialContent(editor, imageHtml(testBlobDataUri));
@@ -228,11 +229,12 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     });
 
     assertEventsLength(0);
-    return editor.uploadImages(assertResultRetainsUrl).then(assertResultRetainsUrl).then(() => {
+    return editor.uploadImages().then((results) => {
+      assertResultRetainsUrl(results);
       uploadedBlobInfo = null;
       assertEventsLength(0);
 
-      return editor.uploadImages(Fun.noop).then((result) => {
+      return editor.uploadImages().then((result) => {
         assert.lengthOf(result, 0, 'uploadImages retain blob urls after upload');
         assert.isNull(uploadedBlobInfo, 'uploadImages retain blob urls after upload');
       });
@@ -260,10 +262,10 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     };
 
     assertEventsLength(0);
-    return editor.uploadImages((result) => {
+    return editor.uploadImages().then((result) => {
       assertResultReusesFilename(editor, uploadedBlobInfo, result);
 
-      editor.uploadImages((_result) => {
+      editor.uploadImages().then((_result) => {
         const img = editor.dom.select('img')[0];
         assertEventsLength(1);
         assert.isFalse(hasBlobAsSource(img), 'uploadImages reuse filename');
@@ -303,8 +305,8 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     assertEventsLength(0);
     return Promise.all([
-      editor.uploadImages(uploadDone),
-      editor.uploadImages(uploadDone)
+      editor.uploadImages().then(uploadDone),
+      editor.uploadImages().then(uploadDone)
     ]);
   });
 
@@ -338,8 +340,8 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     assertEventsLength(0);
     return Promise.all([
-      editor.uploadImages(uploadDone),
-      editor.uploadImages(uploadDone)
+      editor.uploadImages().then(uploadDone),
+      editor.uploadImages().then(uploadDone)
     ]);
   });
 
@@ -378,8 +380,8 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     assertEventsLength(0);
     return Promise.all([
-      editor.uploadImages(uploadDone),
-      editor.uploadImages(uploadDone)
+      editor.uploadImages().then(uploadDone),
+      editor.uploadImages().then(uploadDone)
     ]);
   });
 
@@ -400,7 +402,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       success('url');
     });
 
-    return editor.uploadImages(uploadDone);
+    return editor.uploadImages().then(uploadDone);
   });
 
   it(`TBA: Don't upload bogus image`, () => {
@@ -420,7 +422,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       success('url');
     });
 
-    return editor.uploadImages(uploadDone);
+    return editor.uploadImages().then(uploadDone);
   });
 
   it(`TBA: Don't upload api filtered image`, () => {
@@ -447,7 +449,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       success('url');
     });
 
-    return editor.uploadImages(uploadDone);
+    return editor.uploadImages().then(uploadDone);
   });
 
   it('TBA: Retain blobs not in blob cache', () => {
@@ -494,6 +496,6 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       }
     });
 
-    return editor.uploadImages(uploadDone);
+    return editor.uploadImages().then(uploadDone);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -119,8 +119,8 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
   it('TBA: replace uploaded blob uri with result uri (copy/paste of an uploaded blob uri)', () => {
     const editor = hook.editor();
     editor.options.set('automatic_uploads', true);
-    editor.options.set('images_upload_handler', (_data: BlobInfo, success) => {
-      success('file.png');
+    editor.options.set('images_upload_handler', (_data: BlobInfo) => {
+      return Promise.resolve('file.png');
     });
 
     setInitialContent(editor, imageHtml(testBlobDataUri));
@@ -143,8 +143,8 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     editor.options.set('images_replace_blob_uris', false);
     setInitialContent(editor, imageHtml(testBlobDataUri));
 
-    editor.options.set('images_upload_handler', (_data: BlobInfo, success) => {
-      success('file.png');
+    editor.options.set('images_upload_handler', (_data: BlobInfo) => {
+      return Promise.resolve('file.png');
     });
 
     return editor._scanForImages().then((result) => {
@@ -166,10 +166,10 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     setInitialContent(editor, imageHtml(testBlobDataUri));
 
-    editor.options.set('images_upload_handler', (data: BlobInfo, success) => {
+    editor.options.set('images_upload_handler', (data: BlobInfo) => {
       uploadedBlobInfo = data;
       uploadUri = data.id() + '.png';
-      success(uploadUri);
+      return Promise.resolve(uploadUri);
     });
 
     assertEventsLength(0);
@@ -188,10 +188,10 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     setInitialContent(editor, imageHtml(testBlobDataUri));
 
-    editor.options.set('images_upload_handler', (data: BlobInfo, success) => {
+    editor.options.set('images_upload_handler', (data: BlobInfo) => {
       uploadedBlobInfo = data;
       uploadUri = data.id() + '.png';
-      success(uploadUri);
+      return Promise.resolve(uploadUri);
     });
 
     assertEventsLength(0);
@@ -223,9 +223,9 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     setInitialContent(editor, imageHtml(testBlobDataUri));
 
     editor.options.set('images_replace_blob_uris', false);
-    editor.options.set('images_upload_handler', (data: BlobInfo, success) => {
+    editor.options.set('images_upload_handler', (data: BlobInfo) => {
       uploadedBlobInfo = data;
-      success(data.id() + '.png');
+      return Promise.resolve(data.id() + '.png');
     });
 
     assertEventsLength(0);
@@ -248,9 +248,9 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     editor.options.set('images_reuse_filename', true);
     setInitialContent(editor, imageHtml(testBlobDataUri));
 
-    editor.options.set('images_upload_handler', (data: BlobInfo, success) => {
+    editor.options.set('images_upload_handler', (data: BlobInfo) => {
       uploadedBlobInfo = data;
-      success('custom.png?size=small');
+      return Promise.resolve('custom.png?size=small');
     });
 
     const assertResultReusesFilename = (editor: Editor, _uploadedBlobInfo: BlobInfo, result: UploadResult[]) => {
@@ -295,12 +295,14 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     setInitialContent(editor, imageHtml(testBlobDataUri));
 
-    editor.options.set('images_upload_handler', (_data: BlobInfo, success) => {
+    editor.options.set('images_upload_handler', (_data: BlobInfo) => {
       uploadCount++;
 
-      setTimeout(() => {
-        success('myimage.png');
-      }, 0);
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve('myimage.png');
+        }, 0);
+      });
     });
 
     assertEventsLength(0);
@@ -330,12 +332,14 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     setInitialContent(editor, imageHtml(testBlobDataUri));
 
-    editor.options.set('images_upload_handler', (_data: BlobInfo, _success, failure) => {
+    editor.options.set('images_upload_handler', (_data: BlobInfo) => {
       uploadCount++;
 
-      setTimeout(() => {
-        failure('Error');
-      }, 0);
+      return new Promise((_resolve, reject) => {
+        setTimeout(() => {
+          reject('Error');
+        }, 0);
+      });
     });
 
     assertEventsLength(0);
@@ -370,12 +374,14 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     editor.resetContent(imageHtml(testBlobDataUri));
 
-    editor.options.set('images_upload_handler', (_data: BlobInfo, _success, failure) => {
+    editor.options.set('images_upload_handler', (_data: BlobInfo) => {
       uploadCount++;
 
-      setTimeout(() => {
-        failure('Error', { remove: true });
-      }, 0);
+      return new Promise((_resolve, reject) => {
+        setTimeout(() => {
+          reject({ message: 'Error', remove: true });
+        }, 0);
+      });
     });
 
     assertEventsLength(0);
@@ -397,9 +403,9 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     editor.setContent(imageHtml(Env.transparentSrc));
 
-    editor.options.set('images_upload_handler', (_data: BlobInfo, success) => {
+    editor.options.set('images_upload_handler', (_data: BlobInfo) => {
       uploadCount++;
-      success('url');
+      return Promise.resolve('url');
     });
 
     return editor.uploadImages().then(uploadDone);
@@ -417,9 +423,9 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     editor.setContent('<img src="' + testBlobDataUri + '" data-mce-bogus="1">');
 
-    editor.options.set('images_upload_handler', (_data: BlobInfo, success) => {
+    editor.options.set('images_upload_handler', (_data: BlobInfo) => {
       uploadCount++;
-      success('url');
+      return Promise.resolve('url');
     });
 
     return editor.uploadImages().then(uploadDone);
@@ -444,9 +450,9 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     editor.setContent('<img src="' + testBlobDataUri + '" data-skip="1">');
     filterCount = 0;
 
-    editor.options.set('images_upload_handler', (_data: BlobInfo, success) => {
+    editor.options.set('images_upload_handler', (_data: BlobInfo) => {
       uploadCount++;
-      success('url');
+      return Promise.resolve('url');
     });
 
     return editor.uploadImages().then(uploadDone);
@@ -478,22 +484,24 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     setInitialContent(editor, imgHtml1 + imgHtml2 + imgHtml3);
 
-    editor.options.set('images_upload_handler', (_data: BlobInfo, success, failure) => {
+    editor.options.set('images_upload_handler', (_data: BlobInfo) => {
       uploadCount++;
 
-      if (uploadCount === 1 ) {
-        setTimeout(() => {
-          success('file.png');
-        }, 0);
-      } else if (uploadCount === 2 ) {
-        setTimeout(() => {
-          failure('Error');
-        }, 0);
-      } else if (uploadCount === 3 ) {
-        setTimeout(() => {
-          failure('Error', { remove: true });
-        }, 0);
-      }
+      return new Promise((resolve, reject) => {
+        if (uploadCount === 1) {
+          setTimeout(() => {
+            resolve('file.png');
+          }, 0);
+        } else if (uploadCount === 2) {
+          setTimeout(() => {
+            reject('Error');
+          }, 0);
+        } else if (uploadCount === 3) {
+          setTimeout(() => {
+            reject({ message: 'Error', remove: true });
+          }, 0);
+        }
+      });
     });
 
     return editor.uploadImages().then(uploadDone);

--- a/modules/tinymce/src/core/test/ts/browser/dom/ReferrerPolicyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ReferrerPolicyTest.ts
@@ -20,9 +20,8 @@ describe('browser.tinymce.core.dom.ReferrerPolicyTest', () => {
     assert.equal(links.length > 0, expected, `should have link with referrerpolicy="${referrerPolicy}"`);
   };
 
-  const pLoadScript = (url: string): Promise<void> => new Promise((resolve, reject) => {
-    ScriptLoader.ScriptLoader.loadScript(url, resolve, () => reject('Failed to load script'));
-  });
+  const pLoadScript = (url: string): Promise<void> =>
+    ScriptLoader.ScriptLoader.loadScript(url);
 
   after(() => {
     // Clean up by resetting the globals referrer policy

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScriptLoaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScriptLoaderTest.ts
@@ -11,33 +11,26 @@ describe('browser.tinymce.core.dom.ScriptLoaderTest', () => {
 
   const pLoadScript = (url: string): Promise<void> => {
     loadedScripts.push(url);
-    return new Promise((resolve, reject) => {
-      ScriptLoader.ScriptLoader.loadScript(url, () => {
-        loadedCount++;
-        resolve();
-      }, () => reject('Failed to load script'));
+    return ScriptLoader.ScriptLoader.loadScript(url).then(() => {
+      loadedCount++;
     });
   };
 
   const pLoadScripts = (urls: string[]): Promise<void> => {
     loadedScripts.push(...urls);
     const scriptCount = urls.length;
-    return new Promise((resolve, reject) => {
-      ScriptLoader.ScriptLoader.loadScripts(urls, () => {
-        loadedCount += scriptCount;
-        resolve();
-      }, () => reject('Failed to load scripts'));
+    return ScriptLoader.ScriptLoader.loadScripts(urls).then(() => {
+      loadedCount += scriptCount;
     });
   };
 
   const addToQueue = (url: string): void => {
     loadedScripts.push(url);
-    ScriptLoader.ScriptLoader.add(url, () => loadedCount++);
+    ScriptLoader.ScriptLoader.add(url).then(() => loadedCount++);
   };
 
-  const pLoadQueue = (): Promise<void> => new Promise((resolve, reject) => {
-    ScriptLoader.ScriptLoader.loadQueue(resolve, undefined, () => reject('Failed to load queued scripts'));
-  });
+  const pLoadQueue = (): Promise<void> =>
+    ScriptLoader.ScriptLoader.loadQueue();
 
   const assertQueueLoadedCount = (count: number) => {
     assert.equal(loadedCount, count, 'Loaded script count');

--- a/modules/tinymce/src/core/test/ts/browser/dom/StyleSheetLoaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/StyleSheetLoaderTest.ts
@@ -21,13 +21,11 @@ describe('browser.tinymce.core.dom.StyleSheetLoaderTest', () => {
 
   const linkNotExists = (url: string) => UiFinder.notExists(SugarHead.head(), `link[href="${url}"]`);
 
-  const pLoadUrl = (url: string): Promise<void> => new Promise((resolve, reject) => {
-    loader.load(url, resolve, () => reject('Failed to load url: ' + url));
-  });
+  const pLoadUrl = (url: string): Promise<void> =>
+    loader.load(url);
 
-  const pLoadAllUrls = (urls: string[]): Promise<string[]> => new Promise((resolve, reject) => {
-    loader.loadAll(urls, resolve, (failedUrls) => reject('Failed to load urls: ' + failedUrls.join(', ')));
-  });
+  const pLoadAllUrls = (urls: string[]): Promise<string[]> =>
+    loader.loadAll(urls);
 
   const unloadUrl = (url: string) => loader.unload(url);
 

--- a/modules/tinymce/src/core/test/ts/browser/util/ImageUploaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ImageUploaderTest.ts
@@ -46,35 +46,35 @@ describe('browser.tinymce.core.util.ImageUploaderTest', () => {
 
   it('TINY-4601: Image upload success', async () => {
     const editor = hook.editor();
-    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo, success) => success('https://tiny.cloud/image.png'));
+    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo) => Promise.resolve('https://tiny.cloud/image.png'));
     const uploadResults = await uploadImages(editor, [ image1 ], true);
     assertUploadResultSuccess(uploadResults, 1, 'https://tiny.cloud/image.png');
   });
 
   it('TINY-4601: Multiple image upload success', async () => {
     const editor = hook.editor();
-    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo, success) => success('https://tiny.cloud/image.png'));
+    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo) => Promise.resolve('https://tiny.cloud/image.png'));
     const uploadResults = await uploadImages(editor, [ image1, image2 ], true);
     assertUploadResultSuccess(uploadResults, 2, 'https://tiny.cloud/image.png');
   });
 
   it('TINY-4601: Image upload failure', async () => {
     const editor = hook.editor();
-    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo, _success, failure) => failure('Error msg'));
+    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo) => Promise.reject('Error msg'));
     const uploadResults = await uploadImages(editor, [ image1 ], true);
     assertUploadResultFailure(uploadResults, 1, 'Error msg');
   });
 
   it('TINY-4601: Image upload failure for empty array', async () => {
     const editor = hook.editor();
-    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo, _success, failure) => failure('Error msg'));
+    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo) => Promise.reject('Error msg'));
     const uploadResults = await uploadImages(editor, [], true);
     assertUploadResultFailure(uploadResults, 0, 'Error msg');
   });
 
   it('TINY-4601: Multiple image upload failure', async () => {
     const editor = hook.editor();
-    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo, _success, failure) => failure('Error msg'));
+    editor.options.set('images_upload_handler', (_blobInfo: BlobInfo) => Promise.reject('Error msg'));
     const uploadResults = await uploadImages(editor, [ image1, image2 ], true);
     assertUploadResultFailure(uploadResults, 2, 'Error msg');
   });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -77,7 +77,7 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
     editor.setContent('<p><img src="' + src + '" /></p>');
     TinySelections.select(editor, 'img', []);
     editor.options.set('image_uploadtab', false);
-    editor.options.set('images_upload_handler', (blobInfo, success) => success('file.jpg'));
+    editor.options.set('images_upload_handler', (_blobInfo) => Promise.resolve('file.jpg'));
     await pAssertImageTab(editor, 'Upload', false);
     editor.options.set('image_advtab', true);
     editor.options.unset('image_uploadtab');
@@ -89,7 +89,7 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
     editor.setContent('<p><img src="' + src + '" /></p>');
     TinySelections.select(editor, 'img', []);
     editor.options.set('image_advtab', false); // make sure that Advanced tab appears separately
-    editor.options.set('images_upload_handler', (blobInfo, success) => success('file.jpg'));
+    editor.options.set('images_upload_handler', (_blobInfo) => Promise.resolve('file.jpg'));
     await pAssertImageTab(editor, 'Upload', true);
     await pAssertImageTab(editor, 'Advanced', false);
     editor.options.set('image_advtab', true);
@@ -115,7 +115,7 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
   it('TBA: Image uploader test with images_upload_handler', async () => {
     const editor = hook.editor();
     editor.setContent('');
-    editor.options.set('images_upload_handler', (blobInfo, success) => success('file.jpg'));
+    editor.options.set('images_upload_handler', (_blobInfo) => Promise.resolve('file.jpg'));
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     await TinyUiActions.pWaitForDialog(editor);
     TinyUiActions.clickOnUi(editor, '.tox-tab:contains("Upload")');
@@ -128,7 +128,7 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
   it('TBA: Test that we get full base64 string in images_upload_handler', async () => {
     const editor = hook.editor();
     editor.setContent('');
-    editor.options.set('images_upload_handler', (blobInfo, success) => success(blobInfo.base64()));
+    editor.options.set('images_upload_handler', (blobInfo) => Promise.resolve(blobInfo.base64()));
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     await TinyUiActions.pWaitForDialog(editor);
     TinyUiActions.clickOnUi(editor, '.tox-tab:contains("Upload")');
@@ -141,7 +141,7 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
   it('TNY-6020: Image uploader test with upload error', async () => {
     const editor = hook.editor();
     editor.setContent('');
-    editor.options.set('images_upload_handler', (blobInfo, success, failure) => failure('Error occurred'));
+    editor.options.set('images_upload_handler', (_blobInfo) => Promise.reject('Error occurred'));
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     await TinyUiActions.pWaitForDialog(editor);
     TinyUiActions.clickOnUi(editor, '.tox-tab:contains("Upload")');
@@ -172,7 +172,7 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
   it('TINY-6224: Image uploader respects `images_file_types` setting', async () => {
     const editor = hook.editor();
     editor.setContent('');
-    editor.options.set('images_upload_handler', (_blobInfo, success) => success('logo.svg'));
+    editor.options.set('images_upload_handler', (_blobInfo) => Promise.resolve('logo.svg'));
     editor.options.set('images_file_types', 'svg');
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     await TinyUiActions.pWaitForDialog(editor);
@@ -187,7 +187,7 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
   it('TINY-6622: Image uploader retains the file name/extension', async () => {
     const editor = hook.editor();
     editor.setContent('');
-    editor.options.set('images_upload_handler', (blobInfo, success) => success(blobInfo.filename()));
+    editor.options.set('images_upload_handler', (blobInfo) => Promise.resolve(blobInfo.filename()));
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     await TinyUiActions.pWaitForDialog(editor);
     TinyUiActions.clickOnUi(editor, '.tox-tab:contains("Upload")');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
@@ -15,12 +15,11 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Options from '../../api/Options';
 import * as SkinLoaded from './SkinLoaded';
 
-const loadStylesheet = (editor: Editor, stylesheetUrl: string, styleSheetLoader: StyleSheetLoader): Promise<void> => new Promise((resolve, reject) => {
-  styleSheetLoader.load(stylesheetUrl, resolve, reject);
-
+const loadStylesheet = (editor: Editor, stylesheetUrl: string, styleSheetLoader: StyleSheetLoader): Promise<void> => {
   // Ensure the stylesheet is cleaned up when the editor is destroyed
   editor.on('remove', () => styleSheetLoader.unload(stylesheetUrl));
-});
+  return styleSheetLoader.load(stylesheetUrl);
+};
 
 const loadUiSkins = (editor: Editor, skinUrl: string): Promise<void> => {
   const skinUiCss = skinUrl + '/skin.min.css';


### PR DESCRIPTION
Related Ticket: TINY-8325

Description of Changes:
* Update the `ScriptLoader`, `StyleSheetLoader`, `AddOnManager`, `PluginManager` and `ThemeManager` APIs to return Promises instead of having to pass in a callback
* Made the theme load logic fire a new `ThemeLoadError` event if the theme fails to load. This is for consistency with the rest of the error handling and I needed to do something in the `catch`, otherwise we'd get unhandled promise rejection errors.
* Remove the callbacks on the `EditorUpload` APIs
* Changed the `images_upload_handler` to require a Promise be returned instead of passing `success` and `failure` callbacks. This also means if passing the `remove` option for a failure it now requires an object containing the message and remove flag (since we can only return a single item).
* Did some minor general cleanup on the code while making it return Promises.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
