### PR TITLE
TINY-8431: Fix emoticons image database test

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `buttonType` property on dialog button components, supporting `toolbar` style in addition to `primary` and `secondary` #TINY-8304
 - New `imagepreview` dialog component, allowing preview and zoom of any image URL #TINY-8333
 - New `editor.annotator.removeAll` API to remove all annotations by name #TINY-8195
+- New `Resource.unload` API to make it possible to unload resources #TINY-8431
 
 ### Improved
 - The `ScriptLoader`, `StyleSheetLoader`, `AddOnManager`, `PluginManager` and `ThemeManager` APIs will now return a `Promise` when loading resources instead of using callbacks #TINY-8325

--- a/modules/tinymce/src/core/main/ts/api/Resource.ts
+++ b/modules/tinymce/src/core/main/ts/api/Resource.ts
@@ -10,6 +10,7 @@ import ScriptLoader from './dom/ScriptLoader';
 interface Resource {
   load: <T = any>(id: string, url: string) => Promise<T>;
   add: (id: string, data: any) => void;
+  unload: (id: string) => void;
 }
 
 const awaiter = (resolveCb: (data: any) => void, rejectCb: (err?: any) => void, timeout = 1000) => {
@@ -67,9 +68,14 @@ const create = (): Resource => {
     tasks[id] = Promise.resolve(data);
   };
 
+  const unload = (id: string) => {
+    delete tasks[id];
+  };
+
   return {
     load,
-    add
+    add,
+    unload
   };
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorManagerTest.ts
@@ -1,4 +1,5 @@
 import { after, afterEach, before, describe, it } from '@ephox/bedrock-client';
+import { Remove, Selectors } from '@ephox/sugar';
 import { assert } from 'chai';
 import 'tinymce';
 
@@ -106,6 +107,9 @@ describe('browser.tinymce.core.EditorManagerTest', () => {
         setTimeout(() => {
           // Destroy the editor by setting innerHTML common ajax pattern
           viewBlock.update('<textarea id="' + editor1.id + '"></textarea>');
+
+          // We need to remove the sink since it's added to the body
+          Selectors.one('.tox-silver-sink').each(Remove.remove);
 
           // Re-init the editor will have the same id
           EditorManager.init({

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -96,6 +96,6 @@ describe('browser.tinymce.core.EditorRemoveTest', () => {
         });
       }
     });
-    editor.remove();
+    McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -9,6 +9,8 @@ describe('browser.tinymce.core.FakeClipboardTest', () => {
   TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
   }, []);
+
+  afterEach(() => FakeClipboard.clear());
 
   it('TINY-8353: fake clipboard returns undefined when not set', () => {
     assert.isUndefined(FakeClipboard.read());

--- a/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
@@ -10,7 +10,9 @@ describe('browser.tinymce.core.FakeClipboardTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, []);
 
-  afterEach(() => FakeClipboard.clear());
+  afterEach(() => {
+    FakeClipboard.clear();
+  });
 
   it('TINY-8353: fake clipboard returns undefined when not set', () => {
     assert.isUndefined(FakeClipboard.read());

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -11,7 +11,7 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
     entities: 'raw',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, []);
+  }, [], true);
 
   const pressArrowKey = (editor: Editor) => {
     const dom = editor.dom, target = editor.selection.getNode();
@@ -24,7 +24,6 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
 
   it('Wrap single root text node in P', () => {
     const editor = hook.editor();
-    editor.focus();
     editor.getBody().innerHTML = 'abcd';
     LegacyUnit.setSelection(editor, 'body', 2);
     pressArrowKey(editor);

--- a/modules/tinymce/src/core/test/ts/browser/ResourceTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ResourceTest.ts
@@ -6,7 +6,7 @@ import Resource from 'tinymce/core/api/Resource';
 
 declare const tinymce: { Resource: Resource };
 
-describe('Scripts test', () => {
+describe('browser.tinymce.core.ResourceTest', () => {
   const origTiny = Global.tinymce;
 
   before(() => {
@@ -28,8 +28,12 @@ describe('Scripts test', () => {
   const loadScript = (id: string, url: string): Promise<any> =>
     tinymce.Resource.load(id, url);
 
+  const unloadScript = (id: string) => {
+    tinymce.Resource.unload(id);
+  };
+
   const assertLoadSuccess = (actual: Promise<string>, expectedData: string) => {
-    actual.then((data) => {
+    return actual.then((data) => {
       assert.equal(data, expectedData, 'Load succeeded but data did not match expected');
     }, (err) => {
       assert.fail('Load failed with error: ' + err);
@@ -55,9 +59,19 @@ describe('Scripts test', () => {
     return assertLoadSuccess(load, 'value.2');
   });
 
-  it('return cached value', () => {
+  it('return cached value', async () => {
+    await loadScript('script.2', testScript('script.2', 'value.2'));
+
     const load = loadScript('script.2', testScript('script.2', 'value.3'));
     return assertLoadSuccess(load, 'value.2');
+  });
+
+  it('unload cached value', async () => {
+    await loadScript('script.2', testScript('script.2', 'value.2'));
+    unloadScript('script.2');
+
+    const load = loadScript('script.2', testScript('script.2', 'value.3'));
+    return assertLoadSuccess(load, 'value.3');
   });
 
   it('invalid URL fails', () => {

--- a/modules/tinymce/src/core/test/ts/browser/ResourceTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ResourceTest.ts
@@ -66,14 +66,6 @@ describe('browser.tinymce.core.ResourceTest', () => {
     return assertLoadSuccess(load, 'value.2');
   });
 
-  it('unload cached value', async () => {
-    await loadScript('script.2', testScript('script.2', 'value.2'));
-    unloadScript('script.2');
-
-    const load = loadScript('script.2', testScript('script.2', 'value.3'));
-    return assertLoadSuccess(load, 'value.3');
-  });
-
   it('invalid URL fails', () => {
     const load = loadScript('script.3', '/custom/404');
     return assertLoadFailure(load, 'Script at URL "/custom/404" failed to load');
@@ -82,5 +74,13 @@ describe('browser.tinymce.core.ResourceTest', () => {
   it('invalid id fails', () => {
     const load = loadScript('script.4', testScript('invalid-id', 'value.4')); // this takes 1 second to timeout
     return assertLoadFailure(load, `Script at URL "data:text/javascript,tinymce.Resource.add('invalid-id', 'value.4')" did not call \`tinymce.Resource.add('script.4', data)\` within 1 second`);
+  });
+
+  it('unload cached value', async () => {
+    await loadScript('script.5', testScript('script.5', 'value.1'));
+    unloadScript('script.5');
+
+    const load = loadScript('script.5', testScript('script.5', 'value.2'));
+    return assertLoadSuccess(load, 'value.2');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -18,14 +18,12 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     custom_elements: 'custom1,~custom2',
     extended_valid_elements: 'custom1,custom2',
     base_url: '/project/tinymce/js/tinymce'
-  }, []);
+  }, [], true);
 
   it('getContent', () => {
     const editor = hook.editor();
     let rng = editor.dom.createRng();
     let eventObj;
-
-    editor.focus();
 
     // Get selected contents
     editor.setContent('<p>text</p>');
@@ -1173,6 +1171,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
   it('setRng invalid range removed parent context', () => {
     const editor = hook.editor();
+
     editor.setContent('<p><strong><em>x</em></strong></p>');
     const textNode = editor.dom.select('em')[0].firstChild;
 
@@ -1184,9 +1183,9 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     editor.selection.setRng(rng);
 
     const curRng = editor.selection.getRng();
-    LegacyUnit.equal(curRng.startContainer.nodeName, 'BODY');
+    LegacyUnit.equal(curRng.startContainer.nodeName, 'P');
     LegacyUnit.equal(curRng.startOffset, 0);
-    LegacyUnit.equal(curRng.endContainer.nodeName, 'BODY');
+    LegacyUnit.equal(curRng.endContainer.nodeName, 'P');
     LegacyUnit.equal(curRng.endOffset, 0);
   });
   /*

--- a/modules/tinymce/src/core/test/ts/browser/init/ContentCssTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ContentCssTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { before, describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -6,9 +6,14 @@ import EditorManager from 'tinymce/core/api/EditorManager';
 import { appendContentCssFromSettings } from 'tinymce/core/init/ContentCss';
 
 describe('browser.tinymce.core.init.ContentCssTest', () => {
-  // Needs to be thunked since other tests might mutate these before the tests gets executed
-  const baseUrl = () => EditorManager.documentBaseURL.replace(/\/$/, '');
-  const skinsBaseUrl = () => EditorManager.baseURL + '/skins/content';
+  let baseUrl: string;
+  let skinsBaseUrl: string;
+
+  before(() => {
+    // Needs to be read here since other tests might mutate these globals before the tests gets executed
+    baseUrl = EditorManager.documentBaseURL.replace(/\/$/, '');
+    skinsBaseUrl = EditorManager.baseURL + '/skins/content';
+  });
 
   const testContentCss = (expectedContentCss: string[], inputContentCss: string[] | string | boolean, inline: boolean = false) => {
     const editor = new Editor('id', {
@@ -23,22 +28,22 @@ describe('browser.tinymce.core.init.ContentCssTest', () => {
 
   it('Expected empty array on empty input', () => testContentCss([], []));
   it('Expected empty array on boolean false value', () => testContentCss([], false));
-  it('Expected default content css on undefined value', () => testContentCss([ `${skinsBaseUrl()}/default/content.css` ], undefined));
-  it('Expected array with absolute url from .css file name', () => testContentCss([ `${baseUrl()}/test.css` ], 'test.css'));
-  it('Expected array with absolute url from relative string', () => testContentCss([ `${baseUrl()}/content/test.css` ], '/content/test.css'));
-  it('Expected array with absolute url from array with relative string', () => testContentCss([ `${baseUrl()}/content/test.css` ], [ '/content/test.css' ]));
+  it('Expected default content css on undefined value', () => testContentCss([ `${skinsBaseUrl}/default/content.css` ], undefined));
+  it('Expected array with absolute url from .css file name', () => testContentCss([ `${baseUrl}/test.css` ], 'test.css'));
+  it('Expected array with absolute url from relative string', () => testContentCss([ `${baseUrl}/content/test.css` ], '/content/test.css'));
+  it('Expected array with absolute url from array with relative string', () => testContentCss([ `${baseUrl}/content/test.css` ], [ '/content/test.css' ]));
   it('Expected array with two absolute urls from an array of relative strings', () => testContentCss(
-    [ `${baseUrl()}/content/a.css`, `${baseUrl()}/content/b.css` ],
+    [ `${baseUrl}/content/a.css`, `${baseUrl}/content/b.css` ],
     [ '/content/a.css', '/content/b.css' ]
   ));
   it('Expected array with absolute url from absolute string', () => testContentCss([ 'http://localhost/a/b/test.css' ], 'http://localhost/a/b/test.css'));
-  it('Expected array with absolute url from string with skin name', () => testContentCss([ `${skinsBaseUrl()}/document/content.css` ], 'document'));
-  it('Expected array with absolute url from array with skin name', () => testContentCss([ `${skinsBaseUrl()}/document/content.css` ], [ 'document' ]));
-  it('Expected array with absolute url from string with skin name with dash', () => testContentCss([ `${skinsBaseUrl()}/business-letter/content.css` ], 'business-letter'));
+  it('Expected array with absolute url from string with skin name', () => testContentCss([ `${skinsBaseUrl}/document/content.css` ], 'document'));
+  it('Expected array with absolute url from array with skin name', () => testContentCss([ `${skinsBaseUrl}/document/content.css` ], [ 'document' ]));
+  it('Expected array with absolute url from string with skin name with dash', () => testContentCss([ `${skinsBaseUrl}/business-letter/content.css` ], 'business-letter'));
   it('Expected array with absolute url from a comma separated list of css files', () => testContentCss(
-    [ `${baseUrl()}/a.css`, `${baseUrl()}/b.css` ],
+    [ `${baseUrl}/a.css`, `${baseUrl}/b.css` ],
     'a.css,b.css'
   ));
 
-  it('Expected array without content skins for inline editors', () => testContentCss([ `${baseUrl()}/document` ], 'document', true));
+  it('Expected array without content skins for inline editors', () => testContentCss([ `${baseUrl}/document` ], 'document', true));
 });

--- a/modules/tinymce/src/core/test/ts/browser/init/ContentCssTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ContentCssTest.ts
@@ -6,40 +6,39 @@ import EditorManager from 'tinymce/core/api/EditorManager';
 import { appendContentCssFromSettings } from 'tinymce/core/init/ContentCss';
 
 describe('browser.tinymce.core.init.ContentCssTest', () => {
-  const baseUrl = EditorManager.documentBaseURL.replace(/\/$/, '');
-  const skinsBaseUrl = EditorManager.baseURL + '/skins/content';
+  // Needs to be thunked since other tests might mutate these before the tests gets executed
+  const baseUrl = () => EditorManager.documentBaseURL.replace(/\/$/, '');
+  const skinsBaseUrl = () => EditorManager.baseURL + '/skins/content';
 
-  const testContentCss = (label: string, expectedContentCss: string[], inputContentCss: string[] | string | boolean, inline: boolean = false) => {
-    it(label, () => {
-      const editor = new Editor('id', {
-        content_css: inputContentCss,
-        inline
-      }, EditorManager);
+  const testContentCss = (expectedContentCss: string[], inputContentCss: string[] | string | boolean, inline: boolean = false) => {
+    const editor = new Editor('id', {
+      content_css: inputContentCss,
+      inline
+    }, EditorManager);
 
-      appendContentCssFromSettings(editor);
+    appendContentCssFromSettings(editor);
 
-      assert.deepEqual(editor.contentCSS, expectedContentCss, label);
-    });
+    assert.deepEqual(editor.contentCSS, expectedContentCss);
   };
 
-  testContentCss('Expected empty array on empty input', [], []);
-  testContentCss('Expected empty array on boolean false value', [], false);
-  testContentCss('Expected default content css on undefined value', [ `${skinsBaseUrl}/default/content.css` ], undefined);
-  testContentCss('Expected array with absolute url from .css file name', [ `${baseUrl}/test.css` ], 'test.css');
-  testContentCss('Expected array with absolute url from relative string', [ `${baseUrl}/content/test.css` ], '/content/test.css');
-  testContentCss('Expected array with absolute url from array with relative string', [ `${baseUrl}/content/test.css` ], [ '/content/test.css' ]);
-  testContentCss('Expected array with two absolute urls from an array of relative strings',
-    [ `${baseUrl}/content/a.css`, `${baseUrl}/content/b.css` ],
+  it('Expected empty array on empty input', () => testContentCss([], []));
+  it('Expected empty array on boolean false value', () => testContentCss([], false));
+  it('Expected default content css on undefined value', () => testContentCss([ `${skinsBaseUrl()}/default/content.css` ], undefined));
+  it('Expected array with absolute url from .css file name', () => testContentCss([ `${baseUrl()}/test.css` ], 'test.css'));
+  it('Expected array with absolute url from relative string', () => testContentCss([ `${baseUrl()}/content/test.css` ], '/content/test.css'));
+  it('Expected array with absolute url from array with relative string', () => testContentCss([ `${baseUrl()}/content/test.css` ], [ '/content/test.css' ]));
+  it('Expected array with two absolute urls from an array of relative strings', () => testContentCss(
+    [ `${baseUrl()}/content/a.css`, `${baseUrl()}/content/b.css` ],
     [ '/content/a.css', '/content/b.css' ]
-  );
-  testContentCss('Expected array with absolute url from absolute string', [ 'http://localhost/a/b/test.css' ], 'http://localhost/a/b/test.css');
-  testContentCss('Expected array with absolute url from string with skin name', [ `${skinsBaseUrl}/document/content.css` ], 'document');
-  testContentCss('Expected array with absolute url from array with skin name', [ `${skinsBaseUrl}/document/content.css` ], [ 'document' ]);
-  testContentCss('Expected array with absolute url from string with skin name with dash', [ `${skinsBaseUrl}/business-letter/content.css` ], 'business-letter');
-  testContentCss('Expected array with absolute url from a comma separated list of css files',
-    [ `${baseUrl}/a.css`, `${baseUrl}/b.css` ],
+  ));
+  it('Expected array with absolute url from absolute string', () => testContentCss([ 'http://localhost/a/b/test.css' ], 'http://localhost/a/b/test.css'));
+  it('Expected array with absolute url from string with skin name', () => testContentCss([ `${skinsBaseUrl()}/document/content.css` ], 'document'));
+  it('Expected array with absolute url from array with skin name', () => testContentCss([ `${skinsBaseUrl()}/document/content.css` ], [ 'document' ]));
+  it('Expected array with absolute url from string with skin name with dash', () => testContentCss([ `${skinsBaseUrl()}/business-letter/content.css` ], 'business-letter'));
+  it('Expected array with absolute url from a comma separated list of css files', () => testContentCss(
+    [ `${baseUrl()}/a.css`, `${baseUrl()}/b.css` ],
     'a.css,b.css'
-  );
+  ));
 
-  testContentCss('Expected array without content skins for inline editors', [ `${baseUrl}/document` ], 'document', true);
+  it('Expected array without content skins for inline editors', () => testContentCss([ `${baseUrl()}/document` ], 'document', true));
 });

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmojiTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmojiTest.ts
@@ -10,8 +10,6 @@ import Plugin from 'tinymce/plugins/emoticons/Plugin';
 
 import { fakeEvent } from '../module/test/Utils';
 
-declare const tinymce: { Resource: Resource };
-
 describe('browser.tinymce.plugins.emoticons.ImageEmojiTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'emoticons',
@@ -19,7 +17,7 @@ describe('browser.tinymce.plugins.emoticons.ImageEmojiTest', () => {
     base_url: '/project/tinymce/js/tinymce',
     emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojiimages.js',
     setup: () => {
-      tinymce.Resource.unload('tinymce.plugins.emoticons');
+      Resource.unload('tinymce.plugins.emoticons');
     }
   }, [ Plugin ], true);
 

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmojiTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmojiTest.ts
@@ -5,16 +5,22 @@ import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import Resource from 'tinymce/core/api/Resource';
 import Plugin from 'tinymce/plugins/emoticons/Plugin';
 
 import { fakeEvent } from '../module/test/Utils';
+
+declare const tinymce: { Resource: Resource };
 
 describe('browser.tinymce.plugins.emoticons.ImageEmojiTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'emoticons',
     toolbar: 'emoticons',
     base_url: '/project/tinymce/js/tinymce',
-    emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojiimages.js'
+    emoticons_database_url: '/project/tinymce/src/plugins/emoticons/main/js/emojiimages.js',
+    setup: () => {
+      tinymce.Resource.unload('tinymce.plugins.emoticons');
+    }
   }, [ Plugin ], true);
 
   it('TBA: Open dialog, Search for "dog", Dog should be first option', async () => {

--- a/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
@@ -10,54 +10,55 @@ import { getPreviewContent } from 'tinymce/plugins/template/ui/Dialog';
 import { Settings } from '../module/Settings';
 
 const metaKey = Env.os.isMacOS() || Env.os.isiOS() ? 'e.metaKey' : 'e.ctrlKey && !e.altKey';
+const host = document.location.host;
 
 const noCorsNoStyle = '<!DOCTYPE html><html><head>' +
-  '<base href="http://localhost:8000/">' +
-  '<link type="text/css" rel="stylesheet" href="http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css">' +
-  '<link type="text/css" rel="stylesheet" href="http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css">' +
+  `<base href="http://${host}/">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/content/default/content.css">` +
   '<script>document.addEventListener && document.addEventListener("click", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === "A" && !(' +
   metaKey +
   ')) {e.preventDefault();}}}, false);</script> ' +
   '</head><body class=""></body></html>';
 
 const corsNoStyle = '<!DOCTYPE html><html><head>' +
-  '<base href=\"http://localhost:8000/\">' +
-  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css\" crossorigin=\"anonymous\">' +
-  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css\" crossorigin=\"anonymous\">' +
-  '<script>document.addEventListener && document.addEventListener(\"click\", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === \"A\" && !(' +
+  `<base href="http://${host}/">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css" crossorigin="anonymous">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/content/default/content.css" crossorigin="anonymous">` +
+  '<script>document.addEventListener && document.addEventListener("click", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === "A" && !(' +
   metaKey +
-  ')) {e.preventDefault();}}}, false);</script> </head><body class=\"\"></body></html>';
+  ')) {e.preventDefault();}}}, false);</script> </head><body class=""></body></html>';
 
 const noCorsStyle = '<!DOCTYPE html><html><head>' +
-  '<base href=\"http://localhost:8000/\">' +
-  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css\">' +
-  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css\">' +
-  '<style type=\"text/css\">This is the style inserted into the document</style>' +
-  '<script>document.addEventListener && document.addEventListener(\"click\", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === \"A\" && !(' +
+  `<base href="http://${host}/">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/content/default/content.css">` +
+  '<style type="text/css">This is the style inserted into the document</style>' +
+  '<script>document.addEventListener && document.addEventListener("click", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === "A" && !(' +
   metaKey +
   ')) {e.preventDefault();}}}, false);</script> ' +
-  '</head><body class=\"\"></body></html>';
+  '</head><body class=""></body></html>';
 
 const corsStyle = '<!DOCTYPE html><html><head>' +
-  '<base href=\"http://localhost:8000/\">' +
-  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css\" crossorigin=\"anonymous\">' +
-  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css\" crossorigin=\"anonymous\">' +
-  '<style type=\"text/css\">This is the style inserted into the document</style>' +
-  '<script>document.addEventListener && document.addEventListener(\"click\", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === \"A\" && !(' +
+  `<base href="http://${host}/">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css" crossorigin="anonymous">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/content/default/content.css" crossorigin="anonymous">` +
+  '<style type="text/css">This is the style inserted into the document</style>' +
+  '<script>document.addEventListener && document.addEventListener("click", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === "A" && !(' +
   metaKey +
   ')) {e.preventDefault();}}}, false);</script> ' +
-  '</head><body class=\"\"></body></html>';
+  '</head><body class=""></body></html>';
 
 const corsStyleAndContent = '<!DOCTYPE html><html><head>' +
-  '<base href=\"http://localhost:8000/\">' +
-  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css\" crossorigin=\"anonymous\">' +
-  '<link type=\"text/css\" rel=\"stylesheet\" href=\"http://localhost:8000/project/tinymce/js/tinymce/skins/content/default/content.css\" crossorigin=\"anonymous\">' +
-  '<style type=\"text/css\">This is the style inserted into the document</style>' +
-  '<script>document.addEventListener && document.addEventListener(\"click\", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === \"A\" && !(' +
+  `<base href="http://${host}/">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/ui/oxide/content.min.css" crossorigin="anonymous">` +
+  `<link type="text/css" rel="stylesheet" href="http://${host}/project/tinymce/js/tinymce/skins/content/default/content.css" crossorigin="anonymous">` +
+  '<style type="text/css">This is the style inserted into the document</style>' +
+  '<script>document.addEventListener && document.addEventListener("click", function(e) {for (var elm = e.target; elm; elm = elm.parentNode) {if (elm.nodeName === "A" && !(' +
   metaKey +
   ')) {e.preventDefault();}}}, false);</script> ' +
   '</head>' +
-  '<body class=\"\">Custom content which was provided</body></html>';
+  '<body class="">Custom content which was provided</body></html>';
 
 describe('browser.tinymce.plugins.template.Dialog.getPreviewContent', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Fixed an annoying test that has been failing for me for a long time when running the tests locally. The ImageEmoji tests fails since a previous test has already setup a resource id for the database so it will load the data from the previous test not the current one. I added a tinymce.Resource.unload that lets you remove a previously loaded resource this is probably only useful for tests so not sure we need to document it.
* Fixed a few issues with the test for the Resource it was not returning promises correctly and it was not properly isolated tests they depended on each other.
* Fixed various other tests that either depend on state from a previous test or break if a state exists from a previous test. These will flake on/off if the 100 tests pivot point shifts while you are adding or removing tests.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
