### PR TITLE
TINY-3799: Added a workaround to improve anchor rendering when using allow_html_in_named_anchor: true

### DIFF
--- a/modules/oxide/src/less/theme/content/anchor/anchor.less
+++ b/modules/oxide/src/less/theme/content/anchor/anchor.less
@@ -20,16 +20,26 @@
       background: transparent data-uri('image/svg+xml;charset=UTF-8', '../../../../svg/anchor.svg') no-repeat center;
     }
 
-    cursor: default;
-    display: inline-block;
-    height: 12px !important;
-    padding: 0 2px;
-    -webkit-user-modify: read-only;
-    -moz-user-modify: read-only;
-    -webkit-user-select: all;
-    -moz-user-select: all;
-    user-select: all;
-    width: 8px !important;
+    // empty named anchor (allow_html_in_named_anchor: false)
+    &:empty {
+      cursor: default;
+      display: inline-block;
+      height: 12px !important;
+      padding: 0 2px;
+      -webkit-user-modify: read-only;
+      -moz-user-modify: read-only;
+      -webkit-user-select: all;
+      -moz-user-select: all;
+      user-select: all;
+      width: 8px !important;
+    }
+
+    // named anchor with content (allow_html_in_named_anchor: true)
+    &:not(:empty) {
+      background-position-x: 2px;
+      display: inline-block;
+      padding-left: 12px;
+    }
   }
 
   .mce-item-anchor[data-mce-selected] {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dialog labels and other text-based UI properties did not escape HTML markup #TINY-7524
 - Deleting content would sometimes not fire `beforeinput` and `input` events as expected #TINY-8168  #TINY-8329
 - Alignment would sometimes be removed on parent elements when changing alignment on certain inline nodes, such as images #TINY-8308
+- Anchor elements would render incorrectly when using the `allow_html_in_named_anchor` option #TINY-3799
 
 ### Removed
 - Removed the jQuery integration #TINY-4518

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -235,6 +235,7 @@ const Quirks = (editor: Editor): Quirks => {
    * by clicking on them so we need to fake that.
    */
   const selectControlElements = () => {
+    const visualAidsAnchorClass = Options.getVisualAidsAnchorClass(editor);
     editor.on('click', (e) => {
       const target = e.target;
 
@@ -247,7 +248,7 @@ const Quirks = (editor: Editor): Quirks => {
         editor.nodeChanged();
       }
 
-      if (target.nodeName === 'A' && dom.hasClass(target, 'mce-item-anchor')) {
+      if (target.nodeName === 'A' && dom.hasClass(target, visualAidsAnchorClass) && target.childNodes.length === 0) {
         e.preventDefault();
         selection.select(target);
       }


### PR DESCRIPTION
Related Ticket: TINY-3799

Description of Changes:

This just makes some improvements and fixes the visual rendering issues with using `allow_html_in_named_anchor: true`. The screenshot below shows the two different versions should render the same now, with the top being an anchor with HTML content (`<a id="dfdfd">dfdfd</a>`) and the second being empty (`<a id="dfdfd"></a>dfdfd`).
![image](https://user-images.githubusercontent.com/1575550/152283438-2b93e3b5-97a1-4531-aa91-eda0a8901ccf.png)

**Note:** This in no way attempts to solve all the issues with enabling this option and only attempts to fix the poor rendering.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ (Visual changes so no automated tests)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
