### PR TITLE
TINY-6679: Separate notification closeButton and timeout settings

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dialog API `setData` method now uses a deep merge algorithm to support partial nested objects #TINY-8333
 - The dialog spec `initialData` type is now `Partial<T>` to match the underlying implementation details #TINY-8334
 - Improved support for placing the caret before or after noneditable elements within the editor #TINY-8169
+- Notifications no longer require a timeout to disable the close button #TINY-6679
 
 ### Changed
 - The `DomParser` API no longer uses a custom parser internally and instead uses the native `DOMParser` API #TINY-4627

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -16,7 +16,6 @@ import * as Options from './Options';
 export interface NotificationManagerImpl {
   open: (spec: NotificationSpec, closeCallback?: () => void) => NotificationApi;
   close: <T extends NotificationApi>(notification: T) => void;
-  reposition: <T extends NotificationApi>(notifications: T[]) => void;
   getArgs: <T extends NotificationApi>(notification: T) => NotificationSpec;
 }
 
@@ -35,8 +34,7 @@ export interface NotificationApi {
     value: (percent: number) => void;
   };
   text: (text: string) => void;
-  moveTo: (x: number, y: number) => void;
-  moveRel: (element: Element, rel: 'tc-tc' | 'bc-bc' | 'bc-tc' | 'tc-bc' | 'banner') => void;
+  reposition: () => void;
   getEl: () => HTMLElement;
   settings: NotificationSpec;
 }
@@ -77,7 +75,9 @@ const NotificationManager = (editor: Editor): NotificationManager => {
 
   const reposition = () => {
     if (notifications.length > 0) {
-      getImplementation().reposition(notifications);
+      Arr.each(notifications, (notification) => {
+        notification.reposition();
+      });
     }
   };
 

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -74,11 +74,9 @@ const NotificationManager = (editor: Editor): NotificationManager => {
   };
 
   const reposition = () => {
-    if (notifications.length > 0) {
-      Arr.each(notifications, (notification) => {
-        notification.reposition();
-      });
-    }
+    Arr.each(notifications, (notification) => {
+      notification.reposition();
+    });
   };
 
   const addNotification = (notification: NotificationApi) => {

--- a/modules/tinymce/src/core/main/ts/ui/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/core/main/ts/ui/NotificationManagerImpl.ts
@@ -13,7 +13,6 @@ export const NotificationManagerImpl = () => {
   return {
     open: unimplemented,
     close: unimplemented,
-    reposition: unimplemented,
     getArgs: unimplemented
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -52,8 +52,6 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
   };
 
   const open = (settings: NotificationSpec, closeCallback: () => void): NotificationApi => {
-    const hideCloseButton = !settings.closeButton && settings.timeout && (settings.timeout > 0 || settings.timeout < 0);
-
     const close = () => {
       closeCallback();
       InlineView.hide(notificationWrapper);
@@ -65,7 +63,7 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
         level: Arr.contains([ 'success', 'error', 'warning', 'warn', 'info' ], settings.type) ? settings.type : undefined,
         progress: settings.progressBar === true,
         icon: Optional.from(settings.icon),
-        closeButton: !hideCloseButton,
+        closeButton: settings.closeButton,
         onAction: close,
         iconProvider: sharedBackstage.providers.icons,
         translationProvider: sharedBackstage.providers.translate

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -5,8 +5,8 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Boxes, Gui, GuiFactory, InlineView, Layout, LayoutInset, MaxHeight, NodeAnchorSpec } from '@ephox/alloy';
-import { Arr, Num, Optional, Type } from '@ephox/katamari';
+import { Boxes, Gui, GuiFactory, InlineView, Layout, MaxHeight, NodeAnchorSpec } from '@ephox/alloy';
+import { Arr, Num, Optional } from '@ephox/katamari';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -20,35 +20,28 @@ interface Extras {
   readonly backstage: UiFactoryBackstage;
 }
 
-type Location = 'tc-tc' | 'bc-bc' | 'bc-tc' | 'tc-bc';
-
 export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): NotificationManagerImpl => {
   const sharedBackstage = extras.backstage.shared;
 
-  const getLayoutDirection = (rel: Location) => {
-    switch (rel) {
-      case 'bc-bc':
-        return LayoutInset.south;
-      case 'tc-tc':
-        return LayoutInset.north;
-      case 'tc-bc':
-        return Layout.north;
-      case 'bc-tc':
-      default:
-        return Layout.south;
-    }
-  };
-
-  const reposition = (notifications: NotificationApi[]) => {
-    if (notifications.length > 0) {
-      Arr.each(notifications, (notification, index) => {
-        if (index === 0) {
-          notification.moveRel(null, 'banner');
-        } else {
-          notification.moveRel(notifications[index - 1].getEl(), 'bc-tc');
-        }
-      });
-    }
+  const getBounds = () => {
+    /* Attempt to ensure that the notifications render below the top of the header and between
+     * whichever is the larger between the bottom of the content area and the bottom of the viewport
+     *
+     * Note: This isn't perfect, but without being able to use docking and associate the notifications
+     * together due to the `moveTo` and `moveRel` APIs then we're a bit stuck and a proper solution
+     * will have to be done in TinyMCE 6.
+     *
+     * Updated note after TINY-6679: The `moveTo` and `moveRel` apis have been made private.
+     * There wasn't time to implement the proper solution but now that the API is self-contained
+     * that can be done in TINY-8128.
+     */
+    const contentArea = Boxes.box(SugarElement.fromDom(editor.getContentAreaContainer()));
+    const win = Boxes.win();
+    const x = Num.clamp(win.x, contentArea.x, contentArea.right);
+    const y = Num.clamp(win.y, contentArea.y, contentArea.bottom);
+    const right = Math.max(contentArea.right, win.right);
+    const bottom = Math.max(contentArea.bottom, win.bottom);
+    return Optional.some(Boxes.bounds(x, y, right - x, bottom - y));
   };
 
   const open = (settings: NotificationSpec, closeCallback: () => void): NotificationApi => {
@@ -77,8 +70,8 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
           classes: [ 'tox-notifications-container' ]
         },
         lazySink: sharedBackstage.getSink,
-        fireDismissalEventInstead: { },
-        ...sharedBackstage.header.isPositionedAtTop() ? { } : { fireRepositionEventInstead: { }}
+        fireDismissalEventInstead: {},
+        ...sharedBackstage.header.isPositionedAtTop() ? {} : { fireRepositionEventInstead: {}}
       })
     );
 
@@ -90,60 +83,48 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
       }, settings.timeout);
     }
 
-    const getBounds = () => {
-      /* Attempt to ensure that the notifications render below the top of the header and between
-       * whichever is the larger between the bottom of the content area and the bottom of the viewport
-       *
-       * Note: This isn't perfect, but without being able to use docking and associate the notifications
-       * together due to the `moveTo` and `moveRel` APIs then we're a bit stuck and a proper solution
-       * will have to be done in TinyMCE 6.
-       */
-      const contentArea = Boxes.box(SugarElement.fromDom(editor.getContentAreaContainer()));
-      const win = Boxes.win();
-      const x = Num.clamp(win.x, contentArea.x, contentArea.right);
-      const y = Num.clamp(win.y, contentArea.y, contentArea.bottom);
-      const right = Math.max(contentArea.right, win.right);
-      const bottom = Math.max(contentArea.bottom, win.bottom);
-      return Optional.some(Boxes.bounds(x, y, right - x, bottom - y));
+    const reposition = () => {
+      const notificationSpec = GuiFactory.premade(notification);
+      const anchorOverrides = {
+        maxHeightFunction: MaxHeight.expandable()
+      };
+
+      // TODO TINY-8128: This is a nasty hack. This function only works if called on notifications in order.
+      const allNotifications = editor.notificationManager.getNotifications();
+
+      if (allNotifications[0] === thisNotification) {
+        // first notification goes below the banner element
+        const anchor = {
+          ...sharedBackstage.anchors.banner(),
+          overrides: anchorOverrides
+        };
+        InlineView.showWithinBounds(notificationWrapper, notificationSpec, { anchor }, getBounds);
+      } else {
+        // all other notifications go directly below the previous one
+        for (let i = 1; i < allNotifications.length; i++) {
+          if (allNotifications[i] === thisNotification) {
+            const previousNotification = allNotifications[i - 1].getEl();
+
+            const nodeAnchor: NodeAnchorSpec = {
+              type: 'node',
+              root: SugarBody.body(),
+              node: Optional.some(SugarElement.fromDom(previousNotification)),
+              overrides: anchorOverrides,
+              layouts: {
+                onRtl: () => [ Layout.south ],
+                onLtr: () => [ Layout.south ]
+              }
+            };
+            InlineView.showWithinBounds(notificationWrapper, notificationSpec, { anchor: nodeAnchor }, getBounds);
+            break;
+          }
+        }
+      }
     };
 
-    return {
+    const thisNotification = {
       close,
-      moveTo: (x: number, y: number) => {
-        InlineView.showAt(notificationWrapper, GuiFactory.premade(notification), {
-          anchor: {
-            type: 'makeshift',
-            x,
-            y
-          }
-        });
-      },
-      moveRel: (element: HTMLElement | null, rel: Location | 'banner') => {
-        const notificationSpec = GuiFactory.premade(notification);
-        const anchorOverrides = {
-          maxHeightFunction: MaxHeight.expandable()
-        };
-        if (rel !== 'banner' && Type.isNonNullable(element)) {
-          const layoutDirection = getLayoutDirection(rel);
-          const nodeAnchor: NodeAnchorSpec = {
-            type: 'node',
-            root: SugarBody.body(),
-            node: Optional.some(SugarElement.fromDom(element)),
-            overrides: anchorOverrides,
-            layouts: {
-              onRtl: () => [ layoutDirection ],
-              onLtr: () => [ layoutDirection ]
-            }
-          };
-          InlineView.showWithinBounds(notificationWrapper, notificationSpec, { anchor: nodeAnchor }, getBounds);
-        } else {
-          const anchor = {
-            ...sharedBackstage.anchors.banner(),
-            overrides: anchorOverrides
-          };
-          InlineView.showWithinBounds(notificationWrapper, notificationSpec, { anchor }, getBounds);
-        }
-      },
+      reposition,
       text: (nuText: string) => {
         // check if component is still mounted
         Notification.updateText(notification, nuText);
@@ -156,6 +137,7 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
         }
       }
     };
+    return thisNotification;
   };
 
   const close = (notification: NotificationApi) => {
@@ -169,7 +151,6 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
   return {
     open,
     close,
-    reposition,
     getArgs
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -89,7 +89,7 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
         maxHeightFunction: MaxHeight.expandable()
       };
 
-      // TODO TINY-8128: This is a nasty hack. This function only works if called on notifications in order.
+      // TODO TINY-8128: This is a hack. This logic only works if called on every notification in order (as NotificationManager.reposition() does).
       const allNotifications = editor.notificationManager.getNotifications();
 
       if (allNotifications[0] === thisNotification) {
@@ -101,24 +101,21 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
         InlineView.showWithinBounds(notificationWrapper, notificationSpec, { anchor }, getBounds);
       } else {
         // all other notifications go directly below the previous one
-        for (let i = 1; i < allNotifications.length; i++) {
-          if (allNotifications[i] === thisNotification) {
-            const previousNotification = allNotifications[i - 1].getEl();
+        Arr.indexOf(allNotifications, thisNotification).each((idx) => {
+          const previousNotification = allNotifications[idx - 1].getEl();
 
-            const nodeAnchor: NodeAnchorSpec = {
-              type: 'node',
-              root: SugarBody.body(),
-              node: Optional.some(SugarElement.fromDom(previousNotification)),
-              overrides: anchorOverrides,
-              layouts: {
-                onRtl: () => [ Layout.south ],
-                onLtr: () => [ Layout.south ]
-              }
-            };
-            InlineView.showWithinBounds(notificationWrapper, notificationSpec, { anchor: nodeAnchor }, getBounds);
-            break;
-          }
-        }
+          const nodeAnchor: NodeAnchorSpec = {
+            type: 'node',
+            root: SugarBody.body(),
+            node: Optional.some(SugarElement.fromDom(previousNotification)),
+            overrides: anchorOverrides,
+            layouts: {
+              onRtl: () => [ Layout.south ],
+              onLtr: () => [ Layout.south ]
+            }
+          };
+          InlineView.showWithinBounds(notificationWrapper, notificationSpec, { anchor: nodeAnchor }, getBounds);
+        });
       }
     };
 

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -27,13 +27,11 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
     /* Attempt to ensure that the notifications render below the top of the header and between
      * whichever is the larger between the bottom of the content area and the bottom of the viewport
      *
-     * Note: This isn't perfect, but without being able to use docking and associate the notifications
-     * together due to the `moveTo` and `moveRel` APIs then we're a bit stuck and a proper solution
-     * will have to be done in TinyMCE 6.
+     * Note: This isn't perfect, but we have a plan to fix it now that TinyMCE 6 removed public methods restricting
+     * our ability to change anything (TINY-6679).
      *
-     * Updated note after TINY-6679: The `moveTo` and `moveRel` apis have been made private.
-     * There wasn't time to implement the proper solution but now that the API is self-contained
-     * that can be done in TINY-8128.
+     * TODO TINY-8128: use docking and associate the notifications together so they update position automatically
+     * during UI refresh updates.
      */
     const contentArea = Boxes.box(SugarElement.fromDom(editor.getContentAreaContainer()));
     const win = Boxes.win();


### PR DESCRIPTION
Related Ticket: TINY-6679

Description of Changes:
* `closeButton` no longer depends on `timeout`
* Removed undocumented notification APIs (`moveTo` and `moveRel`) that restricted future work. Despite being undocumented this is a breaking change, requiring a major version boundary to release.

The functionality in `moveRel` is unfortunately still required for `notificationManager.reposition()` to operate correctly, so I've added a hack to replicate what reposition was doing. We have already planned TINY-8128 to resolve this issue but ran out of time to do it in the 6.0 release.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
