### PR TITLE
TINY-4627: More minor parser optimizations

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/util/URI.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/URI.ts
@@ -54,7 +54,7 @@ const blockSvgDataUris = (allowSvgDataUrls: boolean | undefined, tagName?: strin
   }
 };
 
-const isInvalidUri = (settings: SafeUriOptions, uri: string, tagName?: string) => {
+export const isInvalidUri = (settings: SafeUriOptions, uri: string, tagName?: string) => {
   if (settings.allow_html_data_urls) {
     return false;
   } else if (/^data:image\//i.test(uri)) {

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Obj, Unicode } from '@ephox/katamari';
+import { Unicode } from '@ephox/katamari';
 
 import { DomParserSettings, ParserArgs } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
@@ -36,7 +36,7 @@ const isEmpty = (schema: Schema, nonEmptyElements: SchemaMap, whitespaceElements
   node.isEmpty(nonEmptyElements, whitespaceElements, (node) => isPadded(schema, node));
 
 const isLineBreakNode = (node: AstNode | undefined, blockElements: SchemaMap): boolean =>
-  node && (Obj.has(blockElements, node.name) || node.name === 'br');
+  node && (node.name in blockElements || node.name === 'br');
 
 export {
   paddEmptyNode,

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -39,8 +39,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     assert.equal(root.firstChild.name, 'b', 'Element name');
     assert.deepEqual(
       root.firstChild.attributes, [
-        { name: 'class', value: 'class' },
         { name: 'title', value: 'title' },
+        { name: 'class', value: 'class' },
       ],
       'Element attributes'
     );
@@ -94,7 +94,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     );
     assert.equal(
       serializer.serialize(root),
-      '<div><img data-mce-src="file.gif" src="file.gif"></div>',
+      '<div><img src="file.gif" data-mce-src="file.gif"></div>',
       'Whitespace where SaxParser will produce multiple whitespace nodes'
     );
     assert.deepEqual(
@@ -567,8 +567,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     );
     assert.equal(
       serializer.serialize(root),
-      '<datalist><option value="b1" label="a1"></option><option value="b2" label="a2"></option>' +
-      '<option value="b3" label="a3"></option></datalist>'
+      '<datalist><option label="a1" value="b1"></option><option label="a2" value="b2"></option>' +
+      '<option label="a3" value="b3"></option></datalist>'
     );
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
@@ -34,7 +34,7 @@ describe('browser.tinymce.core.html.SerializerTest', () => {
 
     assert.equal(
       serializer.serialize(DomParser({ validate: false }, schema).parse('<b a="1" b="2">a</b><i a="1" b="2">b</i>')),
-      '<b b="2" a="1">a</b><i b="2" a="1">b</i>'
+      '<b a="1" b="2">a</b><i a="1" b="2">b</i>'
     );
   });
 });

--- a/patches/dompurify+2.3.4.patch
+++ b/patches/dompurify+2.3.4.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/dompurify/dist/purify.es.js b/node_modules/dompurify/dist/purify.es.js
-index 899e471..5844faf 100644
+index 899e471..414c5d8 100644
 --- a/node_modules/dompurify/dist/purify.es.js
 +++ b/node_modules/dompurify/dist/purify.es.js
 @@ -617,6 +617,12 @@ function createDOMPurify() {
@@ -50,8 +50,62 @@ index 899e471..5844faf 100644
        _forceRemove(currentNode);
        return true;
      }
+@@ -1073,6 +1073,7 @@ function createDOMPurify() {
+ 
+       value = stringTrim(attr.value);
+       lcName = transformCaseFunc(name);
++      var initValue = value;
+ 
+       /* Execute a hook if present */
+       hookEvent.attrName = lcName;
+@@ -1086,11 +1087,9 @@ function createDOMPurify() {
+         continue;
+       }
+ 
+-      /* Remove attribute */
+-      _removeAttribute(name, currentNode);
+-
+       /* Did the hooks approve of the attribute? */
+       if (!hookEvent.keepAttr) {
++        _removeAttribute(name, currentNode);
+         continue;
+       }
+ 
+@@ -1109,20 +1108,23 @@ function createDOMPurify() {
+       /* Is `value` valid for this attribute? */
+       var lcTag = transformCaseFunc(currentNode.nodeName);
+       if (!_isValidAttribute(lcTag, lcName, value)) {
++        _removeAttribute(name, currentNode);
+         continue;
+       }
+ 
+       /* Handle invalid data-* attribute set by try-catching it */
+-      try {
+-        if (namespaceURI) {
+-          currentNode.setAttributeNS(namespaceURI, name, value);
+-        } else {
+-          /* Fallback to setAttribute() for browser-unrecognized namespaces e.g. "x-schema". */
+-          currentNode.setAttribute(name, value);
++      if (value !== initValue) {
++        try {
++          if (namespaceURI) {
++            currentNode.setAttributeNS(namespaceURI, name, value);
++          } else {
++            /* Fallback to setAttribute() for browser-unrecognized namespaces e.g. "x-schema". */
++            currentNode.setAttribute(name, value);
++          }
++        } catch (_) {
++          _removeAttribute(name, currentNode);
+         }
+-
+-        arrayPop(DOMPurify.removed);
+-      } catch (_) {}
++      }
+     }
+ 
+     /* Execute a hook if present */
 diff --git a/node_modules/dompurify/dist/purify.js b/node_modules/dompurify/dist/purify.js
-index 68bc40f..03bd803 100644
+index 68bc40f..f759fa8 100644
 --- a/node_modules/dompurify/dist/purify.js
 +++ b/node_modules/dompurify/dist/purify.js
 @@ -623,6 +623,12 @@
@@ -102,3 +156,57 @@ index 68bc40f..03bd803 100644
          _forceRemove(currentNode);
          return true;
        }
+@@ -1079,6 +1079,7 @@
+ 
+         value = stringTrim(attr.value);
+         lcName = transformCaseFunc(name);
++        var initValue = value;
+ 
+         /* Execute a hook if present */
+         hookEvent.attrName = lcName;
+@@ -1092,11 +1093,9 @@
+           continue;
+         }
+ 
+-        /* Remove attribute */
+-        _removeAttribute(name, currentNode);
+-
+         /* Did the hooks approve of the attribute? */
+         if (!hookEvent.keepAttr) {
++          _removeAttribute(name, currentNode);
+           continue;
+         }
+ 
+@@ -1115,20 +1114,23 @@
+         /* Is `value` valid for this attribute? */
+         var lcTag = transformCaseFunc(currentNode.nodeName);
+         if (!_isValidAttribute(lcTag, lcName, value)) {
++          _removeAttribute(name, currentNode);
+           continue;
+         }
+ 
+         /* Handle invalid data-* attribute set by try-catching it */
+-        try {
+-          if (namespaceURI) {
+-            currentNode.setAttributeNS(namespaceURI, name, value);
+-          } else {
+-            /* Fallback to setAttribute() for browser-unrecognized namespaces e.g. "x-schema". */
+-            currentNode.setAttribute(name, value);
++        if (value !== initValue) {
++          try {
++            if (namespaceURI) {
++              currentNode.setAttributeNS(namespaceURI, name, value);
++            } else {
++              /* Fallback to setAttribute() for browser-unrecognized namespaces e.g. "x-schema". */
++              currentNode.setAttribute(name, value);
++            }
++          } catch (_) {
++            _removeAttribute(name, currentNode);
+           }
+-
+-          arrayPop(DOMPurify.removed);
+-        } catch (_) {}
++        }
+       }
+ 
+       /* Execute a hook if present */


### PR DESCRIPTION
Related Ticket: TINY-4627

Description of Changes:

This is just some more fixes both to our logic and to DOMPurify to help with the parsing speed. This like the previous PR doesn't make a huge difference (largely a number of micro optimizations), but in my testing between this and the previous PR it's shaven off between 10-20% in general (really depends on the content and how much the GC runs).

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
