### PR TITLE
TINY-8442: Backport prevent removing formats if matching selected element

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Alignment would sometimes be removed on parent elements when changing alignment on certain inline nodes, such as images #TINY-8308 
+
 ## 5.10.2 - 2021-11-17
 
 ### Fixed

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.10.2",
+  "version": "5.10.3",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -501,8 +501,9 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
       const removed = removeNodeFormat(node);
 
       // TINY-6567/TINY-7393: Include the parent if using an expanded selector format and no match was found for the current node
+      const currentNodeMatches = removed || Arr.exists(formatList, (f) => MatchFormat.matchName(dom, node, f));
       const parentNode = node.parentNode;
-      if (!removed && Type.isNonNullable(parentNode) && FormatUtils.shouldExpandToSelector(format)) {
+      if (!currentNodeMatches && Type.isNonNullable(parentNode) && FormatUtils.shouldExpandToSelector(format)) {
         removeNodeFormat(parentNode);
       }
     }

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -240,4 +240,26 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
       );
     });
   });
+
+  it('TINY-8308: Change format on selected img element and not surrounding elements', () => {
+    const editor = hook.editor();
+    editor.setContent('<p style="text-align: right;">Test text<img src="link" width="40" height="40"></p>');
+    TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 2);
+
+    RemoveFormat.remove(editor, 'alignright');
+
+    TinyAssertions.assertContent(editor, '<p style="text-align: right;">Test text<img src="link" width="40" height="40" /></p>');
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+  });
+
+  it('TINY-8308: Change format on selected img element when the same format is present on both', () => {
+    const editor = hook.editor();
+    editor.setContent('<p style="text-align: right;">Test text<img src="link" width="40" height="40" style="float: right"></p>');
+    TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 2);
+
+    RemoveFormat.remove(editor, 'alignright');
+
+    TinyAssertions.assertContent(editor, '<p style="text-align: right;">Test text<img src="link" width="40" height="40" /></p>');
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+  });
 });


### PR DESCRIPTION
Related Ticket:

Description of Changes:
A backport of the TINY-8308 fix.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
