### PR TITLE
TINY-8262: Change default for strikethrough format to an `s` tag for html5 schema types

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `media` plugin no longer treats `iframe`, `video`, `audio` or `object` elements as "special" and will validate the contents against the schema #TINY-8382
 - Renamed the `getShortEndedElements` Schema API to `getVoidElements` #TINY-8344
 - Changed the default statusbar element path delimiter from `»` to `›` #TINY-8372
+- Changed the default tag for the strikethrough format to the `s` tag for html5 schema types #TINY-8262
 - Renamed the `font_formats` option to `font_family_formats` #TINY-8328
 - Renamed the `fontselect` toolbar button and `fontformats` menu item to `fontfamily` #TINY-8328
 - Renamed the `fontsize_formats` option to `font_size_formats` #TINY-8328

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -690,7 +690,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
   };
 
   ParserFilters.register(exports, defaultedSettings);
-  LegacyFilter.register(exports, defaultedSettings);
+  LegacyFilter.register(exports, defaultedSettings, schema);
 
   return exports;
 };

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -66,6 +66,7 @@ export interface SchemaMap { [name: string]: {} }
 export interface SchemaRegExpMap { [name: string]: RegExp }
 
 interface Schema {
+  type: SchemaType;
   children: Record<string, SchemaMap>;
   elements: Record<string, SchemaElement>;
   getValidStyles: () => Record<string, string[]> | undefined;
@@ -129,7 +130,7 @@ const split = (items: string, delim?: string): string[] => {
  * @param {String} type html4, html5 or html5-strict schema type.
  * @return {Object} Schema lookup table.
  */
-const compileSchema = (type: SchemaType = 'html5'): SchemaLookupTable => {
+const compileSchema = (type: SchemaType): SchemaLookupTable => {
   const schema: SchemaLookupTable = {};
   let globalAttributes, blockContent;
   let phrasingContent, flowContent, html4BlockContent, html4PhrasingContent;
@@ -438,7 +439,8 @@ const Schema = (settings?: SchemaSettings): Schema => {
   };
 
   settings = settings || {};
-  const schemaItems = compileSchema(settings.schema);
+  const schemaType = settings.schema ?? 'html5';
+  const schemaItems = compileSchema(schemaType);
 
   // Allow all elements and attributes if verify_html is set to false
   if (settings.verify_html === false) {
@@ -697,7 +699,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
     const childRuleRegExp = /^([+\-]?)([A-Za-z0-9_\-.\u00b7\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u037d\u037f-\u1fff\u200c-\u200d\u203f-\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]+)\[([^\]]+)]$/; // from w3c's custom grammar (above)
 
     // Invalidate the schema cache if the schema is mutated
-    mapCache[settings.schema] = null;
+    mapCache[schemaType] = null;
 
     if (validChildren) {
       each(split(validChildren, ','), (rule) => {
@@ -1058,6 +1060,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
    */
 
   return {
+    type: schemaType,
     children,
     elements,
     getValidStyles,

--- a/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
@@ -5,12 +5,15 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import DOMUtils from '../api/dom/DOMUtils';
+import Editor from '../api/Editor';
 import Tools from '../api/util/Tools';
 import * as NodeType from '../dom/NodeType';
-import { Formats, FormatVars } from './FormatTypes';
+import { Format, Formats, FormatVars } from './FormatTypes';
 
-const get = (dom: DOMUtils) => {
+const get = (editor: Editor) => {
+  const dom = editor.dom;
+  const schemaType = editor.schema.type;
+
   const formats: Formats = {
     valigntop: [
       { selector: 'td,th', styles: { verticalAlign: 'top' }}
@@ -167,11 +170,12 @@ const get = (dom: DOMUtils) => {
       { inline: 'u', remove: 'all', preserve_attributes: [ 'class', 'style' ] }
     ],
 
-    strikethrough: [
-      { inline: 'span', styles: { textDecoration: 'line-through' }, exact: true },
-      { inline: 'strike', remove: 'all', preserve_attributes: [ 'class', 'style' ] },
-      { inline: 's', remove: 'all', preserve_attributes: [ 'class', 'style' ] }
-    ],
+    strikethrough: (() => {
+      const span: Format = { inline: 'span', styles: { textDecoration: 'line-through' }, exact: true };
+      const strike: Format = { inline: 'strike', remove: 'all', preserve_attributes: [ 'class', 'style' ] };
+      const s: Format = { inline: 's', remove: 'all', preserve_attributes: [ 'class', 'style' ] };
+      return schemaType !== 'html4' ? [ s, span, strike ] : [ span, s, strike ];
+    })(),
 
     forecolor: { inline: 'span', styles: { color: '%value' }, links: true, remove_similar: true, clear_child_styles: true },
     hilitecolor: { inline: 'span', styles: { backgroundColor: '%value' }, links: true, remove_similar: true, clear_child_styles: true },

--- a/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatRegistry.ts
@@ -85,7 +85,7 @@ export const FormatRegistry = (editor: Editor): FormatRegistry => {
     return formats;
   };
 
-  register(DefaultFormats.get(editor.dom));
+  register(DefaultFormats.get(editor));
   register(Options.getFormats(editor));
 
   return {

--- a/modules/tinymce/src/core/main/ts/html/LegacyFilter.ts
+++ b/modules/tinymce/src/core/main/ts/html/LegacyFilter.ts
@@ -9,6 +9,7 @@ import { Arr } from '@ephox/katamari';
 
 import DomParser, { DomParserSettings } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
+import Schema from '../api/html/Schema';
 import Styles from '../api/html/Styles';
 import Tools from '../api/util/Tools';
 
@@ -45,32 +46,37 @@ const addFontToSpansFilter = (domParser: DomParser, styles: Styles, fontSizes: s
   });
 };
 
-const addStrikeToSpanFilter = (domParser: DomParser, styles: Styles): void => {
+const addStrikeFilter = (domParser: DomParser, schema: Schema, styles: Styles): void => {
   domParser.addNodeFilter('strike', (nodes) => {
+    const convertToSTag = schema.type !== 'html4';
     Arr.each(nodes, (node) => {
-      const props = styles.parse(node.attr('style'));
+      if (convertToSTag) {
+        node.name = 's';
+      } else {
+        const props = styles.parse(node.attr('style'));
 
-      props['text-decoration'] = 'line-through';
+        props['text-decoration'] = 'line-through';
 
-      node.name = 'span';
-      node.attr('style', styles.serialize(props));
+        node.name = 'span';
+        node.attr('style', styles.serialize(props));
+      }
     });
   });
 };
 
-const addFilters = (domParser: DomParser, settings: DomParserSettings): void => {
+const addFilters = (domParser: DomParser, settings: DomParserSettings, schema: Schema): void => {
   const styles = Styles();
 
   if (settings.convert_fonts_to_spans) {
     addFontToSpansFilter(domParser, styles, Tools.explode(settings.font_size_legacy_values));
   }
 
-  addStrikeToSpanFilter(domParser, styles);
+  addStrikeFilter(domParser, schema, styles);
 };
 
-const register = (domParser: DomParser, settings: DomParserSettings): void => {
+const register = (domParser: DomParser, settings: DomParserSettings, schema: Schema): void => {
   if (settings.inline_styles) {
-    addFilters(domParser, settings);
+    addFilters(domParser, settings, schema);
   }
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -2041,7 +2041,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.getBody().innerHTML = '<p>a <em><em>em</em> </em></p>';
     LegacyUnit.setSelection(editor, 'p', 0, 'em em', 0);
     editor.formatter.apply('strikethrough');
-    assert.equal(getContent(editor), '<p><span style="text-decoration: line-through;">a </span><em><em>em</em> </em></p>');
+    assert.equal(getContent(editor), '<p><s>a </s><em><em>em</em> </em></p>');
   });
 
   it('Superscript on subscript removes the subscript element', () => {

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -50,7 +50,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('Strikethrough');
-    assert.equal(editor.getContent(), '<p><span style="text-decoration: line-through;">test 123</span></p>');
+    assert.equal(editor.getContent(), '<p><s>test 123</s></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
@@ -100,7 +100,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     assert.equal(editor.getContent(), '<p><span style="font-size: xx-large;">test 123</span></p>');
 
     editor.setContent('<p><strike>test 123</strike></p>');
-    assert.equal(editor.getContent(), '<p><span style="text-decoration: line-through;">test 123</span></p>');
+    assert.equal(editor.getContent(), '<p><s>test 123</s></p>');
 
     editor.setContent('<p><font face="Arial">test 123</font></p>');
     assert.equal(editor.getContent(), '<p><span style="font-family: Arial;">test 123</span></p>');

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
@@ -280,7 +280,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.execCommand('mceInsertContent', false, '<strike>strike</strike><font size="7">font</font>');
     assert.equal(
       editor.getContent(),
-      '<p><span style="text-decoration: line-through;">strike</span><span style="font-size: 300%;">font</span></p>'
+      '<p><s>strike</s><span style="font-size: 300%;">font</span></p>'
     );
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/DefaultFormatsWithSchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/DefaultFormatsWithSchemaTest.ts
@@ -1,0 +1,79 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.fmt.DefaultFormatsWithSchemaTest', () => {
+  const defaultOptions = {
+    toolbar: 'forecolor backcolor | bold italic underline strikethrough | alignleft',
+    base_url: '/project/tinymce/js/tinymce'
+  };
+
+  const toggleInlineStyle = (editor: Editor, style: string) => {
+    TinyUiActions.clickOnToolbar(editor, `[aria-label="${style}"]`);
+  };
+
+  context(`schema version: html5`, () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      ...defaultOptions,
+      schema: 'html5'
+    }, []);
+
+    it('TINY-8262: should apply strikethrough using a "s" tag', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>Test</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      toggleInlineStyle(editor, 'Strikethrough');
+      TinyAssertions.assertContent(editor, '<p><s>Test</s></p>');
+      toggleInlineStyle(editor, 'Strikethrough');
+      editor.setContent('<p>Test</p>');
+    });
+
+    // Note: This test does not apply to html5-strict as "strike" is not valid in the schema
+    it('TINY-8262: should convert "strike" tag to "s" tag', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><strike>Test</strike></p>');
+      TinyAssertions.assertContent(editor, '<p><s>Test</s></p>');
+    });
+  });
+
+  context(`schema version: html5-strict`, () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      ...defaultOptions,
+      schema: 'html5-strict'
+    }, []);
+
+    it('TINY-8262: should apply strikethrough using a "s" tag', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>Test</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      toggleInlineStyle(editor, 'Strikethrough');
+      TinyAssertions.assertContent(editor, '<p><s>Test</s></p>');
+      toggleInlineStyle(editor, 'Strikethrough');
+      editor.setContent('<p>Test</p>');
+    });
+  });
+
+  context('schema version: html4', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      ...defaultOptions,
+      schema: 'html4'
+    }, []);
+
+    it('TINY-8262: should apply strikethrough using a "span" tag', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>Test</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      toggleInlineStyle(editor, 'Strikethrough');
+      TinyAssertions.assertContent(editor, '<p><span style="text-decoration: line-through;">Test</span></p>');
+      toggleInlineStyle(editor, 'Strikethrough');
+      editor.setContent('<p>Test</p>');
+    });
+
+    it('TINY-8262: should convert "strike" tag to "span" tag', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><strike>Test</strike></p>');
+      TinyAssertions.assertContent(editor, '<p><span style="text-decoration: line-through;">Test</span></p>');
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -92,7 +92,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
 
       testFormat(testId, 'Strikethrough', {
         ...config,
-        selector: 'span[style*="text-decoration: line-through;"]',
+        selector: 's',
         apply: toggleInlineStyle('Strikethrough'),
         remove: toggleInlineStyle('Strikethrough')
       });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TextDecorationColorTest.ts
@@ -22,7 +22,11 @@ describe('browser.tinymce.core.fmt.TextDecorationColorTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     toolbar: 'forecolor backcolor | bold italic underline strikethrough',
     formats: {
-      custom_format: { inline: 'span', classes: 'abc', styles: { textDecoration: 'underline' }}
+      custom_format: { inline: 'span', classes: 'abc', styles: { textDecoration: 'underline' }},
+      // Overwrite the default strikethrough format from an "s" tag to the "span" variant to be able to test the merging logic in RemoveFormat.ts
+      strikethrough: [
+        { inline: 'span', styles: { textDecoration: 'line-through' }, exact: true }
+      ],
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [], true);


### PR DESCRIPTION
Related Ticket: TINY-8262

Description of Changes:
* Change the strikethrough format so that it applies an `s` tag for html5 content and applies the `span` tag with text-decoration for html4 content

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
