### PR TITLE
TINY-8214: Revert removing the Schema elements property

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -100,7 +100,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `editor.settings` property as it's been replaced by the new Options API #TINY-8236
 - Removed the `shortEnded` and `fixed` properties on `tinymce.html.Node` class #TINY-8205
 - Removed the `mceInsertRawHTML` command #TINY-8214
-- Removed the `elements` property from `Schema` #TINY-8214
 
 ### Deprecated
 - The dialog button component `primary` property has been deprecated in favour of the new `buttonType` property #TINY-8304

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -67,6 +67,7 @@ export interface SchemaRegExpMap { [name: string]: RegExp }
 
 interface Schema {
   children: Record<string, SchemaMap>;
+  elements: Record<string, SchemaElement>;
   getValidStyles: () => Record<string, string[]> | undefined;
   getValidClasses: () => Record<string, SchemaMap> | undefined;
   getBlockElements: () => SchemaMap;
@@ -409,7 +410,7 @@ const compileElementMap = (value: string | Record<string, string>, mode?: string
 };
 
 const Schema = (settings?: SchemaSettings): Schema => {
-  let elements: Record<string, SchemaElement> = {};
+  const elements: Record<string, SchemaElement> = {};
   const children: Record<string, {}> = {};
   let patternElements = [];
   const customElementsMap = {}, specialElements = {} as SchemaRegExpMap;
@@ -631,8 +632,12 @@ const Schema = (settings?: SchemaSettings): Schema => {
   };
 
   const setValidElements = (validElements: string) => {
-    elements = {};
+    // Clear any existing rules. Note that since `elements` is exposed we can't
+    // overwrite it, so instead we delete all the properties
     patternElements = [];
+    Arr.each(Obj.keys(elements), (name) => {
+      delete elements[name];
+    });
 
     addValidElements(validElements);
 
@@ -1054,6 +1059,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
 
   return {
     children,
+    elements,
     getValidStyles,
     getValidClasses,
     getBlockElements,


### PR DESCRIPTION
Related Ticket: TINY-8214/TINY-4627

Description of Changes:

This just brings back the `elements` property on the schema and updates the `setValidElements` function to clear all properties instead of create a new object. It's not great for performance having to manually delete each property, but this isn't something that's called often, if at all so it should be okay.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
