### PR TITLE
TINY-8414: Added a guard for an edge case issue with inline textpattern detection

### DIFF
--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -260,7 +260,7 @@ const findPatterns = (editor: Editor, patterns: InlinePattern[], space: boolean)
   }
 
   return Utils.getParentBlock(editor, rng).bind((block) => {
-    const offset = rng.startOffset > 0 ? rng.startOffset - (space ? 1 : 0) : rng.startOffset;
+    const offset = Math.max(0, rng.startOffset - (space ? 1 : 0));
     return findPatternsRec(editor, patterns, rng.startContainer, offset, block);
   }).fold(() => [], (result) => result.matches);
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -260,7 +260,7 @@ const findPatterns = (editor: Editor, patterns: InlinePattern[], space: boolean)
   }
 
   return Utils.getParentBlock(editor, rng).bind((block) => {
-    const offset = rng.startOffset - (space ? 1 : 0);
+    const offset = rng.startOffset > 0 ? rng.startOffset - (space ? 1 : 0) : rng.startOffset;
     return findPatternsRec(editor, patterns, rng.startContainer, offset, block);
   }).fold(() => [], (result) => result.matches);
 };

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -204,4 +204,13 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
     Utils.setContentAndPressEnter(editor, '* **important list**');
     TinyAssertions.assertContentPresence(editor, { ul: 1, li: 2, strong: 1 });
   });
+
+  it('TINY-8414: should not throw an error if triggered at the start of a text node', () => {
+    // Note: This case is largely nonsense and not something that should ever occur naturally
+    const editor = hook.editor();
+    editor.setContent('<p><a href="about:blank"><span class="test">www</span>.google.com</a></p>');
+    TinySelections.setCursor(editor, [ 0, 0, 1 ], 0);
+    TinyContentActions.keyup(editor, Keys.space());
+    TinyAssertions.assertContent(editor, '<p><a href="about:blank"><span class="test">www</span>.google.com</a></p>');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-8414

Description of Changes:

This is something that came up with the spellchecker tests when upgrading. The inline textpattern detection code expects that when it's triggered via space the offset will be 1 at minimum, but when using APIs it's possible for that to not be the case. While it's a pretty unlikely case to occur and can't happen naturally, as discussed via slack it was thought it was still worthwhile adding a guard for this case, so that's that guard.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
