### PR TITLE
TINY-8414: Fixed aria attributes incorrectly being stripped

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -198,7 +198,7 @@ const setupPurify = (settings: DomParserSettings, schema: Schema): DOMPurifyI =>
     const tagName = ele.tagName.toLowerCase();
     const { attrName, attrValue } = evt;
 
-    evt.keepAttr = !validate || Strings.startsWith(attrName, 'data-') || schema.isValid(tagName, attrName);
+    evt.keepAttr = !validate || schema.isValid(tagName, attrName) || Strings.startsWith(attrName, 'data-') || Strings.startsWith(attrName, 'aria-');
     if (!settings.allow_script_urls && attrName in filteredUrlAttrs && URI.isInvalidUri(settings, attrValue, tagName)) {
       evt.keepAttr = false;
     }

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -958,5 +958,13 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
       assert.equal(serializedHtml, '<p>Hello world!<a>XSS</a></p>');
     });
+
+    it('data and aria attributes should always be retained', () => {
+      const parser = DomParser();
+      const html = '<p><a href="http://www.google.com/fake1" data-custom="custom" aria-invalid="true">Hello world!</a></p>';
+      const serializedHtml = serializer.serialize(parser.parse(html));
+
+      assert.equal(serializedHtml, html);
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8414

Description of Changes:
* Fixed `aria-*` attributes being incorrectly stripped (this was something Neil and I had missed porting from SaxParser). This was found when upgrading TinyMCE in premium plugins.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
