### PR TITLE
TINY-8410: Ported relevant SaxParser tests and fixed issues found

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -667,6 +667,33 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     );
   });
 
+  it('Preserve internal elements', () => {
+    const html = '<span id="id" class="class"><b>text</b></span><span id="test" data-mce-type="something"></span>';
+
+    const parser1 = DomParser({}, Schema({ valid_elements: 'b' }));
+    const serializerHtml1 = serializer.serialize(parser1.parse(html));
+    assert.equal(
+      serializerHtml1,
+      '<b>text</b><span id="test" data-mce-type="something"></span>',
+      'Preserve internal span element without any span schema rule.'
+    );
+
+    const parser2 = DomParser({}, Schema({ valid_elements: 'b,span[class]' }));
+    const serializerHtml2 = serializer.serialize(parser2.parse(html));
+    assert.equal(
+      serializerHtml2,
+      '<span class="class"><b>text</b></span><span id="test" data-mce-type="something"></span>',
+      'Preserve internal span element with a span schema rule.'
+    );
+
+    const serializedHtml3 = serializer.serialize(parser1.parse('<b data-mce-type="test" id="x" style="color: red" src="1" data="2" onclick="3"></b>'));
+    assert.equal(
+      serializedHtml3,
+      '<b data-mce-type="test" id="x" style="color: red"></b>',
+      'Removes disallowed elements'
+    );
+  });
+
   // TODO: TINY-4627/TINY-8363 - the iframe innerHTML on safari is `&lt;textarea&gt;` whereas on other browsers
   //       is `<textarea>`. This causes the mXSS cleaner in DOMPurify to run and causes the different assertions below
   it('parse iframe XSS', () => {
@@ -676,6 +703,26 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       serializer.serialize(DomParser().parse('<iframe><textarea></iframe><img src="a" onerror="alert(document.domain)" />')),
       browser.isSafari() ? '<iframe><textarea></iframe><img src="a">' : '<img src="a">'
     );
+  });
+
+  it('Conditional comments (allowed)', () => {
+    const parser = DomParser({ allow_conditional_comments: true, validate: false }, schema);
+    const html = '<!--[if gte IE 4]>alert(1)<![endif]-->';
+    const serializedHtml = serializer.serialize(parser.parse(html));
+    assert.equal(serializedHtml, '<!--[if gte IE 4]>alert(1)<![endif]-->');
+  });
+
+  it('Conditional comments (denied)', () => {
+    const parser = DomParser({ allow_conditional_comments: false, validate: false }, schema);
+
+    let serializedHtml = serializer.serialize(parser.parse('<!--[if gte IE 4]>alert(1)<![endif]-->'));
+    assert.equal(serializedHtml, '<!-- [if gte IE 4]>alert(1)<![endif]-->');
+
+    serializedHtml = serializer.serialize(parser.parse('<!--[if !IE]>alert(1)<![endif]-->'));
+    assert.equal(serializedHtml, '<!-- [if !IE]>alert(1)<![endif]-->');
+
+    serializedHtml = serializer.serialize(parser.parse('<!--[iF !IE]>alert(1)<![endif]-->'));
+    assert.equal(serializedHtml, '<!-- [iF !IE]>alert(1)<![endif]-->');
   });
 
   it('allow_script_urls should allow any URIs', () => {
@@ -701,6 +748,62 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       '<a>1</a>' +
       '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">2</a>' +
       '<a href="data:image/svg+xml;base64,x">3</a>'
+    );
+  });
+
+  it('Parse script urls (disallow svg data image uris)', () => {
+    const parser = DomParser({ allow_svg_data_urls: false, allow_html_data_urls: false, validate: false }, schema);
+    const html = '<a href="data:image/svg+xml;base64,x">1</a>' +
+      '<img src="data:image/svg+xml;base64,x">';
+    const serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(
+      serializedHtml,
+      '<a>1</a>' +
+      '<img>'
+    );
+  });
+
+  it('Parse script urls (denied)', () => {
+    const parser = DomParser({ allow_script_urls: false, validate: false }, schema);
+    const html = '<a href="jAvaScript:alert(1)">1</a>' +
+      '<a href="vbscript:alert(2)">2</a>' +
+      '<a href="javascript:alert(3)">3</a>' +
+      '<a href="\njavascript:alert(4)">4</a>' +
+      '<a href="java\nscript:alert(5)">5</a>' +
+      '<a href="java\tscript:alert(6)">6</a>' +
+      '<a href="%6aavascript:alert(7)">7</a>' +
+      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">8</a>' +
+      '<a href=" dAt%61: tExt/html  ; bAse64 , PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">9</a>' +
+      '<object data="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">10</object>' +
+      '<button formaction="javascript:alert(11)">11</button>' +
+      '<form action="javascript:alert(12)">12</form>' +
+      '<table background="javascript:alert(13)"><tbody><tr><td>13</td></tr></tbody></table>' +
+      '<a href="mhtml:14">14</a>' +
+      '<a xlink:href="jAvaScript:alert(15)">15</a>' +
+      '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
+      '<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>';
+    const serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(
+      serializedHtml,
+      '<a>1</a>' +
+      '<a>2</a>' +
+      '<a>3</a>' +
+      '<a>4</a>' +
+      '<a>5</a>' +
+      '<a>6</a>' +
+      '<a>7</a>' +
+      '<a>8</a>' +
+      '<a>9</a>' +
+      '<object>10</object>' +
+      '<button>11</button>' +
+      '<form>12</form>' +
+      '<table><tbody><tr><td>13</td></tr></tbody></table>' +
+      '<a>14</a>' +
+      '<a>15</a>' +
+      '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
+      '<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>'
     );
   });
 
@@ -841,6 +944,44 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     assert.equal(serializedHtml, html, 'Should be html with base64 uri retained');
   });
 
+  it('Parse away bogus elements', () => {
+    const testBogusParsing = (inputHtml: string, outputHtml: string) => {
+      const parser = DomParser({}, schema);
+      const serializedHtml = serializer.serialize(parser.parse(inputHtml));
+      assert.equal(serializedHtml, outputHtml);
+    };
+
+    testBogusParsing('a<b data-mce-bogus="1">b</b>c', 'abc');
+    testBogusParsing('a<b data-mce-bogus="true">b</b>c', 'abc');
+    testBogusParsing('a<b data-mce-bogus="1"></b>c', 'ac');
+    testBogusParsing('a<b data-mce-bogus="all">b</b>c', 'ac');
+    testBogusParsing('a<b data-mce-bogus="all"><!-- x --><?xml?></b>c', 'ac');
+    testBogusParsing('a<b data-mce-bogus="all"><b>b</b></b>c', 'ac');
+    testBogusParsing('a<b data-mce-bogus="all"><br>b</b><b>c</b>', 'a<b>c</b>');
+    testBogusParsing('a<b data-mce-bogus="all"><img>b</b><b>c</b>', 'a<b>c</b>');
+    testBogusParsing('a<b data-mce-bogus="all"><b attr="x">b</b></b>c', 'ac');
+    testBogusParsing('a<b data-mce-bogus="all"></b>c', 'ac');
+    testBogusParsing('a<b data-mce-bogus="all"></b><b>c</b>', 'a<b>c</b>');
+  });
+
+  it('remove bogus elements even if not part of valid_elements', () => {
+    const parser = DomParser({}, Schema({ valid_elements: 'p,span,' }));
+    const html = '<p>a <span data-mce-bogus="all">&nbsp;<span contenteditable="false">X</span>&nbsp;</span>b</p>';
+    const serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml, '<p>a b</p>');
+  });
+
+  it('Parse cdata with comments', () => {
+    const parser = DomParser({}, schema);
+
+    const serializedHtml = serializer.serialize(parser.parse('<div><![CDATA[<!--x--><!--y--!>-->]]></div>', { format: 'html' }));
+    assert.equal(serializedHtml, '<div><!--[CDATA[<!--x----><!--y-->--&gt;]]&gt;</div>');
+
+    const serializedXHtml = serializer.serialize(parser.parse('<div><![CDATA[<!--x--><!--y-->--><!--]]></div>', { format: 'xhtml' }));
+    assert.equal(serializedXHtml, '<div><![CDATA[<!--x--><!--y-->--><!--]]></div>');
+  });
+
   it('TINY-7756: Parsing invalid nested children', () => {
     const schema = Schema({ valid_children: '-td[button|a|div]' });
     const parser = DomParser({}, schema);
@@ -900,6 +1041,28 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const serializedHtml = serializer.serialize(parser.parse(html, { context: 'p' }));
 
     assert.equal(serializedHtml, '<p>Hello world! <button>This is a button with a meta tag in it</button></p>');
+  });
+
+  it('TINY-7756: should prevent dom clobbering overriding document/form properties', () => {
+    const parser = DomParser({}, Schema({ valid_elements: '*[id|src|name|class]' }));
+    const html = '<img src="x" name="getElementById" />' +
+      '<input id="attributes" />' +
+      '<output id="style"></output>' +
+      '<button name="action"></button>' +
+      '<select name="getElementsByName"></select>' +
+      '<fieldset name="method"></fieldset>' +
+      '<textarea name="click"></textarea>';
+    const serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<img src="x">' +
+      '<input>' +
+      '<output></output>' +
+      '<button></button>' +
+      '<select></select>' +
+      '<fieldset></fieldset>' +
+      '<textarea></textarea>'
+    );
   });
 
   context('validate: false', () => {

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -9,11 +9,11 @@ import { Arr, Obj, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
-import DomParser from 'tinymce/core/api/html/DomParser';
 import AstNode from 'tinymce/core/api/html/Node';
 import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 
 import * as Options from '../api/Options';
+import { Parser } from './Parser';
 
 declare let escape: any;
 
@@ -49,7 +49,7 @@ const setDimensions = (node: AstNode, previewNode: AstNode, styles: Record<strin
 };
 
 const appendNodeContent = (editor: Editor, nodeName: string, previewNode: AstNode, html: string): void => {
-  const newNode = DomParser({ forced_root_block: false, validate: false }, editor.schema).parse(html, { context: nodeName });
+  const newNode = Parser(editor.schema).parse(html, { context: nodeName });
   while (newNode.firstChild) {
     previewNode.append(newNode.firstChild);
   }

--- a/modules/tinymce/src/plugins/media/main/ts/core/Parser.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Parser.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ */
+
+import DomParser, { DomParserSettings } from 'tinymce/core/api/html/DomParser';
+import Schema from 'tinymce/core/api/html/Schema';
+
+export const Parser = (schema: Schema, settings: DomParserSettings = {}): DomParser => DomParser({
+  forced_root_block: false,
+  validate: false,
+  allow_conditional_comments: true,
+  ...settings
+}, schema);

--- a/modules/tinymce/src/plugins/media/main/ts/core/Sanitize.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Sanitize.ts
@@ -6,15 +6,14 @@
  */
 
 import Editor from 'tinymce/core/api/Editor';
-import DomParser from 'tinymce/core/api/html/DomParser';
 import AstNode from 'tinymce/core/api/html/Node';
 
 import * as Options from '../api/Options';
+import { Parser } from './Parser';
 
 const parseAndSanitize = (editor: Editor, context: string, html: string): AstNode => {
   const validate = Options.shouldFilterHtml(editor);
-  const parser = DomParser({ validate, forced_root_block: false }, editor.schema);
-  return parser.parse(html, { context });
+  return Parser(editor.schema, { validate }).parse(html, { context });
 };
 
 export {

--- a/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
@@ -6,11 +6,11 @@
  */
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
-import DomParser from 'tinymce/core/api/html/DomParser';
 import AstNode from 'tinymce/core/api/html/Node';
 import Schema from 'tinymce/core/api/html/Schema';
 import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 
+import { Parser } from './Parser';
 import { MediaData } from './Types';
 
 const DOM = DOMUtils.DOM;
@@ -32,7 +32,7 @@ const updateHtml = (html: string, data: Partial<MediaData>, updateAll?: boolean,
   let numSources = 0;
   let sourceCount = 0;
 
-  const parser = DomParser({ validate: false, forced_root_block: false }, schema);
+  const parser = Parser(schema);
   parser.addNodeFilter('source', (nodes) => numSources = nodes.length);
   const rootNode = parser.parse(html);
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -12,6 +12,7 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
     media_live_embeds: false,
     document_base_url: '/tinymce/tinymce/trunk/tests/',
     extended_valid_elements: 'script[src|type]',
+    allow_conditional_comments: true
   }, [ Plugin ]);
 
   it('TBA: Object retained as is', () => {


### PR DESCRIPTION
Related Ticket: TINY-8410

Description of Changes:
* Ports a number of useful tests from `SaxParserTest` to `DomParserTest`
* Fixed an issue where bogus elements weren't removed correctly if the element wasn't in the schema
* Fixed `allow_conditional_comments` not being used
* Fixed attribute values not being URL decoded which means some older unsafe values weren't stripped
* Added some logic to preserve certain internal element attributes (this is different to 5.x, but this is a safe option for now given the changes and TINY-8452 has been logged to investigate this further)
* Cleaned up the media code a little

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
